### PR TITLE
Fix for the rejection reason method name

### DIFF
--- a/WireExtensionComponents/Utilities/NetworkStatus.h
+++ b/WireExtensionComponents/Utilities/NetworkStatus.h
@@ -39,7 +39,8 @@ typedef NS_ENUM(NSInteger, ServerReachability) {
 @protocol NetworkStatusObserver <NSObject>
 
 /// note.object is the NetworkStatus instance doing the monitoring.
-- (void)networkStatusDidChange:(NSNotification *)note;
+/// Method name @c `-networkStatusDidChange:` conflicts with some apple internal method name.
+- (void)wr_networkStatusDidChange:(NSNotification *)note;
 
 @end
 

--- a/WireExtensionComponents/Utilities/NetworkStatus.m
+++ b/WireExtensionComponents/Utilities/NetworkStatus.m
@@ -155,7 +155,7 @@ void ReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkReachability
     [self sharedStatus];
     
     [[NSNotificationCenter defaultCenter] addObserver:observer
-                                             selector:@selector(networkStatusDidChange:)
+                                             selector:@selector(wr_networkStatusDidChange:)
                                                  name:NetworkStatusNotificationName
                                                object:nil];
 }


### PR DESCRIPTION
# Issue

Apple rejected the binary of 2.16 because it thinks that our internal method name `-networkStatusDidChange:` in our internal protocol is violating the private API use.

# Solution

~~Use android.~~ Rename the method.