### PR TITLE
Fix animations order for like state in timestamp

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell+Like.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell+Like.swift
@@ -44,10 +44,9 @@ public extension ConversationCell {
 
         ZMUserSession.sharedSession().performChanges {
             self.message.liked = !self.message.liked
+            self.likeButton.setSelected(self.message.liked, animated: true)
+            self.messageToolboxView.configureForMessage(self.message, animated: true)
         }
-        
-        self.likeButton.setSelected(self.message.liked, animated: true)
-        self.messageToolboxView.configureForMessage(self.message, animated: true)
     }
     
 }


### PR DESCRIPTION
- On slow device we first set the new state, then update the view with animation
- On fast device the notification of update arrive before we put the animations in
- Solution is to perform the animated update right after property is set