### PR TITLE
Fix contraint causing status label not being clipped

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
@@ -97,7 +97,7 @@ extension ZMConversationMessage {
         labelClipView.addSubview(statusLabel)
         
         constrain(self, self.reactionsView, self.statusLabel, self.labelClipView) { selfView, reactionsView, statusLabel, labelClipView in
-            labelClipView.left <= selfView.left
+            labelClipView.left == selfView.left
             labelClipView.centerY == selfView.centerY
             labelClipView.right == selfView.right
             


### PR DESCRIPTION
## Changes in this PR
Constraint was allowing the `statusLabel` to grow indefinitely.