### PR TITLE
Fix crash on message deletion

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
@@ -205,11 +205,13 @@ const NSTimeInterval ConversationCellSelectionAnimationDuration = 0.33;
 
 - (void)prepareForReuse
 {
+    self.message = nil;
+    [self.messageToolboxView prepareForReuse];
+    
     [super prepareForReuse];
     
     self.topMarginConstraint.constant = 0;
     self.authorImageTopMarginConstraint.constant = 0;
-    self.message = nil;
     self.beingEdited = NO;
 }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
@@ -58,6 +58,7 @@ extension ZMMessage {
     private var previousLayoutBounds: CGRect = CGRectZero
     
     private(set) weak var message: ZMMessage?
+    
     public var forceShowTimestamp: Bool = false {
         didSet {
             guard let message = self.message else {
@@ -236,6 +237,10 @@ extension ZMMessage {
         if let message = self.message where !message.likers().isEmpty {
             self.delegate?.messageToolboxViewDidSelectLikers(self)
         }
+    }
+    
+    @objc func prepareForReuse() {
+        self.message = nil
     }
 }
 


### PR DESCRIPTION
# Reason for this pull request
Crash on deleting a message, then inserting another message

When a message is deleted, the cell in the table view is disposed. However, the cell keeps a reference to the message. When a new message is inserted, the cell is prepared for reuse, and it still has a reference to the old message; accessing the old message causes a crash.

# Changes
- Clear any reference to the old message before preparing the cell for reuse