### PR TITLE
Use safer random functions

### DIFF
--- a/Wire-iOS/Sources/Helpers/syncengine/ZMUser+Additions.m
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMUser+Additions.m
@@ -107,7 +107,7 @@ ZMUser *BareUserToUser(id bareUser) {
     ZMAccentColor accentColorValue;
 
     do {
-        accentColorValue = arc4random() % (ZMAccentColorMax) + 1;
+        accentColorValue = arc4random_uniform(ZMAccentColorMax) + 1;
     }
     while (accentColorValue == ZMAccentColorSoftPink ||
            accentColorValue == ZMAccentColorStrongLimeGreen ||
@@ -120,7 +120,7 @@ ZMUser *BareUserToUser(id bareUser) {
 {
     ZMAccentColor accentColorValue;
     
-    accentColorValue = arc4random() % (ZMAccentColorMax) + 1;
+    accentColorValue = arc4random_uniform(ZMAccentColorMax) + 1;
 
     return accentColorValue;
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
@@ -165,7 +165,8 @@ import CocoaLumberjackSwift
                 $0 != .none
             }
             
-            let randomEffect = suitableEffects[Int(arc4random()) % suitableEffects.count]
+            let maxEffect : UInt32 = UInt32(suitableEffects.count)
+            let randomEffect = suitableEffects[Int(arc4random_uniform(maxEffect))]
             let randomEffectImage = UIImage(for: randomEffect.icon, iconSize: .searchBar, color: colorScheme.color(withName: ColorSchemeColorTextDimmed))
 
             let tipEffectImageAttachment = NSTextAttachment()


### PR DESCRIPTION
# Reason for this pull request
Crash on this line:
> `suitableEffects[Int(arc4random()) % suitableEffects.count]`

On 32-bit platforms, `Int` is actually `Int32` which ranges from `-2^31` to `2^31-1`. However `arc4random` returns `UInt32` up to `2^32-1`. I think the crash we were seeing was on 32-bit machine generating a random that was too big to fit in `Int32`.

# Changes
Additionally, according to Apple's documentation:
> arc4random_uniform() is recommended over constructions like ``arc4random() % upper_bound'' as it avoids
> "modulo bias" when the upper bound is not a power of two.

(https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man3/arc4random.3.html)

so I replaced all `arc4random() % ...` with `arc4random_uniform()`