### PR TITLE
Fix upside down snapshot view when saving an image

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -513,7 +513,6 @@
     [cell.savableImage saveToLibraryWithCompletion:^{
         UIView *snapshot = [cell.fullImageView snapshotViewAfterScreenUpdates:YES];
         snapshot.translatesAutoresizingMaskIntoConstraints = YES;
-        snapshot.transform = CGAffineTransformInvert(self.tableView.transform); // UpsideDownTableView
         CGRect sourceRect = [self.view convertRect:cell.fullImageView.frame fromView:cell.fullImageView.superview];
         [self.delegate conversationContentViewController:self performImageSaveAnimation:snapshot sourceRect:sourceRect];
     }];

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -623,7 +623,7 @@
     [UIView animateWithDuration:0.33 delay:0 options:UIViewAnimationOptionCurveEaseIn animations:^{
         snapshotView.center = targetCenter;
         snapshotView.alpha = 0;
-        snapshotView.transform = CGAffineTransformConcat(snapshotView.transform, CGAffineTransformMakeScale(0.01, 0.01));
+        snapshotView.transform = CGAffineTransformMakeScale(0.01, 0.01);
     } completion:^(__unused BOOL finished) {
         [snapshotView removeFromSuperview];
         [self.inputBarController bounceCameraIcon];


### PR DESCRIPTION
# What's in this PR?

* Fixes a bug that lead to the snapshot view being upside down when saving an image.
* Inverting the transform is no longer needed as we now create a snapshot of the image view.