### PR TITLE
Fix slow performance when scrolling in emoji sections

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/Emoji/EmojiKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/Emoji/EmojiKeyboardViewController.swift
@@ -129,12 +129,12 @@ protocol EmojiKeyboardViewControllerDelegate: class {
 
 extension EmojiKeyboardViewController: EmojiSectionViewControllerDelegate {
 
-    func sectionViewController(_ viewController: EmojiSectionViewController, didSelect type: EmojiSectionType) {
+    func sectionViewController(_ viewController: EmojiSectionViewController, didSelect type: EmojiSectionType, scrolling: Bool) {
         guard let section = emojiDataSource.sectionIndex(for: type) else { return }
         let indexPath = IndexPath(item: 0, section: section)
-        collectionView.scrollToItem(at: indexPath, at: .left, animated: true)
+        collectionView.scrollToItem(at: indexPath, at: .left, animated: !scrolling)
     }
-    
+
 }
 
 
@@ -160,7 +160,7 @@ extension EmojiKeyboardViewController: UICollectionViewDelegateFlowLayout {
         return UIEdgeInsets(top: 0, left: !first ? 12 : 0, bottom: 0, right: !last ? 12 : 0)
     }
 
-    func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+    func scrollViewDidScroll(_ scrolLView: UIScrollView) {
         updateSectionSelection()
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/Emoji/EmojiRessources/emoji_objects.plist
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/Emoji/EmojiRessources/emoji_objects.plist
@@ -24,7 +24,7 @@
 	<string>🎻</string>
 	<string>📱</string>
 	<string>📲</string>
-	<string>☎</string>
+	<string>☎️</string>
 	<string>📞</string>
 	<string>📟</string>
 	<string>📠</string>

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/Emoji/EmojiRessources/emoji_symbols.plist
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/Emoji/EmojiRessources/emoji_symbols.plist
@@ -15,7 +15,7 @@
 	<string>🛃</string>
 	<string>🛄</string>
 	<string>🛅</string>
-	<string>⚠</string>
+	<string>⚠️</string>
 	<string>🚸</string>
 	<string>⛔</string>
 	<string>🚫</string>
@@ -28,20 +28,20 @@
 	<string>🔞</string>
 	<string>☢</string>
 	<string>☣</string>
-	<string>⬆</string>
-	<string>↗</string>
-	<string>➡</string>
-	<string>↘</string>
-	<string>⬇</string>
-	<string>↙</string>
-	<string>⬅</string>
-	<string>↖</string>
-	<string>↕</string>
-	<string>↔</string>
-	<string>↩</string>
-	<string>↪</string>
-	<string>⤴</string>
-	<string>⤵</string>
+	<string>⬆️</string>
+	<string>↗️</string>
+	<string>➡️</string>
+	<string>↘️</string>
+	<string>⬇️</string>
+	<string>↙️</string>
+	<string>⬅️</string>
+	<string>↖️</string>
+	<string>↕️</string>
+	<string>↔️</string>
+	<string>↩️</string>
+	<string>↪️</string>
+	<string>⤴️</string>
+	<string>⤵️</string>
 	<string>🔃</string>
 	<string>🔄</string>
 	<string>🔙</string>
@@ -50,10 +50,10 @@
 	<string>🔜</string>
 	<string>🔝</string>
 	<string>⚛</string>
-	<string>✡</string>
+	<string>✡️</string>
 	<string>☸</string>
-	<string>☯</string>
-	<string>✝</string>
+	<string>☯️</string>
+	<string>✝️</string>
 	<string>☦</string>
 	<string>☪</string>
 	<string>☮</string>
@@ -74,34 +74,33 @@
 	<string>🔀</string>
 	<string>🔁</string>
 	<string>🔂</string>
-	<string>▶</string>
+	<string>▶️</string>
 	<string>⏩</string>
 	<string>⏭</string>
 	<string>⏯</string>
-	<string>◀</string>
+	<string>◀️</string>
 	<string>⏪</string>
 	<string>⏮</string>
 	<string>🔼</string>
 	<string>⏫</string>
 	<string>🔽</string>
 	<string>⏬</string>
-	<string>⏏</string>
 	<string>🎦</string>
 	<string>🔅</string>
 	<string>🔆</string>
 	<string>📶</string>
 	<string>📳</string>
 	<string>📴</string>
-	<string>♻</string>
+	<string>♻️</string>
 	<string>📛</string>
 	<string>⚜</string>
 	<string>🔰</string>
 	<string>🔱</string>
 	<string>⭕</string>
 	<string>✅</string>
-	<string>☑</string>
-	<string>✔</string>
-	<string>✖</string>
+	<string>☑️</string>
+	<string>✔️</string>
+	<string>✖️</string>
 	<string>❌</string>
 	<string>❎</string>
 	<string>➕</string>
@@ -109,20 +108,20 @@
 	<string>➗</string>
 	<string>➰</string>
 	<string>➿</string>
-	<string>〽</string>
-	<string>✳</string>
-	<string>✴</string>
-	<string>❇</string>
-	<string>‼</string>
-	<string>⁉</string>
+	<string>〽️</string>
+	<string>✳️</string>
+	<string>✴️</string>
+	<string>❇️</string>
+	<string>‼️</string>
+	<string>⁉️</string>
 	<string>❓</string>
 	<string>❔</string>
 	<string>❕</string>
 	<string>❗</string>
-	<string>〰</string>
-	<string>©</string>
-	<string>®</string>
-	<string>™</string>
+	<string>〰️</string>
+	<string>©️</string>
+	<string>®️</string>
+	<string>™️</string>
 	<string>#️⃣</string>
 	<string>*️⃣</string>
 	<string>0️⃣</string>
@@ -142,26 +141,26 @@
 	<string>🔢</string>
 	<string>🔣</string>
 	<string>🔤</string>
-	<string>🅰</string>
+	<string>🅰️</string>
 	<string>🆎</string>
-	<string>🅱</string>
+	<string>🅱️</string>
 	<string>🆑</string>
 	<string>🆒</string>
 	<string>🆓</string>
-	<string>ℹ</string>
+	<string>ℹ️</string>
 	<string>🆔</string>
-	<string>Ⓜ</string>
+	<string>Ⓜ️</string>
 	<string>🆕</string>
 	<string>🆖</string>
-	<string>🅾</string>
+	<string>🅾️</string>
 	<string>🆗</string>
-	<string>🅿</string>
+	<string>🅿️</string>
 	<string>🆘</string>
 	<string>🆙</string>
 	<string>🆚</string>
 	<string>🈁</string>
-	<string>🈂</string>
-	<string>🈷</string>
+	<string>🈂️</string>
+	<string>🈷️</string>
 	<string>🈶</string>
 	<string>🈯</string>
 	<string>🉐</string>
@@ -172,14 +171,14 @@
 	<string>🈸</string>
 	<string>🈴</string>
 	<string>🈳</string>
-	<string>㊗</string>
-	<string>㊙</string>
+	<string>㊗️</string>
+	<string>㊙️</string>
 	<string>🈺</string>
 	<string>🈵</string>
-	<string>▪</string>
-	<string>▫</string>
-	<string>◻</string>
-	<string>◼</string>
+	<string>▪️</string>
+	<string>▫️</string>
+	<string>◻️</string>
+	<string>◼️</string>
 	<string>◽</string>
 	<string>◾</string>
 	<string>⬛</string>

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/Emoji/EmojiRessources/emoji_travel.plist
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/Emoji/EmojiRessources/emoji_travel.plist
@@ -39,7 +39,7 @@
 	<string>🌆</string>
 	<string>🌇</string>
 	<string>🌉</string>
-	<string>♨</string>
+	<string>♨️</string>
 	<string>🌌</string>
 	<string>🎠</string>
 	<string>🎡</string>
@@ -143,24 +143,24 @@
 	<string>🌚</string>
 	<string>🌛</string>
 	<string>🌜</string>
-	<string>☀</string>
+	<string>☀️</string>
 	<string>🌝</string>
 	<string>🌞</string>
 	<string>⭐</string>
 	<string>🌟</string>
 	<string>🌠</string>
-	<string>☁</string>
+	<string>☁️</string>
 	<string>⛅</string>
 	<string>⛈</string>
 	<string>🌀</string>
 	<string>🌈</string>
 	<string>🌂</string>
-	<string>☂</string>
+	<string>☂️</string>
 	<string>☔</string>
 	<string>⛱</string>
 	<string>⚡</string>
-	<string>❄</string>
-	<string>☃</string>
+	<string>❄️</string>
+	<string>☃️</string>
 	<string>⛄</string>
 	<string>☄</string>
 	<string>🔥</string>

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/EmojiSectionViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/EmojiSectionViewController.swift
@@ -22,7 +22,7 @@ import Cartography
 
 
 protocol EmojiSectionViewControllerDelegate: class {
-    func sectionViewController(_ viewController: EmojiSectionViewController, didSelect: EmojiSectionType)
+    func sectionViewController(_ viewController: EmojiSectionViewController, didSelect: EmojiSectionType, scrolling: Bool)
 }
 
 
@@ -87,7 +87,7 @@ class EmojiSectionViewController: UIViewController {
     
     @objc private func didTappButton(_ sender: IconButton) {
         guard let type = typesByButton[sender] else { return }
-        sectionDelegate?.sectionViewController(self, didSelect: type)
+        sectionDelegate?.sectionViewController(self, didSelect: type, scrolling: false)
     }
 
     @objc private func didPan(_ recognizer: UIPanGestureRecognizer) {
@@ -100,7 +100,7 @@ class EmojiSectionViewController: UIViewController {
             let location = recognizer.location(in: view)
             guard let button = sectionButtons.filter ({ $0.frame.contains(location) }).first else { return }
             guard let type = typesByButton[button] else { return }
-            sectionDelegate?.sectionViewController(self, didSelect: type)
+            sectionDelegate?.sectionViewController(self, didSelect: type, scrolling: true)
             selectedType = type
         case .ended, .failed, .cancelled:
             ignoreSelectionUpdates = false


### PR DESCRIPTION
# What's in this PR?

* Don't animate scrolling to a emoji section when the user pans between the sections.
* Update section selection in `scrollViewDidScroll` instead of `collectionView(willDisplayCell:)` as it's not ensured there there will be new cells displayed when the selection should change.
* Some emoji were missing their correct variation selector to be displayed properly (`U+FE0F`).