### PR TITLE
Insert missing delegate call

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationViewController.m
@@ -260,6 +260,7 @@
     self.rootNavigationController.showLoadingView = NO;
     
     if (AutomationHelper.sharedHelper.skipFirstLoginAlerts) {
+        [self.delegate registrationViewControllerDidSignIn];
         return;
     }
     


### PR DESCRIPTION
There was a delegate call missing to notify that the sign in did succeed.