### PR TITLE
Fix UI corruption after rotation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
@@ -158,13 +158,15 @@ extension ConversationInputBarViewController: CameraKeyboardViewControllerDelega
         
         confirmImageViewController.onEdit = { [unowned self] in
             self.dismissViewControllerAnimated(true) {
-                let sketchViewController = SketchViewController()
-                sketchViewController.transitioningDelegate = FastTransitioningDelegate.sharedDelegate
-                sketchViewController.sketchTitle = "image.edit_image".localized
-                sketchViewController.delegate = self
-                
-                self.presentViewController(sketchViewController, animated: true, completion: .None)
-                sketchViewController.canvasBackgroundImage = image
+                delay(0.01){
+                    let sketchViewController = SketchViewController()
+                    sketchViewController.transitioningDelegate = FastTransitioningDelegate.sharedDelegate
+                    sketchViewController.sketchTitle = "image.edit_image".localized
+                    sketchViewController.delegate = self
+                    
+                    self.presentViewController(sketchViewController, animated: true, completion: .None)
+                    sketchViewController.canvasBackgroundImage = image
+                }
             }
         }
         


### PR DESCRIPTION
- Common transitioning delegate `FastTransitioningDelegate.sharedDelegate` gets confused when it's used to dismiss a controller, and then immediately to present the new one
- Inserted minimal artificial delay