### PR TITLE
Avoid crashing on inconsistent soundcloud response

### DIFF
--- a/Wire-iOS/Sources/Components/Soundcloud/SoundcloudService.m
+++ b/Wire-iOS/Sources/Components/Soundcloud/SoundcloudService.m
@@ -137,7 +137,7 @@
     NSError *error = nil;
     NSDictionary *JSON = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
     
-    if (error != nil) {
+    if (error != nil || ![JSON isKindOfClass:[NSDictionary class]]) {
         return nil;
     }
     


### PR DESCRIPTION
- On link "soundcloud.com/sirdonqui/likes" and similar the API response gives an Array instead of HashMap (Dictionary)
- Swift can help in this case next time