### PR TITLE
Handle the case when NSDataDetector detects URLs wrong gracefully

### DIFF
--- a/Wire-iOS Tests/Message+FormattingTests.swift
+++ b/Wire-iOS Tests/Message+FormattingTests.swift
@@ -141,5 +141,16 @@ class Message_FormattingTests: XCTestCase {
         // then
         XCTAssertEqual(formattedText.string, "")
     }
+    
+    func testTextWithInvalidLinkAttachment() {
+        // given
+        let textMessageData = createTextMessageData(withMessageTemplate: "hello:{preview-url}") // NSDataDetector gets confused by the this text
+        
+        // when
+        let formattedText = Message.formattedTextWithLinkAttachments(Message.linkAttachments(textMessageData), forMessage: textMessageData, isGiphy: false)
+        
+        // then
+        XCTAssertEqual(formattedText.string, "hello:")
+    }
 
 }

--- a/Wire-iOS Tests/Message+FormattingTests.swift
+++ b/Wire-iOS Tests/Message+FormattingTests.swift
@@ -144,7 +144,7 @@ class Message_FormattingTests: XCTestCase {
     
     func testTextWithInvalidLinkAttachment() {
         // given
-        let textMessageData = createTextMessageData(withMessageTemplate: "hello:{preview-url}") // NSDataDetector gets confused by the this text
+        let textMessageData = createTextMessageData(withMessageTemplate: "hello:{preview-url}") // NSDataDetector gets confused by this text
         
         // when
         let formattedText = Message.formattedTextWithLinkAttachments(Message.linkAttachments(textMessageData), forMessage: textMessageData, isGiphy: false)


### PR DESCRIPTION
`NSDataDetector` gets confused by URLs prefixed with `abc:` which led to a crash. We avoid this by checking that any URL attachment is in range.