### PR TITLE
Set the alert title as title and not as message to ensure non-bold font

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageDeletion.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageDeletion.swift
@@ -85,8 +85,8 @@ private enum AlertAction {
 private extension UIAlertController {
 
     static func alertControllerForMessageDeletion(showDelete: Bool, selectedAction: AlertAction -> Void) -> UIAlertController {
-        let alertMessage = "message.delete_dialog.message".localized
-        let alert = UIAlertController(title: nil, message: alertMessage, preferredStyle: .ActionSheet)
+        let alertTitle = "message.delete_dialog.message".localized
+        let alert = UIAlertController(title: alertTitle, message: nil, preferredStyle: .ActionSheet)
 
         let hideTitle = "message.delete_dialog.action.hide".localized
         let hideAction = UIAlertAction(title: hideTitle, style: .Default, handler: { _ in selectedAction(.Delete(.Local)) })


### PR DESCRIPTION
**What's in this PR?**

* The "This can not be undone" description of the `UIAlertController` shown when deleting a message should not be displayed using a medium font weight, which is the case if a message is set and no title is set. To avoid this we now set the title and not the message.