### PR TITLE
Fix keychain deletion on logout

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
@@ -138,7 +138,6 @@ import Foundation
             let signOutButton = SettingsButtonCellDescriptor(title: "Sign out", isDestructive: false) { (cellDescriptor: SettingsCellDescriptorType) -> () in
                 Settings.shared().reset()
                 ZMUserSession.resetStateAndExit()
-                exit(0)
             }
             signOutSection = SettingsSectionDescriptor(cellDescriptors: [signOutButton], header: .none, footer: .none)
         }


### PR DESCRIPTION
# What's in this PR?

* `ZMUserSession.resetStateAndExit` already calls `exit(0)` after deleting the keychain items (for the QA logout function), but it does this async and the app was terminated before the keychain could be deleted.