### PR TITLE
Only show the delete for everyone option if self is still a member of the conversation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageDeletion.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageDeletion.swift
@@ -20,7 +20,7 @@
 extension ConversationContentViewController {
 
     func presentDeletionAlertController(forMessage message: ZMConversationMessage) {
-        let showDelete = message.sender?.isSelfUser ?? false && conversation.isSelfAnActiveMember
+        let showDelete = (message.sender?.isSelfUser ?? false) && conversation.isSelfAnActiveMember
         let alert = UIAlertController.alertControllerForMessageDeletion(showDelete) { [weak self] action in
             ZMUserSession.sharedSession().enqueueChanges {
                 switch action {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageDeletion.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageDeletion.swift
@@ -20,7 +20,7 @@
 extension ConversationContentViewController {
 
     func presentDeletionAlertController(forMessage message: ZMConversationMessage) {
-        let showDelete = message.sender?.isSelfUser ?? false
+        let showDelete = message.sender?.isSelfUser ?? false && conversation.isSelfAnActiveMember
         let alert = UIAlertController.alertControllerForMessageDeletion(showDelete) { [weak self] action in
             ZMUserSession.sharedSession().enqueueChanges {
                 switch action {


### PR DESCRIPTION
**What's in this PR?**

* [7085](https://wearezeta.atlassian.net/browse/ZIOS-7085): Message should only be deleted if the selfUser is still an active member of the conversation