### PR TITLE
Restrict liking to `normal` message types

### DIFF
--- a/Wire-iOS/Sources/Helpers/syncengine/Message.m
+++ b/Wire-iOS/Sources/Helpers/syncengine/Message.m
@@ -100,7 +100,7 @@
 
 + (BOOL)isNormalMessage:(id<ZMConversationMessage>)message
 {
-    return [self isTextMessage:message] || [self isImageMessage:message] || [self isKnockMessage:message] || [self isFileTransferMessage:message] || [self isVideoMessage:message] || [self isAudioMessage:message] || [self isLocationMessage:message] ;
+    return [self isTextMessage:message] || [self isImageMessage:message] || [self isKnockMessage:message] || [self isFileTransferMessage:message] || [self isVideoMessage:message] || [self isAudioMessage:message] || [self isLocationMessage:message];
 }
 
 + (BOOL)isConnectionRequestMessage:(id<ZMConversationMessage>)message

--- a/Wire-iOS/Sources/Helpers/syncengine/ZMMessage+Likes.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMMessage+Likes.swift
@@ -27,7 +27,9 @@ public enum ZMMessageReaction: String {
 extension ZMConversationMessage {
 
     var canBeLiked: Bool {
-        return [ZMDeliveryState.Sent, .Delivered].contains(deliveryState)
+        let sentOrDelivered = [ZMDeliveryState.Sent, .Delivered].contains(deliveryState)
+        let likableType = Message.isNormalMessage(self)
+        return sentOrDelivered && likableType
     }
 
     var liked: Bool {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
@@ -470,7 +470,7 @@ const NSTimeInterval ConversationCellSelectionAnimationDuration = 0.33;
     UIMenuController *menuController = UIMenuController.sharedMenuController;
     NSMutableArray <UIMenuItem *> *items = menuConfigurationProperties.additionalItems.mutableCopy;
 
-    if (self.message.deliveryState == ZMDeliveryStateDelivered || self.message.deliveryState == ZMDeliveryStateSent) {
+    if ([Message messageCanBeLiked:self.message]) {
         NSString *likeTitleKey = [Message isLikedMessage:self.message] ? @"content.message.unlike" : @"content.message.like";
         UIMenuItem *likeItem = [[UIMenuItem alloc] initWithTitle:NSLocalizedString(likeTitleKey, @"") action:@selector(likeMessage:)];
         [items insertObject:likeItem atIndex:0];


### PR DESCRIPTION
# What's in this PR?

* Restrict liking to `normal` message types as liking of the "deleted" system message was possible and the like button was shown.