### PR TITLE
Camera keyboard bugfixes

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/AssetCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/AssetCell.swift
@@ -81,17 +81,20 @@ public class AssetCell: UICollectionViewCell {
             }
             
             let maxDimensionRetina = max(self.bounds.size.width, self.bounds.size.height) * (self.window ?? UIApplication.sharedApplication().keyWindow!).screen.scale
-            
             self.imageRequestTag = manager.requestImageForAsset(asset,
                                                                  targetSize: CGSizeMake(maxDimensionRetina, maxDimensionRetina),
                                                                  contentMode: .AspectFill,
                                                                  options: self.dynamicType.imageFetchOptions,
                                                                  resultHandler: { [weak self] result, info -> Void in
-                                                                    guard let `self` = self else {
+                                                                    guard let `self` = self,
+                                                                        let requesId = info?[PHImageResultRequestIDKey] as? Int
+                                                                        else {
                                                                         return
                                                                     }
                                                                     
-                                                                    self.imageView.image = result
+                                                                    if requesId == Int(self.imageRequestTag) {
+                                                                        self.imageView.image = result
+                                                                    }
             })
             
             if asset.mediaType == .Video {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraCell.swift
@@ -139,6 +139,11 @@ public class CameraCell: UICollectionViewCell {
     
     private func updateVideoOrientation() {
         let statusBarOrientation = AVCaptureVideoOrientation(rawValue: UIApplication.sharedApplication().statusBarOrientation.rawValue)!
+        
+        if let connection = self.cameraController.previewLayer.connection where connection.supportsVideoOrientation {
+            connection.videoOrientation = statusBarOrientation
+        }
+        
         if UIDevice.currentDevice().userInterfaceIdiom == .Pad {
             self.cameraController.snapshotVideoOrientation = statusBarOrientation
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
@@ -228,11 +228,13 @@ public class CameraKeyboardViewController: UIViewController {
         let options = PHVideoRequestOptions()
         options.deliveryMode = .HighQualityFormat
         options.networkAccessAllowed = true
-        
+        options.version = .Original
+
         self.showLoadingView = true
         manager.requestAVAssetForVideo(asset, options: options, resultHandler: { videoAsset, audioMix, info in
             dispatch_async(dispatch_get_main_queue(), {
                 self.showLoadingView = false
+
                 guard let videoAsset = videoAsset as? AVURLAsset else {
                     return
                 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
@@ -44,6 +44,8 @@ public class CameraKeyboardViewController: UIViewController {
     
     private let sideMargin: CGFloat = 14
     
+    private var viewWasHidden: Bool = false
+    
     private var goBackButtonRevealed: Bool = false {
         didSet {
             if goBackButtonRevealed {
@@ -140,11 +142,14 @@ public class CameraKeyboardViewController: UIViewController {
         self.collectionViewLayout.invalidateLayout()
         self.collectionView.reloadData()
         DeviceOrientationObserver.sharedInstance().startMonitoringDeviceOrientation()
-        self.assetLibrary.refetchAssets()
+        if self.viewWasHidden {
+            self.assetLibrary.refetchAssets()
+        }
     }
     
     public override func viewWillDisappear(animated: Bool) {
         super.viewWillDisappear(animated)
+        self.viewWasHidden = true
         DeviceOrientationObserver.sharedInstance().stopMonitoringDeviceOrientation()
     }
     

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Files.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Files.m
@@ -148,6 +148,16 @@ const NSTimeInterval ConversationUploadMaxVideoDuration = 4.0f * 60.0f; // 4 min
         pickerController.mediaTypes = mediaTypes;
         pickerController.videoMaximumDuration = ConversationUploadMaxVideoDuration;
         pickerController.transitioningDelegate = [FastTransitioningDelegate sharedDelegate];
+        if (sourceType == UIImagePickerControllerSourceTypeCamera) {
+            switch ([Settings sharedSettings].preferredCamera) {
+                case CameraControllerCameraBack:
+                    pickerController.cameraDevice = UIImagePickerControllerCameraDeviceRear;
+                    break;
+                case CameraControllerCameraFront:
+                    pickerController.cameraDevice = UIImagePickerControllerCameraDeviceFront;
+                    break;
+            }
+        }
         [self.parentViewController presentViewController:pickerController animated:YES completion:nil];
     }];
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Files.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Files.m
@@ -343,12 +343,20 @@ const NSTimeInterval ConversationUploadMaxVideoDuration = 4.0f * 60.0f; // 4 min
         }
         
         if (image != nil) {
-            picker.showLoadingView = YES;
+            if (picker.sourceType == UIImagePickerControllerSourceTypeCamera) {
+                picker.showLoadingView = YES;
+                
+                [self.sendController sendMessageWithImageData:UIImageJPEGRepresentation(image, 0.9) completion:^{
+                    picker.showLoadingView = NO;
+                    [self.parentViewController dismissViewControllerAnimated:YES completion:nil];
+                }];
+            }
+            else {
+                [self.parentViewController dismissViewControllerAnimated:YES completion:^(){
+                    [self showConfirmationForImage:UIImageJPEGRepresentation(image, 0.9) source:picker.sourceType];
+                }];
+            }
             
-            [self.sendController sendMessageWithImageData:UIImageJPEGRepresentation(image, 0.9) completion:^{
-                picker.showLoadingView = NO;
-                [self.parentViewController dismissViewControllerAnimated:YES completion:nil];
-            }];
         }
     }
     else {

--- a/Wire-iOS/Sources/UserInterface/Helpers/UIView+Zeta.m
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UIView+Zeta.m
@@ -87,8 +87,19 @@ static NSString * const WireLastCachedKeyboardHeightKey = @"WireLastCachedKeyboa
     else {
         CGSize keyboardSize = CGSizeFromString(currentLastValue);
         
+        // If keyboardSize value is clearly off we need to pull default value
         if (keyboardSize.height < 150) {
-            keyboardSize.height = 216;
+            if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+                if (UIInterfaceOrientationIsPortrait([UIApplication sharedApplication].statusBarOrientation)) {
+                    keyboardSize.height = 264;
+                }
+                else {
+                    keyboardSize.height = 352;
+                }
+            }
+            else {
+                keyboardSize.height = 216;
+            }
         }
         
         return keyboardSize;


### PR DESCRIPTION
- Fixed blinking previews on iPad
- Do not reload previews twice
- Use default camera for fullscreen camera
- Fixed camera orientation on iPad
- Fixed camera keyboard too small on iPad