### PR TITLE
Align permission request copy

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/InfoPlist.strings
+++ b/Wire-iOS/Resources/Base.lproj/InfoPlist.strings
@@ -16,7 +16,7 @@
  *  along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-"NSContactsUsageDescription" = "We’d like to access your Contacts so we can connect you with people you might know. Your data is safely stored with us and not shared with anyone else.";
-"NSMicrophoneUsageDescription" = "You will be able to talk to people and send audio messages";
+"NSContactsUsageDescription" = "Allow Wire to access your contacts to connect you with others. We anonymize all information and do not share it with anyone else.";
+"NSMicrophoneUsageDescription" = "Allow Wire to access your microphone so you can talk to people and send audio messages.";
 "NSLocationWhenInUseUsageDescription" = "Allow Wire to access your location so you can send your location to others.";
-"NSCameraUsageDescription" = "You would be able to place video calls and send photos";
+"NSCameraUsageDescription" = "Allow Wire to access your camera so you can place video calls and send photos.";


### PR DESCRIPTION
Use parallel constructions: “Allow Wire to access…”

@teller This fixes the issue you raised with the “You would be able to…” copy, which was introduced on September 23 in fe24cba with Feature/swift3 (#235).