### PR TITLE
Animate image moving down into the photo button on save

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.m
@@ -258,7 +258,7 @@
     [self.topOverlay addConstraintForHeight:[WAZUIMagic floatForIdentifier:@"one_message.top_gradient_height"]];
 
     [self.closeButton addConstraintForAligningVerticallyWithView:self.topOverlay offset:10];
-    [self.closeButton addConstraintForRightMargin:[WAZUIMagic cgFloatForIdentifier:@"one_message.overlay_right_margin"] relativeToView:self.topOverlay];
+    [self.closeButton addConstraintForRightMargin:8 relativeToView:self.topOverlay];
     [self.closeButton autoSetDimension:ALDimensionWidth toSize:32];
     [self.closeButton autoMatchDimension:ALDimensionWidth toDimension:ALDimensionHeight ofView:self.closeButton];
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ImageMessageCell.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ImageMessageCell.h
@@ -19,9 +19,11 @@
 
 #import "ConversationCell.h"
 @class SavableImage;
+@class FLAnimatedImageView;
 
 @interface ImageMessageCell : ConversationCell
 
+@property (nonatomic, readonly) FLAnimatedImageView *fullImageView;
 @property (nonatomic, readonly) SavableImage *savableImage;
 
 @end

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -508,10 +508,14 @@
     [Analytics shared].sessionSummary.imageContentsClicks++;
 }
 
-- (void)saveImage:(SavableImage *)savableImage
+- (void)saveImageFromCell:(ImageMessageCell *)cell
 {
-    [savableImage saveToLibraryWithCompletion:^{
-        [self.delegate conversationContentViewControllerDidSaveImage:self];
+    [cell.savableImage saveToLibraryWithCompletion:^{
+        UIView *snapshot = [cell.fullImageView snapshotViewAfterScreenUpdates:YES];
+        snapshot.translatesAutoresizingMaskIntoConstraints = YES;
+        snapshot.transform = CGAffineTransformInvert(self.tableView.transform); // UpsideDownTableView
+        CGRect sourceRect = [self.view convertRect:cell.fullImageView.frame fromView:cell.fullImageView.superview];
+        [self.delegate conversationContentViewController:self performImageSaveAnimation:snapshot sourceRect:sourceRect];
     }];
 }
 
@@ -803,7 +807,7 @@
         case ConversationCellActionSave:
         {
             if ([cell isKindOfClass:ImageMessageCell.class]) {
-                [self saveImage:[(ImageMessageCell *)cell savableImage]];
+                [self saveImageFromCell:(ImageMessageCell *)cell];
             } else {
                 self.conversationMessageWindowTableViewAdapter.selectedMessage = cell.message;
                 [self openDocumentControllerForMessage:cell.message atIndexPath:[self.tableView indexPathForCell:cell] withPreview:NO];

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewControllerDelegate.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewControllerDelegate.h
@@ -48,7 +48,7 @@ didEndDisplayingActiveMediaPlayerForMessage:(id<ZMConversationMessage>)message;
 
 - (void)conversationContentViewController:(ConversationContentViewController *)contentViewController didTriggerEditingMessage:(ZMMessage *)message;
 
-- (void)conversationContentViewControllerDidSaveImage:(ConversationContentViewController *)contentViewController;
+- (void)conversationContentViewController:(ConversationContentViewController *)contentViewController performImageSaveAnimation:(UIView *)snapshotView sourceRect:(CGRect)sourceRect;
 
 - (BOOL)conversationContentViewController:(ConversationContentViewController *)controller shouldBecomeFirstResponderWhenShowMenuFromCell:(UITableViewCell *)cell;
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -65,7 +65,6 @@
 #import "AddContactsViewController.h"
 #import "ContactsDataSource.h"
 #import "VerticalTransition.h"
-#import "UIView+MTAnimation.h"
 
 #import "UIColor+WAZExtensions.h"
 #import "KeyboardFrameObserver+iOS.h"
@@ -611,7 +610,9 @@
     }
 }
 
-- (void)conversationContentViewController:(ConversationContentViewController *)contentViewController performImageSaveAnimation:(UIView *)snapshotView sourceRect:(CGRect)sourceRect
+- (void)conversationContentViewController:(ConversationContentViewController *)contentViewController
+                performImageSaveAnimation:(UIView *)snapshotView
+                               sourceRect:(CGRect)sourceRect
 {
     [self.view addSubview:snapshotView];
     snapshotView.frame = [self.view convertRect:sourceRect fromView:contentViewController.view];
@@ -619,11 +620,11 @@
     UIView *targetView = self.inputBarController.photoButton;
     CGPoint targetCenter = [self.view convertPoint:targetView.center fromView:targetView.superview];
     
-    [UIView mt_animateWithViews:@[snapshotView] duration:0.55 timingFunction:kMTEaseInExpo animations:^{
+    [UIView animateWithDuration:0.33 delay:0 options:UIViewAnimationOptionCurveEaseIn animations:^{
         snapshotView.center = targetCenter;
         snapshotView.alpha = 0;
         snapshotView.transform = CGAffineTransformConcat(snapshotView.transform, CGAffineTransformMakeScale(0.01, 0.01));
-    } completion:^{
+    } completion:^(__unused BOOL finished) {
         [snapshotView removeFromSuperview];
         [self.inputBarController bounceCameraIcon];
     }];

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -65,6 +65,7 @@
 #import "AddContactsViewController.h"
 #import "ContactsDataSource.h"
 #import "VerticalTransition.h"
+#import "UIView+MTAnimation.h"
 
 #import "UIColor+WAZExtensions.h"
 #import "KeyboardFrameObserver+iOS.h"
@@ -610,9 +611,22 @@
     }
 }
 
-- (void)conversationContentViewControllerDidSaveImage:(ConversationContentViewController *)contentViewController
+- (void)conversationContentViewController:(ConversationContentViewController *)contentViewController performImageSaveAnimation:(UIView *)snapshotView sourceRect:(CGRect)sourceRect
 {
-    [self.inputBarController bounceCameraIcon];
+    [self.view addSubview:snapshotView];
+    snapshotView.frame = [self.view convertRect:sourceRect fromView:contentViewController.view];
+
+    UIView *targetView = self.inputBarController.photoButton;
+    CGPoint targetCenter = [self.view convertPoint:targetView.center fromView:targetView.superview];
+    
+    [UIView mt_animateWithViews:@[snapshotView] duration:0.55 timingFunction:kMTEaseInExpo animations:^{
+        snapshotView.center = targetCenter;
+        snapshotView.alpha = 0;
+        snapshotView.transform = CGAffineTransformConcat(snapshotView.transform, CGAffineTransformMakeScale(0.01, 0.01));
+    } completion:^{
+        [snapshotView removeFromSuperview];
+        [self.inputBarController bounceCameraIcon];
+    }];
 }
 
 @end

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.h
@@ -20,6 +20,7 @@
 #import <UIKit/UIKit.h>
 
 @class InputBar;
+@class IconButton;
 @class ZMConversation;
 @class ConversationInputBarViewController;
 @class AnalyticsTracker;
@@ -47,6 +48,7 @@ typedef NS_ENUM(NSUInteger, ConversationInputBarViewControllerMode) {
 
 @interface ConversationInputBarViewController : UIViewController <UIPopoverPresentationControllerDelegate>
 
+@property (nonatomic, readonly) IconButton *photoButton;
 @property (nonatomic, readonly) InputBar *inputBar;
 @property (nonatomic, readonly) ZMConversation *conversation;
 @property (nonatomic, weak) id <ConversationInputBarViewControllerDelegate> delegate;

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -573,7 +573,7 @@
         self.photoButton.transform = CGAffineTransformIdentity;
     };
 
-    [UIView animateWithDuration:0.1 delay:0.2 options:UIViewAnimationOptionCurveEaseIn animations:scaleUp completion:^(__unused BOOL finished) {
+    [UIView animateWithDuration:0.1 delay:0 options:UIViewAnimationOptionCurveEaseIn animations:scaleUp completion:^(__unused BOOL finished) {
         [UIView animateWithDuration:0.3 delay:0 usingSpringWithDamping:0.5 initialSpringVelocity:0.6 options:UIViewAnimationOptionCurveEaseOut animations:scaleDown completion:nil];
     }];
 }


### PR DESCRIPTION
# What's in this PR?

* Animate the image moving into the photo button when saving (the animation is the same as previously in `FullScreenImageViewController`).
* Fix close button alignment in `FullScreenImageViewController`.