### PR TITLE
Disable likes for knock messages

### DIFF
--- a/Wire-iOS/Sources/Helpers/syncengine/ZMMessage+Likes.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMMessage+Likes.swift
@@ -28,7 +28,7 @@ extension ZMConversationMessage {
 
     var canBeLiked: Bool {
         let sentOrDelivered = [ZMDeliveryState.Sent, .Delivered].contains(deliveryState)
-        let likableType = Message.isNormalMessage(self)
+        let likableType = Message.isNormalMessage(self) && !Message.isKnockMessage(self)
         return sentOrDelivered && likableType
     }
 


### PR DESCRIPTION
# What's in this PR?

* Knock messages should not be likable, the wrong behavior was introduced in https://github.com/wireapp/wire-ios/pull/151