### PR TITLE
Only query image picker camera device if it has a sourceType .Camera

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/ImagePickerConfirmationController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/ImagePickerConfirmationController.m
@@ -76,7 +76,9 @@
                     if (imageData != nil) {
                         ImageMetadata *metadata = [[ImageMetadata alloc] init];
                         metadata.source = picker.sourceType == UIImagePickerControllerSourceTypeCamera ? ConversationMediaPictureSourceCamera : ConversationMediaPictureSourceGallery;
-                        metadata.camera = picker.cameraDevice == UIImagePickerControllerCameraDeviceFront ? ConversationMediaPictureCameraFront : ConversationMediaPictureCameraBack;
+                        if (picker.sourceType == UIImagePickerControllerSourceTypeCamera) {
+                            metadata.camera = picker.cameraDevice == UIImagePickerControllerCameraDeviceFront ? ConversationMediaPictureCameraFront : ConversationMediaPictureCameraBack;
+                        }
                         metadata.method = ConversationMediaPictureTakeMethodQuickMenu;
                         
                         self.imagePickedBlock(imageData, metadata);


### PR DESCRIPTION
**What's in this PR?**

* Fixes [7049](https://wearezeta.atlassian.net/browse/ZIOS-7049), crash when querying the `cameraDevice` when the source type was not camera