### PR TITLE
Re-enable delivery receipts showing

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
@@ -324,9 +324,8 @@ const NSTimeInterval ConversationCellSelectionAnimationDuration = 0.33;
     
     ZMDeliveryState deliveryState = self.message.deliveryState;
     
-    // Code disabled until the majority would send the delivery receipts
-//    BOOL shouldShowPendingDeliveryState = self.message.conversation.conversationType == ZMConversationTypeOneOnOne;
-    BOOL shouldShowDeliveryState = /*(deliveryState == ZMDeliveryStatePending && shouldShowPendingDeliveryState) ||*/ deliveryState == ZMDeliveryStateFailedToSend || self.layoutProperties.alwaysShowDeliveryState;
+    BOOL shouldShowPendingDeliveryState = self.message.conversation.conversationType == ZMConversationTypeOneOnOne;
+    BOOL shouldShowDeliveryState = (deliveryState == ZMDeliveryStatePending && shouldShowPendingDeliveryState) || deliveryState == ZMDeliveryStateFailedToSend || self.layoutProperties.alwaysShowDeliveryState;
     BOOL shouldBeVisible = self.selected || self.message.usersReaction.count > 0 || shouldShowDeliveryState;
     
     if (! [Message shouldShowTimestamp:self.message]) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
@@ -252,9 +252,7 @@ extension ZMConversationMessage {
             case .pending:
                 deliveryStateString = "content.system.pending_message_timestamp".localized
             case .delivered:
-                // Code disabled until the majority would send the delivery receipts
-                // deliveryStateString = "content.system.message_delivered_timestamp".localized
-                fallthrough
+                deliveryStateString = "content.system.message_delivered_timestamp".localized
             case .sent:
                 deliveryStateString = "content.system.message_sent_timestamp".localized
             case .failedToSend:

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ZMConversationMessageWindow+Formatting.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ZMConversationMessageWindow+Formatting.m
@@ -68,14 +68,13 @@
 
 - (BOOL)shouldShowAlwaysDeliveryStateForMessage:(id<ZMConversationMessage>)message
 {
-    // Code disabled until the majority would send the delivery receipts
-//    // Loop back and check if this was last message sent by us
-//    if (message.sender.isSelfUser && message.conversation.conversationType == ZMConversationTypeOneOnOne) {
-//        if ([message.conversation lastMessageSentByUser:[ZMUser selfUser] limit:10] == message) {
-//            return YES;
-//        }
-//    }
-//    
+    // Loop back and check if this was last message sent by us
+    if (message.sender.isSelfUser && message.conversation.conversationType == ZMConversationTypeOneOnOne) {
+        if ([message.conversation lastMessageSentByUser:[ZMUser selfUser] limit:10] == message) {
+            return YES;
+        }
+    }
+    
     return NO;
 }
 


### PR DESCRIPTION
# Info

Showing the delivery receipts was suppressed due to rollout schedule. Now it's time to show them.