### PR TITLE
Move dark theme and send button into new options section

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -760,6 +760,7 @@
 		BFC914921D1814AF001F068B /* LocationMessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFC914911D1814AF001F068B /* LocationMessageCell.swift */; };
 		BFC9149B1D181BE7001F068B /* LocationMessageCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFC914991D181B7C001F068B /* LocationMessageCellTests.swift */; };
 		BFCF31D51D9E91880039B3DC /* RecentlyUsedEmojis.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFCF31D41D9E91880039B3DC /* RecentlyUsedEmojis.swift */; };
+		BFCF31D71DA3A9350039B3DC /* SettingsCellDescriptorFactory+Options.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFCF31D61DA3A9350039B3DC /* SettingsCellDescriptorFactory+Options.swift */; };
 		BFE08C1C1D5B5CFA002367F6 /* MessageDeletedCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE08C1B1D5B5CFA002367F6 /* MessageDeletedCell.swift */; };
 		BFE08C1E1D5B6F34002367F6 /* MessageDeletedCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE08C1D1D5B6F34002367F6 /* MessageDeletedCellTests.swift */; };
 		BFE277631D5B4FC50074DC6D /* ConversationContentViewController+MessageDeletion.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE277621D5B4FC50074DC6D /* ConversationContentViewController+MessageDeletion.swift */; };
@@ -2043,6 +2044,7 @@
 		BFC914911D1814AF001F068B /* LocationMessageCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationMessageCell.swift; sourceTree = "<group>"; };
 		BFC914991D181B7C001F068B /* LocationMessageCellTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationMessageCellTests.swift; sourceTree = "<group>"; };
 		BFCF31D41D9E91880039B3DC /* RecentlyUsedEmojis.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecentlyUsedEmojis.swift; sourceTree = "<group>"; };
+		BFCF31D61DA3A9350039B3DC /* SettingsCellDescriptorFactory+Options.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SettingsCellDescriptorFactory+Options.swift"; sourceTree = "<group>"; };
 		BFE08C1B1D5B5CFA002367F6 /* MessageDeletedCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageDeletedCell.swift; sourceTree = "<group>"; };
 		BFE08C1D1D5B6F34002367F6 /* MessageDeletedCellTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageDeletedCellTests.swift; sourceTree = "<group>"; };
 		BFE277621D5B4FC50074DC6D /* ConversationContentViewController+MessageDeletion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ConversationContentViewController+MessageDeletion.swift"; sourceTree = "<group>"; };
@@ -2674,6 +2676,7 @@
 			children = (
 				871067371C0DC5570035603B /* SettingsCellDescriptor.swift */,
 				871067381C0DC5570035603B /* SettingsCellDescriptorFactory.swift */,
+				BFCF31D61DA3A9350039B3DC /* SettingsCellDescriptorFactory+Options.swift */,
 				871067361C0DC5570035603B /* SettingsButtonCellDescriptor.swift */,
 				871067391C0DC5570035603B /* SettingsPropertySelectValueCellDescriptor.swift */,
 				8710673A1C0DC5570035603B /* SettingsPropertyTextValueCellDescriptor.swift */,
@@ -5255,6 +5258,7 @@
 				8F89140D1A9F287E0056AB0C /* ConnectRequestsCell.m in Sources */,
 				871BC28A1D34F8F800DF0793 /* UIImagePickerController+GetImage.m in Sources */,
 				8F264BA119E808A8005FF4BE /* ProximityMonitorManager.m in Sources */,
+				BFCF31D71DA3A9350039B3DC /* SettingsCellDescriptorFactory+Options.swift in Sources */,
 				871BC2851D34F8F800DF0793 /* UIColor+WAZExtensions.m in Sources */,
 				87302F4E1B15F3B0001F478C /* SearchView.m in Sources */,
 				8FC854A2199245770008B66B /* ParticipantsListCell.m in Sources */,

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -473,10 +473,10 @@
 "self.settings.sound_menu.sounds.wire_message" = "Wire Message";
 "self.settings.sound_menu.sounds.wire_ping" = "Wire Ping";
 
-// Send Button
-"self.settings.send_button.title" = "Use return key to send messages";
-"self.settings.send_button.header" = "Send Button";
-"self.settings.send_button.footer" = "If turned on, messages will be send when tapping the return key instead of the dedicated send button";
+// By popular demand
+"self.settings.popular_demand.title" = "By popular demand";
+"self.settings.popular_demand.send_button.title" = "Send Button";
+"self.settings.popular_demand.send_button.footer" = "Disable to send via the return key";
 
 // Sound alerts (TO BE UPDPATED)
 "self.settings.sound_menu.title" = "Sound alerts";

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -511,6 +511,7 @@
 "self.settings.advanced.reset_push_token.subtitle" = "If you experience problems with push notifications, Wire Support may ask you to reset this token.";
 "self.settings.advanced.reset_push_token_alert.title" = "Push token has been reset";
 "self.settings.advanced.reset_push_token_alert.message" = "Notifications will be restored in a few seconds.";
+"self.settings.advanced.version_technical_details.title" = "Version Technical Details";
 
 // Technical Report
 "self.settings.technical_report_section.title" = "Technical Report";

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptor.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptor.swift
@@ -247,7 +247,7 @@ func SettingsPropertyLabelText(_ name: SettingsPropertyName) -> String {
     case .accentColor:
         return "self.settings.account_picture_group.color".localized
     case .disableSendButton:
-        return "self.settings.send_button.title".localized
+        return "self.settings.popular_demand.send_button.title".localized
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Options.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Options.swift
@@ -1,0 +1,135 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import Foundation
+
+
+extension SettingsCellDescriptorFactory {
+
+    func optionsGroup() -> SettingsCellDescriptorType {
+
+        let shareButtonTitleDisabled = "self.settings.privacy_contacts_menu.settings_button.title".localized
+        let shareContactsDisabledSettingsButton = SettingsButtonCellDescriptor(title: shareButtonTitleDisabled, isDestructive: false, selectAction: { (descriptor: SettingsCellDescriptorType) -> () in
+            UIApplication.shared.openURL(URL(string:UIApplicationOpenSettingsURLString)!)
+        }) { (descriptor: SettingsCellDescriptorType) -> (Bool) in
+            if AddressBookHelper.sharedHelper.addressBookSearchPerformedAtLeastOnce {
+                if AddressBookHelper.sharedHelper.isAddressBookAccessDisabled || AddressBookHelper.sharedHelper.isAddressBookAccessUnknown {
+                    return true
+                }
+                else {
+                    return false
+                }
+            }
+            else {
+                return true
+            }
+        }
+        let headerText = "self.settings.privacy_contacts_section.title".localized
+        let shareFooterDisabledText = "self.settings.privacy_contacts_menu.description_disabled.title".localized
+
+        let shareContactsDisabledSection = SettingsSectionDescriptor(cellDescriptors: [shareContactsDisabledSettingsButton], header: headerText, footer: shareFooterDisabledText) { (descriptor: SettingsSectionDescriptorType) -> (Bool) in
+            return AddressBookHelper.sharedHelper.isAddressBookAccessDisabled
+        }
+
+        let clearHistoryButton = SettingsButtonCellDescriptor(title: "self.settings.privacy.clear_history.title".localized, isDestructive: false) { (cellDescriptor: SettingsCellDescriptorType) -> () in
+            // erase history is not supported yet
+        }
+        let subtitleText = "self.settings.privacy.clear_history.subtitle".localized
+
+        let clearHistorySection = SettingsSectionDescriptor(cellDescriptors: [clearHistoryButton], header: .none, footer: subtitleText)  { (_) -> (Bool) in return false }
+
+        let notificationHeader = "self.settings.notifications.push_notification.title".localized
+        let notification = SettingsPropertyToggleCellDescriptor(settingsProperty: self.settingsPropertyFactory.property(.notificationContentVisible), inverse: true)
+        let notificationFooter = "self.settings.notifications.push_notification.footer".localized
+        let notificationVisibleSection = SettingsSectionDescriptor(cellDescriptors: [notification], header: notificationHeader, footer: notificationFooter)
+
+
+        let chatHeads = SettingsPropertyToggleCellDescriptor(settingsProperty: self.settingsPropertyFactory.property(.chatHeadsDisabled), inverse: true)
+        let chatHeadsFooter = "self.settings.notifications.chat_alerts.footer".localized
+        let chatHeadsSection = SettingsSectionDescriptor(cellDescriptors: [chatHeads], header: nil, footer: chatHeadsFooter)
+
+        let soundAlert : SettingsCellDescriptorType = {
+            let titleLabel = "self.settings.sound_menu.title".localized
+
+            let soundAlertProperty = self.settingsPropertyFactory.property(.soundAlerts)
+
+            let allAlerts = SettingsPropertySelectValueCellDescriptor(settingsProperty: soundAlertProperty,
+                                                                      value: SettingsPropertyValue.number(value: Int(AVSIntensityLevel.full.rawValue)),
+                                                                      title: "self.settings.sound_menu.all_sounds.title".localized)
+
+            let someAlerts = SettingsPropertySelectValueCellDescriptor(settingsProperty: soundAlertProperty,
+                                                                       value: SettingsPropertyValue.number(value: Int(AVSIntensityLevel.some.rawValue)),
+                                                                       title: "self.settings.sound_menu.mute_while_talking.title".localized)
+
+            let noneAlerts = SettingsPropertySelectValueCellDescriptor(settingsProperty: soundAlertProperty,
+                                                                       value: SettingsPropertyValue.number(value: Int(AVSIntensityLevel.none.rawValue)),
+                                                                       title: "self.settings.sound_menu.no_sounds.title".localized)
+
+            let alertsSection = SettingsSectionDescriptor(cellDescriptors: [allAlerts, someAlerts, noneAlerts], header: titleLabel, footer: .none)
+
+            let alertPreviewGenerator : PreviewGeneratorType = {
+                let value = soundAlertProperty.value()
+                guard let rawValue = value.value() as? UInt,
+                    let intensityLevel = AVSIntensityLevel(rawValue: rawValue) else { return .text($0.title) }
+
+                switch intensityLevel {
+                case .full:
+                    return .text("self.settings.sound_menu.all_sounds.title".localized)
+                case .some:
+                    return .text("self.settings.sound_menu.mute_while_talking.title".localized)
+                case .none:
+                    return .text("self.settings.sound_menu.no_sounds.title".localized)
+                }
+
+            }
+            return SettingsGroupCellDescriptor(items: [alertsSection], title: titleLabel, identifier: .none, previewGenerator: alertPreviewGenerator)
+        }()
+
+        let soundAlertSection = SettingsSectionDescriptor(cellDescriptors: [soundAlert])
+
+
+        let soundsHeader = "self.settings.sound_menu.sounds.title".localized
+
+        let callSoundProperty = self.settingsPropertyFactory.property(.callSoundName)
+        let callSoundGroup = self.soundGroupForSetting(callSoundProperty, title: SettingsPropertyLabelText(callSoundProperty.propertyName), callSound: true, fallbackSoundName: MediaManagerSoundRingingFromThemSound, defaultSoundTitle: "self.settings.sound_menu.sounds.wire_call".localized)
+
+        let messageSoundProperty = self.settingsPropertyFactory.property(.messageSoundName)
+        let messageSoundGroup = self.soundGroupForSetting(messageSoundProperty, title: SettingsPropertyLabelText(messageSoundProperty.propertyName), callSound: false, fallbackSoundName: MediaManagerSoundMessageReceivedSound, defaultSoundTitle: "self.settings.sound_menu.sounds.wire_message".localized)
+
+        let pingSoundProperty = self.settingsPropertyFactory.property(.pingSoundName)
+        let pingSoundGroup = self.soundGroupForSetting(pingSoundProperty, title: SettingsPropertyLabelText(pingSoundProperty.propertyName), callSound: false, fallbackSoundName: MediaManagerSoundIncomingKnockSound, defaultSoundTitle: "self.settings.sound_menu.sounds.wire_ping".localized)
+
+        let soundsSection = SettingsSectionDescriptor(cellDescriptors: [callSoundGroup, messageSoundGroup, pingSoundGroup], header: soundsHeader)
+
+        let sendButtonDescriptor = SettingsPropertyToggleCellDescriptor(settingsProperty: settingsPropertyFactory.property(.disableSendButton), inverse: true)
+
+        var popularDemandDescriptors: [SettingsCellDescriptorType] = [sendButtonDescriptor]
+        if UIDevice.current.userInterfaceIdiom != .pad {
+            let darkThemeElement = SettingsPropertyToggleCellDescriptor(settingsProperty: settingsPropertyFactory.property(.darkMode))
+            popularDemandDescriptors.insert(darkThemeElement, at: 0)
+        }
+        let byPopularDemandSection = SettingsSectionDescriptor(
+            cellDescriptors: popularDemandDescriptors,
+            header: "self.settings.popular_demand.title".localized,
+            footer: "self.settings.popular_demand.send_button.footer".localized
+        )
+
+        return SettingsGroupCellDescriptor(items: [shareContactsDisabledSection, clearHistorySection, notificationVisibleSection, chatHeadsSection, soundAlertSection, soundsSection, byPopularDemandSection], title: "self.settings.options_menu.title".localized, icon: .settingsOptions)
+    }
+}

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
@@ -111,18 +111,8 @@ import Foundation
                 return .color(ZMUser.selfUser().accentColor)
         })
         
-        let appearanceCells: [SettingsCellDescriptorType]
-        
-        if UIDevice.current.userInterfaceIdiom == .pad {
-            appearanceCells = [pictureElement, colorElement]
-        }
-        else {
-            let darkThemeElement = SettingsPropertyToggleCellDescriptor(settingsProperty: self.settingsPropertyFactory.property(.darkMode))
-            appearanceCells = [pictureElement, colorElement, darkThemeElement]
-        }
-        
         let appearanceSectionTitle = "self.settings.account_appearance_group.title".localized
-        let appearanceSection = SettingsSectionDescriptor(cellDescriptors: appearanceCells, header: appearanceSectionTitle)
+        let appearanceSection = SettingsSectionDescriptor(cellDescriptors: [pictureElement, colorElement], header: appearanceSectionTitle)
         
         
         let resetPasswordTitle = "self.settings.password_reset_menu.title".localized
@@ -171,110 +161,7 @@ import Foundation
         
         return SettingsGroupCellDescriptor(items: items, title: "self.settings.account_section".localized, icon: .settingsAccount)
     }
-    
-    func optionsGroup() -> SettingsCellDescriptorType {
-        let shareButtonTitleDisabled = "self.settings.privacy_contacts_menu.settings_button.title".localized
-        let shareContactsDisabledSettingsButton = SettingsButtonCellDescriptor(title: shareButtonTitleDisabled, isDestructive: false, selectAction: { (descriptor: SettingsCellDescriptorType) -> () in
-                UIApplication.shared.openURL(URL(string:UIApplicationOpenSettingsURLString)!)
-            }) { (descriptor: SettingsCellDescriptorType) -> (Bool) in
-                if AddressBookHelper.sharedHelper.addressBookSearchPerformedAtLeastOnce {
-                    if AddressBookHelper.sharedHelper.isAddressBookAccessDisabled || AddressBookHelper.sharedHelper.isAddressBookAccessUnknown {
-                        return true
-                    }
-                    else {
-                        return false
-                    }
-                }
-                else {
-                    return true
-                }
-            }
-        let headerText = "self.settings.privacy_contacts_section.title".localized
-        let shareFooterDisabledText = "self.settings.privacy_contacts_menu.description_disabled.title".localized
-        
-        let shareContactsDisabledSection = SettingsSectionDescriptor(cellDescriptors: [shareContactsDisabledSettingsButton], header: headerText, footer: shareFooterDisabledText) { (descriptor: SettingsSectionDescriptorType) -> (Bool) in
-            return AddressBookHelper.sharedHelper.isAddressBookAccessDisabled
-        }
 
-        let clearHistoryButton = SettingsButtonCellDescriptor(title: "self.settings.privacy.clear_history.title".localized, isDestructive: false) { (cellDescriptor: SettingsCellDescriptorType) -> () in
-            // erase history is not supported yet
-        }
-        let subtitleText = "self.settings.privacy.clear_history.subtitle".localized
-        
-        let clearHistorySection = SettingsSectionDescriptor(cellDescriptors: [clearHistoryButton], header: .none, footer: subtitleText)  { (_) -> (Bool) in return false }
-        
-        let notificationHeader = "self.settings.notifications.push_notification.title".localized
-        let notification = SettingsPropertyToggleCellDescriptor(settingsProperty: self.settingsPropertyFactory.property(.notificationContentVisible), inverse: true)
-        let notificationFooter = "self.settings.notifications.push_notification.footer".localized
-        let notificationVisibleSection = SettingsSectionDescriptor(cellDescriptors: [notification], header: notificationHeader, footer: notificationFooter)
-        
-        
-        let chatHeads = SettingsPropertyToggleCellDescriptor(settingsProperty: self.settingsPropertyFactory.property(.chatHeadsDisabled), inverse: true)
-        let chatHeadsFooter = "self.settings.notifications.chat_alerts.footer".localized
-        let chatHeadsSection = SettingsSectionDescriptor(cellDescriptors: [chatHeads], header: nil, footer: chatHeadsFooter)
-        
-        let soundAlert : SettingsCellDescriptorType = {
-            let titleLabel = "self.settings.sound_menu.title".localized
-            
-            let soundAlertProperty = self.settingsPropertyFactory.property(.soundAlerts)
-            
-            let allAlerts = SettingsPropertySelectValueCellDescriptor(settingsProperty: soundAlertProperty,
-                                                                      value: SettingsPropertyValue.number(value: Int(AVSIntensityLevel.full.rawValue)),
-                                                                      title: "self.settings.sound_menu.all_sounds.title".localized)
-            
-            let someAlerts = SettingsPropertySelectValueCellDescriptor(settingsProperty: soundAlertProperty,
-                                                                       value: SettingsPropertyValue.number(value: Int(AVSIntensityLevel.some.rawValue)),
-                                                                       title: "self.settings.sound_menu.mute_while_talking.title".localized)
-            
-            let noneAlerts = SettingsPropertySelectValueCellDescriptor(settingsProperty: soundAlertProperty,
-                                                                       value: SettingsPropertyValue.number(value: Int(AVSIntensityLevel.none.rawValue)),
-                                                                       title: "self.settings.sound_menu.no_sounds.title".localized)
-            
-            let alertsSection = SettingsSectionDescriptor(cellDescriptors: [allAlerts, someAlerts, noneAlerts], header: titleLabel, footer: .none)
-            
-            let alertPreviewGenerator : PreviewGeneratorType = {
-                let value = soundAlertProperty.value()
-                guard let rawValue = value.value() as? UInt,
-                    let intensityLevel = AVSIntensityLevel(rawValue: rawValue) else { return .text($0.title) }
-                
-                switch intensityLevel {
-                case .full:
-                    return .text("self.settings.sound_menu.all_sounds.title".localized)
-                case .some:
-                    return .text("self.settings.sound_menu.mute_while_talking.title".localized)
-                case .none:
-                    return .text("self.settings.sound_menu.no_sounds.title".localized)
-                }
-                
-            }
-            return SettingsGroupCellDescriptor(items: [alertsSection], title: titleLabel, identifier: .none, previewGenerator: alertPreviewGenerator)
-        }()
-        
-        let soundAlertSection = SettingsSectionDescriptor(cellDescriptors: [soundAlert])
-        
-        
-        let soundsHeader = "self.settings.sound_menu.sounds.title".localized
-        
-        let callSoundProperty = self.settingsPropertyFactory.property(.callSoundName)
-        let callSoundGroup = self.soundGroupForSetting(callSoundProperty, title: SettingsPropertyLabelText(callSoundProperty.propertyName), callSound: true, fallbackSoundName: MediaManagerSoundRingingFromThemSound, defaultSoundTitle: "self.settings.sound_menu.sounds.wire_call".localized)
-        
-        let messageSoundProperty = self.settingsPropertyFactory.property(.messageSoundName)
-        let messageSoundGroup = self.soundGroupForSetting(messageSoundProperty, title: SettingsPropertyLabelText(messageSoundProperty.propertyName), callSound: false, fallbackSoundName: MediaManagerSoundMessageReceivedSound, defaultSoundTitle: "self.settings.sound_menu.sounds.wire_message".localized)
-        
-        let pingSoundProperty = self.settingsPropertyFactory.property(.pingSoundName)
-        let pingSoundGroup = self.soundGroupForSetting(pingSoundProperty, title: SettingsPropertyLabelText(pingSoundProperty.propertyName), callSound: false, fallbackSoundName: MediaManagerSoundIncomingKnockSound, defaultSoundTitle: "self.settings.sound_menu.sounds.wire_ping".localized)
-        
-        let soundsSection = SettingsSectionDescriptor(cellDescriptors: [callSoundGroup, messageSoundGroup, pingSoundGroup], header: soundsHeader)
-        
-        let sendButtonDescriptor = SettingsPropertyToggleCellDescriptor(settingsProperty: settingsPropertyFactory.property(.disableSendButton))
-        let sendButtonSection = SettingsSectionDescriptor(
-            cellDescriptors: [sendButtonDescriptor],
-            header: "self.settings.send_button.header".localized,
-            footer: "self.settings.send_button.footer".localized
-        )
-        
-        return SettingsGroupCellDescriptor(items: [shareContactsDisabledSection, clearHistorySection, notificationVisibleSection, chatHeadsSection, soundAlertSection, soundsSection, sendButtonSection], title: "self.settings.options_menu.title".localized, icon: .settingsOptions)
-    }
     
     func devicesGroup() -> SettingsCellDescriptorType {
         return SettingsExternalScreenCellDescriptor(title: "self.settings.privacy_analytics_menu.devices.title".localized,


### PR DESCRIPTION
# What's in this PR?

* Move dark theme toggle and send button toggle into new settings section "By popular demand" in the options menu.
* Extract options descriptor into it's own file.
* Move the dependency version info into the advanced section and add the build number to the footer in the about section