### PR TITLE
Updated private xcconfigs loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,4 @@ Carthage/
 *.xcscmblueprint
 Wire-iOS/ComponentsVersions.plist
 /Libraries
-/ConfigurationSets/Private
+/wire-ios-build-assets

--- a/ConfigurationSets/Base.xcconfig
+++ b/ConfigurationSets/Base.xcconfig
@@ -21,7 +21,7 @@
 
 #include "Warnings.xcconfig"
 #include "Version.xcconfig"
-#include "Private/Base_private.xcconfig"
+#include "../wire-ios-build-assets/Base_private.xcconfig"
 
 
 // Packaging

--- a/ConfigurationSets/Development.xcconfig
+++ b/ConfigurationSets/Development.xcconfig
@@ -18,7 +18,7 @@
 
 
 #include "Base.xcconfig"
-#include "Private/Development_private.xcconfig"
+#include "../wire-ios-build-assets/Development_private.xcconfig"
 
 
 // Code Signing

--- a/ConfigurationSets/Release.xcconfig
+++ b/ConfigurationSets/Release.xcconfig
@@ -18,7 +18,7 @@
 
 
 #include "Base.xcconfig"
-#include "Private/Release_private.xcconfig"
+#include "../wire-ios-build-assets/Release_private.xcconfig"
 
 
 //Code Signature

--- a/Scripts/download-assets.sh
+++ b/Scripts/download-assets.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+#
+# Wire
+# Copyright (C) 2016 Wire Swiss GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see http://www.gnu.org/licenses/.
+#
+
+
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $DIR/..
+
+
+REPO_NAME=wire-ios-build-assets
+REPO_URL=github.com:wireapp/${REPO_NAME}.git
+
+##################################
+# Checout assets
+##################################
+if [ -e "${REPO_NAME}" ]; then
+	cd ${REPO_NAME}
+	echo "Pulling assets..."
+	git pull
+else
+	git ls-remote "git@${REPO_URL}" &> /dev/null
+	if [ "$?" -ne 0 ]; then
+		echo "No access to assets"
+	else 
+		echo "Cloning assets..."
+		git clone --depth 1 git@${REPO_URL}
+	fi
+fi

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -204,7 +204,6 @@
 		1EE9DCCD1B5F9D0000E347DF /* WireExtensionComponents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1EE85C501B5F96FB008E084B /* WireExtensionComponents.framework */; };
 		1EE9DCD61B5FA4AD00E347DF /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8FC850A0199245760008B66B /* Images.xcassets */; };
 		1EE9DCD91B5FA4B200E347DF /* icon-no-appstore.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DBF597571A3600FC00269B7F /* icon-no-appstore.xcassets */; };
-		1EE9DCE41B5FC34A00E347DF /* (null) in Resources */ = {isa = PBXBuildFile; };
 		1EE9DCED1B5FC4A100E347DF /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 1EE9DCEC1B5FC4A100E347DF /* Localizable.strings */; };
 		1EE9DCF21B5FCA5E00E347DF /* UIColor+Accent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EE9DCF11B5FCA5E00E347DF /* UIColor+Accent.swift */; };
 		1EE9DCFB1B5FE76600E347DF /* UIAlertController+NSError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EE9DCFA1B5FE76600E347DF /* UIAlertController+NSError.swift */; };
@@ -517,7 +516,6 @@
 		8786072F1D33E3FF00971A19 /* metamacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 878607171D33E3FF00971A19 /* metamacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		878607301D33E3FF00971A19 /* weakify.h in Headers */ = {isa = PBXBuildFile; fileRef = 878607181D33E3FF00971A19 /* weakify.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8787BDD91BF374420096B1B5 /* SettingsPropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8787BDD61BF374420096B1B5 /* SettingsPropertyTests.swift */; };
-		878893641D49113600086646 /* JPSimulatorHackFramework.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 878893621D490EB600086646 /* JPSimulatorHackFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		878C21A01AE4F45600CB9FC4 /* CheckmarkView.m in Sources */ = {isa = PBXBuildFile; fileRef = 878C219F1AE4F45600CB9FC4 /* CheckmarkView.m */; };
 		878D65C71C84664A0067E3D9 /* zmessaging.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 095275931B7E834400123BAF /* zmessaging.framework */; };
 		878F85B419F6635A0020F2F1 /* AddressBookHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 878F85B319F6635A0020F2F1 /* AddressBookHelper.m */; };
@@ -769,7 +767,6 @@
 		DB888FB61ADD18B400CE9A88 /* RegistrationEmailFlowViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = DB888FB51ADD18B400CE9A88 /* RegistrationEmailFlowViewController.m */; };
 		DB888FBB1ADD195F00CE9A88 /* EmailStepViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = DB888FBA1ADD195F00CE9A88 /* EmailStepViewController.m */; };
 		DBACFF7A1B3C96E1004062E0 /* MentionsBubbleView.m in Sources */ = {isa = PBXBuildFile; fileRef = DBACFF781B3C96E1004062E0 /* MentionsBubbleView.m */; };
-		DBB45F371B53CA9A0010053C /* (null) in Sources */ = {isa = PBXBuildFile; };
 		DBB45F3B1B53F8DE0010053C /* NSString+MentionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DBB45F3A1B53F8DE0010053C /* NSString+MentionsTests.m */; };
 		DBBC190F1B5E3C5D00E84607 /* StopWatch.m in Sources */ = {isa = PBXBuildFile; fileRef = DBBC190E1B5E3C5D00E84607 /* StopWatch.m */; };
 		DBBFBCB919D2CBCB00557444 /* TitleBar.m in Sources */ = {isa = PBXBuildFile; fileRef = DBBFBCB819D2CBCB00557444 /* TitleBar.m */; };
@@ -832,7 +829,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				878893641D49113600086646 /* JPSimulatorHackFramework.framework in CopyFiles */,
 				871BE95F1CD0C462002267E8 /* FBSnapshotTestCase.framework in CopyFiles */,
 				871BE95E1CD0C459002267E8 /* OCMock.framework in CopyFiles */,
 			);
@@ -1593,6 +1589,7 @@
 		875B6B441C5953DA007C61E5 /* VideoToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VideoToolbox.framework; path = System/Library/Frameworks/VideoToolbox.framework; sourceTree = SDKROOT; };
 		875D48A51A6D087F00BB17B5 /* ConversationListViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ConversationListViewController.h; sourceTree = "<group>"; };
 		875D48A61A6D087F00BB17B5 /* ConversationListViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ConversationListViewController.m; sourceTree = "<group>"; };
+		876513521D66F06C00D1D77E /* wire-ios-build-assets */ = {isa = PBXFileReference; lastKnownFileType = folder; path = "wire-ios-build-assets"; sourceTree = SOURCE_ROOT; };
 		876AE75F1C159A9C00E3E743 /* NSStringFingerprintTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSStringFingerprintTests.m; sourceTree = "<group>"; };
 		876BF80F1AEFDA7900A3810F /* SignInViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SignInViewController.h; sourceTree = "<group>"; };
 		876BF8101AEFDA7900A3810F /* SignInViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SignInViewController.m; sourceTree = "<group>"; };
@@ -4322,6 +4319,7 @@
 		8FC85543199246EF0008B66B /* ConfigurationSets */ = {
 			isa = PBXGroup;
 			children = (
+				876513521D66F06C00D1D77E /* wire-ios-build-assets */,
 				8FC8554C199246EF0008B66B /* Warnings.xcconfig */,
 				1E8666E21BE21BC3000B013E /* Version.xcconfig */,
 				8FC8554B199246EF0008B66B /* Base.xcconfig */,
@@ -4746,7 +4744,6 @@
 				1EE9DCD61B5FA4AD00E347DF /* Images.xcassets in Resources */,
 				1EE9DCED1B5FC4A100E347DF /* Localizable.strings in Resources */,
 				1EBA8C691B70C15D0089CC44 /* common-controls.cas in Resources */,
-				1EE9DCE41B5FC34A00E347DF /* (null) in Resources */,
 				1EBA8C6D1B70CCB10089CC44 /* stylesheet-share-ext.cas in Resources */,
 				1EE9DC8A1B5F991900E347DF /* Media.xcassets in Resources */,
 				1E5E0D0C1B6B9A33003B0CAC /* colors.cas in Resources */,
@@ -5184,7 +5181,6 @@
 				8FC8549C199245770008B66B /* NetworkStatusViewController.m in Sources */,
 				8F8914131A9F287E0056AB0C /* ConversationListItemView.m in Sources */,
 				16063CEB1BCFCEB70097F62C /* InviteBannerViewController.m in Sources */,
-				DBB45F371B53CA9A0010053C /* (null) in Sources */,
 				1600E2051AD5799400C0DBA8 /* PhoneNumberStepViewController.m in Sources */,
 				DBACFF7A1B3C96E1004062E0 /* MentionsBubbleView.m in Sources */,
 				871BBFFE1D34F56300DF0793 /* Analytics+Metrics.m in Sources */,

--- a/setup.sh
+++ b/setup.sh
@@ -58,4 +58,8 @@ echo "ℹ️  Downloading AVS library..."
 ./Scripts/download-avs.sh
 echo ""
 
+echo "ℹ️  Downloading additional assets..."
+./Scripts/download-assets.sh
+echo ""
+
 echo "✅  Wire project was set up, you can now open Wire-iOS.xcworkspace"


### PR DESCRIPTION
- It was unclear for Wire developers where the private assets are located
- The CI system required extra configuration to fetch assets from GitHub
- Solution is to make a setup of private assets as part of `setup.sh`
- The 3rd party developers who don't have access to private repos would not have issues with compilation, since the assets and step in `setup.sh` are optional