### PR TITLE
Fix wrong send button color after presenting modal view controller

### DIFF
--- a/Wire-iOS/Resources/Classy/stylesheet.cas
+++ b/Wire-iOS/Resources/Classy/stylesheet.cas
@@ -882,15 +882,16 @@ InputBarEditView: {
     }
 }
 
-ConversationInputBarViewController {
-    sendButton: @{
-        circular: true;
-        borderWidth: 0.0;
-        iconColor: $color-background-light;
-        backgroundImageColor[state:highlighted]: $color-accent-current-darken;
-        backgroundImageColor[state:normal]: $color-accent-current;
-    }
+IconButton.send-button {
+    circular: true;
+    borderWidth: 0.0;
+    iconColor[state: highlighted]: $color-background-light;
+    iconColor[state: normal]: $color-background-light;
+    backgroundImageColor[state:highlighted]: $color-accent-current-darken;
+    backgroundImageColor[state:normal]: $color-accent-current;
+}
 
+ConversationInputBarViewController {
     audioRecorderTooltip: @{
         font: $font-small;
         textColor: $color-text-dimmed;

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -329,8 +329,10 @@
 {
     self.sendButton = [IconButton iconButtonDefault];
     self.sendButton.translatesAutoresizingMaskIntoConstraints = NO;
-    [self.sendButton setIcon:ZetaIconTypeSend withSize:ZetaIconSizeTiny forState:UIControlStateNormal renderingMode:UIImageRenderingModeAlwaysTemplate];
+    [self.sendButton setIcon:ZetaIconTypeSend withSize:ZetaIconSizeTiny forState:UIControlStateNormal];
+
     self.sendButton.accessibilityIdentifier = @"sendButton";
+    self.sendButton.cas_styleClass = @"send-button";
     self.sendButton.adjustsImageWhenHighlighted = NO;
 
     [self.inputBar.rightAccessoryView addSubview:self.sendButton];


### PR DESCRIPTION
# What's in this PR?

* For some reason classy got confused after a vie controller was presented modally and the send button lost it's styling. Using a style class fixes this issue.