### PR TITLE
Only notify the delegate that the likers have been tapped when they are shown

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
@@ -241,8 +241,9 @@ extension ZMMessage {
     }
     
     // MARK: - Events
-    
-    @objc func onTapContent(button: UIButton!) {        
+
+    @objc func onTapContent(sender: UITapGestureRecognizer!) {
+        guard !forceShowTimestamp else { return }
         if let message = self.message where !message.likers().isEmpty {
             self.delegate?.messageToolboxViewDidSelectLikers(self)
         }


### PR DESCRIPTION
# What's in this PR?

* Only notify the delegate that the likers have been tapped if they are currently shown in the `MessageToolBoxView`