### PR TITLE
Update emoji size on iPad and right margin of new send button

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -761,6 +761,7 @@
 		BFC9149B1D181BE7001F068B /* LocationMessageCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFC914991D181B7C001F068B /* LocationMessageCellTests.swift */; };
 		BFCF31D51D9E91880039B3DC /* RecentlyUsedEmojis.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFCF31D41D9E91880039B3DC /* RecentlyUsedEmojis.swift */; };
 		BFCF31D71DA3A9350039B3DC /* SettingsCellDescriptorFactory+Options.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFCF31D61DA3A9350039B3DC /* SettingsCellDescriptorFactory+Options.swift */; };
+		BFCF31DD1DA52ECE0039B3DC /* KeyboardHeight.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFCF31DC1DA52ECE0039B3DC /* KeyboardHeight.swift */; };
 		BFE08C1C1D5B5CFA002367F6 /* MessageDeletedCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE08C1B1D5B5CFA002367F6 /* MessageDeletedCell.swift */; };
 		BFE08C1E1D5B6F34002367F6 /* MessageDeletedCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE08C1D1D5B6F34002367F6 /* MessageDeletedCellTests.swift */; };
 		BFE277631D5B4FC50074DC6D /* ConversationContentViewController+MessageDeletion.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE277621D5B4FC50074DC6D /* ConversationContentViewController+MessageDeletion.swift */; };
@@ -2045,6 +2046,7 @@
 		BFC914991D181B7C001F068B /* LocationMessageCellTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationMessageCellTests.swift; sourceTree = "<group>"; };
 		BFCF31D41D9E91880039B3DC /* RecentlyUsedEmojis.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecentlyUsedEmojis.swift; sourceTree = "<group>"; };
 		BFCF31D61DA3A9350039B3DC /* SettingsCellDescriptorFactory+Options.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SettingsCellDescriptorFactory+Options.swift"; sourceTree = "<group>"; };
+		BFCF31DC1DA52ECE0039B3DC /* KeyboardHeight.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardHeight.swift; sourceTree = "<group>"; };
 		BFE08C1B1D5B5CFA002367F6 /* MessageDeletedCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageDeletedCell.swift; sourceTree = "<group>"; };
 		BFE08C1D1D5B6F34002367F6 /* MessageDeletedCellTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageDeletedCellTests.swift; sourceTree = "<group>"; };
 		BFE277621D5B4FC50074DC6D /* ConversationContentViewController+MessageDeletion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ConversationContentViewController+MessageDeletion.swift"; sourceTree = "<group>"; };
@@ -3163,6 +3165,7 @@
 				871BC2171D34F8F800DF0793 /* UIView+WR_Snapshot.m */,
 				871BC2181D34F8F800DF0793 /* UIView+Zeta.h */,
 				871BC2191D34F8F800DF0793 /* UIView+Zeta.m */,
+				BFCF31DC1DA52ECE0039B3DC /* KeyboardHeight.swift */,
 				871BC21A1D34F8F800DF0793 /* UIViewController+Errors.h */,
 				871BC21B1D34F8F800DF0793 /* UIViewController+Errors.m */,
 				871BC21C1D34F8F800DF0793 /* UIViewController+Orientation.h */,
@@ -5596,6 +5599,7 @@
 				8FD5A08619F0490500550525 /* ZMUserSession+Additions.m in Sources */,
 				871BC3641D34F94200DF0793 /* SoundcloudService.m in Sources */,
 				8FC85498199245770008B66B /* MediaBar.m in Sources */,
+				BFCF31DD1DA52ECE0039B3DC /* KeyboardHeight.swift in Sources */,
 				871BC35B1D34F94200DF0793 /* AVSProvider.swift in Sources */,
 				87DCF4F21D34EA4500BB420F /* SearchTokenStore.m in Sources */,
 				87D21AD71D8A98620075AB7A /* AccentColorPickerController.swift in Sources */,

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -408,9 +408,11 @@
 
 - (void)updateRightAccessoryView
 {
-    const NSUInteger textLength = self.inputBar.textView.text.length;
+    NSString *trimmed = [self.inputBar.textView.text stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+    const NSUInteger textLength = trimmed.length;
     BOOL hideSendButton = Settings.sharedSettings.disableSendButton && self.mode != ConversationInputBarViewControllerModeEmojiInput;
-    self.sendButton.hidden = textLength == 0 || hideSendButton;
+    BOOL editing = nil != self.editingMessage;
+    self.sendButton.hidden = textLength == 0 || hideSendButton || editing;
 
     self.verifiedShieldButton.hidden = self.conversation.securityLevel != ZMConversationSecurityLevelSecure || textLength > 0;
 }
@@ -449,7 +451,7 @@
 
 - (void)onSingleTap:(UITapGestureRecognizer *)recognier
 {
-    if (recognier.state == UIGestureRecognizerStateRecognized) {
+    if (recognier.state == UIGestureRecognizerStateRecognized && self.mode != ConversationInputBarViewControllerModeEmojiInput) {
         self.mode = ConversationInputBarViewControllerModeTextInput;
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -55,6 +55,7 @@
 #import "UIView+WR_ExtendedBlockAnimations.h"
 #import "UIView+Borders.h"
 #import "ImageMessageCell.h"
+#import "WAZUIMagic.h"
 
 
 @interface ConversationInputBarViewController (Commands)
@@ -343,8 +344,10 @@
     self.sendButton.cas_styleClass = @"send-button";
 
     [self.inputBar.rightAccessoryView addSubview:self.sendButton];
-    [self.sendButton autoSetDimensionsToSize:CGSizeMake(28, 28)];
-    [self.sendButton autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsMake(14, 0, 0, 0) excludingEdge:ALEdgeBottom];
+    CGFloat edgeLength = 28;
+    [self.sendButton autoSetDimensionsToSize:CGSizeMake(edgeLength, edgeLength)];
+    CGFloat rightInset = ([WAZUIMagic cgFloatForIdentifier:@"content.left_margin"] - edgeLength) / 2;
+    [self.sendButton autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsMake(14, 0, 0, rightInset) excludingEdge:ALEdgeBottom];
 }
 
 - (void)createVerifiedView
@@ -533,7 +536,7 @@
 - (void)clearTextInputAssistentItemIfNeeded
 {
     if (nil != [UITextInputAssistantItem class]) {
-        UITextInputAssistantItem* item = self.inputBar.textView.inputAssistantItem;
+        UITextInputAssistantItem *item = self.inputBar.textView.inputAssistantItem;
         item.leadingBarButtonGroups = @[];
         item.trailingBarButtonGroups = @[];
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/Emoji/EmojiKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/Emoji/EmojiKeyboardViewController.swift
@@ -52,10 +52,14 @@ protocol EmojiKeyboardViewControllerDelegate: class {
         createConstraints()
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        collectionView.reloadItems(at: collectionView.indexPathsForVisibleItems)
+    }
+
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         updateSectionSelection()
-        collectionView.reloadItems(at: collectionView.indexPathsForVisibleItems)
     }
     
     func setupViews() {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/Emoji/EmojiKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/Emoji/EmojiKeyboardViewController.swift
@@ -55,6 +55,7 @@ protocol EmojiKeyboardViewControllerDelegate: class {
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         updateSectionSelection()
+        collectionView.reloadItems(at: collectionView.indexPathsForVisibleItems)
     }
     
     func setupViews() {
@@ -189,7 +190,8 @@ class EmojiCollectionViewCell: UICollectionViewCell {
     
     func setupViews() {
         titleLabel.textAlignment = .center
-        titleLabel.font = .systemFont(ofSize: 28)
+        let fontSize: CGFloat =  UIDevice.current.userInterfaceIdiom == .pad ? 40 : 28
+        titleLabel.font = .systemFont(ofSize: fontSize)
         titleLabel.adjustsFontSizeToFitWidth = true
         addSubview(titleLabel)
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
@@ -44,8 +44,8 @@ public func ==(lhs: InputBarState, rhs: InputBarState) -> Bool {
 
 private struct InputBarConstants {
     let buttonsBarHeight: CGFloat = 56
-    let contentLeftMargin = CGFloat(WAZUIMagic.float(forIdentifier: "content.left_margin"))
-    let contentRightMargin = CGFloat(WAZUIMagic.float(forIdentifier: "content.right_margin"))
+    let contentLeftMargin = WAZUIMagic.cgFloat(forIdentifier: "content.left_margin")
+    let contentRightMargin = WAZUIMagic.cgFloat(forIdentifier: "content.right_margin")
 }
 
 @objc open class InputBar: UIView {
@@ -179,8 +179,8 @@ private struct InputBarConstants {
             leftAccessoryView.top == leftAccessoryView.superview!.top
             leftAccessoryView.bottom == buttonContainer.top
             leftAccessoryView.width == constants.contentLeftMargin
-            
-            rightAccessoryView.trailing == rightAccessoryView.superview!.trailing - 16
+
+            rightAccessoryView.trailing == rightAccessoryView.superview!.trailing
             rightAccessoryView.top == rightAccessoryView.superview!.top
             rightAccessoryView.width == 0 ~ LayoutPriority(750)
             rightAccessoryView.bottom == buttonContainer.top

--- a/Wire-iOS/Sources/UserInterface/Helpers/KeyboardHeight.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/KeyboardHeight.swift
@@ -1,0 +1,40 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+@objc public class KeyboardHeight: NSObject {
+
+    /// The height of the system keyboard with the prediction row
+    public static var current: CGFloat {
+        switch UIDevice.current.userInterfaceIdiom {
+        case .pad:
+            return UIInterfaceOrientationIsPortrait(UIApplication.shared.statusBarOrientation) ? 264 : 352
+        default:
+            return phoneKeyboardHeight()
+        }
+    }
+
+    private static func phoneKeyboardHeight() -> CGFloat {
+        switch UIScreen.main.bounds.height {
+        case 667: return 258
+        case 736: return 271
+        default: return 253
+        }
+    }
+
+}

--- a/Wire-iOS/Sources/UserInterface/Helpers/UIView+Zeta.m
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UIView+Zeta.m
@@ -19,6 +19,7 @@
 
 #import "UIView+Zeta.h"
 #import "UIResponder+FirstResponder.h"
+#import "Wire-Swift.h"
 
 static NSString * const WireLastCachedKeyboardHeightKey = @"WireLastCachedKeyboardHeightKey";
 
@@ -81,25 +82,16 @@ static NSString * const WireLastCachedKeyboardHeightKey = @"WireLastCachedKeyboa
 + (CGSize)wr_lastKeyboardSize
 {
     NSString *currentLastValue = [[NSUserDefaults standardUserDefaults] objectForKey:WireLastCachedKeyboardHeightKey];
+    
     if (currentLastValue == nil) {
-        return CGSizeMake([UIScreen mainScreen].bounds.size.width, 216);
+        return CGSizeMake([UIScreen mainScreen].bounds.size.width, KeyboardHeight.current);
     }
     else {
         CGSize keyboardSize = CGSizeFromString(currentLastValue);
         
         // If keyboardSize value is clearly off we need to pull default value
         if (keyboardSize.height < 150) {
-            if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
-                if (UIInterfaceOrientationIsPortrait([UIApplication sharedApplication].statusBarOrientation)) {
-                    keyboardSize.height = 264;
-                }
-                else {
-                    keyboardSize.height = 352;
-                }
-            }
-            else {
-                keyboardSize.height = 216;
-            }
+            keyboardSize.height = KeyboardHeight.current;
         }
         
         return keyboardSize;


### PR DESCRIPTION
# What's in this PR?

* Larger emoji in the keyboard on iPad.
* Increase right margin of the new send button.
* Update default keyboard sizes with values for different device types.
* Don't show send button when editing
* Do not allow switching from emoji to text input with tap on input field, only tapping the text input button should show the alphabetic keyboard again.
* Whitespace only text should not trigger the send button to be shown in the input bar.