### PR TITLE
Only allow valid center coordinates and region spans

### DIFF
--- a/Wire-iOS Tests/LocationDataTests.swift
+++ b/Wire-iOS Tests/LocationDataTests.swift
@@ -1,0 +1,61 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+@testable import Wire
+import ZMCDataModel
+import XCTest
+import MapKit
+
+
+class LocationDataTests: XCTestCase {
+    
+    func testThatLocationDataCanBeConvertedToADictionary() {
+        // given
+        let sut = LocationData.locationData(
+            withLatitude: 45,
+            longitude: 75,
+            name: name,
+            zoomLevel: 5
+        )
+        
+        // when
+        let dict = sut.toDictionary()
+        
+        // then
+        XCTAssertEqual(dict["LastLocationLatitudeKey"] as? Float, Float(45))
+        XCTAssertEqual(dict["LastLocationLongitudeKey"] as? Float, Float(75))
+        XCTAssertEqual(dict["LastLocationZoomLevelKey"] as? Int, 5)
+    }
+    
+    func testThatLocationDataCanBeCreatedFromADictionary() {
+        // when
+        let sut = LocationData.locationData(fromDictionary: [
+            "LastLocationLatitudeKey": 45,
+            "LastLocationLongitudeKey": 75,
+            "LastLocationZoomLevelKey": 5
+            ])
+
+        // then
+        XCTAssertEqual(sut?.latitude, 45)
+        XCTAssertEqual(sut?.longitude, 75)
+        XCTAssertEqual(sut?.zoomLevel, 5)
+        XCTAssertNil(sut?.name)
+    }
+
+}

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -723,6 +723,7 @@
 		BF606D751CAC16FF002BAC94 /* ToolTipViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF606D741CAC16FF002BAC94 /* ToolTipViewController.swift */; };
 		BF606D771CAC1C0A002BAC94 /* ToolTipViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BF606D761CAC1C0A002BAC94 /* ToolTipViewControllerTests.m */; };
 		BF74EE4C1CD249B000D626CB /* HockeySDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF74EE4B1CD249B000D626CB /* HockeySDK.framework */; };
+		BF78687F1D86B3710063762F /* LocationDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF78687D1D86B36D0063762F /* LocationDataTests.swift */; };
 		BF8042271BFC741F004CD789 /* NSURL+WireURLs.m in Sources */ = {isa = PBXBuildFile; fileRef = BF8042261BFC741F004CD789 /* NSURL+WireURLs.m */; };
 		BF86E11B1C245BF9001D9430 /* UserClient+Fingerprint.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF86E11A1C245BF9001D9430 /* UserClient+Fingerprint.swift */; };
 		BF8CADD91D6CAAFC007602B8 /* Conversation+SortedParticipants.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF8CADD81D6CAAFC007602B8 /* Conversation+SortedParticipants.swift */; };
@@ -2001,6 +2002,7 @@
 		BF606D741CAC16FF002BAC94 /* ToolTipViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ToolTipViewController.swift; path = ../Conversation/ToolTipViewController.swift; sourceTree = "<group>"; };
 		BF606D761CAC1C0A002BAC94 /* ToolTipViewControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ToolTipViewControllerTests.m; sourceTree = "<group>"; };
 		BF74EE4B1CD249B000D626CB /* HockeySDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = HockeySDK.framework; path = Carthage/Build/iOS/HockeySDK.framework; sourceTree = "<group>"; };
+		BF78687D1D86B36D0063762F /* LocationDataTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationDataTests.swift; sourceTree = "<group>"; };
 		BF8042251BFC741F004CD789 /* NSURL+WireURLs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURL+WireURLs.h"; sourceTree = "<group>"; };
 		BF8042261BFC741F004CD789 /* NSURL+WireURLs.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURL+WireURLs.m"; sourceTree = "<group>"; };
 		BF86E11A1C245BF9001D9430 /* UserClient+Fingerprint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UserClient+Fingerprint.swift"; sourceTree = "<group>"; };
@@ -4425,6 +4427,7 @@
 				8732670C1D2D0C49005A62C1 /* AudioRecordKeyboardViewControllerTests.swift */,
 				87F6B6351D2E9CF500F057A5 /* EmojiOnlyStringTests.swift */,
 				873DC9581D4796C100C1C9B0 /* CameraKeyboardViewControllerTests.swift */,
+				BF78687D1D86B36D0063762F /* LocationDataTests.swift */,
 				BFA13E151D4A5F7100F0A91B /* ConfirmAssetViewControllerTests.swift */,
 				1651F9BF1D36789C00A9FAE8 /* Message+FormattingTests.swift */,
 			);
@@ -5700,6 +5703,7 @@
 				8787BDD91BF374420096B1B5 /* SettingsPropertyTests.swift in Sources */,
 				1E8772231B0C8B0F005BDDC6 /* EmoticonSubstitutionConfigurationMocks.m in Sources */,
 				1651F9BC1D352C5700A9FAE8 /* ArticleViewTests.swift in Sources */,
+				BF78687F1D86B3710063762F /* LocationDataTests.swift in Sources */,
 				BF2A74751CEB595E002608BF /* AudioButtonOverlayTests.swift in Sources */,
 				BF52C15E1CAEC1430037331F /* ArchivedNavigationBarTests.m in Sources */,
 				8732670E1D2D0C5C005A62C1 /* AudioRecordKeyboardViewControllerTests.swift in Sources */,

--- a/Wire-iOS/Sources/UserInterface/Location/MapKit+Helper.swift
+++ b/Wire-iOS/Sources/UserInterface/Location/MapKit+Helper.swift
@@ -52,8 +52,10 @@ extension MKMapView {
     }
     
     func setCenterCoordinate(coordinate: CLLocationCoordinate2D, zoomLevel: Int, animated: Bool = false) {
-        let span = MKCoordinateSpanMake(360 / pow(2, Double(zoomLevel)) * Double(frame.height) / 256, 0)
-        setRegion(MKCoordinateRegionMake(coordinate, span), animated: animated)
+        guard CLLocationCoordinate2DIsValid(coordinate) else { return }
+        let latitudeDelta = min(360 / pow(2, Double(zoomLevel)) * Double(frame.height) / 256, 180)
+        let region = MKCoordinateRegionMake(coordinate, MKCoordinateSpanMake(latitudeDelta, 0))
+        setRegion(region, animated: animated)
     }
 
 }


### PR DESCRIPTION
# What's in this PR?

* Fixes [7261](https://wearezeta.atlassian.net/browse/ZIOS-7261):  Only allow valid regions and spans when setting a location on a  `MKMapView`.
* Add tests to location persistence helper.