### PR TITLE
Update backgroundViewController state to avert wrong initial state

### DIFF
--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
@@ -135,6 +135,7 @@
 
     [self.backgroundViewController.view addConstraintsFittingToView:self.view];
 
+    [self.backgroundViewController setForceFullScreen:NO animated:NO];
     [self.backgroundViewController setUser:[ZMUser selfUser] animated:YES];
 
     [self setupChildViewControllers];


### PR DESCRIPTION
**What's in this PR?**

* The `BackgroundViewController` had the wrong initial state on iPad. Enforcing non-fullscreen state initially fixes this.