### PR TITLE
The like reactions was not updating properly when double tapping a message

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.h
@@ -58,7 +58,7 @@ typedef void (^SelectedMenuBlock)(BOOL selected, BOOL animated);
 
 @property (nonatomic, assign) BOOL showSender;
 @property (nonatomic, assign) BOOL showBurstTimestamp;
-@property (nonatomic, assign) BOOL showToolbox;
+@property (nonatomic, assign) BOOL alwaysShowDeliveryState;
 @property (nonatomic, assign) BOOL showUnreadMarker;
 @property (nonatomic, assign) CGFloat topPadding;
 @property (nonatomic, strong) NSArray *linkAttachments;

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
@@ -318,7 +318,11 @@ const NSTimeInterval ConversationCellSelectionAnimationDuration = 0.33;
 
 - (void)updateToolboxVisibilityAnimated:(BOOL)animated
 {
-    BOOL shouldBeVisible = self.selected || self.layoutProperties.showToolbox;
+    ZMDeliveryState deliveryState = self.message.deliveryState;
+    
+    BOOL shouldShowPendingDeliveryState = self.message.conversation.conversationType == ZMConversationTypeOneOnOne;
+    BOOL shouldShowDeliveryState = (deliveryState == ZMDeliveryStatePending && shouldShowPendingDeliveryState) || deliveryState == ZMDeliveryStateFailedToSend || self.layoutProperties.alwaysShowDeliveryState;
+    BOOL shouldBeVisible = self.selected || self.message.usersReaction.count > 0 || shouldShowDeliveryState;
     
     if (! [Message shouldShowTimestamp:self.message]) {
         shouldBeVisible = NO;
@@ -547,7 +551,6 @@ const NSTimeInterval ConversationCellSelectionAnimationDuration = 0.33;
 
 - (BOOL)updateForMessage:(MessageChangeInfo *)change
 {
-    
     // If a text message changes, the only thing that can change at the moment is its delivery state
     if (change.deliveryStateChanged || change.reactionsChanged) {
         self.messageToolboxView.forceShowTimestamp = NO;
@@ -561,6 +564,8 @@ const NSTimeInterval ConversationCellSelectionAnimationDuration = 0.33;
     if (change.userChangeInfo.nameChanged || change.senderChanged) {
         [self updateSenderAndSenderImage:change.message];
     }
+    
+    [self updateToolboxVisibilityAnimated:YES];
     
     return change.reactionsChanged || (change.deliveryStateChanged);
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter.m
@@ -178,7 +178,6 @@ static NSString *const ConversationMessageDeletedCellId     = @"conversationMess
     }
     
     if (needsToLayoutCells) {
-        [self reconfigureVisibleCells];
         // Make table view to update cells with animation
         [self.tableView beginUpdates];
         [self.tableView endUpdates];

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ZMConversationMessageWindow+Formatting.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ZMConversationMessageWindow+Formatting.m
@@ -32,7 +32,7 @@
     layoutProperties.showUnreadMarker = lastUnreadMessage != nil && [message isEqual:lastUnreadMessage];
     layoutProperties.showBurstTimestamp = [self shouldShowBurstSeparatorForMessage:message] || layoutProperties.showUnreadMarker;
     layoutProperties.topPadding       = [self topPaddingForMessage:message showingSender:layoutProperties.showSender showingTimestamp:layoutProperties.showBurstTimestamp];
-    layoutProperties.showToolbox      = [self shouldShowToolboxForMessage:message];
+    layoutProperties.alwaysShowDeliveryState = [self shouldShowAlwaysDeliveryStateForMessage:message];
     
     if ([Message isTextMessage:message]) {
         layoutProperties.linkAttachments = [Message linkAttachments:message.textMessageData];
@@ -66,12 +66,8 @@
     return NO;
 }
 
-- (BOOL)shouldShowToolboxForMessage:(id<ZMConversationMessage>)message
+- (BOOL)shouldShowAlwaysDeliveryStateForMessage:(id<ZMConversationMessage>)message
 {
-    if (! [Message shouldShowTimestamp:message]) {
-        return NO;
-    }
-    
     // Loop back and check if this was last message sent by us
     if (message.sender.isSelfUser && message.conversation.conversationType == ZMConversationTypeOneOnOne) {
         if ([message.conversation lastMessageSentByUser:[ZMUser selfUser] limit:10] == message) {
@@ -79,11 +75,7 @@
         }
     }
     
-    if (message.deliveryState == ZMDeliveryStateFailedToSend) {
-        return YES;
-    }
-    
-    return [Message hasReactions:message];
+    return NO;
 }
 
 - (BOOL)shouldShowSenderForMessage:(id<ZMConversationMessage>)message


### PR DESCRIPTION
# What this PR fixes
- The message toolbox was not correctly updated when liking by double tapping. 
- The message toolbox was not collapsed when unliking.

# what changed
`showToolbox` was computed once when configuring the cell and became outdated on message updates. The fix is to do the computation on each message update instead.