### PR TITLE
Insert missing break leading to wrong cell being displayed

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter.m
@@ -266,6 +266,7 @@ static NSString *const ConversationMessageDeletedCellId     = @"conversationMess
             case ZMSystemMessageTypeParticipantsRemoved:
             case ZMSystemMessageTypeNewConversation:
                 cellIdentifier = ConversationParticipantsCellId;
+                break;
                 
             case ZMSystemMessageTypeMessageDeletedForEveryone:
                 cellIdentifier = ConversationMessageDeletedCellId;


### PR DESCRIPTION
**What's in this PR?**

* Today in "Bugs that could have been prevented using Swift": A missing `break` statement lead to the wrong cell being displayed in certain scenarios. 