### PR TITLE
Remove observer on deinit

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/TypingIndicatorView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/TypingIndicatorView.swift
@@ -33,6 +33,10 @@ class AnimatedPenView : UIView {
         }
     }
     
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         


### PR DESCRIPTION
# Reason for this pull request
Crash because observer was not unregistered