### PR TITLE
Fix corrupted ui after sketch dismissal

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
@@ -107,8 +107,9 @@ extension ConversationInputBarViewController: CameraKeyboardViewControllerDelega
     }
     
     public func cameraKeyboardViewController(controller: CameraKeyboardViewController, didSelectImageData imageData: NSData, source: UIImagePickerControllerSourceType) {
-        
-        self.showConfirmationForImage(imageData, source: source)
+        hideCameraKeyboardViewController {
+            self.showConfirmationForImage(imageData, source: source)
+        }
     }
     
     @objc private func image(image: UIImage?, didFinishSavingWithError error: NSError?, contextInfo: AnyObject) {
@@ -159,13 +160,15 @@ extension ConversationInputBarViewController: CameraKeyboardViewControllerDelega
         confirmImageViewController.onEdit = { [unowned self] in
             self.dismissViewControllerAnimated(true) {
                 delay(0.01){
-                    let sketchViewController = SketchViewController()
-                    sketchViewController.transitioningDelegate = FastTransitioningDelegate.sharedDelegate
-                    sketchViewController.sketchTitle = "image.edit_image".localized
-                    sketchViewController.delegate = self
-                    
-                    self.presentViewController(sketchViewController, animated: true, completion: .None)
-                    sketchViewController.canvasBackgroundImage = image
+                    self.hideCameraKeyboardViewController {
+                        let sketchViewController = SketchViewController()
+                        sketchViewController.transitioningDelegate = FastTransitioningDelegate.sharedDelegate
+                        sketchViewController.sketchTitle = "image.edit_image".localized
+                        sketchViewController.delegate = self
+                        
+                        self.presentViewController(sketchViewController, animated: true, completion: .None)
+                        sketchViewController.canvasBackgroundImage = image
+                    }
                 }
             }
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
@@ -107,9 +107,7 @@ extension ConversationInputBarViewController: CameraKeyboardViewControllerDelega
     }
     
     public func cameraKeyboardViewController(controller: CameraKeyboardViewController, didSelectImageData imageData: NSData, source: UIImagePickerControllerSourceType) {
-        hideCameraKeyboardViewController {
-            self.showConfirmationForImage(imageData, source: source)
-        }
+        showConfirmationForImage(imageData, source: source)
     }
     
     @objc private func image(image: UIImage?, didFinishSavingWithError error: NSError?, contextInfo: AnyObject) {
@@ -165,6 +163,7 @@ extension ConversationInputBarViewController: CameraKeyboardViewControllerDelega
                         sketchViewController.transitioningDelegate = FastTransitioningDelegate.sharedDelegate
                         sketchViewController.sketchTitle = "image.edit_image".localized
                         sketchViewController.delegate = self
+                        sketchViewController.confirmsWithoutSketch = true
                         
                         self.presentViewController(sketchViewController, animated: true, completion: .None)
                         sketchViewController.canvasBackgroundImage = image

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -722,14 +722,17 @@
 
 - (void)sketchViewController:(SketchViewController *)controller didSketchImage:(UIImage *)image
 {
-    [self.parentViewController dismissViewControllerAnimated:YES completion:nil];
-    if (image) {
-        
-        NSData *imageData = UIImagePNGRepresentation(image);
-        [self.sendController sendMessageWithImageData:imageData completion:^{
-            [self.analyticsTracker tagPictureTakenWithSource:AnalyticsEventTypePictureTakenSourceSketch];
-        }];
-    }
+    @weakify(self);
+    [self hideCameraKeyboardViewController:^{
+        @strongify(self);
+        [self.parentViewController dismissViewControllerAnimated:YES completion:nil];
+        if (image) {
+            NSData *imageData = UIImagePNGRepresentation(image);
+            [self.sendController sendMessageWithImageData:imageData completion:^{
+                [self.analyticsTracker tagPictureTakenWithSource:AnalyticsEventTypePictureTakenSourceSketch];
+            }];
+        }
+    }];
 }
 
 @end

--- a/Wire-iOS/Sources/UserInterface/Sketchpad/SketchViewController.h
+++ b/Wire-iOS/Sources/UserInterface/Sketchpad/SketchViewController.h
@@ -32,6 +32,7 @@
 @property (nonatomic) UIImage *canvasBackgroundImage;
 @property (nonatomic, weak) id <SketchViewControllerDelegate> delegate;
 @property (nonatomic, copy) NSString *sketchTitle;
+@property (nonatomic) BOOL confirmsWithoutSketch;
 
 @end
 

--- a/Wire-iOS/Sources/UserInterface/Sketchpad/SketchViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Sketchpad/SketchViewController.m
@@ -412,9 +412,8 @@ static const CGFloat SketchBrushWidthThin = 6;
 - (void)confirmButtonPressed:(id)sender
 {
     // Has anything been drew check
-    if (! [self.sketchView canUndo]) {
+    if (! [self.sketchView canUndo] && !self.confirmsWithoutSketch) {
         [self cancelButtonPressed:nil];
-        
         return;
     }
 


### PR DESCRIPTION
**What's in this PR?**

* The issue from https://github.com/wireapp/wire-ios/pull/62 was still present on iPhones.
* I could only reproduce it when the camera keyboard was not dismissed when dismissing the `SketchViewController`. We now ensure the keyboard is dismissed before dismissing the controller.
* This PR also fixes an issue where the image selected from the camera keyboard was lost when tapping the " Add a sketch " button and then confirming without sketching.