### PR TITLE
Don't always track `Not Now` tap as denied preflight permissions

### DIFF
--- a/Wire-iOS/Sources/Permissions/ShareContactsViewController.h
+++ b/Wire-iOS/Sources/Permissions/ShareContactsViewController.h
@@ -30,5 +30,6 @@
 @property (nonatomic) BOOL backgroundBlurDisabled;
 @property (nonatomic) BOOL notNowButtonHidden;
 @property (nonatomic) BOOL monochromeStyle;
+@property (nonatomic, readonly) BOOL showingAddressBookAccessDeniedViewController;
 
 @end

--- a/Wire-iOS/Sources/Permissions/ShareContactsViewController.m
+++ b/Wire-iOS/Sources/Permissions/ShareContactsViewController.m
@@ -38,6 +38,7 @@
 @property (nonatomic) UIView *shareContactsContainerView;
 @property (nonatomic) PermissionDeniedViewController *addressBookAccessDeniedViewController;
 @property (nonatomic) UIVisualEffectView *backgroundBlurView;
+@property (nonatomic) BOOL showingAddressBookAccessDeniedViewController;
 
 @end
 
@@ -153,6 +154,8 @@
 
 - (void)displayContactsAccessDeniedMessageAnimated:(BOOL)animated
 {
+    self.showingAddressBookAccessDeniedViewController = YES;
+
     if (animated) {
         [UIView transitionFromView:self.shareContactsContainerView
                             toView:self.addressBookAccessDeniedViewController.view
@@ -203,7 +206,10 @@
 
 - (IBAction)shareContactsLater:(id)sender
 {
-    [self.analyticsTracker tagAddressBookPreflightPermissions:NO];
+    if (!self.showingAddressBookAccessDeniedViewController) {
+        [self.analyticsTracker tagAddressBookPreflightPermissions:NO];
+    }
+
     [[AddressBookHelper sharedHelper] addressBookUploadWasProposed];
     [self.formStepDelegate didSkipFormStep:self];
 }

--- a/Wire-iOS/Sources/UserInterface/Registration/ShareContactsStepViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/ShareContactsStepViewController.m
@@ -95,8 +95,11 @@
 {
     // We use a ShareContactsViewController but our own `later` button,
     // that's why we need to track the tap manually here.
-    [self.analyticsTracker tagAddressBookPreflightPermissions:NO];
-    [[AddressBookHelper sharedHelper] addressBookUploadWasProposed];
+    if (!self.shareContactsViewController.showingAddressBookAccessDeniedViewController) {
+        [self.analyticsTracker tagAddressBookPreflightPermissions:NO];
+        [[AddressBookHelper sharedHelper] addressBookUploadWasProposed];
+    }
+    
     [self.formStepDelegate didSkipFormStep:self];
 }
 


### PR DESCRIPTION
### **What's in this PR?**

* [6943](https://wearezeta.atlassian.net/browse/ZIOS-6943): If an onboarding user selects to share his contacts in the preflight dialog an then decides not to share them in the system alert we display the permission denied dialog. The `Not Now` button on the top right is owned by the `ShareContactsStepViewController` and would still trigger the tracking of the preflight analytics if tapped in this state.