### PR TITLE
Fix being able to send empty edits and sending unedited content from return key

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -561,10 +561,11 @@
 
         NSString *candidateText = textView.text;
         candidateText = [candidateText stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
-        BOOL conversationWasNotDeleted  = self.conversation.managedObjectContext != nil;
+        BOOL conversationWasNotDeleted = self.conversation.managedObjectContext != nil;
 
         if (self.inputBar.isEditing && nil != self.editingMessage) {
-            if (![candidateText isEqualToString:self.editingMessage.textMessageData.messageText]) {
+            NSString *previousText = [self.editingMessage.textMessageData.messageText stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+            if (![candidateText isEqualToString:previousText]) {
                 [self sendEditedMessageAndUpdateStateWithText:candidateText];
             }
    

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -558,10 +558,19 @@
 - (BOOL)textView:(UITextView *)textView shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)text
 {
     if ([text isEqualToString:@"\n"]) {
-        
+
         NSString *candidateText = textView.text;
         candidateText = [candidateText stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
         BOOL conversationWasNotDeleted  = self.conversation.managedObjectContext != nil;
+
+        if (self.inputBar.isEditing && nil != self.editingMessage) {
+            if (![candidateText isEqualToString:self.editingMessage.textMessageData.messageText]) {
+                [self sendEditedMessageAndUpdateStateWithText:candidateText];
+            }
+   
+            return NO;
+        }
+        
         if (candidateText.length && conversationWasNotDeleted) {
             
             [self clearInputBar];
@@ -569,9 +578,6 @@
             NSArray *args = candidateText.args;
             if(args.count > 0) {
                 [self runCommand:args];
-            }
-            else if (self.inputBar.isEditing && nil != self.editingMessage) {
-                [self sendEditedMessageAndUpdateStateWithText:candidateText];
             }
             else {
                 [self.sendController sendTextMessage:candidateText];

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
@@ -337,7 +337,8 @@ private struct InputBarConstants {
 
             // We do not want to enable the confirm button when
             // the text is the same as the original message
-            let hasChanges = text != textView.text && canUndo
+            let trimmedText = textView.text.stringByTrimmingCharactersInSet(.whitespaceAndNewlineCharacterSet())
+            let hasChanges = text != trimmedText && canUndo
             editingView.confirmButton.enabled = hasChanges
         }
     }


### PR DESCRIPTION
**What's in this PR?**

* [7093](https://wearezeta.atlassian.net/browse/ZIOS-7093): "Message edited with spaces isn't shown as deleted"
* [7094](https://wearezeta.atlassian.net/browse/ZIOS-7094): "Message edited with space is impossible to send by tapping on send button on the keyboard" 
* [7095](https://wearezeta.atlassian.net/browse/ZIOS-7095): "Not edited but submited message is shown as edited"