### PR TITLE
Restrict showing the `like this message` tooltip to likable messages

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
@@ -127,8 +127,10 @@ extension ZMConversationMessage {
         self.forceShowTimestamp = forceShowTimestamp
         self.message = message
         
+        let canShowTooltip = !Settings.sharedSettings().likeTutorialCompleted && !message.hasReactions() && message.canBeLiked
+        
         // Show like tip
-        if let sender = message.sender where !Settings.sharedSettings().likeTutorialCompleted && !sender.isSelfUser && !message.hasReactions() {
+        if let sender = message.sender where !sender.isSelfUser && canShowTooltip {
             self.reactionsView.hidden = !message.hasReactions()
             self.likeTooltipArrow.hidden = false
             self.tapGestureRecogniser.enabled = message.hasReactions()


### PR DESCRIPTION
# What's in this PR?

* Some message are not likable and the tooltip to like them should not be displayed, sorry ping.