### PR TITLE
Check if animation is needed when camera change notification arrives

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraCell.swift
@@ -174,7 +174,11 @@ public class CameraCell: UICollectionViewCell {
     }
     
     func cameraControllerWillChangeCurrentCamera(notification: NSNotification!) {
-        let snapshotImage = self.cameraController.videoSnapshot.imageScaledWithFactor(0.5)
+        
+        guard let _ = self.window,
+                let snapshotImage = self.cameraController.videoSnapshot.imageScaledWithFactor(0.5) else {
+            return
+        }
     
         let blurredSnapshotImage = snapshotImage.blurredImageWithContext(self.dynamicType.ciContext, blurRadius: 12)
         


### PR DESCRIPTION
- Camera keyboard observes current camera change
- When user clicks back button with camera keyboard it is not being deallocated
- When user starts to pick image in self profile camera sends current camera change notification, that is received also by camera keyboard
- Camera keyboard tries to animate the camera change and fails unboxing the videoSnapshot
- To avoid this behaviour we verify if animation is needed