### PR TITLE
Guard for non-nan progress

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ProgressView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ProgressView.swift
@@ -78,6 +78,12 @@ import Foundation
     }
 
     fileprivate func updateProgress(_ animated: Bool) {
+        guard self.progress.isNormal &&
+                self.bounds.width != 0 &&
+                    self.bounds.height != 0 else {
+            return
+        }
+        
         let progress = (self.deterministic ?? false) ? self.progress : 1;
         
         let setBlock = {


### PR DESCRIPTION
# Issue

The midi player reports incorrect progress. 

More general issue is that midi does not really play. This we can fix in the future by declaring midi as a non-media type or finding the way to play it.

# Fix

Guard for correct progress in `ProgressView`