### PR TITLE
Remove draft message text when leaving editing mode

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Editing.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Editing.swift
@@ -48,6 +48,9 @@ extension ConversationInputBarViewController {
         guard nil != editingMessage else { return }
         delegate.conversationInputBarViewControllerDidCancelEditingMessage?(editingMessage)
         editingMessage = nil
+        ZMUserSession.sharedSession().enqueueChanges {
+            self.conversation.draftMessageText = ""
+        }
         inputBar.inputBarState = .Writing
         NSNotificationCenter.defaultCenter().removeObserver(
             self,
@@ -69,7 +72,7 @@ extension ConversationInputBarViewController: InputBarEditViewDelegate {
         switch buttonType {
         case .Undo: inputBar.undo()
         case .Cancel: endEditingMessageIfNeeded()
-        case .Confirm: sendEditedMessageAndUpdateState(withText: inputBar.textView.text)
+        case .Confirm: sendOrEditText(inputBar.textView.text)
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Private.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Private.h
@@ -32,9 +32,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable) id <ZMConversationMessage> editingMessage;
 
 @property (nonatomic)           BOOL shouldRefocusKeyboardAfterImagePickerDismiss;
-
 @property (nonatomic)           NSUInteger videoSendContext;
+
 - (void)createAudioRecordViewController;
+- (void)sendOrEditText:(NSString *)text;
 @end
 
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -530,6 +530,34 @@
     }
 }
 
+- (void)sendOrEditText:(NSString *)text
+{
+    NSString *candidateText = [text stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+    BOOL conversationWasNotDeleted = self.conversation.managedObjectContext != nil;
+    
+    if (self.inputBar.isEditing && nil != self.editingMessage) {
+        NSString *previousText = [self.editingMessage.textMessageData.messageText stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+        if (![candidateText isEqualToString:previousText]) {
+            [self sendEditedMessageAndUpdateStateWithText:candidateText];
+        }
+        
+        return;
+    }
+    
+    if (candidateText.length && conversationWasNotDeleted) {
+        
+        [self clearInputBar];
+        
+        NSArray *args = candidateText.args;
+        if(args.count > 0) {
+            [self runCommand:args];
+        }
+        else {
+            [self.sendController sendTextMessage:candidateText];
+        }
+    }
+}
+
 @end
 
 #pragma mark - Categories
@@ -558,33 +586,7 @@
 - (BOOL)textView:(UITextView *)textView shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)text
 {
     if ([text isEqualToString:@"\n"]) {
-
-        NSString *candidateText = textView.text;
-        candidateText = [candidateText stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
-        BOOL conversationWasNotDeleted = self.conversation.managedObjectContext != nil;
-
-        if (self.inputBar.isEditing && nil != self.editingMessage) {
-            NSString *previousText = [self.editingMessage.textMessageData.messageText stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
-            if (![candidateText isEqualToString:previousText]) {
-                [self sendEditedMessageAndUpdateStateWithText:candidateText];
-            }
-   
-            return NO;
-        }
-        
-        if (candidateText.length && conversationWasNotDeleted) {
-            
-            [self clearInputBar];
-            
-            NSArray *args = candidateText.args;
-            if(args.count > 0) {
-                [self runCommand:args];
-            }
-            else {
-                [self.sendController sendTextMessage:candidateText];
-            }
-        }
-
+        [self sendOrEditText:textView.text];
         return NO;
     }
     


### PR DESCRIPTION
### **What's in this PR?**

* The input field was pre-filled with the `draftMessageText` text when leaving the conversation while editing and then re-entering again.
* Unify the sending editing logic when using the return key and confirm button.