### PR TITLE
Revert wrapping liking in enqueue changes, as this is already done a level higher

### DIFF
--- a/Wire-iOS/Sources/Helpers/syncengine/ZMMessage+Likes.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMMessage+Likes.swift
@@ -29,9 +29,7 @@ extension ZMConversationMessage {
     var liked: Bool {
         set {
             let reaction: String? = newValue ? ZMMessageReaction.Like.rawValue : .None
-            ZMUserSession.sharedSession().enqueueChanges {
-                ZMMessage.addReaction(reaction, toMessage: self)
-            }
+            ZMMessage.addReaction(reaction, toMessage: self)
         }
         get {
             let onlyLikes = self.usersReaction.filter { (reaction, users) in


### PR DESCRIPTION
# What's in this PR?

* Revert https://github.com/wireapp/wire-ios/pull/144 as the action already is enqueued on level higher