### PR TITLE
Fix deletion popover location for image message cells

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ImageMessageCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ImageMessageCell.m
@@ -427,11 +427,21 @@ static ImageCache *imageCache(void)
     }
 }
 
+- (CGRect)selectionRect
+{
+    return self.imageViewContainer.bounds;
+}
+
+- (UIView *)selectionView
+{
+    return self.imageViewContainer;
+}
+
 - (MenuConfigurationProperties *)menuConfigurationProperties;
 {
     MenuConfigurationProperties *properties = [[MenuConfigurationProperties alloc] init];
-    properties.targetRect = self.imageViewContainer.bounds;
-    properties.targetView = self.imageViewContainer;
+    properties.targetRect = self.selectionRect;
+    properties.targetView = self.selectionView;
     properties.selectedMenuBlock = ^(BOOL selected, BOOL animated) {
         [self setSelectedByMenu:selected animated:animated];
     };


### PR DESCRIPTION
**What's in this PR?**

* The `selectionRect` and `selectionView` properties were not overridden by `ImageMessageCell` which lead to a wrong location for the deletion popover [(7080)](https://wearezeta.atlassian.net/browse/ZIOS-7080)