### PR TITLE
Unify UIMenuController item order to make `delete` always appear last

### DIFF
--- a/Wire-iOS Tests/DeleteMessageTests.m
+++ b/Wire-iOS Tests/DeleteMessageTests.m
@@ -144,24 +144,31 @@ typedef NS_ENUM(NSUInteger, ConversationCellType) {
 
 - (void)testThatTheExpectedCellsCanBeDeleted;
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
+
     // can perform action decides if the action will be present in menu, therefor be deletable
     ConversationCell *textMessageCell = [self conversationCellForType:ConversationCellTypeText];
-    XCTAssertTrue([textMessageCell canPerformAction:@selector(delete:) withSender:nil]);
+    XCTAssertTrue([textMessageCell canPerformAction:@selector(deleteMessage:) withSender:nil]);
+    XCTAssertFalse([textMessageCell canPerformAction:@selector(delete:) withSender:nil]);
 
     ConversationCell *richMediaMessageCell = [self conversationCellForType:ConversationCellTypeTextWithRichMedia];
-    XCTAssertTrue([richMediaMessageCell canPerformAction:@selector(delete:) withSender:nil]);
+    XCTAssertTrue([richMediaMessageCell canPerformAction:@selector(deleteMessage:) withSender:nil]);
+    XCTAssertFalse([richMediaMessageCell canPerformAction:@selector(delete:) withSender:nil]);
     
     ConversationCell *fileMessageCell = [self conversationCellForType:ConversationCellTypeFileTransfer];
-    XCTAssertTrue([fileMessageCell canPerformAction:@selector(delete:) withSender:nil]);
+    XCTAssertTrue([fileMessageCell canPerformAction:@selector(deleteMessage:) withSender:nil]);
+    XCTAssertFalse([fileMessageCell canPerformAction:@selector(delete:) withSender:nil]);
     
     ConversationCell *pingMessageCell = [self conversationCellForType:ConversationCellTypePing];
-    XCTAssertTrue([pingMessageCell canPerformAction:@selector(delete:) withSender:nil]);
+    XCTAssertTrue([pingMessageCell canPerformAction:@selector(deleteMessage:) withSender:nil]);
+    XCTAssertFalse([pingMessageCell canPerformAction:@selector(delete:) withSender:nil]);
     
     ConversationCell *imageMessageCell = [self conversationCellForType:ConversationCellTypeImage];
-    XCTAssertTrue([imageMessageCell canPerformAction:@selector(delete:) withSender:nil]);
-    
-    ConversationCell *systemMessageCell = [self conversationCellForType:ConversationCellTypeSystemMessage];
-    XCTAssertFalse([systemMessageCell canPerformAction:@selector(delete:) withSender:nil]);
+    XCTAssertTrue([imageMessageCell canPerformAction:@selector(deleteMessage:) withSender:nil]);
+    XCTAssertFalse([imageMessageCell canPerformAction:@selector(delete:) withSender:nil]);
+
+#pragma clang diagnostic pop
 }
 
 @end

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -266,6 +266,8 @@
 "content.file.save_video" = "Save";
 "content.file.save_audio" = "Save";
 
+"content.message.delete" = "Delete";
+
 "content.file.too_big" = "You can send files up to %@";
 // Someone pinged
 "content.ping.text" = "%1$@ PINGED";

--- a/Wire-iOS/Resources/de.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/de.lproj/Localizable.strings
@@ -264,6 +264,8 @@
 "content.file.save_video" = "Speichern";
 "content.file.save_audio" = "Speichern";
 
+"content.message.delete" = "Löschen";
+
 "content.file.too_big" = "Du kannst Dateien bis zu %@ senden";
 // Someone pinged
 "content.ping.text" = "%1$@ HAT GEPINGT";

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/AudioMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/AudioMessageCell.swift
@@ -439,19 +439,14 @@ import CocoaLumberjackSwift
         properties.targetRect = selectionRect
         properties.targetView = selectionView
         properties.selectedMenuBlock = setSelectedByMenu
+        if message.audioCanBeSaved() {
+            let menuItem = UIMenuItem(title:"content.file.save_audio".localized, action:#selector(wr_saveAudio))
+            properties.additionalItems = [menuItem]
+        } else {
+            properties.additionalItems = []
+        }
         
         return properties
-    }
-    
-    override public func showMenu() {
-        if self.message.audioCanBeSaved() {
-            let menuItem = UIMenuItem(title:"content.file.save_audio".localized, action:#selector(wr_saveAudio))
-            UIMenuController.sharedMenuController().menuItems = [menuItem]
-        }
-        else {
-            UIMenuController.sharedMenuController().menuItems = nil
-        }
-        super.showMenu()
     }
     
     override public func canPerformAction(action: Selector, withSender sender: AnyObject?) -> Bool {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.h
@@ -76,7 +76,7 @@ typedef void (^SelectedMenuBlock)(BOOL selected, BOOL animated);
 @end
 
 
-@interface ConversationCell : UITableViewCell <UserImageViewDelegate, UIKeyInput>
+@interface ConversationCell : UITableViewCell <UserImageViewDelegate>
 
 @property (nonatomic, readonly) ConversationCellLayoutProperties *layoutProperties;
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
@@ -443,26 +443,4 @@ const NSTimeInterval ConversationCellSelectionAnimationDuration = 0.33;
     return NO;
 }
 
-#pragma mark - UIKeyInput
-
-// We need to conform the cell to UIKeyInput to avoid the keyboard being dismissed
-// when showing the UIMenuController, we might want to forward the calls to the text input field
-// or post a notification to make it first responder again.
-
-- (void)insertText:(NSString *)text
-{
- // no-op
-}
-
-- (void)deleteBackward
-{
-    // no-op
-}
-
-- (BOOL)hasText
-{
-    return NO;
-}
-
-
 @end

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
@@ -371,18 +371,20 @@ const NSTimeInterval ConversationCellSelectionAnimationDuration = 0.33;
      */
     [self.window makeKeyWindow];
     [self.window becomeFirstResponder];
-    
+
     [self becomeFirstResponder];
-    
+
     UIMenuController *menuController = [UIMenuController sharedMenuController];
-    menuController.menuItems = menuConfigurationProperties.additionalItems;
+    UIMenuItem *deleteItem = [[UIMenuItem alloc] initWithTitle:NSLocalizedString(@"content.message.delete", @"") action:@selector(deleteMessage:)];
+    NSArray <UIMenuItem *> *items = menuConfigurationProperties.additionalItems ?: @[];
+    menuController.menuItems = [items arrayByAddingObject:deleteItem];
     [menuController setTargetRect:menuConfigurationProperties.targetRect inView:menuConfigurationProperties.targetView];
     [menuController setMenuVisible:YES animated:YES];
-    
+
     if ([self.delegate respondsToSelector:@selector(conversationCell:didOpenMenuForCellType:)]) {
         [self.delegate conversationCell:self didOpenMenuForCellType:[self messageType]];
     }
-    
+
 }
 
 
@@ -402,14 +404,14 @@ const NSTimeInterval ConversationCellSelectionAnimationDuration = 0.33;
 
 - (BOOL)canPerformAction:(SEL)action withSender:(id)sender;
 {
-    if (action == @selector(delete:) && self.message.canBeDeleted) {
+    if (action == @selector(deleteMessage:) && self.message.canBeDeleted) {
         return YES;
     }
     
     return [super canPerformAction:action withSender:sender];
 }
 
-- (void)delete:(id)sender;
+- (void)deleteMessage:(id)sender;
 {
     if([self.delegate respondsToSelector:@selector(conversationCell:didSelectAction:)]) {
         [self.delegate conversationCell:self didSelectAction:ConversationCellActionDelete];

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/VideoMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/VideoMessageCell.swift
@@ -250,22 +250,17 @@ extension ZMConversationMessage {
         properties.targetRect = selectionRect
         properties.targetView = selectionView
         properties.selectedMenuBlock = setSelectedByMenu
-        
+
+        if message.videoCanBeSavedToCameraRoll() {
+            let menuItem = UIMenuItem(title:"content.file.save_video".localized, action:#selector(wr_saveVideo))
+            properties.additionalItems = [menuItem]
+        } else {
+            properties.additionalItems = []
+        }
+
         return properties
     }
-    
-    override public func showMenu() {
-        if self.message.videoCanBeSavedToCameraRoll() {
-            
-            let menuItem = UIMenuItem(title:"content.file.save_video".localized, action:#selector(wr_saveVideo))
-            UIMenuController.sharedMenuController().menuItems = [menuItem]
-        }
-        else {
-            UIMenuController.sharedMenuController().menuItems = nil
-        }
-        super.showMenu()
-    }
-    
+
     override public func canPerformAction(action: Selector, withSender sender: AnyObject?) -> Bool {
         if action == #selector(wr_saveVideo) {
             if self.message.videoCanBeSavedToCameraRoll() {


### PR DESCRIPTION
### **What's in this PR?**

* The delete menu item in the `UIMenuController` is now always the last item ([7086](https://wearezeta.atlassian.net/browse/ZIOS-7086)).

* Reverting the changes made in https://github.com/wireapp/wire-ios/pull/90 conforming `ConversationCell` to `UIKeyInput`, these changes were made to prohibit the keyboard of being hidden when displaying the `UIMenuController`, but made it always appear instead if it was not being shown (which makes sense as the cell was expecting text input then).
___

From the Apple documentation:  
> Custom items appear in the menu after any system menu items. 

This means that the `-delete:` selector can not be used, but instead a custom menu item has to be added to the menu controller to guarantee that the delete item is displayed last (after other custom items like for example `save`). Because the `-delete:` can not be used we now use `-deleteMessage:` as custom selector and spend a custom menu item to the menu controller.

This also has the advantage that we can use the `additionalItems` property on `MenuConfigurationProperties` and don't need to override `-showMenu:` in `ConversationCell` subclasses anymore.