### PR TITLE
Fix crash when delete option presenting action sheet on iPad

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/AudioMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/AudioMessageCell.swift
@@ -426,10 +426,18 @@ import CocoaLumberjackSwift
         }
     }
     
+    public override var selectionRect: CGRect {
+        return containerView.bounds
+    }
+    
+    public override var selectionView: UIView! {
+        return containerView
+    }
+    
     override public func menuConfigurationProperties() -> MenuConfigurationProperties! {
         let properties = MenuConfigurationProperties()
-        properties.targetRect = self.containerView.bounds
-        properties.targetView = self.containerView
+        properties.targetRect = selectionRect
+        properties.targetView = selectionView
         properties.selectedMenuBlock = setSelectedByMenu
         
         return properties

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.h
@@ -80,6 +80,8 @@ typedef void (^SelectedMenuBlock)(BOOL selected, BOOL animated);
 @property (nonatomic, readonly) id<ZMConversationMessage>message;
 @property (nonatomic, readonly) UILabel *authorLabel;
 @property (nonatomic, readonly) UIView *messageContentView;
+@property (nonatomic, strong, readonly) UIView *selectionView;
+@property (nonatomic, readonly) CGRect selectionRect;
 
 @property (nonatomic) CGFloat burstTimestampSpacing;
 @property (nonatomic) BOOL showsMenu;

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
@@ -288,6 +288,16 @@ const NSTimeInterval ConversationCellSelectionAnimationDuration = 0.33;
 
 #pragma mark - Long press management
 
+- (UIView *)selectionView
+{
+    return self;
+}
+
+- (CGRect)selectionRect
+{
+    return self.frame;
+}
+
 - (BOOL)canBecomeFirstResponder;
 {
     return YES;

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransferCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransferCell.swift
@@ -240,12 +240,14 @@ public class FileTransferCell: ConversationCell {
         self.actionButton.layer.cornerRadius = self.actionButton.bounds.size.width / 2.0
     }
     
+    // MARK: - Selection
+    
     public override var selectionView: UIView! {
-        return messageContentView
+        return containerView
     }
     
     public override var selectionRect: CGRect {
-        return messageContentView.bounds
+        return containerView.bounds
     }
 
     // MARK: - Actions

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransferCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransferCell.swift
@@ -240,6 +240,14 @@ public class FileTransferCell: ConversationCell {
         self.actionButton.layer.cornerRadius = self.actionButton.bounds.size.width / 2.0
     }
     
+    public override var selectionView: UIView! {
+        return messageContentView
+    }
+    
+    public override var selectionRect: CGRect {
+        return messageContentView.bounds
+    }
+
     // MARK: - Actions
     
     public func onActionButtonPressed(sender: UIButton) {
@@ -266,8 +274,8 @@ public class FileTransferCell: ConversationCell {
     
     override public func menuConfigurationProperties() -> MenuConfigurationProperties! {
         let properties = MenuConfigurationProperties()
-        properties.targetRect = self.messageContentView.bounds
-        properties.targetView = self.messageContentView
+        properties.targetRect = selectionRect
+        properties.targetView = selectionView
         properties.selectedMenuBlock = { [weak self] selected, animated in
             UIView.animateWithDuration(animated ? ConversationCellSelectionAnimationDuration : 0) {
                 self?.messageContentView.alpha = selected ? ConversationCellSelectedOpacity : 1.0

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/LocationMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/LocationMessageCell.swift
@@ -136,6 +136,16 @@ import AddressBook
         return .Location
     }
     
+    // MARK: - Selection
+    
+    public override var selectionRect: CGRect {
+        return containerView.bounds
+    }
+    
+    public override var selectionView: UIView! {
+        return containerView
+    }
+    
     // MARK: - Selection, Copy & Delete
     
     public override func canPerformAction(action: Selector, withSender sender: AnyObject?) -> Bool {
@@ -157,8 +167,8 @@ import AddressBook
     
     public override func menuConfigurationProperties() -> MenuConfigurationProperties! {
         let properties = MenuConfigurationProperties()
-        properties.targetRect = containerView.bounds
-        properties.targetView = containerView
+        properties.targetRect = selectionRect
+        properties.targetView = selectionView
         properties.selectedMenuBlock = setSelectedByMenu
         return properties
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/PingCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/PingCell.m
@@ -138,11 +138,21 @@ typedef void (^AnimationBlock)(id, NSInteger);
     return needsLayout;
 }
 
+- (UIView *)selectionView
+{
+    return self.authorLabel;
+}
+
+- (CGRect)selectionRect
+{
+    return self.authorLabel.bounds;
+}
+
 - (MenuConfigurationProperties *)menuConfigurationProperties;
 {
     MenuConfigurationProperties *properties = [[MenuConfigurationProperties alloc] init];
-    properties.targetRect = self.authorLabel.bounds;
-    properties.targetView = self.authorLabel;
+    properties.targetRect = self.selectionRect;
+    properties.targetView = self.selectionView;
     properties.selectedMenuBlock = ^(BOOL selected, BOOL animated) {
         [self setSelectedByMenu:selected animated:animated];
     };

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/TextMessageCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/TextMessageCell.m
@@ -357,20 +357,30 @@
     }
 }
 
+- (CGRect)selectionRect
+{
+    if (self.message.textMessageData.linkPreview && self.linkAttachmentView) {
+        return self.messageTextView.bounds;
+    } else {
+        return [self.messageTextView.layoutManager usedRectForTextContainer:self.messageTextView.textContainer];
+    }
+}
+
+- (UIView *)selectionView
+{
+    return self.messageTextView;
+}
+
 - (MenuConfigurationProperties *)menuConfigurationProperties
 {
     MenuConfigurationProperties *properties = [[MenuConfigurationProperties alloc] init];
     
-    if (self.message.textMessageData.linkPreview && self.linkAttachmentView) {
-        properties.targetRect = self.messageTextView.bounds;
-    } else {
-        properties.targetRect = [self.messageTextView.layoutManager usedRectForTextContainer:self.messageTextView.textContainer];
-    }
-
-    properties.targetView = self.messageTextView;
+    properties.targetRect = self.selectionRect;
+    properties.targetView = self.selectionView;
     properties.selectedMenuBlock = ^(BOOL selected, BOOL animated) {
         [self setSelectedByMenu:selected animated:animated];
     };
+
     return properties;
 }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/VideoMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/VideoMessageCell.swift
@@ -220,6 +220,16 @@ extension ZMConversationMessage {
         }
     }
 
+    // MARK: - Selection
+    
+    public override var selectionView: UIView! {
+        return previewImageView
+    }
+    
+    public override var selectionRect: CGRect {
+        return previewImageView.bounds
+    }
+    
     // MARK: - Menu
     
     public func setSelectedByMenu(selected: Bool, animated: Bool) {
@@ -237,8 +247,8 @@ extension ZMConversationMessage {
     
     override public func menuConfigurationProperties() -> MenuConfigurationProperties! {
         let properties = MenuConfigurationProperties()
-        properties.targetRect = self.previewImageView.bounds
-        properties.targetView = self.previewImageView
+        properties.targetRect = selectionRect
+        properties.targetView = selectionView
         properties.selectedMenuBlock = setSelectedByMenu
         
         return properties

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageDeletion.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageDeletion.swift
@@ -33,6 +33,11 @@ extension ConversationContentViewController {
             self?.dismissViewControllerAnimated(true, completion: nil)
         }
 
+        if let presentationController = alert.popoverPresentationController,
+            cell = cellForMessage(message) as? ConversationCell {
+            presentationController.sourceView = cell.selectionView
+            presentationController.sourceRect = cell.selectionRect
+        }
         presentViewController(alert, animated: true, completion: nil)
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Private.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Private.h
@@ -34,6 +34,7 @@
 @property (nonatomic) ZMConversationMessageWindow *messageWindow;
 
 - (void)removeHighlightsAndMenu;
+- (UITableViewCell *)cellForMessage:(id<ZMConversationMessage>)message;
 
 @end
 

--- a/Wire-iOS/WireBridgingHeader.h
+++ b/Wire-iOS/WireBridgingHeader.h
@@ -45,7 +45,7 @@
 #import "InvisibleInputAccessoryView.h"
 #import <SCSiriWaveformView/SCSiriWaveformView.h>
 #import "ConversationInputBarSendController.h"
-#import "ConversationContentViewController.h"
+#import "ConversationContentViewController+Private.h"
 #import "MessageTimestampView.h"
 
 // View Controllers


### PR DESCRIPTION
**What's in this PR?**

* The `UIAlertController` showing the different delete options did not have a target view and rect and did crash no iPad as it is presented as popover on tablets. 
* To prevent this the view and rect used to present the `UIMenuController` have been extracted to be a getter on `ConversationCell` so that they can be reused in different contexts, e.g. presenting the delete option action sheet.