### PR TITLE
Show correctly name set error on iPad

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Helpers/UIApplication+StatusBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UIApplication+StatusBar.swift
@@ -65,7 +65,7 @@ public extension UIApplication {
                 return .none
         }
         
-        while let presentedController = topController.presentedViewController, ((onlyFullScreen && presentedController.modalPresentationStyle == .fullScreen) || !onlyFullScreen) {
+        while let presentedController = topController.presentedViewController, (!onlyFullScreen || presentedController.modalPresentationStyle == .fullScreen) {
             topController = presentedController
         }
         

--- a/Wire-iOS/Sources/UserInterface/Helpers/UIApplication+StatusBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UIApplication+StatusBar.swift
@@ -43,7 +43,7 @@ public extension UIApplication {
         }
     }
     
-    fileprivate func wr_topmostController() -> UIViewController? {
+    public func wr_topmostController(onlyFullScreen: Bool = true) -> UIViewController? {
         let orderedWindows = self.windows.sorted { win1, win2 in
             win1.windowLevel > win2.windowLevel
         }
@@ -65,8 +65,7 @@ public extension UIApplication {
                 return .none
         }
         
-        while let presentedController = topController.presentedViewController
-                , presentedController.modalPresentationStyle == .fullScreen {
+        while let presentedController = topController.presentedViewController, ((onlyFullScreen && presentedController.modalPresentationStyle == .fullScreen) || !onlyFullScreen) {
             topController = presentedController
         }
         

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsPropertyTextValueCellDescriptor.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsPropertyTextValueCellDescriptor.swift
@@ -55,7 +55,7 @@ class SettingsPropertyTextValueCellDescriptor: SettingsPropertyCellDescriptorTyp
                 let alertView = UIAlertController(title: "error.full_name".localized, message: error.localizedDescription, preferredStyle: .alert)
                 let actionCancel = UIAlertAction(title: "general.cancel".localized, style: .cancel, handler: nil)
                 alertView.addAction(actionCancel)
-                UIApplication.shared.keyWindow!.rootViewController?.present(alertView, animated: true, completion: .none)
+                UIApplication.shared.wr_topmostController(onlyFullScreen: false)?.present(alertView, animated: true, completion: .none)
                 
             }
             catch let generalError {


### PR DESCRIPTION
# Issue

The alert was shown over controller that has modal presented. 

# Solution

Now alert is shown over current topmost controller.