### PR TITLE
Use UITableViewRowAnimationFade when deleting cells in a conversation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter.m
@@ -122,7 +122,7 @@ static NSString *const ConversationMessageDeletedCellId     = @"conversationMess
         [self.tableView beginUpdates];
         
         if (change.deletedIndexes.count) {
-            [self.tableView deleteRowsAtIndexPaths:[change.deletedIndexes indexPaths] withRowAnimation:UITableViewRowAnimationAutomatic];
+            [self.tableView deleteRowsAtIndexPaths:[change.deletedIndexes indexPaths] withRowAnimation:UITableViewRowAnimationFade];
         }
         
         if (change.insertedIndexes.count) {


### PR DESCRIPTION
**What's in this PR?**

* Always use `UITableViewRowAnimationFade` for deletion animations