### PR TITLE
Disable Hockey when localytics is disabled

### DIFF
--- a/Wire-iOS Tests/Settings/SettingsPropertyTests.swift
+++ b/Wire-iOS Tests/Settings/SettingsPropertyTests.swift
@@ -58,6 +58,9 @@ class ZMMockAnalytics: AnalyticsInterface {
     var isOptedOut: Bool = false
 }
 
+class ZMMockCrashlogManager: CrashlogManager {
+    var isCrashManagerDisabled: Bool = false
+}
 
 class SettingsPropertyTests: XCTestCase {
     let userDefaults: UserDefaults = UserDefaults.standard
@@ -98,7 +101,7 @@ class SettingsPropertyTests: XCTestCase {
         let mediaManager = ZMMockAVSMediaManager()
         let analytics = ZMMockAnalytics()
         
-        let factory = SettingsPropertyFactory(userDefaults: self.userDefaults, analytics: analytics, mediaManager: mediaManager, userSession : userSession, selfUser: selfUser)
+        let factory = SettingsPropertyFactory(userDefaults: self.userDefaults, analytics: analytics, mediaManager: mediaManager, userSession: userSession, selfUser: selfUser)
         
         let property = factory.property(SettingsPropertyName.ProfileName)
         // when & then
@@ -112,7 +115,7 @@ class SettingsPropertyTests: XCTestCase {
         let mediaManager = ZMMockAVSMediaManager()
         let analytics = ZMMockAnalytics()
 
-        let factory = SettingsPropertyFactory(userDefaults: self.userDefaults, analytics: analytics, mediaManager: mediaManager, userSession : userSession, selfUser: selfUser)
+        let factory = SettingsPropertyFactory(userDefaults: self.userDefaults, analytics: analytics, mediaManager: mediaManager, userSession: userSession, selfUser: selfUser)
         
         let property = factory.property(SettingsPropertyName.SoundAlerts)
         // when & then
@@ -125,8 +128,9 @@ class SettingsPropertyTests: XCTestCase {
         let userSession = MockZMUserSession()
         let mediaManager = ZMMockAVSMediaManager()
         let analytics = ZMMockAnalytics()
-
-        let factory = SettingsPropertyFactory(userDefaults: self.userDefaults, analytics: analytics, mediaManager: mediaManager, userSession : userSession, selfUser: selfUser)
+        let crashlogManager = ZMMockCrashlogManager()
+        
+        let factory = SettingsPropertyFactory(userDefaults: self.userDefaults, analytics: analytics, mediaManager: mediaManager, userSession: userSession, selfUser: selfUser, crashlogManager: crashlogManager)
         
         let property = factory.property(SettingsPropertyName.AnalyticsOptOut)
         // when & then

--- a/Wire-iOS/Sources/AppDelegate+Hockey.m
+++ b/Wire-iOS/Sources/AppDelegate+Hockey.m
@@ -34,6 +34,7 @@
         [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"kBITExcludeApplicationSupportFromBackup"];
         
         BITHockeyManager *hockeyManager = [BITHockeyManager sharedHockeyManager];
+        hockeyManager.disableCrashManager = [Analytics.shared isOptedOut];
         [hockeyManager configureWithIdentifier:@STRINGIZE(HOCKEY_APP_ID_KEY) delegate:self];
         [hockeyManager.authenticator setIdentificationType:BITAuthenticatorIdentificationTypeAnonymous];
         if (! [BITHockeyManager sharedHockeyManager].crashManager.didCrashInLastSession) {

--- a/Wire-iOS/Sources/Components/Settings/SettingsPropertyFactory.swift
+++ b/Wire-iOS/Sources/Components/Settings/SettingsPropertyFactory.swift
@@ -56,12 +56,20 @@ enum SettingsPropertyError: Error {
     case WrongValue(String)
 }
 
+protocol CrashlogManager {
+   var isCrashManagerDisabled: Bool { get set }
+}
+
+extension BITHockeyManager: CrashlogManager {
+}
+
 class SettingsPropertyFactory {
     let userDefaults: UserDefaults
     var analytics: AnalyticsInterface?
     var mediaManager: AVSMediaManagerInterface?
     var userSession: ZMUserSessionInterface
     let selfUser: SettingsSelfUser
+    var crashlogManager: CrashlogManager?
     
     static let userDefaultsPropertiesToKeys: [SettingsPropertyName: String] = [
         SettingsPropertyName.Markdown                   : UserDefaultMarkdown,
@@ -76,12 +84,13 @@ class SettingsPropertyFactory {
         SettingsPropertyName.DisableAnalytics           : UserDefaultDisableAnalytics,
     ]
     
-    init(userDefaults: UserDefaults, analytics: AnalyticsInterface?, mediaManager: AVSMediaManagerInterface?, userSession: ZMUserSessionInterface, selfUser: SettingsSelfUser) {
+    init(userDefaults: UserDefaults, analytics: AnalyticsInterface?, mediaManager: AVSMediaManagerInterface?, userSession: ZMUserSessionInterface, selfUser: SettingsSelfUser, crashlogManager: CrashlogManager? = .none) {
         self.userDefaults = userDefaults
         self.analytics = analytics
         self.mediaManager = mediaManager
         self.userSession = userSession
         self.selfUser = selfUser
+        self.crashlogManager = crashlogManager
     }
     
     func property(_ propertyName: SettingsPropertyName) -> SettingsProperty {
@@ -175,12 +184,15 @@ class SettingsPropertyFactory {
                 }
             }
             let setAction : SetAction = { (property: SettingsBlockProperty, value: SettingsPropertyValue) throws -> () in
-                if var analytics = self.analytics {
+                if var analytics = self.analytics,
+                    var crashlogManager = self.crashlogManager {
                     switch(value) {
                     case .number(let intValue):
                         analytics.isOptedOut = Bool(intValue)
+                        crashlogManager.isCrashManagerDisabled = Bool(intValue)
                     case .bool(let boolValue):
                         analytics.isOptedOut = boolValue
+                        crashlogManager.isCrashManagerDisabled = boolValue
                     default:
                         throw SettingsPropertyError.WrongValue("Incorrect type \(value) for key \(propertyName)")
                     }

--- a/Wire-iOS/Sources/Helpers/sound/AVSMediaManager+CustomSounds.swift
+++ b/Wire-iOS/Sources/Helpers/sound/AVSMediaManager+CustomSounds.swift
@@ -25,7 +25,8 @@ extension AVSMediaManager {
                                                               analytics: Analytics.shared(),
                                                               mediaManager: AVSProvider.shared.mediaManager,
                                                               userSession: ZMUserSession.shared(),
-                                                              selfUser: ZMUser.selfUser())
+                                                              selfUser: ZMUser.selfUser(),
+                                                              crashlogManager: BITHockeyManager.shared())
         return settingsPropertyFactory
     }
     

--- a/Wire-iOS/Sources/UserInterface/Settings/SettingsNavigationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/SettingsNavigationController.swift
@@ -36,7 +36,8 @@ import Foundation
             analytics: Analytics.shared(),
             mediaManager: AVSProvider.shared.mediaManager,
             userSession: ZMUserSession.shared(),
-            selfUser: ZMUser.selfUser())
+            selfUser: ZMUser.selfUser(),
+            crashlogManager: BITHockeyManager.shared())
         
         let settingsCellDescriptorFactory = SettingsCellDescriptorFactory(settingsPropertyFactory: settingsPropertyFactory)
         

--- a/Wire-iOS/WireBridgingHeader.h
+++ b/Wire-iOS/WireBridgingHeader.h
@@ -116,6 +116,7 @@
 #import "UIView+UIAppearanceSwift.h"
 #import "LinkAttachment.h"
 #import "Message+Formatting.h"
+@import HockeySDK;
 
 // Camera
 #import "CameraController.h"


### PR DESCRIPTION
# Issue

We continue to use hockey when user selected not to track.

# Solution

Check the proper settings and sync the state between hockey and localytics.