### PR TITLE
Enforce line endings and keep binary data

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,15 +1,12 @@
 # Reference: https://help.github.com/articles/dealing-with-line-endings/
+# Auto detect text files
+* text=auto
 
-# Enforce LF line endings
-* text eol=lf
+# Files that are truly text-based
+*.h text eol=lf
+*.m text eol=lf
+*.swift text eol=lf
 
-# Files that are truly binary and should not be modified
-*.eot binary
-*.jar binary
+# Files that are truly binary
 *.jpg binary
-*.otf binary
 *.png binary
-*.svg binary
-*.ttf binary
-*.woff binary
-*.woff2 binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Reference: https://help.github.com/articles/dealing-with-line-endings/
+
+# Enforce LF line endings
+* text eol=lf
+
+# Files that are truly binary and should not be modified
+*.eot binary
+*.jar binary
+*.jpg binary
+*.otf binary
+*.png binary
+*.svg binary
+*.ttf binary
+*.woff binary
+*.woff2 binary


### PR DESCRIPTION
If you're using Git to collaborate with others on GitHub, ensure that Git is properly configured to handle line endings. This is done by enforcing line endings via [gitattributes](https://git-scm.com/docs/gitattributes). 

To not touch line endings of images, they are declared as binary data.