### PR TITLE
Properly reset call establish date when call ended

### DIFF
--- a/Wire-iOS/Sources/Analytics/AnalyticsVoiceChannelTracker.m
+++ b/Wire-iOS/Sources/Analytics/AnalyticsVoiceChannelTracker.m
@@ -94,6 +94,7 @@
                                  initiatedCall:self.initiatedCall
                                       duration:-[self.callEstablishedDate timeIntervalSinceNow]
                                         reason:note.reason];
+    self.callEstablishedDate = nil;
 }
 
 @end


### PR DESCRIPTION
**What is in this PR**
We failed to reset the call establish date when the call ended, failing to report any other call established. This is now fixed.