### PR TITLE
Extract version of AVS to separate file for ease of access

### DIFF
--- a/Scripts/download-avs.sh
+++ b/Scripts/download-avs.sh
@@ -20,9 +20,10 @@
 
 
 set -e
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $DIR/..
 
-OPEN_SOURCE_AVS_VERSION=24
-APPSTORE_AVS_VERSION=2.7.21
+source avs-versions
 AVS_SEARCH_PATH="wire-avs-ios"
 
 ##################################

--- a/avs-versions
+++ b/avs-versions
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# Wire
+# Copyright (C) 2016 Wire Swiss GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see http://www.gnu.org/licenses/.
+#
+
+export OPEN_SOURCE_AVS_VERSION=24
+export APPSTORE_AVS_VERSION=2.7.21


### PR DESCRIPTION
Extract version of AVS to separate file for ease of access

This was requested to make it easier for people outside of the team to find the version and bump it