### PR TITLE
Update .travis.yml to only build pushes to master and develop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ notifications:
     on_success: never
     on_failure: always
 
+branches:
+  only:
+    - develop
+    - master
+
 cache:
   - bundler
   - cocoapods


### PR DESCRIPTION
**What's in this PR?**

* Only build pushes to `master` and `develop` to avoid creating 2 integrations for each push to a PR.