### PR TITLE
Camera keyboard follow ups

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -650,7 +650,6 @@
 {
     if (! self.contentViewController.isScrolledToBottom) {
         [self.contentViewController scrollToBottomAnimated:YES];
-        return YES;
     }
 
     return YES;

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -650,7 +650,7 @@
 {
     if (! self.contentViewController.isScrolledToBottom) {
         [self.contentViewController scrollToBottomAnimated:YES];
-        return controller.inputBar.textView.text.length != 0;
+        return YES;
     }
 
     return YES;

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
@@ -77,6 +77,7 @@ public class CameraKeyboardViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
         self.assetLibrary.delegate = self
         NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(splitLayoutChanged(_:)), name: SplitLayoutObservableDidChangeToLayoutSizeNotification, object: self.splitLayoutObservable)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(applicationDidBecomeActive(_:)), name: UIApplicationDidBecomeActiveNotification, object: nil)
     }
     
     required public init?(coder aDecoder: NSCoder) {
@@ -90,6 +91,10 @@ public class CameraKeyboardViewController: UIViewController {
             self.collectionViewLayout.invalidateLayout()
             self.collectionView.reloadData()
         }
+    }
+    
+    @objc public func applicationDidBecomeActive(notification: NSNotification!) {
+        self.assetLibrary.refetchAssets()
     }
     
     override public func viewDidLoad() {
@@ -137,7 +142,7 @@ public class CameraKeyboardViewController: UIViewController {
         self.collectionViewLayout.invalidateLayout()
         self.collectionView.reloadData()
         DeviceOrientationObserver.sharedInstance().startMonitoringDeviceOrientation()
-
+        self.assetLibrary.refetchAssets()
     }
     
     public override func viewWillDisappear(animated: Bool) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Files.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Files.m
@@ -330,9 +330,11 @@ const NSTimeInterval ConversationUploadMaxVideoDuration = 4.0f * 60.0f; // 4 min
         }
         
         if (image != nil) {
-            [self.parentViewController dismissViewControllerAnimated:YES completion:^(){
-                CameraKeyboardSource source = (picker.sourceType == UIImagePickerControllerSourceTypeCamera) ? CameraKeyboardSourceCamera : CameraKeyboardSourceLibrary;
-                [self showConfirmationForImage:UIImageJPEGRepresentation(image, 0.9) source:source];
+            picker.showLoadingView = YES;
+            
+            [self.sendController sendMessageWithImageData:UIImageJPEGRepresentation(image, 0.9) completion:^{
+                picker.showLoadingView = NO;
+                [self.parentViewController dismissViewControllerAnimated:YES completion:nil];
             }];
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Files.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Files.m
@@ -37,6 +37,9 @@ const NSTimeInterval ConversationUploadMaxVideoDuration = 4.0f * 60.0f; // 4 min
 {
     [Analytics.shared tagMediaAction:ConversationMediaActionFileTransfer inConversation:self.conversation];
     
+    self.mode = ConversationInputBarViewControllerModeTextInput;
+    [self.inputBar.textView resignFirstResponder];
+    
     UIDocumentMenuViewController *docController = [[UIDocumentMenuViewController alloc] initWithDocumentTypes:@[(NSString *)kUTTypeItem]
                                                                                                        inMode:UIDocumentPickerModeImport];
     docController.modalPresentationStyle = UIModalPresentationPopover;

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -670,7 +670,7 @@
         });
     }
     else {
-        [self executeWithVideoPermissions:^{
+        [UIApplication wr_requestOrWarnAboutVideoAccess:^(BOOL granted) {
             [self executeWithCameraRollPermission:^(BOOL success){
                 self.mode = ConversationInputBarViewControllerModeCamera;
                 [self.inputBar.textView becomeFirstResponder];


### PR DESCRIPTION
- Removed unnecessary second confirmation when taking picture/video with integrated camera
- Do not ask for sound recording permissions immediately when opening camera keyboard
- Open camera keyboard even if scrolled back in conversation on tap
- Close keyboard when doing file sharing
- Fetch new images when app becomes active