### PR TITLE
Fix calling tracking

### DIFF
--- a/Wire-iOS/Sources/Analytics/AnalyticsVoiceChannelTracker.m
+++ b/Wire-iOS/Sources/Analytics/AnalyticsVoiceChannelTracker.m
@@ -79,7 +79,7 @@
         self.initiatedCall = (previousState == ZMVoiceChannelStateOutgoingCall || previousState == ZMVoiceChannelStateOutgoingCallInactive);
         [self.analytics tagJoinedCallInConversation:conversation video:self.isVideoCall initiatedCall:self.initiatedCall];
     }
-    else if (currentState == ZMVoiceChannelStateSelfConnectedToActiveChannel) {
+    else if (currentState == ZMVoiceChannelStateSelfConnectedToActiveChannel && nil == self.callEstablishedDate) {
         self.callEstablishedDate = [NSDate date];
         [self.analytics tagEstablishedCallInConversation:conversation video:self.isVideoCall initiatedCall:self.initiatedCall];
     }


### PR DESCRIPTION
**What's in this PR**
We would send too many `ConnectionEstablished` tracking call because every time we switch connection (3G, Wifi, 2G etc), we would be notified that the connection is established.
This is now fix.