### PR TITLE
Wrap adding a like in a `enqueue changes` block

### DIFF
--- a/Wire-iOS/Sources/Helpers/syncengine/ZMMessage+Likes.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMMessage+Likes.swift
@@ -28,11 +28,9 @@ extension ZMConversationMessage {
     
     var liked: Bool {
         set {
-            if newValue {
-                ZMMessage.addReaction(ZMMessageReaction.Like.rawValue, toMessage: self)
-            }
-            else {
-                ZMMessage.addReaction(.None, toMessage: self)
+            let reaction: String? = newValue ? ZMMessageReaction.Like.rawValue : .None
+            ZMUserSession.sharedSession().enqueueChanges {
+                ZMMessage.addReaction(reaction, toMessage: self)
             }
         }
         get {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
@@ -568,7 +568,7 @@ const NSTimeInterval ConversationCellSelectionAnimationDuration = 0.33;
         [self updateSenderAndSenderImage:change.message];
     }
     
-    return (change.reactionChangeInfo != nil) || (change.deliveryStateChanged);
+    return change.reactionsChanged || (change.deliveryStateChanged);
 }
 
 @end


### PR DESCRIPTION
# What's in this PR?

[7180](https://wearezeta.atlassian.net/browse/ZIOS-7180): The adding of a reaction was not performed inside of a `ZMUserSession.enqueueChanges(_:)` block.
