### PR TITLE
Fix send button staying visible when starting edit with text input

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Editing.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Editing.swift
@@ -35,6 +35,8 @@ extension ConversationInputBarViewController {
         guard let text = message.textMessageData?.messageText else { return }
         mode = .textInput
         editingMessage = message
+        updateSendButtonVisibility()
+
         inputBar.inputBarState = .editing(originalText: text)
         NotificationCenter.default.addObserver(
             self,

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Private.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Private.h
@@ -38,6 +38,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)createAudioRecordViewController;
 - (void)sendOrEditText:(NSString *)text;
+- (void)updateSendButtonVisibility;
+
 @end
 
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -210,7 +210,7 @@
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
-    [self updateRightAccessoryView];
+    [self updateSendButtonVisibility];
     [self.inputBar updateReturnKey];
 }
 
@@ -374,7 +374,7 @@
     self.authorImageView.alpha = self.inputBar.textView.isFirstResponder ? 1 : 0;
 }
 
-- (void)updateRightAccessoryView
+- (void)updateSendButtonVisibility
 {
     NSString *trimmed = [self.inputBar.textView.text stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
     const NSUInteger textLength = trimmed.length;
@@ -386,13 +386,13 @@
 - (void)updateAccessoryViews
 {
     [self updateLeftAccessoryView];
-    [self updateRightAccessoryView];
+    [self updateSendButtonVisibility];
 }
 
 - (void)clearInputBar
 {
     self.inputBar.textView.text = @"";
-    [self updateRightAccessoryView];
+    [self updateSendButtonVisibility];
 }
 
 - (void)setTypingUsers:(NSSet *)typingUsers
@@ -489,7 +489,7 @@
             break;
     }
     
-    [self updateRightAccessoryView];
+    [self updateSendButtonVisibility];
 }
 
 - (void)selectInputControllerButton:(IconButton *)button
@@ -616,7 +616,7 @@
         }
     }
     
-    [self updateRightAccessoryView];
+    [self updateSendButtonVisibility];
 }
 
 - (BOOL)textView:(UITextView *)textView shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)text


### PR DESCRIPTION
# What's in this PR?

* If an edit of a message was started while there was text input in the input bar / the send button was visible, then we did not update the state of the send button correctly.