### PR TITLE
Fix crash when force unwrapping a view snapshot

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
@@ -100,7 +100,10 @@ extension ZMConversationMessage {
             labelClipView.centerY == selfView.centerY
             labelClipView.right == selfView.rightMargin
             
-            statusLabel.edges == labelClipView.edges
+            statusLabel.left == labelClipView.left
+            statusLabel.top == labelClipView.top
+            statusLabel.bottom == labelClipView.bottom
+            statusLabel.right <= reactionsView.left
             
             reactionsView.right == selfView.rightMargin
             reactionsView.centerY == selfView.centerY

--- a/Wire-iOS/Sources/UserInterface/Helpers/UIView+SlideInState.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UIView+SlideInState.swift
@@ -25,11 +25,9 @@ public enum SlideDirection: UInt {
 
 public extension UIView {
     func wr_animateSlideTo(_ direction: SlideDirection = .down, newState: ()->()) {
-        guard let superview = self.superview else {
+        guard let superview = self.superview, let screenshot = snapshotView(afterScreenUpdates: false) else {
             return
         }
-        
-        let screenshot = self.snapshotView(afterScreenUpdates: false)!
         
         let offset = direction == .down ? -self.frame.size.height : self.frame.size.height
         screenshot.frame = self.frame


### PR DESCRIPTION
# What's in this PR?

* We were force unwrapping a view snapshot that might be `nil` in rare cases.
* Fix a layout bug where the `ReactionsView` was included in the status label.