### PR TITLE
Remove requirement that device has to be held vertically to switch to earpiece

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/DeviceProximityListener.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/DeviceProximityListener.swift
@@ -21,9 +21,6 @@ import Foundation
 import CoreMotion
 
 class DeviceProximityListener: NSObject {
-
-    private var heldVertically = false
-    private let motionManager = CMMotionManager()
     
     private(set) var raisedToEar: Bool = false {
         didSet {
@@ -38,47 +35,30 @@ class DeviceProximityListener: NSObject {
     var stateChanged: RaisedToEarHandler? = nil
     var listening: Bool = false
     
-    override init() {
-        super.init()
-        motionManager.deviceMotionUpdateInterval = 10.0 / 60.0
-    }
-    
     func startListening() {
         guard !self.listening else {
             return
         }
+
         self.listening = true
-        startMotionListener()
         UIDevice.currentDevice().proximityMonitoringEnabled = true
         NSNotificationCenter.defaultCenter().addObserver(self,
                                                selector: #selector(handleProximityChange),
-                                                   name: UIDeviceProximityStateDidChangeNotification, object: nil)
+                                                   name: UIDeviceProximityStateDidChangeNotification,
+                                                 object: nil)
     }
     
-    func startMotionListener() {
-        let handler: CMDeviceMotionHandler = { [weak self] weakMotion, error in
-            guard let `self` = self, motion = weakMotion else { return }
-        
-            // Only listen for UIDevice proximity if the device is held vertically
-            self.heldVertically = (motion.gravity.z > -0.4 &&
-                motion.gravity.z < 0.4 &&
-                motion.gravity.y < -0.7)
-        }
-        
-        motionManager.startDeviceMotionUpdatesUsingReferenceFrame(.XArbitraryZVertical, toQueue: NSOperationQueue(), withHandler: handler)
-    }
     func stopListening() {
         guard self.listening else {
             return
         }
         self.listening = false
-        motionManager.stopDeviceMotionUpdates()
         UIDevice.currentDevice().proximityMonitoringEnabled = false
         NSNotificationCenter.defaultCenter().removeObserver(self)
     }
     
     func handleProximityChange(notification: NSNotification) {
-        self.raisedToEar = UIDevice.currentDevice().proximityState && self.heldVertically
+        self.raisedToEar = UIDevice.currentDevice().proximityState
     }
     
     deinit {


### PR DESCRIPTION
**What's in this PR?**

* When playing an audio message, we were checking the proximity sensor as well as the device orientation and only switched to the earpiece when the device was held vertically.
* This PR removes the requirement for the phone to beheld vertically which makes this functionality less fragile as some people don't hold there phone vertical when listening.