### PR TITLE
Fixed crash while unboxing firstActiveParticipantOtherThanSelf

### DIFF
--- a/Wire-iOS/Sources/Analytics/Events/Analytics+MediaActionEvents.swift
+++ b/Wire-iOS/Sources/Analytics/Events/Analytics+MediaActionEvents.swift
@@ -207,7 +207,9 @@ public extension Analytics {
     @objc public func tagMediaActionCompleted(action: ConversationMediaAction, inConversation conversation: ZMConversation) {
         var attributes = ["action": action.attributeValue]
         if let typeAttribute = conversationTypeAttribute(conversation) {
-            attributes["with_bot"] = conversation.firstActiveParticipantOtherThanSelf().isBot ? "true" : "false";
+            if let otherParticipant = conversation.firstActiveParticipantOtherThanSelf() {
+                attributes["with_bot"] = otherParticipant.isBot ? "true" : "false";
+            }
             attributes["conversation_type"] = typeAttribute
         }
         tagEvent(conversationMediaCompleteActionEventName, attributes: attributes)

--- a/Wire-iOS/Sources/Helpers/syncengine/ZMConversation+Additions.h
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMConversation+Additions.h
@@ -21,26 +21,24 @@
 
 @protocol ZMConversationMessage;
 
-
+NS_ASSUME_NONNULL_BEGIN
 
 @interface ZMConversation (Additions)
 
 - (NSUInteger)participantsCount;
-- (id<ZMConversationMessage>)firstTextMessage;
-- (id<ZMConversationMessage>)lastTextMessage;
+- (nullable id<ZMConversationMessage>)firstTextMessage;
+- (nullable id<ZMConversationMessage>)lastTextMessage;
 
 /// Convenience method for easier access of the last active user in the conversation. This method also contains the logic of selecting the other user in case its of a 1:1 conversation. Might return @c nil
-- (ZMUser *)lastMessageSender;
-
-- (ZMUser *)participantWithObjectIDString:(NSString *)objectIDString;
+- (nullable ZMUser *)lastMessageSender;
 
 /// YES = this message is the first in a burst, and UI should present a burst separator (timestamp header) with it.
 - (BOOL)shouldShowBurstSeparatorForMessage:(id<ZMConversationMessage>)message;
 
 - (BOOL)selfUserIsActiveParticipant;
 
-- (ZMUser *)firstActiveParticipantOtherThanSelf;
-- (ZMUser *)firstActiveCallingParticipantOtherThanSelf;
+- (nullable ZMUser *)firstActiveParticipantOtherThanSelf;
+- (nullable ZMUser *)firstActiveCallingParticipantOtherThanSelf;
 
 - (ZMConversation *)addParticipants:(NSSet *)participants;
 - (void)removeParticipants:(NSArray *)participants;
@@ -51,7 +49,9 @@
 - (BOOL)isCallingSupported;
 
 - (void)acceptIncomingCall;
-- (void)startAudioCallWithCompletionHandler:(void(^)(BOOL joined))completion;
-- (void)startVideoCallWithCompletionHandler:(void(^)(BOOL joined))completion;
+- (void)startAudioCallWithCompletionHandler:(nullable void(^)(BOOL joined))completion;
+- (void)startVideoCallWithCompletionHandler:(nullable void(^)(BOOL joined))completion;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Wire-iOS/Sources/Helpers/syncengine/ZMConversation+Additions.m
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMConversation+Additions.m
@@ -158,19 +158,6 @@
     return message;
 }
 
-- (ZMUser *)participantWithObjectIDString:(NSString *)objectIDString
-{
-    ZMUser *user = nil;
-    NSManagedObjectID *moid = [ZMConversation objectIDForURIRepresentation:[NSURL URLWithString:objectIDString] inUserSession:[ZMUserSession sharedSession]];
-    for (ZMUser *current in self.allParticipants) {
-        if ([current.objectID isEqual:moid]) {
-            user = current;
-            break;
-        }
-    }
-    return user;
-}
-
 - (BOOL)shouldShowBurstSeparatorForMessage:(id<ZMConversationMessage>)message
 {
     // Missed calls should always show timestamp


### PR DESCRIPTION
- All ObjC methods without nullability declarations are visible in Swift as force-unwrap
- It is sad and annoying, while in ObjC they are just optional per default
- Solution: add proper nullability in headers