### PR TITLE
Fix invisible loading indicator when stop and start loading

### DIFF
--- a/WireExtensionComponents/Views/Loading/UIViewController+LoadingView.m
+++ b/WireExtensionComponents/Views/Loading/UIViewController+LoadingView.m
@@ -51,9 +51,11 @@ const NSString *LoadingViewKey = @"loadingView";
 {
     self.loadingView.hidden = ! shouldShow;
     if (shouldShow) {
+        self.activityIndicator.hidden = NO;
         [self.activityIndicator startAnimation:nil];
     }
     else {
+        self.activityIndicator.hidden = YES;
         [self.activityIndicator stopAnimation:nil];
     }
 }
@@ -73,6 +75,7 @@ const NSString *LoadingViewKey = @"loadingView";
 
         self.activityIndicator = [[ProgressSpinner alloc] init];
         self.activityIndicator.translatesAutoresizingMaskIntoConstraints = NO;
+        self.activityIndicator.hidesWhenStopped = NO;
         [_loadingView addSubview:self.activityIndicator];
         [self.activityIndicator addConstraintsCenteringToView:_loadingView];
 


### PR DESCRIPTION
- Issue happens when `showLoadingView:YES` is called immediately after `showLoadingView:NO`
- What happens is when loading view stops loading it removes the animation from layer, this makes it call animationDidStop on next run loop spin (1)
- When it asked to start again, the animation is re-added to the layer and view is set to be visible
- However, when (1) occurs the view is set to be invisible again
- Fix: do not use `hidesWhenStopped`