### PR TITLE
Fix crash when sending image

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ImageMessageCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ImageMessageCell.m
@@ -347,6 +347,10 @@ static ImageCache *imageCache(void)
 - (void)updateSavableImage
 {
     NSData *data = self.message.imageMessageData.mediumData;
+    if (nil == data) {
+        return;
+    }
+
     UIImageOrientation orientation = self.fullImageView.image.imageOrientation;
     self.savableImage = [[SavableImage alloc] initWithData:data orientation:orientation];
 }


### PR DESCRIPTION
# What's in this PR?

* We were passing a `nullable` `NSData` into a method expecting a non-optional , which now crashes ¯\\\_(ツ)_/¯