### PR TITLE
Add possibility to skip notification and other login alerts for automation

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -711,6 +711,7 @@
 		BF2A74751CEB595E002608BF /* AudioButtonOverlayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2A74741CEB595E002608BF /* AudioButtonOverlayTests.swift */; };
 		BF38FAF11C9B1D0500E2ACBB /* ConversationTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF38FAF01C9B1D0500E2ACBB /* ConversationTitleView.swift */; };
 		BF415B271C3C354C00DF57B7 /* MissingMessagesCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF415B261C3C354C00DF57B7 /* MissingMessagesCell.swift */; };
+		BF4A15D21D4900930051E8BA /* AutomationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4A15D11D4900930051E8BA /* AutomationHelper.swift */; };
 		BF5127161CC9119400F23DEA /* ZMSnapshotTestCase+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF5127141CC9118F00F23DEA /* ZMSnapshotTestCase+Swift.swift */; };
 		BF52C1571CAEB9E10037331F /* ArchivedListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF52C1561CAEB9E10037331F /* ArchivedListViewController.swift */; };
 		BF52C1591CAEBD8D0037331F /* ArchivedNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF52C1581CAEBD8D0037331F /* ArchivedNavigationBar.swift */; };
@@ -1968,6 +1969,7 @@
 		BF2A74741CEB595E002608BF /* AudioButtonOverlayTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioButtonOverlayTests.swift; sourceTree = "<group>"; };
 		BF38FAF01C9B1D0500E2ACBB /* ConversationTitleView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConversationTitleView.swift; sourceTree = "<group>"; };
 		BF415B261C3C354C00DF57B7 /* MissingMessagesCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MissingMessagesCell.swift; sourceTree = "<group>"; };
+		BF4A15D11D4900930051E8BA /* AutomationHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutomationHelper.swift; sourceTree = "<group>"; };
 		BF5127141CC9118F00F23DEA /* ZMSnapshotTestCase+Swift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMSnapshotTestCase+Swift.swift"; sourceTree = "<group>"; };
 		BF52C1561CAEB9E10037331F /* ArchivedListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ArchivedListViewController.swift; path = ../Conversation/ArchivedListViewController.swift; sourceTree = "<group>"; };
 		BF52C1581CAEBD8D0037331F /* ArchivedNavigationBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArchivedNavigationBar.swift; sourceTree = "<group>"; };
@@ -2423,6 +2425,7 @@
 				878607091D33E3FF00971A19 /* NetworkStatus.m */,
 				8795A5A61D34CF7A0024101B /* NSLayoutConstraint+Helpers.h */,
 				8795A5A71D34CF7A0024101B /* NSLayoutConstraint+Helpers.m */,
+				BF4A15D11D4900930051E8BA /* AutomationHelper.swift */,
 				878607161D33E3FF00971A19 /* weakify */,
 				1EB9BF361BC7ED3D002EF0F3 /* SharedAnalytics */,
 				871878BB1C1ACA72001FFCC5 /* NSDate+WRFormat.h */,
@@ -5040,6 +5043,7 @@
 				1E5E0CFC1B6B8EDB003B0CAC /* UIImage+ZetaIconsNeue.m in Sources */,
 				8786071E1D33E3FF00971A19 /* KeyValueObserver.m in Sources */,
 				1EE9DCC01B5F9A6D00E347DF /* PageControl.m in Sources */,
+				BF4A15D21D4900930051E8BA /* AutomationHelper.swift in Sources */,
 				1E5E0D031B6B8EDB003B0CAC /* UIColor+Mixing.m in Sources */,
 				1E5E0D071B6B8EDB003B0CAC /* UIImage+ImageUtilities.m in Sources */,
 				16F9EB351BCBB0270021EF39 /* CheckBoxButton.m in Sources */,

--- a/Wire-iOS/Sources/AppController.m
+++ b/Wire-iOS/Sources/AppController.m
@@ -442,8 +442,9 @@ NSString *const ZMUserSessionDidBecomeAvailableNotification = @"ZMUserSessionDid
 - (void)authenticationDidSucceed
 {
     self.seState = AppSEStateAuthenticated;
-    
-    [[ZMUserSession sharedSession] setupPushNotificationsForApplication:[UIApplication sharedApplication]];
+    if (!AutomationHelper.skipFirstLoginAlerts) {
+        [[ZMUserSession sharedSession] setupPushNotificationsForApplication:[UIApplication sharedApplication]];
+    }
     [self loadAppropriateController];
 }
 

--- a/Wire-iOS/Sources/AppDelegate+Hockey.m
+++ b/Wire-iOS/Sources/AppDelegate+Hockey.m
@@ -22,24 +22,13 @@
 #import "Analytics+iOS.h"
 #import "Application+runDuration.h"
 #import "Settings.h"
-
+#import "Wire-Swift.h"
 
 @implementation AppDelegate (Hockey)
 
 - (void)setupHockeyWithCompletion:(dispatch_block_t)completed
 {
-    NSNumber *commandLineHockey = [[NSUserDefaults standardUserDefaults] objectForKey:@"UseHockey"];
-
-    BOOL userDefaultsConfigureHockey = NO;
-    BOOL userDefaultsEnableHockey = NO;
-
-    if (commandLineHockey != nil) {
-        userDefaultsConfigureHockey = YES;
-        userDefaultsEnableHockey = [commandLineHockey boolValue];
-    }
-
-
-    if (((userDefaultsConfigureHockey && userDefaultsEnableHockey) || (! userDefaultsConfigureHockey && USE_HOCKEY)) && ![[Settings sharedSettings] disableHockey]) {
+    if ((AutomationHelper.useHockey || (!AutomationHelper.useHockey && USE_HOCKEY)) && ![[Settings sharedSettings] disableHockey]) {
         // see https://github.com/bitstadium/HockeySDK-iOS/releases/tag/4.0.1
         [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"kBITExcludeApplicationSupportFromBackup"];
         

--- a/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsViewController.m
+++ b/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsViewController.m
@@ -94,7 +94,7 @@ static NSString * const ContactsViewControllerSectionHeaderID = @"ContactsSectio
     [self setupViews];
     [self setupLayout];
     
-    if (self.sharingContactsRequired && ! [[AddressBookHelper sharedHelper] isAddressBookAccessGranted]) {
+    if (self.sharingContactsRequired && ! [[AddressBookHelper sharedHelper] isAddressBookAccessGranted] && !AutomationHelper.skipFirstLoginAlerts) {
         [self presentShareContactsStepViewController];
     }
     

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController.m
@@ -698,6 +698,10 @@
 
 - (void)showPushPermissionDeniedDialogIfNeeded
 {
+    if (AutomationHelper.skipFirstLoginAlerts) {
+        return;
+    }
+    
     BOOL pushAlertHappenedMoreThan1DayBefore = [[Settings sharedSettings] lastPushAlertDate] == nil ||
     fabs([[[Settings sharedSettings] lastPushAlertDate] timeIntervalSinceNow]) > 60 * 60 * 24;
     

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationViewController.m
@@ -259,6 +259,10 @@
 {
     self.rootNavigationController.showLoadingView = NO;
     
+    if (AutomationHelper.skipFirstLoginAlerts) {
+        return;
+    }
+    
     if (! [[ZMUserSession sharedSession] registeredOnThisDevice] && [ZMUser selfUserHasIncompleteUserDetails]) {
         self.rootNavigationController.logoEnabled = NO;
         self.rootNavigationController.backButtonEnabled = NO;

--- a/WireExtensionComponents/Utilities/AutomationHelper.swift
+++ b/WireExtensionComponents/Utilities/AutomationHelper.swift
@@ -1,0 +1,39 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import Foundation
+
+/// This class is used to retrieve specific arguments passed on the 
+/// command line when running automation tests. 
+/// These values typically do not need to be stored in `Settings`.
+@objc final class AutomationHelper: NSObject {
+
+    private static let defaults = NSUserDefaults.standardUserDefaults()
+
+    ///  - returns: The value specified for the `UseHockey` argument on the command line
+    class var useHockey: Bool {
+        return defaults.boolForKey("UseHockey")
+    }
+
+    ///  - returns: The value specified for the `SkipLoginAlerts` argument on the command line
+    class var skipFirstLoginAlerts: Bool {
+        return defaults.boolForKey("SkipLoginAlerts")
+    }
+
+}


### PR DESCRIPTION
**What's in this PR?**

If the argument `SkipLoginAlerts` is provided with a value other than 0 on the command line the registration for notifications, reminder for notifications, address-book upload screen, screens to add missing phone numbers or email addresses, as well as the modals used to communicate a missing history will not be displayed.