### PR TITLE
Don't scroll to the bottom of the conversation when editing

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -656,9 +656,9 @@
 
 @implementation ConversationViewController (InputBar)
 
-- (BOOL)conversationInputBarViewControllerShouldBeginEditing:(ConversationInputBarViewController *)controller
+- (BOOL)conversationInputBarViewControllerShouldBeginEditing:(ConversationInputBarViewController *)controller isEditingMessage:(BOOL)isEditing
 {
-    if (! self.contentViewController.isScrolledToBottom) {
+    if (! self.contentViewController.isScrolledToBottom && !isEditing) {
         [self.contentViewController scrollToBottomAnimated:YES];
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.h
@@ -36,7 +36,7 @@ typedef NS_ENUM(NSUInteger, ConversationInputBarViewControllerMode) {
 @protocol ConversationInputBarViewControllerDelegate <NSObject>
 
 @optional
-- (BOOL)conversationInputBarViewControllerShouldBeginEditing:(ConversationInputBarViewController *)controller;
+- (BOOL)conversationInputBarViewControllerShouldBeginEditing:(ConversationInputBarViewController *)controller isEditingMessage:(BOOL)isEditing;
 - (BOOL)conversationInputBarViewControllerShouldEndEditing:(ConversationInputBarViewController *)controller;
 - (void)conversationInputBarViewControllerDidNotSendMessageConversationDegraded:(ConversationInputBarViewController *)controller;
 - (void)conversationInputBarViewControllerDidFinishEditingMessage:(id <ZMConversationMessage>)message withText:(NSString *)newText;

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -586,14 +586,11 @@
 
 - (BOOL)textViewShouldBeginEditing:(UITextView *)textView
 {
-    BOOL isEditing = (nil != self.editingMessage);
-    
     if (self.mode == ConversationInputBarViewControllerModeAudioRecord) {
         return YES;
     }
-    else if (!isEditing && [self.delegate respondsToSelector:@selector(conversationInputBarViewControllerShouldBeginEditing:)]) {
-        // This call scrolls to the bottom of the conversation, we don't want this behaviour if we are editing a message
-        return [self.delegate conversationInputBarViewControllerShouldBeginEditing:self];
+    else if ([self.delegate respondsToSelector:@selector(conversationInputBarViewControllerShouldBeginEditing:isEditingMessage:)]) {
+        return [self.delegate conversationInputBarViewControllerShouldBeginEditing:self isEditingMessage:(nil != self.editingMessage)];
     }
     else {
         return YES;

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -586,10 +586,13 @@
 
 - (BOOL)textViewShouldBeginEditing:(UITextView *)textView
 {
+    BOOL isEditing = (nil != self.editingMessage);
+    
     if (self.mode == ConversationInputBarViewControllerModeAudioRecord) {
         return YES;
     }
-    else if ([self.delegate respondsToSelector:@selector(conversationInputBarViewControllerShouldBeginEditing:)]) {
+    else if (!isEditing && [self.delegate respondsToSelector:@selector(conversationInputBarViewControllerShouldBeginEditing:)]) {
+        // This call scrolls to the bottom of the conversation, we don't want this behaviour if we are editing a message
         return [self.delegate conversationInputBarViewControllerShouldBeginEditing:self];
     }
     else {


### PR DESCRIPTION
**What's in this PR?**

* When the input bar becomes first responder we scroll the conversation to the bottom, we don't want this behavior when editing a message.