### PR TITLE
Add command line option for disabling auto correction

### DIFF
--- a/WireExtensionComponents/Utilities/AutomationHelper.swift
+++ b/WireExtensionComponents/Utilities/AutomationHelper.swift
@@ -35,5 +35,10 @@ import Foundation
     class var skipFirstLoginAlerts: Bool {
         return defaults.boolForKey("SkipLoginAlerts")
     }
+    
+    ///  - returns: The value specified for the `DisableAutoCorrection` argument on the command line
+    class var disableAutoCorrection: Bool {
+        return defaults.boolForKey("DisableAutoCorrection")
+    }
 
 }

--- a/WireExtensionComponents/Views/TextView.m
+++ b/WireExtensionComponents/Views/TextView.m
@@ -25,6 +25,7 @@
 #import <PureLayout/PureLayout.h>
 #import "MediaAsset.h"
 #import "UILabel+TextTransform.h"
+#import <WireExtensionComponents/WireExtensionComponents-Swift.h>
 @import Classy;
 
 @interface TextView ()
@@ -80,6 +81,10 @@
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(textChanged:) name:UITextViewTextDidChangeNotification object:self];
     self.placeholderTextColor = [UIColor lightGrayColor];
     self.placeholderTextContainerInset = self.textContainerInset;
+    
+    if ([AutomationHelper disableAutoCorrection]) {
+        self.autocorrectionType = UITextAutocorrectionTypeNo;
+    }
 }
 
 - (void)dealloc


### PR DESCRIPTION
This PR allows disabling auto correction for `TextView` instances by passing `-DisableAutoCorrection` as launch argument.