### PR TITLE
Do not instaniate Vimeo helper when API key is not present

### DIFF
--- a/Wire-iOS/Sources/Components/Vimeo/VimeoService.m
+++ b/Wire-iOS/Sources/Components/Vimeo/VimeoService.m
@@ -47,8 +47,14 @@ static const NSUInteger MaxRetryCount = 3;
     static VimeoService *sharedInstance = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        sharedInstance = [[self alloc] initWithClientKey:@STRINGIZE(VIMEO_API_KEY)
-                                            clientSecret:@STRINGIZE(VIMEO_API_SECRET)];
+        
+        NSString *clientKey = @STRINGIZE(VIMEO_API_KEY);
+        NSString *secret = @STRINGIZE(VIMEO_API_SECRET);
+        
+        if (clientKey.length > 0 && secret.length > 0) {
+            sharedInstance = [[self alloc] initWithClientKey:clientKey
+                                                clientSecret:secret];
+        }
     });
     
     return sharedInstance;


### PR DESCRIPTION
- This should make the open-source client stop crashing on Vimeo videos
- Implication: the preview for Vimeo is not loaded