### PR TITLE
Remove title and timestamp from single image view, bounce photo icon

### DIFF
--- a/Wire-iOS/Resources/Magic/conversation.plist
+++ b/Wire-iOS/Resources/Magic/conversation.plist
@@ -255,7 +255,7 @@
 		<key>bottom_gradient_height</key>
 		<integer>68</integer>
 		<key>top_gradient_height</key>
-		<integer>88</integer>
+		<integer>60</integer>
 		<key>button_color</key>
 		<array>
 			<integer>0</integer>

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.m
@@ -472,8 +472,8 @@
 - (void)saveImage
 {
     NSData *imageData = self.message.imageMessageData.imageData;
-    SavableImage *savableImage = [[SavableImage alloc] initWithData:imageData orientation:self.imageView.image.imageOrientation completion:nil];
-    [savableImage saveToLibrary];
+    SavableImage *savableImage = [[SavableImage alloc] initWithData:imageData orientation:self.imageView.image.imageOrientation];
+    [savableImage saveToLibrary:nil];
 }
 
 - (void)setSelectedByMenu:(BOOL)selected animated:(BOOL)animated

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.m
@@ -473,7 +473,7 @@
 {
     NSData *imageData = self.message.imageMessageData.imageData;
     SavableImage *savableImage = [[SavableImage alloc] initWithData:imageData orientation:self.imageView.image.imageOrientation];
-    [savableImage saveToLibrary:nil];
+    [savableImage saveToLibraryWithCompletion:nil];
 }
 
 - (void)setSelectedByMenu:(BOOL)selected animated:(BOOL)animated

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.m
@@ -84,8 +84,6 @@
 @property (nonatomic, strong) UIView *topOverlay;
 @property (nonatomic, strong) CALayer *highlightLayer;
 
-@property (nonatomic, strong) UILabel *senderLabel;
-@property (nonatomic, strong) UILabel *timestampLabel;
 @property (nonatomic, strong) IconButton *closeButton;
 
 @property (nonatomic, strong, readwrite) UIImageView *imageView;
@@ -245,67 +243,24 @@
     self.topOverlay.translatesAutoresizingMaskIntoConstraints = NO;
     [self.view addSubview:self.topOverlay];
 
-    UIView *authorContainer = [[UIView alloc] init];
-    authorContainer.translatesAutoresizingMaskIntoConstraints = NO;
-    [self.topOverlay addSubview:authorContainer];
-
-    // Sender name
-
-    self.senderLabel = [[UILabel alloc] init];
-    self.senderLabel.translatesAutoresizingMaskIntoConstraints = NO;
-    [self.senderLabel setContentHuggingPriority:UILayoutPriorityFittingSizeLevel forAxis:UILayoutConstraintAxisHorizontal];
-    [authorContainer addSubview:self.senderLabel];
-
-    self.senderLabel.accessibilityIdentifier = @"fullScreenSenderName";
-    self.senderLabel.attributedText = [self attributedNameStringForDisplayName:self.message.sender.displayName];
-
-    // Timestamp
-
-    self.timestampLabel = [[UILabel alloc] init];
-    self.timestampLabel.translatesAutoresizingMaskIntoConstraints = NO;
-    [self.timestampLabel setContentHuggingPriority:UILayoutPriorityFittingSizeLevel forAxis:UILayoutConstraintAxisHorizontal];
-    [authorContainer addSubview:self.timestampLabel];
-
-    self.timestampLabel.text = [self.message.serverTimestamp extendedFormat];
-    self.timestampLabel.font = [UIFont fontWithMagicIdentifier:@"style.text.small.font_spec_light"];
-    self.timestampLabel.textColor = [UIColor wr_colorFromColorScheme:ColorSchemeColorTextForeground];
-    self.timestampLabel.accessibilityIdentifier = @"fullScreenTimeStamp";
-    
     // Close button
-    
     self.closeButton = [IconButton iconButtonCircular];
     self.closeButton.translatesAutoresizingMaskIntoConstraints = NO;
     [self.closeButton setIcon:ZetaIconTypeX withSize:ZetaIconSizeTiny forState:UIControlStateNormal];
     [self.topOverlay addSubview:self.closeButton];
-        
     [self.closeButton addTarget:self action:@selector(closeButtonTapped:) forControlEvents:UIControlEventTouchUpInside];
-    
     self.closeButton.accessibilityIdentifier = @"fullScreenCloseButton";
     
     // Constraints
-    
     [self.topOverlay addConstraintForRightMargin:0 relativeToView:self.view];
     [self.topOverlay addConstraintForLeftMargin:0 relativeToView:self.view];
     [self.topOverlay addConstraintForTopMargin:0 relativeToView:self.view];
     [self.topOverlay addConstraintForHeight:[WAZUIMagic floatForIdentifier:@"one_message.top_gradient_height"]];
-    
-    [authorContainer addConstraintForLeftMargin:[WAZUIMagic cgFloatForIdentifier:@"one_message.overlay_left_margin"] relativeToView:self.topOverlay];
-    [authorContainer addConstraintForAligningRightToLeftOfView:self.closeButton distance:0];
-    [authorContainer addConstraintForAligningVerticallyWithView:self.topOverlay offset:10];
-    
+
     [self.closeButton addConstraintForAligningVerticallyWithView:self.topOverlay offset:10];
     [self.closeButton addConstraintForRightMargin:[WAZUIMagic cgFloatForIdentifier:@"one_message.overlay_right_margin"] relativeToView:self.topOverlay];
     [self.closeButton autoSetDimension:ALDimensionWidth toSize:32];
     [self.closeButton autoMatchDimension:ALDimensionWidth toDimension:ALDimensionHeight ofView:self.closeButton];
-    
-    [self.senderLabel addConstraintForLeftMargin:0 relativeToView:authorContainer];
-    [self.senderLabel addConstraintForRightMargin:0 relativeToView:authorContainer];
-    [self.senderLabel addConstraintForTopMargin:0 relativeToView:authorContainer];
-    
-    [self.timestampLabel addConstraintForAligningTopToBottomOfView:self.senderLabel distance:0];
-    [self.timestampLabel addConstraintForRightMargin:0 relativeToView:authorContainer];
-    [self.timestampLabel addConstraintForLeftMargin:0 relativeToView:authorContainer];
-    [self.timestampLabel addConstraintForBottomMargin:0 relativeToView:authorContainer];
 }
 
 - (void)showChrome:(BOOL)shouldShow

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ImageMessageCell.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ImageMessageCell.h
@@ -18,7 +18,10 @@
 
 
 #import "ConversationCell.h"
+@class SavableImage;
 
 @interface ImageMessageCell : ConversationCell
+
+@property (nonatomic, readonly) SavableImage *savableImage;
 
 @end

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ImageMessageCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ImageMessageCell.m
@@ -38,7 +38,6 @@
 #import "UIView+Borders.h"
 
 
-NSString * const ImageMessageCellDidSaveImageNotificationName = @"ImageMessageCellDidSaveImageNotificationName";
 
 
 @interface Message (DataIdentifier)

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ImageMessageCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ImageMessageCell.m
@@ -462,10 +462,11 @@ static ImageCache *imageCache(void)
 
 - (void)saveImage
 {
-    NSData *data = [self.message imageMessageData].mediumData;
-    SavableImage *savableImage = [[SavableImage alloc] initWithData:data
-                                                        orientation:self.fullImageView.image.imageOrientation
-                                                         completion:nil];
+    NSData *data = self.message.imageMessageData.mediumData;
+    UIImageOrientation orientation = self.fullImageView.image.imageOrientation;
+    SavableImage *savableImage = [[SavableImage alloc] initWithData:data orientation:orientation completion:^{
+        [NSNotificationCenter.defaultCenter postNotificationName:@"BounceCameraIcon" object:nil];
+    }];
 
     [savableImage saveToLibrary];
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/LikeButton.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/LikeButton.swift
@@ -45,7 +45,6 @@ public class LikeButton: IconButton {
             imageView.superview!.addSubview(animationImageView)
 
             imageView.alpha = 0
-            
             if selected { // gets like
                 animationImageView.alpha = 0.0
                 animationImageView.transform = CGAffineTransformMakeScale(6.3, 6.3)

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/SavableImage.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/SavableImage.swift
@@ -34,7 +34,7 @@ import AssetsLibrary
         super.init()
     }
     
-    public func saveToLibrary(completion: ImageSaveCompletion?) {
+    public func saveToLibrary(withCompletion completion: ImageSaveCompletion?) {
         guard !writeInProgess else { return }
         writeInProgess = true
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/SavableImage.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/SavableImage.swift
@@ -21,28 +21,28 @@ import AssetsLibrary
 
 @objc final public class SavableImage: NSObject {
 
-    typealias ImageSaveCompletion = () -> Void
+    public typealias ImageSaveCompletion = () -> Void
     
     private let imageData: NSData
     private let imageOrientation: UIImageOrientation
     private let library = ALAssetsLibrary()
     private var writeInProgess = false
-    private let saveCompletion: ImageSaveCompletion?
-    
-    init(data: NSData, orientation: UIImageOrientation, completion: ImageSaveCompletion?) {
+
+    init(data: NSData, orientation: UIImageOrientation) {
         imageData = data
         imageOrientation = orientation
-        saveCompletion = completion
         super.init()
     }
     
-    public func saveToLibrary() {
+    public func saveToLibrary(completion: ImageSaveCompletion?) {
         guard !writeInProgess else { return }
         writeInProgess = true
-        
+
         let metadata: [String: NSObject] = [ALAssetPropertyOrientation: imageOrientation.exifOrientiation]
-        library.writeImageDataToSavedPhotosAlbum(imageData, metadata: metadata) { _, _ in
-            self.saveCompletion?()
+        library.writeImageDataToSavedPhotosAlbum(imageData, metadata: metadata) { [weak self] _, _ in
+            guard let `self` = self else { return }
+            self.writeInProgess = false
+            completion?()
         }
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/SavableImage.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/SavableImage.swift
@@ -41,8 +41,8 @@ import AssetsLibrary
         writeInProgess = true
         
         let metadata: [String: NSObject] = [ALAssetPropertyOrientation: imageOrientation.exifOrientiation]
-        library.writeImageDataToSavedPhotosAlbum(imageData, metadata: metadata) { [weak self] _, _ in
-            self?.saveCompletion?()
+        library.writeImageDataToSavedPhotosAlbum(imageData, metadata: metadata) { _, _ in
+            self.saveCompletion?()
         }
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -510,7 +510,7 @@
 
 - (void)saveImage:(SavableImage *)savableImage
 {
-    [savableImage saveToLibrary:^{
+    [savableImage saveToLibraryWithCompletion:^{
         [self.delegate conversationContentViewControllerDidSaveImage:self];
     }];
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -62,6 +62,7 @@
 #import "TextMessageCell.h"
 #import "PingCell.h"
 #import "StopWatch.h"
+#import "ImageMessageCell.h"
 
 #import "SketchViewController.h"
 #import "AnalyticsTracker+Sketchpad.h"
@@ -507,6 +508,13 @@
     [Analytics shared].sessionSummary.imageContentsClicks++;
 }
 
+- (void)saveImage:(SavableImage *)savableImage
+{
+    [savableImage saveToLibrary:^{
+        [self.delegate conversationContentViewControllerDidSaveImage:self];
+    }];
+}
+
 - (void)fullscreenImageViewController:(FullscreenImageViewController *)controller wantsEditImageMessage:(id<ZMConversationMessage>)message
 {
     [controller dismissViewControllerAnimated:NO completion:nil];
@@ -802,8 +810,12 @@
             break;
         case ConversationCellActionSave:
         {
-            self.conversationMessageWindowTableViewAdapter.selectedMessage = cell.message;
-            [self openDocumentControllerForMessage:cell.message atIndexPath:[self.tableView indexPathForCell:cell] withPreview:NO];
+            if ([cell isKindOfClass:ImageMessageCell.class]) {
+                [self saveImage:[(ImageMessageCell *)cell savableImage]];
+            } else {
+                self.conversationMessageWindowTableViewAdapter.selectedMessage = cell.message;
+                [self openDocumentControllerForMessage:cell.message atIndexPath:[self.tableView indexPathForCell:cell] withPreview:NO];
+            }
         }
             break;
         case ConversationCellActionEdit:

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewControllerDelegate.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewControllerDelegate.h
@@ -48,6 +48,8 @@ didEndDisplayingActiveMediaPlayerForMessage:(id<ZMConversationMessage>)message;
 
 - (void)conversationContentViewController:(ConversationContentViewController *)contentViewController didTriggerEditingMessage:(ZMMessage *)message;
 
+- (void)conversationContentViewControllerDidSaveImage:(ConversationContentViewController *)contentViewController;
+
 - (BOOL)conversationContentViewController:(ConversationContentViewController *)controller shouldBecomeFirstResponderWhenShowMenuFromCell:(UITableViewCell *)cell;
 
 @optional

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -610,6 +610,11 @@
     }
 }
 
+- (void)conversationContentViewControllerDidSaveImage:(ConversationContentViewController *)contentViewController
+{
+    [self.inputBarController bounceCameraIcon];
+}
+
 @end
 
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.h
@@ -55,5 +55,6 @@ typedef NS_ENUM(NSUInteger, ConversationInputBarViewControllerMode) {
 @property (nonatomic, readonly) UIViewController *inputController;
 
 - (instancetype)initWithConversation:(ZMConversation *)conversation;
+- (void)bounceCameraIcon;
 
 @end

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -563,7 +563,7 @@
 
 - (void)bounceCameraIcon;
 {
-    CGAffineTransform scaleTransform = CGAffineTransformMakeScale(1.2, 1.2);
+    CGAffineTransform scaleTransform = CGAffineTransformMakeScale(1.3, 1.3);
     
     dispatch_block_t scaleUp = ^{
         self.photoButton.transform = scaleTransform;

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -55,6 +55,7 @@
 #import "Wire-Swift.h"
 #import "UIView+WR_ExtendedBlockAnimations.h"
 #import "UIView+Borders.h"
+#import "ImageMessageCell.h"
 
 #import "Wire-Swift.h"
 
@@ -160,7 +161,6 @@
         }
         
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardDidHide:) name:UIKeyboardDidHideNotification object:nil];
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(bounceCameraIcon:) name:@"BounceCameraIcon" object:nil];
     }
     return self;
 }
@@ -173,23 +173,6 @@
     if ([self.conversation shouldDisplayIsTyping]) {
         [ZMConversation removeTypingObserver:self];
     }
-}
-
-- (void)bounceCameraIcon:(NSNotification *)note
-{
-    CGAffineTransform scaleTransform = CGAffineTransformMakeScale(1.2, 1.2);
-    
-    dispatch_block_t scaleUp = ^{
-        self.photoButton.transform = scaleTransform;
-    };
-    
-    dispatch_block_t scaleDown = ^{
-        self.photoButton.transform = CGAffineTransformInvert(scaleTransform);
-    };
-
-    [UIView animateWithDuration:0.1 delay:0.2 options:UIViewAnimationOptionCurveEaseIn animations:scaleUp completion:^(__unused BOOL finished) {
-        [UIView animateWithDuration:0.25 delay:0 usingSpringWithDamping:0.7 initialSpringVelocity:0.6 options:UIViewAnimationOptionCurveEaseOut animations:scaleDown completion:nil];
-    }];
 }
 
 - (void)viewDidLoad
@@ -574,6 +557,25 @@
             [self.sendController sendTextMessage:candidateText];
         }
     }
+}
+
+#pragma mark - Animations
+
+- (void)bounceCameraIcon;
+{
+    CGAffineTransform scaleTransform = CGAffineTransformMakeScale(1.2, 1.2);
+    
+    dispatch_block_t scaleUp = ^{
+        self.photoButton.transform = scaleTransform;
+    };
+    
+    dispatch_block_t scaleDown = ^{
+        self.photoButton.transform = CGAffineTransformIdentity;
+    };
+
+    [UIView animateWithDuration:0.1 delay:0.2 options:UIViewAnimationOptionCurveEaseIn animations:scaleUp completion:^(__unused BOOL finished) {
+        [UIView animateWithDuration:0.3 delay:0 usingSpringWithDamping:0.5 initialSpringVelocity:0.6 options:UIViewAnimationOptionCurveEaseOut animations:scaleDown completion:nil];
+    }];
 }
 
 @end

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -160,6 +160,7 @@
         }
         
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardDidHide:) name:UIKeyboardDidHideNotification object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(bounceCameraIcon:) name:@"BounceCameraIcon" object:nil];
     }
     return self;
 }
@@ -172,6 +173,23 @@
     if ([self.conversation shouldDisplayIsTyping]) {
         [ZMConversation removeTypingObserver:self];
     }
+}
+
+- (void)bounceCameraIcon:(NSNotification *)note
+{
+    CGAffineTransform scaleTransform = CGAffineTransformMakeScale(1.2, 1.2);
+    
+    dispatch_block_t scaleUp = ^{
+        self.photoButton.transform = scaleTransform;
+    };
+    
+    dispatch_block_t scaleDown = ^{
+        self.photoButton.transform = CGAffineTransformInvert(scaleTransform);
+    };
+
+    [UIView animateWithDuration:0.1 delay:0.2 options:UIViewAnimationOptionCurveEaseIn animations:scaleUp completion:^(__unused BOOL finished) {
+        [UIView animateWithDuration:0.25 delay:0 usingSpringWithDamping:0.7 initialSpringVelocity:0.6 options:UIViewAnimationOptionCurveEaseOut animations:scaleDown completion:nil];
+    }];
 }
 
 - (void)viewDidLoad


### PR DESCRIPTION
# What's in this PR?

* From design review: The full screen image view should only show the close button.
* When saving from the image cells menu the camera icon should bounce.