### PR TITLE
Fix incorrect cell menu in conversation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.h
@@ -70,7 +70,7 @@ typedef void (^SelectedMenuBlock)(BOOL selected, BOOL animated);
 - (void)conversationCell:(ConversationCell *)cell userTapped:(ZMUser *)user inView:(UIView *)view;
 - (void)conversationCell:(ConversationCell *)cell resendMessageTapped:(ZMMessage *)message;
 - (void)conversationCell:(ConversationCell *)cell didSelectAction:(ConversationCellAction)actionId;
-- (void)conversationCell:(ConversationCell *)cell willOpenMenuForCellType:(MessageType)messageType;
+- (BOOL)conversationCell:(ConversationCell *)cell shouldBecomeFirstResponderWhenShowMenuWithCellType:(MessageType)messageType;
 - (void)conversationCell:(ConversationCell *)cell didOpenMenuForCellType:(MessageType)messageType;
 
 @end

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
@@ -348,8 +348,9 @@ const NSTimeInterval ConversationCellSelectionAnimationDuration = 0.33;
 
 - (void)showMenu;
 {
-    if ([self.delegate respondsToSelector:@selector(conversationCell:willOpenMenuForCellType:)]) {
-        [self.delegate conversationCell:self willOpenMenuForCellType:[self messageType]];
+    BOOL shouldBecomeFirstResponder = YES;
+    if ([self.delegate respondsToSelector:@selector(conversationCell:shouldBecomeFirstResponderWhenShowMenuWithCellType:)]) {
+        shouldBecomeFirstResponder = [self.delegate conversationCell:self shouldBecomeFirstResponderWhenShowMenuWithCellType:[self messageType]];
     }
     
     MenuConfigurationProperties *menuConfigurationProperties = [self menuConfigurationProperties];
@@ -373,7 +374,7 @@ const NSTimeInterval ConversationCellSelectionAnimationDuration = 0.33;
     [self.window makeKeyWindow];
     [self.window becomeFirstResponder];
 
-    if ([UIResponder wr_currentFirstResponder] == nil) {
+    if (shouldBecomeFirstResponder) {
         [self becomeFirstResponder];
     }
     

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -806,12 +806,14 @@
     }
 }
 
-- (void)conversationCell:(ConversationCell *)cell willOpenMenuForCellType:(MessageType)messageType;
+- (BOOL)conversationCell:(ConversationCell *)cell shouldBecomeFirstResponderWhenShowMenuWithCellType:(MessageType)messageType;
 {
-    if ([self.delegate respondsToSelector:@selector(conversationContentViewController:didShowMenuFromCell:)]) {
-        [self.delegate conversationContentViewController:self didShowMenuFromCell:cell];
+    BOOL shouldBecomeFirstResponder = YES;
+    if ([self.delegate respondsToSelector:@selector(conversationContentViewController:shouldBecomeFirstResponderWhenShowMenuFromCell:)]) {
+        shouldBecomeFirstResponder = [self.delegate conversationContentViewController:self shouldBecomeFirstResponderWhenShowMenuFromCell:cell];
     }
     [ConversationInputBarViewController endEditingMessage];
+    return shouldBecomeFirstResponder;
 }
 
 - (void)conversationCell:(ConversationCell *)cell didOpenMenuForCellType:(MessageType)messageType;

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewControllerDelegate.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewControllerDelegate.h
@@ -48,7 +48,7 @@ didEndDisplayingActiveMediaPlayerForMessage:(id<ZMConversationMessage>)message;
 
 - (void)conversationContentViewController:(ConversationContentViewController *)contentViewController didTriggerEditingMessage:(ZMMessage *)message;
 
-- (void)conversationContentViewController:(ConversationContentViewController *)controller didShowMenuFromCell:(UITableViewCell *)cell;
+- (BOOL)conversationContentViewController:(ConversationContentViewController *)controller shouldBecomeFirstResponderWhenShowMenuFromCell:(UITableViewCell *)cell;
 
 @optional
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -593,12 +593,21 @@
     }
 }
 
-- (void)conversationContentViewController:(ConversationContentViewController *)controller didShowMenuFromCell:(UITableViewCell *)cell
+- (BOOL)conversationContentViewController:(ConversationContentViewController *)controller shouldBecomeFirstResponderWhenShowMenuFromCell:(UITableViewCell *)cell
 {
-    self.inputBarController.inputBar.textView.overrideNextResponder = cell;
-    
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(menuDidHide:) name:UIMenuControllerDidHideMenuNotification object:nil];
-    
+    if ([self.inputBarController.inputBar.textView isFirstResponder]) {
+        self.inputBarController.inputBar.textView.overrideNextResponder = cell;
+        
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(menuDidHide:)
+                                                     name:UIMenuControllerDidHideMenuNotification
+                                                   object:nil];
+        
+        return NO;
+    }
+    else {
+        return YES;
+    }
 }
 
 @end


### PR DESCRIPTION
- The issue is that sometimes the menu is showing wrong elements in conversation view
- It happens because of the new responder logic in connection to keeping the keyboard up
- The exact issue is that the cell is not always becoming first responder, but only if there is no other current responder (implemented in that way to keep keyboard up)
- So the previously selected cell is remaining "selected"
- Solution is to check with delegate if cell should become first responder when showing menu. Delegate knows if the keyboard is up.