### PR TITLE
Restrict editing to messages in conversations where self is an active member

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/TextMessageCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/TextMessageCell.m
@@ -409,7 +409,8 @@
 {
     MenuConfigurationProperties *properties = [[MenuConfigurationProperties alloc] init];
     
-    if ([self.message.conversation isSelfAnActiveMember]) {
+    BOOL isEditableMessage = self.message.conversation.isSelfAnActiveMember && self.message.deliveryState == ZMDeliveryStateDelivered;
+    if (isEditableMessage) {
         properties.additionalItems = @[[[UIMenuItem alloc] initWithTitle:NSLocalizedString(@"message.menu.edit.title", @"") action:@selector(edit:)]];
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/TextMessageCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/TextMessageCell.m
@@ -408,8 +408,11 @@
 - (MenuConfigurationProperties *)menuConfigurationProperties
 {
     MenuConfigurationProperties *properties = [[MenuConfigurationProperties alloc] init];
-    properties.additionalItems = @[[[UIMenuItem alloc] initWithTitle:NSLocalizedString(@"message.menu.edit.title", @"") action:@selector(edit:)]];
     
+    if ([self.message.conversation isSelfAnActiveMember]) {
+        properties.additionalItems = @[[[UIMenuItem alloc] initWithTitle:NSLocalizedString(@"message.menu.edit.title", @"") action:@selector(edit:)]];
+    }
+
     properties.targetRect = self.selectionRect;
     properties.targetView = self.selectionView;
     properties.selectedMenuBlock = ^(BOOL selected, BOOL animated) {


### PR DESCRIPTION
**What's in this PR?**

Fixes for: 
* [7097](https://wearezeta.atlassian.net/browse/ZIOS-7097): "Do not show Edit option if user has been removed/left the group conversation"
* [7098](https://wearezeta.atlassian.net/browse/ZIOS-7098): "Edited unsent message is shown as sent to the sender" – This is now restricted from the UI side but will be added in `wire-iso-sync-engine` as well.