### PR TITLE
If the additional items were nil no other menu items would be added

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
@@ -469,7 +469,9 @@ const NSTimeInterval ConversationCellSelectionAnimationDuration = 0.33;
     }
     
     UIMenuController *menuController = UIMenuController.sharedMenuController;
-    NSMutableArray <UIMenuItem *> *items = menuConfigurationProperties.additionalItems.mutableCopy;
+    
+    NSMutableArray <UIMenuItem *> *items = [NSMutableArray array];
+    [items addObjectsFromArray:menuConfigurationProperties.additionalItems];
 
     if ([Message messageCanBeLiked:self.message]) {
         NSString *likeTitleKey = [Message isLikedMessage:self.message] ? @"content.message.unlike" : @"content.message.like";


### PR DESCRIPTION
# What's in this PR?

There was a bug preventing the delete menu to be added to the `UIMenuController` of the `LocationMessageCell`, it was caused by making a mutable copy of the menu configuration properties `additionalItems` which can be nil.