### PR TITLE
Remove disabling AVS by default

### DIFF
--- a/Wire-iOS/Sources/AppDelegate.m
+++ b/Wire-iOS/Sources/AppDelegate.m
@@ -113,11 +113,7 @@
 
 - (BOOL)application:(UIApplication *)application willFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-#if TARGET_OS_SIMULATOR
-    #pragma mark TEMPORARILY disable AVS on simulator
-    [Settings sharedSettings].disableAVS = YES;
-#endif
-    
+
     DDLogInfo(@"application:willFinishLaunchingWithOptions %@ (applicationState = %ld)", launchOptions, (long)application.applicationState);
     
     [self setupLogging];

--- a/Wire-iOS/Sources/Helpers/NSData+MD5.swift
+++ b/Wire-iOS/Sources/Helpers/NSData+MD5.swift
@@ -23,7 +23,7 @@ extension Data {
     func wr_MD5Hash() -> String {
         let digestLen = Int(CC_MD5_DIGEST_LENGTH)
         let result = UnsafeMutablePointer<CUnsignedChar>.allocate(capacity: digestLen)
-        self.withUnsafeBytes { bytes in
+        let _ = withUnsafeBytes { bytes in
             CC_MD5(bytes, CC_LONG(self.count), result)
         }
         


### PR DESCRIPTION
# What's in this PR?

* The  new AVS version 2.9.5 has a workaround for the `AVCaptureSession` crash on Simulator
* Fix a unused result warning