### PR TITLE
Add new address book analytics events

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,25 +1,13 @@
 
-copyright_header = "//
-// Wire
-// Copyright (C) 2016 Wire Swiss GmbH
-//
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program. If not, see http://www.gnu.org/licenses/.
-//"
+# Warn if touched files are missing the copyright header
+copyright_header = "////Wire//Copyright(C)2016WireSwissGmbH////Thisprogramisfreesoftware:youcanredistributeitand/ormodify//itunderthetermsoftheGNUGeneralPublicLicenseaspublishedby//theFreeSoftwareFoundation,eitherversion3oftheLicense,or//(atyouroption)anylaterversion.////Thisprogramisdistributedinthehopethatitwillbeuseful,//butWITHOUTANYWARRANTY;withouteventheimpliedwarrantyof//MERCHANTABILITYorFITNESSFORAPARTICULARPURPOSE.Seethe//GNUGeneralPublicLicenseformoredetails.////YoushouldhavereceivedacopyoftheGNUGeneralPublicLicense//alongwiththisprogram.Ifnot,seehttp://www.gnu.org/licenses/.//"
 
 touched = git.added_files | git.modified_files
 paths = touched.select { |f| f.end_with? ".h", ".m", ".swift", ".mm" }
-missing = paths.map { |p| File.read(p).start_with? copyright_header }
+paths.each do |p|
+  content = File.read(p).delete("\s").delete("\n")
+  warn "Missing copyright headers in #{p.split('/').last}" unless content.include? copyright_header
+end
 
-warn "Missing copyright headers" if missing.include? true
+# Warn if there are no labels attached to the PR
 warn "Please add labels to this PR" if github.pr_labels.count == 0

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -707,6 +707,7 @@
 		BF2A74711CEB466A002608BF /* ConversationInputBarViewController+Audio.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2A74701CEB466A002608BF /* ConversationInputBarViewController+Audio.swift */; };
 		BF2A74731CEB4882002608BF /* AudioButtonOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2A74721CEB4882002608BF /* AudioButtonOverlay.swift */; };
 		BF2A74751CEB595E002608BF /* AudioButtonOverlayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2A74741CEB595E002608BF /* AudioButtonOverlayTests.swift */; };
+		BF381FDF1D4F922F00075672 /* AnalyticsTracker+AddressBookPermissions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF381FDE1D4F922F00075672 /* AnalyticsTracker+AddressBookPermissions.swift */; };
 		BF38FAF11C9B1D0500E2ACBB /* ConversationTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF38FAF01C9B1D0500E2ACBB /* ConversationTitleView.swift */; };
 		BF415B271C3C354C00DF57B7 /* MissingMessagesCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF415B261C3C354C00DF57B7 /* MissingMessagesCell.swift */; };
 		BF4A15D21D4900930051E8BA /* AutomationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4A15D11D4900930051E8BA /* AutomationHelper.swift */; };
@@ -1965,6 +1966,7 @@
 		BF2A74701CEB466A002608BF /* ConversationInputBarViewController+Audio.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ConversationInputBarViewController+Audio.swift"; sourceTree = "<group>"; };
 		BF2A74721CEB4882002608BF /* AudioButtonOverlay.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioButtonOverlay.swift; sourceTree = "<group>"; };
 		BF2A74741CEB595E002608BF /* AudioButtonOverlayTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioButtonOverlayTests.swift; sourceTree = "<group>"; };
+		BF381FDE1D4F922F00075672 /* AnalyticsTracker+AddressBookPermissions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AnalyticsTracker+AddressBookPermissions.swift"; sourceTree = "<group>"; };
 		BF38FAF01C9B1D0500E2ACBB /* ConversationTitleView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConversationTitleView.swift; sourceTree = "<group>"; };
 		BF415B261C3C354C00DF57B7 /* MissingMessagesCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MissingMessagesCell.swift; sourceTree = "<group>"; };
 		BF4A15D11D4900930051E8BA /* AutomationHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutomationHelper.swift; sourceTree = "<group>"; };
@@ -2795,6 +2797,7 @@
 			children = (
 				871BBFF21D34F56300DF0793 /* AnalyticsTracker+Permissions.h */,
 				871BBFF31D34F56300DF0793 /* AnalyticsTracker+Permissions.m */,
+				BF381FDE1D4F922F00075672 /* AnalyticsTracker+AddressBookPermissions.swift */,
 			);
 			path = Permissions;
 			sourceTree = "<group>";
@@ -5146,6 +5149,7 @@
 				BF1A81281C9848DB00A96CAA /* ConversationRootViewController.swift in Sources */,
 				8F3C945519D1CC5600288AFE /* VoiceChannelOverlayController.m in Sources */,
 				168634E51ADD7C5A00EDC7D9 /* ProfilePictureStepViewController.m in Sources */,
+				BF381FDF1D4F922F00075672 /* AnalyticsTracker+AddressBookPermissions.swift in Sources */,
 				871BC2881D34F8F800DF0793 /* UIImage+Dotted.swift in Sources */,
 				871BC00C1D34F56300DF0793 /* Analytics+ConversationEvents.m in Sources */,
 				16063CFF1BDA60C10097F62C /* ConnectionStatusHeader.m in Sources */,

--- a/Wire-iOS/Sources/Analytics/AnalyticsTracker.h
+++ b/Wire-iOS/Sources/Analytics/AnalyticsTracker.h
@@ -98,7 +98,6 @@ FOUNDATION_EXTERN NSString *const AnalyticsEventTypePermissionsStateKey;
 
 FOUNDATION_EXTERN NSString *const AnalyticsEventTypePermissionsCategoryCamera;
 FOUNDATION_EXTERN NSString *const AnalyticsEventTypePermissionsCategoryPhotoLibrary;
-FOUNDATION_EXTERN NSString *const AnalyticsEventTypePermissionsCategoryAddressBook;
 FOUNDATION_EXTERN NSString *const AnalyticsEventTypePermissionsCategoryPushNotifications;
 
 FOUNDATION_EXTERN NSString *const AnalyticsEventTypePermissionsStateAllowed;

--- a/Wire-iOS/Sources/Analytics/AnalyticsTracker.m
+++ b/Wire-iOS/Sources/Analytics/AnalyticsTracker.m
@@ -99,7 +99,6 @@ NSString *const AnalyticsEventTypePermissionsStateKey = @"state";
 
 NSString *const AnalyticsEventTypePermissionsCategoryCamera = @"camera";
 NSString *const AnalyticsEventTypePermissionsCategoryPhotoLibrary = @"photoLibrary";
-NSString *const AnalyticsEventTypePermissionsCategoryAddressBook = @"addressBook";
 NSString *const AnalyticsEventTypePermissionsCategoryPushNotifications = @"pushNotifications";
 
 NSString *const AnalyticsEventTypePermissionsStateAllowed = @"allowed";
@@ -153,7 +152,7 @@ NSString *const AnalyticsEventAcceptedGenericInvite = @"connect.accepted_generic
 
 @implementation AnalyticsTracker
 
-+(instancetype)analyticsTrackerWithContext:(NSString *)context
++ (instancetype)analyticsTrackerWithContext:(NSString *)context
 {
     id tracker = [[self alloc] initWithContext:context];
     return tracker;

--- a/Wire-iOS/Sources/Analytics/Permissions/AnalyticsTracker+AddressBookPermissions.swift
+++ b/Wire-iOS/Sources/Analytics/Permissions/AnalyticsTracker+AddressBookPermissions.swift
@@ -1,0 +1,77 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+private enum PermissionsType: String {
+    case AddressBook = "addressBook"
+}
+
+private enum PermissionEvent: String {
+    case Preflight = "onboarding.proceeded_from_contacts_screen"
+    case System = "onboarding.changed_contacts_permssion"
+}
+
+private enum PermissionKey: String {
+    case Category = "category"
+    case State = "state"
+}
+
+private extension Bool {
+    var preflightDescription: String {
+        return self ? "ask_for_permission" : "not_now"
+    }
+}
+
+private extension Bool {
+    var grantedDescription: String {
+        return self ? "granted" : "denied"
+    }
+}
+
+public extension AnalyticsTracker {
+    
+    /// Tracks how the address book upload `preflight` permissions on the `nag screens` was answered
+    @objc public func tagAddressBookSystemPermissions(granted: Bool) {
+        tagSystemPermissions(ofType: .AddressBook, granted: granted)
+    }
+
+    /// Tracks how the address book upload `preflight` permissions on the `nag screens` was answered
+    @objc public  func tagAddressBookPreflightPermissions(shouldAsk: Bool) {
+        tagPreflightPermissions(ofType: .AddressBook, shouldAsk: shouldAsk)
+    }
+    
+    /// Used to track the answer of the `nag screens` shown before asking the OS for permissions
+    private func tagPreflightPermissions(ofType type: PermissionsType, shouldAsk: Bool) {
+        let attributes = [
+            PermissionKey.Category.rawValue: type.rawValue,
+            PermissionKey.State.rawValue: shouldAsk.preflightDescription
+        ]
+        
+        tagEvent(PermissionEvent.Preflight.rawValue, attributes: attributes)
+    }
+    
+    /// Used to track the answer of the `nag screens` shown before asking the OS for permissions
+    private func tagSystemPermissions(ofType type: PermissionsType, granted: Bool) {
+        let attributes = [
+            PermissionKey.Category.rawValue: type.rawValue,
+            PermissionKey.State.rawValue: granted.grantedDescription
+        ]
+
+        tagEvent(PermissionEvent.System.rawValue, attributes: attributes)
+    }
+    
+}

--- a/Wire-iOS/Sources/Analytics/Permissions/AnalyticsTracker+Permissions.h
+++ b/Wire-iOS/Sources/Analytics/Permissions/AnalyticsTracker+Permissions.h
@@ -22,7 +22,6 @@
 @interface AnalyticsTracker (Permissions)
 
 - (void)tagCameraPermissions:(BOOL)allowed;
-- (void)tagAddressBookPermissions:(BOOL)allowed;
 - (void)tagPushNotificationsPermissions:(BOOL)allowed;
 
 

--- a/Wire-iOS/Sources/Analytics/Permissions/AnalyticsTracker+Permissions.m
+++ b/Wire-iOS/Sources/Analytics/Permissions/AnalyticsTracker+Permissions.m
@@ -27,12 +27,6 @@
     [self tagPermissionEventWithAttributes:attributes];
 }
 
-- (void)tagAddressBookPermissions:(BOOL)allowed
-{
-    NSDictionary *attributes = [self attributesForCategory:AnalyticsEventTypePermissionsCategoryAddressBook allowed:allowed];
-    [self tagPermissionEventWithAttributes:attributes];
-}
-
 - (void)tagPushNotificationsPermissions:(BOOL)allowed
 {
     NSDictionary *attributes = [self attributesForCategory:AnalyticsEventTypePermissionsCategoryPushNotifications allowed:allowed];

--- a/Wire-iOS/Sources/Managers/AddressBookHelper.m
+++ b/Wire-iOS/Sources/Managers/AddressBookHelper.m
@@ -106,7 +106,7 @@ static NSString * const UserDefaultsKeyAddressBookExportDate = @"UserDefaultsKey
 
 - (void)internalUploadAddressBook
 {
-    self.addressBookUploadWasPosponed = NO;
+    self.addressBookUploadWasPostponed = NO;
     self.addressBookWasUploaded = YES;
 #if !TARGET_IPHONE_SIMULATOR
     [[ZMUserSession sharedSession] uploadAddressBook];
@@ -124,9 +124,9 @@ static NSString * const UserDefaultsKeyAddressBookExportDate = @"UserDefaultsKey
     return [[NSUserDefaults standardUserDefaults] boolForKey:@"AddressBookWasUploaded"];
 }
 
-- (void)setAddressBookUploadWasPosponed:(BOOL)addressBookUploadWasPosponed
+- (void)setAddressBookUploadWasPostponed:(BOOL)addressBookUploadWasPostponed
 {
-    [[NSUserDefaults standardUserDefaults] setBool:addressBookUploadWasPosponed forKey:@"AddressBookUploadWasPosponed"];
+    [[NSUserDefaults standardUserDefaults] setBool:addressBookUploadWasPostponed forKey:@"AddressBookUploadWasPosponed"];
 }
 
 - (BOOL)addressBookUploadWasPostponed

--- a/Wire-iOS/Sources/Permissions/ShareContactsViewController.m
+++ b/Wire-iOS/Sources/Permissions/ShareContactsViewController.m
@@ -25,6 +25,7 @@
 #import "AddressBookHelper.h"
 #import "AnalyticsTracker+Permissions.h"
 #import "NSString+Wire.h"
+#import "Wire-Swift.h"
 
 
 #import <PureLayout/PureLayout.h>
@@ -180,10 +181,12 @@
 
 - (IBAction)shareContacts:(id)sender
 {
-    [[AddressBookHelper sharedHelper] requestPermissions:^(BOOL success) {
+    [self.analyticsTracker tagAddressBookPreflightPermissions:YES];
+
+    [AddressBookHelper.sharedHelper requestPermissions:^(BOOL success) {
+        [self.analyticsTracker tagAddressBookSystemPermissions:success];
+
         if (success) {
-            [self.analyticsTracker tagAddressBookPermissions:YES];
-            
             if (self.uploadAddressBookImmediately) {
                 [[AddressBookHelper sharedHelper] forceUploadAddressBook];
             }
@@ -193,7 +196,6 @@
             
             [self.formStepDelegate didCompleteFormStep:self];
         } else {
-            [self.analyticsTracker tagAddressBookPermissions:NO];
             [self displayContactsAccessDeniedMessageAnimated:YES];
         }
     }];
@@ -201,6 +203,7 @@
 
 - (IBAction)shareContactsLater:(id)sender
 {
+    [self.analyticsTracker tagAddressBookPreflightPermissions:NO];
     [[AddressBookHelper sharedHelper] addressBookUploadWasProposed];
     [self.formStepDelegate didSkipFormStep:self];
 }

--- a/Wire-iOS/Sources/UserInterface/Registration/ShareContactsStepViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/ShareContactsStepViewController.m
@@ -29,6 +29,7 @@
 #import "RegistrationFormController.h"
 #import "ShareContactsViewController.h"
 #import "NSString+Wire.h"
+#import "Wire-Swift.h"
 
 @interface ShareContactsStepViewController () <FormStepDelegate>
 
@@ -92,6 +93,9 @@
 
 - (IBAction)shareContactsLater:(id)sender
 {
+    // We use a ShareContactsViewController but our own `later` button,
+    // that's why we need to track the tap manually here.
+    [self.analyticsTracker tagAddressBookPreflightPermissions:NO];
     [[AddressBookHelper sharedHelper] addressBookUploadWasProposed];
     [self.formStepDelegate didSkipFormStep:self];
 }

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.m
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.m
@@ -53,6 +53,7 @@
 #import "Constants.h"
 #import "UIView+PopoverBorder.h"
 #import "UIViewController+WR_Invite.h"
+#import "Wire-Swift.h"
 
 
 static NSUInteger const StartUIInitiallyShowsKeyboardConversationThreshold = 10;
@@ -186,7 +187,7 @@ static NSUInteger const StartUIInitiallyShowsKeyboardConversationThreshold = 10;
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
-    [[Analytics shared]tagScreen:@"PEOPLE_PICKER"];
+    [[Analytics shared] tagScreen:@"PEOPLE_PICKER"];
 }
 
 - (void)handleUploadAddressBookLogicIfNeeded
@@ -206,6 +207,7 @@ static NSUInteger const StartUIInitiallyShowsKeyboardConversationThreshold = 10;
     }
     else if ([[AddressBookHelper sharedHelper] isAddressBookAccessUnknown]) {
         [[AddressBookHelper sharedHelper] requestPermissions:^(BOOL success) {
+            [self.analyticsTracker tagAddressBookSystemPermissions:success];
             if (success) {
                 dispatch_async(dispatch_get_main_queue(), ^{
                     [[AddressBookHelper sharedHelper] uploadAddressBook];


### PR DESCRIPTION
**What's in this PR?**

* All address book related events have been moved into AnalyticsTracker+AddressBookPermissions.
* We now track the result of the `preflight` screen shown before asking for system permissions as well as the system permissions result.