### PR TITLE
Support for slow-mo export

### DIFF
--- a/Wire-iOS Tests/CameraKeyboardViewControllerTests.swift
+++ b/Wire-iOS Tests/CameraKeyboardViewControllerTests.swift
@@ -37,7 +37,7 @@ class CameraKeyboardViewControllerDelegateMock: CameraKeyboardViewControllerDele
     }
     
     var cameraKeyboardDidSelectVideoHitCount: UInt = 0
-    @objc func cameraKeyboardViewController(controller: CameraKeyboardViewController, didSelectVideo: AVURLAsset) {
+    @objc func cameraKeyboardViewController(controller: CameraKeyboardViewController, didSelectVideo: NSURL, duration: NSTimeInterval) {
         cameraKeyboardDidSelectVideoHitCount = cameraKeyboardDidSelectVideoHitCount + 1
     }
     


### PR DESCRIPTION
- Slow-motion videos are exported as regular per default
- Using export session, it can be exported as slow motion and converted to mp4 / network quality in one go