### PR TITLE
Enable CocoaPods and Bundler caching on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: objective-c
 osx_image: xcode7.3
-cache: cocoapods
+
+cache:
+  - bundler
+  - cocoapods
 
 script:
 - set pipefail

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: objective-c
 osx_image: xcode7.3
+cache: cocoapods
 
-script: 
+script:
 - set pipefail
 - ./setup.sh
 - xcodebuild test -workspace Wire-iOS.xcworkspace -scheme Wire-iOS -destination 'platform=iOS Simulator,name=iPhone 6s,OS=9.3' | xcpretty


### PR DESCRIPTION
* Enables caching of CocoaPods and Bundler on Travis-CI, see https://docs.travis-ci.com/user/caching/ 