### PR TITLE
Adding new languages: Japanese, Italian, Dutch, Turkish

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1932,6 +1932,18 @@
 		AF65A25B1D7E202D00EBA38E /* ReactionsListViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReactionsListViewControllerTests.swift; sourceTree = "<group>"; };
 		AF917BAC1C6E9B2F00491EA9 /* AppControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppControllerTests.m; sourceTree = "<group>"; };
 		AF917BAE1C6E9D3F00491EA9 /* AppController+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "AppController+Internal.h"; sourceTree = "<group>"; };
+		B419513D1DAD1182002FC027 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
+		B419513E1DAD1182002FC027 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = ja; path = ja.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		B419513F1DAD1182002FC027 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		B41951401DAD1188002FC027 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
+		B41951411DAD1188002FC027 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = it; path = it.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		B41951421DAD1188002FC027 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		B41951431DAD119C002FC027 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
+		B41951441DAD119C002FC027 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = nl; path = nl.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		B41951451DAD119D002FC027 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		B41951461DAD11A5002FC027 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/Localizable.strings; sourceTree = "<group>"; };
+		B41951471DAD11A5002FC027 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = tr; path = tr.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		B41951481DAD11A6002FC027 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		B4446E1E1CFDF115005C83A7 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		B4446E1F1CFDF115005C83A7 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = "pt-BR"; path = "pt-BR.lproj/Localizable.stringsdict"; sourceTree = "<group>"; };
 		B4446E201CFDF116005C83A7 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
@@ -4749,6 +4761,10 @@
 				uk,
 				es,
 				ru,
+				ja,
+				it,
+				nl,
+				tr,
 			);
 			mainGroup = 8F42C52F199244A700288E4D;
 			productRefGroup = 8F42C539199244A700288E4D /* Products */;
@@ -5768,6 +5784,10 @@
 				B4D37F991D7EEDD800D0C1BC /* uk */,
 				B4D37F9C1D7EEDE300D0C1BC /* es */,
 				B4D37F9F1D7EEDEB00D0C1BC /* ru */,
+				B419513E1DAD1182002FC027 /* ja */,
+				B41951411DAD1188002FC027 /* it */,
+				B41951441DAD119C002FC027 /* nl */,
+				B41951471DAD11A5002FC027 /* tr */,
 			);
 			name = Localizable.stringsdict;
 			sourceTree = "<group>";
@@ -5781,6 +5801,10 @@
 				B4D37F9A1D7EEDD800D0C1BC /* uk */,
 				B4D37F9D1D7EEDE300D0C1BC /* es */,
 				B4D37FA01D7EEDEB00D0C1BC /* ru */,
+				B419513F1DAD1182002FC027 /* ja */,
+				B41951421DAD1188002FC027 /* it */,
+				B41951451DAD119D002FC027 /* nl */,
+				B41951481DAD11A6002FC027 /* tr */,
 			);
 			name = InfoPlist.strings;
 			path = "Wire-iOS/Resources";
@@ -5795,6 +5819,10 @@
 				B4D37F981D7EEDD800D0C1BC /* uk */,
 				B4D37F9B1D7EEDE300D0C1BC /* es */,
 				B4D37F9E1D7EEDEB00D0C1BC /* ru */,
+				B419513D1DAD1182002FC027 /* ja */,
+				B41951401DAD1188002FC027 /* it */,
+				B41951431DAD119C002FC027 /* nl */,
+				B41951461DAD11A5002FC027 /* tr */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";

--- a/Wire-iOS/Resources/de.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/de.lproj/Localizable.strings
@@ -128,6 +128,7 @@
 
 "conversation.input_bar.verified" = "Überprüft";
 "conversation.input_bar.placeholder" = "Schreibe eine Nachricht";
+"conversation.input_bar.placeholder_ephemeral" = "Selbstzerstörende Nachricht";
 
 "conversation.input_bar.audio_message.tooltip.pull_send" = "Zum Senden nach oben Wischen";
 "conversation.input_bar.audio_message.tooltip.tap_send" = "Tippe, um zu senden";
@@ -161,6 +162,10 @@
 
 // Twitter
 "twitter_status.on_twitter" = "%@ auf Twitter";
+
+// Ephemeral message
+"input.ephemeral.timeout.none" = "Aus";
+"input.ephemeral.title" = "Dauer für temporäre Nachrichten";
 
 // System messages
 "content.system.continued_conversation" = "Beginne eine Unterhaltung mit %@";
@@ -221,6 +226,8 @@
 "content.system.cannot_decrypt.identity.you_part" = "Deine";
 "content.system.cannot_decrypt.identity.otherUser_part" = "%@s"; // posessive apostrophe - might differ in different languages
 "content.system.cannot_decrypt.identity.why_part" = "Erfahre mehr";
+"content.system.cannot_decrypt.otherDevice_part" = "(Gerät %@)"; // example " (device d1b23c54f34a)".
+// Full sentence: "A message from %@ was not received. [...] (device d1b23c54f34a). This is a debug information.
 
 "content.file.uploading" = "Hochladen…";
 "content.file.downloading" = "Herunterladen…";
@@ -705,7 +712,7 @@
 
 "giphy.confirm" = "senden";
 "giphy.cancel" = "abbrechen";
-"giphy.search_placeholder" = "Auf Giphy suchen";
+"giphy.search_placeholder" = "Giphy-Suche";
 
 "invite_banner.title" = "Hole deine Freunde zu Wire!";
 "invite_banner.message" = "Anrufen, Bilder teilen, Musik, GIFs\nund vieles mehr in persönlichen und Gruppenunterhaltungen.";

--- a/Wire-iOS/Resources/de.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/de.lproj/Localizable.strings
@@ -712,7 +712,7 @@
 
 "giphy.confirm" = "senden";
 "giphy.cancel" = "abbrechen";
-"giphy.search_placeholder" = "Giphy-Suche";
+"giphy.search_placeholder" = "Auf Giphy suchen";
 
 "invite_banner.title" = "Hole deine Freunde zu Wire!";
 "invite_banner.message" = "Anrufen, Bilder teilen, Musik, GIFs\nund vieles mehr in persönlichen und Gruppenunterhaltungen.";

--- a/Wire-iOS/Resources/es.lproj/InfoPlist.strings
+++ b/Wire-iOS/Resources/es.lproj/InfoPlist.strings
@@ -16,7 +16,7 @@
  *  along with this program. If not, see http://www.gnu.org/licenses/.
 */
 
-"NSContactsUsageDescription" = "Allow Wire to access your contacts to connect you with others. We anonymize all information and do not share it with anyone else.";
-"NSMicrophoneUsageDescription" = "Allow Wire to access your microphone so you can talk to people and send audio messages.";
+"NSContactsUsageDescription" = "Compartir tus contactos te ayuda a conectarte con otros. Toda la información es anónima y no será compartida con nadie más.";
+"NSMicrophoneUsageDescription" = "Permita el acceso al micrófono para que pueda hablar con la gente y enviar mensajes de audio.";
 "NSLocationWhenInUseUsageDescription" = "Permita a Wire acceder a su ubicación para que pueda compartirla con otros.";
-"NSCameraUsageDescription" = "Allow Wire to access your camera so you can place video calls and send photos.";
+"NSCameraUsageDescription" = "Permita el acceso su cámara para que puedas hacer vídeo llamadas y enviar fotos.";

--- a/Wire-iOS/Resources/es.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/es.lproj/Localizable.strings
@@ -128,6 +128,7 @@
 
 "conversation.input_bar.verified" = "Verificado";
 "conversation.input_bar.placeholder" = "Escriba un mensaje";
+"conversation.input_bar.placeholder_ephemeral" = "Timed message";
 
 "conversation.input_bar.audio_message.tooltip.pull_send" = "Deslice hacia arriba para enviar";
 "conversation.input_bar.audio_message.tooltip.tap_send" = "Oprime para enviar";
@@ -161,6 +162,10 @@
 
 // Twitter
 "twitter_status.on_twitter" = "%@ en Twitter";
+
+// Ephemeral message
+"input.ephemeral.timeout.none" = "Off";
+"input.ephemeral.title" = "Set a timer for temporary messages";
 
 // System messages
 "content.system.continued_conversation" = "Inicia una conversación con %@";
@@ -221,6 +226,8 @@
 "content.system.cannot_decrypt.identity.you_part" = "Su";
 "content.system.cannot_decrypt.identity.otherUser_part" = "de %@"; // posessive apostrophe - might differ in different languages
 "content.system.cannot_decrypt.identity.why_part" = "Más información";
+"content.system.cannot_decrypt.otherDevice_part" = "(dispositivo %@)"; // example " (device d1b23c54f34a)".
+// Full sentence: "A message from %@ was not received. [...] (device d1b23c54f34a). This is a debug information.
 
 "content.file.uploading" = "Cargando…";
 "content.file.downloading" = "Descargando…";
@@ -427,7 +434,7 @@
 "self.settings.account_section.email.title" = "Correo electrónico";
 "self.settings.account_section.phone.title" = "Teléfono";
 
-"self.settings.account_details_group.footer" = "La gente puede encontrarte con estos detalles. La información es encriptada y no es visible a nadie mas.";
+"self.settings.account_details_group.footer" = "Las personas pueden encontrarse con estos detalles.";
 
 "self.settings.account_details.remove_device.title" = "Eliminar dispositivo";
 "self.settings.account_details.key_fingerprint.title" = "Huella digital";
@@ -439,11 +446,11 @@
 "self.settings.account_picture_group.picture" = "Imagen";
 "self.settings.account_picture_group.color" = "Color";
 
-"self.settings.account_picture_group.theme" = "Tema oscuro";
+"self.settings.account_picture_group.theme" = "Tema Oscuro";
 
 "self.settings.device_details.fingerprint.subtitle" = "Wire proporciona a cada dispositivo una huella digital única. Compare las huellas dactilares para verificar su dispositivos y conversaciones.";
-"self.settings.device_details.reset_session.subtitle" = "If fingerprints don’t match, reset the session to generate new encryption keys on both sides.";
-"self.settings.device_details.remove_device.subtitle" = "Remove this device if you have stopped using it. Your message history will be erased and you will be logged out.";
+"self.settings.device_details.reset_session.subtitle" = "Si no coinciden las huellas digitales, reiniciar la sesión para generar nuevas claves de cifrado en ambos lados.";
+"self.settings.device_details.remove_device.subtitle" = "Eliminar este dispositivo si ha dejado de usarlo. Se borrará el historial de mensajes y será desconectado.";
 "self.settings.device_details.reset_session.success" = "La sesión ha sido restablecida";
 
 "self.settings.account_details.actions.title" = "Acciones";
@@ -473,10 +480,10 @@
 "self.settings.sound_menu.sounds.wire_message" = "Mensaje por Wire";
 "self.settings.sound_menu.sounds.wire_ping" = "Ping por Wire";
 
-// Send Button
-"self.settings.send_button.title" = "Use return key to send messages";
-"self.settings.send_button.header" = "Send Button";
-"self.settings.send_button.footer" = "If turned on, messages will be send when tapping the return key instead of the dedicated send button";
+// By popular demand
+"self.settings.popular_demand.title" = "Por demanda popular";
+"self.settings.popular_demand.send_button.title" = "Botón de enviar";
+"self.settings.popular_demand.send_button.footer" = "Deshabilitar para enviar via teclado.";
 
 // Sound alerts (TO BE UPDPATED)
 "self.settings.sound_menu.title" = "Alertas de sonido";
@@ -493,7 +500,7 @@
 
 "self.settings.privacy_contacts_section.title" = "Contactos";
 "self.settings.privacy_contacts_menu.settings_button.title" = "Abrir ajustes de contactos";
-"self.settings.privacy_contacts_menu.description_disabled.title" = "This helps you connect with others. We anonymize all the information and do not share it with anyone else. Allow access via Settings > Privacy > Contacts.";
+"self.settings.privacy_contacts_menu.description_disabled.title" = "Compartir tus contactos te ayuda a conectar con los demás. Toda la información es anónima y no la compartiremos con nadie más. Permite el acceso a través de Ajustes > Privacidad > Contactos.";
 
 "self.settings.privacy_analytics_menu.devices.title" = "Dispositivos";
 
@@ -505,12 +512,13 @@
 
 "self.settings.advanced.title" = "Avanzado";
 "self.settings.advanced.troubleshooting.title" = "Solución de problemas";
-"self.settings.advanced.troubleshooting.submit_debug.title" = "Calling Debug Report";
-"self.settings.advanced.troubleshooting.submit_debug.subtitle" = "This information helps Wire Support diagnose calling problems.";
+"self.settings.advanced.troubleshooting.submit_debug.title" = "Enviar informe de depuración";
+"self.settings.advanced.troubleshooting.submit_debug.subtitle" = "Esto ayuda al equipo de soporte de Wire a diagnosticar problemas.";
 "self.settings.advanced.reset_push_token.title" = "Restablece el Token de las Notificaciones Push";
-"self.settings.advanced.reset_push_token.subtitle" = "If you experience problems with push notifications, Wire Support may ask you to reset this token.";
+"self.settings.advanced.reset_push_token.subtitle" = "Si tiene problemas con las notificaciones push, el soporte de Wire puede pedirle de restablecer este token.";
 "self.settings.advanced.reset_push_token_alert.title" = "El Token Push ha sido restablecido";
 "self.settings.advanced.reset_push_token_alert.message" = "Las notificaciones se restaurarán en unos segundos.";
+"self.settings.advanced.version_technical_details.title" = "Detalles técnicos de la versión";
 
 // Technical Report
 "self.settings.technical_report_section.title" = "Informe técnico";
@@ -616,7 +624,7 @@
 "registration.devices.title" = "Dispositivos";
 "registration.devices.active_list_header" = "Activo";
 "registration.devices.current_list_header" = "Actual";
-"registration.devices.active_list_subtitle" = "If you don’t recognize a device above, remove it and reset your password.";
+"registration.devices.active_list_subtitle" = "Si no reconoce un dispositivo anterior, quitar y restablecer la contraseña.";
 "registration.devices.activated_in" = "Activado en";
 "registration.devices.id" = "ID:";
 
@@ -703,6 +711,8 @@
 "giphy.error.no_result" = "no se encontró gif";
 
 "giphy.confirm" = "enviar";
+"giphy.cancel" = "cancelar";
+"giphy.search_placeholder" = "Búsqueda Giphy";
 
 "invite_banner.title" = "¡Trae a tus amigos a Wire!";
 "invite_banner.message" = "Disfruta de llamadas, mensajes, dibujos, GIFs y más en privado o con grupos.";

--- a/Wire-iOS/Resources/it.lproj/InfoPlist.strings
+++ b/Wire-iOS/Resources/it.lproj/InfoPlist.strings
@@ -1,0 +1,22 @@
+/*
+ *  Wire
+ *  Copyright (C) 2016 Wire Swiss GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+"NSContactsUsageDescription" = "Allow Wire to access your contacts to connect you with others. We anonymize all information and do not share it with anyone else.";
+"NSMicrophoneUsageDescription" = "Allow Wire to access your microphone so you can talk to people and send audio messages.";
+"NSLocationWhenInUseUsageDescription" = "Allow Wire to access your location so you can send your location to others.";
+"NSCameraUsageDescription" = "Allow Wire to access your camera so you can place video calls and send photos.";

--- a/Wire-iOS/Resources/it.lproj/InfoPlist.strings
+++ b/Wire-iOS/Resources/it.lproj/InfoPlist.strings
@@ -1,4 +1,4 @@
-/*
+/* 
  *  Wire
  *  Copyright (C) 2016 Wire Swiss GmbH
  *
@@ -14,9 +14,9 @@
  *
  *  You should have received a copy of the GNU General Public License
  *  along with this program. If not, see http://www.gnu.org/licenses/.
- */
+*/
 
-"NSContactsUsageDescription" = "Allow Wire to access your contacts to connect you with others. We anonymize all information and do not share it with anyone else.";
-"NSMicrophoneUsageDescription" = "Allow Wire to access your microphone so you can talk to people and send audio messages.";
-"NSLocationWhenInUseUsageDescription" = "Allow Wire to access your location so you can send your location to others.";
-"NSCameraUsageDescription" = "Allow Wire to access your camera so you can place video calls and send photos.";
+"NSContactsUsageDescription" = "Consenti a Wire di accedere ai tuoi contatti, così possiamo connetterti con altre persone. Rendiamo anonimi tutti i tuoi dati e non li condividiamo con nessuno.";
+"NSMicrophoneUsageDescription" = "Consenti a Wire di accedere al tuo microfono in modo da poter parlare con persone e inviare messaggi audio.";
+"NSLocationWhenInUseUsageDescription" = "Consenti a Wire di accedere alla tua posizione in modo da poter inviare la tua posizione agli altri.";
+"NSCameraUsageDescription" = "Consentire a Wire di accedere alla tua fotocamera in modo da poter effettuare videochiamate e inviare foto.";

--- a/Wire-iOS/Resources/it.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/it.lproj/Localizable.strings
@@ -1,0 +1,712 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+"general.ok" = "OK";
+"general.cancel" = "Cancel";
+"general.open_settings" = "Open Wire Settings";
+
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++
+// People picker/start UI
+"peoplepicker.search_placeholder" = "Search by name or email";
+"peoplepicker.header.top_people" = "Top people";
+"peoplepicker.button.create_conversation" = "Create group";
+"peoplepicker.button.add_to_conversation" = "Add";
+"peoplepicker.header.conversations" = "Groups";
+"peoplepicker.header.send_invitation" = "Invite";
+"peoplepicker.header.contacts" = "Connections";
+"peoplepicker.header.directory" = "Connect";
+"peoplepicker.title.create_conversation" = "Create group";
+"peoplepicker.title.add_to_conversation" = "Add people";
+
+"peoplepicker.no_contacts_title" = "No Contacts.";
+
+"peoplepicker.no_matching_results_title" = "No results.";
+"peoplepicker.no_matching_results_message" = "Enter a full email address.";
+
+"peoplepicker.no_matching_results.action.send_invite" = "Send an invitation";
+"peoplepicker.no_matching_results.action.share_contacts" = "Share contacts";
+
+"peoplepicker.no_matching_results_provide_valid_email" = "Please enter a valid email address";
+"peoplepicker.no_matching_results_after_address_book_upload_title" = "No results.";
+/* This sentence ends with button title, contained in peoplepicker.no_matching_results_after_address_book_upload_button */
+"peoplepicker.no_matching_results_after_address_book_upload_message" = "Enter a full email address or";
+/*  */
+"peoplepicker.no_matching_results_after_address_book_upload_button" = "share contacts";
+
+"peoplepicker.share_contacts.no_results.title" = "Find people by name or email address";
+
+"peoplepicker.send_invitation.dialog.title" = "Invitation sent";
+"peoplepicker.send_invitation.dialog.message" = "It can be used for 2 weeks. Send a new one if it expires.";
+"peoplepicker.send_invitation.dialog.ok" = "OK";
+
+"peoplepicker.invite_more_people" = "Invite more people";
+"peoplepicker.quick-action.open-conversation" = "Open";
+"peoplepicker.quick-action.create-conversation" = "Create group";
+
+// Contacts UI
+"contacts_ui.search_placeholder" = "Search by name";
+"contacts_ui.invite_others" = "Invite others";
+"contacts_ui.name_in_contacts" = "%@ in address book";
+"contacts_ui.connection_request" = "Requested to connect";
+"contacts_ui.action_button.invite" = "Invite";
+"contacts_ui.action_button.open" = "Open";
+"contacts_ui.invite_sheet.cancel_button_title" = "Cancel";
+"contacts_ui.notification.invitation_sent" = "Invitation sent";
+"contacts_ui.notification.invitation_failed" = "Failed to send invitation";
+"contacts_ui.title" = "Invite people";
+
+"contacts_ui.no_contact.title" = "No active conversations\n";
+"contacts_ui.no_contact.message" = "Tap contacts to start a conversation";
+
+// Conversation List Bottom Bar
+"bottom_bar.contacts_button.title" = "contacts";
+
+// Archived List
+"archived_list.title" = "archive";
+
+// Add contact tool tip
+"tool_tip.contacts.title" = "Conversations start here";
+"tool_tip.contacts.message" = "Start a conversation or invite more people to join. Call, message and share in private or with groups.";
+
+// "Knows" subtitle in cell: "Knows Indrek", "Knows Indrek and Jane", "Knows Indrek and 5 others"
+"peoplepicker.suggested.knows_one" = "Knows %@";
+"peoplepicker.suggested.knows_two" = "Knows %@ and %@";
+"peoplepicker.hide_search_result" = "Hide";
+"peoplepicker.hide_search_result_progress" = "Hiding…";
+
+"send_invitation.subject" = "Connect with me on Wire";
+"send_invitation.text" = "I’m on Wire. Search for %@\nor visit https://get.wire.com to connect with me.";
+"send_invitation_no_email.text" = "I’m on Wire. Visit https://get.wire.com to connect with me.";
+
+"send_personal_invitation.text" = "I’m on Wire, talk to you there. https://get.wire.com";
+
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++x
+// In-app notifications (chat heads)
+"notifications.shared_a_photo" = "shared a picture";
+"notifications.pinged" = "pinged";
+"notifications.sent_file" = "shared a file";
+"notifications.sent_location" = "shared a location";
+"notifications.sent_video" = "shared a video";
+"notifications.sent_audio" = "shared an audio";
+"notifications.in_conversation" = "%@ - %@";
+"notifications.this_conversation" = "%@ in this conversation";
+
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++
+// List (labels) - Needs to be revised with updated guidance
+"list.archived_conversations" = "ARCHIVE";
+"list.archived_conversations_close" = "Close archive";
+
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++
+// Conversation
+"conversation.invite_more_people.title" = "Spread the word!";
+"conversation.invite_more_people.description" = "Add people to this conversation";
+"conversation.invite_more_people.explanation_url" = "https://support.wire.com";
+"conversation.invite_more_people.button_title" = "Add People";
+
+// Conversation names
+"conversation.displayname.emptygroup" = "Empty group conversation";
+
+"conversation.input_bar.verified" = "Verified";
+"conversation.input_bar.placeholder" = "Type a message";
+
+"conversation.input_bar.audio_message.tooltip.pull_send" = "Swipe up to send";
+"conversation.input_bar.audio_message.tooltip.tap_send" = "Tap to send";
+"conversation.input_bar.audio_message.too_long.title" = "Recording Stopped";
+"conversation.input_bar.audio_message.too_long.message" = "Audio messages are limited to %@. Send this message?";
+"conversation.input_bar.audio_message.send" = "Send";
+
+"conversation.input_bar.audio_message.keyboard.record_tip" = "Tap to record\nYou can  %@  it after that";
+"conversation.input_bar.audio_message.keyboard.filter_tip" = "Choose a filter above";
+
+// Image confirmation dialogue
+"image_confirmer.confirm" = "OK";
+"image_confirmer.cancel" = "Cancel";
+"image.add_sketch" = "Add a sketch";
+"image.edit_image" = "Edit image";
+
+// Camera access
+"camera_access.denied" = "Wire needs access to the Camera.";
+"camera_access.denied.instruction" = "";
+"camera_access.denied.open_settings" = "Enable it in Wire Settings";
+
+// Camera Controls
+"camera_controls.aeaf_lock" = "AE/AF Lock";
+
+// Location
+"location.send_button.title" = "Send";
+"location.unauthorized_alert.title" = "Enable Location Services";
+"location.unauthorized_alert.message" = "To send your location, enable Location Services and allow Wire to access your location.";
+"location.unauthorized_alert.cancel" = "Cancel";
+"location.unauthorized_alert.settings" = "Settings";
+
+// Twitter
+"twitter_status.on_twitter" = "%@ on Twitter";
+
+// System messages
+"content.system.continued_conversation" = "Start a conversation with %@";
+
+"content.system.other_started_conversation" = "%@ started a conversation with %@";
+"content.system.you_started_conversation" = "You started a conversation with %@";
+
+"content.system.you_added_participant" = "You added %@";
+"content.system.other_added_participant" = "%@ added %@";
+"content.system.other_added_you" = "%@ added you";
+
+"content.system.participants_you" = "You";
+"content.system.participants_1_other" = "%@ and %@";
+"content.system.other_left" = "%@ left";
+"content.system.you_left" = "You left";
+"content.system.other_removed_other" = "%@ removed %@";
+"content.system.other_removed_you" = "%@ removed you";
+"content.system.you_removed_other" = "You removed %@";
+"content.system.other_renamed_conv" = "%@ renamed the conversation";
+"content.system.you_renamed_conv" = "You renamed the conversation";
+"content.system.other_renamed_conv_to_nothing" = "%@ removed the conversation name";
+"content.system.you_renamed_conv_to_nothing" = "You removed the conversation name";
+"content.system.pending_message_timestamp" = "Sending…";
+"content.system.message_sent_timestamp" = "Sent";
+"content.system.message_delivered_timestamp" = "Delivered";
+"content.system.failedtosend_message_timestamp" = "Sending failed.";
+"content.system.failedtosend_message_timestamp_resend" = "Resend";
+"content.system.like_tooltip" = "Tap to like";
+"content.system.deleted_message_prefix_timestamp" = "Deleted on %@";
+"content.system.edited_message_prefix_timestamp" = "Edited on %@";
+"content.system.connecting_to" = "Connecting to %@.\nStart a conversation";
+"content.system.connected_to" = "Connected to %@\nStart a conversation";
+"content.system.other_wanted_to_talk" = "%@ called";
+"content.system.you_wanted_to_talk" = "You called";
+
+"content.system.you_started" = "You";
+"content.system.this_device" = "this device";
+
+"content.system.reactivated_device" = "You started using %@ again. Messages sent in the meantime will not appear here";
+
+"content.system.new_device" = "a new device";
+"content.system.started_using" = "started using";
+"content.system.is_verified" = "All fingerprints are verified";
+
+"content.system.unverified" = "%@ unverified one of %@"; //example "You unverified one of Jule's devices"
+"content.system.your_devices" = "your devices";
+"content.system.other_devices" = "%@'s devices";
+
+"content.system.missing_messages.title" = "You haven't used this device for a while. Some messages may not appear here.";
+"content.system.missing_messages.subtitle_start" = "Meanwhile,";
+
+"content.system.cannot_decrypt" = "A message from %@ was not received.";
+
+"content.system.cannot_decrypt.you_part" = "you";
+"content.system.cannot_decrypt.why_part" = "Why?";
+
+"content.system.cannot_decrypt.identity" = "%@ device identity changed. Undelivered message.";
+"content.system.cannot_decrypt.identity.you_part" = "Your";
+"content.system.cannot_decrypt.identity.otherUser_part" = "%@'s"; // posessive apostrophe - might differ in different languages
+"content.system.cannot_decrypt.identity.why_part" = "Learn More";
+
+"content.file.uploading" = "Uploading…";
+"content.file.downloading" = "Downloading…";
+"content.file.upload_failed" = "Upload failed";
+"content.file.upload_cancelled" = "Upload cancelled";
+"content.file.upload_video" = "Videos";
+"content.file.take_video" = "Record a video";
+
+"content.file.save_video" = "Save";
+"content.file.save_audio" = "Save";
+"content.image.save_image" = "Save";
+
+"content.message.delete" = "Delete";
+
+"content.message.like" = "Like";
+"content.message.unlike" = "Unlike";
+
+"content.reactions_list.likers" = "Liked by";
+
+"content.file.too_big" = "You can send files up to %@";
+// Someone pinged
+"content.ping.text" = "%1$@ PINGED";
+
+// Current user pinged
+"content.ping.you.text" = "YOU PINGED";
+
+// Inline Player
+"content.player.unable_to_play" = "UNABLE TO PLAY TRACK";
+
+// Connecting (NEW IMPLEMENTATION, REVIEW LATER)
+"connection_request.title" = "Connect to %@"; //check UPPERCASE implementation in code
+"missive.connection_request.default_message" = "Hi %@,\nLet’s connect on Wire.\n%@";
+
+"connection_request.send_button_title" = "Connect";
+"inbox.connection_request.connect_button_title" = "Connect";
+"inbox.connection_request.ignore_button_title" = "Ignore";
+
+// Voice
+"voice.status.one_to_one.incoming" = "%@\nCalling";
+"voice.status.group_call.incoming" = "%@\nRinging";
+"voice.status.one_to_one.outgoing" = "%@\nRinging";
+"voice.status.joining" = "%@\nConnecting";
+"voice.status.video_not_available" = "Video turned off";
+"voice.status.low_connection" = "Bad connection";
+"voice.network_error.title" = "No Internet Connection";
+"voice.network_error.body" = "You must be online to call. Check your connection and try again.";
+"voice.alert.call_in_progress.title" = "Call in progress";
+"voice.alert.call_in_progress.message" = "Another of your devices is already participating in the call";
+"voice.alert.call_in_progress.confirm" = "Ok";
+"voice.accept_button.title" = "Accept";
+"voice.decline_button.title" = "Decline";
+"voice.hang_up_button.title" = "Hang Up";
+"voice.mute_button.title" = "Mute";
+"voice.video_button.title" = "Video";
+"voice.speaker_button.title" = "Speaker";
+
+"voice.alert.microphone_warning.title" = "Wire needs access to the Microphone.";
+"voice.alert.microphone_warning.explanation" = "Enable it in Wire Settings.";
+
+"voice.alert.camera_warning.title" = "Wire needs access to the Camera.";
+"voice.alert.camera_warning.explanation" = "Go to Settings and allow Wire to access the camera.";
+
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++
+// Profile and Participants
+
+"participants.add_people_button_title" = "Add people";
+
+// Meta Menu
+"meta.menu.rename" = "Rename";
+"meta.menu.leave" = "Leave";
+"meta.menu.archive" = "Archive";
+"meta.menu.unarchive" = "Unarchive";
+"meta.menu.delete" = "Delete";
+"meta.menu.silence.mute" = "Mute";
+"meta.menu.silence.unmute" = "Unmute";
+"meta.menu.cancel" = "Cancel";
+"meta.menu.cancel_connection_request" = "Cancel Request";
+
+// Delete conversation
+"meta.menu.delete_content.dialog_title" = "Delete content?";
+"meta.menu.delete_content.dialog_message" = "This will clear the conversation history and remove it from the list.";
+"meta.menu.delete_content.leave_as_well_message" = "Also leave the conversation";
+"meta.menu.delete_content.button_cancel" = "Cancel";
+"meta.menu.delete_content.button_delete" = "Delete";
+
+// Leave conversation
+"meta.leave_conversation_dialog_title" = "Leave conversation?";
+"meta.leave_conversation_dialog_message" = "The participants will be notified and the conversation will be removed from your list.";
+"meta.leave_conversation.delete_content_as_well_message" = "Also delete the content";
+"meta.leave_conversation_button_cancel" = "Cancel";
+"meta.leave_conversation_button_leave" = "Leave";
+
+// Conversation Degraded (security level lowered)
+"meta.degraded.degradation_reason_message.singular" = "%@ started using a new device.";
+"meta.degraded.degradation_reason_message.plural" = "%@ started using new devices.";
+"meta.degraded.dialog_message" = "Do you still want to send your message?";
+"meta.degraded.show_device_button" = "Show device";
+"meta.degraded.send_anyway_button" = "Send anyway";
+
+// Remove from conversation dialogue
+"profile.remove_dialog_title" = "Remove?";
+"profile.remove_dialog_message" = "%@ won’t be able to send or receive messages in this conversation.";
+"profile.remove_dialog_button_cancel" = "Cancel";
+"profile.remove_dialog_button_remove" = "Remove";
+
+// Block dialog
+"profile.block_dialog.title" = "Block?";
+"profile.block_dialog.message" = "%@ won’t be able to find or contact you on Wire.";
+"profile.block_dialog.button_cancel" = "Cancel";
+"profile.block_dialog.button_block" = "Block";
+
+// Delete message dialog
+"message.delete_dialog.message" = "This cannot be undone.";
+"message.delete_dialog.action.cancel" = "Cancel";
+"message.delete_dialog.action.hide" = "Delete for Me";
+"message.delete_dialog.action.delete" = "Delete for Everyone";
+
+// Edit message
+"message.menu.edit.title" = "Edit";
+
+// Accept connection request
+"profile.connection_request_dialog.title" = "Accept?";
+"profile.connection_request_dialog.message" = "This will connect you and open the conversation with %@.";
+"profile.connection_request_dialog.button_cancel" = "Ignore";
+"profile.connection_request_dialog.button_connect" = "Connect";
+
+// Cancel connection request
+"profile.cancel_connection_request_dialog.title" = "Cancel Request?";
+"profile.cancel_connection_request_dialog.message" = "Remove connection request to %@.";
+"profile.cancel_connection_request_dialog.button_no" = "No";
+"profile.cancel_connection_request_dialog.button_yes" = "Yes";
+
+// Unblock button
+"profile.unblock_button_title" = "Unblock";
+
+"profile.cancel_connection_button_title" = "CANCEL REQUEST";
+"profile.connection_request_state.blocked" = "BLOCKED";
+"profile.create_conversation_button_title" = "Create group";
+"profile.open_conversation_button_title" = "Open conversation";
+
+// User Details
+"profile.details.title" = "Details";
+
+// Device list
+"profile.devices.title" = "Devices";
+"profile.devices.fingerprint_message_unencrypted" = "%@ is using an old version of Wire. No devices are shown here.";
+"profile.devices.fingerprint_message" = "Wire gives every device a unique fingerprint. Compare them with %@ and verify your conversation. Why verify conversations?";
+"profile.devices.fingerprint_message.link" = "Why verify conversations?";
+
+// Device detail
+"profile.devices.detail.verify_message" = "Verify that this matches the fingerprint shown on %@'s device.";
+"profile.devices.detail.verify_message.link" = "How do I do that?";
+"profile.devices.detail.show_my_device.title" = "Show my device fingerprint";
+"device.verified" = "Verified";
+"device.not_verified" = "Not Verified";
+"device.class.desktop" = "Desktop";
+"device.class.tablet" = "Tablet";
+"device.class.phone" = "Phone";
+"profile.devices.detail.reset_session.title" = "Reset Session";
+
+// General strings
+"general.confirm" = "OK";
+
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++
+// Self profile
+
+// Options menu contents
+"self.settings" = "Settings";
+"self.help_center" = "Support";
+"self.help_center.support_website" = "Wire Support Website";
+"self.help_center.contact_support" = "Contact Support";
+"self.about" = "About";
+"self.sign_out" = "Log Out";
+"self.report_abuse" = "Report Misuse";
+
+"self.add_phone_number" = "Add phone number";
+"self.add_email_password" = "Add email address and password";
+
+// About screen
+"about.tos.title"="Terms of Use";
+"about.privacy.title"="Privacy Policy";
+"about.license.title" = "License Information";
+"about.website.title"="Wire Website";
+"about.copyright.title"="© Wire Swiss GmbH";
+
+// Self new devices
+"self.new_device_alert.title" = "You have connected %@ to your Wire account";
+"self.new_device_alert.title_prefix.tablet" = "a tablet";
+"self.new_device_alert.title_prefix.phone" = "a phone";
+"self.new_device_alert.title_prefix.devices" = "%d devices";
+"self.new_device_alert.message" = "%@\n\nIf you didn’t do this, remove the device and reset your password.";
+"self.new_device_alert.message_plural" = "%@\n\nIf you didn’t do this, remove those devices and reset your password.";
+"self.new_device_alert.manage_devices" = "Manage devices";
+"self.new_device_alert.trust_devices" = "OK";
+
+// Settings - Account details
+"self.settings.account_section" = "Account";
+
+"self.settings.account_details_group.title" = "Info";
+
+"self.settings.account_section.name.title" = "Name";
+"self.settings.account_section.email.title" = "Email";
+"self.settings.account_section.phone.title" = "Phone";
+
+"self.settings.account_details_group.footer" = "People can find you with these details.";
+
+"self.settings.account_details.remove_device.title" = "Remove Device";
+"self.settings.account_details.key_fingerprint.title" = "Key Fingerprint";
+"self.settings.account_details.remove_device.message" = "Your password is required to remove the device";
+"self.settings.account_details.remove_device.password" = "Password";
+"self.settings.account_details.remove_device.password.error" = "Wrong password";
+
+"self.settings.account_appearance_group.title" = "Appearance";
+"self.settings.account_picture_group.picture" = "Picture";
+"self.settings.account_picture_group.color" = "Color";
+
+"self.settings.account_picture_group.theme" = "Dark Theme";
+
+"self.settings.device_details.fingerprint.subtitle" = "Wire gives every device a unique fingerprint. Compare them and verify your devices and conversations.";
+"self.settings.device_details.reset_session.subtitle" = "If fingerprints don’t match, reset the session to generate new encryption keys on both sides.";
+"self.settings.device_details.remove_device.subtitle" = "Remove this device if you have stopped using it. Your message history will be erased and you will be logged out.";
+"self.settings.device_details.reset_session.success" = "The session has been reset";
+
+"self.settings.account_details.actions.title" = "Actions";
+
+"self.settings.account_details.delete_account.title" = "Delete Account";
+
+"self.settings.account_details.delete_account.alert.title" = "Delete Account";
+"self.settings.account_details.delete_account.alert.message" = "We will send you a message via email or SMS. Follow the link to permanently delete your account.";
+
+
+// Chat alerts
+"self.settings.notifications.push_notification.title" = "Notifications";
+"self.settings.notifications.push_notification.toogle" = "Message Previews";
+"self.settings.notifications.push_notification.footer" = "Sender name and message on the lock screen and in Notification Center.";
+
+"self.settings.notifications.chat_alerts.toggle" = "Message Banners";
+"self.settings.notifications.chat_alerts.footer" = "New messages in other conversations.";
+
+"self.settings.sound_menu.sounds.title" = "Sounds";
+"self.settings.sound_menu.ringtone.title" = "Ringtone";
+"self.settings.sound_menu.message.title" = "Text Tone";
+"self.settings.sound_menu.ping.title" = "Ping";
+"self.settings.sound_menu.ringtones.title" = "Ringtones";
+"self.settings.sound_menu.sounds.wire_sound" = "Wire";
+
+"self.settings.sound_menu.sounds.wire_call" = "Wire Call";
+"self.settings.sound_menu.sounds.wire_message" = "Wire Message";
+"self.settings.sound_menu.sounds.wire_ping" = "Wire Ping";
+
+// By popular demand
+"self.settings.popular_demand.title" = "By popular demand";
+"self.settings.popular_demand.send_button.title" = "Send Button";
+"self.settings.popular_demand.send_button.footer" = "Disable to send via the return key.";
+
+// Sound alerts (TO BE UPDPATED)
+"self.settings.sound_menu.title" = "Sound Alerts";
+"self.settings.sound_menu.no_sounds.title" = "None";
+"self.settings.sound_menu.all_sounds.title" = "All";
+"self.settings.sound_menu.mute_while_talking.title" = "First message, pings, calls";
+
+// Developer options
+"self.settings.developer_options.title" = "Developer Options";
+"self.settings.apns_logging.title" = "APNS Logging";
+
+// Privacy (visibility) options
+"self.settings.options_menu.title" = "Options";
+
+"self.settings.privacy_contacts_section.title" = "Contacts";
+"self.settings.privacy_contacts_menu.settings_button.title" = "Open Contacts Settings";
+"self.settings.privacy_contacts_menu.description_disabled.title" = "This helps you connect with others. We anonymize all the information and do not share it with anyone else. Allow access via Settings > Privacy > Contacts.";
+
+"self.settings.privacy_analytics_menu.devices.title" = "Devices";
+
+"self.settings.privacy_analytics_section.title" = "Usage and Crash Reports";
+"self.settings.privacy_analytics_menu.description.title" = "Make Wire better by sending anonymous information.\n";
+
+"self.settings.privacy.clear_history.title" = "Clear History";
+"self.settings.privacy.clear_history.subtitle" = "This will permanently erase the content of all your conversations.";
+
+"self.settings.advanced.title" = "Advanced";
+"self.settings.advanced.troubleshooting.title" = "Troubleshooting";
+"self.settings.advanced.troubleshooting.submit_debug.title" = "Calling Debug Report";
+"self.settings.advanced.troubleshooting.submit_debug.subtitle" = "This information helps Wire Support diagnose calling problems.";
+"self.settings.advanced.reset_push_token.title" = "Reset Push Notifications Token";
+"self.settings.advanced.reset_push_token.subtitle" = "If you experience problems with push notifications, Wire Support may ask you to reset this token.";
+"self.settings.advanced.reset_push_token_alert.title" = "Push token has been reset";
+"self.settings.advanced.reset_push_token_alert.message" = "Notifications will be restored in a few seconds.";
+"self.settings.advanced.version_technical_details.title" = "Version Technical Details";
+
+// Technical Report
+"self.settings.technical_report_section.title" = "Technical Report";
+"self.settings.technical_report.send_report" = "Send report to Wire";
+"self.settings.technical_report.mail.recipient" = "callingsupport@wire.com";
+"self.settings.technical_report.mail.subject" = "Wire Calling Report";
+"self.settings.technical_report.include_log" = "Include detailed log";
+
+// Password reset
+"self.settings.password_reset_menu.title" = "Reset Password";
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++
+// System status
+"system_status_bar.no_internet.title" = "No Internet";
+"system_status_bar.no_internet.explanation" = "There seems to be a problem with your Internet connection. Please make sure it’s working.";
+"system_status_bar.poor_connectivity.title" = "Slow Internet, can’t call now";
+"system_status_bar.poor_connectivity.explanation" = "We can’t guarantee voice quality. Connect to Wi-Fi or try changing your location.";
+
+// Common connections on profile view
+"profile_other.common_connections" = "You both know";
+
+// View user profile and options menu
+"name.placeholder" = "Your full name";
+"name.guidance.tooshort" = "At least 2 characters";
+"name.guidance.toolong" = "Too many characters";
+
+"email.placeholder" = "Email";
+
+"password.placeholder" = "Password";
+"password.guidance.tooshort" = "At least 8 characters";
+"password.guidance.toolong" = "Too many characters";
+
+"registration.title" = "Registration";
+"registration.close_email_invitation_button.email_title" = "Use another email";
+"registration.close_email_invitation_button.phone_title" = "Register by phone";
+"registration.close_phone_invitation_button.email_title" = "Register by email";
+"registration.close_phone_invitation_button.phone_title" = "Use another phone";
+
+"registration.enter_phone_number.title" = "Edit phone number";
+"registration.enter_phone_number.placeholder" = "Phone number";
+
+"registration.verify_phone_number.instructions" = "Enter the verification code we sent to %@";
+"registration.verify_phone_number.resend" = "Resend";
+"registration.verify_phone_number.resend_placeholder" = "No code showing up?\nYou can request a new one in %.0f seconds";
+
+"registration.verify_email.instructions" = "We sent an email to %@.\n Follow the link to verify your address.";
+"registration.verify_email.resend.instructions" = "Didn't get the message?";
+"registration.verify_email.resend.button_title" = "Re-send";
+
+"registration.select_picture.subtitle" = "Wire is so much nicer with a picture.";
+"registration.select_picture.button_title" = "Choose your own";
+"registration.keep_picture.button_title" = "Keep this one";
+"registration.camera_action.title" = "Take photo";
+"registration.photo_gallery_action.title" = "Choose Photo";
+"registration.cancel_action.title" = "Cancel";
+
+"registration.no_history.hero" = "It’s the first time you’re using Wire on this device.";
+"registration.no_history.subtitle" = "For privacy reasons, your conversation history will not appear here.";
+"registration.no_history.got_it" = "OK";
+
+"registration.no_history.logged_out.hero" = "You've used Wire on this device before.";
+"registration.no_history.logged_out.subtitle" = "Messages sent in the meantime will not appear.";
+"registration.no_history.logged_out.got_it" = "OK";
+
+"registration.enter_name.title" = "Edit Name";
+"registration.enter_name.hero" = "What should we call you?";
+"registration.enter_name.placeholder" = "Your full name";
+
+"registration.terms_of_use.title" = "Welcome to Wire.";
+"registration.terms_of_use.terms" = "By continuing you agree to the Wire Terms of Use.";
+"registration.terms_of_use.terms.link" = "Terms of Use";
+"registration.terms_of_use.agree" = "I agree";
+
+"registration.email_flow.title" = "Register by Email";
+"registration.email_flow.email_step.title" = "Edit Details";
+
+"registration.country_select.title" = "Country";
+
+"registration.share_contacts.hero.title" = "Find people on Wire";
+"registration.share_contacts.hero.paragraph"  = "Share your contacts so we can connect you with others. We anonymize all information and do not share it with anyone else.";
+"registration.share_contacts.find_friends_button.title" = "Share contacts";
+"registration.share_contacts.skip_button.title" = "Not now";
+
+"registration.address_book_access_denied.hero.title" = "Wire does not have access to your contacts.";
+"registration.address_book_access_denied.hero.paragraph1" = "Wire helps find your friends if you share your contacts.";
+"registration.address_book_access_denied.hero.paragraph2" = "To enable access tap Settings and turn on Contacts.";
+"registration.address_book_access_denied.settings_button.title" = "Settings";
+"registration.address_book_access_denied.maybe_later_button.title" = "Maybe later";
+
+"registration.push_access_denied.hero.title" = "Never miss a call or a message.";
+"registration.push_access_denied.hero.paragraph1" = "Enable Notifications in Settings.";
+"registration.push_access_denied.settings_button.title" = "Go to Settings";
+"registration.push_access_denied.maybe_later_button.title" = "Maybe later";
+
+"registration.signin.title" = "Log In";
+"registration.signin.too_many_devices.title" = "";
+"registration.signin.too_many_devices.subtitle" = "Remove one of your other devices to start using Wire on this one.";
+"registration.signin.too_many_devices.manage_button.title" = "Manage devices";
+"registration.signin.too_many_devices.sign_out_button.title" = "Log out";
+"registration.signin.email_button.title" = "Email";
+"registration.signin.phone_button.title" = "Phone";
+
+"registration.devices.title" = "Devices";
+"registration.devices.active_list_header" = "Active";
+"registration.devices.current_list_header" = "Current";
+"registration.devices.active_list_subtitle" = "If you don’t recognize a device above, remove it and reset your password.";
+"registration.devices.activated_in" = "Activated in";
+"registration.devices.id" = "ID:";
+
+"signin.forgot_password" = "Forgot password?";
+
+"registration.add_phone_number.hero.title" = "Add phone number";
+"registration.add_phone_number.hero.paragraph" = "This helps us find people you may know. We never share it.";
+"registration.add_phone_number.skip_button.title" = "Not now";
+
+"registration.add_email_password.hero.title" = "Add your email and password.";
+"registration.add_email_password.hero.paragraph" = "This lets you use Wire on multiple devices.";
+
+"registration.email_invitation.title" = "Invitation";
+"registration.email_invitation.hero.title" = "Hello, %@";
+"registration.email_invitation.hero.paragraph" = "Choose a password to create your account.";
+
+"registration.phone_invitation.title" = "Invitation";
+"registration.phone_invitation.hero.title" = "Hello, %@";
+"registration.phone_invitation.hero.paragraph" = "You are one step away from creating your account.";
+
+"error.name_and_email" = "Please enter your full name and a valid email address";
+"error.full_name" = "Please enter your full name";
+"error.email" = "Please enter a valid email address";
+"error.input.too_long" = "Input too long";
+"error.input.too_short" = "Input too short";
+"error.email.invalid" = "Please enter a valid email address";
+"error.phone.invalid" = "Please enter a valid phone number";
+
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++
+// ZMUserSessionErrorCode mapping. Used during registration and profile edit
+"error.user.unkown_error" = "Something went wrong, please try again";
+"error.user.needs_credentials" = "Please verify your details and try again.";
+"error.user.invalid_credentials" = "Please verify your details and try again.";
+"error.user.account_pending_activation" = "The account you are trying access is pending activation. Please verify your details.";
+"error.user.network_error" = "There seems to be a problem with your network. Please try again later.";
+"error.user.email_is_taken" = "The email address you provided has already been registered. Please try again.";
+"error.user.phone_is_taken" = "The phone number you provided has already been registered. Please try again.";
+"error.user.phone_code_invalid" = "Please enter a valid code";
+"error.user.phone_code_too_many" = "We already sent you a code via SMS. Tap Resend after 10 minutes to get a new one.";
+"error.user.registration_unknown_error" = "Something went wrong. Please try again.";
+"error.user.device_deleted_remotely" = "You have been logged out from another device.";
+
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++
+// Those are caught by the UI without involving the SE validation. Basically very similar to ZMUserSessionErrorCode onces
+"error.updating_password" = "Couldn't update your password.";
+
+"error.group_call.too_many_members_in_conversation.title" = "Too many people to call";
+"error.group_call.too_many_members_in_conversation" = "Calls work in conversations with up to %d people.";
+"error.group_call.too_many_participants_in_the_call.title" = "The call is full";
+"error.group_call.too_many_participants_in_the_call" = "There’s only room for %d people in here.";
+"error.call.gsm_ongoing.title" = "Cellular call";
+"error.call.gsm_ongoing" = "Please cancel the cellular call before calling on Wire.";
+"error.call.general.title" = "Call error";
+"error.call.general" = "Please try calling again in several minutes.";
+"error.call.slow_connection.title" = "Slow connection";
+"error.call.slow_connection" = "You might experience issues during the call";
+"error.call.slow_connection.call_anyway" = "Call anyway";
+
+"error.invite.no_email_provider" = "Please configure your email client to be able to send the invites via email";
+"error.invite.no_messaging_provider" = "Please configure your SMS to be able to send the invites via SMS";
+
+"sketchpad.initial_hint" = "Tap color to change brush size\nPress and hold to fill an area\nShake to remove a photo";
+
+"migration.please_wait_message" = "One moment, please";
+
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++
+// Those are used by the backend to localize APNS
+"push.notification.new_user" = "%@ joined Wire";
+"push.notification.new_message" = "New message";
+
+
+//Force Update
+"force.update.title" = "Update necessary";
+"force.update.message" = "You are missing out on new features.\nGet the latest version of Wire in the App Store.";
+"force.update.ok_button" = "Go to App Store";
+
+// Third Party
+"giphy.conversation.message" = "%@ · via giphy.com";
+"giphy.conversation.random_message" = "via giphy.com";
+"giphy.error.no_more_results" = "no more gifs";
+"giphy.error.no_result" = "no gif found";
+
+"giphy.confirm" = "send";
+"giphy.cancel" = "cancel";
+"giphy.search_placeholder" = "Search giphy";
+
+"invite_banner.title" = "Bring your friends to Wire!";
+"invite_banner.message" = "Enjoy calls, messages, sketches, GIFs and more in private or with groups.";
+"invite_banner.invite_button_title" = "Invite more people";

--- a/Wire-iOS/Resources/it.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/it.lproj/Localizable.strings
@@ -1,386 +1,386 @@
-//
+// 
 // Wire
 // Copyright (C) 2016 Wire Swiss GmbH
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
 
 "general.ok" = "OK";
-"general.cancel" = "Cancel";
-"general.open_settings" = "Open Wire Settings";
+"general.cancel" = "Annulla";
+"general.open_settings" = "Apri le impostazioni di Wire";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // People picker/start UI
-"peoplepicker.search_placeholder" = "Search by name or email";
-"peoplepicker.header.top_people" = "Top people";
-"peoplepicker.button.create_conversation" = "Create group";
-"peoplepicker.button.add_to_conversation" = "Add";
-"peoplepicker.header.conversations" = "Groups";
-"peoplepicker.header.send_invitation" = "Invite";
-"peoplepicker.header.contacts" = "Connections";
-"peoplepicker.header.directory" = "Connect";
-"peoplepicker.title.create_conversation" = "Create group";
-"peoplepicker.title.add_to_conversation" = "Add people";
+"peoplepicker.search_placeholder" = "Ricerca per nome o e-mail";
+"peoplepicker.header.top_people" = "Più contattati";
+"peoplepicker.button.create_conversation" = "Crea gruppo";
+"peoplepicker.button.add_to_conversation" = "Aggiungi";
+"peoplepicker.header.conversations" = "Gruppi";
+"peoplepicker.header.send_invitation" = "Invita";
+"peoplepicker.header.contacts" = "Connessioni";
+"peoplepicker.header.directory" = "Connetti";
+"peoplepicker.title.create_conversation" = "Crea gruppo";
+"peoplepicker.title.add_to_conversation" = "Aggiungi persone";
 
-"peoplepicker.no_contacts_title" = "No Contacts.";
+"peoplepicker.no_contacts_title" = "Nessun contatto.";
 
-"peoplepicker.no_matching_results_title" = "No results.";
-"peoplepicker.no_matching_results_message" = "Enter a full email address.";
+"peoplepicker.no_matching_results_title" = "Nessun risultato.";
+"peoplepicker.no_matching_results_message" = "Metti un indirizzo email completo.";
 
-"peoplepicker.no_matching_results.action.send_invite" = "Send an invitation";
-"peoplepicker.no_matching_results.action.share_contacts" = "Share contacts";
+"peoplepicker.no_matching_results.action.send_invite" = "Manda un invito";
+"peoplepicker.no_matching_results.action.share_contacts" = "Condividi contatti";
 
-"peoplepicker.no_matching_results_provide_valid_email" = "Please enter a valid email address";
-"peoplepicker.no_matching_results_after_address_book_upload_title" = "No results.";
+"peoplepicker.no_matching_results_provide_valid_email" = "Inserisci un indirizzo email valido";
+"peoplepicker.no_matching_results_after_address_book_upload_title" = "Nessun risultato.";
 /* This sentence ends with button title, contained in peoplepicker.no_matching_results_after_address_book_upload_button */
-"peoplepicker.no_matching_results_after_address_book_upload_message" = "Enter a full email address or";
+"peoplepicker.no_matching_results_after_address_book_upload_message" = "Metti un indirizzo email completo o";
 /*  */
-"peoplepicker.no_matching_results_after_address_book_upload_button" = "share contacts";
+"peoplepicker.no_matching_results_after_address_book_upload_button" = "condividi contatti";
 
-"peoplepicker.share_contacts.no_results.title" = "Find people by name or email address";
+"peoplepicker.share_contacts.no_results.title" = "Trova le persone per nome o indirizzo email";
 
-"peoplepicker.send_invitation.dialog.title" = "Invitation sent";
-"peoplepicker.send_invitation.dialog.message" = "It can be used for 2 weeks. Send a new one if it expires.";
+"peoplepicker.send_invitation.dialog.title" = "Invito spedito";
+"peoplepicker.send_invitation.dialog.message" = "Può essere usato per 2 settimane. Inviane un altro quando scade.";
 "peoplepicker.send_invitation.dialog.ok" = "OK";
 
-"peoplepicker.invite_more_people" = "Invite more people";
-"peoplepicker.quick-action.open-conversation" = "Open";
-"peoplepicker.quick-action.create-conversation" = "Create group";
+"peoplepicker.invite_more_people" = "Invita più persone";
+"peoplepicker.quick-action.open-conversation" = "Apri";
+"peoplepicker.quick-action.create-conversation" = "Crea gruppo";
 
 // Contacts UI
-"contacts_ui.search_placeholder" = "Search by name";
-"contacts_ui.invite_others" = "Invite others";
-"contacts_ui.name_in_contacts" = "%@ in address book";
-"contacts_ui.connection_request" = "Requested to connect";
-"contacts_ui.action_button.invite" = "Invite";
-"contacts_ui.action_button.open" = "Open";
-"contacts_ui.invite_sheet.cancel_button_title" = "Cancel";
-"contacts_ui.notification.invitation_sent" = "Invitation sent";
-"contacts_ui.notification.invitation_failed" = "Failed to send invitation";
-"contacts_ui.title" = "Invite people";
+"contacts_ui.search_placeholder" = "Cerca per nome";
+"contacts_ui.invite_others" = "Invita altri";
+"contacts_ui.name_in_contacts" = "%@ nel libro degl' indirizzi";
+"contacts_ui.connection_request" = "Richiesta di connessione";
+"contacts_ui.action_button.invite" = "Invita";
+"contacts_ui.action_button.open" = "Apri";
+"contacts_ui.invite_sheet.cancel_button_title" = "Annulla";
+"contacts_ui.notification.invitation_sent" = "Invito spedito";
+"contacts_ui.notification.invitation_failed" = "Invio dell'invito fallito";
+"contacts_ui.title" = "Invita persone";
 
-"contacts_ui.no_contact.title" = "No active conversations\n";
-"contacts_ui.no_contact.message" = "Tap contacts to start a conversation";
+"contacts_ui.no_contact.title" = "Nessuna conversazione attiva\n";
+"contacts_ui.no_contact.message" = "Tocca contatti per iniziare una conversazione";
 
 // Conversation List Bottom Bar
-"bottom_bar.contacts_button.title" = "contacts";
+"bottom_bar.contacts_button.title" = "contatti";
 
 // Archived List
-"archived_list.title" = "archive";
+"archived_list.title" = "archivio";
 
 // Add contact tool tip
-"tool_tip.contacts.title" = "Conversations start here";
-"tool_tip.contacts.message" = "Start a conversation or invite more people to join. Call, message and share in private or with groups.";
+"tool_tip.contacts.title" = "Le conversazioni iniziano qui";
+"tool_tip.contacts.message" = "Inizia una conversazione o invita altre persone a partecipare. Chiama, manda messaggi e condividi contenuti in privato o in gruppo.";
 
 // "Knows" subtitle in cell: "Knows Indrek", "Knows Indrek and Jane", "Knows Indrek and 5 others"
-"peoplepicker.suggested.knows_one" = "Knows %@";
-"peoplepicker.suggested.knows_two" = "Knows %@ and %@";
-"peoplepicker.hide_search_result" = "Hide";
-"peoplepicker.hide_search_result_progress" = "Hiding…";
+"peoplepicker.suggested.knows_one" = "Conosce %@";
+"peoplepicker.suggested.knows_two" = "Conosce %@ e %@";
+"peoplepicker.hide_search_result" = "Nascondi";
+"peoplepicker.hide_search_result_progress" = "Nascondendo…";
 
-"send_invitation.subject" = "Connect with me on Wire";
-"send_invitation.text" = "I’m on Wire. Search for %@\nor visit https://get.wire.com to connect with me.";
-"send_invitation_no_email.text" = "I’m on Wire. Visit https://get.wire.com to connect with me.";
+"send_invitation.subject" = "Connettiti con me su Wire";
+"send_invitation.text" = "Sono su Wire. Cerca %@\no visita https://get.wire.com per connetterti con me.";
+"send_invitation_no_email.text" = "Sono su Wire. Visita https://get.wire.com per connetterti con me.";
 
-"send_personal_invitation.text" = "I’m on Wire, talk to you there. https://get.wire.com";
+"send_personal_invitation.text" = "Sono su wire, ci sentiamo lì. https://get.wire.com";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++x
 // In-app notifications (chat heads)
-"notifications.shared_a_photo" = "shared a picture";
-"notifications.pinged" = "pinged";
-"notifications.sent_file" = "shared a file";
-"notifications.sent_location" = "shared a location";
-"notifications.sent_video" = "shared a video";
-"notifications.sent_audio" = "shared an audio";
+"notifications.shared_a_photo" = "ha condiviso un'immagine";
+"notifications.pinged" = "ha fatto un trillo";
+"notifications.sent_file" = "ha condiviso un file";
+"notifications.sent_location" = "ha condiviso una posizione";
+"notifications.sent_video" = "ha condiviso un video";
+"notifications.sent_audio" = "ha condiviso un audio";
 "notifications.in_conversation" = "%@ - %@";
-"notifications.this_conversation" = "%@ in this conversation";
+"notifications.this_conversation" = "%@ in questa conversazione";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // List (labels) - Needs to be revised with updated guidance
-"list.archived_conversations" = "ARCHIVE";
-"list.archived_conversations_close" = "Close archive";
+"list.archived_conversations" = "ARCHIVIO";
+"list.archived_conversations_close" = "Chiudi archivio";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Conversation
-"conversation.invite_more_people.title" = "Spread the word!";
-"conversation.invite_more_people.description" = "Add people to this conversation";
+"conversation.invite_more_people.title" = "Passa parola!";
+"conversation.invite_more_people.description" = "Aggiungi persone a questa conversazione";
 "conversation.invite_more_people.explanation_url" = "https://support.wire.com";
-"conversation.invite_more_people.button_title" = "Add People";
+"conversation.invite_more_people.button_title" = "Aggiungi persone";
 
 // Conversation names
-"conversation.displayname.emptygroup" = "Empty group conversation";
+"conversation.displayname.emptygroup" = "Conversazione di gruppo vuota";
 
-"conversation.input_bar.verified" = "Verified";
-"conversation.input_bar.placeholder" = "Type a message";
+"conversation.input_bar.verified" = "Verificato";
+"conversation.input_bar.placeholder" = "Digita un messaggio";
 
-"conversation.input_bar.audio_message.tooltip.pull_send" = "Swipe up to send";
-"conversation.input_bar.audio_message.tooltip.tap_send" = "Tap to send";
-"conversation.input_bar.audio_message.too_long.title" = "Recording Stopped";
-"conversation.input_bar.audio_message.too_long.message" = "Audio messages are limited to %@. Send this message?";
-"conversation.input_bar.audio_message.send" = "Send";
+"conversation.input_bar.audio_message.tooltip.pull_send" = "Scorri in su per inviare";
+"conversation.input_bar.audio_message.tooltip.tap_send" = "Tocca per inviare";
+"conversation.input_bar.audio_message.too_long.title" = "Registrazione interrotta";
+"conversation.input_bar.audio_message.too_long.message" = "I messaggi audio sono limitati a %@. Inviare questo messaggio?";
+"conversation.input_bar.audio_message.send" = "Invia";
 
-"conversation.input_bar.audio_message.keyboard.record_tip" = "Tap to record\nYou can  %@  it after that";
-"conversation.input_bar.audio_message.keyboard.filter_tip" = "Choose a filter above";
+"conversation.input_bar.audio_message.keyboard.record_tip" = "Tocca per registrare un messaggio\nLo puoi %@ in seguito";
+"conversation.input_bar.audio_message.keyboard.filter_tip" = "Scegli un filtro qui sopra";
 
 // Image confirmation dialogue
 "image_confirmer.confirm" = "OK";
-"image_confirmer.cancel" = "Cancel";
-"image.add_sketch" = "Add a sketch";
-"image.edit_image" = "Edit image";
+"image_confirmer.cancel" = "Annulla";
+"image.add_sketch" = "Aggiungi uno schizzo";
+"image.edit_image" = "Modifica immagine";
 
 // Camera access
-"camera_access.denied" = "Wire needs access to the Camera.";
+"camera_access.denied" = "Wire ha bisogno di accedere alla fotocamera.";
 "camera_access.denied.instruction" = "";
-"camera_access.denied.open_settings" = "Enable it in Wire Settings";
+"camera_access.denied.open_settings" = "Abilitalo nelle impostazioni di Wire";
 
 // Camera Controls
-"camera_controls.aeaf_lock" = "AE/AF Lock";
+"camera_controls.aeaf_lock" = "Blocco AE/AF";
 
 // Location
-"location.send_button.title" = "Send";
-"location.unauthorized_alert.title" = "Enable Location Services";
-"location.unauthorized_alert.message" = "To send your location, enable Location Services and allow Wire to access your location.";
-"location.unauthorized_alert.cancel" = "Cancel";
-"location.unauthorized_alert.settings" = "Settings";
+"location.send_button.title" = "Invia";
+"location.unauthorized_alert.title" = "Attiva i servizi di localizzazione";
+"location.unauthorized_alert.message" = "Per inviare la tua posizione, attivare servizi di localizzazione e consenti a Wire di accedere alla tua posizione.";
+"location.unauthorized_alert.cancel" = "Annulla";
+"location.unauthorized_alert.settings" = "Impostazioni";
 
 // Twitter
-"twitter_status.on_twitter" = "%@ on Twitter";
+"twitter_status.on_twitter" = "%@ su Twitter";
 
 // System messages
-"content.system.continued_conversation" = "Start a conversation with %@";
+"content.system.continued_conversation" = "Inizia una conversazione con %@";
 
-"content.system.other_started_conversation" = "%@ started a conversation with %@";
-"content.system.you_started_conversation" = "You started a conversation with %@";
+"content.system.other_started_conversation" = "%@ ha iniziato una conversazione con %@";
+"content.system.you_started_conversation" = "Hai iniziato una conversazione con %@";
 
-"content.system.you_added_participant" = "You added %@";
-"content.system.other_added_participant" = "%@ added %@";
-"content.system.other_added_you" = "%@ added you";
+"content.system.you_added_participant" = "Hai aggiunto %@";
+"content.system.other_added_participant" = "%@ ha aggiunto %@";
+"content.system.other_added_you" = "%@ ti ha aggiunto";
 
-"content.system.participants_you" = "You";
-"content.system.participants_1_other" = "%@ and %@";
-"content.system.other_left" = "%@ left";
-"content.system.you_left" = "You left";
-"content.system.other_removed_other" = "%@ removed %@";
-"content.system.other_removed_you" = "%@ removed you";
-"content.system.you_removed_other" = "You removed %@";
-"content.system.other_renamed_conv" = "%@ renamed the conversation";
-"content.system.you_renamed_conv" = "You renamed the conversation";
-"content.system.other_renamed_conv_to_nothing" = "%@ removed the conversation name";
-"content.system.you_renamed_conv_to_nothing" = "You removed the conversation name";
-"content.system.pending_message_timestamp" = "Sending…";
-"content.system.message_sent_timestamp" = "Sent";
-"content.system.message_delivered_timestamp" = "Delivered";
-"content.system.failedtosend_message_timestamp" = "Sending failed.";
-"content.system.failedtosend_message_timestamp_resend" = "Resend";
-"content.system.like_tooltip" = "Tap to like";
-"content.system.deleted_message_prefix_timestamp" = "Deleted on %@";
-"content.system.edited_message_prefix_timestamp" = "Edited on %@";
-"content.system.connecting_to" = "Connecting to %@.\nStart a conversation";
-"content.system.connected_to" = "Connected to %@\nStart a conversation";
-"content.system.other_wanted_to_talk" = "%@ called";
-"content.system.you_wanted_to_talk" = "You called";
+"content.system.participants_you" = "Tu";
+"content.system.participants_1_other" = "%@ e %@";
+"content.system.other_left" = "%@ ha lasciato la conversazione";
+"content.system.you_left" = "Hai lasciato la conversazione";
+"content.system.other_removed_other" = "%@ rimosso %@";
+"content.system.other_removed_you" = "%@ sei stato rimosso";
+"content.system.you_removed_other" = "Sei stato rimosso %@";
+"content.system.other_renamed_conv" = "%@ ha rinominato la conversazione";
+"content.system.you_renamed_conv" = "Hai rinominato la conversazione";
+"content.system.other_renamed_conv_to_nothing" = "%@ ha rimosso il nome della conversazione";
+"content.system.you_renamed_conv_to_nothing" = "Hai rimosso il nome della conversazione";
+"content.system.pending_message_timestamp" = "Invio in corso…";
+"content.system.message_sent_timestamp" = "Inviato";
+"content.system.message_delivered_timestamp" = "Consegnato";
+"content.system.failedtosend_message_timestamp" = "Invio non riuscito.";
+"content.system.failedtosend_message_timestamp_resend" = "Inviare di nuovo";
+"content.system.like_tooltip" = "Tocca per mettere mi piace";
+"content.system.deleted_message_prefix_timestamp" = "Cancellato il %@";
+"content.system.edited_message_prefix_timestamp" = "Modificato il %@";
+"content.system.connecting_to" = "Connesso a %@.\nInizia una conversazione";
+"content.system.connected_to" = "Connesso a %@ \nInizia una conversazione";
+"content.system.other_wanted_to_talk" = "%@ ha chiamato";
+"content.system.you_wanted_to_talk" = "Hai chiamato";
 
-"content.system.you_started" = "You";
-"content.system.this_device" = "this device";
+"content.system.you_started" = "Tu";
+"content.system.this_device" = "questo dispositivo";
 
-"content.system.reactivated_device" = "You started using %@ again. Messages sent in the meantime will not appear here";
+"content.system.reactivated_device" = "Hai iniziato a utilizzare %@ nuovamente. I messaggi inviati nel frattempo non verranno visualizzato qui";
 
-"content.system.new_device" = "a new device";
-"content.system.started_using" = "started using";
-"content.system.is_verified" = "All fingerprints are verified";
+"content.system.new_device" = "un nuovo dispositivo";
+"content.system.started_using" = "iniziato ad utilizzare";
+"content.system.is_verified" = "Tutte le impronte digitali sono state verificate";
 
-"content.system.unverified" = "%@ unverified one of %@"; //example "You unverified one of Jule's devices"
-"content.system.your_devices" = "your devices";
-"content.system.other_devices" = "%@'s devices";
+"content.system.unverified" = "%@ hai tolto la verifica di %@"; // example "You unverified one of Jule's devices"
+"content.system.your_devices" = "i tuoi dispositivi";
+"content.system.other_devices" = "dispositivi di %@";
 
-"content.system.missing_messages.title" = "You haven't used this device for a while. Some messages may not appear here.";
-"content.system.missing_messages.subtitle_start" = "Meanwhile,";
+"content.system.missing_messages.title" = "Non hai utilizzato questo dispositivo per un po' di tempo. Alcuni messaggi potrebbero non apparire qui.";
+"content.system.missing_messages.subtitle_start" = "Nel frattempo,";
 
-"content.system.cannot_decrypt" = "A message from %@ was not received.";
+"content.system.cannot_decrypt" = "Non è stato ricevuto un messaggio da %@.";
 
-"content.system.cannot_decrypt.you_part" = "you";
-"content.system.cannot_decrypt.why_part" = "Why?";
+"content.system.cannot_decrypt.you_part" = "tu";
+"content.system.cannot_decrypt.why_part" = "Perchè?";
 
-"content.system.cannot_decrypt.identity" = "%@ device identity changed. Undelivered message.";
-"content.system.cannot_decrypt.identity.you_part" = "Your";
-"content.system.cannot_decrypt.identity.otherUser_part" = "%@'s"; // posessive apostrophe - might differ in different languages
-"content.system.cannot_decrypt.identity.why_part" = "Learn More";
+"content.system.cannot_decrypt.identity" = "%@ ha cambiato identità del dispositivo. Messaggio non recapitato.";
+"content.system.cannot_decrypt.identity.you_part" = "Il tuo";
+"content.system.cannot_decrypt.identity.otherUser_part" = "di %@"; // posessive apostrophe - might differ in different languages
+"content.system.cannot_decrypt.identity.why_part" = "Ulteriori informazioni";
 
-"content.file.uploading" = "Uploading…";
-"content.file.downloading" = "Downloading…";
-"content.file.upload_failed" = "Upload failed";
-"content.file.upload_cancelled" = "Upload cancelled";
-"content.file.upload_video" = "Videos";
-"content.file.take_video" = "Record a video";
+"content.file.uploading" = "Caricamento…";
+"content.file.downloading" = "Download in corso…";
+"content.file.upload_failed" = "Caricamento fallito";
+"content.file.upload_cancelled" = "Caricamento annullato";
+"content.file.upload_video" = "Video";
+"content.file.take_video" = "Registra un video";
 
-"content.file.save_video" = "Save";
-"content.file.save_audio" = "Save";
-"content.image.save_image" = "Save";
+"content.file.save_video" = "Salva";
+"content.file.save_audio" = "Salva";
+"content.image.save_image" = "Salva";
 
-"content.message.delete" = "Delete";
+"content.message.delete" = "Elimina";
 
-"content.message.like" = "Like";
-"content.message.unlike" = "Unlike";
+"content.message.like" = "Mi piace";
+"content.message.unlike" = "Non mi piace più";
 
-"content.reactions_list.likers" = "Liked by";
+"content.reactions_list.likers" = "Piace a";
 
-"content.file.too_big" = "You can send files up to %@";
+"content.file.too_big" = "Puoi inviare file fino a %@";
 // Someone pinged
-"content.ping.text" = "%1$@ PINGED";
+"content.ping.text" = "%1$@ HA FATTO UN TRILLO";
 
 // Current user pinged
-"content.ping.you.text" = "YOU PINGED";
+"content.ping.you.text" = "HAI FATTO UN TRILLO";
 
 // Inline Player
-"content.player.unable_to_play" = "UNABLE TO PLAY TRACK";
+"content.player.unable_to_play" = "IMPOSSIBILE RIPRODURRE LA TRACCIA";
 
 // Connecting (NEW IMPLEMENTATION, REVIEW LATER)
-"connection_request.title" = "Connect to %@"; //check UPPERCASE implementation in code
-"missive.connection_request.default_message" = "Hi %@,\nLet’s connect on Wire.\n%@";
+"connection_request.title" = "Connettiti a %@"; // check UPPERCASE implementation in code
+"missive.connection_request.default_message" = "Ciao %@,\nConnettiamoci su Wire.\n%@";
 
-"connection_request.send_button_title" = "Connect";
-"inbox.connection_request.connect_button_title" = "Connect";
-"inbox.connection_request.ignore_button_title" = "Ignore";
+"connection_request.send_button_title" = "Connetti";
+"inbox.connection_request.connect_button_title" = "Connetti";
+"inbox.connection_request.ignore_button_title" = "Ignora";
 
 // Voice
-"voice.status.one_to_one.incoming" = "%@\nCalling";
-"voice.status.group_call.incoming" = "%@\nRinging";
-"voice.status.one_to_one.outgoing" = "%@\nRinging";
-"voice.status.joining" = "%@\nConnecting";
-"voice.status.video_not_available" = "Video turned off";
-"voice.status.low_connection" = "Bad connection";
-"voice.network_error.title" = "No Internet Connection";
-"voice.network_error.body" = "You must be online to call. Check your connection and try again.";
-"voice.alert.call_in_progress.title" = "Call in progress";
-"voice.alert.call_in_progress.message" = "Another of your devices is already participating in the call";
+"voice.status.one_to_one.incoming" = "%@\nChiamata in corso";
+"voice.status.group_call.incoming" = "%@\nSta squillando";
+"voice.status.one_to_one.outgoing" = "%@\nSta squillando";
+"voice.status.joining" = "%@\nIn attesa di connessione";
+"voice.status.video_not_available" = "Video spento";
+"voice.status.low_connection" = "Connessione scarsa";
+"voice.network_error.title" = "Nessuna connessione internet";
+"voice.network_error.body" = "È necessario essere online per chiamare. Controlla la connessione e riprova.";
+"voice.alert.call_in_progress.title" = "Chiamata in corso";
+"voice.alert.call_in_progress.message" = "Un altro dei tuoi dispositivi sta già partecipando alla chiamata";
 "voice.alert.call_in_progress.confirm" = "Ok";
-"voice.accept_button.title" = "Accept";
-"voice.decline_button.title" = "Decline";
-"voice.hang_up_button.title" = "Hang Up";
-"voice.mute_button.title" = "Mute";
+"voice.accept_button.title" = "Accetta";
+"voice.decline_button.title" = "Rifiuta";
+"voice.hang_up_button.title" = "Riattacca";
+"voice.mute_button.title" = "Silenzia";
 "voice.video_button.title" = "Video";
-"voice.speaker_button.title" = "Speaker";
+"voice.speaker_button.title" = "Altoparlante";
 
-"voice.alert.microphone_warning.title" = "Wire needs access to the Microphone.";
-"voice.alert.microphone_warning.explanation" = "Enable it in Wire Settings.";
+"voice.alert.microphone_warning.title" = "Wire ha bisogno di accedere al microfono.";
+"voice.alert.microphone_warning.explanation" = "Abilitalo nelle impostazioni di Wire.";
 
-"voice.alert.camera_warning.title" = "Wire needs access to the Camera.";
-"voice.alert.camera_warning.explanation" = "Go to Settings and allow Wire to access the camera.";
+"voice.alert.camera_warning.title" = "Wire ha bisogno di accedere alla fotocamera.";
+"voice.alert.camera_warning.explanation" = "Vai nelle impostazioni e consenti a Wire di accedere alla fotocamera.";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Profile and Participants
 
-"participants.add_people_button_title" = "Add people";
+"participants.add_people_button_title" = "Aggiungi persone";
 
 // Meta Menu
-"meta.menu.rename" = "Rename";
-"meta.menu.leave" = "Leave";
-"meta.menu.archive" = "Archive";
-"meta.menu.unarchive" = "Unarchive";
-"meta.menu.delete" = "Delete";
-"meta.menu.silence.mute" = "Mute";
-"meta.menu.silence.unmute" = "Unmute";
-"meta.menu.cancel" = "Cancel";
-"meta.menu.cancel_connection_request" = "Cancel Request";
+"meta.menu.rename" = "Rinomina";
+"meta.menu.leave" = "Abbandona";
+"meta.menu.archive" = "Archivia";
+"meta.menu.unarchive" = "Disarchivia";
+"meta.menu.delete" = "Elimina";
+"meta.menu.silence.mute" = "Silenzia";
+"meta.menu.silence.unmute" = "Riattiva audio";
+"meta.menu.cancel" = "Annulla";
+"meta.menu.cancel_connection_request" = "Annulla richiesta";
 
 // Delete conversation
-"meta.menu.delete_content.dialog_title" = "Delete content?";
-"meta.menu.delete_content.dialog_message" = "This will clear the conversation history and remove it from the list.";
-"meta.menu.delete_content.leave_as_well_message" = "Also leave the conversation";
-"meta.menu.delete_content.button_cancel" = "Cancel";
-"meta.menu.delete_content.button_delete" = "Delete";
+"meta.menu.delete_content.dialog_title" = "Eliminare il contenuto?";
+"meta.menu.delete_content.dialog_message" = "Questo cancellerà la cronologia e rimuoverà la conversazione dall'elenco.";
+"meta.menu.delete_content.leave_as_well_message" = "In aggiunta, abbandona la conversazione";
+"meta.menu.delete_content.button_cancel" = "Annulla";
+"meta.menu.delete_content.button_delete" = "Elimina";
 
 // Leave conversation
-"meta.leave_conversation_dialog_title" = "Leave conversation?";
-"meta.leave_conversation_dialog_message" = "The participants will be notified and the conversation will be removed from your list.";
-"meta.leave_conversation.delete_content_as_well_message" = "Also delete the content";
-"meta.leave_conversation_button_cancel" = "Cancel";
-"meta.leave_conversation_button_leave" = "Leave";
+"meta.leave_conversation_dialog_title" = "Abbandonare la conversazione?";
+"meta.leave_conversation_dialog_message" = "I partecipanti saranno informati e la conversazione verrà rimossa dalla tua lista.";
+"meta.leave_conversation.delete_content_as_well_message" = "Elimina anche il contenuto";
+"meta.leave_conversation_button_cancel" = "Annulla";
+"meta.leave_conversation_button_leave" = "Abbandona";
 
 // Conversation Degraded (security level lowered)
-"meta.degraded.degradation_reason_message.singular" = "%@ started using a new device.";
-"meta.degraded.degradation_reason_message.plural" = "%@ started using new devices.";
-"meta.degraded.dialog_message" = "Do you still want to send your message?";
-"meta.degraded.show_device_button" = "Show device";
-"meta.degraded.send_anyway_button" = "Send anyway";
+"meta.degraded.degradation_reason_message.singular" = "%@ ha iniziato a usare un nuovo dispositivo.";
+"meta.degraded.degradation_reason_message.plural" = "%@ ha iniziato a usare dei nuovi dispositivi.";
+"meta.degraded.dialog_message" = "Vuoi comunque mandare il messaggio?";
+"meta.degraded.show_device_button" = "Visualizza dispositivo";
+"meta.degraded.send_anyway_button" = "Invia comunque";
 
 // Remove from conversation dialogue
-"profile.remove_dialog_title" = "Remove?";
-"profile.remove_dialog_message" = "%@ won’t be able to send or receive messages in this conversation.";
-"profile.remove_dialog_button_cancel" = "Cancel";
-"profile.remove_dialog_button_remove" = "Remove";
+"profile.remove_dialog_title" = "Rimuovere?";
+"profile.remove_dialog_message" = "%@ non sarà più in grado di inviare o ricevere messaggi in questa conversazione.";
+"profile.remove_dialog_button_cancel" = "Annulla";
+"profile.remove_dialog_button_remove" = "Rimuovi";
 
 // Block dialog
-"profile.block_dialog.title" = "Block?";
-"profile.block_dialog.message" = "%@ won’t be able to find or contact you on Wire.";
-"profile.block_dialog.button_cancel" = "Cancel";
-"profile.block_dialog.button_block" = "Block";
+"profile.block_dialog.title" = "Blocca?";
+"profile.block_dialog.message" = "%@ non sarà più in grado di trovarti o contattarti su Wire.";
+"profile.block_dialog.button_cancel" = "Annulla";
+"profile.block_dialog.button_block" = "Blocca";
 
 // Delete message dialog
-"message.delete_dialog.message" = "This cannot be undone.";
-"message.delete_dialog.action.cancel" = "Cancel";
-"message.delete_dialog.action.hide" = "Delete for Me";
-"message.delete_dialog.action.delete" = "Delete for Everyone";
+"message.delete_dialog.message" = "Questa azione non può essere annullata.";
+"message.delete_dialog.action.cancel" = "Annulla";
+"message.delete_dialog.action.hide" = "Elimina per me";
+"message.delete_dialog.action.delete" = "Elimina per tutti";
 
 // Edit message
-"message.menu.edit.title" = "Edit";
+"message.menu.edit.title" = "Modifica";
 
 // Accept connection request
-"profile.connection_request_dialog.title" = "Accept?";
-"profile.connection_request_dialog.message" = "This will connect you and open the conversation with %@.";
-"profile.connection_request_dialog.button_cancel" = "Ignore";
-"profile.connection_request_dialog.button_connect" = "Connect";
+"profile.connection_request_dialog.title" = "Accettare?";
+"profile.connection_request_dialog.message" = "Questo vi collegherà e aprirà la conversazione con %@.";
+"profile.connection_request_dialog.button_cancel" = "Ignora";
+"profile.connection_request_dialog.button_connect" = "Connetti";
 
 // Cancel connection request
-"profile.cancel_connection_request_dialog.title" = "Cancel Request?";
-"profile.cancel_connection_request_dialog.message" = "Remove connection request to %@.";
+"profile.cancel_connection_request_dialog.title" = "Annullare la richiesta?";
+"profile.cancel_connection_request_dialog.message" = "Rimuovere la richiesta di connessione a %@.";
 "profile.cancel_connection_request_dialog.button_no" = "No";
-"profile.cancel_connection_request_dialog.button_yes" = "Yes";
+"profile.cancel_connection_request_dialog.button_yes" = "Sì";
 
 // Unblock button
-"profile.unblock_button_title" = "Unblock";
+"profile.unblock_button_title" = "Sblocca";
 
-"profile.cancel_connection_button_title" = "CANCEL REQUEST";
-"profile.connection_request_state.blocked" = "BLOCKED";
-"profile.create_conversation_button_title" = "Create group";
-"profile.open_conversation_button_title" = "Open conversation";
+"profile.cancel_connection_button_title" = "ANNULLA RICHIESTA";
+"profile.connection_request_state.blocked" = "BLOCCATO";
+"profile.create_conversation_button_title" = "Crea gruppo";
+"profile.open_conversation_button_title" = "Apri conversazione";
 
 // User Details
-"profile.details.title" = "Details";
+"profile.details.title" = "Dettagli";
 
 // Device list
-"profile.devices.title" = "Devices";
-"profile.devices.fingerprint_message_unencrypted" = "%@ is using an old version of Wire. No devices are shown here.";
-"profile.devices.fingerprint_message" = "Wire gives every device a unique fingerprint. Compare them with %@ and verify your conversation. Why verify conversations?";
-"profile.devices.fingerprint_message.link" = "Why verify conversations?";
+"profile.devices.title" = "Dispositivi";
+"profile.devices.fingerprint_message_unencrypted" = "%@ sta utilizzando una vecchia versione di filo. Nessun dispositivo viene visualizzato qui.";
+"profile.devices.fingerprint_message" = "Wire dà un'impronta unica a ogni dispositivo. Confrontale con %@ e verifica la tua conversazione. Perché verificare la conversazione?";
+"profile.devices.fingerprint_message.link" = "Perché verificare le conversazioni?";
 
 // Device detail
-"profile.devices.detail.verify_message" = "Verify that this matches the fingerprint shown on %@'s device.";
-"profile.devices.detail.verify_message.link" = "How do I do that?";
-"profile.devices.detail.show_my_device.title" = "Show my device fingerprint";
-"device.verified" = "Verified";
-"device.not_verified" = "Not Verified";
+"profile.devices.detail.verify_message" = "Verifica che questa corrisponda all'impronta digitale mostrata sul dispositivo di %@.";
+"profile.devices.detail.verify_message.link" = "Come si fa?";
+"profile.devices.detail.show_my_device.title" = "Visualizza impronta digitale del dispositivo";
+"device.verified" = "Verificato";
+"device.not_verified" = "Non verificato";
 "device.class.desktop" = "Desktop";
 "device.class.tablet" = "Tablet";
-"device.class.phone" = "Phone";
-"profile.devices.detail.reset_session.title" = "Reset Session";
+"device.class.phone" = "Telefono";
+"profile.devices.detail.reset_session.title" = "Resetta la sessione";
 
 // General strings
 "general.confirm" = "OK";
@@ -388,34 +388,34 @@
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Self profile
-
 // Options menu contents
-"self.settings" = "Settings";
-"self.help_center" = "Support";
-"self.help_center.support_website" = "Wire Support Website";
-"self.help_center.contact_support" = "Contact Support";
-"self.about" = "About";
-"self.sign_out" = "Log Out";
-"self.report_abuse" = "Report Misuse";
 
-"self.add_phone_number" = "Add phone number";
-"self.add_email_password" = "Add email address and password";
+"self.settings" = "Impostazioni";
+"self.help_center" = "Supporto";
+"self.help_center.support_website" = "Sito assistenza clienti Wire";
+"self.help_center.contact_support" = "Contatta il supporto";
+"self.about" = "Info";
+"self.sign_out" = "Esci dall’account";
+"self.report_abuse" = "Riporta un errore";
+
+"self.add_phone_number" = "Aggiungi un numero di telefono";
+"self.add_email_password" = "Aggiungi indirizzo email e password";
 
 // About screen
-"about.tos.title"="Terms of Use";
-"about.privacy.title"="Privacy Policy";
-"about.license.title" = "License Information";
-"about.website.title"="Wire Website";
-"about.copyright.title"="© Wire Swiss GmbH";
+"about.tos.title" = "Termini di utilizzo";
+"about.privacy.title" = "Informativa sulla privacy";
+"about.license.title" = "Informazioni sulla licenza";
+"about.website.title" = "Sito di Wire";
+"about.copyright.title" = "© Wire Swiss GmbH";
 
 // Self new devices
-"self.new_device_alert.title" = "You have connected %@ to your Wire account";
-"self.new_device_alert.title_prefix.tablet" = "a tablet";
-"self.new_device_alert.title_prefix.phone" = "a phone";
-"self.new_device_alert.title_prefix.devices" = "%d devices";
-"self.new_device_alert.message" = "%@\n\nIf you didn’t do this, remove the device and reset your password.";
-"self.new_device_alert.message_plural" = "%@\n\nIf you didn’t do this, remove those devices and reset your password.";
-"self.new_device_alert.manage_devices" = "Manage devices";
+"self.new_device_alert.title" = "Hai collegato %@ al tuo account Wire";
+"self.new_device_alert.title_prefix.tablet" = "un tablet";
+"self.new_device_alert.title_prefix.phone" = "un telefono";
+"self.new_device_alert.title_prefix.devices" = "%d dispositivi";
+"self.new_device_alert.message" = "%@\n\nSe non sei stato tu, rimuovi il dispositivo e reimposta la password.";
+"self.new_device_alert.message_plural" = "%@\n\nSe non sei stato tu, rimuovi quei dispositivi e reimposta la password.";
+"self.new_device_alert.manage_devices" = "Gestione dei dispositivi";
 "self.new_device_alert.trust_devices" = "OK";
 
 // Settings - Account details
@@ -423,290 +423,290 @@
 
 "self.settings.account_details_group.title" = "Info";
 
-"self.settings.account_section.name.title" = "Name";
+"self.settings.account_section.name.title" = "Nome";
 "self.settings.account_section.email.title" = "Email";
-"self.settings.account_section.phone.title" = "Phone";
+"self.settings.account_section.phone.title" = "Telefono";
 
-"self.settings.account_details_group.footer" = "People can find you with these details.";
+"self.settings.account_details_group.footer" = "Le persone ti possono trovare con questi dettagli.";
 
-"self.settings.account_details.remove_device.title" = "Remove Device";
-"self.settings.account_details.key_fingerprint.title" = "Key Fingerprint";
-"self.settings.account_details.remove_device.message" = "Your password is required to remove the device";
+"self.settings.account_details.remove_device.title" = "Rimuovi dispositivo";
+"self.settings.account_details.key_fingerprint.title" = "Impronta digitale della chiave";
+"self.settings.account_details.remove_device.message" = "La password è necessaria per rimuovere il dispositivo";
 "self.settings.account_details.remove_device.password" = "Password";
-"self.settings.account_details.remove_device.password.error" = "Wrong password";
+"self.settings.account_details.remove_device.password.error" = "Password errata";
 
-"self.settings.account_appearance_group.title" = "Appearance";
-"self.settings.account_picture_group.picture" = "Picture";
-"self.settings.account_picture_group.color" = "Color";
+"self.settings.account_appearance_group.title" = "Aspetto";
+"self.settings.account_picture_group.picture" = "Foto";
+"self.settings.account_picture_group.color" = "Colore";
 
-"self.settings.account_picture_group.theme" = "Dark Theme";
+"self.settings.account_picture_group.theme" = "Tema scuro";
 
-"self.settings.device_details.fingerprint.subtitle" = "Wire gives every device a unique fingerprint. Compare them and verify your devices and conversations.";
-"self.settings.device_details.reset_session.subtitle" = "If fingerprints don’t match, reset the session to generate new encryption keys on both sides.";
-"self.settings.device_details.remove_device.subtitle" = "Remove this device if you have stopped using it. Your message history will be erased and you will be logged out.";
-"self.settings.device_details.reset_session.success" = "The session has been reset";
+"self.settings.device_details.fingerprint.subtitle" = "Wire dà un'impronta unica a ogni dispositivo. Confrontale per verificare i tuoi dispositivi e le conversazioni.";
+"self.settings.device_details.reset_session.subtitle" = "Se le impronte digitali non corrispondono, è necessario resettare la sessione per generare nuove chiavi di crittografia per entrambe le parti.";
+"self.settings.device_details.remove_device.subtitle" = "Rimuovi questo dispositivo se hai smesso di usarlo. La cronologia dei messaggi sarà cancellata e tu verrai disconnesso.";
+"self.settings.device_details.reset_session.success" = "La sessione è stata reimpostata";
 
-"self.settings.account_details.actions.title" = "Actions";
+"self.settings.account_details.actions.title" = "Azioni";
 
-"self.settings.account_details.delete_account.title" = "Delete Account";
+"self.settings.account_details.delete_account.title" = "Cancella account";
 
-"self.settings.account_details.delete_account.alert.title" = "Delete Account";
-"self.settings.account_details.delete_account.alert.message" = "We will send you a message via email or SMS. Follow the link to permanently delete your account.";
+"self.settings.account_details.delete_account.alert.title" = "Cancella account";
+"self.settings.account_details.delete_account.alert.message" = "Ti invieremo un SMS o una email. Segui il link per eliminare definitivamente il tuo account.";
 
 
 // Chat alerts
-"self.settings.notifications.push_notification.title" = "Notifications";
-"self.settings.notifications.push_notification.toogle" = "Message Previews";
-"self.settings.notifications.push_notification.footer" = "Sender name and message on the lock screen and in Notification Center.";
+"self.settings.notifications.push_notification.title" = "Notifiche";
+"self.settings.notifications.push_notification.toogle" = "Anteprima messaggio";
+"self.settings.notifications.push_notification.footer" = "Nome del mittente e messaggio nella schermata di blocco e nel centro notifiche.";
 
-"self.settings.notifications.chat_alerts.toggle" = "Message Banners";
-"self.settings.notifications.chat_alerts.footer" = "New messages in other conversations.";
+"self.settings.notifications.chat_alerts.toggle" = "Banners di messaggio";
+"self.settings.notifications.chat_alerts.footer" = "Nuovi messaggi in altre conversazioni.";
 
-"self.settings.sound_menu.sounds.title" = "Sounds";
-"self.settings.sound_menu.ringtone.title" = "Ringtone";
-"self.settings.sound_menu.message.title" = "Text Tone";
-"self.settings.sound_menu.ping.title" = "Ping";
-"self.settings.sound_menu.ringtones.title" = "Ringtones";
+"self.settings.sound_menu.sounds.title" = "Suoni";
+"self.settings.sound_menu.ringtone.title" = "Suoneria";
+"self.settings.sound_menu.message.title" = "Suono messaggi";
+"self.settings.sound_menu.ping.title" = "Fai un trillo";
+"self.settings.sound_menu.ringtones.title" = "Suoneria";
 "self.settings.sound_menu.sounds.wire_sound" = "Wire";
 
-"self.settings.sound_menu.sounds.wire_call" = "Wire Call";
-"self.settings.sound_menu.sounds.wire_message" = "Wire Message";
-"self.settings.sound_menu.sounds.wire_ping" = "Wire Ping";
+"self.settings.sound_menu.sounds.wire_call" = "Chiamata Wire";
+"self.settings.sound_menu.sounds.wire_message" = "Messaggio Wire";
+"self.settings.sound_menu.sounds.wire_ping" = "Trillo Wire";
 
 // By popular demand
-"self.settings.popular_demand.title" = "By popular demand";
-"self.settings.popular_demand.send_button.title" = "Send Button";
-"self.settings.popular_demand.send_button.footer" = "Disable to send via the return key.";
+"self.settings.popular_demand.title" = "A grande richiesta";
+"self.settings.popular_demand.send_button.title" = "Pulsante Invia";
+"self.settings.popular_demand.send_button.footer" = "Disattiva per inviare tramite il tasto invio.";
 
 // Sound alerts (TO BE UPDPATED)
-"self.settings.sound_menu.title" = "Sound Alerts";
-"self.settings.sound_menu.no_sounds.title" = "None";
-"self.settings.sound_menu.all_sounds.title" = "All";
-"self.settings.sound_menu.mute_while_talking.title" = "First message, pings, calls";
+"self.settings.sound_menu.title" = "Suono di allerta";
+"self.settings.sound_menu.no_sounds.title" = "Nessuno";
+"self.settings.sound_menu.all_sounds.title" = "Tutto";
+"self.settings.sound_menu.mute_while_talking.title" = "Primo messaggio, trilli, chiamate";
 
 // Developer options
-"self.settings.developer_options.title" = "Developer Options";
-"self.settings.apns_logging.title" = "APNS Logging";
+"self.settings.developer_options.title" = "Impostazioni per sviluppatori";
+"self.settings.apns_logging.title" = "Registrazione di APNS";
 
 // Privacy (visibility) options
-"self.settings.options_menu.title" = "Options";
+"self.settings.options_menu.title" = "Opzioni";
 
-"self.settings.privacy_contacts_section.title" = "Contacts";
-"self.settings.privacy_contacts_menu.settings_button.title" = "Open Contacts Settings";
-"self.settings.privacy_contacts_menu.description_disabled.title" = "This helps you connect with others. We anonymize all the information and do not share it with anyone else. Allow access via Settings > Privacy > Contacts.";
+"self.settings.privacy_contacts_section.title" = "Contatti";
+"self.settings.privacy_contacts_menu.settings_button.title" = "Apri impostazioni contatti";
+"self.settings.privacy_contacts_menu.description_disabled.title" = "Questo ti aiuta a connetterti con gli altri. Rendiamo tutte le informazioni dai contatti anonime e non sono cedute a nessun altro. Consenti l'accesso tramite Impostazioni > Privacy > Contatti.";
 
-"self.settings.privacy_analytics_menu.devices.title" = "Devices";
+"self.settings.privacy_analytics_menu.devices.title" = "Dispositivi";
 
-"self.settings.privacy_analytics_section.title" = "Usage and Crash Reports";
-"self.settings.privacy_analytics_menu.description.title" = "Make Wire better by sending anonymous information.\n";
+"self.settings.privacy_analytics_section.title" = "Segnalazioni di crash e dati di utilizzo";
+"self.settings.privacy_analytics_menu.description.title" = "Migliora Wire con l'invio di informazioni anonime.\n";
 
-"self.settings.privacy.clear_history.title" = "Clear History";
-"self.settings.privacy.clear_history.subtitle" = "This will permanently erase the content of all your conversations.";
+"self.settings.privacy.clear_history.title" = "Cancella cronologia";
+"self.settings.privacy.clear_history.subtitle" = "Questo cancellerà il contenuto di tutte le tue conversazioni.";
 
-"self.settings.advanced.title" = "Advanced";
-"self.settings.advanced.troubleshooting.title" = "Troubleshooting";
-"self.settings.advanced.troubleshooting.submit_debug.title" = "Calling Debug Report";
-"self.settings.advanced.troubleshooting.submit_debug.subtitle" = "This information helps Wire Support diagnose calling problems.";
-"self.settings.advanced.reset_push_token.title" = "Reset Push Notifications Token";
-"self.settings.advanced.reset_push_token.subtitle" = "If you experience problems with push notifications, Wire Support may ask you to reset this token.";
-"self.settings.advanced.reset_push_token_alert.title" = "Push token has been reset";
-"self.settings.advanced.reset_push_token_alert.message" = "Notifications will be restored in a few seconds.";
-"self.settings.advanced.version_technical_details.title" = "Version Technical Details";
+"self.settings.advanced.title" = "Avanzate";
+"self.settings.advanced.troubleshooting.title" = "Risoluzione dei problemi";
+"self.settings.advanced.troubleshooting.submit_debug.title" = "Report di chiamata";
+"self.settings.advanced.troubleshooting.submit_debug.subtitle" = "Queste informazioni aiutano il supporto di Wirea diagnosticare problemi di chiamata.";
+"self.settings.advanced.reset_push_token.title" = "Reimpostazione delle notifiche Push Token";
+"self.settings.advanced.reset_push_token.subtitle" = "Se si verificano problemi con le notifiche push, il supporto di Wire può chiedere di reimpostare questo token.";
+"self.settings.advanced.reset_push_token_alert.title" = "Push Token è stata resettata";
+"self.settings.advanced.reset_push_token_alert.message" = "Le notifiche verranno ripristinate in pochi secondi.";
+"self.settings.advanced.version_technical_details.title" = "Dettagli tecnici della versione";
 
 // Technical Report
-"self.settings.technical_report_section.title" = "Technical Report";
-"self.settings.technical_report.send_report" = "Send report to Wire";
+"self.settings.technical_report_section.title" = "Relazione tecnica";
+"self.settings.technical_report.send_report" = "Invia una relazione a Wire";
 "self.settings.technical_report.mail.recipient" = "callingsupport@wire.com";
-"self.settings.technical_report.mail.subject" = "Wire Calling Report";
-"self.settings.technical_report.include_log" = "Include detailed log";
+"self.settings.technical_report.mail.subject" = "Report di chiamata di Wire";
+"self.settings.technical_report.include_log" = "Includere file di registro dettagliato";
 
 // Password reset
-"self.settings.password_reset_menu.title" = "Reset Password";
+"self.settings.password_reset_menu.title" = "Reimposta password";
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // System status
-"system_status_bar.no_internet.title" = "No Internet";
-"system_status_bar.no_internet.explanation" = "There seems to be a problem with your Internet connection. Please make sure it’s working.";
-"system_status_bar.poor_connectivity.title" = "Slow Internet, can’t call now";
-"system_status_bar.poor_connectivity.explanation" = "We can’t guarantee voice quality. Connect to Wi-Fi or try changing your location.";
+"system_status_bar.no_internet.title" = "Internet assente";
+"system_status_bar.no_internet.explanation" = "Sembra esserci un problema con la connessione a Internet. Per favore assicurati che funziona.";
+"system_status_bar.poor_connectivity.title" = "Internet lento, non è possibile chiamare ora";
+"system_status_bar.poor_connectivity.explanation" = "Non possiamo garantire la qualità della voce. Connettiti al Wi-Fi o prova a cambiare la tua posizione.";
 
 // Common connections on profile view
-"profile_other.common_connections" = "You both know";
+"profile_other.common_connections" = "Conoscete entrambi";
 
 // View user profile and options menu
-"name.placeholder" = "Your full name";
-"name.guidance.tooshort" = "At least 2 characters";
-"name.guidance.toolong" = "Too many characters";
+"name.placeholder" = "Il tuo nome e cognome";
+"name.guidance.tooshort" = "Almeno 2 caratteri";
+"name.guidance.toolong" = "Troppi caratteri";
 
 "email.placeholder" = "Email";
 
 "password.placeholder" = "Password";
-"password.guidance.tooshort" = "At least 8 characters";
-"password.guidance.toolong" = "Too many characters";
+"password.guidance.tooshort" = "Almeno 8 caratteri";
+"password.guidance.toolong" = "Troppi caratteri";
 
-"registration.title" = "Registration";
-"registration.close_email_invitation_button.email_title" = "Use another email";
-"registration.close_email_invitation_button.phone_title" = "Register by phone";
-"registration.close_phone_invitation_button.email_title" = "Register by email";
-"registration.close_phone_invitation_button.phone_title" = "Use another phone";
+"registration.title" = "Registrazione";
+"registration.close_email_invitation_button.email_title" = "Usa un altro indirizzo email";
+"registration.close_email_invitation_button.phone_title" = "Registrati con il telefono";
+"registration.close_phone_invitation_button.email_title" = "Registrati con l'email";
+"registration.close_phone_invitation_button.phone_title" = "Usa un altro numero";
 
-"registration.enter_phone_number.title" = "Edit phone number";
-"registration.enter_phone_number.placeholder" = "Phone number";
+"registration.enter_phone_number.title" = "Modificare il numero di telefono";
+"registration.enter_phone_number.placeholder" = "Numero di telefono";
 
-"registration.verify_phone_number.instructions" = "Enter the verification code we sent to %@";
-"registration.verify_phone_number.resend" = "Resend";
-"registration.verify_phone_number.resend_placeholder" = "No code showing up?\nYou can request a new one in %.0f seconds";
+"registration.verify_phone_number.instructions" = "Inserisci il codice di verifica che abbiamo inviato a %@";
+"registration.verify_phone_number.resend" = "Inviare di nuovo";
+"registration.verify_phone_number.resend_placeholder" = "Non ti è arrivato nulla?\nPuoi richiedere un nuovo codice in %.0f secondi";
 
-"registration.verify_email.instructions" = "We sent an email to %@.\n Follow the link to verify your address.";
-"registration.verify_email.resend.instructions" = "Didn't get the message?";
-"registration.verify_email.resend.button_title" = "Re-send";
+"registration.verify_email.instructions" = "Abbiamo inviato un'email a %@.\nClicca il link per verificare il tuo indirizzo.";
+"registration.verify_email.resend.instructions" = "Non hai ricevuto il messaggio?";
+"registration.verify_email.resend.button_title" = "Invia di nuovo";
 
-"registration.select_picture.subtitle" = "Wire is so much nicer with a picture.";
-"registration.select_picture.button_title" = "Choose your own";
-"registration.keep_picture.button_title" = "Keep this one";
-"registration.camera_action.title" = "Take photo";
-"registration.photo_gallery_action.title" = "Choose Photo";
-"registration.cancel_action.title" = "Cancel";
+"registration.select_picture.subtitle" = "Wire è molto più bello con una foto.";
+"registration.select_picture.button_title" = "Scegline una tua";
+"registration.keep_picture.button_title" = "Tieni questa";
+"registration.camera_action.title" = "Scatta foto";
+"registration.photo_gallery_action.title" = "Scegli foto";
+"registration.cancel_action.title" = "Annulla";
 
-"registration.no_history.hero" = "It’s the first time you’re using Wire on this device.";
-"registration.no_history.subtitle" = "For privacy reasons, your conversation history will not appear here.";
+"registration.no_history.hero" = "È la prima volta che utilizzi Wire questo dispositivo.";
+"registration.no_history.subtitle" = "Per motivi di privacy, la cronologia delle tue conversazioni non apparirà qui.";
 "registration.no_history.got_it" = "OK";
 
-"registration.no_history.logged_out.hero" = "You've used Wire on this device before.";
-"registration.no_history.logged_out.subtitle" = "Messages sent in the meantime will not appear.";
+"registration.no_history.logged_out.hero" = "Hai utilizzato Wire su questo dispositivo prima.";
+"registration.no_history.logged_out.subtitle" = "I messaggi inviati nel frattempo non verranno visualizzato.";
 "registration.no_history.logged_out.got_it" = "OK";
 
-"registration.enter_name.title" = "Edit Name";
-"registration.enter_name.hero" = "What should we call you?";
-"registration.enter_name.placeholder" = "Your full name";
+"registration.enter_name.title" = "Modifica nome";
+"registration.enter_name.hero" = "Come ti dobbiamo chiamare?";
+"registration.enter_name.placeholder" = "Il tuo nome e cognome";
 
-"registration.terms_of_use.title" = "Welcome to Wire.";
-"registration.terms_of_use.terms" = "By continuing you agree to the Wire Terms of Use.";
-"registration.terms_of_use.terms.link" = "Terms of Use";
-"registration.terms_of_use.agree" = "I agree";
+"registration.terms_of_use.title" = "Benvenuto su Wire.";
+"registration.terms_of_use.terms" = "Continuando accetti le condizioni d'uso di Wire.";
+"registration.terms_of_use.terms.link" = "Termini di utilizzo";
+"registration.terms_of_use.agree" = "Accetto";
 
-"registration.email_flow.title" = "Register by Email";
-"registration.email_flow.email_step.title" = "Edit Details";
+"registration.email_flow.title" = "Registrati con l'email";
+"registration.email_flow.email_step.title" = "Modifica dettagli";
 
-"registration.country_select.title" = "Country";
+"registration.country_select.title" = "Paese";
 
-"registration.share_contacts.hero.title" = "Find people on Wire";
-"registration.share_contacts.hero.paragraph"  = "Share your contacts so we can connect you with others. We anonymize all information and do not share it with anyone else.";
-"registration.share_contacts.find_friends_button.title" = "Share contacts";
-"registration.share_contacts.skip_button.title" = "Not now";
+"registration.share_contacts.hero.title" = "Trova persone su Wire";
+"registration.share_contacts.hero.paragraph" = "Condividi i tuoi contatti, così possiamo connetterti con altre persone. Rendiamo anonimi tutti i tuoi dati e non li condividiamo con nessuno.";
+"registration.share_contacts.find_friends_button.title" = "Condividi contatti";
+"registration.share_contacts.skip_button.title" = "Non ora";
 
-"registration.address_book_access_denied.hero.title" = "Wire does not have access to your contacts.";
-"registration.address_book_access_denied.hero.paragraph1" = "Wire helps find your friends if you share your contacts.";
-"registration.address_book_access_denied.hero.paragraph2" = "To enable access tap Settings and turn on Contacts.";
-"registration.address_book_access_denied.settings_button.title" = "Settings";
-"registration.address_book_access_denied.maybe_later_button.title" = "Maybe later";
+"registration.address_book_access_denied.hero.title" = "Wire non ha accesso ai tuoi contatti.";
+"registration.address_book_access_denied.hero.paragraph1" = "Wire ti aiuta a trovare i tuoi amici se Condividi i tuoi contatti.";
+"registration.address_book_access_denied.hero.paragraph2" = "Per abilitare vai su Impostazioni e attiva i contatti.";
+"registration.address_book_access_denied.settings_button.title" = "Impostazioni";
+"registration.address_book_access_denied.maybe_later_button.title" = "Forse dopo";
 
-"registration.push_access_denied.hero.title" = "Never miss a call or a message.";
-"registration.push_access_denied.hero.paragraph1" = "Enable Notifications in Settings.";
-"registration.push_access_denied.settings_button.title" = "Go to Settings";
-"registration.push_access_denied.maybe_later_button.title" = "Maybe later";
+"registration.push_access_denied.hero.title" = "Non perdere mai una chiamata o un messaggio.";
+"registration.push_access_denied.hero.paragraph1" = "Attiva le notifiche nelle impostazioni.";
+"registration.push_access_denied.settings_button.title" = "Vai nelle Impostazioni";
+"registration.push_access_denied.maybe_later_button.title" = "Forse dopo";
 
-"registration.signin.title" = "Log In";
+"registration.signin.title" = "Log in";
 "registration.signin.too_many_devices.title" = "";
-"registration.signin.too_many_devices.subtitle" = "Remove one of your other devices to start using Wire on this one.";
-"registration.signin.too_many_devices.manage_button.title" = "Manage devices";
-"registration.signin.too_many_devices.sign_out_button.title" = "Log out";
+"registration.signin.too_many_devices.subtitle" = "Rimuovere uno dei tuoi altri dispositivi per iniziare a utilizzare Wire su questo.";
+"registration.signin.too_many_devices.manage_button.title" = "Gestisci dispositivi";
+"registration.signin.too_many_devices.sign_out_button.title" = "Logout";
 "registration.signin.email_button.title" = "Email";
-"registration.signin.phone_button.title" = "Phone";
+"registration.signin.phone_button.title" = "Telefono";
 
-"registration.devices.title" = "Devices";
-"registration.devices.active_list_header" = "Active";
-"registration.devices.current_list_header" = "Current";
-"registration.devices.active_list_subtitle" = "If you don’t recognize a device above, remove it and reset your password.";
-"registration.devices.activated_in" = "Activated in";
+"registration.devices.title" = "Dispositivi";
+"registration.devices.active_list_header" = "Attivi";
+"registration.devices.current_list_header" = "Corrente";
+"registration.devices.active_list_subtitle" = "Se non riconosci un dispositivo qui sopra, rimuovilo e reimposta la password.";
+"registration.devices.activated_in" = "Attivato a";
 "registration.devices.id" = "ID:";
 
-"signin.forgot_password" = "Forgot password?";
+"signin.forgot_password" = "Hai dimenticato la password?";
 
-"registration.add_phone_number.hero.title" = "Add phone number";
-"registration.add_phone_number.hero.paragraph" = "This helps us find people you may know. We never share it.";
-"registration.add_phone_number.skip_button.title" = "Not now";
+"registration.add_phone_number.hero.title" = "Aggiungi numero di telefono";
+"registration.add_phone_number.hero.paragraph" = "Questo ci aiuta a trovare persone che potresti conoscere. Non lo condivideremo mai.";
+"registration.add_phone_number.skip_button.title" = "Non ora";
 
-"registration.add_email_password.hero.title" = "Add your email and password.";
-"registration.add_email_password.hero.paragraph" = "This lets you use Wire on multiple devices.";
+"registration.add_email_password.hero.title" = "Aggiungi il tuo indirizzo email e la password.";
+"registration.add_email_password.hero.paragraph" = "Questo ti consente di usare Wire su più dispositivi.";
 
-"registration.email_invitation.title" = "Invitation";
-"registration.email_invitation.hero.title" = "Hello, %@";
-"registration.email_invitation.hero.paragraph" = "Choose a password to create your account.";
+"registration.email_invitation.title" = "Invito";
+"registration.email_invitation.hero.title" = "Ciao, %@";
+"registration.email_invitation.hero.paragraph" = "Scegli una password per creare il tuo account.";
 
-"registration.phone_invitation.title" = "Invitation";
-"registration.phone_invitation.hero.title" = "Hello, %@";
-"registration.phone_invitation.hero.paragraph" = "You are one step away from creating your account.";
+"registration.phone_invitation.title" = "Invito";
+"registration.phone_invitation.hero.title" = "Ciao, %@";
+"registration.phone_invitation.hero.paragraph" = "Sei a un passo dal creare il tuo account.";
 
-"error.name_and_email" = "Please enter your full name and a valid email address";
-"error.full_name" = "Please enter your full name";
-"error.email" = "Please enter a valid email address";
-"error.input.too_long" = "Input too long";
-"error.input.too_short" = "Input too short";
-"error.email.invalid" = "Please enter a valid email address";
-"error.phone.invalid" = "Please enter a valid phone number";
+"error.name_and_email" = "Inserisci il tuo nome e cognome e un indirizzo email valido";
+"error.full_name" = "Si prega di inserire il nome intero";
+"error.email" = "Inserisci un indirizzo email valido";
+"error.input.too_long" = "Input troppo lungo";
+"error.input.too_short" = "Input troppo corto";
+"error.email.invalid" = "Inserisci un indirizzo email valido";
+"error.phone.invalid" = "Inserisci un numero di telefono valido";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // ZMUserSessionErrorCode mapping. Used during registration and profile edit
-"error.user.unkown_error" = "Something went wrong, please try again";
-"error.user.needs_credentials" = "Please verify your details and try again.";
-"error.user.invalid_credentials" = "Please verify your details and try again.";
-"error.user.account_pending_activation" = "The account you are trying access is pending activation. Please verify your details.";
-"error.user.network_error" = "There seems to be a problem with your network. Please try again later.";
-"error.user.email_is_taken" = "The email address you provided has already been registered. Please try again.";
-"error.user.phone_is_taken" = "The phone number you provided has already been registered. Please try again.";
-"error.user.phone_code_invalid" = "Please enter a valid code";
-"error.user.phone_code_too_many" = "We already sent you a code via SMS. Tap Resend after 10 minutes to get a new one.";
-"error.user.registration_unknown_error" = "Something went wrong. Please try again.";
-"error.user.device_deleted_remotely" = "You have been logged out from another device.";
+"error.user.unkown_error" = "Qualcosa è andato storto, si prega di riprovare";
+"error.user.needs_credentials" = "Verifica i tuoi dati e riprova.";
+"error.user.invalid_credentials" = "Verifica i tuoi dati e riprova.";
+"error.user.account_pending_activation" = "L'account a cui stai cercando di accedere è in attesa di attivazione. Verifica i dati inseriti.";
+"error.user.network_error" = "Sembra esserci un problema con la tua rete. Per favore, riprova più tardi.";
+"error.user.email_is_taken" = "L'indirizzo email che hai fornito è già stato registrato. Prova un indirizzo email diverso.";
+"error.user.phone_is_taken" = "Il numero di telefono che hai fornito è già stato registrato. Si prega di riprovare.";
+"error.user.phone_code_invalid" = "Inserisci un codice valido";
+"error.user.phone_code_too_many" = "Ti abbiamo già inviato un codice via SMS. Tocca Invia di nuovo dopo 10 minuti per ottenerne un altro.";
+"error.user.registration_unknown_error" = "Qualcosa è andato storto. Si prega di riprovare.";
+"error.user.device_deleted_remotely" = "Sei stato disconnesso da un altro dispositivo.";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Those are caught by the UI without involving the SE validation. Basically very similar to ZMUserSessionErrorCode onces
-"error.updating_password" = "Couldn't update your password.";
+"error.updating_password" = "Impossibile aggiornare la password.";
 
-"error.group_call.too_many_members_in_conversation.title" = "Too many people to call";
-"error.group_call.too_many_members_in_conversation" = "Calls work in conversations with up to %d people.";
-"error.group_call.too_many_participants_in_the_call.title" = "The call is full";
-"error.group_call.too_many_participants_in_the_call" = "There’s only room for %d people in here.";
-"error.call.gsm_ongoing.title" = "Cellular call";
-"error.call.gsm_ongoing" = "Please cancel the cellular call before calling on Wire.";
-"error.call.general.title" = "Call error";
-"error.call.general" = "Please try calling again in several minutes.";
-"error.call.slow_connection.title" = "Slow connection";
-"error.call.slow_connection" = "You might experience issues during the call";
-"error.call.slow_connection.call_anyway" = "Call anyway";
+"error.group_call.too_many_members_in_conversation.title" = "Troppe persone da chiamare";
+"error.group_call.too_many_members_in_conversation" = "Le chiamate funzionano in conversazioni fino a %d persone.";
+"error.group_call.too_many_participants_in_the_call.title" = "La chiamata è piena";
+"error.group_call.too_many_participants_in_the_call" = "C'è spazio solo per %d persone qui.";
+"error.call.gsm_ongoing.title" = "Chiamata cellulare";
+"error.call.gsm_ongoing" = "Per favore annulla la chiamata cellulare prima di chiamare con Wire.";
+"error.call.general.title" = "Errore chiamata";
+"error.call.general" = "Per favore prova a chiamare nuovamente tra alcuni minuti.";
+"error.call.slow_connection.title" = "Connessione lenta";
+"error.call.slow_connection" = "Potresti riscontrare problemi durante la chiamata";
+"error.call.slow_connection.call_anyway" = "Chiama comunque";
 
-"error.invite.no_email_provider" = "Please configure your email client to be able to send the invites via email";
-"error.invite.no_messaging_provider" = "Please configure your SMS to be able to send the invites via SMS";
+"error.invite.no_email_provider" = "Per favore configura la tua posta elettronica per essere in grado di inviare gli inviti via email";
+"error.invite.no_messaging_provider" = "Per favore configura i tuoi SMS per essere in grado di inviare gli inviti via SMS";
 
-"sketchpad.initial_hint" = "Tap color to change brush size\nPress and hold to fill an area\nShake to remove a photo";
+"sketchpad.initial_hint" = "Tocca un colore per cambiare la dimensione del pennello\nTieni premuto per riempire un'area\nScuoti per rimuovere una foto";
 
-"migration.please_wait_message" = "One moment, please";
+"migration.please_wait_message" = "Un attimo, per favore";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Those are used by the backend to localize APNS
-"push.notification.new_user" = "%@ joined Wire";
-"push.notification.new_message" = "New message";
+"push.notification.new_user" = "%@ è su Wire";
+"push.notification.new_message" = "Nuovo messaggio";
 
 
-//Force Update
-"force.update.title" = "Update necessary";
-"force.update.message" = "You are missing out on new features.\nGet the latest version of Wire in the App Store.";
-"force.update.ok_button" = "Go to App Store";
+// Force Update
+"force.update.title" = "Aggiornamento necessario";
+"force.update.message" = "Ti stai perdendo le novità di Wire. Scarica l'ultima versione dall'App Store.";
+"force.update.ok_button" = "Vai all'App Store";
 
 // Third Party
 "giphy.conversation.message" = "%@ · via giphy.com";
 "giphy.conversation.random_message" = "via giphy.com";
-"giphy.error.no_more_results" = "no more gifs";
-"giphy.error.no_result" = "no gif found";
+"giphy.error.no_more_results" = "nessun altra gif";
+"giphy.error.no_result" = "nessuna gif trovata";
 
-"giphy.confirm" = "send";
-"giphy.cancel" = "cancel";
-"giphy.search_placeholder" = "Search giphy";
+"giphy.confirm" = "invia";
+"giphy.cancel" = "annulla";
+"giphy.search_placeholder" = "Ricerca Giphy";
 
-"invite_banner.title" = "Bring your friends to Wire!";
-"invite_banner.message" = "Enjoy calls, messages, sketches, GIFs and more in private or with groups.";
-"invite_banner.invite_button_title" = "Invite more people";
+"invite_banner.title" = "Porta i tuoi amici su Wire!";
+"invite_banner.message" = "Chiama, invia messaggi, schizzi, GIFs e molto altro in privato o in gruppo.";
+"invite_banner.invite_button_title" = "Invita più persone";

--- a/Wire-iOS/Resources/it.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/it.lproj/Localizable.strings
@@ -128,6 +128,7 @@
 
 "conversation.input_bar.verified" = "Verificato";
 "conversation.input_bar.placeholder" = "Digita un messaggio";
+"conversation.input_bar.placeholder_ephemeral" = "Timed message";
 
 "conversation.input_bar.audio_message.tooltip.pull_send" = "Scorri in su per inviare";
 "conversation.input_bar.audio_message.tooltip.tap_send" = "Tocca per inviare";
@@ -161,6 +162,10 @@
 
 // Twitter
 "twitter_status.on_twitter" = "%@ su Twitter";
+
+// Ephemeral message
+"input.ephemeral.timeout.none" = "Off";
+"input.ephemeral.title" = "Set a timer for temporary messages";
 
 // System messages
 "content.system.continued_conversation" = "Inizia una conversazione con %@";
@@ -221,6 +226,8 @@
 "content.system.cannot_decrypt.identity.you_part" = "Il tuo";
 "content.system.cannot_decrypt.identity.otherUser_part" = "di %@"; // posessive apostrophe - might differ in different languages
 "content.system.cannot_decrypt.identity.why_part" = "Ulteriori informazioni";
+"content.system.cannot_decrypt.otherDevice_part" = "(dispositivo %@)"; // example " (device d1b23c54f34a)".
+// Full sentence: "A message from %@ was not received. [...] (device d1b23c54f34a). This is a debug information.
 
 "content.file.uploading" = "Caricamento…";
 "content.file.downloading" = "Download in corso…";

--- a/Wire-iOS/Resources/it.lproj/Localizable.stringsdict
+++ b/Wire-iOS/Resources/it.lproj/Localizable.stringsdict
@@ -1,0 +1,191 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+        <key>self.new_device_alert.title_prefix.devices</key>
+        <dict>
+            <key>NSStringLocalizedFormatKey</key>
+            <string>%#@device_count@</string>
+            <key>device_count</key>
+            <dict>
+                <key>NSStringFormatSpecTypeKey</key>
+                <string>NSStringPluralRuleType</string>
+                <key>NSStringFormatValueTypeKey</key>
+                <string>lu</string>
+                <key>zero</key>
+                <string></string>
+                <key>one</key>
+                <string>a device</string>
+                <key>few</key>
+                <string>%lu devices</string>
+                <key>many</key>
+                <string>%lu devices</string>
+                <key>other</key>
+                <string>%lu devices</string>
+            </dict>
+        </dict>
+		<key>participants.people.count</key>
+		<dict>
+			<key>NSStringLocalizedFormatKey</key>
+			<string>%#@lu_number_of_people@</string>
+			<key>lu_number_of_people</key>
+			<dict>
+				<key>NSStringFormatSpecTypeKey</key>
+				<string>NSStringPluralRuleType</string>
+				<key>NSStringFormatValueTypeKey</key>
+				<string>lu</string>
+				<key>zero</key>
+				<string>No people</string>
+				<key>one</key>
+				<string>One person</string>
+				<key>few</key>
+				<string>%lu people</string>
+				<key>many</key>
+				<string>%lu people</string>
+				<key>other</key>
+				<string>%lu people</string>
+			</dict>
+		</dict>
+        <key>content.system.missing_messages.subtitle_added</key>
+        <dict>
+            <key>NSStringLocalizedFormatKey</key>
+            <string>%@ %#@lu_number_of_users@ been added</string>
+            <key>lu_number_of_users</key>
+            <dict>
+                <key>NSStringFormatSpecTypeKey</key>
+                <string>NSStringPluralRuleType</string>
+                <key>NSStringFormatValueTypeKey</key>
+                <string>lu</string>
+                <key>zero</key>
+                <string></string>
+                <key>one</key>
+                <string>has</string>
+                <key>other</key>
+                <string>have</string>
+            </dict>
+        </dict>
+        <key>content.system.missing_messages.subtitle_removed</key>
+        <dict>
+            <key>NSStringLocalizedFormatKey</key>
+            <string>%@ %#@lu_number_of_users@ been removed</string>
+            <key>lu_number_of_users</key>
+            <dict>
+                <key>NSStringFormatSpecTypeKey</key>
+                <string>NSStringPluralRuleType</string>
+                <key>NSStringFormatValueTypeKey</key>
+                <string>lu</string>
+                <key>zero</key>
+                <string></string>
+                <key>one</key>
+                <string>has</string>
+                <key>other</key>
+                <string>have</string>
+            </dict>
+        </dict>
+		<key>list.connect_request.people_waiting</key>
+		<dict>
+			<key>NSStringLocalizedFormatKey</key>
+			<string>%#@d_number_of_people@ waiting</string>
+			<key>d_number_of_people</key>
+			<dict>
+				<key>NSStringFormatSpecTypeKey</key>
+				<string>NSStringPluralRuleType</string>
+				<key>NSStringFormatValueTypeKey</key>
+				<string>d</string>
+				<key>zero</key>
+				<string></string>
+				<key>one</key>
+				<string>One person</string>
+				<key>few</key>
+				<string>%d people</string>
+				<key>many</key>
+				<string>%d people</string>
+				<key>other</key>
+				<string>%d people</string>
+			</dict>
+		</dict>
+		<key>content.system.participants_n_others</key>
+		<dict>
+			<key>NSStringLocalizedFormatKey</key>
+			<string>%@ %#@and_number_of_others@</string>
+			<key>and_number_of_others</key>
+			<dict>
+				<key>NSStringFormatSpecTypeKey</key>
+				<string>NSStringPluralRuleType</string>
+				<key>NSStringFormatValueTypeKey</key>
+				<string>d</string>
+				<key>zero</key>
+				<string/>
+				<key>one</key>
+				<string>and one more</string>
+				<key>few</key>
+				<string>and %d others</string>
+				<key>many</key>
+				<string>and %d others</string>
+				<key>other</key>
+				<string>and %d others</string>
+			</dict>
+		</dict>
+		<key>peoplepicker.suggested.knows_more</key>
+		<dict>
+			<key>NSStringLocalizedFormatKey</key>
+			<string>Knows %@ and %#@d_number_of_others@</string>
+			<key>d_number_of_others</key>
+			<dict>
+				<key>NSStringFormatSpecTypeKey</key>
+				<string>NSStringPluralRuleType</string>
+				<key>NSStringFormatValueTypeKey</key>
+				<string>d</string>
+				<key>few</key>
+				<string>%d others</string>
+				<key>many</key>
+				<string>%d others</string>
+				<key>other</key>
+				<string>%d others</string>
+			</dict>
+		</dict>
+        <key>content.system.people_started_using</key>
+        <dict>
+            <key>NSStringLocalizedFormatKey</key>
+            <string>%@ %#@d_number_of_others@ started using %#@d_new_devices@</string>
+            <key>d_number_of_others</key>
+            <dict>
+                <key>NSStringFormatSpecTypeKey</key>
+                <string>NSStringPluralRuleType</string>
+                <key>NSStringFormatValueTypeKey</key>
+                <string>d</string>
+                <key>one</key>
+                <string></string>
+                <key>other</key>
+                <string>and %d others</string>
+            </dict>
+            <key>d_new_devices</key>
+            <dict>
+                <key>NSStringFormatSpecTypeKey</key>
+                <string>NSStringPluralRuleType</string>
+                <key>NSStringFormatValueTypeKey</key>
+                <string>d</string>
+                <key>one</key>
+                <string>a new device</string>
+                <key>other</key>
+                <string>new devices</string>
+            </dict>
+        </dict>
+        <key>content.system.new_devices</key>
+        <dict>
+            <key>NSStringLocalizedFormatKey</key>
+            <string>%#@d_new_devices@</string>
+            <key>d_new_devices</key>
+            <dict>
+                <key>NSStringFormatSpecTypeKey</key>
+                <string>NSStringPluralRuleType</string>
+                <key>NSStringFormatValueTypeKey</key>
+                <string>d</string>
+                <key>one</key>
+                <string>a new device</string>
+                <key>other</key>
+                <string>new devices</string>
+            </dict>
+        </dict>
+	</dict>
+</plist>

--- a/Wire-iOS/Resources/it.lproj/Localizable.stringsdict
+++ b/Wire-iOS/Resources/it.lproj/Localizable.stringsdict
@@ -15,13 +15,13 @@
                 <key>zero</key>
                 <string></string>
                 <key>one</key>
-                <string>a device</string>
+                <string>un dispositivo</string>
                 <key>few</key>
-                <string>%lu devices</string>
+                <string>%lu dispositivi</string>
                 <key>many</key>
-                <string>%lu devices</string>
+                <string>%lu dispositivi</string>
                 <key>other</key>
-                <string>%lu devices</string>
+                <string>%lu dispositivi</string>
             </dict>
         </dict>
 		<key>participants.people.count</key>
@@ -35,21 +35,21 @@
 				<key>NSStringFormatValueTypeKey</key>
 				<string>lu</string>
 				<key>zero</key>
-				<string>No people</string>
+				<string>Nessuna persona</string>
 				<key>one</key>
-				<string>One person</string>
+				<string>Una persona</string>
 				<key>few</key>
-				<string>%lu people</string>
+				<string>%lu persone</string>
 				<key>many</key>
-				<string>%lu people</string>
+				<string>%lu persone</string>
 				<key>other</key>
-				<string>%lu people</string>
+				<string>%lu persone</string>
 			</dict>
 		</dict>
         <key>content.system.missing_messages.subtitle_added</key>
         <dict>
             <key>NSStringLocalizedFormatKey</key>
-            <string>%@ %#@lu_number_of_users@ been added</string>
+            <string>%@ %#@lu_number_of_users@ sono state aggiunte</string>
             <key>lu_number_of_users</key>
             <dict>
                 <key>NSStringFormatSpecTypeKey</key>
@@ -59,15 +59,15 @@
                 <key>zero</key>
                 <string></string>
                 <key>one</key>
-                <string>has</string>
+                <string>ha</string>
                 <key>other</key>
-                <string>have</string>
+                <string>hai</string>
             </dict>
         </dict>
         <key>content.system.missing_messages.subtitle_removed</key>
         <dict>
             <key>NSStringLocalizedFormatKey</key>
-            <string>%@ %#@lu_number_of_users@ been removed</string>
+            <string>%@ %#@lu_number_of_users@ sono state rimosse</string>
             <key>lu_number_of_users</key>
             <dict>
                 <key>NSStringFormatSpecTypeKey</key>
@@ -77,15 +77,15 @@
                 <key>zero</key>
                 <string></string>
                 <key>one</key>
-                <string>has</string>
+                <string>ha</string>
                 <key>other</key>
-                <string>have</string>
+                <string>hai</string>
             </dict>
         </dict>
 		<key>list.connect_request.people_waiting</key>
 		<dict>
 			<key>NSStringLocalizedFormatKey</key>
-			<string>%#@d_number_of_people@ waiting</string>
+			<string>%#@d_number_of_people@ in attesa</string>
 			<key>d_number_of_people</key>
 			<dict>
 				<key>NSStringFormatSpecTypeKey</key>
@@ -95,13 +95,13 @@
 				<key>zero</key>
 				<string></string>
 				<key>one</key>
-				<string>One person</string>
+				<string>Una persona</string>
 				<key>few</key>
-				<string>%d people</string>
+				<string>%d persone</string>
 				<key>many</key>
-				<string>%d people</string>
+				<string>%d persone</string>
 				<key>other</key>
-				<string>%d people</string>
+				<string>%d persone</string>
 			</dict>
 		</dict>
 		<key>content.system.participants_n_others</key>
@@ -117,19 +117,19 @@
 				<key>zero</key>
 				<string/>
 				<key>one</key>
-				<string>and one more</string>
+				<string>ed un altro</string>
 				<key>few</key>
-				<string>and %d others</string>
+				<string>e %d altri</string>
 				<key>many</key>
-				<string>and %d others</string>
+				<string>e %d altri</string>
 				<key>other</key>
-				<string>and %d others</string>
+				<string>e %d altri</string>
 			</dict>
 		</dict>
 		<key>peoplepicker.suggested.knows_more</key>
 		<dict>
 			<key>NSStringLocalizedFormatKey</key>
-			<string>Knows %@ and %#@d_number_of_others@</string>
+			<string>Conosce %@ e %#@d_number_of_others@</string>
 			<key>d_number_of_others</key>
 			<dict>
 				<key>NSStringFormatSpecTypeKey</key>
@@ -137,17 +137,17 @@
 				<key>NSStringFormatValueTypeKey</key>
 				<string>d</string>
 				<key>few</key>
-				<string>%d others</string>
+				<string>%d altri</string>
 				<key>many</key>
-				<string>%d others</string>
+				<string>%d altri</string>
 				<key>other</key>
-				<string>%d others</string>
+				<string>%d altri</string>
 			</dict>
 		</dict>
         <key>content.system.people_started_using</key>
         <dict>
             <key>NSStringLocalizedFormatKey</key>
-            <string>%@ %#@d_number_of_others@ started using %#@d_new_devices@</string>
+            <string>%@ %#@d_number_of_others@ hanno iniziato ad utilizzare %#@d_new_devices@</string>
             <key>d_number_of_others</key>
             <dict>
                 <key>NSStringFormatSpecTypeKey</key>
@@ -157,7 +157,7 @@
                 <key>one</key>
                 <string></string>
                 <key>other</key>
-                <string>and %d others</string>
+                <string>e %d altri</string>
             </dict>
             <key>d_new_devices</key>
             <dict>
@@ -166,9 +166,9 @@
                 <key>NSStringFormatValueTypeKey</key>
                 <string>d</string>
                 <key>one</key>
-                <string>a new device</string>
+                <string>un nuovo dispositivo</string>
                 <key>other</key>
-                <string>new devices</string>
+                <string>nuovi dispositivi</string>
             </dict>
         </dict>
         <key>content.system.new_devices</key>
@@ -182,9 +182,9 @@
                 <key>NSStringFormatValueTypeKey</key>
                 <string>d</string>
                 <key>one</key>
-                <string>a new device</string>
+                <string>un nuovo dispositivo</string>
                 <key>other</key>
-                <string>new devices</string>
+                <string>nuovi dispositivi</string>
             </dict>
         </dict>
 	</dict>

--- a/Wire-iOS/Resources/ja.lproj/InfoPlist.strings
+++ b/Wire-iOS/Resources/ja.lproj/InfoPlist.strings
@@ -1,0 +1,22 @@
+/*
+ *  Wire
+ *  Copyright (C) 2016 Wire Swiss GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+"NSContactsUsageDescription" = "Allow Wire to access your contacts to connect you with others. We anonymize all information and do not share it with anyone else.";
+"NSMicrophoneUsageDescription" = "Allow Wire to access your microphone so you can talk to people and send audio messages.";
+"NSLocationWhenInUseUsageDescription" = "Allow Wire to access your location so you can send your location to others.";
+"NSCameraUsageDescription" = "Allow Wire to access your camera so you can place video calls and send photos.";

--- a/Wire-iOS/Resources/ja.lproj/InfoPlist.strings
+++ b/Wire-iOS/Resources/ja.lproj/InfoPlist.strings
@@ -1,4 +1,4 @@
-/*
+/* 
  *  Wire
  *  Copyright (C) 2016 Wire Swiss GmbH
  *
@@ -14,9 +14,9 @@
  *
  *  You should have received a copy of the GNU General Public License
  *  along with this program. If not, see http://www.gnu.org/licenses/.
- */
+*/
 
-"NSContactsUsageDescription" = "Allow Wire to access your contacts to connect you with others. We anonymize all information and do not share it with anyone else.";
-"NSMicrophoneUsageDescription" = "Allow Wire to access your microphone so you can talk to people and send audio messages.";
-"NSLocationWhenInUseUsageDescription" = "Allow Wire to access your location so you can send your location to others.";
-"NSCameraUsageDescription" = "Allow Wire to access your camera so you can place video calls and send photos.";
+"NSContactsUsageDescription" = "他のユーザーとつながるために、Wireがあなたの連絡先にアクセスすることを許可してください。私たちはすべての情報を匿名化し、他の誰ともあなたの連絡先に関する情報をシェアしません。";
+"NSMicrophoneUsageDescription" = "電話や音声メッセージ送信のためにWireがあなたのマイクにアクセスすることを許可してください。";
+"NSLocationWhenInUseUsageDescription" = "Wireに位置情報へのアクセスを許可することで、あなたの位置情報を送信することができます";
+"NSCameraUsageDescription" = "ビデオ通話や写真を送信するためにWireがカメラにアクセスすることを許可してください。";

--- a/Wire-iOS/Resources/ja.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/ja.lproj/Localizable.strings
@@ -128,6 +128,7 @@
 
 "conversation.input_bar.verified" = "検証する";
 "conversation.input_bar.placeholder" = "メッセージを入力します";
+"conversation.input_bar.placeholder_ephemeral" = "Timed message";
 
 "conversation.input_bar.audio_message.tooltip.pull_send" = "上にスワイプして送信";
 "conversation.input_bar.audio_message.tooltip.tap_send" = "タップして送信";
@@ -161,6 +162,10 @@
 
 // Twitter
 "twitter_status.on_twitter" = "ツイッターに%@します";
+
+// Ephemeral message
+"input.ephemeral.timeout.none" = "Off";
+"input.ephemeral.title" = "Set a timer for temporary messages";
 
 // System messages
 "content.system.continued_conversation" = "%@と会話を始めます";
@@ -221,6 +226,8 @@
 "content.system.cannot_decrypt.identity.you_part" = "あなたの";
 "content.system.cannot_decrypt.identity.otherUser_part" = "%@の"; // posessive apostrophe - might differ in different languages
 "content.system.cannot_decrypt.identity.why_part" = "もっと知る";
+"content.system.cannot_decrypt.otherDevice_part" = "(device %@)"; // example " (device d1b23c54f34a)".
+// Full sentence: "A message from %@ was not received. [...] (device d1b23c54f34a). This is a debug information.
 
 "content.file.uploading" = "アップロード中...";
 "content.file.downloading" = "ダウンロード中…";

--- a/Wire-iOS/Resources/ja.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/ja.lproj/Localizable.strings
@@ -1,386 +1,386 @@
-//
+// 
 // Wire
 // Copyright (C) 2016 Wire Swiss GmbH
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
 
 "general.ok" = "OK";
-"general.cancel" = "Cancel";
-"general.open_settings" = "Open Wire Settings";
+"general.cancel" = "キャンセル";
+"general.open_settings" = "Wireの設定を開く";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // People picker/start UI
-"peoplepicker.search_placeholder" = "Search by name or email";
-"peoplepicker.header.top_people" = "Top people";
-"peoplepicker.button.create_conversation" = "Create group";
-"peoplepicker.button.add_to_conversation" = "Add";
-"peoplepicker.header.conversations" = "Groups";
-"peoplepicker.header.send_invitation" = "Invite";
-"peoplepicker.header.contacts" = "Connections";
-"peoplepicker.header.directory" = "Connect";
-"peoplepicker.title.create_conversation" = "Create group";
-"peoplepicker.title.add_to_conversation" = "Add people";
+"peoplepicker.search_placeholder" = "名前またはメールアドレスで検索します";
+"peoplepicker.header.top_people" = "友達を追加します";
+"peoplepicker.button.create_conversation" = "グループを作成";
+"peoplepicker.button.add_to_conversation" = "追加";
+"peoplepicker.header.conversations" = "グループ";
+"peoplepicker.header.send_invitation" = "招待";
+"peoplepicker.header.contacts" = "接続";
+"peoplepicker.header.directory" = "接続";
+"peoplepicker.title.create_conversation" = "グループを作成します";
+"peoplepicker.title.add_to_conversation" = "人を追加します";
 
-"peoplepicker.no_contacts_title" = "No Contacts.";
+"peoplepicker.no_contacts_title" = "連絡先がありません";
 
-"peoplepicker.no_matching_results_title" = "No results.";
-"peoplepicker.no_matching_results_message" = "Enter a full email address.";
+"peoplepicker.no_matching_results_title" = "結果はありません";
+"peoplepicker.no_matching_results_message" = "メールアドレスを正確に入力します";
 
-"peoplepicker.no_matching_results.action.send_invite" = "Send an invitation";
-"peoplepicker.no_matching_results.action.share_contacts" = "Share contacts";
+"peoplepicker.no_matching_results.action.send_invite" = "招待状を送信します";
+"peoplepicker.no_matching_results.action.share_contacts" = "連絡先を共有します";
 
-"peoplepicker.no_matching_results_provide_valid_email" = "Please enter a valid email address";
-"peoplepicker.no_matching_results_after_address_book_upload_title" = "No results.";
+"peoplepicker.no_matching_results_provide_valid_email" = "有効なメール アドレスを入力してください";
+"peoplepicker.no_matching_results_after_address_book_upload_title" = "結果はありません";
 /* This sentence ends with button title, contained in peoplepicker.no_matching_results_after_address_book_upload_button */
-"peoplepicker.no_matching_results_after_address_book_upload_message" = "Enter a full email address or";
+"peoplepicker.no_matching_results_after_address_book_upload_message" = "メールアドレスを正確に入力します";
 /*  */
-"peoplepicker.no_matching_results_after_address_book_upload_button" = "share contacts";
+"peoplepicker.no_matching_results_after_address_book_upload_button" = "連絡先を共有します";
 
-"peoplepicker.share_contacts.no_results.title" = "Find people by name or email address";
+"peoplepicker.share_contacts.no_results.title" = "名前またはメールアドレスて見つけます";
 
-"peoplepicker.send_invitation.dialog.title" = "Invitation sent";
-"peoplepicker.send_invitation.dialog.message" = "It can be used for 2 weeks. Send a new one if it expires.";
+"peoplepicker.send_invitation.dialog.title" = "招待状を送信しました";
+"peoplepicker.send_invitation.dialog.message" = "2週間使用できます。\n期限が切れた時は新しいものを送ります";
 "peoplepicker.send_invitation.dialog.ok" = "OK";
 
-"peoplepicker.invite_more_people" = "Invite more people";
-"peoplepicker.quick-action.open-conversation" = "Open";
-"peoplepicker.quick-action.create-conversation" = "Create group";
+"peoplepicker.invite_more_people" = "多くの人を招待します";
+"peoplepicker.quick-action.open-conversation" = "開ける";
+"peoplepicker.quick-action.create-conversation" = "グループを作成します";
 
 // Contacts UI
-"contacts_ui.search_placeholder" = "Search by name";
-"contacts_ui.invite_others" = "Invite others";
-"contacts_ui.name_in_contacts" = "%@ in address book";
-"contacts_ui.connection_request" = "Requested to connect";
-"contacts_ui.action_button.invite" = "Invite";
-"contacts_ui.action_button.open" = "Open";
-"contacts_ui.invite_sheet.cancel_button_title" = "Cancel";
-"contacts_ui.notification.invitation_sent" = "Invitation sent";
-"contacts_ui.notification.invitation_failed" = "Failed to send invitation";
-"contacts_ui.title" = "Invite people";
+"contacts_ui.search_placeholder" = "名前で検索します";
+"contacts_ui.invite_others" = "他の人を招待します";
+"contacts_ui.name_in_contacts" = "アドレス帳に登録されている%@";
+"contacts_ui.connection_request" = "接続を要求します";
+"contacts_ui.action_button.invite" = "招待";
+"contacts_ui.action_button.open" = "開ける";
+"contacts_ui.invite_sheet.cancel_button_title" = "キャンセル";
+"contacts_ui.notification.invitation_sent" = "招待状を送信しました";
+"contacts_ui.notification.invitation_failed" = "招待状を送信できませんでした";
+"contacts_ui.title" = "友達を招待する";
 
-"contacts_ui.no_contact.title" = "No active conversations\n";
-"contacts_ui.no_contact.message" = "Tap contacts to start a conversation";
+"contacts_ui.no_contact.title" = "有効な会話が有りません\n";
+"contacts_ui.no_contact.message" = "連絡先をタップして会話を始めます";
 
 // Conversation List Bottom Bar
-"bottom_bar.contacts_button.title" = "contacts";
+"bottom_bar.contacts_button.title" = "連絡先";
 
 // Archived List
-"archived_list.title" = "archive";
+"archived_list.title" = "アーカイブ";
 
 // Add contact tool tip
-"tool_tip.contacts.title" = "Conversations start here";
-"tool_tip.contacts.message" = "Start a conversation or invite more people to join. Call, message and share in private or with groups.";
+"tool_tip.contacts.title" = "ここから会話を始めます";
+"tool_tip.contacts.message" = "会話を始めるか、参加する人をさらに招待します。プライベートまたはグループと通話、メッセージ、共有します。";
 
 // "Knows" subtitle in cell: "Knows Indrek", "Knows Indrek and Jane", "Knows Indrek and 5 others"
-"peoplepicker.suggested.knows_one" = "Knows %@";
-"peoplepicker.suggested.knows_two" = "Knows %@ and %@";
-"peoplepicker.hide_search_result" = "Hide";
-"peoplepicker.hide_search_result_progress" = "Hiding…";
+"peoplepicker.suggested.knows_one" = "%@を知っています";
+"peoplepicker.suggested.knows_two" = "%@と%@を知っています";
+"peoplepicker.hide_search_result" = "隠す";
+"peoplepicker.hide_search_result_progress" = "隠しています...";
 
-"send_invitation.subject" = "Connect with me on Wire";
-"send_invitation.text" = "I’m on Wire. Search for %@\nor visit https://get.wire.com to connect with me.";
-"send_invitation_no_email.text" = "I’m on Wire. Visit https://get.wire.com to connect with me.";
+"send_invitation.subject" = "Wireで繋がります";
+"send_invitation.text" = "Wireを使っています。%@で検索するか、https://get.wire.com のページを参照して下さい";
+"send_invitation_no_email.text" = "私はWireを使っています。https://get.wire. に接続して私に繋がりましょう。";
 
-"send_personal_invitation.text" = "I’m on Wire, talk to you there. https://get.wire.com";
+"send_personal_invitation.text" = "私は Wire を利用しています。Wireで話しましょう。https://get.wire.com";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++x
 // In-app notifications (chat heads)
-"notifications.shared_a_photo" = "shared a picture";
-"notifications.pinged" = "pinged";
-"notifications.sent_file" = "shared a file";
-"notifications.sent_location" = "shared a location";
-"notifications.sent_video" = "shared a video";
-"notifications.sent_audio" = "shared an audio";
-"notifications.in_conversation" = "%@ - %@";
-"notifications.this_conversation" = "%@ in this conversation";
+"notifications.shared_a_photo" = "写真を共有します";
+"notifications.pinged" = "ping を実行しました";
+"notifications.sent_file" = "ファイルを共有します";
+"notifications.sent_location" = "場所を共有します";
+"notifications.sent_video" = "ビデオを共有します";
+"notifications.sent_audio" = "音声を共有します";
+"notifications.in_conversation" = "%@%@";
+"notifications.this_conversation" = "%@はこの会話に参加しています";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // List (labels) - Needs to be revised with updated guidance
-"list.archived_conversations" = "ARCHIVE";
-"list.archived_conversations_close" = "Close archive";
+"list.archived_conversations" = "アーカイブ";
+"list.archived_conversations_close" = "アーカイブして閉じます";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Conversation
-"conversation.invite_more_people.title" = "Spread the word!";
-"conversation.invite_more_people.description" = "Add people to this conversation";
-"conversation.invite_more_people.explanation_url" = "https://support.wire.com";
-"conversation.invite_more_people.button_title" = "Add People";
+"conversation.invite_more_people.title" = "言葉を広めよう！";
+"conversation.invite_more_people.description" = "この会話に人を追加します";
+"conversation.invite_more_people.explanation_url" = "サポートアドレス https://support.wire.com";
+"conversation.invite_more_people.button_title" = "友達を追加しまし";
 
 // Conversation names
-"conversation.displayname.emptygroup" = "Empty group conversation";
+"conversation.displayname.emptygroup" = "空のグループ";
 
-"conversation.input_bar.verified" = "Verified";
-"conversation.input_bar.placeholder" = "Type a message";
+"conversation.input_bar.verified" = "検証する";
+"conversation.input_bar.placeholder" = "メッセージを入力します";
 
-"conversation.input_bar.audio_message.tooltip.pull_send" = "Swipe up to send";
-"conversation.input_bar.audio_message.tooltip.tap_send" = "Tap to send";
-"conversation.input_bar.audio_message.too_long.title" = "Recording Stopped";
-"conversation.input_bar.audio_message.too_long.message" = "Audio messages are limited to %@. Send this message?";
-"conversation.input_bar.audio_message.send" = "Send";
+"conversation.input_bar.audio_message.tooltip.pull_send" = "上にスワイプして送信";
+"conversation.input_bar.audio_message.tooltip.tap_send" = "タップして送信";
+"conversation.input_bar.audio_message.too_long.title" = "録音を停止";
+"conversation.input_bar.audio_message.too_long.message" = "音声メッセージは %@に制限されています。このメッセージを送信しますか？";
+"conversation.input_bar.audio_message.send" = "送信";
 
-"conversation.input_bar.audio_message.keyboard.record_tip" = "Tap to record\nYou can  %@  it after that";
-"conversation.input_bar.audio_message.keyboard.filter_tip" = "Choose a filter above";
+"conversation.input_bar.audio_message.keyboard.record_tip" = "タッチして録音を開始します、その後  %@  できます。";
+"conversation.input_bar.audio_message.keyboard.filter_tip" = "上記のフィルターを選択します。";
 
 // Image confirmation dialogue
 "image_confirmer.confirm" = "OK";
-"image_confirmer.cancel" = "Cancel";
-"image.add_sketch" = "Add a sketch";
-"image.edit_image" = "Edit image";
+"image_confirmer.cancel" = "キャンセル";
+"image.add_sketch" = "スケッチを追加";
+"image.edit_image" = "イメージを編集します";
 
 // Camera access
-"camera_access.denied" = "Wire needs access to the Camera.";
+"camera_access.denied" = "Wireはカメラへのアクセスする必要が有ります";
 "camera_access.denied.instruction" = "";
-"camera_access.denied.open_settings" = "Enable it in Wire Settings";
+"camera_access.denied.open_settings" = "Wireの設定で有効にします";
 
 // Camera Controls
-"camera_controls.aeaf_lock" = "AE/AF Lock";
+"camera_controls.aeaf_lock" = "AE/AF ロック";
 
 // Location
-"location.send_button.title" = "Send";
-"location.unauthorized_alert.title" = "Enable Location Services";
-"location.unauthorized_alert.message" = "To send your location, enable Location Services and allow Wire to access your location.";
-"location.unauthorized_alert.cancel" = "Cancel";
-"location.unauthorized_alert.settings" = "Settings";
+"location.send_button.title" = "送信";
+"location.unauthorized_alert.title" = "位置情報サービスを有効にします。";
+"location.unauthorized_alert.message" = "位置情報を送信するには、位置情報サービスを有効にして、Wireが位置情報にアクセス出来るようにする必要が有ります。";
+"location.unauthorized_alert.cancel" = "キャンセル";
+"location.unauthorized_alert.settings" = "設定";
 
 // Twitter
-"twitter_status.on_twitter" = "%@ on Twitter";
+"twitter_status.on_twitter" = "ツイッターに%@します";
 
 // System messages
-"content.system.continued_conversation" = "Start a conversation with %@";
+"content.system.continued_conversation" = "%@と会話を始めます";
 
-"content.system.other_started_conversation" = "%@ started a conversation with %@";
-"content.system.you_started_conversation" = "You started a conversation with %@";
+"content.system.other_started_conversation" = "%@と%@は会話を始めました";
+"content.system.you_started_conversation" = "%@と会話を始めました";
 
-"content.system.you_added_participant" = "You added %@";
-"content.system.other_added_participant" = "%@ added %@";
-"content.system.other_added_you" = "%@ added you";
+"content.system.you_added_participant" = "%@を追加しました";
+"content.system.other_added_participant" = "%@は%@を追加しました";
+"content.system.other_added_you" = "%@はあなたを追加しました";
 
-"content.system.participants_you" = "You";
-"content.system.participants_1_other" = "%@ and %@";
-"content.system.other_left" = "%@ left";
-"content.system.you_left" = "You left";
-"content.system.other_removed_other" = "%@ removed %@";
-"content.system.other_removed_you" = "%@ removed you";
-"content.system.you_removed_other" = "You removed %@";
-"content.system.other_renamed_conv" = "%@ renamed the conversation";
-"content.system.you_renamed_conv" = "You renamed the conversation";
-"content.system.other_renamed_conv_to_nothing" = "%@ removed the conversation name";
-"content.system.you_renamed_conv_to_nothing" = "You removed the conversation name";
-"content.system.pending_message_timestamp" = "Sending…";
-"content.system.message_sent_timestamp" = "Sent";
-"content.system.message_delivered_timestamp" = "Delivered";
-"content.system.failedtosend_message_timestamp" = "Sending failed.";
-"content.system.failedtosend_message_timestamp_resend" = "Resend";
-"content.system.like_tooltip" = "Tap to like";
-"content.system.deleted_message_prefix_timestamp" = "Deleted on %@";
-"content.system.edited_message_prefix_timestamp" = "Edited on %@";
-"content.system.connecting_to" = "Connecting to %@.\nStart a conversation";
-"content.system.connected_to" = "Connected to %@\nStart a conversation";
-"content.system.other_wanted_to_talk" = "%@ called";
-"content.system.you_wanted_to_talk" = "You called";
+"content.system.participants_you" = "あなた";
+"content.system.participants_1_other" = "%@と%@";
+"content.system.other_left" = "%@が退出しました";
+"content.system.you_left" = "あなたは退出しました";
+"content.system.other_removed_other" = "%@は%@を削除しました";
+"content.system.other_removed_you" = "%@はあなたを削除しました";
+"content.system.you_removed_other" = "あなたは%@を削除しました";
+"content.system.other_renamed_conv" = "%@が会話に名前を付けました";
+"content.system.you_renamed_conv" = "あなたは会話に名前を付けました";
+"content.system.other_renamed_conv_to_nothing" = "%@が会話の名前を削除しました";
+"content.system.you_renamed_conv_to_nothing" = "あなたは会話の名前を削除しました";
+"content.system.pending_message_timestamp" = "送信中…";
+"content.system.message_sent_timestamp" = "送信済み";
+"content.system.message_delivered_timestamp" = "到達済み";
+"content.system.failedtosend_message_timestamp" = "送信できませんでした";
+"content.system.failedtosend_message_timestamp_resend" = "再送する";
+"content.system.like_tooltip" = "タップしていいね！";
+"content.system.deleted_message_prefix_timestamp" = "%@を削除";
+"content.system.edited_message_prefix_timestamp" = "%@を編集";
+"content.system.connecting_to" = "%@に接続し、会話を始めます";
+"content.system.connected_to" = "%@に接続し、会話が始まりました";
+"content.system.other_wanted_to_talk" = "%@が呼ぶ";
+"content.system.you_wanted_to_talk" = "あなたが呼ぶ";
 
-"content.system.you_started" = "You";
-"content.system.this_device" = "this device";
+"content.system.you_started" = "あなた";
+"content.system.this_device" = "このデバイス";
 
-"content.system.reactivated_device" = "You started using %@ again. Messages sent in the meantime will not appear here";
+"content.system.reactivated_device" = "あなたは%@を再び利用しています。いままでのメッセージはここには表示されません。";
 
-"content.system.new_device" = "a new device";
-"content.system.started_using" = "started using";
-"content.system.is_verified" = "All fingerprints are verified";
+"content.system.new_device" = "新しいデバイス";
+"content.system.started_using" = "使用を始めます";
+"content.system.is_verified" = "すべての指紋を確認します。";
 
-"content.system.unverified" = "%@ unverified one of %@"; //example "You unverified one of Jule's devices"
-"content.system.your_devices" = "your devices";
-"content.system.other_devices" = "%@'s devices";
+"content.system.unverified" = "%@%@デバイスの一つは認証されませんでした。"; // example "You unverified one of Jule's devices"
+"content.system.your_devices" = "お使いのデバイス";
+"content.system.other_devices" = "%@ のデバイス";
 
-"content.system.missing_messages.title" = "You haven't used this device for a while. Some messages may not appear here.";
-"content.system.missing_messages.subtitle_start" = "Meanwhile,";
+"content.system.missing_messages.title" = "しばらくの間、このデバイスでWireを利用していなかったため、いくつかのメッセージがここに表示されない可能性があります。";
+"content.system.missing_messages.subtitle_start" = "同時に";
 
-"content.system.cannot_decrypt" = "A message from %@ was not received.";
+"content.system.cannot_decrypt" = "%@からのメッセージは受信されませんでした。";
 
-"content.system.cannot_decrypt.you_part" = "you";
-"content.system.cannot_decrypt.why_part" = "Why?";
+"content.system.cannot_decrypt.you_part" = "あなた";
+"content.system.cannot_decrypt.why_part" = "なぜ？";
 
-"content.system.cannot_decrypt.identity" = "%@ device identity changed. Undelivered message.";
-"content.system.cannot_decrypt.identity.you_part" = "Your";
-"content.system.cannot_decrypt.identity.otherUser_part" = "%@'s"; // posessive apostrophe - might differ in different languages
-"content.system.cannot_decrypt.identity.why_part" = "Learn More";
+"content.system.cannot_decrypt.identity" = "%@のデバイスIDが変更されました。配信不能なメッセージです。";
+"content.system.cannot_decrypt.identity.you_part" = "あなたの";
+"content.system.cannot_decrypt.identity.otherUser_part" = "%@の"; // posessive apostrophe - might differ in different languages
+"content.system.cannot_decrypt.identity.why_part" = "もっと知る";
 
-"content.file.uploading" = "Uploading…";
-"content.file.downloading" = "Downloading…";
-"content.file.upload_failed" = "Upload failed";
-"content.file.upload_cancelled" = "Upload cancelled";
-"content.file.upload_video" = "Videos";
-"content.file.take_video" = "Record a video";
+"content.file.uploading" = "アップロード中...";
+"content.file.downloading" = "ダウンロード中…";
+"content.file.upload_failed" = "アップロードに失敗しました";
+"content.file.upload_cancelled" = "アップロードがキャンセルされました";
+"content.file.upload_video" = "ビデオ";
+"content.file.take_video" = "ビデオを録画";
 
-"content.file.save_video" = "Save";
-"content.file.save_audio" = "Save";
-"content.image.save_image" = "Save";
+"content.file.save_video" = "保存";
+"content.file.save_audio" = "保存";
+"content.image.save_image" = "保存";
 
-"content.message.delete" = "Delete";
+"content.message.delete" = "削除";
 
-"content.message.like" = "Like";
-"content.message.unlike" = "Unlike";
+"content.message.like" = "いいね！";
+"content.message.unlike" = "いいね！取消";
 
-"content.reactions_list.likers" = "Liked by";
+"content.reactions_list.likers" = "いいね！しました";
 
-"content.file.too_big" = "You can send files up to %@";
+"content.file.too_big" = "%@までのファイルを送信できます。";
 // Someone pinged
-"content.ping.text" = "%1$@ PINGED";
+"content.ping.text" = "%1$@がPINGをしました";
 
 // Current user pinged
-"content.ping.you.text" = "YOU PINGED";
+"content.ping.you.text" = "あなたがPINGしました";
 
 // Inline Player
-"content.player.unable_to_play" = "UNABLE TO PLAY TRACK";
+"content.player.unable_to_play" = "トラックを再生できません";
 
 // Connecting (NEW IMPLEMENTATION, REVIEW LATER)
-"connection_request.title" = "Connect to %@"; //check UPPERCASE implementation in code
-"missive.connection_request.default_message" = "Hi %@,\nLet’s connect on Wire.\n%@";
+"connection_request.title" = "%@とつながる"; // check UPPERCASE implementation in code
+"missive.connection_request.default_message" = "こんにちは。%@\nWireでつながりましょう。\n%@";
 
-"connection_request.send_button_title" = "Connect";
-"inbox.connection_request.connect_button_title" = "Connect";
-"inbox.connection_request.ignore_button_title" = "Ignore";
+"connection_request.send_button_title" = "接続";
+"inbox.connection_request.connect_button_title" = "接続";
+"inbox.connection_request.ignore_button_title" = "放置";
 
 // Voice
-"voice.status.one_to_one.incoming" = "%@\nCalling";
-"voice.status.group_call.incoming" = "%@\nRinging";
-"voice.status.one_to_one.outgoing" = "%@\nRinging";
-"voice.status.joining" = "%@\nConnecting";
-"voice.status.video_not_available" = "Video turned off";
-"voice.status.low_connection" = "Bad connection";
-"voice.network_error.title" = "No Internet Connection";
-"voice.network_error.body" = "You must be online to call. Check your connection and try again.";
-"voice.alert.call_in_progress.title" = "Call in progress";
-"voice.alert.call_in_progress.message" = "Another of your devices is already participating in the call";
+"voice.status.one_to_one.incoming" = "%@を呼出中";
+"voice.status.group_call.incoming" = "%@から呼出中";
+"voice.status.one_to_one.outgoing" = "%@から呼出中";
+"voice.status.joining" = "%@に接続中";
+"voice.status.video_not_available" = "ビデオ通話がオフになっています";
+"voice.status.low_connection" = "接続不良";
+"voice.network_error.title" = "インターネット接続がありません";
+"voice.network_error.body" = "オンラインにしてから通話する必要が有ります。接続を確認してもう一度やり直して下さい。";
+"voice.alert.call_in_progress.title" = "通話中です";
+"voice.alert.call_in_progress.message" = "あなたの別のデバイスが電話を受けています";
 "voice.alert.call_in_progress.confirm" = "Ok";
-"voice.accept_button.title" = "Accept";
-"voice.decline_button.title" = "Decline";
-"voice.hang_up_button.title" = "Hang Up";
-"voice.mute_button.title" = "Mute";
-"voice.video_button.title" = "Video";
-"voice.speaker_button.title" = "Speaker";
+"voice.accept_button.title" = "受け入れる";
+"voice.decline_button.title" = "辞退";
+"voice.hang_up_button.title" = "通話を切断";
+"voice.mute_button.title" = "ミュート";
+"voice.video_button.title" = "ビデオ";
+"voice.speaker_button.title" = "スピーカー";
 
-"voice.alert.microphone_warning.title" = "Wire needs access to the Microphone.";
-"voice.alert.microphone_warning.explanation" = "Enable it in Wire Settings.";
+"voice.alert.microphone_warning.title" = "Wireはマイクにアクセスする必要が有ります";
+"voice.alert.microphone_warning.explanation" = "Wireの設定で有効にして下さい";
 
-"voice.alert.camera_warning.title" = "Wire needs access to the Camera.";
-"voice.alert.camera_warning.explanation" = "Go to Settings and allow Wire to access the camera.";
+"voice.alert.camera_warning.title" = "Wireはカメラへのアクセスする必要が有ります";
+"voice.alert.camera_warning.explanation" = "設定に移動して、Wireがカメラにアクセスすることを有効にして下さい";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Profile and Participants
 
-"participants.add_people_button_title" = "Add people";
+"participants.add_people_button_title" = "人を追加します";
 
 // Meta Menu
-"meta.menu.rename" = "Rename";
-"meta.menu.leave" = "Leave";
-"meta.menu.archive" = "Archive";
-"meta.menu.unarchive" = "Unarchive";
-"meta.menu.delete" = "Delete";
-"meta.menu.silence.mute" = "Mute";
-"meta.menu.silence.unmute" = "Unmute";
-"meta.menu.cancel" = "Cancel";
-"meta.menu.cancel_connection_request" = "Cancel Request";
+"meta.menu.rename" = "名前の変更";
+"meta.menu.leave" = "退室";
+"meta.menu.archive" = "アーカイブ";
+"meta.menu.unarchive" = "解答する";
+"meta.menu.delete" = "削除";
+"meta.menu.silence.mute" = "ミュート";
+"meta.menu.silence.unmute" = "ミュート解除します。";
+"meta.menu.cancel" = "キャンセル";
+"meta.menu.cancel_connection_request" = "リクエストを取り消す";
 
 // Delete conversation
-"meta.menu.delete_content.dialog_title" = "Delete content?";
-"meta.menu.delete_content.dialog_message" = "This will clear the conversation history and remove it from the list.";
-"meta.menu.delete_content.leave_as_well_message" = "Also leave the conversation";
-"meta.menu.delete_content.button_cancel" = "Cancel";
-"meta.menu.delete_content.button_delete" = "Delete";
+"meta.menu.delete_content.dialog_title" = "コンテンツを削除しますか?";
+"meta.menu.delete_content.dialog_message" = "これにより会話の履歴がクリアされ、リストから削除します。";
+"meta.menu.delete_content.leave_as_well_message" = "会話からも退室する";
+"meta.menu.delete_content.button_cancel" = "キャンセル";
+"meta.menu.delete_content.button_delete" = "削除";
 
 // Leave conversation
-"meta.leave_conversation_dialog_title" = "Leave conversation?";
-"meta.leave_conversation_dialog_message" = "The participants will be notified and the conversation will be removed from your list.";
-"meta.leave_conversation.delete_content_as_well_message" = "Also delete the content";
-"meta.leave_conversation_button_cancel" = "Cancel";
-"meta.leave_conversation_button_leave" = "Leave";
+"meta.leave_conversation_dialog_title" = "会話から退室しますか？";
+"meta.leave_conversation_dialog_message" = "参加者に通知され、あなたのリストから会話が削除されます。";
+"meta.leave_conversation.delete_content_as_well_message" = "コンテンツも削除されます";
+"meta.leave_conversation_button_cancel" = "キャンセル";
+"meta.leave_conversation_button_leave" = "離れる";
 
 // Conversation Degraded (security level lowered)
-"meta.degraded.degradation_reason_message.singular" = "%@ started using a new device.";
-"meta.degraded.degradation_reason_message.plural" = "%@ started using new devices.";
-"meta.degraded.dialog_message" = "Do you still want to send your message?";
-"meta.degraded.show_device_button" = "Show device";
-"meta.degraded.send_anyway_button" = "Send anyway";
+"meta.degraded.degradation_reason_message.singular" = "%@が新しいデバイスを使い始めました。";
+"meta.degraded.degradation_reason_message.plural" = "%@が新しいデバイスを使い始めました。";
+"meta.degraded.dialog_message" = "まだメッセージを送信しますか？";
+"meta.degraded.show_device_button" = "デバイスを表示する。";
+"meta.degraded.send_anyway_button" = "このまま送信";
 
 // Remove from conversation dialogue
-"profile.remove_dialog_title" = "Remove?";
-"profile.remove_dialog_message" = "%@ won’t be able to send or receive messages in this conversation.";
-"profile.remove_dialog_button_cancel" = "Cancel";
-"profile.remove_dialog_button_remove" = "Remove";
+"profile.remove_dialog_title" = "削除しますか?";
+"profile.remove_dialog_message" = "%@ は、この会話でメッセージを送受信することができません。";
+"profile.remove_dialog_button_cancel" = "キャンセル";
+"profile.remove_dialog_button_remove" = "削除";
 
 // Block dialog
-"profile.block_dialog.title" = "Block?";
-"profile.block_dialog.message" = "%@ won’t be able to find or contact you on Wire.";
-"profile.block_dialog.button_cancel" = "Cancel";
-"profile.block_dialog.button_block" = "Block";
+"profile.block_dialog.title" = "ブロックしますか?";
+"profile.block_dialog.message" = "%@はWireであなたを見つけるか連絡することができません。";
+"profile.block_dialog.button_cancel" = "キャンセル";
+"profile.block_dialog.button_block" = "ブロック";
 
 // Delete message dialog
-"message.delete_dialog.message" = "This cannot be undone.";
-"message.delete_dialog.action.cancel" = "Cancel";
-"message.delete_dialog.action.hide" = "Delete for Me";
-"message.delete_dialog.action.delete" = "Delete for Everyone";
+"message.delete_dialog.message" = "この操作は元に戻すことができません。";
+"message.delete_dialog.action.cancel" = "キャンセル";
+"message.delete_dialog.action.hide" = "削除します";
+"message.delete_dialog.action.delete" = "削除します";
 
 // Edit message
-"message.menu.edit.title" = "Edit";
+"message.menu.edit.title" = "編集";
 
 // Accept connection request
-"profile.connection_request_dialog.title" = "Accept?";
-"profile.connection_request_dialog.message" = "This will connect you and open the conversation with %@.";
-"profile.connection_request_dialog.button_cancel" = "Ignore";
-"profile.connection_request_dialog.button_connect" = "Connect";
+"profile.connection_request_dialog.title" = "許可しますか？";
+"profile.connection_request_dialog.message" = "%@とのつながって、会話を始める。";
+"profile.connection_request_dialog.button_cancel" = "放置";
+"profile.connection_request_dialog.button_connect" = "接続";
 
 // Cancel connection request
-"profile.cancel_connection_request_dialog.title" = "Cancel Request?";
-"profile.cancel_connection_request_dialog.message" = "Remove connection request to %@.";
-"profile.cancel_connection_request_dialog.button_no" = "No";
-"profile.cancel_connection_request_dialog.button_yes" = "Yes";
+"profile.cancel_connection_request_dialog.title" = "リクエストを取り消しますか？";
+"profile.cancel_connection_request_dialog.message" = "%@への接続リクエストを削除します。";
+"profile.cancel_connection_request_dialog.button_no" = "いいえ";
+"profile.cancel_connection_request_dialog.button_yes" = "はい";
 
 // Unblock button
-"profile.unblock_button_title" = "Unblock";
+"profile.unblock_button_title" = "ブロック解除";
 
-"profile.cancel_connection_button_title" = "CANCEL REQUEST";
-"profile.connection_request_state.blocked" = "BLOCKED";
-"profile.create_conversation_button_title" = "Create group";
-"profile.open_conversation_button_title" = "Open conversation";
+"profile.cancel_connection_button_title" = "リクエストをキャンセルします";
+"profile.connection_request_state.blocked" = "ブロックしています";
+"profile.create_conversation_button_title" = "グループを作成します";
+"profile.open_conversation_button_title" = "会話を始めます";
 
 // User Details
-"profile.details.title" = "Details";
+"profile.details.title" = "詳細";
 
 // Device list
-"profile.devices.title" = "Devices";
-"profile.devices.fingerprint_message_unencrypted" = "%@ is using an old version of Wire. No devices are shown here.";
-"profile.devices.fingerprint_message" = "Wire gives every device a unique fingerprint. Compare them with %@ and verify your conversation. Why verify conversations?";
-"profile.devices.fingerprint_message.link" = "Why verify conversations?";
+"profile.devices.title" = "デバイス";
+"profile.devices.fingerprint_message_unencrypted" = "%@は古いバージョンのWireを使用しています。端末は表示されません。";
+"profile.devices.fingerprint_message" = "Wire はそれぞれのデバイスに固有のフィンガープリントを付与します。それを %@と比較して、会話を確認します。なぜ会話を確認するか。";
+"profile.devices.fingerprint_message.link" = "なぜ会話を確認するのですか? _";
 
 // Device detail
-"profile.devices.detail.verify_message" = "Verify that this matches the fingerprint shown on %@'s device.";
-"profile.devices.detail.verify_message.link" = "How do I do that?";
-"profile.devices.detail.show_my_device.title" = "Show my device fingerprint";
-"device.verified" = "Verified";
-"device.not_verified" = "Not Verified";
-"device.class.desktop" = "Desktop";
-"device.class.tablet" = "Tablet";
-"device.class.phone" = "Phone";
-"profile.devices.detail.reset_session.title" = "Reset Session";
+"profile.devices.detail.verify_message" = "%@のデバイスに表示されるフィンガー プリントと一致することを確認します。";
+"profile.devices.detail.verify_message.link" = "どうすればいいですか?";
+"profile.devices.detail.show_my_device.title" = "自分のデバイスのフィンガープリントを表示";
+"device.verified" = "検証する";
+"device.not_verified" = "未確認";
+"device.class.desktop" = "PC";
+"device.class.tablet" = "タブレット";
+"device.class.phone" = "携帯電話";
+"profile.devices.detail.reset_session.title" = "セッションをリセットする";
 
 // General strings
 "general.confirm" = "OK";
@@ -388,325 +388,325 @@
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Self profile
-
 // Options menu contents
-"self.settings" = "Settings";
-"self.help_center" = "Support";
-"self.help_center.support_website" = "Wire Support Website";
-"self.help_center.contact_support" = "Contact Support";
-"self.about" = "About";
-"self.sign_out" = "Log Out";
-"self.report_abuse" = "Report Misuse";
 
-"self.add_phone_number" = "Add phone number";
-"self.add_email_password" = "Add email address and password";
+"self.settings" = "設定";
+"self.help_center" = "サポート";
+"self.help_center.support_website" = "Wire サポート ウェブサイト";
+"self.help_center.contact_support" = "サポートへの問い合わせ";
+"self.about" = "...について";
+"self.sign_out" = "ログアウト";
+"self.report_abuse" = "悪用を報告する";
+
+"self.add_phone_number" = "電話番号を追加する";
+"self.add_email_password" = "メールアドレスとパスワードを追加";
 
 // About screen
-"about.tos.title"="Terms of Use";
-"about.privacy.title"="Privacy Policy";
-"about.license.title" = "License Information";
-"about.website.title"="Wire Website";
-"about.copyright.title"="© Wire Swiss GmbH";
+"about.tos.title" = "利用規約";
+"about.privacy.title" = "プライバシーポリシー";
+"about.license.title" = "ライセンス情報";
+"about.website.title" = "Wire のウェブサイト";
+"about.copyright.title" = "© Wire Swiss GmbH";
 
 // Self new devices
-"self.new_device_alert.title" = "You have connected %@ to your Wire account";
-"self.new_device_alert.title_prefix.tablet" = "a tablet";
-"self.new_device_alert.title_prefix.phone" = "a phone";
-"self.new_device_alert.title_prefix.devices" = "%d devices";
-"self.new_device_alert.message" = "%@\n\nIf you didn’t do this, remove the device and reset your password.";
-"self.new_device_alert.message_plural" = "%@\n\nIf you didn’t do this, remove those devices and reset your password.";
-"self.new_device_alert.manage_devices" = "Manage devices";
+"self.new_device_alert.title" = "%@とワイヤでつながりました。";
+"self.new_device_alert.title_prefix.tablet" = "タブレット";
+"self.new_device_alert.title_prefix.phone" = "電話";
+"self.new_device_alert.title_prefix.devices" = "%d のデバイス";
+"self.new_device_alert.message" = "%@\nもしあなたがこれをしてなかった場合、デバイスを削除しパスワードを削除してください。";
+"self.new_device_alert.message_plural" = "%@\nもしあなたがこれをしてなかった場合、これらのデバイスとあなたのパスワードを削除してください。";
+"self.new_device_alert.manage_devices" = "デバイスを管理";
 "self.new_device_alert.trust_devices" = "OK";
 
 // Settings - Account details
-"self.settings.account_section" = "Account";
+"self.settings.account_section" = "アカウント";
 
-"self.settings.account_details_group.title" = "Info";
+"self.settings.account_details_group.title" = "情報";
 
-"self.settings.account_section.name.title" = "Name";
-"self.settings.account_section.email.title" = "Email";
-"self.settings.account_section.phone.title" = "Phone";
+"self.settings.account_section.name.title" = "名前";
+"self.settings.account_section.email.title" = "メール";
+"self.settings.account_section.phone.title" = "携帯電話";
 
-"self.settings.account_details_group.footer" = "People can find you with these details.";
+"self.settings.account_details_group.footer" = "この情報で他の人があなたを見つけることができます。";
 
-"self.settings.account_details.remove_device.title" = "Remove Device";
-"self.settings.account_details.key_fingerprint.title" = "Key Fingerprint";
-"self.settings.account_details.remove_device.message" = "Your password is required to remove the device";
-"self.settings.account_details.remove_device.password" = "Password";
-"self.settings.account_details.remove_device.password.error" = "Wrong password";
+"self.settings.account_details.remove_device.title" = "デバイスを削除する";
+"self.settings.account_details.key_fingerprint.title" = "鍵のフィンガープリント";
+"self.settings.account_details.remove_device.message" = "デバイスを削除するにはパスワードが必要です。";
+"self.settings.account_details.remove_device.password" = "パスワード";
+"self.settings.account_details.remove_device.password.error" = "パスワードが間違っています";
 
-"self.settings.account_appearance_group.title" = "Appearance";
-"self.settings.account_picture_group.picture" = "Picture";
-"self.settings.account_picture_group.color" = "Color";
+"self.settings.account_appearance_group.title" = "外観";
+"self.settings.account_picture_group.picture" = "写真";
+"self.settings.account_picture_group.color" = "色";
 
-"self.settings.account_picture_group.theme" = "Dark Theme";
+"self.settings.account_picture_group.theme" = "ダークテーマ";
 
-"self.settings.device_details.fingerprint.subtitle" = "Wire gives every device a unique fingerprint. Compare them and verify your devices and conversations.";
-"self.settings.device_details.reset_session.subtitle" = "If fingerprints don’t match, reset the session to generate new encryption keys on both sides.";
-"self.settings.device_details.remove_device.subtitle" = "Remove this device if you have stopped using it. Your message history will be erased and you will be logged out.";
-"self.settings.device_details.reset_session.success" = "The session has been reset";
+"self.settings.device_details.fingerprint.subtitle" = "Wireは各デバイスに固有のフィンガープリントを付与します。これを比較することでお使いのデバイスと会話を確認します。";
+"self.settings.device_details.reset_session.subtitle" = "フィンガープリントが一致しない場合は、セッションをリセットして、会話相手と双方で新しい暗号化キーを生成します。";
+"self.settings.device_details.remove_device.subtitle" = "使用を停止している場合、このデバイスを削除します。メッセージ履歴は消去され、ログアウトされます。";
+"self.settings.device_details.reset_session.success" = "このセッションはリセットされました";
 
-"self.settings.account_details.actions.title" = "Actions";
+"self.settings.account_details.actions.title" = "アクション";
 
-"self.settings.account_details.delete_account.title" = "Delete Account";
+"self.settings.account_details.delete_account.title" = "アカウントを削除";
 
-"self.settings.account_details.delete_account.alert.title" = "Delete Account";
-"self.settings.account_details.delete_account.alert.message" = "We will send you a message via email or SMS. Follow the link to permanently delete your account.";
+"self.settings.account_details.delete_account.alert.title" = "アカウントを削除";
+"self.settings.account_details.delete_account.alert.message" = "EメールまたはSMSをあなたに送信します。リンクに従ってあなたのアカウントを削除してください";
 
 
 // Chat alerts
-"self.settings.notifications.push_notification.title" = "Notifications";
-"self.settings.notifications.push_notification.toogle" = "Message Previews";
-"self.settings.notifications.push_notification.footer" = "Sender name and message on the lock screen and in Notification Center.";
+"self.settings.notifications.push_notification.title" = "通知センター";
+"self.settings.notifications.push_notification.toogle" = "メッセージプレビュー";
+"self.settings.notifications.push_notification.footer" = "ロックスクリーンと通知センターでの送信者名およびメッセージ";
 
-"self.settings.notifications.chat_alerts.toggle" = "Message Banners";
-"self.settings.notifications.chat_alerts.footer" = "New messages in other conversations.";
+"self.settings.notifications.chat_alerts.toggle" = "メッセージ バナー";
+"self.settings.notifications.chat_alerts.footer" = "他の会話での新しいメッセージ";
 
-"self.settings.sound_menu.sounds.title" = "Sounds";
-"self.settings.sound_menu.ringtone.title" = "Ringtone";
-"self.settings.sound_menu.message.title" = "Text Tone";
+"self.settings.sound_menu.sounds.title" = "サウンド";
+"self.settings.sound_menu.ringtone.title" = "着信音";
+"self.settings.sound_menu.message.title" = "テキスト トーン";
 "self.settings.sound_menu.ping.title" = "Ping";
-"self.settings.sound_menu.ringtones.title" = "Ringtones";
+"self.settings.sound_menu.ringtones.title" = "着信音";
 "self.settings.sound_menu.sounds.wire_sound" = "Wire";
 
-"self.settings.sound_menu.sounds.wire_call" = "Wire Call";
-"self.settings.sound_menu.sounds.wire_message" = "Wire Message";
+"self.settings.sound_menu.sounds.wire_call" = "Wireコール";
+"self.settings.sound_menu.sounds.wire_message" = "Wireメッセージ";
 "self.settings.sound_menu.sounds.wire_ping" = "Wire Ping";
 
 // By popular demand
-"self.settings.popular_demand.title" = "By popular demand";
-"self.settings.popular_demand.send_button.title" = "Send Button";
-"self.settings.popular_demand.send_button.footer" = "Disable to send via the return key.";
+"self.settings.popular_demand.title" = "人気の高い順";
+"self.settings.popular_demand.send_button.title" = "送信ボタン";
+"self.settings.popular_demand.send_button.footer" = "キーボードからの送信を無効にします。";
 
 // Sound alerts (TO BE UPDPATED)
-"self.settings.sound_menu.title" = "Sound Alerts";
-"self.settings.sound_menu.no_sounds.title" = "None";
-"self.settings.sound_menu.all_sounds.title" = "All";
-"self.settings.sound_menu.mute_while_talking.title" = "First message, pings, calls";
+"self.settings.sound_menu.title" = "アラートのサウンド";
+"self.settings.sound_menu.no_sounds.title" = "なし";
+"self.settings.sound_menu.all_sounds.title" = "すべて";
+"self.settings.sound_menu.mute_while_talking.title" = "最初のメッセージ、ping、通話";
 
 // Developer options
-"self.settings.developer_options.title" = "Developer Options";
-"self.settings.apns_logging.title" = "APNS Logging";
+"self.settings.developer_options.title" = "開発者向けオプション";
+"self.settings.apns_logging.title" = "APNS ログ";
 
 // Privacy (visibility) options
-"self.settings.options_menu.title" = "Options";
+"self.settings.options_menu.title" = "オプション";
 
-"self.settings.privacy_contacts_section.title" = "Contacts";
-"self.settings.privacy_contacts_menu.settings_button.title" = "Open Contacts Settings";
-"self.settings.privacy_contacts_menu.description_disabled.title" = "This helps you connect with others. We anonymize all the information and do not share it with anyone else. Allow access via Settings > Privacy > Contacts.";
+"self.settings.privacy_contacts_section.title" = "連絡先";
+"self.settings.privacy_contacts_menu.settings_button.title" = "連絡先の設定を開く";
+"self.settings.privacy_contacts_menu.description_disabled.title" = "これはあなたが友人とつながるを容易にします。私たちはすべての情報を匿名化し、他の第三者と共有することはしません。アクセスを許可するためには、設定>プライバシー>連絡先で設定します。";
 
-"self.settings.privacy_analytics_menu.devices.title" = "Devices";
+"self.settings.privacy_analytics_menu.devices.title" = "デバイス";
 
-"self.settings.privacy_analytics_section.title" = "Usage and Crash Reports";
-"self.settings.privacy_analytics_menu.description.title" = "Make Wire better by sending anonymous information.\n";
+"self.settings.privacy_analytics_section.title" = "使用状況データと障害報告";
+"self.settings.privacy_analytics_menu.description.title" = "匿名の情報を送信することによって Wire の改良に協力します。\n";
 
-"self.settings.privacy.clear_history.title" = "Clear History";
-"self.settings.privacy.clear_history.subtitle" = "This will permanently erase the content of all your conversations.";
+"self.settings.privacy.clear_history.title" = "履歴をクリア";
+"self.settings.privacy.clear_history.subtitle" = "すべてのあなたの会話の内容が完全に消去されます。";
 
-"self.settings.advanced.title" = "Advanced";
-"self.settings.advanced.troubleshooting.title" = "Troubleshooting";
-"self.settings.advanced.troubleshooting.submit_debug.title" = "Calling Debug Report";
-"self.settings.advanced.troubleshooting.submit_debug.subtitle" = "This information helps Wire Support diagnose calling problems.";
-"self.settings.advanced.reset_push_token.title" = "Reset Push Notifications Token";
-"self.settings.advanced.reset_push_token.subtitle" = "If you experience problems with push notifications, Wire Support may ask you to reset this token.";
-"self.settings.advanced.reset_push_token_alert.title" = "Push token has been reset";
-"self.settings.advanced.reset_push_token_alert.message" = "Notifications will be restored in a few seconds.";
-"self.settings.advanced.version_technical_details.title" = "Version Technical Details";
+"self.settings.advanced.title" = "高度";
+"self.settings.advanced.troubleshooting.title" = "トラブルシューティング";
+"self.settings.advanced.troubleshooting.submit_debug.title" = "デバッグ報告を送信";
+"self.settings.advanced.troubleshooting.submit_debug.subtitle" = "この情報は通話の問題をWire が診断するのに役立ます";
+"self.settings.advanced.reset_push_token.title" = "プッシュ通知のトークンをリセットする";
+"self.settings.advanced.reset_push_token.subtitle" = "プッシュ通知に関して問題があった場合、Wireサポートチームはあなたにトークンのリセットを求めることがあります。";
+"self.settings.advanced.reset_push_token_alert.title" = "プッシュトークンがリセットされました。";
+"self.settings.advanced.reset_push_token_alert.message" = "通知は数秒で復元されます。";
+"self.settings.advanced.version_technical_details.title" = "バージョンの技術的詳細";
 
 // Technical Report
-"self.settings.technical_report_section.title" = "Technical Report";
-"self.settings.technical_report.send_report" = "Send report to Wire";
+"self.settings.technical_report_section.title" = "テクニカルリポート";
+"self.settings.technical_report.send_report" = "Wireにレポートを送信する";
 "self.settings.technical_report.mail.recipient" = "callingsupport@wire.com";
-"self.settings.technical_report.mail.subject" = "Wire Calling Report";
-"self.settings.technical_report.include_log" = "Include detailed log";
+"self.settings.technical_report.mail.subject" = "Wire通話のレポート";
+"self.settings.technical_report.include_log" = "詳細なログを含める";
 
 // Password reset
-"self.settings.password_reset_menu.title" = "Reset Password";
+"self.settings.password_reset_menu.title" = "パスワードをリセット";
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // System status
-"system_status_bar.no_internet.title" = "No Internet";
-"system_status_bar.no_internet.explanation" = "There seems to be a problem with your Internet connection. Please make sure it’s working.";
-"system_status_bar.poor_connectivity.title" = "Slow Internet, can’t call now";
-"system_status_bar.poor_connectivity.explanation" = "We can’t guarantee voice quality. Connect to Wi-Fi or try changing your location.";
+"system_status_bar.no_internet.title" = "インターネットがありません";
+"system_status_bar.no_internet.explanation" = "インターネット接続に問題があるようです。インターネット接続を確認してください。";
+"system_status_bar.poor_connectivity.title" = "インターネット接続が遅いため、いまは通話はできません。";
+"system_status_bar.poor_connectivity.explanation" = "音声品質を保証できません。Wi-Fiに接続するか、場所を変えて接続してください。";
 
 // Common connections on profile view
-"profile_other.common_connections" = "You both know";
+"profile_other.common_connections" = "あなたが両方知っている";
 
 // View user profile and options menu
-"name.placeholder" = "Your full name";
-"name.guidance.tooshort" = "At least 2 characters";
-"name.guidance.toolong" = "Too many characters";
+"name.placeholder" = "あなたの氏名";
+"name.guidance.tooshort" = "少なくとも2文字";
+"name.guidance.toolong" = "文字が多すぎます";
 
-"email.placeholder" = "Email";
+"email.placeholder" = "メール";
 
-"password.placeholder" = "Password";
-"password.guidance.tooshort" = "At least 8 characters";
-"password.guidance.toolong" = "Too many characters";
+"password.placeholder" = "パスワード";
+"password.guidance.tooshort" = "8 文字以上";
+"password.guidance.toolong" = "文字が多すぎます";
 
-"registration.title" = "Registration";
-"registration.close_email_invitation_button.email_title" = "Use another email";
-"registration.close_email_invitation_button.phone_title" = "Register by phone";
-"registration.close_phone_invitation_button.email_title" = "Register by email";
-"registration.close_phone_invitation_button.phone_title" = "Use another phone";
+"registration.title" = "登録";
+"registration.close_email_invitation_button.email_title" = "別のメール アドレスを使う";
+"registration.close_email_invitation_button.phone_title" = "電話番号で登録する";
+"registration.close_phone_invitation_button.email_title" = "メールで登録する";
+"registration.close_phone_invitation_button.phone_title" = "別の携帯電話を使用する";
 
-"registration.enter_phone_number.title" = "Edit phone number";
-"registration.enter_phone_number.placeholder" = "Phone number";
+"registration.enter_phone_number.title" = "電話番号を編集する";
+"registration.enter_phone_number.placeholder" = "電話番号";
 
-"registration.verify_phone_number.instructions" = "Enter the verification code we sent to %@";
-"registration.verify_phone_number.resend" = "Resend";
-"registration.verify_phone_number.resend_placeholder" = "No code showing up?\nYou can request a new one in %.0f seconds";
+"registration.verify_phone_number.instructions" = "%@に送信された認証コードを入力してください。";
+"registration.verify_phone_number.resend" = "再送する";
+"registration.verify_phone_number.resend_placeholder" = "コードが表示されませんか？\n新しいコードを%.0f秒以内にリクエストすることができます。";
 
-"registration.verify_email.instructions" = "We sent an email to %@.\n Follow the link to verify your address.";
-"registration.verify_email.resend.instructions" = "Didn't get the message?";
-"registration.verify_email.resend.button_title" = "Re-send";
+"registration.verify_email.instructions" = "%@にメールを送信しました。\n リンクに従ってあなたのメールアドレスを確認してください。";
+"registration.verify_email.resend.instructions" = "メッセージを取得できませんでしたか?";
+"registration.verify_email.resend.button_title" = "再送信";
 
-"registration.select_picture.subtitle" = "Wire is so much nicer with a picture.";
-"registration.select_picture.button_title" = "Choose your own";
-"registration.keep_picture.button_title" = "Keep this one";
-"registration.camera_action.title" = "Take photo";
-"registration.photo_gallery_action.title" = "Choose Photo";
-"registration.cancel_action.title" = "Cancel";
+"registration.select_picture.subtitle" = "Wire は写真があると素敵です。";
+"registration.select_picture.button_title" = "自分で選ぶ";
+"registration.keep_picture.button_title" = "これにする";
+"registration.camera_action.title" = "写真を撮影する";
+"registration.photo_gallery_action.title" = "写真を選択してください。";
+"registration.cancel_action.title" = "キャンセル";
 
-"registration.no_history.hero" = "It’s the first time you’re using Wire on this device.";
-"registration.no_history.subtitle" = "For privacy reasons, your conversation history will not appear here.";
+"registration.no_history.hero" = "このデバイスで Wire を使用するのは初めてです。";
+"registration.no_history.subtitle" = "プライバシー上の理由から、会話の履歴はここに表示されません。";
 "registration.no_history.got_it" = "OK";
 
-"registration.no_history.logged_out.hero" = "You've used Wire on this device before.";
-"registration.no_history.logged_out.subtitle" = "Messages sent in the meantime will not appear.";
+"registration.no_history.logged_out.hero" = "前にこのデバイスのワイヤーを使用しました。";
+"registration.no_history.logged_out.subtitle" = "同時に送信されたメッセージは表示されません。";
 "registration.no_history.logged_out.got_it" = "OK";
 
-"registration.enter_name.title" = "Edit Name";
-"registration.enter_name.hero" = "What should we call you?";
-"registration.enter_name.placeholder" = "Your full name";
+"registration.enter_name.title" = "名前を編集";
+"registration.enter_name.hero" = "あなたを何と呼べばいいですか?";
+"registration.enter_name.placeholder" = "あなたの氏名";
 
-"registration.terms_of_use.title" = "Welcome to Wire.";
-"registration.terms_of_use.terms" = "By continuing you agree to the Wire Terms of Use.";
-"registration.terms_of_use.terms.link" = "Terms of Use";
-"registration.terms_of_use.agree" = "I agree";
+"registration.terms_of_use.title" = "Wireにようこそ！";
+"registration.terms_of_use.terms" = "継続することによってあなたはWireの利用規約に同意したことになります。";
+"registration.terms_of_use.terms.link" = "利用規約";
+"registration.terms_of_use.agree" = "同意する";
 
-"registration.email_flow.title" = "Register by Email";
-"registration.email_flow.email_step.title" = "Edit Details";
+"registration.email_flow.title" = "メールで登録する。";
+"registration.email_flow.email_step.title" = "詳細を編集する";
 
-"registration.country_select.title" = "Country";
+"registration.country_select.title" = "国";
 
-"registration.share_contacts.hero.title" = "Find people on Wire";
-"registration.share_contacts.hero.paragraph"  = "Share your contacts so we can connect you with others. We anonymize all information and do not share it with anyone else.";
-"registration.share_contacts.find_friends_button.title" = "Share contacts";
-"registration.share_contacts.skip_button.title" = "Not now";
+"registration.share_contacts.hero.title" = "Wireで友人を見つける";
+"registration.share_contacts.hero.paragraph" = "他のユーザーとつながるために、Wireがあなたの連絡先にアクセスすることを許可してください。私たちはすべての情報を匿名化し、他の誰ともあなたの連絡先に関する情報をシェアしません。";
+"registration.share_contacts.find_friends_button.title" = "連絡先を共有します";
+"registration.share_contacts.skip_button.title" = "いまは行わない";
 
-"registration.address_book_access_denied.hero.title" = "Wire does not have access to your contacts.";
-"registration.address_book_access_denied.hero.paragraph1" = "Wire helps find your friends if you share your contacts.";
-"registration.address_book_access_denied.hero.paragraph2" = "To enable access tap Settings and turn on Contacts.";
-"registration.address_book_access_denied.settings_button.title" = "Settings";
-"registration.address_book_access_denied.maybe_later_button.title" = "Maybe later";
+"registration.address_book_access_denied.hero.title" = "Wireはあなたの連絡先へのアクセスしていません。";
+"registration.address_book_access_denied.hero.paragraph1" = "連絡先をシェアした場合、Wireで友人を探すことが容易になります。";
+"registration.address_book_access_denied.hero.paragraph2" = "設定から連絡先を有効にすることで連絡先にアクセスできるようになります。";
+"registration.address_book_access_denied.settings_button.title" = "設定";
+"registration.address_book_access_denied.maybe_later_button.title" = "後で";
 
-"registration.push_access_denied.hero.title" = "Never miss a call or a message.";
-"registration.push_access_denied.hero.paragraph1" = "Enable Notifications in Settings.";
-"registration.push_access_denied.settings_button.title" = "Go to Settings";
-"registration.push_access_denied.maybe_later_button.title" = "Maybe later";
+"registration.push_access_denied.hero.title" = "電話やメッセージを見逃さない";
+"registration.push_access_denied.hero.paragraph1" = "設定で通知を有効にする";
+"registration.push_access_denied.settings_button.title" = "設定に移動する";
+"registration.push_access_denied.maybe_later_button.title" = "後で";
 
-"registration.signin.title" = "Log In";
+"registration.signin.title" = "ログイン";
 "registration.signin.too_many_devices.title" = "";
-"registration.signin.too_many_devices.subtitle" = "Remove one of your other devices to start using Wire on this one.";
-"registration.signin.too_many_devices.manage_button.title" = "Manage devices";
-"registration.signin.too_many_devices.sign_out_button.title" = "Log out";
-"registration.signin.email_button.title" = "Email";
-"registration.signin.phone_button.title" = "Phone";
+"registration.signin.too_many_devices.subtitle" = "このデバイスで Wire を使用するため、他のデバイスを 1 つ削除してください。";
+"registration.signin.too_many_devices.manage_button.title" = "デバイスを管理";
+"registration.signin.too_many_devices.sign_out_button.title" = "ログアウト";
+"registration.signin.email_button.title" = "メール";
+"registration.signin.phone_button.title" = "携帯電話";
 
-"registration.devices.title" = "Devices";
-"registration.devices.active_list_header" = "Active";
-"registration.devices.current_list_header" = "Current";
-"registration.devices.active_list_subtitle" = "If you don’t recognize a device above, remove it and reset your password.";
-"registration.devices.activated_in" = "Activated in";
+"registration.devices.title" = "端末";
+"registration.devices.active_list_header" = "アクティブ";
+"registration.devices.current_list_header" = "最新";
+"registration.devices.active_list_subtitle" = "もし上のデバイスを了承してしない場合は、それを削除して、パスワードをリセットしてください。";
+"registration.devices.activated_in" = "アクティベートする";
 "registration.devices.id" = "ID:";
 
-"signin.forgot_password" = "Forgot password?";
+"signin.forgot_password" = "パスワードをお忘れですか？";
 
-"registration.add_phone_number.hero.title" = "Add phone number";
-"registration.add_phone_number.hero.paragraph" = "This helps us find people you may know. We never share it.";
-"registration.add_phone_number.skip_button.title" = "Not now";
+"registration.add_phone_number.hero.title" = "電話番号を追加する";
+"registration.add_phone_number.hero.paragraph" = "これはあなたが友人を探すことを容易にします。私たちは決して第三者とシェアいません。";
+"registration.add_phone_number.skip_button.title" = "いまは行わない";
 
-"registration.add_email_password.hero.title" = "Add your email and password.";
-"registration.add_email_password.hero.paragraph" = "This lets you use Wire on multiple devices.";
+"registration.add_email_password.hero.title" = "メールアドレスとパスワードを追加してください。";
+"registration.add_email_password.hero.paragraph" = "これにより、複数のデバイスで Wire を使用できます。";
 
-"registration.email_invitation.title" = "Invitation";
-"registration.email_invitation.hero.title" = "Hello, %@";
-"registration.email_invitation.hero.paragraph" = "Choose a password to create your account.";
+"registration.email_invitation.title" = "招待状";
+"registration.email_invitation.hero.title" = "こんにちは、%@";
+"registration.email_invitation.hero.paragraph" = "アカウントを作成するためのパスワードを選択してください。";
 
-"registration.phone_invitation.title" = "Invitation";
-"registration.phone_invitation.hero.title" = "Hello, %@";
-"registration.phone_invitation.hero.paragraph" = "You are one step away from creating your account.";
+"registration.phone_invitation.title" = "招待状";
+"registration.phone_invitation.hero.title" = "こんにちは、%@";
+"registration.phone_invitation.hero.paragraph" = "アカウントの作成までもうひと息です。";
 
-"error.name_and_email" = "Please enter your full name and a valid email address";
-"error.full_name" = "Please enter your full name";
-"error.email" = "Please enter a valid email address";
-"error.input.too_long" = "Input too long";
-"error.input.too_short" = "Input too short";
-"error.email.invalid" = "Please enter a valid email address";
-"error.phone.invalid" = "Please enter a valid phone number";
+"error.name_and_email" = "名前と有効なメールアドレスを入力してください。";
+"error.full_name" = "氏名を入力してください";
+"error.email" = "有効なメール アドレスを入力してください";
+"error.input.too_long" = "入力が長すぎます";
+"error.input.too_short" = "入力が短すぎます";
+"error.email.invalid" = "有効なメール アドレスを入力してください";
+"error.phone.invalid" = "有効な電話番号を入力してください";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // ZMUserSessionErrorCode mapping. Used during registration and profile edit
-"error.user.unkown_error" = "Something went wrong, please try again";
-"error.user.needs_credentials" = "Please verify your details and try again.";
-"error.user.invalid_credentials" = "Please verify your details and try again.";
-"error.user.account_pending_activation" = "The account you are trying access is pending activation. Please verify your details.";
-"error.user.network_error" = "There seems to be a problem with your network. Please try again later.";
-"error.user.email_is_taken" = "The email address you provided has already been registered. Please try again.";
-"error.user.phone_is_taken" = "The phone number you provided has already been registered. Please try again.";
-"error.user.phone_code_invalid" = "Please enter a valid code";
-"error.user.phone_code_too_many" = "We already sent you a code via SMS. Tap Resend after 10 minutes to get a new one.";
-"error.user.registration_unknown_error" = "Something went wrong. Please try again.";
-"error.user.device_deleted_remotely" = "You have been logged out from another device.";
+"error.user.unkown_error" = "問題が生じたようです。もう一度やり直してください。";
+"error.user.needs_credentials" = "詳細を確認して、もう一度やり直してください。";
+"error.user.invalid_credentials" = "詳細を確認して、もう一度やり直してください。";
+"error.user.account_pending_activation" = "アクセスをしようとしているアカウントは、ライセンス認証の保留中です。詳細をご確認ください。";
+"error.user.network_error" = "ネットワークに問題があるようです。後でもう一度お試しください。";
+"error.user.email_is_taken" = "入力したメール アドレスはすでに登録されています。もう一度、やり直して頂けますようお願いします。";
+"error.user.phone_is_taken" = "指定した電話番号はすでに登録されています。もう一度やり直してください。";
+"error.user.phone_code_invalid" = "有効なコードを入力してください。";
+"error.user.phone_code_too_many" = "すでに SMS 経由でコードを送信しました。新しいものを取得するには 10 分後に、再送信をタップします。";
+"error.user.registration_unknown_error" = "何か問題が起きたようです。もう一度やり直してください。";
+"error.user.device_deleted_remotely" = "別のデバイスからログアウトしました。";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Those are caught by the UI without involving the SE validation. Basically very similar to ZMUserSessionErrorCode onces
-"error.updating_password" = "Couldn't update your password.";
+"error.updating_password" = "パスワードの更新ができませんでした。";
 
-"error.group_call.too_many_members_in_conversation.title" = "Too many people to call";
-"error.group_call.too_many_members_in_conversation" = "Calls work in conversations with up to %d people.";
-"error.group_call.too_many_participants_in_the_call.title" = "The call is full";
-"error.group_call.too_many_participants_in_the_call" = "There’s only room for %d people in here.";
-"error.call.gsm_ongoing.title" = "Cellular call";
-"error.call.gsm_ongoing" = "Please cancel the cellular call before calling on Wire.";
-"error.call.general.title" = "Call error";
-"error.call.general" = "Please try calling again in several minutes.";
-"error.call.slow_connection.title" = "Slow connection";
-"error.call.slow_connection" = "You might experience issues during the call";
-"error.call.slow_connection.call_anyway" = "Call anyway";
+"error.group_call.too_many_members_in_conversation.title" = "呼び出す人が多すぎます";
+"error.group_call.too_many_members_in_conversation" = "電話は最大%d人までとの間ですることができます。";
+"error.group_call.too_many_participants_in_the_call.title" = "通話チャンネルがいっぱいです";
+"error.group_call.too_many_participants_in_the_call" = "この部屋にはあと%d人まで入ることができます。";
+"error.call.gsm_ongoing.title" = "携帯電話通話";
+"error.call.gsm_ongoing" = "Wireでの通話の前に、携帯電話の通話を終わらせてください。";
+"error.call.general.title" = "呼び出しエラー";
+"error.call.general" = "数分後に再度電話をしてみてください。";
+"error.call.slow_connection.title" = "インターネット接続が遅いです";
+"error.call.slow_connection" = "通話中に問題が発生する可能性があります";
+"error.call.slow_connection.call_anyway" = "とにかく電話をする";
 
-"error.invite.no_email_provider" = "Please configure your email client to be able to send the invites via email";
-"error.invite.no_messaging_provider" = "Please configure your SMS to be able to send the invites via SMS";
+"error.invite.no_email_provider" = "メールで招待状を送るために、メールクライアントの設定をしてください。";
+"error.invite.no_messaging_provider" = "SMSで招待状を送るために、SMSの設定をしてください。";
 
-"sketchpad.initial_hint" = "Tap color to change brush size\nPress and hold to fill an area\nShake to remove a photo";
+"sketchpad.initial_hint" = "ブラシのサイズを変更するためにカラーをタップする\n隙間を埋めるために長押しをする\n写真を削除するために振動させる";
 
-"migration.please_wait_message" = "One moment, please";
+"migration.please_wait_message" = "どうぞしばらくお待ちください";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Those are used by the backend to localize APNS
-"push.notification.new_user" = "%@ joined Wire";
-"push.notification.new_message" = "New message";
+"push.notification.new_user" = "%@がWireに参加しました";
+"push.notification.new_message" = "新着メッセージ";
 
 
-//Force Update
-"force.update.title" = "Update necessary";
-"force.update.message" = "You are missing out on new features.\nGet the latest version of Wire in the App Store.";
-"force.update.ok_button" = "Go to App Store";
+// Force Update
+"force.update.title" = "アップデートが必要です。";
+"force.update.message" = "新しい機能を利用できていないようです。\n最新バージョンのWireをApp Storeでダウンロードしてください。";
+"force.update.ok_button" = "App Storeに行く";
 
 // Third Party
-"giphy.conversation.message" = "%@ · via giphy.com";
-"giphy.conversation.random_message" = "via giphy.com";
-"giphy.error.no_more_results" = "no more gifs";
-"giphy.error.no_result" = "no gif found";
+"giphy.conversation.message" = "%@ giphy.comから";
+"giphy.conversation.random_message" = "giphy.comから";
+"giphy.error.no_more_results" = "これ以上gifがありません。";
+"giphy.error.no_result" = "gifが見つかりませんでした。";
 
-"giphy.confirm" = "send";
-"giphy.cancel" = "cancel";
-"giphy.search_placeholder" = "Search giphy";
+"giphy.confirm" = "送信する";
+"giphy.cancel" = "キャンセル";
+"giphy.search_placeholder" = "Giphy を検索";
 
-"invite_banner.title" = "Bring your friends to Wire!";
-"invite_banner.message" = "Enjoy calls, messages, sketches, GIFs and more in private or with groups.";
-"invite_banner.invite_button_title" = "Invite more people";
+"invite_banner.title" = "Wireに友達を連れてくる！";
+"invite_banner.message" = "二人またはグループで、電話、メッセージ、スケッチ、Gifのやり取りを楽しんでください！";
+"invite_banner.invite_button_title" = "多くの人を招待します";

--- a/Wire-iOS/Resources/ja.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/ja.lproj/Localizable.strings
@@ -1,0 +1,712 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+"general.ok" = "OK";
+"general.cancel" = "Cancel";
+"general.open_settings" = "Open Wire Settings";
+
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++
+// People picker/start UI
+"peoplepicker.search_placeholder" = "Search by name or email";
+"peoplepicker.header.top_people" = "Top people";
+"peoplepicker.button.create_conversation" = "Create group";
+"peoplepicker.button.add_to_conversation" = "Add";
+"peoplepicker.header.conversations" = "Groups";
+"peoplepicker.header.send_invitation" = "Invite";
+"peoplepicker.header.contacts" = "Connections";
+"peoplepicker.header.directory" = "Connect";
+"peoplepicker.title.create_conversation" = "Create group";
+"peoplepicker.title.add_to_conversation" = "Add people";
+
+"peoplepicker.no_contacts_title" = "No Contacts.";
+
+"peoplepicker.no_matching_results_title" = "No results.";
+"peoplepicker.no_matching_results_message" = "Enter a full email address.";
+
+"peoplepicker.no_matching_results.action.send_invite" = "Send an invitation";
+"peoplepicker.no_matching_results.action.share_contacts" = "Share contacts";
+
+"peoplepicker.no_matching_results_provide_valid_email" = "Please enter a valid email address";
+"peoplepicker.no_matching_results_after_address_book_upload_title" = "No results.";
+/* This sentence ends with button title, contained in peoplepicker.no_matching_results_after_address_book_upload_button */
+"peoplepicker.no_matching_results_after_address_book_upload_message" = "Enter a full email address or";
+/*  */
+"peoplepicker.no_matching_results_after_address_book_upload_button" = "share contacts";
+
+"peoplepicker.share_contacts.no_results.title" = "Find people by name or email address";
+
+"peoplepicker.send_invitation.dialog.title" = "Invitation sent";
+"peoplepicker.send_invitation.dialog.message" = "It can be used for 2 weeks. Send a new one if it expires.";
+"peoplepicker.send_invitation.dialog.ok" = "OK";
+
+"peoplepicker.invite_more_people" = "Invite more people";
+"peoplepicker.quick-action.open-conversation" = "Open";
+"peoplepicker.quick-action.create-conversation" = "Create group";
+
+// Contacts UI
+"contacts_ui.search_placeholder" = "Search by name";
+"contacts_ui.invite_others" = "Invite others";
+"contacts_ui.name_in_contacts" = "%@ in address book";
+"contacts_ui.connection_request" = "Requested to connect";
+"contacts_ui.action_button.invite" = "Invite";
+"contacts_ui.action_button.open" = "Open";
+"contacts_ui.invite_sheet.cancel_button_title" = "Cancel";
+"contacts_ui.notification.invitation_sent" = "Invitation sent";
+"contacts_ui.notification.invitation_failed" = "Failed to send invitation";
+"contacts_ui.title" = "Invite people";
+
+"contacts_ui.no_contact.title" = "No active conversations\n";
+"contacts_ui.no_contact.message" = "Tap contacts to start a conversation";
+
+// Conversation List Bottom Bar
+"bottom_bar.contacts_button.title" = "contacts";
+
+// Archived List
+"archived_list.title" = "archive";
+
+// Add contact tool tip
+"tool_tip.contacts.title" = "Conversations start here";
+"tool_tip.contacts.message" = "Start a conversation or invite more people to join. Call, message and share in private or with groups.";
+
+// "Knows" subtitle in cell: "Knows Indrek", "Knows Indrek and Jane", "Knows Indrek and 5 others"
+"peoplepicker.suggested.knows_one" = "Knows %@";
+"peoplepicker.suggested.knows_two" = "Knows %@ and %@";
+"peoplepicker.hide_search_result" = "Hide";
+"peoplepicker.hide_search_result_progress" = "Hiding…";
+
+"send_invitation.subject" = "Connect with me on Wire";
+"send_invitation.text" = "I’m on Wire. Search for %@\nor visit https://get.wire.com to connect with me.";
+"send_invitation_no_email.text" = "I’m on Wire. Visit https://get.wire.com to connect with me.";
+
+"send_personal_invitation.text" = "I’m on Wire, talk to you there. https://get.wire.com";
+
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++x
+// In-app notifications (chat heads)
+"notifications.shared_a_photo" = "shared a picture";
+"notifications.pinged" = "pinged";
+"notifications.sent_file" = "shared a file";
+"notifications.sent_location" = "shared a location";
+"notifications.sent_video" = "shared a video";
+"notifications.sent_audio" = "shared an audio";
+"notifications.in_conversation" = "%@ - %@";
+"notifications.this_conversation" = "%@ in this conversation";
+
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++
+// List (labels) - Needs to be revised with updated guidance
+"list.archived_conversations" = "ARCHIVE";
+"list.archived_conversations_close" = "Close archive";
+
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++
+// Conversation
+"conversation.invite_more_people.title" = "Spread the word!";
+"conversation.invite_more_people.description" = "Add people to this conversation";
+"conversation.invite_more_people.explanation_url" = "https://support.wire.com";
+"conversation.invite_more_people.button_title" = "Add People";
+
+// Conversation names
+"conversation.displayname.emptygroup" = "Empty group conversation";
+
+"conversation.input_bar.verified" = "Verified";
+"conversation.input_bar.placeholder" = "Type a message";
+
+"conversation.input_bar.audio_message.tooltip.pull_send" = "Swipe up to send";
+"conversation.input_bar.audio_message.tooltip.tap_send" = "Tap to send";
+"conversation.input_bar.audio_message.too_long.title" = "Recording Stopped";
+"conversation.input_bar.audio_message.too_long.message" = "Audio messages are limited to %@. Send this message?";
+"conversation.input_bar.audio_message.send" = "Send";
+
+"conversation.input_bar.audio_message.keyboard.record_tip" = "Tap to record\nYou can  %@  it after that";
+"conversation.input_bar.audio_message.keyboard.filter_tip" = "Choose a filter above";
+
+// Image confirmation dialogue
+"image_confirmer.confirm" = "OK";
+"image_confirmer.cancel" = "Cancel";
+"image.add_sketch" = "Add a sketch";
+"image.edit_image" = "Edit image";
+
+// Camera access
+"camera_access.denied" = "Wire needs access to the Camera.";
+"camera_access.denied.instruction" = "";
+"camera_access.denied.open_settings" = "Enable it in Wire Settings";
+
+// Camera Controls
+"camera_controls.aeaf_lock" = "AE/AF Lock";
+
+// Location
+"location.send_button.title" = "Send";
+"location.unauthorized_alert.title" = "Enable Location Services";
+"location.unauthorized_alert.message" = "To send your location, enable Location Services and allow Wire to access your location.";
+"location.unauthorized_alert.cancel" = "Cancel";
+"location.unauthorized_alert.settings" = "Settings";
+
+// Twitter
+"twitter_status.on_twitter" = "%@ on Twitter";
+
+// System messages
+"content.system.continued_conversation" = "Start a conversation with %@";
+
+"content.system.other_started_conversation" = "%@ started a conversation with %@";
+"content.system.you_started_conversation" = "You started a conversation with %@";
+
+"content.system.you_added_participant" = "You added %@";
+"content.system.other_added_participant" = "%@ added %@";
+"content.system.other_added_you" = "%@ added you";
+
+"content.system.participants_you" = "You";
+"content.system.participants_1_other" = "%@ and %@";
+"content.system.other_left" = "%@ left";
+"content.system.you_left" = "You left";
+"content.system.other_removed_other" = "%@ removed %@";
+"content.system.other_removed_you" = "%@ removed you";
+"content.system.you_removed_other" = "You removed %@";
+"content.system.other_renamed_conv" = "%@ renamed the conversation";
+"content.system.you_renamed_conv" = "You renamed the conversation";
+"content.system.other_renamed_conv_to_nothing" = "%@ removed the conversation name";
+"content.system.you_renamed_conv_to_nothing" = "You removed the conversation name";
+"content.system.pending_message_timestamp" = "Sending…";
+"content.system.message_sent_timestamp" = "Sent";
+"content.system.message_delivered_timestamp" = "Delivered";
+"content.system.failedtosend_message_timestamp" = "Sending failed.";
+"content.system.failedtosend_message_timestamp_resend" = "Resend";
+"content.system.like_tooltip" = "Tap to like";
+"content.system.deleted_message_prefix_timestamp" = "Deleted on %@";
+"content.system.edited_message_prefix_timestamp" = "Edited on %@";
+"content.system.connecting_to" = "Connecting to %@.\nStart a conversation";
+"content.system.connected_to" = "Connected to %@\nStart a conversation";
+"content.system.other_wanted_to_talk" = "%@ called";
+"content.system.you_wanted_to_talk" = "You called";
+
+"content.system.you_started" = "You";
+"content.system.this_device" = "this device";
+
+"content.system.reactivated_device" = "You started using %@ again. Messages sent in the meantime will not appear here";
+
+"content.system.new_device" = "a new device";
+"content.system.started_using" = "started using";
+"content.system.is_verified" = "All fingerprints are verified";
+
+"content.system.unverified" = "%@ unverified one of %@"; //example "You unverified one of Jule's devices"
+"content.system.your_devices" = "your devices";
+"content.system.other_devices" = "%@'s devices";
+
+"content.system.missing_messages.title" = "You haven't used this device for a while. Some messages may not appear here.";
+"content.system.missing_messages.subtitle_start" = "Meanwhile,";
+
+"content.system.cannot_decrypt" = "A message from %@ was not received.";
+
+"content.system.cannot_decrypt.you_part" = "you";
+"content.system.cannot_decrypt.why_part" = "Why?";
+
+"content.system.cannot_decrypt.identity" = "%@ device identity changed. Undelivered message.";
+"content.system.cannot_decrypt.identity.you_part" = "Your";
+"content.system.cannot_decrypt.identity.otherUser_part" = "%@'s"; // posessive apostrophe - might differ in different languages
+"content.system.cannot_decrypt.identity.why_part" = "Learn More";
+
+"content.file.uploading" = "Uploading…";
+"content.file.downloading" = "Downloading…";
+"content.file.upload_failed" = "Upload failed";
+"content.file.upload_cancelled" = "Upload cancelled";
+"content.file.upload_video" = "Videos";
+"content.file.take_video" = "Record a video";
+
+"content.file.save_video" = "Save";
+"content.file.save_audio" = "Save";
+"content.image.save_image" = "Save";
+
+"content.message.delete" = "Delete";
+
+"content.message.like" = "Like";
+"content.message.unlike" = "Unlike";
+
+"content.reactions_list.likers" = "Liked by";
+
+"content.file.too_big" = "You can send files up to %@";
+// Someone pinged
+"content.ping.text" = "%1$@ PINGED";
+
+// Current user pinged
+"content.ping.you.text" = "YOU PINGED";
+
+// Inline Player
+"content.player.unable_to_play" = "UNABLE TO PLAY TRACK";
+
+// Connecting (NEW IMPLEMENTATION, REVIEW LATER)
+"connection_request.title" = "Connect to %@"; //check UPPERCASE implementation in code
+"missive.connection_request.default_message" = "Hi %@,\nLet’s connect on Wire.\n%@";
+
+"connection_request.send_button_title" = "Connect";
+"inbox.connection_request.connect_button_title" = "Connect";
+"inbox.connection_request.ignore_button_title" = "Ignore";
+
+// Voice
+"voice.status.one_to_one.incoming" = "%@\nCalling";
+"voice.status.group_call.incoming" = "%@\nRinging";
+"voice.status.one_to_one.outgoing" = "%@\nRinging";
+"voice.status.joining" = "%@\nConnecting";
+"voice.status.video_not_available" = "Video turned off";
+"voice.status.low_connection" = "Bad connection";
+"voice.network_error.title" = "No Internet Connection";
+"voice.network_error.body" = "You must be online to call. Check your connection and try again.";
+"voice.alert.call_in_progress.title" = "Call in progress";
+"voice.alert.call_in_progress.message" = "Another of your devices is already participating in the call";
+"voice.alert.call_in_progress.confirm" = "Ok";
+"voice.accept_button.title" = "Accept";
+"voice.decline_button.title" = "Decline";
+"voice.hang_up_button.title" = "Hang Up";
+"voice.mute_button.title" = "Mute";
+"voice.video_button.title" = "Video";
+"voice.speaker_button.title" = "Speaker";
+
+"voice.alert.microphone_warning.title" = "Wire needs access to the Microphone.";
+"voice.alert.microphone_warning.explanation" = "Enable it in Wire Settings.";
+
+"voice.alert.camera_warning.title" = "Wire needs access to the Camera.";
+"voice.alert.camera_warning.explanation" = "Go to Settings and allow Wire to access the camera.";
+
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++
+// Profile and Participants
+
+"participants.add_people_button_title" = "Add people";
+
+// Meta Menu
+"meta.menu.rename" = "Rename";
+"meta.menu.leave" = "Leave";
+"meta.menu.archive" = "Archive";
+"meta.menu.unarchive" = "Unarchive";
+"meta.menu.delete" = "Delete";
+"meta.menu.silence.mute" = "Mute";
+"meta.menu.silence.unmute" = "Unmute";
+"meta.menu.cancel" = "Cancel";
+"meta.menu.cancel_connection_request" = "Cancel Request";
+
+// Delete conversation
+"meta.menu.delete_content.dialog_title" = "Delete content?";
+"meta.menu.delete_content.dialog_message" = "This will clear the conversation history and remove it from the list.";
+"meta.menu.delete_content.leave_as_well_message" = "Also leave the conversation";
+"meta.menu.delete_content.button_cancel" = "Cancel";
+"meta.menu.delete_content.button_delete" = "Delete";
+
+// Leave conversation
+"meta.leave_conversation_dialog_title" = "Leave conversation?";
+"meta.leave_conversation_dialog_message" = "The participants will be notified and the conversation will be removed from your list.";
+"meta.leave_conversation.delete_content_as_well_message" = "Also delete the content";
+"meta.leave_conversation_button_cancel" = "Cancel";
+"meta.leave_conversation_button_leave" = "Leave";
+
+// Conversation Degraded (security level lowered)
+"meta.degraded.degradation_reason_message.singular" = "%@ started using a new device.";
+"meta.degraded.degradation_reason_message.plural" = "%@ started using new devices.";
+"meta.degraded.dialog_message" = "Do you still want to send your message?";
+"meta.degraded.show_device_button" = "Show device";
+"meta.degraded.send_anyway_button" = "Send anyway";
+
+// Remove from conversation dialogue
+"profile.remove_dialog_title" = "Remove?";
+"profile.remove_dialog_message" = "%@ won’t be able to send or receive messages in this conversation.";
+"profile.remove_dialog_button_cancel" = "Cancel";
+"profile.remove_dialog_button_remove" = "Remove";
+
+// Block dialog
+"profile.block_dialog.title" = "Block?";
+"profile.block_dialog.message" = "%@ won’t be able to find or contact you on Wire.";
+"profile.block_dialog.button_cancel" = "Cancel";
+"profile.block_dialog.button_block" = "Block";
+
+// Delete message dialog
+"message.delete_dialog.message" = "This cannot be undone.";
+"message.delete_dialog.action.cancel" = "Cancel";
+"message.delete_dialog.action.hide" = "Delete for Me";
+"message.delete_dialog.action.delete" = "Delete for Everyone";
+
+// Edit message
+"message.menu.edit.title" = "Edit";
+
+// Accept connection request
+"profile.connection_request_dialog.title" = "Accept?";
+"profile.connection_request_dialog.message" = "This will connect you and open the conversation with %@.";
+"profile.connection_request_dialog.button_cancel" = "Ignore";
+"profile.connection_request_dialog.button_connect" = "Connect";
+
+// Cancel connection request
+"profile.cancel_connection_request_dialog.title" = "Cancel Request?";
+"profile.cancel_connection_request_dialog.message" = "Remove connection request to %@.";
+"profile.cancel_connection_request_dialog.button_no" = "No";
+"profile.cancel_connection_request_dialog.button_yes" = "Yes";
+
+// Unblock button
+"profile.unblock_button_title" = "Unblock";
+
+"profile.cancel_connection_button_title" = "CANCEL REQUEST";
+"profile.connection_request_state.blocked" = "BLOCKED";
+"profile.create_conversation_button_title" = "Create group";
+"profile.open_conversation_button_title" = "Open conversation";
+
+// User Details
+"profile.details.title" = "Details";
+
+// Device list
+"profile.devices.title" = "Devices";
+"profile.devices.fingerprint_message_unencrypted" = "%@ is using an old version of Wire. No devices are shown here.";
+"profile.devices.fingerprint_message" = "Wire gives every device a unique fingerprint. Compare them with %@ and verify your conversation. Why verify conversations?";
+"profile.devices.fingerprint_message.link" = "Why verify conversations?";
+
+// Device detail
+"profile.devices.detail.verify_message" = "Verify that this matches the fingerprint shown on %@'s device.";
+"profile.devices.detail.verify_message.link" = "How do I do that?";
+"profile.devices.detail.show_my_device.title" = "Show my device fingerprint";
+"device.verified" = "Verified";
+"device.not_verified" = "Not Verified";
+"device.class.desktop" = "Desktop";
+"device.class.tablet" = "Tablet";
+"device.class.phone" = "Phone";
+"profile.devices.detail.reset_session.title" = "Reset Session";
+
+// General strings
+"general.confirm" = "OK";
+
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++
+// Self profile
+
+// Options menu contents
+"self.settings" = "Settings";
+"self.help_center" = "Support";
+"self.help_center.support_website" = "Wire Support Website";
+"self.help_center.contact_support" = "Contact Support";
+"self.about" = "About";
+"self.sign_out" = "Log Out";
+"self.report_abuse" = "Report Misuse";
+
+"self.add_phone_number" = "Add phone number";
+"self.add_email_password" = "Add email address and password";
+
+// About screen
+"about.tos.title"="Terms of Use";
+"about.privacy.title"="Privacy Policy";
+"about.license.title" = "License Information";
+"about.website.title"="Wire Website";
+"about.copyright.title"="© Wire Swiss GmbH";
+
+// Self new devices
+"self.new_device_alert.title" = "You have connected %@ to your Wire account";
+"self.new_device_alert.title_prefix.tablet" = "a tablet";
+"self.new_device_alert.title_prefix.phone" = "a phone";
+"self.new_device_alert.title_prefix.devices" = "%d devices";
+"self.new_device_alert.message" = "%@\n\nIf you didn’t do this, remove the device and reset your password.";
+"self.new_device_alert.message_plural" = "%@\n\nIf you didn’t do this, remove those devices and reset your password.";
+"self.new_device_alert.manage_devices" = "Manage devices";
+"self.new_device_alert.trust_devices" = "OK";
+
+// Settings - Account details
+"self.settings.account_section" = "Account";
+
+"self.settings.account_details_group.title" = "Info";
+
+"self.settings.account_section.name.title" = "Name";
+"self.settings.account_section.email.title" = "Email";
+"self.settings.account_section.phone.title" = "Phone";
+
+"self.settings.account_details_group.footer" = "People can find you with these details.";
+
+"self.settings.account_details.remove_device.title" = "Remove Device";
+"self.settings.account_details.key_fingerprint.title" = "Key Fingerprint";
+"self.settings.account_details.remove_device.message" = "Your password is required to remove the device";
+"self.settings.account_details.remove_device.password" = "Password";
+"self.settings.account_details.remove_device.password.error" = "Wrong password";
+
+"self.settings.account_appearance_group.title" = "Appearance";
+"self.settings.account_picture_group.picture" = "Picture";
+"self.settings.account_picture_group.color" = "Color";
+
+"self.settings.account_picture_group.theme" = "Dark Theme";
+
+"self.settings.device_details.fingerprint.subtitle" = "Wire gives every device a unique fingerprint. Compare them and verify your devices and conversations.";
+"self.settings.device_details.reset_session.subtitle" = "If fingerprints don’t match, reset the session to generate new encryption keys on both sides.";
+"self.settings.device_details.remove_device.subtitle" = "Remove this device if you have stopped using it. Your message history will be erased and you will be logged out.";
+"self.settings.device_details.reset_session.success" = "The session has been reset";
+
+"self.settings.account_details.actions.title" = "Actions";
+
+"self.settings.account_details.delete_account.title" = "Delete Account";
+
+"self.settings.account_details.delete_account.alert.title" = "Delete Account";
+"self.settings.account_details.delete_account.alert.message" = "We will send you a message via email or SMS. Follow the link to permanently delete your account.";
+
+
+// Chat alerts
+"self.settings.notifications.push_notification.title" = "Notifications";
+"self.settings.notifications.push_notification.toogle" = "Message Previews";
+"self.settings.notifications.push_notification.footer" = "Sender name and message on the lock screen and in Notification Center.";
+
+"self.settings.notifications.chat_alerts.toggle" = "Message Banners";
+"self.settings.notifications.chat_alerts.footer" = "New messages in other conversations.";
+
+"self.settings.sound_menu.sounds.title" = "Sounds";
+"self.settings.sound_menu.ringtone.title" = "Ringtone";
+"self.settings.sound_menu.message.title" = "Text Tone";
+"self.settings.sound_menu.ping.title" = "Ping";
+"self.settings.sound_menu.ringtones.title" = "Ringtones";
+"self.settings.sound_menu.sounds.wire_sound" = "Wire";
+
+"self.settings.sound_menu.sounds.wire_call" = "Wire Call";
+"self.settings.sound_menu.sounds.wire_message" = "Wire Message";
+"self.settings.sound_menu.sounds.wire_ping" = "Wire Ping";
+
+// By popular demand
+"self.settings.popular_demand.title" = "By popular demand";
+"self.settings.popular_demand.send_button.title" = "Send Button";
+"self.settings.popular_demand.send_button.footer" = "Disable to send via the return key.";
+
+// Sound alerts (TO BE UPDPATED)
+"self.settings.sound_menu.title" = "Sound Alerts";
+"self.settings.sound_menu.no_sounds.title" = "None";
+"self.settings.sound_menu.all_sounds.title" = "All";
+"self.settings.sound_menu.mute_while_talking.title" = "First message, pings, calls";
+
+// Developer options
+"self.settings.developer_options.title" = "Developer Options";
+"self.settings.apns_logging.title" = "APNS Logging";
+
+// Privacy (visibility) options
+"self.settings.options_menu.title" = "Options";
+
+"self.settings.privacy_contacts_section.title" = "Contacts";
+"self.settings.privacy_contacts_menu.settings_button.title" = "Open Contacts Settings";
+"self.settings.privacy_contacts_menu.description_disabled.title" = "This helps you connect with others. We anonymize all the information and do not share it with anyone else. Allow access via Settings > Privacy > Contacts.";
+
+"self.settings.privacy_analytics_menu.devices.title" = "Devices";
+
+"self.settings.privacy_analytics_section.title" = "Usage and Crash Reports";
+"self.settings.privacy_analytics_menu.description.title" = "Make Wire better by sending anonymous information.\n";
+
+"self.settings.privacy.clear_history.title" = "Clear History";
+"self.settings.privacy.clear_history.subtitle" = "This will permanently erase the content of all your conversations.";
+
+"self.settings.advanced.title" = "Advanced";
+"self.settings.advanced.troubleshooting.title" = "Troubleshooting";
+"self.settings.advanced.troubleshooting.submit_debug.title" = "Calling Debug Report";
+"self.settings.advanced.troubleshooting.submit_debug.subtitle" = "This information helps Wire Support diagnose calling problems.";
+"self.settings.advanced.reset_push_token.title" = "Reset Push Notifications Token";
+"self.settings.advanced.reset_push_token.subtitle" = "If you experience problems with push notifications, Wire Support may ask you to reset this token.";
+"self.settings.advanced.reset_push_token_alert.title" = "Push token has been reset";
+"self.settings.advanced.reset_push_token_alert.message" = "Notifications will be restored in a few seconds.";
+"self.settings.advanced.version_technical_details.title" = "Version Technical Details";
+
+// Technical Report
+"self.settings.technical_report_section.title" = "Technical Report";
+"self.settings.technical_report.send_report" = "Send report to Wire";
+"self.settings.technical_report.mail.recipient" = "callingsupport@wire.com";
+"self.settings.technical_report.mail.subject" = "Wire Calling Report";
+"self.settings.technical_report.include_log" = "Include detailed log";
+
+// Password reset
+"self.settings.password_reset_menu.title" = "Reset Password";
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++
+// System status
+"system_status_bar.no_internet.title" = "No Internet";
+"system_status_bar.no_internet.explanation" = "There seems to be a problem with your Internet connection. Please make sure it’s working.";
+"system_status_bar.poor_connectivity.title" = "Slow Internet, can’t call now";
+"system_status_bar.poor_connectivity.explanation" = "We can’t guarantee voice quality. Connect to Wi-Fi or try changing your location.";
+
+// Common connections on profile view
+"profile_other.common_connections" = "You both know";
+
+// View user profile and options menu
+"name.placeholder" = "Your full name";
+"name.guidance.tooshort" = "At least 2 characters";
+"name.guidance.toolong" = "Too many characters";
+
+"email.placeholder" = "Email";
+
+"password.placeholder" = "Password";
+"password.guidance.tooshort" = "At least 8 characters";
+"password.guidance.toolong" = "Too many characters";
+
+"registration.title" = "Registration";
+"registration.close_email_invitation_button.email_title" = "Use another email";
+"registration.close_email_invitation_button.phone_title" = "Register by phone";
+"registration.close_phone_invitation_button.email_title" = "Register by email";
+"registration.close_phone_invitation_button.phone_title" = "Use another phone";
+
+"registration.enter_phone_number.title" = "Edit phone number";
+"registration.enter_phone_number.placeholder" = "Phone number";
+
+"registration.verify_phone_number.instructions" = "Enter the verification code we sent to %@";
+"registration.verify_phone_number.resend" = "Resend";
+"registration.verify_phone_number.resend_placeholder" = "No code showing up?\nYou can request a new one in %.0f seconds";
+
+"registration.verify_email.instructions" = "We sent an email to %@.\n Follow the link to verify your address.";
+"registration.verify_email.resend.instructions" = "Didn't get the message?";
+"registration.verify_email.resend.button_title" = "Re-send";
+
+"registration.select_picture.subtitle" = "Wire is so much nicer with a picture.";
+"registration.select_picture.button_title" = "Choose your own";
+"registration.keep_picture.button_title" = "Keep this one";
+"registration.camera_action.title" = "Take photo";
+"registration.photo_gallery_action.title" = "Choose Photo";
+"registration.cancel_action.title" = "Cancel";
+
+"registration.no_history.hero" = "It’s the first time you’re using Wire on this device.";
+"registration.no_history.subtitle" = "For privacy reasons, your conversation history will not appear here.";
+"registration.no_history.got_it" = "OK";
+
+"registration.no_history.logged_out.hero" = "You've used Wire on this device before.";
+"registration.no_history.logged_out.subtitle" = "Messages sent in the meantime will not appear.";
+"registration.no_history.logged_out.got_it" = "OK";
+
+"registration.enter_name.title" = "Edit Name";
+"registration.enter_name.hero" = "What should we call you?";
+"registration.enter_name.placeholder" = "Your full name";
+
+"registration.terms_of_use.title" = "Welcome to Wire.";
+"registration.terms_of_use.terms" = "By continuing you agree to the Wire Terms of Use.";
+"registration.terms_of_use.terms.link" = "Terms of Use";
+"registration.terms_of_use.agree" = "I agree";
+
+"registration.email_flow.title" = "Register by Email";
+"registration.email_flow.email_step.title" = "Edit Details";
+
+"registration.country_select.title" = "Country";
+
+"registration.share_contacts.hero.title" = "Find people on Wire";
+"registration.share_contacts.hero.paragraph"  = "Share your contacts so we can connect you with others. We anonymize all information and do not share it with anyone else.";
+"registration.share_contacts.find_friends_button.title" = "Share contacts";
+"registration.share_contacts.skip_button.title" = "Not now";
+
+"registration.address_book_access_denied.hero.title" = "Wire does not have access to your contacts.";
+"registration.address_book_access_denied.hero.paragraph1" = "Wire helps find your friends if you share your contacts.";
+"registration.address_book_access_denied.hero.paragraph2" = "To enable access tap Settings and turn on Contacts.";
+"registration.address_book_access_denied.settings_button.title" = "Settings";
+"registration.address_book_access_denied.maybe_later_button.title" = "Maybe later";
+
+"registration.push_access_denied.hero.title" = "Never miss a call or a message.";
+"registration.push_access_denied.hero.paragraph1" = "Enable Notifications in Settings.";
+"registration.push_access_denied.settings_button.title" = "Go to Settings";
+"registration.push_access_denied.maybe_later_button.title" = "Maybe later";
+
+"registration.signin.title" = "Log In";
+"registration.signin.too_many_devices.title" = "";
+"registration.signin.too_many_devices.subtitle" = "Remove one of your other devices to start using Wire on this one.";
+"registration.signin.too_many_devices.manage_button.title" = "Manage devices";
+"registration.signin.too_many_devices.sign_out_button.title" = "Log out";
+"registration.signin.email_button.title" = "Email";
+"registration.signin.phone_button.title" = "Phone";
+
+"registration.devices.title" = "Devices";
+"registration.devices.active_list_header" = "Active";
+"registration.devices.current_list_header" = "Current";
+"registration.devices.active_list_subtitle" = "If you don’t recognize a device above, remove it and reset your password.";
+"registration.devices.activated_in" = "Activated in";
+"registration.devices.id" = "ID:";
+
+"signin.forgot_password" = "Forgot password?";
+
+"registration.add_phone_number.hero.title" = "Add phone number";
+"registration.add_phone_number.hero.paragraph" = "This helps us find people you may know. We never share it.";
+"registration.add_phone_number.skip_button.title" = "Not now";
+
+"registration.add_email_password.hero.title" = "Add your email and password.";
+"registration.add_email_password.hero.paragraph" = "This lets you use Wire on multiple devices.";
+
+"registration.email_invitation.title" = "Invitation";
+"registration.email_invitation.hero.title" = "Hello, %@";
+"registration.email_invitation.hero.paragraph" = "Choose a password to create your account.";
+
+"registration.phone_invitation.title" = "Invitation";
+"registration.phone_invitation.hero.title" = "Hello, %@";
+"registration.phone_invitation.hero.paragraph" = "You are one step away from creating your account.";
+
+"error.name_and_email" = "Please enter your full name and a valid email address";
+"error.full_name" = "Please enter your full name";
+"error.email" = "Please enter a valid email address";
+"error.input.too_long" = "Input too long";
+"error.input.too_short" = "Input too short";
+"error.email.invalid" = "Please enter a valid email address";
+"error.phone.invalid" = "Please enter a valid phone number";
+
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++
+// ZMUserSessionErrorCode mapping. Used during registration and profile edit
+"error.user.unkown_error" = "Something went wrong, please try again";
+"error.user.needs_credentials" = "Please verify your details and try again.";
+"error.user.invalid_credentials" = "Please verify your details and try again.";
+"error.user.account_pending_activation" = "The account you are trying access is pending activation. Please verify your details.";
+"error.user.network_error" = "There seems to be a problem with your network. Please try again later.";
+"error.user.email_is_taken" = "The email address you provided has already been registered. Please try again.";
+"error.user.phone_is_taken" = "The phone number you provided has already been registered. Please try again.";
+"error.user.phone_code_invalid" = "Please enter a valid code";
+"error.user.phone_code_too_many" = "We already sent you a code via SMS. Tap Resend after 10 minutes to get a new one.";
+"error.user.registration_unknown_error" = "Something went wrong. Please try again.";
+"error.user.device_deleted_remotely" = "You have been logged out from another device.";
+
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++
+// Those are caught by the UI without involving the SE validation. Basically very similar to ZMUserSessionErrorCode onces
+"error.updating_password" = "Couldn't update your password.";
+
+"error.group_call.too_many_members_in_conversation.title" = "Too many people to call";
+"error.group_call.too_many_members_in_conversation" = "Calls work in conversations with up to %d people.";
+"error.group_call.too_many_participants_in_the_call.title" = "The call is full";
+"error.group_call.too_many_participants_in_the_call" = "There’s only room for %d people in here.";
+"error.call.gsm_ongoing.title" = "Cellular call";
+"error.call.gsm_ongoing" = "Please cancel the cellular call before calling on Wire.";
+"error.call.general.title" = "Call error";
+"error.call.general" = "Please try calling again in several minutes.";
+"error.call.slow_connection.title" = "Slow connection";
+"error.call.slow_connection" = "You might experience issues during the call";
+"error.call.slow_connection.call_anyway" = "Call anyway";
+
+"error.invite.no_email_provider" = "Please configure your email client to be able to send the invites via email";
+"error.invite.no_messaging_provider" = "Please configure your SMS to be able to send the invites via SMS";
+
+"sketchpad.initial_hint" = "Tap color to change brush size\nPress and hold to fill an area\nShake to remove a photo";
+
+"migration.please_wait_message" = "One moment, please";
+
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++
+// Those are used by the backend to localize APNS
+"push.notification.new_user" = "%@ joined Wire";
+"push.notification.new_message" = "New message";
+
+
+//Force Update
+"force.update.title" = "Update necessary";
+"force.update.message" = "You are missing out on new features.\nGet the latest version of Wire in the App Store.";
+"force.update.ok_button" = "Go to App Store";
+
+// Third Party
+"giphy.conversation.message" = "%@ · via giphy.com";
+"giphy.conversation.random_message" = "via giphy.com";
+"giphy.error.no_more_results" = "no more gifs";
+"giphy.error.no_result" = "no gif found";
+
+"giphy.confirm" = "send";
+"giphy.cancel" = "cancel";
+"giphy.search_placeholder" = "Search giphy";
+
+"invite_banner.title" = "Bring your friends to Wire!";
+"invite_banner.message" = "Enjoy calls, messages, sketches, GIFs and more in private or with groups.";
+"invite_banner.invite_button_title" = "Invite more people";

--- a/Wire-iOS/Resources/ja.lproj/Localizable.stringsdict
+++ b/Wire-iOS/Resources/ja.lproj/Localizable.stringsdict
@@ -1,0 +1,191 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+        <key>self.new_device_alert.title_prefix.devices</key>
+        <dict>
+            <key>NSStringLocalizedFormatKey</key>
+            <string>%#@device_count@</string>
+            <key>device_count</key>
+            <dict>
+                <key>NSStringFormatSpecTypeKey</key>
+                <string>NSStringPluralRuleType</string>
+                <key>NSStringFormatValueTypeKey</key>
+                <string>lu</string>
+                <key>zero</key>
+                <string></string>
+                <key>one</key>
+                <string>a device</string>
+                <key>few</key>
+                <string>%lu devices</string>
+                <key>many</key>
+                <string>%lu devices</string>
+                <key>other</key>
+                <string>%lu devices</string>
+            </dict>
+        </dict>
+		<key>participants.people.count</key>
+		<dict>
+			<key>NSStringLocalizedFormatKey</key>
+			<string>%#@lu_number_of_people@</string>
+			<key>lu_number_of_people</key>
+			<dict>
+				<key>NSStringFormatSpecTypeKey</key>
+				<string>NSStringPluralRuleType</string>
+				<key>NSStringFormatValueTypeKey</key>
+				<string>lu</string>
+				<key>zero</key>
+				<string>No people</string>
+				<key>one</key>
+				<string>One person</string>
+				<key>few</key>
+				<string>%lu people</string>
+				<key>many</key>
+				<string>%lu people</string>
+				<key>other</key>
+				<string>%lu people</string>
+			</dict>
+		</dict>
+        <key>content.system.missing_messages.subtitle_added</key>
+        <dict>
+            <key>NSStringLocalizedFormatKey</key>
+            <string>%@ %#@lu_number_of_users@ been added</string>
+            <key>lu_number_of_users</key>
+            <dict>
+                <key>NSStringFormatSpecTypeKey</key>
+                <string>NSStringPluralRuleType</string>
+                <key>NSStringFormatValueTypeKey</key>
+                <string>lu</string>
+                <key>zero</key>
+                <string></string>
+                <key>one</key>
+                <string>has</string>
+                <key>other</key>
+                <string>have</string>
+            </dict>
+        </dict>
+        <key>content.system.missing_messages.subtitle_removed</key>
+        <dict>
+            <key>NSStringLocalizedFormatKey</key>
+            <string>%@ %#@lu_number_of_users@ been removed</string>
+            <key>lu_number_of_users</key>
+            <dict>
+                <key>NSStringFormatSpecTypeKey</key>
+                <string>NSStringPluralRuleType</string>
+                <key>NSStringFormatValueTypeKey</key>
+                <string>lu</string>
+                <key>zero</key>
+                <string></string>
+                <key>one</key>
+                <string>has</string>
+                <key>other</key>
+                <string>have</string>
+            </dict>
+        </dict>
+		<key>list.connect_request.people_waiting</key>
+		<dict>
+			<key>NSStringLocalizedFormatKey</key>
+			<string>%#@d_number_of_people@ waiting</string>
+			<key>d_number_of_people</key>
+			<dict>
+				<key>NSStringFormatSpecTypeKey</key>
+				<string>NSStringPluralRuleType</string>
+				<key>NSStringFormatValueTypeKey</key>
+				<string>d</string>
+				<key>zero</key>
+				<string></string>
+				<key>one</key>
+				<string>One person</string>
+				<key>few</key>
+				<string>%d people</string>
+				<key>many</key>
+				<string>%d people</string>
+				<key>other</key>
+				<string>%d people</string>
+			</dict>
+		</dict>
+		<key>content.system.participants_n_others</key>
+		<dict>
+			<key>NSStringLocalizedFormatKey</key>
+			<string>%@ %#@and_number_of_others@</string>
+			<key>and_number_of_others</key>
+			<dict>
+				<key>NSStringFormatSpecTypeKey</key>
+				<string>NSStringPluralRuleType</string>
+				<key>NSStringFormatValueTypeKey</key>
+				<string>d</string>
+				<key>zero</key>
+				<string/>
+				<key>one</key>
+				<string>and one more</string>
+				<key>few</key>
+				<string>and %d others</string>
+				<key>many</key>
+				<string>and %d others</string>
+				<key>other</key>
+				<string>and %d others</string>
+			</dict>
+		</dict>
+		<key>peoplepicker.suggested.knows_more</key>
+		<dict>
+			<key>NSStringLocalizedFormatKey</key>
+			<string>Knows %@ and %#@d_number_of_others@</string>
+			<key>d_number_of_others</key>
+			<dict>
+				<key>NSStringFormatSpecTypeKey</key>
+				<string>NSStringPluralRuleType</string>
+				<key>NSStringFormatValueTypeKey</key>
+				<string>d</string>
+				<key>few</key>
+				<string>%d others</string>
+				<key>many</key>
+				<string>%d others</string>
+				<key>other</key>
+				<string>%d others</string>
+			</dict>
+		</dict>
+        <key>content.system.people_started_using</key>
+        <dict>
+            <key>NSStringLocalizedFormatKey</key>
+            <string>%@ %#@d_number_of_others@ started using %#@d_new_devices@</string>
+            <key>d_number_of_others</key>
+            <dict>
+                <key>NSStringFormatSpecTypeKey</key>
+                <string>NSStringPluralRuleType</string>
+                <key>NSStringFormatValueTypeKey</key>
+                <string>d</string>
+                <key>one</key>
+                <string></string>
+                <key>other</key>
+                <string>and %d others</string>
+            </dict>
+            <key>d_new_devices</key>
+            <dict>
+                <key>NSStringFormatSpecTypeKey</key>
+                <string>NSStringPluralRuleType</string>
+                <key>NSStringFormatValueTypeKey</key>
+                <string>d</string>
+                <key>one</key>
+                <string>a new device</string>
+                <key>other</key>
+                <string>new devices</string>
+            </dict>
+        </dict>
+        <key>content.system.new_devices</key>
+        <dict>
+            <key>NSStringLocalizedFormatKey</key>
+            <string>%#@d_new_devices@</string>
+            <key>d_new_devices</key>
+            <dict>
+                <key>NSStringFormatSpecTypeKey</key>
+                <string>NSStringPluralRuleType</string>
+                <key>NSStringFormatValueTypeKey</key>
+                <string>d</string>
+                <key>one</key>
+                <string>a new device</string>
+                <key>other</key>
+                <string>new devices</string>
+            </dict>
+        </dict>
+	</dict>
+</plist>

--- a/Wire-iOS/Resources/ja.lproj/Localizable.stringsdict
+++ b/Wire-iOS/Resources/ja.lproj/Localizable.stringsdict
@@ -15,13 +15,13 @@
                 <key>zero</key>
                 <string></string>
                 <key>one</key>
-                <string>a device</string>
+                <string>デバイス</string>
                 <key>few</key>
-                <string>%lu devices</string>
+                <string>%lu デバイス</string>
                 <key>many</key>
-                <string>%lu devices</string>
+                <string>%lu デバイス</string>
                 <key>other</key>
-                <string>%lu devices</string>
+                <string>%lu デバイス</string>
             </dict>
         </dict>
 		<key>participants.people.count</key>
@@ -35,21 +35,21 @@
 				<key>NSStringFormatValueTypeKey</key>
 				<string>lu</string>
 				<key>zero</key>
-				<string>No people</string>
+				<string>誰もいません</string>
 				<key>one</key>
-				<string>One person</string>
+				<string>一人</string>
 				<key>few</key>
-				<string>%lu people</string>
+				<string>%lu人</string>
 				<key>many</key>
-				<string>%lu people</string>
+				<string>%lu人</string>
 				<key>other</key>
-				<string>%lu people</string>
+				<string>%lu人</string>
 			</dict>
 		</dict>
         <key>content.system.missing_messages.subtitle_added</key>
         <dict>
             <key>NSStringLocalizedFormatKey</key>
-            <string>%@ %#@lu_number_of_users@ been added</string>
+            <string>%@%#@lu_number_of_users@が追加された</string>
             <key>lu_number_of_users</key>
             <dict>
                 <key>NSStringFormatSpecTypeKey</key>
@@ -59,15 +59,15 @@
                 <key>zero</key>
                 <string></string>
                 <key>one</key>
-                <string>has</string>
+                <string>持つ</string>
                 <key>other</key>
-                <string>have</string>
+                <string>所有数</string>
             </dict>
         </dict>
         <key>content.system.missing_messages.subtitle_removed</key>
         <dict>
             <key>NSStringLocalizedFormatKey</key>
-            <string>%@ %#@lu_number_of_users@ been removed</string>
+            <string>%@ 人が%#@lu_number_of_users@ 削除されました。</string>
             <key>lu_number_of_users</key>
             <dict>
                 <key>NSStringFormatSpecTypeKey</key>
@@ -77,15 +77,15 @@
                 <key>zero</key>
                 <string></string>
                 <key>one</key>
-                <string>has</string>
+                <string>持つ</string>
                 <key>other</key>
-                <string>have</string>
+                <string>所有数</string>
             </dict>
         </dict>
 		<key>list.connect_request.people_waiting</key>
 		<dict>
 			<key>NSStringLocalizedFormatKey</key>
-			<string>%#@d_number_of_people@ waiting</string>
+			<string>%#@d_number_of_people@ 人が待っています。</string>
 			<key>d_number_of_people</key>
 			<dict>
 				<key>NSStringFormatSpecTypeKey</key>
@@ -95,19 +95,19 @@
 				<key>zero</key>
 				<string></string>
 				<key>one</key>
-				<string>One person</string>
+				<string>一人</string>
 				<key>few</key>
-				<string>%d people</string>
+				<string>%d 人</string>
 				<key>many</key>
-				<string>%d people</string>
+				<string>%d 人</string>
 				<key>other</key>
-				<string>%d people</string>
+				<string>%d 人</string>
 			</dict>
 		</dict>
 		<key>content.system.participants_n_others</key>
 		<dict>
 			<key>NSStringLocalizedFormatKey</key>
-			<string>%@ %#@and_number_of_others@</string>
+			<string>%@%#@and_number_of_others@</string>
 			<key>and_number_of_others</key>
 			<dict>
 				<key>NSStringFormatSpecTypeKey</key>
@@ -117,19 +117,19 @@
 				<key>zero</key>
 				<string/>
 				<key>one</key>
-				<string>and one more</string>
+				<string>さらにひとつ</string>
 				<key>few</key>
-				<string>and %d others</string>
+				<string>その他%d</string>
 				<key>many</key>
-				<string>and %d others</string>
+				<string>%dとその他</string>
 				<key>other</key>
-				<string>and %d others</string>
+				<string>その他%d</string>
 			</dict>
 		</dict>
 		<key>peoplepicker.suggested.knows_more</key>
 		<dict>
 			<key>NSStringLocalizedFormatKey</key>
-			<string>Knows %@ and %#@d_number_of_others@</string>
+			<string>%@ と%#@d_number_of_others@ を知っています。</string>
 			<key>d_number_of_others</key>
 			<dict>
 				<key>NSStringFormatSpecTypeKey</key>
@@ -137,17 +137,17 @@
 				<key>NSStringFormatValueTypeKey</key>
 				<string>d</string>
 				<key>few</key>
-				<string>%d others</string>
+				<string>その他 %d</string>
 				<key>many</key>
-				<string>%d others</string>
+				<string>その他 %d</string>
 				<key>other</key>
-				<string>%d others</string>
+				<string>その他 %d</string>
 			</dict>
 		</dict>
         <key>content.system.people_started_using</key>
         <dict>
             <key>NSStringLocalizedFormatKey</key>
-            <string>%@ %#@d_number_of_others@ started using %#@d_new_devices@</string>
+            <string>%@%#@d_number_of_others@ が%#@d_new_devices@ を使い始めました</string>
             <key>d_number_of_others</key>
             <dict>
                 <key>NSStringFormatSpecTypeKey</key>
@@ -157,7 +157,7 @@
                 <key>one</key>
                 <string></string>
                 <key>other</key>
-                <string>and %d others</string>
+                <string>その他%d</string>
             </dict>
             <key>d_new_devices</key>
             <dict>
@@ -166,9 +166,9 @@
                 <key>NSStringFormatValueTypeKey</key>
                 <string>d</string>
                 <key>one</key>
-                <string>a new device</string>
+                <string>新しいデバイス</string>
                 <key>other</key>
-                <string>new devices</string>
+                <string>新しいデバイス</string>
             </dict>
         </dict>
         <key>content.system.new_devices</key>
@@ -182,9 +182,9 @@
                 <key>NSStringFormatValueTypeKey</key>
                 <string>d</string>
                 <key>one</key>
-                <string>a new device</string>
+                <string>新しいデバイス</string>
                 <key>other</key>
-                <string>new devices</string>
+                <string>新しいデバイス</string>
             </dict>
         </dict>
 	</dict>

--- a/Wire-iOS/Resources/nl.lproj/InfoPlist.strings
+++ b/Wire-iOS/Resources/nl.lproj/InfoPlist.strings
@@ -1,0 +1,22 @@
+/*
+ *  Wire
+ *  Copyright (C) 2016 Wire Swiss GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+"NSContactsUsageDescription" = "Allow Wire to access your contacts to connect you with others. We anonymize all information and do not share it with anyone else.";
+"NSMicrophoneUsageDescription" = "Allow Wire to access your microphone so you can talk to people and send audio messages.";
+"NSLocationWhenInUseUsageDescription" = "Allow Wire to access your location so you can send your location to others.";
+"NSCameraUsageDescription" = "Allow Wire to access your camera so you can place video calls and send photos.";

--- a/Wire-iOS/Resources/nl.lproj/InfoPlist.strings
+++ b/Wire-iOS/Resources/nl.lproj/InfoPlist.strings
@@ -1,4 +1,4 @@
-/*
+/* 
  *  Wire
  *  Copyright (C) 2016 Wire Swiss GmbH
  *
@@ -14,9 +14,9 @@
  *
  *  You should have received a copy of the GNU General Public License
  *  along with this program. If not, see http://www.gnu.org/licenses/.
- */
+*/
 
-"NSContactsUsageDescription" = "Allow Wire to access your contacts to connect you with others. We anonymize all information and do not share it with anyone else.";
-"NSMicrophoneUsageDescription" = "Allow Wire to access your microphone so you can talk to people and send audio messages.";
-"NSLocationWhenInUseUsageDescription" = "Allow Wire to access your location so you can send your location to others.";
-"NSCameraUsageDescription" = "Allow Wire to access your camera so you can place video calls and send photos.";
+"NSContactsUsageDescription" = "Geef Wire toegang tot je contacten om je te verbinden met andere mensen. We anonimiseren de date an delen het met niemand anders.";
+"NSMicrophoneUsageDescription" = "Geef Wire toegang tot je microfoon zodat je met andere mensen kan praten en audio berichten kan sturen.";
+"NSLocationWhenInUseUsageDescription" = "Sta Wire toe tot je locatie locatie, zodat jij het kan versturen naar anderen.";
+"NSCameraUsageDescription" = "Geef Wire toegang tot je camera zodat je video gesprekken kan voeren en foto's kan sturen.";

--- a/Wire-iOS/Resources/nl.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/nl.lproj/Localizable.strings
@@ -128,6 +128,7 @@
 
 "conversation.input_bar.verified" = "Geverifieerd";
 "conversation.input_bar.placeholder" = "Typ een bericht";
+"conversation.input_bar.placeholder_ephemeral" = "Timed message";
 
 "conversation.input_bar.audio_message.tooltip.pull_send" = "Swipe omhoog om te versturen";
 "conversation.input_bar.audio_message.tooltip.tap_send" = "Tik om te verzenden";
@@ -161,6 +162,10 @@
 
 // Twitter
 "twitter_status.on_twitter" = "%@ op Twitter";
+
+// Ephemeral message
+"input.ephemeral.timeout.none" = "Off";
+"input.ephemeral.title" = "Set a timer for temporary messages";
 
 // System messages
 "content.system.continued_conversation" = "Begin een gesprek met %@";
@@ -221,6 +226,8 @@
 "content.system.cannot_decrypt.identity.you_part" = "Jou";
 "content.system.cannot_decrypt.identity.otherUser_part" = "%@'s"; // posessive apostrophe - might differ in different languages
 "content.system.cannot_decrypt.identity.why_part" = "Leer meer";
+"content.system.cannot_decrypt.otherDevice_part" = "(device %@)"; // example " (device d1b23c54f34a)".
+// Full sentence: "A message from %@ was not received. [...] (device d1b23c54f34a). This is a debug information.
 
 "content.file.uploading" = "Uploaden…";
 "content.file.downloading" = "Downloaden…";
@@ -705,7 +712,7 @@
 
 "giphy.confirm" = "stuur";
 "giphy.cancel" = "anuleer";
-"giphy.search_placeholder" = "Zoek giphy";
+"giphy.search_placeholder" = "Zoek Giphy";
 
 "invite_banner.title" = "Nodig je vrienden uit tot Wire!";
 "invite_banner.message" = "Geniet van bellen, berichten, schetsen, GIF's en meer in privé gesprekken of in groepen.";

--- a/Wire-iOS/Resources/nl.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/nl.lproj/Localizable.strings
@@ -1,0 +1,712 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+"general.ok" = "OK";
+"general.cancel" = "Cancel";
+"general.open_settings" = "Open Wire Settings";
+
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++
+// People picker/start UI
+"peoplepicker.search_placeholder" = "Search by name or email";
+"peoplepicker.header.top_people" = "Top people";
+"peoplepicker.button.create_conversation" = "Create group";
+"peoplepicker.button.add_to_conversation" = "Add";
+"peoplepicker.header.conversations" = "Groups";
+"peoplepicker.header.send_invitation" = "Invite";
+"peoplepicker.header.contacts" = "Connections";
+"peoplepicker.header.directory" = "Connect";
+"peoplepicker.title.create_conversation" = "Create group";
+"peoplepicker.title.add_to_conversation" = "Add people";
+
+"peoplepicker.no_contacts_title" = "No Contacts.";
+
+"peoplepicker.no_matching_results_title" = "No results.";
+"peoplepicker.no_matching_results_message" = "Enter a full email address.";
+
+"peoplepicker.no_matching_results.action.send_invite" = "Send an invitation";
+"peoplepicker.no_matching_results.action.share_contacts" = "Share contacts";
+
+"peoplepicker.no_matching_results_provide_valid_email" = "Please enter a valid email address";
+"peoplepicker.no_matching_results_after_address_book_upload_title" = "No results.";
+/* This sentence ends with button title, contained in peoplepicker.no_matching_results_after_address_book_upload_button */
+"peoplepicker.no_matching_results_after_address_book_upload_message" = "Enter a full email address or";
+/*  */
+"peoplepicker.no_matching_results_after_address_book_upload_button" = "share contacts";
+
+"peoplepicker.share_contacts.no_results.title" = "Find people by name or email address";
+
+"peoplepicker.send_invitation.dialog.title" = "Invitation sent";
+"peoplepicker.send_invitation.dialog.message" = "It can be used for 2 weeks. Send a new one if it expires.";
+"peoplepicker.send_invitation.dialog.ok" = "OK";
+
+"peoplepicker.invite_more_people" = "Invite more people";
+"peoplepicker.quick-action.open-conversation" = "Open";
+"peoplepicker.quick-action.create-conversation" = "Create group";
+
+// Contacts UI
+"contacts_ui.search_placeholder" = "Search by name";
+"contacts_ui.invite_others" = "Invite others";
+"contacts_ui.name_in_contacts" = "%@ in address book";
+"contacts_ui.connection_request" = "Requested to connect";
+"contacts_ui.action_button.invite" = "Invite";
+"contacts_ui.action_button.open" = "Open";
+"contacts_ui.invite_sheet.cancel_button_title" = "Cancel";
+"contacts_ui.notification.invitation_sent" = "Invitation sent";
+"contacts_ui.notification.invitation_failed" = "Failed to send invitation";
+"contacts_ui.title" = "Invite people";
+
+"contacts_ui.no_contact.title" = "No active conversations\n";
+"contacts_ui.no_contact.message" = "Tap contacts to start a conversation";
+
+// Conversation List Bottom Bar
+"bottom_bar.contacts_button.title" = "contacts";
+
+// Archived List
+"archived_list.title" = "archive";
+
+// Add contact tool tip
+"tool_tip.contacts.title" = "Conversations start here";
+"tool_tip.contacts.message" = "Start a conversation or invite more people to join. Call, message and share in private or with groups.";
+
+// "Knows" subtitle in cell: "Knows Indrek", "Knows Indrek and Jane", "Knows Indrek and 5 others"
+"peoplepicker.suggested.knows_one" = "Knows %@";
+"peoplepicker.suggested.knows_two" = "Knows %@ and %@";
+"peoplepicker.hide_search_result" = "Hide";
+"peoplepicker.hide_search_result_progress" = "Hiding…";
+
+"send_invitation.subject" = "Connect with me on Wire";
+"send_invitation.text" = "I’m on Wire. Search for %@\nor visit https://get.wire.com to connect with me.";
+"send_invitation_no_email.text" = "I’m on Wire. Visit https://get.wire.com to connect with me.";
+
+"send_personal_invitation.text" = "I’m on Wire, talk to you there. https://get.wire.com";
+
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++x
+// In-app notifications (chat heads)
+"notifications.shared_a_photo" = "shared a picture";
+"notifications.pinged" = "pinged";
+"notifications.sent_file" = "shared a file";
+"notifications.sent_location" = "shared a location";
+"notifications.sent_video" = "shared a video";
+"notifications.sent_audio" = "shared an audio";
+"notifications.in_conversation" = "%@ - %@";
+"notifications.this_conversation" = "%@ in this conversation";
+
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++
+// List (labels) - Needs to be revised with updated guidance
+"list.archived_conversations" = "ARCHIVE";
+"list.archived_conversations_close" = "Close archive";
+
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++
+// Conversation
+"conversation.invite_more_people.title" = "Spread the word!";
+"conversation.invite_more_people.description" = "Add people to this conversation";
+"conversation.invite_more_people.explanation_url" = "https://support.wire.com";
+"conversation.invite_more_people.button_title" = "Add People";
+
+// Conversation names
+"conversation.displayname.emptygroup" = "Empty group conversation";
+
+"conversation.input_bar.verified" = "Verified";
+"conversation.input_bar.placeholder" = "Type a message";
+
+"conversation.input_bar.audio_message.tooltip.pull_send" = "Swipe up to send";
+"conversation.input_bar.audio_message.tooltip.tap_send" = "Tap to send";
+"conversation.input_bar.audio_message.too_long.title" = "Recording Stopped";
+"conversation.input_bar.audio_message.too_long.message" = "Audio messages are limited to %@. Send this message?";
+"conversation.input_bar.audio_message.send" = "Send";
+
+"conversation.input_bar.audio_message.keyboard.record_tip" = "Tap to record\nYou can  %@  it after that";
+"conversation.input_bar.audio_message.keyboard.filter_tip" = "Choose a filter above";
+
+// Image confirmation dialogue
+"image_confirmer.confirm" = "OK";
+"image_confirmer.cancel" = "Cancel";
+"image.add_sketch" = "Add a sketch";
+"image.edit_image" = "Edit image";
+
+// Camera access
+"camera_access.denied" = "Wire needs access to the Camera.";
+"camera_access.denied.instruction" = "";
+"camera_access.denied.open_settings" = "Enable it in Wire Settings";
+
+// Camera Controls
+"camera_controls.aeaf_lock" = "AE/AF Lock";
+
+// Location
+"location.send_button.title" = "Send";
+"location.unauthorized_alert.title" = "Enable Location Services";
+"location.unauthorized_alert.message" = "To send your location, enable Location Services and allow Wire to access your location.";
+"location.unauthorized_alert.cancel" = "Cancel";
+"location.unauthorized_alert.settings" = "Settings";
+
+// Twitter
+"twitter_status.on_twitter" = "%@ on Twitter";
+
+// System messages
+"content.system.continued_conversation" = "Start a conversation with %@";
+
+"content.system.other_started_conversation" = "%@ started a conversation with %@";
+"content.system.you_started_conversation" = "You started a conversation with %@";
+
+"content.system.you_added_participant" = "You added %@";
+"content.system.other_added_participant" = "%@ added %@";
+"content.system.other_added_you" = "%@ added you";
+
+"content.system.participants_you" = "You";
+"content.system.participants_1_other" = "%@ and %@";
+"content.system.other_left" = "%@ left";
+"content.system.you_left" = "You left";
+"content.system.other_removed_other" = "%@ removed %@";
+"content.system.other_removed_you" = "%@ removed you";
+"content.system.you_removed_other" = "You removed %@";
+"content.system.other_renamed_conv" = "%@ renamed the conversation";
+"content.system.you_renamed_conv" = "You renamed the conversation";
+"content.system.other_renamed_conv_to_nothing" = "%@ removed the conversation name";
+"content.system.you_renamed_conv_to_nothing" = "You removed the conversation name";
+"content.system.pending_message_timestamp" = "Sending…";
+"content.system.message_sent_timestamp" = "Sent";
+"content.system.message_delivered_timestamp" = "Delivered";
+"content.system.failedtosend_message_timestamp" = "Sending failed.";
+"content.system.failedtosend_message_timestamp_resend" = "Resend";
+"content.system.like_tooltip" = "Tap to like";
+"content.system.deleted_message_prefix_timestamp" = "Deleted on %@";
+"content.system.edited_message_prefix_timestamp" = "Edited on %@";
+"content.system.connecting_to" = "Connecting to %@.\nStart a conversation";
+"content.system.connected_to" = "Connected to %@\nStart a conversation";
+"content.system.other_wanted_to_talk" = "%@ called";
+"content.system.you_wanted_to_talk" = "You called";
+
+"content.system.you_started" = "You";
+"content.system.this_device" = "this device";
+
+"content.system.reactivated_device" = "You started using %@ again. Messages sent in the meantime will not appear here";
+
+"content.system.new_device" = "a new device";
+"content.system.started_using" = "started using";
+"content.system.is_verified" = "All fingerprints are verified";
+
+"content.system.unverified" = "%@ unverified one of %@"; //example "You unverified one of Jule's devices"
+"content.system.your_devices" = "your devices";
+"content.system.other_devices" = "%@'s devices";
+
+"content.system.missing_messages.title" = "You haven't used this device for a while. Some messages may not appear here.";
+"content.system.missing_messages.subtitle_start" = "Meanwhile,";
+
+"content.system.cannot_decrypt" = "A message from %@ was not received.";
+
+"content.system.cannot_decrypt.you_part" = "you";
+"content.system.cannot_decrypt.why_part" = "Why?";
+
+"content.system.cannot_decrypt.identity" = "%@ device identity changed. Undelivered message.";
+"content.system.cannot_decrypt.identity.you_part" = "Your";
+"content.system.cannot_decrypt.identity.otherUser_part" = "%@'s"; // posessive apostrophe - might differ in different languages
+"content.system.cannot_decrypt.identity.why_part" = "Learn More";
+
+"content.file.uploading" = "Uploading…";
+"content.file.downloading" = "Downloading…";
+"content.file.upload_failed" = "Upload failed";
+"content.file.upload_cancelled" = "Upload cancelled";
+"content.file.upload_video" = "Videos";
+"content.file.take_video" = "Record a video";
+
+"content.file.save_video" = "Save";
+"content.file.save_audio" = "Save";
+"content.image.save_image" = "Save";
+
+"content.message.delete" = "Delete";
+
+"content.message.like" = "Like";
+"content.message.unlike" = "Unlike";
+
+"content.reactions_list.likers" = "Liked by";
+
+"content.file.too_big" = "You can send files up to %@";
+// Someone pinged
+"content.ping.text" = "%1$@ PINGED";
+
+// Current user pinged
+"content.ping.you.text" = "YOU PINGED";
+
+// Inline Player
+"content.player.unable_to_play" = "UNABLE TO PLAY TRACK";
+
+// Connecting (NEW IMPLEMENTATION, REVIEW LATER)
+"connection_request.title" = "Connect to %@"; //check UPPERCASE implementation in code
+"missive.connection_request.default_message" = "Hi %@,\nLet’s connect on Wire.\n%@";
+
+"connection_request.send_button_title" = "Connect";
+"inbox.connection_request.connect_button_title" = "Connect";
+"inbox.connection_request.ignore_button_title" = "Ignore";
+
+// Voice
+"voice.status.one_to_one.incoming" = "%@\nCalling";
+"voice.status.group_call.incoming" = "%@\nRinging";
+"voice.status.one_to_one.outgoing" = "%@\nRinging";
+"voice.status.joining" = "%@\nConnecting";
+"voice.status.video_not_available" = "Video turned off";
+"voice.status.low_connection" = "Bad connection";
+"voice.network_error.title" = "No Internet Connection";
+"voice.network_error.body" = "You must be online to call. Check your connection and try again.";
+"voice.alert.call_in_progress.title" = "Call in progress";
+"voice.alert.call_in_progress.message" = "Another of your devices is already participating in the call";
+"voice.alert.call_in_progress.confirm" = "Ok";
+"voice.accept_button.title" = "Accept";
+"voice.decline_button.title" = "Decline";
+"voice.hang_up_button.title" = "Hang Up";
+"voice.mute_button.title" = "Mute";
+"voice.video_button.title" = "Video";
+"voice.speaker_button.title" = "Speaker";
+
+"voice.alert.microphone_warning.title" = "Wire needs access to the Microphone.";
+"voice.alert.microphone_warning.explanation" = "Enable it in Wire Settings.";
+
+"voice.alert.camera_warning.title" = "Wire needs access to the Camera.";
+"voice.alert.camera_warning.explanation" = "Go to Settings and allow Wire to access the camera.";
+
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++
+// Profile and Participants
+
+"participants.add_people_button_title" = "Add people";
+
+// Meta Menu
+"meta.menu.rename" = "Rename";
+"meta.menu.leave" = "Leave";
+"meta.menu.archive" = "Archive";
+"meta.menu.unarchive" = "Unarchive";
+"meta.menu.delete" = "Delete";
+"meta.menu.silence.mute" = "Mute";
+"meta.menu.silence.unmute" = "Unmute";
+"meta.menu.cancel" = "Cancel";
+"meta.menu.cancel_connection_request" = "Cancel Request";
+
+// Delete conversation
+"meta.menu.delete_content.dialog_title" = "Delete content?";
+"meta.menu.delete_content.dialog_message" = "This will clear the conversation history and remove it from the list.";
+"meta.menu.delete_content.leave_as_well_message" = "Also leave the conversation";
+"meta.menu.delete_content.button_cancel" = "Cancel";
+"meta.menu.delete_content.button_delete" = "Delete";
+
+// Leave conversation
+"meta.leave_conversation_dialog_title" = "Leave conversation?";
+"meta.leave_conversation_dialog_message" = "The participants will be notified and the conversation will be removed from your list.";
+"meta.leave_conversation.delete_content_as_well_message" = "Also delete the content";
+"meta.leave_conversation_button_cancel" = "Cancel";
+"meta.leave_conversation_button_leave" = "Leave";
+
+// Conversation Degraded (security level lowered)
+"meta.degraded.degradation_reason_message.singular" = "%@ started using a new device.";
+"meta.degraded.degradation_reason_message.plural" = "%@ started using new devices.";
+"meta.degraded.dialog_message" = "Do you still want to send your message?";
+"meta.degraded.show_device_button" = "Show device";
+"meta.degraded.send_anyway_button" = "Send anyway";
+
+// Remove from conversation dialogue
+"profile.remove_dialog_title" = "Remove?";
+"profile.remove_dialog_message" = "%@ won’t be able to send or receive messages in this conversation.";
+"profile.remove_dialog_button_cancel" = "Cancel";
+"profile.remove_dialog_button_remove" = "Remove";
+
+// Block dialog
+"profile.block_dialog.title" = "Block?";
+"profile.block_dialog.message" = "%@ won’t be able to find or contact you on Wire.";
+"profile.block_dialog.button_cancel" = "Cancel";
+"profile.block_dialog.button_block" = "Block";
+
+// Delete message dialog
+"message.delete_dialog.message" = "This cannot be undone.";
+"message.delete_dialog.action.cancel" = "Cancel";
+"message.delete_dialog.action.hide" = "Delete for Me";
+"message.delete_dialog.action.delete" = "Delete for Everyone";
+
+// Edit message
+"message.menu.edit.title" = "Edit";
+
+// Accept connection request
+"profile.connection_request_dialog.title" = "Accept?";
+"profile.connection_request_dialog.message" = "This will connect you and open the conversation with %@.";
+"profile.connection_request_dialog.button_cancel" = "Ignore";
+"profile.connection_request_dialog.button_connect" = "Connect";
+
+// Cancel connection request
+"profile.cancel_connection_request_dialog.title" = "Cancel Request?";
+"profile.cancel_connection_request_dialog.message" = "Remove connection request to %@.";
+"profile.cancel_connection_request_dialog.button_no" = "No";
+"profile.cancel_connection_request_dialog.button_yes" = "Yes";
+
+// Unblock button
+"profile.unblock_button_title" = "Unblock";
+
+"profile.cancel_connection_button_title" = "CANCEL REQUEST";
+"profile.connection_request_state.blocked" = "BLOCKED";
+"profile.create_conversation_button_title" = "Create group";
+"profile.open_conversation_button_title" = "Open conversation";
+
+// User Details
+"profile.details.title" = "Details";
+
+// Device list
+"profile.devices.title" = "Devices";
+"profile.devices.fingerprint_message_unencrypted" = "%@ is using an old version of Wire. No devices are shown here.";
+"profile.devices.fingerprint_message" = "Wire gives every device a unique fingerprint. Compare them with %@ and verify your conversation. Why verify conversations?";
+"profile.devices.fingerprint_message.link" = "Why verify conversations?";
+
+// Device detail
+"profile.devices.detail.verify_message" = "Verify that this matches the fingerprint shown on %@'s device.";
+"profile.devices.detail.verify_message.link" = "How do I do that?";
+"profile.devices.detail.show_my_device.title" = "Show my device fingerprint";
+"device.verified" = "Verified";
+"device.not_verified" = "Not Verified";
+"device.class.desktop" = "Desktop";
+"device.class.tablet" = "Tablet";
+"device.class.phone" = "Phone";
+"profile.devices.detail.reset_session.title" = "Reset Session";
+
+// General strings
+"general.confirm" = "OK";
+
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++
+// Self profile
+
+// Options menu contents
+"self.settings" = "Settings";
+"self.help_center" = "Support";
+"self.help_center.support_website" = "Wire Support Website";
+"self.help_center.contact_support" = "Contact Support";
+"self.about" = "About";
+"self.sign_out" = "Log Out";
+"self.report_abuse" = "Report Misuse";
+
+"self.add_phone_number" = "Add phone number";
+"self.add_email_password" = "Add email address and password";
+
+// About screen
+"about.tos.title"="Terms of Use";
+"about.privacy.title"="Privacy Policy";
+"about.license.title" = "License Information";
+"about.website.title"="Wire Website";
+"about.copyright.title"="© Wire Swiss GmbH";
+
+// Self new devices
+"self.new_device_alert.title" = "You have connected %@ to your Wire account";
+"self.new_device_alert.title_prefix.tablet" = "a tablet";
+"self.new_device_alert.title_prefix.phone" = "a phone";
+"self.new_device_alert.title_prefix.devices" = "%d devices";
+"self.new_device_alert.message" = "%@\n\nIf you didn’t do this, remove the device and reset your password.";
+"self.new_device_alert.message_plural" = "%@\n\nIf you didn’t do this, remove those devices and reset your password.";
+"self.new_device_alert.manage_devices" = "Manage devices";
+"self.new_device_alert.trust_devices" = "OK";
+
+// Settings - Account details
+"self.settings.account_section" = "Account";
+
+"self.settings.account_details_group.title" = "Info";
+
+"self.settings.account_section.name.title" = "Name";
+"self.settings.account_section.email.title" = "Email";
+"self.settings.account_section.phone.title" = "Phone";
+
+"self.settings.account_details_group.footer" = "People can find you with these details.";
+
+"self.settings.account_details.remove_device.title" = "Remove Device";
+"self.settings.account_details.key_fingerprint.title" = "Key Fingerprint";
+"self.settings.account_details.remove_device.message" = "Your password is required to remove the device";
+"self.settings.account_details.remove_device.password" = "Password";
+"self.settings.account_details.remove_device.password.error" = "Wrong password";
+
+"self.settings.account_appearance_group.title" = "Appearance";
+"self.settings.account_picture_group.picture" = "Picture";
+"self.settings.account_picture_group.color" = "Color";
+
+"self.settings.account_picture_group.theme" = "Dark Theme";
+
+"self.settings.device_details.fingerprint.subtitle" = "Wire gives every device a unique fingerprint. Compare them and verify your devices and conversations.";
+"self.settings.device_details.reset_session.subtitle" = "If fingerprints don’t match, reset the session to generate new encryption keys on both sides.";
+"self.settings.device_details.remove_device.subtitle" = "Remove this device if you have stopped using it. Your message history will be erased and you will be logged out.";
+"self.settings.device_details.reset_session.success" = "The session has been reset";
+
+"self.settings.account_details.actions.title" = "Actions";
+
+"self.settings.account_details.delete_account.title" = "Delete Account";
+
+"self.settings.account_details.delete_account.alert.title" = "Delete Account";
+"self.settings.account_details.delete_account.alert.message" = "We will send you a message via email or SMS. Follow the link to permanently delete your account.";
+
+
+// Chat alerts
+"self.settings.notifications.push_notification.title" = "Notifications";
+"self.settings.notifications.push_notification.toogle" = "Message Previews";
+"self.settings.notifications.push_notification.footer" = "Sender name and message on the lock screen and in Notification Center.";
+
+"self.settings.notifications.chat_alerts.toggle" = "Message Banners";
+"self.settings.notifications.chat_alerts.footer" = "New messages in other conversations.";
+
+"self.settings.sound_menu.sounds.title" = "Sounds";
+"self.settings.sound_menu.ringtone.title" = "Ringtone";
+"self.settings.sound_menu.message.title" = "Text Tone";
+"self.settings.sound_menu.ping.title" = "Ping";
+"self.settings.sound_menu.ringtones.title" = "Ringtones";
+"self.settings.sound_menu.sounds.wire_sound" = "Wire";
+
+"self.settings.sound_menu.sounds.wire_call" = "Wire Call";
+"self.settings.sound_menu.sounds.wire_message" = "Wire Message";
+"self.settings.sound_menu.sounds.wire_ping" = "Wire Ping";
+
+// By popular demand
+"self.settings.popular_demand.title" = "By popular demand";
+"self.settings.popular_demand.send_button.title" = "Send Button";
+"self.settings.popular_demand.send_button.footer" = "Disable to send via the return key.";
+
+// Sound alerts (TO BE UPDPATED)
+"self.settings.sound_menu.title" = "Sound Alerts";
+"self.settings.sound_menu.no_sounds.title" = "None";
+"self.settings.sound_menu.all_sounds.title" = "All";
+"self.settings.sound_menu.mute_while_talking.title" = "First message, pings, calls";
+
+// Developer options
+"self.settings.developer_options.title" = "Developer Options";
+"self.settings.apns_logging.title" = "APNS Logging";
+
+// Privacy (visibility) options
+"self.settings.options_menu.title" = "Options";
+
+"self.settings.privacy_contacts_section.title" = "Contacts";
+"self.settings.privacy_contacts_menu.settings_button.title" = "Open Contacts Settings";
+"self.settings.privacy_contacts_menu.description_disabled.title" = "This helps you connect with others. We anonymize all the information and do not share it with anyone else. Allow access via Settings > Privacy > Contacts.";
+
+"self.settings.privacy_analytics_menu.devices.title" = "Devices";
+
+"self.settings.privacy_analytics_section.title" = "Usage and Crash Reports";
+"self.settings.privacy_analytics_menu.description.title" = "Make Wire better by sending anonymous information.\n";
+
+"self.settings.privacy.clear_history.title" = "Clear History";
+"self.settings.privacy.clear_history.subtitle" = "This will permanently erase the content of all your conversations.";
+
+"self.settings.advanced.title" = "Advanced";
+"self.settings.advanced.troubleshooting.title" = "Troubleshooting";
+"self.settings.advanced.troubleshooting.submit_debug.title" = "Calling Debug Report";
+"self.settings.advanced.troubleshooting.submit_debug.subtitle" = "This information helps Wire Support diagnose calling problems.";
+"self.settings.advanced.reset_push_token.title" = "Reset Push Notifications Token";
+"self.settings.advanced.reset_push_token.subtitle" = "If you experience problems with push notifications, Wire Support may ask you to reset this token.";
+"self.settings.advanced.reset_push_token_alert.title" = "Push token has been reset";
+"self.settings.advanced.reset_push_token_alert.message" = "Notifications will be restored in a few seconds.";
+"self.settings.advanced.version_technical_details.title" = "Version Technical Details";
+
+// Technical Report
+"self.settings.technical_report_section.title" = "Technical Report";
+"self.settings.technical_report.send_report" = "Send report to Wire";
+"self.settings.technical_report.mail.recipient" = "callingsupport@wire.com";
+"self.settings.technical_report.mail.subject" = "Wire Calling Report";
+"self.settings.technical_report.include_log" = "Include detailed log";
+
+// Password reset
+"self.settings.password_reset_menu.title" = "Reset Password";
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++
+// System status
+"system_status_bar.no_internet.title" = "No Internet";
+"system_status_bar.no_internet.explanation" = "There seems to be a problem with your Internet connection. Please make sure it’s working.";
+"system_status_bar.poor_connectivity.title" = "Slow Internet, can’t call now";
+"system_status_bar.poor_connectivity.explanation" = "We can’t guarantee voice quality. Connect to Wi-Fi or try changing your location.";
+
+// Common connections on profile view
+"profile_other.common_connections" = "You both know";
+
+// View user profile and options menu
+"name.placeholder" = "Your full name";
+"name.guidance.tooshort" = "At least 2 characters";
+"name.guidance.toolong" = "Too many characters";
+
+"email.placeholder" = "Email";
+
+"password.placeholder" = "Password";
+"password.guidance.tooshort" = "At least 8 characters";
+"password.guidance.toolong" = "Too many characters";
+
+"registration.title" = "Registration";
+"registration.close_email_invitation_button.email_title" = "Use another email";
+"registration.close_email_invitation_button.phone_title" = "Register by phone";
+"registration.close_phone_invitation_button.email_title" = "Register by email";
+"registration.close_phone_invitation_button.phone_title" = "Use another phone";
+
+"registration.enter_phone_number.title" = "Edit phone number";
+"registration.enter_phone_number.placeholder" = "Phone number";
+
+"registration.verify_phone_number.instructions" = "Enter the verification code we sent to %@";
+"registration.verify_phone_number.resend" = "Resend";
+"registration.verify_phone_number.resend_placeholder" = "No code showing up?\nYou can request a new one in %.0f seconds";
+
+"registration.verify_email.instructions" = "We sent an email to %@.\n Follow the link to verify your address.";
+"registration.verify_email.resend.instructions" = "Didn't get the message?";
+"registration.verify_email.resend.button_title" = "Re-send";
+
+"registration.select_picture.subtitle" = "Wire is so much nicer with a picture.";
+"registration.select_picture.button_title" = "Choose your own";
+"registration.keep_picture.button_title" = "Keep this one";
+"registration.camera_action.title" = "Take photo";
+"registration.photo_gallery_action.title" = "Choose Photo";
+"registration.cancel_action.title" = "Cancel";
+
+"registration.no_history.hero" = "It’s the first time you’re using Wire on this device.";
+"registration.no_history.subtitle" = "For privacy reasons, your conversation history will not appear here.";
+"registration.no_history.got_it" = "OK";
+
+"registration.no_history.logged_out.hero" = "You've used Wire on this device before.";
+"registration.no_history.logged_out.subtitle" = "Messages sent in the meantime will not appear.";
+"registration.no_history.logged_out.got_it" = "OK";
+
+"registration.enter_name.title" = "Edit Name";
+"registration.enter_name.hero" = "What should we call you?";
+"registration.enter_name.placeholder" = "Your full name";
+
+"registration.terms_of_use.title" = "Welcome to Wire.";
+"registration.terms_of_use.terms" = "By continuing you agree to the Wire Terms of Use.";
+"registration.terms_of_use.terms.link" = "Terms of Use";
+"registration.terms_of_use.agree" = "I agree";
+
+"registration.email_flow.title" = "Register by Email";
+"registration.email_flow.email_step.title" = "Edit Details";
+
+"registration.country_select.title" = "Country";
+
+"registration.share_contacts.hero.title" = "Find people on Wire";
+"registration.share_contacts.hero.paragraph"  = "Share your contacts so we can connect you with others. We anonymize all information and do not share it with anyone else.";
+"registration.share_contacts.find_friends_button.title" = "Share contacts";
+"registration.share_contacts.skip_button.title" = "Not now";
+
+"registration.address_book_access_denied.hero.title" = "Wire does not have access to your contacts.";
+"registration.address_book_access_denied.hero.paragraph1" = "Wire helps find your friends if you share your contacts.";
+"registration.address_book_access_denied.hero.paragraph2" = "To enable access tap Settings and turn on Contacts.";
+"registration.address_book_access_denied.settings_button.title" = "Settings";
+"registration.address_book_access_denied.maybe_later_button.title" = "Maybe later";
+
+"registration.push_access_denied.hero.title" = "Never miss a call or a message.";
+"registration.push_access_denied.hero.paragraph1" = "Enable Notifications in Settings.";
+"registration.push_access_denied.settings_button.title" = "Go to Settings";
+"registration.push_access_denied.maybe_later_button.title" = "Maybe later";
+
+"registration.signin.title" = "Log In";
+"registration.signin.too_many_devices.title" = "";
+"registration.signin.too_many_devices.subtitle" = "Remove one of your other devices to start using Wire on this one.";
+"registration.signin.too_many_devices.manage_button.title" = "Manage devices";
+"registration.signin.too_many_devices.sign_out_button.title" = "Log out";
+"registration.signin.email_button.title" = "Email";
+"registration.signin.phone_button.title" = "Phone";
+
+"registration.devices.title" = "Devices";
+"registration.devices.active_list_header" = "Active";
+"registration.devices.current_list_header" = "Current";
+"registration.devices.active_list_subtitle" = "If you don’t recognize a device above, remove it and reset your password.";
+"registration.devices.activated_in" = "Activated in";
+"registration.devices.id" = "ID:";
+
+"signin.forgot_password" = "Forgot password?";
+
+"registration.add_phone_number.hero.title" = "Add phone number";
+"registration.add_phone_number.hero.paragraph" = "This helps us find people you may know. We never share it.";
+"registration.add_phone_number.skip_button.title" = "Not now";
+
+"registration.add_email_password.hero.title" = "Add your email and password.";
+"registration.add_email_password.hero.paragraph" = "This lets you use Wire on multiple devices.";
+
+"registration.email_invitation.title" = "Invitation";
+"registration.email_invitation.hero.title" = "Hello, %@";
+"registration.email_invitation.hero.paragraph" = "Choose a password to create your account.";
+
+"registration.phone_invitation.title" = "Invitation";
+"registration.phone_invitation.hero.title" = "Hello, %@";
+"registration.phone_invitation.hero.paragraph" = "You are one step away from creating your account.";
+
+"error.name_and_email" = "Please enter your full name and a valid email address";
+"error.full_name" = "Please enter your full name";
+"error.email" = "Please enter a valid email address";
+"error.input.too_long" = "Input too long";
+"error.input.too_short" = "Input too short";
+"error.email.invalid" = "Please enter a valid email address";
+"error.phone.invalid" = "Please enter a valid phone number";
+
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++
+// ZMUserSessionErrorCode mapping. Used during registration and profile edit
+"error.user.unkown_error" = "Something went wrong, please try again";
+"error.user.needs_credentials" = "Please verify your details and try again.";
+"error.user.invalid_credentials" = "Please verify your details and try again.";
+"error.user.account_pending_activation" = "The account you are trying access is pending activation. Please verify your details.";
+"error.user.network_error" = "There seems to be a problem with your network. Please try again later.";
+"error.user.email_is_taken" = "The email address you provided has already been registered. Please try again.";
+"error.user.phone_is_taken" = "The phone number you provided has already been registered. Please try again.";
+"error.user.phone_code_invalid" = "Please enter a valid code";
+"error.user.phone_code_too_many" = "We already sent you a code via SMS. Tap Resend after 10 minutes to get a new one.";
+"error.user.registration_unknown_error" = "Something went wrong. Please try again.";
+"error.user.device_deleted_remotely" = "You have been logged out from another device.";
+
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++
+// Those are caught by the UI without involving the SE validation. Basically very similar to ZMUserSessionErrorCode onces
+"error.updating_password" = "Couldn't update your password.";
+
+"error.group_call.too_many_members_in_conversation.title" = "Too many people to call";
+"error.group_call.too_many_members_in_conversation" = "Calls work in conversations with up to %d people.";
+"error.group_call.too_many_participants_in_the_call.title" = "The call is full";
+"error.group_call.too_many_participants_in_the_call" = "There’s only room for %d people in here.";
+"error.call.gsm_ongoing.title" = "Cellular call";
+"error.call.gsm_ongoing" = "Please cancel the cellular call before calling on Wire.";
+"error.call.general.title" = "Call error";
+"error.call.general" = "Please try calling again in several minutes.";
+"error.call.slow_connection.title" = "Slow connection";
+"error.call.slow_connection" = "You might experience issues during the call";
+"error.call.slow_connection.call_anyway" = "Call anyway";
+
+"error.invite.no_email_provider" = "Please configure your email client to be able to send the invites via email";
+"error.invite.no_messaging_provider" = "Please configure your SMS to be able to send the invites via SMS";
+
+"sketchpad.initial_hint" = "Tap color to change brush size\nPress and hold to fill an area\nShake to remove a photo";
+
+"migration.please_wait_message" = "One moment, please";
+
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++
+// Those are used by the backend to localize APNS
+"push.notification.new_user" = "%@ joined Wire";
+"push.notification.new_message" = "New message";
+
+
+//Force Update
+"force.update.title" = "Update necessary";
+"force.update.message" = "You are missing out on new features.\nGet the latest version of Wire in the App Store.";
+"force.update.ok_button" = "Go to App Store";
+
+// Third Party
+"giphy.conversation.message" = "%@ · via giphy.com";
+"giphy.conversation.random_message" = "via giphy.com";
+"giphy.error.no_more_results" = "no more gifs";
+"giphy.error.no_result" = "no gif found";
+
+"giphy.confirm" = "send";
+"giphy.cancel" = "cancel";
+"giphy.search_placeholder" = "Search giphy";
+
+"invite_banner.title" = "Bring your friends to Wire!";
+"invite_banner.message" = "Enjoy calls, messages, sketches, GIFs and more in private or with groups.";
+"invite_banner.invite_button_title" = "Invite more people";

--- a/Wire-iOS/Resources/nl.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/nl.lproj/Localizable.strings
@@ -1,386 +1,386 @@
-//
+// 
 // Wire
 // Copyright (C) 2016 Wire Swiss GmbH
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
 
 "general.ok" = "OK";
-"general.cancel" = "Cancel";
-"general.open_settings" = "Open Wire Settings";
+"general.cancel" = "Anuleer";
+"general.open_settings" = "Open Wire Instellingen";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // People picker/start UI
-"peoplepicker.search_placeholder" = "Search by name or email";
-"peoplepicker.header.top_people" = "Top people";
-"peoplepicker.button.create_conversation" = "Create group";
-"peoplepicker.button.add_to_conversation" = "Add";
-"peoplepicker.header.conversations" = "Groups";
-"peoplepicker.header.send_invitation" = "Invite";
-"peoplepicker.header.contacts" = "Connections";
-"peoplepicker.header.directory" = "Connect";
-"peoplepicker.title.create_conversation" = "Create group";
-"peoplepicker.title.add_to_conversation" = "Add people";
+"peoplepicker.search_placeholder" = "Op naam of email adres zoeken";
+"peoplepicker.header.top_people" = "Frequente personen";
+"peoplepicker.button.create_conversation" = "Groep creëren";
+"peoplepicker.button.add_to_conversation" = "Toevoegen";
+"peoplepicker.header.conversations" = "Groepen";
+"peoplepicker.header.send_invitation" = "Uitnodigen";
+"peoplepicker.header.contacts" = "Verbindingen";
+"peoplepicker.header.directory" = "Verbind";
+"peoplepicker.title.create_conversation" = "Groep creëren";
+"peoplepicker.title.add_to_conversation" = "Mensen toevoegen";
 
-"peoplepicker.no_contacts_title" = "No Contacts.";
+"peoplepicker.no_contacts_title" = "Geen contacten";
 
-"peoplepicker.no_matching_results_title" = "No results.";
-"peoplepicker.no_matching_results_message" = "Enter a full email address.";
+"peoplepicker.no_matching_results_title" = "Geen resultaten";
+"peoplepicker.no_matching_results_message" = "Email adres invoegen";
 
-"peoplepicker.no_matching_results.action.send_invite" = "Send an invitation";
-"peoplepicker.no_matching_results.action.share_contacts" = "Share contacts";
+"peoplepicker.no_matching_results.action.send_invite" = "Uitnodiging sturen";
+"peoplepicker.no_matching_results.action.share_contacts" = "Contacten delen";
 
-"peoplepicker.no_matching_results_provide_valid_email" = "Please enter a valid email address";
-"peoplepicker.no_matching_results_after_address_book_upload_title" = "No results.";
+"peoplepicker.no_matching_results_provide_valid_email" = "Geldige email adres invoegen a.u.b.";
+"peoplepicker.no_matching_results_after_address_book_upload_title" = "Geen resultaten";
 /* This sentence ends with button title, contained in peoplepicker.no_matching_results_after_address_book_upload_button */
-"peoplepicker.no_matching_results_after_address_book_upload_message" = "Enter a full email address or";
+"peoplepicker.no_matching_results_after_address_book_upload_message" = "Email adres invoegen of";
 /*  */
-"peoplepicker.no_matching_results_after_address_book_upload_button" = "share contacts";
+"peoplepicker.no_matching_results_after_address_book_upload_button" = "Contacten delen";
 
-"peoplepicker.share_contacts.no_results.title" = "Find people by name or email address";
+"peoplepicker.share_contacts.no_results.title" = "Zoek personen op naam of op email adres";
 
-"peoplepicker.send_invitation.dialog.title" = "Invitation sent";
-"peoplepicker.send_invitation.dialog.message" = "It can be used for 2 weeks. Send a new one if it expires.";
+"peoplepicker.send_invitation.dialog.title" = "Uitnodiging verstuurd";
+"peoplepicker.send_invitation.dialog.message" = "Het kan gebruikt worden voor 2 weken. Stuur een nieuwe als het verlopen is.";
 "peoplepicker.send_invitation.dialog.ok" = "OK";
 
-"peoplepicker.invite_more_people" = "Invite more people";
-"peoplepicker.quick-action.open-conversation" = "Open";
-"peoplepicker.quick-action.create-conversation" = "Create group";
+"peoplepicker.invite_more_people" = "Nodig meer mensen uit";
+"peoplepicker.quick-action.open-conversation" = "Openen";
+"peoplepicker.quick-action.create-conversation" = "Groep creëren";
 
 // Contacts UI
-"contacts_ui.search_placeholder" = "Search by name";
-"contacts_ui.invite_others" = "Invite others";
-"contacts_ui.name_in_contacts" = "%@ in address book";
-"contacts_ui.connection_request" = "Requested to connect";
-"contacts_ui.action_button.invite" = "Invite";
-"contacts_ui.action_button.open" = "Open";
-"contacts_ui.invite_sheet.cancel_button_title" = "Cancel";
-"contacts_ui.notification.invitation_sent" = "Invitation sent";
-"contacts_ui.notification.invitation_failed" = "Failed to send invitation";
-"contacts_ui.title" = "Invite people";
+"contacts_ui.search_placeholder" = "Zoeken op naam";
+"contacts_ui.invite_others" = "Nodig anderen uit";
+"contacts_ui.name_in_contacts" = "%@ in contacten";
+"contacts_ui.connection_request" = "Vraag om een verbinding te maken";
+"contacts_ui.action_button.invite" = "Uitnodigen";
+"contacts_ui.action_button.open" = "Openen";
+"contacts_ui.invite_sheet.cancel_button_title" = "Anuleer";
+"contacts_ui.notification.invitation_sent" = "Uitnodiging verstuurd";
+"contacts_ui.notification.invitation_failed" = "Het is mislukt de uitnodiging te versturen";
+"contacts_ui.title" = "Nodig anderen uit";
 
-"contacts_ui.no_contact.title" = "No active conversations\n";
-"contacts_ui.no_contact.message" = "Tap contacts to start a conversation";
+"contacts_ui.no_contact.title" = "Geen actieve gesprekken\n";
+"contacts_ui.no_contact.message" = "Druk op contacten om een gesprek te beginnen";
 
 // Conversation List Bottom Bar
-"bottom_bar.contacts_button.title" = "contacts";
+"bottom_bar.contacts_button.title" = "contacten";
 
 // Archived List
-"archived_list.title" = "archive";
+"archived_list.title" = "archiefeer";
 
 // Add contact tool tip
-"tool_tip.contacts.title" = "Conversations start here";
-"tool_tip.contacts.message" = "Start a conversation or invite more people to join. Call, message and share in private or with groups.";
+"tool_tip.contacts.title" = "Gesprekken beginnen hier";
+"tool_tip.contacts.message" = "Begin een nieuw gesprek of invite meer mensen. Bel, chat en deel in privé of groep gesprekken.";
 
 // "Knows" subtitle in cell: "Knows Indrek", "Knows Indrek and Jane", "Knows Indrek and 5 others"
-"peoplepicker.suggested.knows_one" = "Knows %@";
-"peoplepicker.suggested.knows_two" = "Knows %@ and %@";
-"peoplepicker.hide_search_result" = "Hide";
-"peoplepicker.hide_search_result_progress" = "Hiding…";
+"peoplepicker.suggested.knows_one" = "Kent %@";
+"peoplepicker.suggested.knows_two" = "Kent %@ en %@";
+"peoplepicker.hide_search_result" = "Verberg";
+"peoplepicker.hide_search_result_progress" = "Verbergen…";
 
-"send_invitation.subject" = "Connect with me on Wire";
-"send_invitation.text" = "I’m on Wire. Search for %@\nor visit https://get.wire.com to connect with me.";
-"send_invitation_no_email.text" = "I’m on Wire. Visit https://get.wire.com to connect with me.";
+"send_invitation.subject" = "Verbind met mij op Wire";
+"send_invitation.text" = "Ik ben op Wire. Zoek voor %@ \nof bezoek https://get.wire.com om met mij te verbinden.";
+"send_invitation_no_email.text" = "Ik ben op Wire. Bezoek https://get.wire.com om met mij te verbinden.";
 
-"send_personal_invitation.text" = "I’m on Wire, talk to you there. https://get.wire.com";
+"send_personal_invitation.text" = "Ik ben op Wire, praat met mij daar. https://get.wire.com";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++x
 // In-app notifications (chat heads)
-"notifications.shared_a_photo" = "shared a picture";
+"notifications.shared_a_photo" = "deelde een foto";
 "notifications.pinged" = "pinged";
-"notifications.sent_file" = "shared a file";
-"notifications.sent_location" = "shared a location";
-"notifications.sent_video" = "shared a video";
-"notifications.sent_audio" = "shared an audio";
+"notifications.sent_file" = "deelde een bestand";
+"notifications.sent_location" = "deelde een locatie";
+"notifications.sent_video" = "deelde een video";
+"notifications.sent_audio" = "deelde een audio bestand";
 "notifications.in_conversation" = "%@ - %@";
-"notifications.this_conversation" = "%@ in this conversation";
+"notifications.this_conversation" = "%@ in dit gesprek";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // List (labels) - Needs to be revised with updated guidance
-"list.archived_conversations" = "ARCHIVE";
-"list.archived_conversations_close" = "Close archive";
+"list.archived_conversations" = "ARCHIEF";
+"list.archived_conversations_close" = "Archief sluiten";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Conversation
-"conversation.invite_more_people.title" = "Spread the word!";
-"conversation.invite_more_people.description" = "Add people to this conversation";
+"conversation.invite_more_people.title" = "Deel het met de wereld!";
+"conversation.invite_more_people.description" = "Voeg mensen toe tot gesprek";
 "conversation.invite_more_people.explanation_url" = "https://support.wire.com";
-"conversation.invite_more_people.button_title" = "Add People";
+"conversation.invite_more_people.button_title" = "Mensen toevoegen";
 
 // Conversation names
-"conversation.displayname.emptygroup" = "Empty group conversation";
+"conversation.displayname.emptygroup" = "Leeg groep gesprek";
 
-"conversation.input_bar.verified" = "Verified";
-"conversation.input_bar.placeholder" = "Type a message";
+"conversation.input_bar.verified" = "Geverifieerd";
+"conversation.input_bar.placeholder" = "Typ een bericht";
 
-"conversation.input_bar.audio_message.tooltip.pull_send" = "Swipe up to send";
-"conversation.input_bar.audio_message.tooltip.tap_send" = "Tap to send";
-"conversation.input_bar.audio_message.too_long.title" = "Recording Stopped";
-"conversation.input_bar.audio_message.too_long.message" = "Audio messages are limited to %@. Send this message?";
-"conversation.input_bar.audio_message.send" = "Send";
+"conversation.input_bar.audio_message.tooltip.pull_send" = "Swipe omhoog om te versturen";
+"conversation.input_bar.audio_message.tooltip.tap_send" = "Tik om te verzenden";
+"conversation.input_bar.audio_message.too_long.title" = "Opname gestopt";
+"conversation.input_bar.audio_message.too_long.message" = "Audio berichten zijn gelimmiteert tot %@. Dit berichtje versturen?";
+"conversation.input_bar.audio_message.send" = "Stuur";
 
-"conversation.input_bar.audio_message.keyboard.record_tip" = "Tap to record\nYou can  %@  it after that";
-"conversation.input_bar.audio_message.keyboard.filter_tip" = "Choose a filter above";
+"conversation.input_bar.audio_message.keyboard.record_tip" = "Tap om op te nemen\nJe kan hier na %@";
+"conversation.input_bar.audio_message.keyboard.filter_tip" = "Kies een filter hier boven";
 
 // Image confirmation dialogue
 "image_confirmer.confirm" = "OK";
-"image_confirmer.cancel" = "Cancel";
-"image.add_sketch" = "Add a sketch";
-"image.edit_image" = "Edit image";
+"image_confirmer.cancel" = "Anuleer";
+"image.add_sketch" = "Voeg een tekening toe";
+"image.edit_image" = "Bewerk afbeelding";
 
 // Camera access
-"camera_access.denied" = "Wire needs access to the Camera.";
+"camera_access.denied" = "Wire heeft toegang nodig tot de camera.";
 "camera_access.denied.instruction" = "";
-"camera_access.denied.open_settings" = "Enable it in Wire Settings";
+"camera_access.denied.open_settings" = "Zet hem aan in Wire instellingen";
 
 // Camera Controls
-"camera_controls.aeaf_lock" = "AE/AF Lock";
+"camera_controls.aeaf_lock" = "AE/AF vergrendeling";
 
 // Location
-"location.send_button.title" = "Send";
-"location.unauthorized_alert.title" = "Enable Location Services";
-"location.unauthorized_alert.message" = "To send your location, enable Location Services and allow Wire to access your location.";
-"location.unauthorized_alert.cancel" = "Cancel";
-"location.unauthorized_alert.settings" = "Settings";
+"location.send_button.title" = "Stuur";
+"location.unauthorized_alert.title" = "Zet locatie services aan";
+"location.unauthorized_alert.message" = "Om je locatie te versturen, heeft Wire toegang nodig tot de locatie service. Ga naar settings en geef Wire toegang tot je locatie.";
+"location.unauthorized_alert.cancel" = "Anuleer";
+"location.unauthorized_alert.settings" = "Instellingen";
 
 // Twitter
-"twitter_status.on_twitter" = "%@ on Twitter";
+"twitter_status.on_twitter" = "%@ op Twitter";
 
 // System messages
-"content.system.continued_conversation" = "Start a conversation with %@";
+"content.system.continued_conversation" = "Begin een gesprek met %@";
 
-"content.system.other_started_conversation" = "%@ started a conversation with %@";
-"content.system.you_started_conversation" = "You started a conversation with %@";
+"content.system.other_started_conversation" = "%@ begon een gesprek met %@";
+"content.system.you_started_conversation" = "Jij begon het gesprek met %@";
 
-"content.system.you_added_participant" = "You added %@";
-"content.system.other_added_participant" = "%@ added %@";
-"content.system.other_added_you" = "%@ added you";
+"content.system.you_added_participant" = "Je hebt %@ toegevoegd";
+"content.system.other_added_participant" = "%@ heeft %@ toegevoegd";
+"content.system.other_added_you" = "%@ heeft jou toegevoegd";
 
-"content.system.participants_you" = "You";
-"content.system.participants_1_other" = "%@ and %@";
-"content.system.other_left" = "%@ left";
-"content.system.you_left" = "You left";
-"content.system.other_removed_other" = "%@ removed %@";
-"content.system.other_removed_you" = "%@ removed you";
-"content.system.you_removed_other" = "You removed %@";
-"content.system.other_renamed_conv" = "%@ renamed the conversation";
-"content.system.you_renamed_conv" = "You renamed the conversation";
-"content.system.other_renamed_conv_to_nothing" = "%@ removed the conversation name";
-"content.system.you_renamed_conv_to_nothing" = "You removed the conversation name";
-"content.system.pending_message_timestamp" = "Sending…";
-"content.system.message_sent_timestamp" = "Sent";
-"content.system.message_delivered_timestamp" = "Delivered";
-"content.system.failedtosend_message_timestamp" = "Sending failed.";
-"content.system.failedtosend_message_timestamp_resend" = "Resend";
-"content.system.like_tooltip" = "Tap to like";
-"content.system.deleted_message_prefix_timestamp" = "Deleted on %@";
-"content.system.edited_message_prefix_timestamp" = "Edited on %@";
-"content.system.connecting_to" = "Connecting to %@.\nStart a conversation";
-"content.system.connected_to" = "Connected to %@\nStart a conversation";
-"content.system.other_wanted_to_talk" = "%@ called";
-"content.system.you_wanted_to_talk" = "You called";
+"content.system.participants_you" = "Jij";
+"content.system.participants_1_other" = "%@ en %@";
+"content.system.other_left" = "%@ verliet";
+"content.system.you_left" = "Jij verliet";
+"content.system.other_removed_other" = "%@ verwijderde %@";
+"content.system.other_removed_you" = "%@ verwijderde jou";
+"content.system.you_removed_other" = "Jij verwijderde %@";
+"content.system.other_renamed_conv" = "%@ hernoemde het gesprek";
+"content.system.you_renamed_conv" = "Je hebt de conversatie hernoemt";
+"content.system.other_renamed_conv_to_nothing" = "%@ verwijderde de naam van de conversatie";
+"content.system.you_renamed_conv_to_nothing" = "Je verwijderde de naam van de conversatie";
+"content.system.pending_message_timestamp" = "Verzenden…";
+"content.system.message_sent_timestamp" = "Verstuurd";
+"content.system.message_delivered_timestamp" = "Afgeleverd";
+"content.system.failedtosend_message_timestamp" = "Verzenden mislukt.";
+"content.system.failedtosend_message_timestamp_resend" = "Opnieuw sturen";
+"content.system.like_tooltip" = "Tap om te liken";
+"content.system.deleted_message_prefix_timestamp" = "Verwijderd op %@";
+"content.system.edited_message_prefix_timestamp" = "Gewijzigd op %@";
+"content.system.connecting_to" = "Verbinden met %@.\nBegin een gesprek";
+"content.system.connected_to" = "Verbinden met %@.\nBegin een gesprek";
+"content.system.other_wanted_to_talk" = "%@ belde";
+"content.system.you_wanted_to_talk" = "Jij belde";
 
-"content.system.you_started" = "You";
-"content.system.this_device" = "this device";
+"content.system.you_started" = "Jij";
+"content.system.this_device" = "dit apparaat";
 
-"content.system.reactivated_device" = "You started using %@ again. Messages sent in the meantime will not appear here";
+"content.system.reactivated_device" = "Jij begon weer %@ gebruiken. Berichten die al verzonden zijn worden hier niet getoond";
 
-"content.system.new_device" = "a new device";
-"content.system.started_using" = "started using";
-"content.system.is_verified" = "All fingerprints are verified";
+"content.system.new_device" = "een nieuw apparaat";
+"content.system.started_using" = "begin gebruiken";
+"content.system.is_verified" = "Alle vingerafdrukken zijn geverifieerd";
 
-"content.system.unverified" = "%@ unverified one of %@"; //example "You unverified one of Jule's devices"
-"content.system.your_devices" = "your devices";
-"content.system.other_devices" = "%@'s devices";
+"content.system.unverified" = "%@ unverified een van %@"; // example "You unverified one of Jule's devices"
+"content.system.your_devices" = "jou apparaten";
+"content.system.other_devices" = "%@'s apparaten";
 
-"content.system.missing_messages.title" = "You haven't used this device for a while. Some messages may not appear here.";
-"content.system.missing_messages.subtitle_start" = "Meanwhile,";
+"content.system.missing_messages.title" = "Je hebt dit apparaat voor een poosje niet gebruikt. Sommige berichten worden hier niet getoond.";
+"content.system.missing_messages.subtitle_start" = "Tijdens,";
 
-"content.system.cannot_decrypt" = "A message from %@ was not received.";
+"content.system.cannot_decrypt" = "Het bericht van %@ was niet ontvangen.";
 
-"content.system.cannot_decrypt.you_part" = "you";
-"content.system.cannot_decrypt.why_part" = "Why?";
+"content.system.cannot_decrypt.you_part" = "jij";
+"content.system.cannot_decrypt.why_part" = "Waarom?";
 
-"content.system.cannot_decrypt.identity" = "%@ device identity changed. Undelivered message.";
-"content.system.cannot_decrypt.identity.you_part" = "Your";
+"content.system.cannot_decrypt.identity" = "%@ apparaat indentiteit is verandert. Het bericht is niet afgeleverd.";
+"content.system.cannot_decrypt.identity.you_part" = "Jou";
 "content.system.cannot_decrypt.identity.otherUser_part" = "%@'s"; // posessive apostrophe - might differ in different languages
-"content.system.cannot_decrypt.identity.why_part" = "Learn More";
+"content.system.cannot_decrypt.identity.why_part" = "Leer meer";
 
-"content.file.uploading" = "Uploading…";
-"content.file.downloading" = "Downloading…";
-"content.file.upload_failed" = "Upload failed";
-"content.file.upload_cancelled" = "Upload cancelled";
-"content.file.upload_video" = "Videos";
-"content.file.take_video" = "Record a video";
+"content.file.uploading" = "Uploaden…";
+"content.file.downloading" = "Downloaden…";
+"content.file.upload_failed" = "Upload mislukt";
+"content.file.upload_cancelled" = "Upload gecanceld";
+"content.file.upload_video" = "Video's";
+"content.file.take_video" = "Neem een video op";
 
-"content.file.save_video" = "Save";
-"content.file.save_audio" = "Save";
-"content.image.save_image" = "Save";
+"content.file.save_video" = "Opslaan";
+"content.file.save_audio" = "Opslaan";
+"content.image.save_image" = "Opslaan";
 
-"content.message.delete" = "Delete";
+"content.message.delete" = "Verwijderen";
 
-"content.message.like" = "Like";
-"content.message.unlike" = "Unlike";
+"content.message.like" = "Vind ik leuk";
+"content.message.unlike" = "Vind ik niet leuk";
 
-"content.reactions_list.likers" = "Liked by";
+"content.reactions_list.likers" = "Leuk gevonden door";
 
-"content.file.too_big" = "You can send files up to %@";
+"content.file.too_big" = "U kunt bestanden versturen tot %@";
 // Someone pinged
 "content.ping.text" = "%1$@ PINGED";
 
 // Current user pinged
-"content.ping.you.text" = "YOU PINGED";
+"content.ping.you.text" = "JIJ PINGDE";
 
 // Inline Player
-"content.player.unable_to_play" = "UNABLE TO PLAY TRACK";
+"content.player.unable_to_play" = "NIET MOGELIJK OM AF TE SPELEN";
 
 // Connecting (NEW IMPLEMENTATION, REVIEW LATER)
-"connection_request.title" = "Connect to %@"; //check UPPERCASE implementation in code
-"missive.connection_request.default_message" = "Hi %@,\nLet’s connect on Wire.\n%@";
+"connection_request.title" = "Verbind met %@"; // check UPPERCASE implementation in code
+"missive.connection_request.default_message" = "Hallo %@, \nLaten we chatten via Wire.\n%@";
 
-"connection_request.send_button_title" = "Connect";
-"inbox.connection_request.connect_button_title" = "Connect";
-"inbox.connection_request.ignore_button_title" = "Ignore";
+"connection_request.send_button_title" = "Verbind";
+"inbox.connection_request.connect_button_title" = "Verbind";
+"inbox.connection_request.ignore_button_title" = "Negeer";
 
 // Voice
-"voice.status.one_to_one.incoming" = "%@\nCalling";
-"voice.status.group_call.incoming" = "%@\nRinging";
-"voice.status.one_to_one.outgoing" = "%@\nRinging";
-"voice.status.joining" = "%@\nConnecting";
-"voice.status.video_not_available" = "Video turned off";
-"voice.status.low_connection" = "Bad connection";
-"voice.network_error.title" = "No Internet Connection";
-"voice.network_error.body" = "You must be online to call. Check your connection and try again.";
-"voice.alert.call_in_progress.title" = "Call in progress";
-"voice.alert.call_in_progress.message" = "Another of your devices is already participating in the call";
+"voice.status.one_to_one.incoming" = "%@ belt";
+"voice.status.group_call.incoming" = "%@\nbellen";
+"voice.status.one_to_one.outgoing" = "%@\nbellen";
+"voice.status.joining" = "%@ Verbinden";
+"voice.status.video_not_available" = "Video is uit";
+"voice.status.low_connection" = "Slechte connectie";
+"voice.network_error.title" = "Geen internet connectie";
+"voice.network_error.body" = "Je moet online zijn om te bellen. Controleer je connectie en probeer opnieuw.";
+"voice.alert.call_in_progress.title" = "Bezig met bellen";
+"voice.alert.call_in_progress.message" = "Een van je andere apparaten heeft de oproep al beantwoord";
 "voice.alert.call_in_progress.confirm" = "Ok";
-"voice.accept_button.title" = "Accept";
-"voice.decline_button.title" = "Decline";
-"voice.hang_up_button.title" = "Hang Up";
-"voice.mute_button.title" = "Mute";
+"voice.accept_button.title" = "Neem op";
+"voice.decline_button.title" = "Leg op";
+"voice.hang_up_button.title" = "Ophangen";
+"voice.mute_button.title" = "Dempen";
 "voice.video_button.title" = "Video";
-"voice.speaker_button.title" = "Speaker";
+"voice.speaker_button.title" = "Luidspreker";
 
-"voice.alert.microphone_warning.title" = "Wire needs access to the Microphone.";
-"voice.alert.microphone_warning.explanation" = "Enable it in Wire Settings.";
+"voice.alert.microphone_warning.title" = "Wire heeft toegang nodig tot de microfoon.";
+"voice.alert.microphone_warning.explanation" = "Zet hem aan in Wire instellingen.";
 
-"voice.alert.camera_warning.title" = "Wire needs access to the Camera.";
-"voice.alert.camera_warning.explanation" = "Go to Settings and allow Wire to access the camera.";
+"voice.alert.camera_warning.title" = "Wire heeft toegang nodig tot de camera.";
+"voice.alert.camera_warning.explanation" = "Ga naar Settings en sta Wire toe tot de camera.";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Profile and Participants
 
-"participants.add_people_button_title" = "Add people";
+"participants.add_people_button_title" = "Mensen toevoegen";
 
 // Meta Menu
-"meta.menu.rename" = "Rename";
-"meta.menu.leave" = "Leave";
-"meta.menu.archive" = "Archive";
-"meta.menu.unarchive" = "Unarchive";
-"meta.menu.delete" = "Delete";
-"meta.menu.silence.mute" = "Mute";
-"meta.menu.silence.unmute" = "Unmute";
-"meta.menu.cancel" = "Cancel";
-"meta.menu.cancel_connection_request" = "Cancel Request";
+"meta.menu.rename" = "Wijzig naam";
+"meta.menu.leave" = "Verlaten";
+"meta.menu.archive" = "Archiveren";
+"meta.menu.unarchive" = "Terugzetten";
+"meta.menu.delete" = "Verwijderen";
+"meta.menu.silence.mute" = "Dempen";
+"meta.menu.silence.unmute" = "Dempen opheffen";
+"meta.menu.cancel" = "Anuleer";
+"meta.menu.cancel_connection_request" = "Annuleer verzoek";
 
 // Delete conversation
-"meta.menu.delete_content.dialog_title" = "Delete content?";
-"meta.menu.delete_content.dialog_message" = "This will clear the conversation history and remove it from the list.";
-"meta.menu.delete_content.leave_as_well_message" = "Also leave the conversation";
-"meta.menu.delete_content.button_cancel" = "Cancel";
-"meta.menu.delete_content.button_delete" = "Delete";
+"meta.menu.delete_content.dialog_title" = "Inhoud verwijderen?";
+"meta.menu.delete_content.dialog_message" = "Dit verwijdert de gespreksgeschiedenis en verwijdert het van de lijst.";
+"meta.menu.delete_content.leave_as_well_message" = "Ook het gesprek verlaten";
+"meta.menu.delete_content.button_cancel" = "Anuleer";
+"meta.menu.delete_content.button_delete" = "Verwijderen";
 
 // Leave conversation
-"meta.leave_conversation_dialog_title" = "Leave conversation?";
-"meta.leave_conversation_dialog_message" = "The participants will be notified and the conversation will be removed from your list.";
-"meta.leave_conversation.delete_content_as_well_message" = "Also delete the content";
-"meta.leave_conversation_button_cancel" = "Cancel";
-"meta.leave_conversation_button_leave" = "Leave";
+"meta.leave_conversation_dialog_title" = "Gesprek verlaten?";
+"meta.leave_conversation_dialog_message" = "De deelnemers ontvangen een notificatie en het gesprek wordt uit je lijst verwijderd.";
+"meta.leave_conversation.delete_content_as_well_message" = "Verwijder content ook";
+"meta.leave_conversation_button_cancel" = "Anuleer";
+"meta.leave_conversation_button_leave" = "Verlaten";
 
 // Conversation Degraded (security level lowered)
-"meta.degraded.degradation_reason_message.singular" = "%@ started using a new device.";
-"meta.degraded.degradation_reason_message.plural" = "%@ started using new devices.";
-"meta.degraded.dialog_message" = "Do you still want to send your message?";
-"meta.degraded.show_device_button" = "Show device";
-"meta.degraded.send_anyway_button" = "Send anyway";
+"meta.degraded.degradation_reason_message.singular" = "%@ begon een nieuw apparaat te gebruiken.";
+"meta.degraded.degradation_reason_message.plural" = "%@ begon een nieuw apparaat te gebruiken.";
+"meta.degraded.dialog_message" = "Wil jet het bericht nog steeds versturen?";
+"meta.degraded.show_device_button" = "Toon apparaat";
+"meta.degraded.send_anyway_button" = "Toch verzenden";
 
 // Remove from conversation dialogue
-"profile.remove_dialog_title" = "Remove?";
-"profile.remove_dialog_message" = "%@ won’t be able to send or receive messages in this conversation.";
-"profile.remove_dialog_button_cancel" = "Cancel";
-"profile.remove_dialog_button_remove" = "Remove";
+"profile.remove_dialog_title" = "Verwijder?";
+"profile.remove_dialog_message" = "%@ kan geen berichten versturen of ontvangen in dit gesprek.";
+"profile.remove_dialog_button_cancel" = "Anuleer";
+"profile.remove_dialog_button_remove" = "Verwijderen";
 
 // Block dialog
-"profile.block_dialog.title" = "Block?";
-"profile.block_dialog.message" = "%@ won’t be able to find or contact you on Wire.";
-"profile.block_dialog.button_cancel" = "Cancel";
-"profile.block_dialog.button_block" = "Block";
+"profile.block_dialog.title" = "Blokken?";
+"profile.block_dialog.message" = "%@ kan je niet meer vinden of berichten sturen op Wire.";
+"profile.block_dialog.button_cancel" = "Anuleer";
+"profile.block_dialog.button_block" = "Blok";
 
 // Delete message dialog
-"message.delete_dialog.message" = "This cannot be undone.";
-"message.delete_dialog.action.cancel" = "Cancel";
-"message.delete_dialog.action.hide" = "Delete for Me";
-"message.delete_dialog.action.delete" = "Delete for Everyone";
+"message.delete_dialog.message" = "Dit kan niet ongedaan gemaakt worden.";
+"message.delete_dialog.action.cancel" = "Anuleer";
+"message.delete_dialog.action.hide" = "Verwijderen voor mij";
+"message.delete_dialog.action.delete" = "Verwijderen voor iedereen";
 
 // Edit message
-"message.menu.edit.title" = "Edit";
+"message.menu.edit.title" = "Bewerken";
 
 // Accept connection request
-"profile.connection_request_dialog.title" = "Accept?";
-"profile.connection_request_dialog.message" = "This will connect you and open the conversation with %@.";
-"profile.connection_request_dialog.button_cancel" = "Ignore";
-"profile.connection_request_dialog.button_connect" = "Connect";
+"profile.connection_request_dialog.title" = "Accepteer?";
+"profile.connection_request_dialog.message" = "Dit zal u verbinden en het gesprek openen met %@.";
+"profile.connection_request_dialog.button_cancel" = "Negeer";
+"profile.connection_request_dialog.button_connect" = "Verbind";
 
 // Cancel connection request
-"profile.cancel_connection_request_dialog.title" = "Cancel Request?";
-"profile.cancel_connection_request_dialog.message" = "Remove connection request to %@.";
-"profile.cancel_connection_request_dialog.button_no" = "No";
-"profile.cancel_connection_request_dialog.button_yes" = "Yes";
+"profile.cancel_connection_request_dialog.title" = "Verzoek annuleren?";
+"profile.cancel_connection_request_dialog.message" = "Verwijder verzoek aan %@.";
+"profile.cancel_connection_request_dialog.button_no" = "Nee";
+"profile.cancel_connection_request_dialog.button_yes" = "Ja";
 
 // Unblock button
-"profile.unblock_button_title" = "Unblock";
+"profile.unblock_button_title" = "Deblokkeer";
 
-"profile.cancel_connection_button_title" = "CANCEL REQUEST";
-"profile.connection_request_state.blocked" = "BLOCKED";
-"profile.create_conversation_button_title" = "Create group";
-"profile.open_conversation_button_title" = "Open conversation";
+"profile.cancel_connection_button_title" = "VERZOEK ANNULEREN";
+"profile.connection_request_state.blocked" = "GEBLOKKEERD";
+"profile.create_conversation_button_title" = "Groep creëren";
+"profile.open_conversation_button_title" = "Open gesprek";
 
 // User Details
-"profile.details.title" = "Details";
+"profile.details.title" = "Beschrijving";
 
 // Device list
-"profile.devices.title" = "Devices";
-"profile.devices.fingerprint_message_unencrypted" = "%@ is using an old version of Wire. No devices are shown here.";
-"profile.devices.fingerprint_message" = "Wire gives every device a unique fingerprint. Compare them with %@ and verify your conversation. Why verify conversations?";
-"profile.devices.fingerprint_message.link" = "Why verify conversations?";
+"profile.devices.title" = "Apparaten";
+"profile.devices.fingerprint_message_unencrypted" = "%@ gebruikt een oude versie van Wire. Er worden daarom geen apparaten getoond.";
+"profile.devices.fingerprint_message" = "Wire geeft elk apparaat een eigen vingerafdruk. Vergelijk deze met %@ en verifieer je apparaten en gesprekken. Waarom gesprekken verifiëren?";
+"profile.devices.fingerprint_message.link" = "Waarom gesprekken verifiëren?";
 
 // Device detail
-"profile.devices.detail.verify_message" = "Verify that this matches the fingerprint shown on %@'s device.";
-"profile.devices.detail.verify_message.link" = "How do I do that?";
-"profile.devices.detail.show_my_device.title" = "Show my device fingerprint";
-"device.verified" = "Verified";
-"device.not_verified" = "Not Verified";
+"profile.devices.detail.verify_message" = "Verifieer dat deze digitale vingerafdruk overeenkomt met %@'s zijn apparaat.";
+"profile.devices.detail.verify_message.link" = "Hoe doe ik dat?";
+"profile.devices.detail.show_my_device.title" = "Toon de digitale vingerafdruk van mijn apparaat";
+"device.verified" = "Geverifieerd";
+"device.not_verified" = "Niet geverifieerd";
 "device.class.desktop" = "Desktop";
 "device.class.tablet" = "Tablet";
-"device.class.phone" = "Phone";
-"profile.devices.detail.reset_session.title" = "Reset Session";
+"device.class.phone" = "Telefoonnummer";
+"profile.devices.detail.reset_session.title" = "Reset session";
 
 // General strings
 "general.confirm" = "OK";
@@ -388,325 +388,325 @@
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Self profile
-
 // Options menu contents
-"self.settings" = "Settings";
-"self.help_center" = "Support";
+
+"self.settings" = "Instellingen";
+"self.help_center" = "Ondersteuning";
 "self.help_center.support_website" = "Wire Support Website";
 "self.help_center.contact_support" = "Contact Support";
-"self.about" = "About";
-"self.sign_out" = "Log Out";
-"self.report_abuse" = "Report Misuse";
+"self.about" = "Over ons";
+"self.sign_out" = "Afmelden";
+"self.report_abuse" = "Misbruik melden";
 
-"self.add_phone_number" = "Add phone number";
-"self.add_email_password" = "Add email address and password";
+"self.add_phone_number" = "Voeg telefoon nummer toe";
+"self.add_email_password" = "E-mailadres en wachtwoord toevoegen";
 
 // About screen
-"about.tos.title"="Terms of Use";
-"about.privacy.title"="Privacy Policy";
-"about.license.title" = "License Information";
-"about.website.title"="Wire Website";
-"about.copyright.title"="© Wire Swiss GmbH";
+"about.tos.title" = "Gebruikersvoorwaarden";
+"about.privacy.title" = "Privacy Beleid";
+"about.license.title" = "Licentie-informatie";
+"about.website.title" = "Wire Website";
+"about.copyright.title" = "© Wire Swiss GmbH";
 
 // Self new devices
-"self.new_device_alert.title" = "You have connected %@ to your Wire account";
-"self.new_device_alert.title_prefix.tablet" = "a tablet";
-"self.new_device_alert.title_prefix.phone" = "a phone";
-"self.new_device_alert.title_prefix.devices" = "%d devices";
-"self.new_device_alert.message" = "%@\n\nIf you didn’t do this, remove the device and reset your password.";
-"self.new_device_alert.message_plural" = "%@\n\nIf you didn’t do this, remove those devices and reset your password.";
-"self.new_device_alert.manage_devices" = "Manage devices";
+"self.new_device_alert.title" = "Je hebt %@ verbonden tot je Wire account";
+"self.new_device_alert.title_prefix.tablet" = "een tablet";
+"self.new_device_alert.title_prefix.phone" = "een telefoon";
+"self.new_device_alert.title_prefix.devices" = "%d apparaten";
+"self.new_device_alert.message" = "%@\n\nAls je dit niet zelf was, verwijder dan het apparaat en stel je wachtwoord opnieuw in.";
+"self.new_device_alert.message_plural" = "%@\n\nAls je dit niet zelf was, verwijder dan deze apparaaten en stel je wachtwoord opnieuw in.";
+"self.new_device_alert.manage_devices" = "Beheer apparaten";
 "self.new_device_alert.trust_devices" = "OK";
 
 // Settings - Account details
-"self.settings.account_section" = "Account";
+"self.settings.account_section" = "Profiel";
 
 "self.settings.account_details_group.title" = "Info";
 
-"self.settings.account_section.name.title" = "Name";
-"self.settings.account_section.email.title" = "Email";
-"self.settings.account_section.phone.title" = "Phone";
+"self.settings.account_section.name.title" = "Naam";
+"self.settings.account_section.email.title" = "E-mail";
+"self.settings.account_section.phone.title" = "Telefoonnummer";
 
-"self.settings.account_details_group.footer" = "People can find you with these details.";
+"self.settings.account_details_group.footer" = "Mensen kunnen mij vinden met deze gegevens.";
 
-"self.settings.account_details.remove_device.title" = "Remove Device";
-"self.settings.account_details.key_fingerprint.title" = "Key Fingerprint";
-"self.settings.account_details.remove_device.message" = "Your password is required to remove the device";
-"self.settings.account_details.remove_device.password" = "Password";
-"self.settings.account_details.remove_device.password.error" = "Wrong password";
+"self.settings.account_details.remove_device.title" = "Verwijder apparaat";
+"self.settings.account_details.key_fingerprint.title" = "Digitale vingerafdruk";
+"self.settings.account_details.remove_device.message" = "Je wachtwoord is nodig om dit apparaat te verwijderen";
+"self.settings.account_details.remove_device.password" = "Wachtwoord";
+"self.settings.account_details.remove_device.password.error" = "Verkeerd wachtwoord";
 
-"self.settings.account_appearance_group.title" = "Appearance";
-"self.settings.account_picture_group.picture" = "Picture";
-"self.settings.account_picture_group.color" = "Color";
+"self.settings.account_appearance_group.title" = "Vormgeving";
+"self.settings.account_picture_group.picture" = "Foto";
+"self.settings.account_picture_group.color" = "Kleur";
 
-"self.settings.account_picture_group.theme" = "Dark Theme";
+"self.settings.account_picture_group.theme" = "Donker thema";
 
-"self.settings.device_details.fingerprint.subtitle" = "Wire gives every device a unique fingerprint. Compare them and verify your devices and conversations.";
-"self.settings.device_details.reset_session.subtitle" = "If fingerprints don’t match, reset the session to generate new encryption keys on both sides.";
-"self.settings.device_details.remove_device.subtitle" = "Remove this device if you have stopped using it. Your message history will be erased and you will be logged out.";
-"self.settings.device_details.reset_session.success" = "The session has been reset";
+"self.settings.device_details.fingerprint.subtitle" = "Wire geeft elk apparaat een eigen vingerafdruk. Vergelijk deze en verifieer je apparaten en gesprekken.";
+"self.settings.device_details.reset_session.subtitle" = "Wanner de digitale vingerprint niet klopt, reset de sessie om nieuwe encryptie sleutels aan te maken op beide apparaten.";
+"self.settings.device_details.remove_device.subtitle" = "Verwijder dit apparaat als je gestopt bent met het gebruiken ervan. Je berichten geschiedenis word verwijdert en je word uitgelogd.";
+"self.settings.device_details.reset_session.success" = "De sessie is gereset";
 
-"self.settings.account_details.actions.title" = "Actions";
+"self.settings.account_details.actions.title" = "Acties";
 
-"self.settings.account_details.delete_account.title" = "Delete Account";
+"self.settings.account_details.delete_account.title" = "Verwijder account";
 
-"self.settings.account_details.delete_account.alert.title" = "Delete Account";
-"self.settings.account_details.delete_account.alert.message" = "We will send you a message via email or SMS. Follow the link to permanently delete your account.";
+"self.settings.account_details.delete_account.alert.title" = "Verwijder account";
+"self.settings.account_details.delete_account.alert.message" = "We vesturen je een bericht via email of SMS. Volg de instructies op in de link om je account te verwijderen.";
 
 
 // Chat alerts
-"self.settings.notifications.push_notification.title" = "Notifications";
-"self.settings.notifications.push_notification.toogle" = "Message Previews";
-"self.settings.notifications.push_notification.footer" = "Sender name and message on the lock screen and in Notification Center.";
+"self.settings.notifications.push_notification.title" = "Meldingen";
+"self.settings.notifications.push_notification.toogle" = "Toon voorvertoning";
+"self.settings.notifications.push_notification.footer" = "Zender naam en het bericht op het lock screen en in het notificatie center.";
 
-"self.settings.notifications.chat_alerts.toggle" = "Message Banners";
-"self.settings.notifications.chat_alerts.footer" = "New messages in other conversations.";
+"self.settings.notifications.chat_alerts.toggle" = "Bericht banners";
+"self.settings.notifications.chat_alerts.footer" = "Nieuw bericht in andere gesprekken.";
 
-"self.settings.sound_menu.sounds.title" = "Sounds";
-"self.settings.sound_menu.ringtone.title" = "Ringtone";
-"self.settings.sound_menu.message.title" = "Text Tone";
+"self.settings.sound_menu.sounds.title" = "Geluiden";
+"self.settings.sound_menu.ringtone.title" = "Beltoon";
+"self.settings.sound_menu.message.title" = "Tekst geluid";
 "self.settings.sound_menu.ping.title" = "Ping";
-"self.settings.sound_menu.ringtones.title" = "Ringtones";
+"self.settings.sound_menu.ringtones.title" = "Beltonen";
 "self.settings.sound_menu.sounds.wire_sound" = "Wire";
 
-"self.settings.sound_menu.sounds.wire_call" = "Wire Call";
-"self.settings.sound_menu.sounds.wire_message" = "Wire Message";
-"self.settings.sound_menu.sounds.wire_ping" = "Wire Ping";
+"self.settings.sound_menu.sounds.wire_call" = "Wire oproep";
+"self.settings.sound_menu.sounds.wire_message" = "Wire berichten";
+"self.settings.sound_menu.sounds.wire_ping" = "Wire ping";
 
 // By popular demand
-"self.settings.popular_demand.title" = "By popular demand";
-"self.settings.popular_demand.send_button.title" = "Send Button";
-"self.settings.popular_demand.send_button.footer" = "Disable to send via the return key.";
+"self.settings.popular_demand.title" = "Op populariteit";
+"self.settings.popular_demand.send_button.title" = "Verstuur knop";
+"self.settings.popular_demand.send_button.footer" = "Zet het verstuur via 'enter' toets uit.";
 
 // Sound alerts (TO BE UPDPATED)
-"self.settings.sound_menu.title" = "Sound Alerts";
-"self.settings.sound_menu.no_sounds.title" = "None";
-"self.settings.sound_menu.all_sounds.title" = "All";
-"self.settings.sound_menu.mute_while_talking.title" = "First message, pings, calls";
+"self.settings.sound_menu.title" = "Alert geluiden";
+"self.settings.sound_menu.no_sounds.title" = "Geen";
+"self.settings.sound_menu.all_sounds.title" = "Alle";
+"self.settings.sound_menu.mute_while_talking.title" = "Eerste bericht, pings, oproepen";
 
 // Developer options
-"self.settings.developer_options.title" = "Developer Options";
-"self.settings.apns_logging.title" = "APNS Logging";
+"self.settings.developer_options.title" = "Ontwikkelaar Opties";
+"self.settings.apns_logging.title" = "APNS logging";
 
 // Privacy (visibility) options
-"self.settings.options_menu.title" = "Options";
+"self.settings.options_menu.title" = "Opties";
 
-"self.settings.privacy_contacts_section.title" = "Contacts";
-"self.settings.privacy_contacts_menu.settings_button.title" = "Open Contacts Settings";
-"self.settings.privacy_contacts_menu.description_disabled.title" = "This helps you connect with others. We anonymize all the information and do not share it with anyone else. Allow access via Settings > Privacy > Contacts.";
+"self.settings.privacy_contacts_section.title" = "Contacten";
+"self.settings.privacy_contacts_menu.settings_button.title" = "Open Contacten Instellingen";
+"self.settings.privacy_contacts_menu.description_disabled.title" = "Dit helpt je te verbinden met anderen. We anonimiseren alle informatie en delen dit nooit met iemand anders. Geef toegang via Instellingen > Privacy > Contacten.";
 
-"self.settings.privacy_analytics_menu.devices.title" = "Devices";
+"self.settings.privacy_analytics_menu.devices.title" = "Apparaten";
 
-"self.settings.privacy_analytics_section.title" = "Usage and Crash Reports";
-"self.settings.privacy_analytics_menu.description.title" = "Make Wire better by sending anonymous information.\n";
+"self.settings.privacy_analytics_section.title" = "Diagnose en gebruik";
+"self.settings.privacy_analytics_menu.description.title" = "Maak Wire beter door anoniem data te versturen.\n";
 
-"self.settings.privacy.clear_history.title" = "Clear History";
-"self.settings.privacy.clear_history.subtitle" = "This will permanently erase the content of all your conversations.";
+"self.settings.privacy.clear_history.title" = "Geschiedenis verwijderen";
+"self.settings.privacy.clear_history.subtitle" = "Dit verwijdert alle content van all je gesprekken.";
 
-"self.settings.advanced.title" = "Advanced";
-"self.settings.advanced.troubleshooting.title" = "Troubleshooting";
-"self.settings.advanced.troubleshooting.submit_debug.title" = "Calling Debug Report";
-"self.settings.advanced.troubleshooting.submit_debug.subtitle" = "This information helps Wire Support diagnose calling problems.";
-"self.settings.advanced.reset_push_token.title" = "Reset Push Notifications Token";
-"self.settings.advanced.reset_push_token.subtitle" = "If you experience problems with push notifications, Wire Support may ask you to reset this token.";
-"self.settings.advanced.reset_push_token_alert.title" = "Push token has been reset";
-"self.settings.advanced.reset_push_token_alert.message" = "Notifications will be restored in a few seconds.";
-"self.settings.advanced.version_technical_details.title" = "Version Technical Details";
+"self.settings.advanced.title" = "Geadvanceerd";
+"self.settings.advanced.troubleshooting.title" = "Probleemoplossing";
+"self.settings.advanced.troubleshooting.submit_debug.title" = "Fout report verzenden";
+"self.settings.advanced.troubleshooting.submit_debug.subtitle" = "Deze informatie helpt Wire support om bel problemen op te lossen.";
+"self.settings.advanced.reset_push_token.title" = "Herstel de Push Notifications Token";
+"self.settings.advanced.reset_push_token.subtitle" = "Als je problemen ondervind met push notificaties, Wire Support kan vragen om deze token te restten.";
+"self.settings.advanced.reset_push_token_alert.title" = "Push token is gereset";
+"self.settings.advanced.reset_push_token_alert.message" = "Notificaties zullen worden hersteld over een paar seconden.";
+"self.settings.advanced.version_technical_details.title" = "Technische versie details";
 
 // Technical Report
-"self.settings.technical_report_section.title" = "Technical Report";
-"self.settings.technical_report.send_report" = "Send report to Wire";
+"self.settings.technical_report_section.title" = "Technical report";
+"self.settings.technical_report.send_report" = "Stuur report naar Wire";
 "self.settings.technical_report.mail.recipient" = "callingsupport@wire.com";
-"self.settings.technical_report.mail.subject" = "Wire Calling Report";
-"self.settings.technical_report.include_log" = "Include detailed log";
+"self.settings.technical_report.mail.subject" = "Wire Bel report";
+"self.settings.technical_report.include_log" = "Voeg gedetailleerde log toe";
 
 // Password reset
-"self.settings.password_reset_menu.title" = "Reset Password";
+"self.settings.password_reset_menu.title" = "Wachtwoord Resetten";
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // System status
-"system_status_bar.no_internet.title" = "No Internet";
-"system_status_bar.no_internet.explanation" = "There seems to be a problem with your Internet connection. Please make sure it’s working.";
-"system_status_bar.poor_connectivity.title" = "Slow Internet, can’t call now";
-"system_status_bar.poor_connectivity.explanation" = "We can’t guarantee voice quality. Connect to Wi-Fi or try changing your location.";
+"system_status_bar.no_internet.title" = "Geen Internet";
+"system_status_bar.no_internet.explanation" = "Er lijkt een probleem te zijn met je internet connectie. Controller of deze werkt.";
+"system_status_bar.poor_connectivity.title" = "Traag internet, Je kan nu niet bellen";
+"system_status_bar.poor_connectivity.explanation" = "We kunnen je geen goede geluidskwaliteit garanderen. Verbind met WiFi of probeer je locatie te veranderen.";
 
 // Common connections on profile view
-"profile_other.common_connections" = "You both know";
+"profile_other.common_connections" = "Julie kennen allebei";
 
 // View user profile and options menu
-"name.placeholder" = "Your full name";
-"name.guidance.tooshort" = "At least 2 characters";
-"name.guidance.toolong" = "Too many characters";
+"name.placeholder" = "Je volledige naam";
+"name.guidance.tooshort" = "Ten minste 2 tekens";
+"name.guidance.toolong" = "Te veel tekens";
 
-"email.placeholder" = "Email";
+"email.placeholder" = "E-mail";
 
-"password.placeholder" = "Password";
-"password.guidance.tooshort" = "At least 8 characters";
-"password.guidance.toolong" = "Too many characters";
+"password.placeholder" = "Wachtwoord";
+"password.guidance.tooshort" = "Ten minste 8 tekens";
+"password.guidance.toolong" = "Te veel karakters";
 
-"registration.title" = "Registration";
-"registration.close_email_invitation_button.email_title" = "Use another email";
-"registration.close_email_invitation_button.phone_title" = "Register by phone";
-"registration.close_phone_invitation_button.email_title" = "Register by email";
-"registration.close_phone_invitation_button.phone_title" = "Use another phone";
+"registration.title" = "Registratie";
+"registration.close_email_invitation_button.email_title" = "Gebruik een ander email";
+"registration.close_email_invitation_button.phone_title" = "Registreer met telefoon";
+"registration.close_phone_invitation_button.email_title" = "Registreer met email";
+"registration.close_phone_invitation_button.phone_title" = "Gebruik een andere telefoon";
 
-"registration.enter_phone_number.title" = "Edit phone number";
-"registration.enter_phone_number.placeholder" = "Phone number";
+"registration.enter_phone_number.title" = "Bewerk telefoon nummer";
+"registration.enter_phone_number.placeholder" = "Telefoonnummer";
 
-"registration.verify_phone_number.instructions" = "Enter the verification code we sent to %@";
-"registration.verify_phone_number.resend" = "Resend";
-"registration.verify_phone_number.resend_placeholder" = "No code showing up?\nYou can request a new one in %.0f seconds";
+"registration.verify_phone_number.instructions" = "Voer de verificatiecode in die we naar %@";
+"registration.verify_phone_number.resend" = "Opnieuw sturen";
+"registration.verify_phone_number.resend_placeholder" = "Krijg je geen code? \nJe kan een nieuwe aanvragen in %.0f seconden";
 
-"registration.verify_email.instructions" = "We sent an email to %@.\n Follow the link to verify your address.";
-"registration.verify_email.resend.instructions" = "Didn't get the message?";
-"registration.verify_email.resend.button_title" = "Re-send";
+"registration.verify_email.instructions" = "We hebben je een email verstuurd naar %@.\nKlik op de link om je email adress te bevestigen.";
+"registration.verify_email.resend.instructions" = "Bericht niet ontvangen?";
+"registration.verify_email.resend.button_title" = "Verstuur opniew";
 
-"registration.select_picture.subtitle" = "Wire is so much nicer with a picture.";
-"registration.select_picture.button_title" = "Choose your own";
-"registration.keep_picture.button_title" = "Keep this one";
-"registration.camera_action.title" = "Take photo";
-"registration.photo_gallery_action.title" = "Choose Photo";
-"registration.cancel_action.title" = "Cancel";
+"registration.select_picture.subtitle" = "Wire is veel mooier met een foto.";
+"registration.select_picture.button_title" = "Kies je eigen";
+"registration.keep_picture.button_title" = "Behoud deze";
+"registration.camera_action.title" = "Maak een foto";
+"registration.photo_gallery_action.title" = "Kies een foto";
+"registration.cancel_action.title" = "Anuleer";
 
-"registration.no_history.hero" = "It’s the first time you’re using Wire on this device.";
-"registration.no_history.subtitle" = "For privacy reasons, your conversation history will not appear here.";
+"registration.no_history.hero" = "Het is de eerste keer dat je Wire op dit apparaat gebruikt.";
+"registration.no_history.subtitle" = "Om privacyredenen wordt je gespreksgeschiedenis hier niet getoond.";
 "registration.no_history.got_it" = "OK";
 
-"registration.no_history.logged_out.hero" = "You've used Wire on this device before.";
-"registration.no_history.logged_out.subtitle" = "Messages sent in the meantime will not appear.";
+"registration.no_history.logged_out.hero" = "Je hebt Wire eerder op dit apparaat gebruikt.";
+"registration.no_history.logged_out.subtitle" = "Berichten die in de tussentijd worden verzonden worden niet weergeven.";
 "registration.no_history.logged_out.got_it" = "OK";
 
-"registration.enter_name.title" = "Edit Name";
-"registration.enter_name.hero" = "What should we call you?";
-"registration.enter_name.placeholder" = "Your full name";
+"registration.enter_name.title" = "Wijzig Naam";
+"registration.enter_name.hero" = "Hoe zullen we je noemen?";
+"registration.enter_name.placeholder" = "Je volledige naam";
 
-"registration.terms_of_use.title" = "Welcome to Wire.";
-"registration.terms_of_use.terms" = "By continuing you agree to the Wire Terms of Use.";
-"registration.terms_of_use.terms.link" = "Terms of Use";
-"registration.terms_of_use.agree" = "I agree";
+"registration.terms_of_use.title" = "Welkom bij Wire.";
+"registration.terms_of_use.terms" = "Wanner je doorgaat accepteer je de voorwaarden van Wire.";
+"registration.terms_of_use.terms.link" = "Gebruikersvoorwaarden";
+"registration.terms_of_use.agree" = "Ik ga akkoord";
 
-"registration.email_flow.title" = "Register by Email";
-"registration.email_flow.email_step.title" = "Edit Details";
+"registration.email_flow.title" = "Registreer met email";
+"registration.email_flow.email_step.title" = "Details bewerken";
 
-"registration.country_select.title" = "Country";
+"registration.country_select.title" = "Land";
 
-"registration.share_contacts.hero.title" = "Find people on Wire";
-"registration.share_contacts.hero.paragraph"  = "Share your contacts so we can connect you with others. We anonymize all information and do not share it with anyone else.";
-"registration.share_contacts.find_friends_button.title" = "Share contacts";
-"registration.share_contacts.skip_button.title" = "Not now";
+"registration.share_contacts.hero.title" = "Vind mensen op Wire";
+"registration.share_contacts.hero.paragraph" = "Geef Wire toegang tot je contacten om je te verbinden met andere mensen. We anonimiseren de date an delen het met niemand anders.";
+"registration.share_contacts.find_friends_button.title" = "Contacten delen";
+"registration.share_contacts.skip_button.title" = "Niet nu";
 
-"registration.address_book_access_denied.hero.title" = "Wire does not have access to your contacts.";
-"registration.address_book_access_denied.hero.paragraph1" = "Wire helps find your friends if you share your contacts.";
-"registration.address_book_access_denied.hero.paragraph2" = "To enable access tap Settings and turn on Contacts.";
-"registration.address_book_access_denied.settings_button.title" = "Settings";
-"registration.address_book_access_denied.maybe_later_button.title" = "Maybe later";
+"registration.address_book_access_denied.hero.title" = "Wire heeft geen toegang tot je contacten.";
+"registration.address_book_access_denied.hero.paragraph1" = "Wire helpt je om je vrienden te vingen als je je contacten deelt.";
+"registration.address_book_access_denied.hero.paragraph2" = "Om toegang te geven ga naar settings en zet contacten aan.";
+"registration.address_book_access_denied.settings_button.title" = "Instellingen";
+"registration.address_book_access_denied.maybe_later_button.title" = "Misschien later";
 
-"registration.push_access_denied.hero.title" = "Never miss a call or a message.";
-"registration.push_access_denied.hero.paragraph1" = "Enable Notifications in Settings.";
-"registration.push_access_denied.settings_button.title" = "Go to Settings";
-"registration.push_access_denied.maybe_later_button.title" = "Maybe later";
+"registration.push_access_denied.hero.title" = "Geen gesprekken of berichten missen";
+"registration.push_access_denied.hero.paragraph1" = "Zet notificaties in in instellingen.";
+"registration.push_access_denied.settings_button.title" = "Ga naar Instellingen";
+"registration.push_access_denied.maybe_later_button.title" = "Misschien later";
 
-"registration.signin.title" = "Log In";
+"registration.signin.title" = "Inloggen";
 "registration.signin.too_many_devices.title" = "";
-"registration.signin.too_many_devices.subtitle" = "Remove one of your other devices to start using Wire on this one.";
-"registration.signin.too_many_devices.manage_button.title" = "Manage devices";
-"registration.signin.too_many_devices.sign_out_button.title" = "Log out";
-"registration.signin.email_button.title" = "Email";
-"registration.signin.phone_button.title" = "Phone";
+"registration.signin.too_many_devices.subtitle" = "Verwijder een van je andere apparaten om Wire op dit apparaat te gebruiken.";
+"registration.signin.too_many_devices.manage_button.title" = "Beheer apparaten";
+"registration.signin.too_many_devices.sign_out_button.title" = "Uitloggen";
+"registration.signin.email_button.title" = "E-mail";
+"registration.signin.phone_button.title" = "Telefoonnummer";
 
-"registration.devices.title" = "Devices";
-"registration.devices.active_list_header" = "Active";
-"registration.devices.current_list_header" = "Current";
-"registration.devices.active_list_subtitle" = "If you don’t recognize a device above, remove it and reset your password.";
-"registration.devices.activated_in" = "Activated in";
+"registration.devices.title" = "Apparaten";
+"registration.devices.active_list_header" = "Actief";
+"registration.devices.current_list_header" = "Huidig";
+"registration.devices.active_list_subtitle" = "Als je bovengenoemde apparaten niet kent, verwijder ze en reset je wachtwoord.";
+"registration.devices.activated_in" = "Geactiveerd in";
 "registration.devices.id" = "ID:";
 
-"signin.forgot_password" = "Forgot password?";
+"signin.forgot_password" = "Wachtwoord vergeten?";
 
-"registration.add_phone_number.hero.title" = "Add phone number";
-"registration.add_phone_number.hero.paragraph" = "This helps us find people you may know. We never share it.";
-"registration.add_phone_number.skip_button.title" = "Not now";
+"registration.add_phone_number.hero.title" = "Voeg telefoon nummer toe";
+"registration.add_phone_number.hero.paragraph" = "Dit helpt ons vinden mensen die u misschien kent. Wij delen deze gegevens nooit.";
+"registration.add_phone_number.skip_button.title" = "Niet nu";
 
-"registration.add_email_password.hero.title" = "Add your email and password.";
-"registration.add_email_password.hero.paragraph" = "This lets you use Wire on multiple devices.";
+"registration.add_email_password.hero.title" = "Voeg je email en wachtwoord toe.";
+"registration.add_email_password.hero.paragraph" = "Dit zorgt ervoor dat je Wire op meerdere apparaten kunt gebruiken.";
 
-"registration.email_invitation.title" = "Invitation";
-"registration.email_invitation.hero.title" = "Hello, %@";
-"registration.email_invitation.hero.paragraph" = "Choose a password to create your account.";
+"registration.email_invitation.title" = "Uitnodiging";
+"registration.email_invitation.hero.title" = "Hooi, %@";
+"registration.email_invitation.hero.paragraph" = "Kies een wachtwoord om je account aan te maken.";
 
-"registration.phone_invitation.title" = "Invitation";
-"registration.phone_invitation.hero.title" = "Hello, %@";
-"registration.phone_invitation.hero.paragraph" = "You are one step away from creating your account.";
+"registration.phone_invitation.title" = "Uitnodiging";
+"registration.phone_invitation.hero.title" = "Hooi, %@";
+"registration.phone_invitation.hero.paragraph" = "Je bent nog maar een stap verwijdert van het maken van je account.";
 
-"error.name_and_email" = "Please enter your full name and a valid email address";
-"error.full_name" = "Please enter your full name";
-"error.email" = "Please enter a valid email address";
-"error.input.too_long" = "Input too long";
-"error.input.too_short" = "Input too short";
-"error.email.invalid" = "Please enter a valid email address";
-"error.phone.invalid" = "Please enter a valid phone number";
+"error.name_and_email" = "Vul je naam en geldig mail adres in";
+"error.full_name" = "Vul je volle naam in alsjeblieft";
+"error.email" = "Geldige email adres invoegen a.u.b.";
+"error.input.too_long" = "Input is te lang";
+"error.input.too_short" = "Input is te kort";
+"error.email.invalid" = "Geldige email adres invoegen a.u.b.";
+"error.phone.invalid" = "Voer een geldig telefoonnummer in";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // ZMUserSessionErrorCode mapping. Used during registration and profile edit
-"error.user.unkown_error" = "Something went wrong, please try again";
-"error.user.needs_credentials" = "Please verify your details and try again.";
-"error.user.invalid_credentials" = "Please verify your details and try again.";
-"error.user.account_pending_activation" = "The account you are trying access is pending activation. Please verify your details.";
-"error.user.network_error" = "There seems to be a problem with your network. Please try again later.";
-"error.user.email_is_taken" = "The email address you provided has already been registered. Please try again.";
-"error.user.phone_is_taken" = "The phone number you provided has already been registered. Please try again.";
-"error.user.phone_code_invalid" = "Please enter a valid code";
-"error.user.phone_code_too_many" = "We already sent you a code via SMS. Tap Resend after 10 minutes to get a new one.";
-"error.user.registration_unknown_error" = "Something went wrong. Please try again.";
-"error.user.device_deleted_remotely" = "You have been logged out from another device.";
+"error.user.unkown_error" = "Er is een fout opgetreden, probeer het nogmaals";
+"error.user.needs_credentials" = "Controleer je gegevens en probeer het nog eens.";
+"error.user.invalid_credentials" = "Controleer je gegevens en probeer het nog eens.";
+"error.user.account_pending_activation" = "Het account dat je probeert te bereiken is nog niet geactiveerd. Verifieer je gegevens.";
+"error.user.network_error" = "Er lijkt een probleem te zijn met je netwerk. Probeer later opnieuw.";
+"error.user.email_is_taken" = "Dit email adres die jij gebruikt is al geregistreerd. Probeer opnieuw.";
+"error.user.phone_is_taken" = "Dit telefoonnummer die jij gebruikt is al geregistreerd. Probeer opnieuw.";
+"error.user.phone_code_invalid" = "Voer een geldige code in";
+"error.user.phone_code_too_many" = "We hebben je al een code via SMS verstuurd. Klik op Opnieuw sturen na 10 minuten om een nieuwe code te krijgen.";
+"error.user.registration_unknown_error" = "Er ging iets mis. Probeer het nog eens.";
+"error.user.device_deleted_remotely" = "Je bent uitgelogd door een ander apparaat.";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Those are caught by the UI without involving the SE validation. Basically very similar to ZMUserSessionErrorCode onces
-"error.updating_password" = "Couldn't update your password.";
+"error.updating_password" = "Je wachtwoord kon niet bijgewerkt worden.";
 
-"error.group_call.too_many_members_in_conversation.title" = "Too many people to call";
-"error.group_call.too_many_members_in_conversation" = "Calls work in conversations with up to %d people.";
-"error.group_call.too_many_participants_in_the_call.title" = "The call is full";
-"error.group_call.too_many_participants_in_the_call" = "There’s only room for %d people in here.";
-"error.call.gsm_ongoing.title" = "Cellular call";
-"error.call.gsm_ongoing" = "Please cancel the cellular call before calling on Wire.";
-"error.call.general.title" = "Call error";
-"error.call.general" = "Please try calling again in several minutes.";
-"error.call.slow_connection.title" = "Slow connection";
-"error.call.slow_connection" = "You might experience issues during the call";
-"error.call.slow_connection.call_anyway" = "Call anyway";
+"error.group_call.too_many_members_in_conversation.title" = "Te veel mensen om te bellen";
+"error.group_call.too_many_members_in_conversation" = "Bellen kan in gesprekken tot %d mensen.";
+"error.group_call.too_many_participants_in_the_call.title" = "De wachtrij is vol";
+"error.group_call.too_many_participants_in_the_call" = "Er is hier alleen plaats voor %d mensen.";
+"error.call.gsm_ongoing.title" = "Mobiel gesprek";
+"error.call.gsm_ongoing" = "Beëindig eerst je telefoon gesprek voordat je belt met Wire.";
+"error.call.general.title" = "Bel fout";
+"error.call.general" = "Probeer nog eens te bellen over een paar minuten.";
+"error.call.slow_connection.title" = "Langzame verbinding";
+"error.call.slow_connection" = "Er kunnen misschien problemen voorkomen tijdens je gesprek";
+"error.call.slow_connection.call_anyway" = "Toch bellen";
 
-"error.invite.no_email_provider" = "Please configure your email client to be able to send the invites via email";
-"error.invite.no_messaging_provider" = "Please configure your SMS to be able to send the invites via SMS";
+"error.invite.no_email_provider" = "Configureer je email applicatie om invites te versturen via email";
+"error.invite.no_messaging_provider" = "Configureer je SMS om berichten te verzenden via SMS";
 
-"sketchpad.initial_hint" = "Tap color to change brush size\nPress and hold to fill an area\nShake to remove a photo";
+"sketchpad.initial_hint" = "Tab op de kleur om de kwast grote aan te passen.\nHoud lang in gedrukt om het hele veld te kleuren. \nSchut om de foto te verwijderen";
 
-"migration.please_wait_message" = "One moment, please";
+"migration.please_wait_message" = "Een moment, alsjeblieft";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Those are used by the backend to localize APNS
-"push.notification.new_user" = "%@ joined Wire";
-"push.notification.new_message" = "New message";
+"push.notification.new_user" = "%@ heeft zich aangemeld bij Wire";
+"push.notification.new_message" = "Nieuw bericht";
 
 
-//Force Update
-"force.update.title" = "Update necessary";
-"force.update.message" = "You are missing out on new features.\nGet the latest version of Wire in the App Store.";
-"force.update.ok_button" = "Go to App Store";
+// Force Update
+"force.update.title" = "Update nodig";
+"force.update.message" = "Je mist nieuwe features. \nDownload de laatste versie van Wire in de App Store.";
+"force.update.ok_button" = "Ga naar de App Store";
 
 // Third Party
 "giphy.conversation.message" = "%@ · via giphy.com";
 "giphy.conversation.random_message" = "via giphy.com";
-"giphy.error.no_more_results" = "no more gifs";
-"giphy.error.no_result" = "no gif found";
+"giphy.error.no_more_results" = "geen gifs meer";
+"giphy.error.no_result" = "geen gif gevonden";
 
-"giphy.confirm" = "send";
-"giphy.cancel" = "cancel";
-"giphy.search_placeholder" = "Search giphy";
+"giphy.confirm" = "stuur";
+"giphy.cancel" = "anuleer";
+"giphy.search_placeholder" = "Zoek giphy";
 
-"invite_banner.title" = "Bring your friends to Wire!";
-"invite_banner.message" = "Enjoy calls, messages, sketches, GIFs and more in private or with groups.";
-"invite_banner.invite_button_title" = "Invite more people";
+"invite_banner.title" = "Nodig je vrienden uit tot Wire!";
+"invite_banner.message" = "Geniet van bellen, berichten, schetsen, GIF's en meer in privé gesprekken of in groepen.";
+"invite_banner.invite_button_title" = "Nodig meer mensen uit";

--- a/Wire-iOS/Resources/nl.lproj/Localizable.stringsdict
+++ b/Wire-iOS/Resources/nl.lproj/Localizable.stringsdict
@@ -1,0 +1,191 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+        <key>self.new_device_alert.title_prefix.devices</key>
+        <dict>
+            <key>NSStringLocalizedFormatKey</key>
+            <string>%#@device_count@</string>
+            <key>device_count</key>
+            <dict>
+                <key>NSStringFormatSpecTypeKey</key>
+                <string>NSStringPluralRuleType</string>
+                <key>NSStringFormatValueTypeKey</key>
+                <string>lu</string>
+                <key>zero</key>
+                <string></string>
+                <key>one</key>
+                <string>a device</string>
+                <key>few</key>
+                <string>%lu devices</string>
+                <key>many</key>
+                <string>%lu devices</string>
+                <key>other</key>
+                <string>%lu devices</string>
+            </dict>
+        </dict>
+		<key>participants.people.count</key>
+		<dict>
+			<key>NSStringLocalizedFormatKey</key>
+			<string>%#@lu_number_of_people@</string>
+			<key>lu_number_of_people</key>
+			<dict>
+				<key>NSStringFormatSpecTypeKey</key>
+				<string>NSStringPluralRuleType</string>
+				<key>NSStringFormatValueTypeKey</key>
+				<string>lu</string>
+				<key>zero</key>
+				<string>No people</string>
+				<key>one</key>
+				<string>One person</string>
+				<key>few</key>
+				<string>%lu people</string>
+				<key>many</key>
+				<string>%lu people</string>
+				<key>other</key>
+				<string>%lu people</string>
+			</dict>
+		</dict>
+        <key>content.system.missing_messages.subtitle_added</key>
+        <dict>
+            <key>NSStringLocalizedFormatKey</key>
+            <string>%@ %#@lu_number_of_users@ been added</string>
+            <key>lu_number_of_users</key>
+            <dict>
+                <key>NSStringFormatSpecTypeKey</key>
+                <string>NSStringPluralRuleType</string>
+                <key>NSStringFormatValueTypeKey</key>
+                <string>lu</string>
+                <key>zero</key>
+                <string></string>
+                <key>one</key>
+                <string>has</string>
+                <key>other</key>
+                <string>have</string>
+            </dict>
+        </dict>
+        <key>content.system.missing_messages.subtitle_removed</key>
+        <dict>
+            <key>NSStringLocalizedFormatKey</key>
+            <string>%@ %#@lu_number_of_users@ been removed</string>
+            <key>lu_number_of_users</key>
+            <dict>
+                <key>NSStringFormatSpecTypeKey</key>
+                <string>NSStringPluralRuleType</string>
+                <key>NSStringFormatValueTypeKey</key>
+                <string>lu</string>
+                <key>zero</key>
+                <string></string>
+                <key>one</key>
+                <string>has</string>
+                <key>other</key>
+                <string>have</string>
+            </dict>
+        </dict>
+		<key>list.connect_request.people_waiting</key>
+		<dict>
+			<key>NSStringLocalizedFormatKey</key>
+			<string>%#@d_number_of_people@ waiting</string>
+			<key>d_number_of_people</key>
+			<dict>
+				<key>NSStringFormatSpecTypeKey</key>
+				<string>NSStringPluralRuleType</string>
+				<key>NSStringFormatValueTypeKey</key>
+				<string>d</string>
+				<key>zero</key>
+				<string></string>
+				<key>one</key>
+				<string>One person</string>
+				<key>few</key>
+				<string>%d people</string>
+				<key>many</key>
+				<string>%d people</string>
+				<key>other</key>
+				<string>%d people</string>
+			</dict>
+		</dict>
+		<key>content.system.participants_n_others</key>
+		<dict>
+			<key>NSStringLocalizedFormatKey</key>
+			<string>%@ %#@and_number_of_others@</string>
+			<key>and_number_of_others</key>
+			<dict>
+				<key>NSStringFormatSpecTypeKey</key>
+				<string>NSStringPluralRuleType</string>
+				<key>NSStringFormatValueTypeKey</key>
+				<string>d</string>
+				<key>zero</key>
+				<string/>
+				<key>one</key>
+				<string>and one more</string>
+				<key>few</key>
+				<string>and %d others</string>
+				<key>many</key>
+				<string>and %d others</string>
+				<key>other</key>
+				<string>and %d others</string>
+			</dict>
+		</dict>
+		<key>peoplepicker.suggested.knows_more</key>
+		<dict>
+			<key>NSStringLocalizedFormatKey</key>
+			<string>Knows %@ and %#@d_number_of_others@</string>
+			<key>d_number_of_others</key>
+			<dict>
+				<key>NSStringFormatSpecTypeKey</key>
+				<string>NSStringPluralRuleType</string>
+				<key>NSStringFormatValueTypeKey</key>
+				<string>d</string>
+				<key>few</key>
+				<string>%d others</string>
+				<key>many</key>
+				<string>%d others</string>
+				<key>other</key>
+				<string>%d others</string>
+			</dict>
+		</dict>
+        <key>content.system.people_started_using</key>
+        <dict>
+            <key>NSStringLocalizedFormatKey</key>
+            <string>%@ %#@d_number_of_others@ started using %#@d_new_devices@</string>
+            <key>d_number_of_others</key>
+            <dict>
+                <key>NSStringFormatSpecTypeKey</key>
+                <string>NSStringPluralRuleType</string>
+                <key>NSStringFormatValueTypeKey</key>
+                <string>d</string>
+                <key>one</key>
+                <string></string>
+                <key>other</key>
+                <string>and %d others</string>
+            </dict>
+            <key>d_new_devices</key>
+            <dict>
+                <key>NSStringFormatSpecTypeKey</key>
+                <string>NSStringPluralRuleType</string>
+                <key>NSStringFormatValueTypeKey</key>
+                <string>d</string>
+                <key>one</key>
+                <string>a new device</string>
+                <key>other</key>
+                <string>new devices</string>
+            </dict>
+        </dict>
+        <key>content.system.new_devices</key>
+        <dict>
+            <key>NSStringLocalizedFormatKey</key>
+            <string>%#@d_new_devices@</string>
+            <key>d_new_devices</key>
+            <dict>
+                <key>NSStringFormatSpecTypeKey</key>
+                <string>NSStringPluralRuleType</string>
+                <key>NSStringFormatValueTypeKey</key>
+                <string>d</string>
+                <key>one</key>
+                <string>a new device</string>
+                <key>other</key>
+                <string>new devices</string>
+            </dict>
+        </dict>
+	</dict>
+</plist>

--- a/Wire-iOS/Resources/nl.lproj/Localizable.stringsdict
+++ b/Wire-iOS/Resources/nl.lproj/Localizable.stringsdict
@@ -15,13 +15,13 @@
                 <key>zero</key>
                 <string></string>
                 <key>one</key>
-                <string>a device</string>
+                <string>een apparaat</string>
                 <key>few</key>
-                <string>%lu devices</string>
+                <string>%lu apparaten</string>
                 <key>many</key>
-                <string>%lu devices</string>
+                <string>%lu apparaten</string>
                 <key>other</key>
-                <string>%lu devices</string>
+                <string>%lu apparaten</string>
             </dict>
         </dict>
 		<key>participants.people.count</key>
@@ -35,21 +35,21 @@
 				<key>NSStringFormatValueTypeKey</key>
 				<string>lu</string>
 				<key>zero</key>
-				<string>No people</string>
+				<string>Geen personen</string>
 				<key>one</key>
-				<string>One person</string>
+				<string>Één persoon</string>
 				<key>few</key>
-				<string>%lu people</string>
+				<string>%lu personen</string>
 				<key>many</key>
-				<string>%lu people</string>
+				<string>%lu personen</string>
 				<key>other</key>
-				<string>%lu people</string>
+				<string>%lu personen</string>
 			</dict>
 		</dict>
         <key>content.system.missing_messages.subtitle_added</key>
         <dict>
             <key>NSStringLocalizedFormatKey</key>
-            <string>%@ %#@lu_number_of_users@ been added</string>
+            <string>%@ %#@lu_number_of_users@ zijn toegevoegd</string>
             <key>lu_number_of_users</key>
             <dict>
                 <key>NSStringFormatSpecTypeKey</key>
@@ -59,15 +59,15 @@
                 <key>zero</key>
                 <string></string>
                 <key>one</key>
-                <string>has</string>
+                <string>heeft</string>
                 <key>other</key>
-                <string>have</string>
+                <string>heeft</string>
             </dict>
         </dict>
         <key>content.system.missing_messages.subtitle_removed</key>
         <dict>
             <key>NSStringLocalizedFormatKey</key>
-            <string>%@ %#@lu_number_of_users@ been removed</string>
+            <string>%@%#@lu_number_of_users@ is verwijdert</string>
             <key>lu_number_of_users</key>
             <dict>
                 <key>NSStringFormatSpecTypeKey</key>
@@ -77,15 +77,15 @@
                 <key>zero</key>
                 <string></string>
                 <key>one</key>
-                <string>has</string>
+                <string>heeft</string>
                 <key>other</key>
-                <string>have</string>
+                <string>heeft</string>
             </dict>
         </dict>
 		<key>list.connect_request.people_waiting</key>
 		<dict>
 			<key>NSStringLocalizedFormatKey</key>
-			<string>%#@d_number_of_people@ waiting</string>
+			<string>%#@d_number_of_people@ wachten</string>
 			<key>d_number_of_people</key>
 			<dict>
 				<key>NSStringFormatSpecTypeKey</key>
@@ -95,13 +95,13 @@
 				<key>zero</key>
 				<string></string>
 				<key>one</key>
-				<string>One person</string>
+				<string>Één persoon</string>
 				<key>few</key>
-				<string>%d people</string>
+				<string>%d personen</string>
 				<key>many</key>
-				<string>%d people</string>
+				<string>%d personen</string>
 				<key>other</key>
-				<string>%d people</string>
+				<string>%d personen</string>
 			</dict>
 		</dict>
 		<key>content.system.participants_n_others</key>
@@ -117,19 +117,19 @@
 				<key>zero</key>
 				<string/>
 				<key>one</key>
-				<string>and one more</string>
+				<string>en een meer</string>
 				<key>few</key>
-				<string>and %d others</string>
+				<string>en %d anderen</string>
 				<key>many</key>
-				<string>and %d others</string>
+				<string>en %d anderen</string>
 				<key>other</key>
-				<string>and %d others</string>
+				<string>en %d anderen</string>
 			</dict>
 		</dict>
 		<key>peoplepicker.suggested.knows_more</key>
 		<dict>
 			<key>NSStringLocalizedFormatKey</key>
-			<string>Knows %@ and %#@d_number_of_others@</string>
+			<string>Kent %@ en %#@d_number_of_others@</string>
 			<key>d_number_of_others</key>
 			<dict>
 				<key>NSStringFormatSpecTypeKey</key>
@@ -137,17 +137,17 @@
 				<key>NSStringFormatValueTypeKey</key>
 				<string>d</string>
 				<key>few</key>
-				<string>%d others</string>
+				<string>%d anderen</string>
 				<key>many</key>
-				<string>%d others</string>
+				<string>%d anderen</string>
 				<key>other</key>
-				<string>%d others</string>
+				<string>%d anderen</string>
 			</dict>
 		</dict>
         <key>content.system.people_started_using</key>
         <dict>
             <key>NSStringLocalizedFormatKey</key>
-            <string>%@ %#@d_number_of_others@ started using %#@d_new_devices@</string>
+            <string>%@ %#@d_number_of_others@ begon gebruiken %#@d_new_devices@</string>
             <key>d_number_of_others</key>
             <dict>
                 <key>NSStringFormatSpecTypeKey</key>
@@ -157,7 +157,7 @@
                 <key>one</key>
                 <string></string>
                 <key>other</key>
-                <string>and %d others</string>
+                <string>en %d anderen</string>
             </dict>
             <key>d_new_devices</key>
             <dict>
@@ -166,9 +166,9 @@
                 <key>NSStringFormatValueTypeKey</key>
                 <string>d</string>
                 <key>one</key>
-                <string>a new device</string>
+                <string>een nieuw apparaat</string>
                 <key>other</key>
-                <string>new devices</string>
+                <string>nieuw apparaat</string>
             </dict>
         </dict>
         <key>content.system.new_devices</key>
@@ -182,9 +182,9 @@
                 <key>NSStringFormatValueTypeKey</key>
                 <string>d</string>
                 <key>one</key>
-                <string>a new device</string>
+                <string>een nieuw apparaat</string>
                 <key>other</key>
-                <string>new devices</string>
+                <string>nieuw apparaat</string>
             </dict>
         </dict>
 	</dict>

--- a/Wire-iOS/Resources/pt-BR.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/pt-BR.lproj/Localizable.strings
@@ -128,6 +128,7 @@
 
 "conversation.input_bar.verified" = "Verificado";
 "conversation.input_bar.placeholder" = "Digite uma mensagem";
+"conversation.input_bar.placeholder_ephemeral" = "Timed message";
 
 "conversation.input_bar.audio_message.tooltip.pull_send" = "Puxe para cima para enviar";
 "conversation.input_bar.audio_message.tooltip.tap_send" = "Toque para enviar";
@@ -157,10 +158,14 @@
 "location.unauthorized_alert.title" = "Habilitar os Serviços de Localização";
 "location.unauthorized_alert.message" = "Para enviar a sua localização, habilite os Serviços de Localização e permita que o Wire acesse sua localização.";
 "location.unauthorized_alert.cancel" = "Cancelar";
-"location.unauthorized_alert.settings" = "Ajustes";
+"location.unauthorized_alert.settings" = "Configurações";
 
 // Twitter
 "twitter_status.on_twitter" = "%@ no Twitter";
+
+// Ephemeral message
+"input.ephemeral.timeout.none" = "Off";
+"input.ephemeral.title" = "Set a timer for temporary messages";
 
 // System messages
 "content.system.continued_conversation" = "Iniciar uma conversa com %@";
@@ -221,6 +226,8 @@
 "content.system.cannot_decrypt.identity.you_part" = "Seu";
 "content.system.cannot_decrypt.identity.otherUser_part" = "de %@"; // posessive apostrophe - might differ in different languages
 "content.system.cannot_decrypt.identity.why_part" = "Saiba Mais";
+"content.system.cannot_decrypt.otherDevice_part" = "(device %@)"; // example " (device d1b23c54f34a)".
+// Full sentence: "A message from %@ was not received. [...] (device d1b23c54f34a). This is a debug information.
 
 "content.file.uploading" = "Enviando…";
 "content.file.downloading" = "Baixando…";

--- a/Wire-iOS/Resources/ru.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/ru.lproj/Localizable.strings
@@ -128,6 +128,7 @@
 
 "conversation.input_bar.verified" = "Проверено";
 "conversation.input_bar.placeholder" = "Наберите сообщение";
+"conversation.input_bar.placeholder_ephemeral" = "Не удалось послать сообщение";
 
 "conversation.input_bar.audio_message.tooltip.pull_send" = "Проведите вверх для отправки";
 "conversation.input_bar.audio_message.tooltip.tap_send" = "Нажмите для отправки";
@@ -161,6 +162,10 @@
 
 // Twitter
 "twitter_status.on_twitter" = "%@ в Twitter";
+
+// Ephemeral message
+"input.ephemeral.timeout.none" = "Off";
+"input.ephemeral.title" = "Set a timer for temporary messages";
 
 // System messages
 "content.system.continued_conversation" = "Начать разговор с %@";
@@ -221,6 +226,8 @@
 "content.system.cannot_decrypt.identity.you_part" = "Ваш";
 "content.system.cannot_decrypt.identity.otherUser_part" = "%@"; // posessive apostrophe - might differ in different languages
 "content.system.cannot_decrypt.identity.why_part" = "Подробнее";
+"content.system.cannot_decrypt.otherDevice_part" = "(device %@)"; // example " (device d1b23c54f34a)".
+// Full sentence: "A message from %@ was not received. [...] (device d1b23c54f34a). This is a debug information.
 
 "content.file.uploading" = "Отправка…";
 "content.file.downloading" = "Загрузка…";

--- a/Wire-iOS/Resources/tr.lproj/InfoPlist.strings
+++ b/Wire-iOS/Resources/tr.lproj/InfoPlist.strings
@@ -1,0 +1,22 @@
+/*
+ *  Wire
+ *  Copyright (C) 2016 Wire Swiss GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+"NSContactsUsageDescription" = "Allow Wire to access your contacts to connect you with others. We anonymize all information and do not share it with anyone else.";
+"NSMicrophoneUsageDescription" = "Allow Wire to access your microphone so you can talk to people and send audio messages.";
+"NSLocationWhenInUseUsageDescription" = "Allow Wire to access your location so you can send your location to others.";
+"NSCameraUsageDescription" = "Allow Wire to access your camera so you can place video calls and send photos.";

--- a/Wire-iOS/Resources/tr.lproj/InfoPlist.strings
+++ b/Wire-iOS/Resources/tr.lproj/InfoPlist.strings
@@ -1,4 +1,4 @@
-/*
+/* 
  *  Wire
  *  Copyright (C) 2016 Wire Swiss GmbH
  *
@@ -14,9 +14,9 @@
  *
  *  You should have received a copy of the GNU General Public License
  *  along with this program. If not, see http://www.gnu.org/licenses/.
- */
+*/
 
-"NSContactsUsageDescription" = "Allow Wire to access your contacts to connect you with others. We anonymize all information and do not share it with anyone else.";
-"NSMicrophoneUsageDescription" = "Allow Wire to access your microphone so you can talk to people and send audio messages.";
-"NSLocationWhenInUseUsageDescription" = "Allow Wire to access your location so you can send your location to others.";
-"NSCameraUsageDescription" = "Allow Wire to access your camera so you can place video calls and send photos.";
+"NSContactsUsageDescription" = "Kişilerinizi paylaşın ki sizi başkalarına bağlayabilelim. Tüm bilgilerinizi gizler ve kimseyle paylaşmayız.";
+"NSMicrophoneUsageDescription" = "Wire'ın mikrofonunuza erişmesine izin verin ki bu sayede insanlar sesli konuşabilir ve sesli mesaj gönderebilirsiniz.";
+"NSLocationWhenInUseUsageDescription" = "Wire'ın konumunuza erişmesine izin verin, bu sayede konumunuzu başkalarıyla paylaşabilirsiniz.";
+"NSCameraUsageDescription" = "Wire'ın kameranıza erişmesine izin verin bu sayede görüntülü görüşmeler yapabilir ve fotoğraf yollayabilirsiniz.";

--- a/Wire-iOS/Resources/tr.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/tr.lproj/Localizable.strings
@@ -1,712 +1,712 @@
-//
+// 
 // Wire
 // Copyright (C) 2016 Wire Swiss GmbH
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
 
-"general.ok" = "OK";
-"general.cancel" = "Cancel";
-"general.open_settings" = "Open Wire Settings";
+"general.ok" = "Tamam";
+"general.cancel" = "İptal";
+"general.open_settings" = "Wire Ayarlarını Aç";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // People picker/start UI
-"peoplepicker.search_placeholder" = "Search by name or email";
-"peoplepicker.header.top_people" = "Top people";
-"peoplepicker.button.create_conversation" = "Create group";
-"peoplepicker.button.add_to_conversation" = "Add";
-"peoplepicker.header.conversations" = "Groups";
-"peoplepicker.header.send_invitation" = "Invite";
-"peoplepicker.header.contacts" = "Connections";
-"peoplepicker.header.directory" = "Connect";
-"peoplepicker.title.create_conversation" = "Create group";
-"peoplepicker.title.add_to_conversation" = "Add people";
+"peoplepicker.search_placeholder" = "İsim veya e-posta ile arayın";
+"peoplepicker.header.top_people" = "Sık Görüşülenler";
+"peoplepicker.button.create_conversation" = "Grup Oluştur";
+"peoplepicker.button.add_to_conversation" = "Ekle";
+"peoplepicker.header.conversations" = "Gruplar";
+"peoplepicker.header.send_invitation" = "Davet et";
+"peoplepicker.header.contacts" = "Bağlantılar";
+"peoplepicker.header.directory" = "Bağlan";
+"peoplepicker.title.create_conversation" = "Grup oluştur";
+"peoplepicker.title.add_to_conversation" = "Kişi ekle";
 
-"peoplepicker.no_contacts_title" = "No Contacts.";
+"peoplepicker.no_contacts_title" = "Kişi yok.";
 
-"peoplepicker.no_matching_results_title" = "No results.";
-"peoplepicker.no_matching_results_message" = "Enter a full email address.";
+"peoplepicker.no_matching_results_title" = "Sonuç yok.";
+"peoplepicker.no_matching_results_message" = "Tam bir e-posta adresi giriniz.";
 
-"peoplepicker.no_matching_results.action.send_invite" = "Send an invitation";
-"peoplepicker.no_matching_results.action.share_contacts" = "Share contacts";
+"peoplepicker.no_matching_results.action.send_invite" = "Davet gönder";
+"peoplepicker.no_matching_results.action.share_contacts" = "Kişileri paylaş";
 
-"peoplepicker.no_matching_results_provide_valid_email" = "Please enter a valid email address";
-"peoplepicker.no_matching_results_after_address_book_upload_title" = "No results.";
+"peoplepicker.no_matching_results_provide_valid_email" = "Lütfen geçerli bir e-posta adresi girin";
+"peoplepicker.no_matching_results_after_address_book_upload_title" = "Sonuç yok.";
 /* This sentence ends with button title, contained in peoplepicker.no_matching_results_after_address_book_upload_button */
-"peoplepicker.no_matching_results_after_address_book_upload_message" = "Enter a full email address or";
+"peoplepicker.no_matching_results_after_address_book_upload_message" = "Tam bir e-posta adresi girin veya";
 /*  */
-"peoplepicker.no_matching_results_after_address_book_upload_button" = "share contacts";
+"peoplepicker.no_matching_results_after_address_book_upload_button" = "kişileri paylaş";
 
-"peoplepicker.share_contacts.no_results.title" = "Find people by name or email address";
+"peoplepicker.share_contacts.no_results.title" = "İsim veya e-posta adresiyle insanları bul";
 
-"peoplepicker.send_invitation.dialog.title" = "Invitation sent";
-"peoplepicker.send_invitation.dialog.message" = "It can be used for 2 weeks. Send a new one if it expires.";
-"peoplepicker.send_invitation.dialog.ok" = "OK";
+"peoplepicker.send_invitation.dialog.title" = "Davet gönderildi";
+"peoplepicker.send_invitation.dialog.message" = "2 hafta için kullanılabilir. Süresi dolduğunda yenisini gönderebilirsiniz.";
+"peoplepicker.send_invitation.dialog.ok" = "TAMAM";
 
-"peoplepicker.invite_more_people" = "Invite more people";
-"peoplepicker.quick-action.open-conversation" = "Open";
-"peoplepicker.quick-action.create-conversation" = "Create group";
+"peoplepicker.invite_more_people" = "Daha fazla kişi davet et";
+"peoplepicker.quick-action.open-conversation" = "Aç";
+"peoplepicker.quick-action.create-conversation" = "Grup oluştur";
 
 // Contacts UI
-"contacts_ui.search_placeholder" = "Search by name";
-"contacts_ui.invite_others" = "Invite others";
-"contacts_ui.name_in_contacts" = "%@ in address book";
-"contacts_ui.connection_request" = "Requested to connect";
-"contacts_ui.action_button.invite" = "Invite";
-"contacts_ui.action_button.open" = "Open";
-"contacts_ui.invite_sheet.cancel_button_title" = "Cancel";
-"contacts_ui.notification.invitation_sent" = "Invitation sent";
-"contacts_ui.notification.invitation_failed" = "Failed to send invitation";
-"contacts_ui.title" = "Invite people";
+"contacts_ui.search_placeholder" = "İsme göre ara";
+"contacts_ui.invite_others" = "Başkalarını davet et";
+"contacts_ui.name_in_contacts" = "%@ adres defterinde";
+"contacts_ui.connection_request" = "Bağlanma isteği gönderildi";
+"contacts_ui.action_button.invite" = "Davet et";
+"contacts_ui.action_button.open" = "Aç";
+"contacts_ui.invite_sheet.cancel_button_title" = "İptal";
+"contacts_ui.notification.invitation_sent" = "Davet gönderildi";
+"contacts_ui.notification.invitation_failed" = "Davet gönderilirken hata oluştu";
+"contacts_ui.title" = "İnsanları davet et";
 
-"contacts_ui.no_contact.title" = "No active conversations\n";
-"contacts_ui.no_contact.message" = "Tap contacts to start a conversation";
+"contacts_ui.no_contact.title" = "Hiç aktif konuşma yok\n";
+"contacts_ui.no_contact.message" = "Bir konuşma başlatmak için kişilere tıklayın";
 
 // Conversation List Bottom Bar
-"bottom_bar.contacts_button.title" = "contacts";
+"bottom_bar.contacts_button.title" = "kişiler";
 
 // Archived List
-"archived_list.title" = "archive";
+"archived_list.title" = "arşiv";
 
 // Add contact tool tip
-"tool_tip.contacts.title" = "Conversations start here";
-"tool_tip.contacts.message" = "Start a conversation or invite more people to join. Call, message and share in private or with groups.";
+"tool_tip.contacts.title" = "Konuşmalar buradan başlıyor";
+"tool_tip.contacts.message" = "Katılmak için bir konuşma başlatın veya daha fazla insan davet edin. Özel olarak veya grupta arayın, mesajlaşın ve paylaşın.";
 
 // "Knows" subtitle in cell: "Knows Indrek", "Knows Indrek and Jane", "Knows Indrek and 5 others"
-"peoplepicker.suggested.knows_one" = "Knows %@";
-"peoplepicker.suggested.knows_two" = "Knows %@ and %@";
-"peoplepicker.hide_search_result" = "Hide";
-"peoplepicker.hide_search_result_progress" = "Hiding…";
+"peoplepicker.suggested.knows_one" = "%@'ı tanıyor";
+"peoplepicker.suggested.knows_two" = "%@ ve %@ tanıyor";
+"peoplepicker.hide_search_result" = "Gizle";
+"peoplepicker.hide_search_result_progress" = "Gizleniyor…";
 
-"send_invitation.subject" = "Connect with me on Wire";
-"send_invitation.text" = "I’m on Wire. Search for %@\nor visit https://get.wire.com to connect with me.";
-"send_invitation_no_email.text" = "I’m on Wire. Visit https://get.wire.com to connect with me.";
+"send_invitation.subject" = "Wire'da bana bağlan";
+"send_invitation.text" = "Wire'dayım. %@ olarak ara ya da bana bağlanmak için https://get.wire.com adresini ziyaret et.";
+"send_invitation_no_email.text" = "Wire'dayım. %@ olarak ara ya da bana bağlanmak için https://get.wire.com adresini ziyaret et.";
 
-"send_personal_invitation.text" = "I’m on Wire, talk to you there. https://get.wire.com";
+"send_personal_invitation.text" = "Wire kullanıyorum, buradan görüşelim: https://get.wire.com";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++x
 // In-app notifications (chat heads)
-"notifications.shared_a_photo" = "shared a picture";
-"notifications.pinged" = "pinged";
-"notifications.sent_file" = "shared a file";
-"notifications.sent_location" = "shared a location";
-"notifications.sent_video" = "shared a video";
-"notifications.sent_audio" = "shared an audio";
+"notifications.shared_a_photo" = "bir resim paylaştı";
+"notifications.pinged" = "pingledi";
+"notifications.sent_file" = "bir dosya paylaştı";
+"notifications.sent_location" = "bir konum paylaştı";
+"notifications.sent_video" = "bir video paylaştı";
+"notifications.sent_audio" = "bir ses paylaştı";
 "notifications.in_conversation" = "%@ - %@";
-"notifications.this_conversation" = "%@ in this conversation";
+"notifications.this_conversation" = "%@ bu konuşmada";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // List (labels) - Needs to be revised with updated guidance
-"list.archived_conversations" = "ARCHIVE";
-"list.archived_conversations_close" = "Close archive";
+"list.archived_conversations" = "ARŞİVLE";
+"list.archived_conversations_close" = "Arşivi kapat";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Conversation
-"conversation.invite_more_people.title" = "Spread the word!";
-"conversation.invite_more_people.description" = "Add people to this conversation";
+"conversation.invite_more_people.title" = "Herkese duyurun!";
+"conversation.invite_more_people.description" = "Bu sohbete kişi ekle";
 "conversation.invite_more_people.explanation_url" = "https://support.wire.com";
-"conversation.invite_more_people.button_title" = "Add People";
+"conversation.invite_more_people.button_title" = "Kişi Ekle";
 
 // Conversation names
-"conversation.displayname.emptygroup" = "Empty group conversation";
+"conversation.displayname.emptygroup" = "Boş grup konuşması";
 
-"conversation.input_bar.verified" = "Verified";
-"conversation.input_bar.placeholder" = "Type a message";
+"conversation.input_bar.verified" = "Doğrulandı";
+"conversation.input_bar.placeholder" = "Bir mesaj yazın";
 
-"conversation.input_bar.audio_message.tooltip.pull_send" = "Swipe up to send";
-"conversation.input_bar.audio_message.tooltip.tap_send" = "Tap to send";
-"conversation.input_bar.audio_message.too_long.title" = "Recording Stopped";
-"conversation.input_bar.audio_message.too_long.message" = "Audio messages are limited to %@. Send this message?";
-"conversation.input_bar.audio_message.send" = "Send";
+"conversation.input_bar.audio_message.tooltip.pull_send" = "Göndermek için kaydırın";
+"conversation.input_bar.audio_message.tooltip.tap_send" = "Göndermek için tıkla";
+"conversation.input_bar.audio_message.too_long.title" = "Kayıt durdu";
+"conversation.input_bar.audio_message.too_long.message" = "Sesli mesajlar %@ ile sınırlıdır. Bu mesaj gönderilsin mi?";
+"conversation.input_bar.audio_message.send" = "Gönder";
 
-"conversation.input_bar.audio_message.keyboard.record_tip" = "Tap to record\nYou can  %@  it after that";
-"conversation.input_bar.audio_message.keyboard.filter_tip" = "Choose a filter above";
+"conversation.input_bar.audio_message.keyboard.record_tip" = "Kaydetmek için tıkla\nDaha sonra %@ bilirsin";
+"conversation.input_bar.audio_message.keyboard.filter_tip" = "Yukarıdan bir filtre seçin";
 
 // Image confirmation dialogue
-"image_confirmer.confirm" = "OK";
-"image_confirmer.cancel" = "Cancel";
-"image.add_sketch" = "Add a sketch";
-"image.edit_image" = "Edit image";
+"image_confirmer.confirm" = "TAMAM";
+"image_confirmer.cancel" = "İptal";
+"image.add_sketch" = "Çizim ekle";
+"image.edit_image" = "Fotoğrafı düzenle";
 
 // Camera access
-"camera_access.denied" = "Wire needs access to the Camera.";
+"camera_access.denied" = "Wire'ın kameraya erişmesi gerek.";
 "camera_access.denied.instruction" = "";
-"camera_access.denied.open_settings" = "Enable it in Wire Settings";
+"camera_access.denied.open_settings" = "Wire Ayarları'ndan etkinleştirin";
 
 // Camera Controls
-"camera_controls.aeaf_lock" = "AE/AF Lock";
+"camera_controls.aeaf_lock" = "AE/AF kilidi";
 
 // Location
-"location.send_button.title" = "Send";
-"location.unauthorized_alert.title" = "Enable Location Services";
-"location.unauthorized_alert.message" = "To send your location, enable Location Services and allow Wire to access your location.";
-"location.unauthorized_alert.cancel" = "Cancel";
-"location.unauthorized_alert.settings" = "Settings";
+"location.send_button.title" = "Gönder";
+"location.unauthorized_alert.title" = "Konum Servislerini Etkinleştir";
+"location.unauthorized_alert.message" = "Konum göndermek için, Konum Servislerini açın ve Wire'ın konumunuza ulaşmasına izin verin.";
+"location.unauthorized_alert.cancel" = "İptal";
+"location.unauthorized_alert.settings" = "Ayarlar";
 
 // Twitter
-"twitter_status.on_twitter" = "%@ on Twitter";
+"twitter_status.on_twitter" = "%@ Twitter'da";
 
 // System messages
-"content.system.continued_conversation" = "Start a conversation with %@";
+"content.system.continued_conversation" = "%@ ile bir konuşma başlat";
 
-"content.system.other_started_conversation" = "%@ started a conversation with %@";
-"content.system.you_started_conversation" = "You started a conversation with %@";
+"content.system.other_started_conversation" = "%@, %@'la konuşma başlattı";
+"content.system.you_started_conversation" = "%@'la bir konuşma başlattın";
 
-"content.system.you_added_participant" = "You added %@";
-"content.system.other_added_participant" = "%@ added %@";
-"content.system.other_added_you" = "%@ added you";
+"content.system.you_added_participant" = "%@'u ekledin";
+"content.system.other_added_participant" = "%@, %@'nu ekledi";
+"content.system.other_added_you" = "%@, seni ekledi";
 
-"content.system.participants_you" = "You";
-"content.system.participants_1_other" = "%@ and %@";
-"content.system.other_left" = "%@ left";
-"content.system.you_left" = "You left";
-"content.system.other_removed_other" = "%@ removed %@";
-"content.system.other_removed_you" = "%@ removed you";
-"content.system.you_removed_other" = "You removed %@";
-"content.system.other_renamed_conv" = "%@ renamed the conversation";
-"content.system.you_renamed_conv" = "You renamed the conversation";
-"content.system.other_renamed_conv_to_nothing" = "%@ removed the conversation name";
-"content.system.you_renamed_conv_to_nothing" = "You removed the conversation name";
-"content.system.pending_message_timestamp" = "Sending…";
-"content.system.message_sent_timestamp" = "Sent";
-"content.system.message_delivered_timestamp" = "Delivered";
-"content.system.failedtosend_message_timestamp" = "Sending failed.";
-"content.system.failedtosend_message_timestamp_resend" = "Resend";
-"content.system.like_tooltip" = "Tap to like";
-"content.system.deleted_message_prefix_timestamp" = "Deleted on %@";
-"content.system.edited_message_prefix_timestamp" = "Edited on %@";
-"content.system.connecting_to" = "Connecting to %@.\nStart a conversation";
-"content.system.connected_to" = "Connected to %@\nStart a conversation";
-"content.system.other_wanted_to_talk" = "%@ called";
-"content.system.you_wanted_to_talk" = "You called";
+"content.system.participants_you" = "Sen";
+"content.system.participants_1_other" = "%@ ve %@";
+"content.system.other_left" = "%@ ayrıldı";
+"content.system.you_left" = "Ayrıldın";
+"content.system.other_removed_other" = "%@, %@'u sildi";
+"content.system.other_removed_you" = "%@, seni sildi";
+"content.system.you_removed_other" = "%@'i sildiniz";
+"content.system.other_renamed_conv" = "%@ bu konuşmanın adını değiştirdi";
+"content.system.you_renamed_conv" = "Bu konuşmanın adını değiştirdiniz";
+"content.system.other_renamed_conv_to_nothing" = "%@ konuşmanın adını kaldırdı";
+"content.system.you_renamed_conv_to_nothing" = "Bu konuşmadının adını kaldırdınız";
+"content.system.pending_message_timestamp" = "Gönderiliyor…";
+"content.system.message_sent_timestamp" = "Şimdi Çevrimiçi";
+"content.system.message_delivered_timestamp" = "Gönderildi";
+"content.system.failedtosend_message_timestamp" = "Gönderme başarısız.";
+"content.system.failedtosend_message_timestamp_resend" = "Yeniden gönder";
+"content.system.like_tooltip" = "Beğenmek için dokunun";
+"content.system.deleted_message_prefix_timestamp" = "%@'de silinmiş";
+"content.system.edited_message_prefix_timestamp" = "%@'de düzenlenmiş0";
+"content.system.connecting_to" = "%@'e bağlanılıyor.\nBir konuşma başlat";
+"content.system.connected_to" = "%@'e bağlanıldı.\nBir konuşma başlat";
+"content.system.other_wanted_to_talk" = "%@ aradı";
+"content.system.you_wanted_to_talk" = "Siz aradınız";
 
-"content.system.you_started" = "You";
-"content.system.this_device" = "this device";
+"content.system.you_started" = "Sen";
+"content.system.this_device" = "bu cihaz";
 
-"content.system.reactivated_device" = "You started using %@ again. Messages sent in the meantime will not appear here";
+"content.system.reactivated_device" = "Tekrar %@ kullanmaya başladın. Bu sırada gönderilmiş mesajlar burada gözükmeyecek";
 
-"content.system.new_device" = "a new device";
-"content.system.started_using" = "started using";
-"content.system.is_verified" = "All fingerprints are verified";
+"content.system.new_device" = "yeni bir cihaz";
+"content.system.started_using" = "kullanmaya başladı";
+"content.system.is_verified" = "Tüm parmak izleri doğrulanmış";
 
-"content.system.unverified" = "%@ unverified one of %@"; //example "You unverified one of Jule's devices"
-"content.system.your_devices" = "your devices";
-"content.system.other_devices" = "%@'s devices";
+"content.system.unverified" = "%@, %@dan birini doğrulamadı"; // example "You unverified one of Jule's devices"
+"content.system.your_devices" = "senin cihazların";
+"content.system.other_devices" = "%@'nin cihazların";
 
-"content.system.missing_messages.title" = "You haven't used this device for a while. Some messages may not appear here.";
-"content.system.missing_messages.subtitle_start" = "Meanwhile,";
+"content.system.missing_messages.title" = "Bu cihazı bir süredir kullanmıyorsunuz. Bazı mesajlar burada görünmeyebilir.";
+"content.system.missing_messages.subtitle_start" = "Bu sırada,";
 
-"content.system.cannot_decrypt" = "A message from %@ was not received.";
+"content.system.cannot_decrypt" = "%@'dan gelen bir mesaj alınmadı.";
 
-"content.system.cannot_decrypt.you_part" = "you";
-"content.system.cannot_decrypt.why_part" = "Why?";
+"content.system.cannot_decrypt.you_part" = "sen";
+"content.system.cannot_decrypt.why_part" = "Neden?";
 
-"content.system.cannot_decrypt.identity" = "%@ device identity changed. Undelivered message.";
-"content.system.cannot_decrypt.identity.you_part" = "Your";
-"content.system.cannot_decrypt.identity.otherUser_part" = "%@'s"; // posessive apostrophe - might differ in different languages
-"content.system.cannot_decrypt.identity.why_part" = "Learn More";
+"content.system.cannot_decrypt.identity" = "%@ cihazı kimlik değiştirdi. Teslim edilmeyen mesaj.";
+"content.system.cannot_decrypt.identity.you_part" = "Senin";
+"content.system.cannot_decrypt.identity.otherUser_part" = "%@'nin"; // posessive apostrophe - might differ in different languages
+"content.system.cannot_decrypt.identity.why_part" = "Daha Fazla";
 
-"content.file.uploading" = "Uploading…";
-"content.file.downloading" = "Downloading…";
-"content.file.upload_failed" = "Upload failed";
-"content.file.upload_cancelled" = "Upload cancelled";
-"content.file.upload_video" = "Videos";
-"content.file.take_video" = "Record a video";
+"content.file.uploading" = "Yükleniyor…";
+"content.file.downloading" = "İndiriliyor…";
+"content.file.upload_failed" = "Yükleme başarısız oldu";
+"content.file.upload_cancelled" = "Yükleme iptal edildi";
+"content.file.upload_video" = "Videolar";
+"content.file.take_video" = "Bir video kaydet";
 
-"content.file.save_video" = "Save";
-"content.file.save_audio" = "Save";
-"content.image.save_image" = "Save";
+"content.file.save_video" = "Kaydet";
+"content.file.save_audio" = "Kaydet";
+"content.image.save_image" = "Kaydet";
 
-"content.message.delete" = "Delete";
+"content.message.delete" = "Sil";
 
-"content.message.like" = "Like";
-"content.message.unlike" = "Unlike";
+"content.message.like" = "Beğen";
+"content.message.unlike" = "Beğenme";
 
-"content.reactions_list.likers" = "Liked by";
+"content.reactions_list.likers" = "Beğenen";
 
-"content.file.too_big" = "You can send files up to %@";
+"content.file.too_big" = "En fazla %@ dosya yükleyebilirsin";
 // Someone pinged
-"content.ping.text" = "%1$@ PINGED";
+"content.ping.text" = "%1$@ PİNGLEDİ";
 
 // Current user pinged
-"content.ping.you.text" = "YOU PINGED";
+"content.ping.you.text" = "SEN PİNGLEDİN";
 
 // Inline Player
-"content.player.unable_to_play" = "UNABLE TO PLAY TRACK";
+"content.player.unable_to_play" = "PARÇA OYNATILAMIYOR";
 
 // Connecting (NEW IMPLEMENTATION, REVIEW LATER)
-"connection_request.title" = "Connect to %@"; //check UPPERCASE implementation in code
-"missive.connection_request.default_message" = "Hi %@,\nLet’s connect on Wire.\n%@";
+"connection_request.title" = "%@'a bağlan"; // check UPPERCASE implementation in code
+"missive.connection_request.default_message" = "Selam %@,\nHaydi Wire'da bağlanalım.\n%@";
 
-"connection_request.send_button_title" = "Connect";
-"inbox.connection_request.connect_button_title" = "Connect";
-"inbox.connection_request.ignore_button_title" = "Ignore";
+"connection_request.send_button_title" = "Bağlan";
+"inbox.connection_request.connect_button_title" = "Bağlan";
+"inbox.connection_request.ignore_button_title" = "Yoksay";
 
 // Voice
-"voice.status.one_to_one.incoming" = "%@\nCalling";
-"voice.status.group_call.incoming" = "%@\nRinging";
-"voice.status.one_to_one.outgoing" = "%@\nRinging";
-"voice.status.joining" = "%@\nConnecting";
-"voice.status.video_not_available" = "Video turned off";
-"voice.status.low_connection" = "Bad connection";
-"voice.network_error.title" = "No Internet Connection";
-"voice.network_error.body" = "You must be online to call. Check your connection and try again.";
-"voice.alert.call_in_progress.title" = "Call in progress";
-"voice.alert.call_in_progress.message" = "Another of your devices is already participating in the call";
-"voice.alert.call_in_progress.confirm" = "Ok";
-"voice.accept_button.title" = "Accept";
-"voice.decline_button.title" = "Decline";
-"voice.hang_up_button.title" = "Hang Up";
-"voice.mute_button.title" = "Mute";
+"voice.status.one_to_one.incoming" = "%@\nArıyor";
+"voice.status.group_call.incoming" = "%@\nÇalıyor";
+"voice.status.one_to_one.outgoing" = "%@\nÇalıyor";
+"voice.status.joining" = "%@\nBağlanıyor";
+"voice.status.video_not_available" = "Video kapandı";
+"voice.status.low_connection" = "Kötü bağlantı";
+"voice.network_error.title" = "Internet bağlantısı yok";
+"voice.network_error.body" = "Arama yapmak için çevrimiçi olmanız gerekir. Bağlantınızı kontrol edin ve yeniden deneyin.";
+"voice.alert.call_in_progress.title" = "Arama sürüyor";
+"voice.alert.call_in_progress.message" = "Cihazlarınızdan biri zaten konuşmada yer alıyor";
+"voice.alert.call_in_progress.confirm" = "Tamam";
+"voice.accept_button.title" = "Kabul et";
+"voice.decline_button.title" = "Reddet";
+"voice.hang_up_button.title" = "Aramayı sonlandır";
+"voice.mute_button.title" = "Sustur";
 "voice.video_button.title" = "Video";
-"voice.speaker_button.title" = "Speaker";
+"voice.speaker_button.title" = "Hoparlör";
 
-"voice.alert.microphone_warning.title" = "Wire needs access to the Microphone.";
-"voice.alert.microphone_warning.explanation" = "Enable it in Wire Settings.";
+"voice.alert.microphone_warning.title" = "Wire'ın mikrofona erişmesi gerek.";
+"voice.alert.microphone_warning.explanation" = "Wire Ayarları'ndan etkinleştirin.";
 
-"voice.alert.camera_warning.title" = "Wire needs access to the Camera.";
-"voice.alert.camera_warning.explanation" = "Go to Settings and allow Wire to access the camera.";
+"voice.alert.camera_warning.title" = "Wire'ın kameraya erişmesi gerek.";
+"voice.alert.camera_warning.explanation" = "Kameraya ulaşmak için Ayarlara gidip Wire'ı etkinleştirin.";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Profile and Participants
 
-"participants.add_people_button_title" = "Add people";
+"participants.add_people_button_title" = "Kişi ekle";
 
 // Meta Menu
-"meta.menu.rename" = "Rename";
-"meta.menu.leave" = "Leave";
-"meta.menu.archive" = "Archive";
-"meta.menu.unarchive" = "Unarchive";
-"meta.menu.delete" = "Delete";
-"meta.menu.silence.mute" = "Mute";
-"meta.menu.silence.unmute" = "Unmute";
-"meta.menu.cancel" = "Cancel";
-"meta.menu.cancel_connection_request" = "Cancel Request";
+"meta.menu.rename" = "Yeniden adlandır";
+"meta.menu.leave" = "Ayrıl";
+"meta.menu.archive" = "Arşivle";
+"meta.menu.unarchive" = "Arşivden kaldır";
+"meta.menu.delete" = "Sil";
+"meta.menu.silence.mute" = "Sustur";
+"meta.menu.silence.unmute" = "Sesi aç";
+"meta.menu.cancel" = "İptal";
+"meta.menu.cancel_connection_request" = "İsteği İptal Et";
 
 // Delete conversation
-"meta.menu.delete_content.dialog_title" = "Delete content?";
-"meta.menu.delete_content.dialog_message" = "This will clear the conversation history and remove it from the list.";
-"meta.menu.delete_content.leave_as_well_message" = "Also leave the conversation";
-"meta.menu.delete_content.button_cancel" = "Cancel";
-"meta.menu.delete_content.button_delete" = "Delete";
+"meta.menu.delete_content.dialog_title" = "İçerik silinsin?";
+"meta.menu.delete_content.dialog_message" = "Sohbet geçmişi silinecek ve bu sohbet listeden kaldırılacak.";
+"meta.menu.delete_content.leave_as_well_message" = "Konuşmadan da ayrıl";
+"meta.menu.delete_content.button_cancel" = "İptal";
+"meta.menu.delete_content.button_delete" = "Sil";
 
 // Leave conversation
-"meta.leave_conversation_dialog_title" = "Leave conversation?";
-"meta.leave_conversation_dialog_message" = "The participants will be notified and the conversation will be removed from your list.";
-"meta.leave_conversation.delete_content_as_well_message" = "Also delete the content";
-"meta.leave_conversation_button_cancel" = "Cancel";
-"meta.leave_conversation_button_leave" = "Leave";
+"meta.leave_conversation_dialog_title" = "Konuşmadan ayrıl?";
+"meta.leave_conversation_dialog_message" = "Katılımcılar bilgilendirilecek ve konuşma listenizden silinecektir.";
+"meta.leave_conversation.delete_content_as_well_message" = "İçeriği de sil";
+"meta.leave_conversation_button_cancel" = "İptal";
+"meta.leave_conversation_button_leave" = "Ayrıl";
 
 // Conversation Degraded (security level lowered)
-"meta.degraded.degradation_reason_message.singular" = "%@ started using a new device.";
-"meta.degraded.degradation_reason_message.plural" = "%@ started using new devices.";
-"meta.degraded.dialog_message" = "Do you still want to send your message?";
-"meta.degraded.show_device_button" = "Show device";
-"meta.degraded.send_anyway_button" = "Send anyway";
+"meta.degraded.degradation_reason_message.singular" = "%@ yeni bir cihaz kullanmaya başladı.";
+"meta.degraded.degradation_reason_message.plural" = "%@ yeni cihazlar kullanmaya başladı.";
+"meta.degraded.dialog_message" = "Hâlâ mesajınızı göndermek istiyor musunuz?";
+"meta.degraded.show_device_button" = "Cihazı göster";
+"meta.degraded.send_anyway_button" = "Yine de gönder";
 
 // Remove from conversation dialogue
-"profile.remove_dialog_title" = "Remove?";
-"profile.remove_dialog_message" = "%@ won’t be able to send or receive messages in this conversation.";
-"profile.remove_dialog_button_cancel" = "Cancel";
-"profile.remove_dialog_button_remove" = "Remove";
+"profile.remove_dialog_title" = "Sil?";
+"profile.remove_dialog_message" = "%@ bu konuşmaya mesaj gönderemeyecek ve bu görüşmeden mesaj alamayacak.";
+"profile.remove_dialog_button_cancel" = "İptal";
+"profile.remove_dialog_button_remove" = "Kaldır";
 
 // Block dialog
-"profile.block_dialog.title" = "Block?";
-"profile.block_dialog.message" = "%@ won’t be able to find or contact you on Wire.";
-"profile.block_dialog.button_cancel" = "Cancel";
-"profile.block_dialog.button_block" = "Block";
+"profile.block_dialog.title" = "Engelle?";
+"profile.block_dialog.message" = "%@ sizi Wire'da bulamayacak ve sizinle iletişime geçemeyecek.";
+"profile.block_dialog.button_cancel" = "İptal";
+"profile.block_dialog.button_block" = "Engelle";
 
 // Delete message dialog
-"message.delete_dialog.message" = "This cannot be undone.";
-"message.delete_dialog.action.cancel" = "Cancel";
-"message.delete_dialog.action.hide" = "Delete for Me";
-"message.delete_dialog.action.delete" = "Delete for Everyone";
+"message.delete_dialog.message" = "Bu işlem geriye alınamaz.";
+"message.delete_dialog.action.cancel" = "İptal";
+"message.delete_dialog.action.hide" = "Benim için silindi";
+"message.delete_dialog.action.delete" = "Herkes için sil";
 
 // Edit message
-"message.menu.edit.title" = "Edit";
+"message.menu.edit.title" = "Düzenle";
 
 // Accept connection request
-"profile.connection_request_dialog.title" = "Accept?";
-"profile.connection_request_dialog.message" = "This will connect you and open the conversation with %@.";
-"profile.connection_request_dialog.button_cancel" = "Ignore";
-"profile.connection_request_dialog.button_connect" = "Connect";
+"profile.connection_request_dialog.title" = "Kabul et?";
+"profile.connection_request_dialog.message" = "Bu sizi, %@ ile bağlayacak ve bir konuşma açacak.";
+"profile.connection_request_dialog.button_cancel" = "Yoksay";
+"profile.connection_request_dialog.button_connect" = "Bağlan";
 
 // Cancel connection request
-"profile.cancel_connection_request_dialog.title" = "Cancel Request?";
-"profile.cancel_connection_request_dialog.message" = "Remove connection request to %@.";
-"profile.cancel_connection_request_dialog.button_no" = "No";
-"profile.cancel_connection_request_dialog.button_yes" = "Yes";
+"profile.cancel_connection_request_dialog.title" = "İstek iptal edilsin mi?";
+"profile.cancel_connection_request_dialog.message" = "%@'a olan bağlanma isteğini kaldır.";
+"profile.cancel_connection_request_dialog.button_no" = "Hayır";
+"profile.cancel_connection_request_dialog.button_yes" = "Evet";
 
 // Unblock button
-"profile.unblock_button_title" = "Unblock";
+"profile.unblock_button_title" = "Engeli kaldır";
 
-"profile.cancel_connection_button_title" = "CANCEL REQUEST";
-"profile.connection_request_state.blocked" = "BLOCKED";
-"profile.create_conversation_button_title" = "Create group";
-"profile.open_conversation_button_title" = "Open conversation";
+"profile.cancel_connection_button_title" = "İSTEĞİ İPTAL ET";
+"profile.connection_request_state.blocked" = "ENGELLENDİ";
+"profile.create_conversation_button_title" = "Grup oluştur";
+"profile.open_conversation_button_title" = "Konuşma aç";
 
 // User Details
-"profile.details.title" = "Details";
+"profile.details.title" = "Ayrıntılar";
 
 // Device list
-"profile.devices.title" = "Devices";
-"profile.devices.fingerprint_message_unencrypted" = "%@ is using an old version of Wire. No devices are shown here.";
-"profile.devices.fingerprint_message" = "Wire gives every device a unique fingerprint. Compare them with %@ and verify your conversation. Why verify conversations?";
-"profile.devices.fingerprint_message.link" = "Why verify conversations?";
+"profile.devices.title" = "Cihazlar";
+"profile.devices.fingerprint_message_unencrypted" = "%@, Wire'ın eski bir versiyonunu kullanıyor. Hiçbir cihaz burada gösterilmiyor.";
+"profile.devices.fingerprint_message" = "Wire her cihaza eşsiz bir parmak izi verir. %@ ile karşılaştır ve konuşmayı doğrulayın. Neden konuşmaları doğrulamalıyız?";
+"profile.devices.fingerprint_message.link" = "Neden konuşmaları doğrulamalıyız?";
 
 // Device detail
-"profile.devices.detail.verify_message" = "Verify that this matches the fingerprint shown on %@'s device.";
-"profile.devices.detail.verify_message.link" = "How do I do that?";
-"profile.devices.detail.show_my_device.title" = "Show my device fingerprint";
-"device.verified" = "Verified";
-"device.not_verified" = "Not Verified";
-"device.class.desktop" = "Desktop";
+"profile.devices.detail.verify_message" = "Bunun %@'ın aygıtında gösterilen parmak iziyle eşleştiğini doğrulayın.";
+"profile.devices.detail.verify_message.link" = "Bunu nasıl yaparım?";
+"profile.devices.detail.show_my_device.title" = "Cihazımın parmak izini göster";
+"device.verified" = "Doğrulanmış";
+"device.not_verified" = "Doğrulanmadı";
+"device.class.desktop" = "Masaüstü";
 "device.class.tablet" = "Tablet";
-"device.class.phone" = "Phone";
-"profile.devices.detail.reset_session.title" = "Reset Session";
+"device.class.phone" = "Telefon";
+"profile.devices.detail.reset_session.title" = "Oturumu sıfırla";
 
 // General strings
-"general.confirm" = "OK";
+"general.confirm" = "TAMAM";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Self profile
-
 // Options menu contents
-"self.settings" = "Settings";
-"self.help_center" = "Support";
-"self.help_center.support_website" = "Wire Support Website";
-"self.help_center.contact_support" = "Contact Support";
-"self.about" = "About";
-"self.sign_out" = "Log Out";
-"self.report_abuse" = "Report Misuse";
 
-"self.add_phone_number" = "Add phone number";
-"self.add_email_password" = "Add email address and password";
+"self.settings" = "Ayarlar";
+"self.help_center" = "Destek";
+"self.help_center.support_website" = "Wire Destek İnternet Sitesi";
+"self.help_center.contact_support" = "Destek Hizmetlerine Ulaşın";
+"self.about" = "Hakkında";
+"self.sign_out" = "Çıkış Yap";
+"self.report_abuse" = "Kötüye Kullanımı Raporla";
+
+"self.add_phone_number" = "Telefon numarası ekleyin";
+"self.add_email_password" = "E-posta adresi ve parola ekleyin";
 
 // About screen
-"about.tos.title"="Terms of Use";
-"about.privacy.title"="Privacy Policy";
-"about.license.title" = "License Information";
-"about.website.title"="Wire Website";
-"about.copyright.title"="© Wire Swiss GmbH";
+"about.tos.title" = "Kullanım Şartları";
+"about.privacy.title" = "Gizlilik Politikası";
+"about.license.title" = "Lisans Bilgileri";
+"about.website.title" = "Wire İnternet Sitesi";
+"about.copyright.title" = "© Wire Swiss GmbH";
 
 // Self new devices
-"self.new_device_alert.title" = "You have connected %@ to your Wire account";
-"self.new_device_alert.title_prefix.tablet" = "a tablet";
-"self.new_device_alert.title_prefix.phone" = "a phone";
-"self.new_device_alert.title_prefix.devices" = "%d devices";
-"self.new_device_alert.message" = "%@\n\nIf you didn’t do this, remove the device and reset your password.";
-"self.new_device_alert.message_plural" = "%@\n\nIf you didn’t do this, remove those devices and reset your password.";
-"self.new_device_alert.manage_devices" = "Manage devices";
-"self.new_device_alert.trust_devices" = "OK";
+"self.new_device_alert.title" = "%@'ı Wire hesabınıza bağladınız";
+"self.new_device_alert.title_prefix.tablet" = "bir tablet";
+"self.new_device_alert.title_prefix.phone" = "bir telefon";
+"self.new_device_alert.title_prefix.devices" = "%d cihaz";
+"self.new_device_alert.message" = "%@\n\nEğer bunu yapmadıysanız, cihazı kaldırın ve şifrenizi sıfırlayın.";
+"self.new_device_alert.message_plural" = "%@\n\nEğer bunu yapmadıysanız, cihazları kaldırın ve şifrenizi sıfırlayın.";
+"self.new_device_alert.manage_devices" = "Cihazları yönet";
+"self.new_device_alert.trust_devices" = "TAMAM";
 
 // Settings - Account details
-"self.settings.account_section" = "Account";
+"self.settings.account_section" = "Hesap";
 
-"self.settings.account_details_group.title" = "Info";
+"self.settings.account_details_group.title" = "Bilgi";
 
-"self.settings.account_section.name.title" = "Name";
-"self.settings.account_section.email.title" = "Email";
-"self.settings.account_section.phone.title" = "Phone";
+"self.settings.account_section.name.title" = "İsim";
+"self.settings.account_section.email.title" = "E-posta";
+"self.settings.account_section.phone.title" = "Telefon";
 
-"self.settings.account_details_group.footer" = "People can find you with these details.";
+"self.settings.account_details_group.footer" = "İnsanlar sizi bu bilgiler ile bulabilirler.";
 
-"self.settings.account_details.remove_device.title" = "Remove Device";
-"self.settings.account_details.key_fingerprint.title" = "Key Fingerprint";
-"self.settings.account_details.remove_device.message" = "Your password is required to remove the device";
-"self.settings.account_details.remove_device.password" = "Password";
-"self.settings.account_details.remove_device.password.error" = "Wrong password";
+"self.settings.account_details.remove_device.title" = "Cihazı Kaldır";
+"self.settings.account_details.key_fingerprint.title" = "Anahtar Parmak İzi";
+"self.settings.account_details.remove_device.message" = "Cihazı kaldırmak için parolanız gerekli";
+"self.settings.account_details.remove_device.password" = "Parola";
+"self.settings.account_details.remove_device.password.error" = "Yanlış parola";
 
-"self.settings.account_appearance_group.title" = "Appearance";
-"self.settings.account_picture_group.picture" = "Picture";
-"self.settings.account_picture_group.color" = "Color";
+"self.settings.account_appearance_group.title" = "Görünüm";
+"self.settings.account_picture_group.picture" = "Resim";
+"self.settings.account_picture_group.color" = "Renk";
 
-"self.settings.account_picture_group.theme" = "Dark Theme";
+"self.settings.account_picture_group.theme" = "Karanlık Tema";
 
-"self.settings.device_details.fingerprint.subtitle" = "Wire gives every device a unique fingerprint. Compare them and verify your devices and conversations.";
-"self.settings.device_details.reset_session.subtitle" = "If fingerprints don’t match, reset the session to generate new encryption keys on both sides.";
-"self.settings.device_details.remove_device.subtitle" = "Remove this device if you have stopped using it. Your message history will be erased and you will be logged out.";
-"self.settings.device_details.reset_session.success" = "The session has been reset";
+"self.settings.device_details.fingerprint.subtitle" = "Wire her cihaza kendine has bir parmak izi verir. Cihazlarınızı ve konuşmalarınızı doğrulamak için parmak izlerinizi karşılaştırın.";
+"self.settings.device_details.reset_session.subtitle" = "Parmak izleri eşleşmezse, her iki tarafta da yeni şifreleme anahtarları oluşturmak için oturumu sıfırlayın.";
+"self.settings.device_details.remove_device.subtitle" = "Bu cihazı kullanmayı bıraktıysanız buradan silin. Mesaj geçmişiniz silinecek ve oturumunuz kapanmış olacak.";
+"self.settings.device_details.reset_session.success" = "Oturum sıfırlandı";
 
-"self.settings.account_details.actions.title" = "Actions";
+"self.settings.account_details.actions.title" = "Eylemler";
 
-"self.settings.account_details.delete_account.title" = "Delete Account";
+"self.settings.account_details.delete_account.title" = "Hesabı Sil";
 
-"self.settings.account_details.delete_account.alert.title" = "Delete Account";
-"self.settings.account_details.delete_account.alert.message" = "We will send you a message via email or SMS. Follow the link to permanently delete your account.";
+"self.settings.account_details.delete_account.alert.title" = "Hesabı Sil";
+"self.settings.account_details.delete_account.alert.message" = "Size e-posta veya SMS üzerinden mesaj göndereceğiz. Hesabınızı kalıcı olarak silmek için bağlantıyı izleyin.";
 
 
 // Chat alerts
-"self.settings.notifications.push_notification.title" = "Notifications";
-"self.settings.notifications.push_notification.toogle" = "Message Previews";
-"self.settings.notifications.push_notification.footer" = "Sender name and message on the lock screen and in Notification Center.";
+"self.settings.notifications.push_notification.title" = "Bildirimler";
+"self.settings.notifications.push_notification.toogle" = "Mesaj önizlemeleri";
+"self.settings.notifications.push_notification.footer" = "Gönderenin adı ve mesaj kilit ekranı ve Bildirim Merkezinde.";
 
-"self.settings.notifications.chat_alerts.toggle" = "Message Banners";
-"self.settings.notifications.chat_alerts.footer" = "New messages in other conversations.";
+"self.settings.notifications.chat_alerts.toggle" = "Mesaj afişleri";
+"self.settings.notifications.chat_alerts.footer" = "Diğer konuşmalarda yeni mesajlar.";
 
-"self.settings.sound_menu.sounds.title" = "Sounds";
-"self.settings.sound_menu.ringtone.title" = "Ringtone";
-"self.settings.sound_menu.message.title" = "Text Tone";
+"self.settings.sound_menu.sounds.title" = "Sesler";
+"self.settings.sound_menu.ringtone.title" = "Arama zil sesi";
+"self.settings.sound_menu.message.title" = "Mesaj Sesi";
 "self.settings.sound_menu.ping.title" = "Ping";
-"self.settings.sound_menu.ringtones.title" = "Ringtones";
+"self.settings.sound_menu.ringtones.title" = "Zil Sesleri";
 "self.settings.sound_menu.sounds.wire_sound" = "Wire";
 
-"self.settings.sound_menu.sounds.wire_call" = "Wire Call";
-"self.settings.sound_menu.sounds.wire_message" = "Wire Message";
-"self.settings.sound_menu.sounds.wire_ping" = "Wire Ping";
+"self.settings.sound_menu.sounds.wire_call" = "Wire Araması";
+"self.settings.sound_menu.sounds.wire_message" = "Wire Mesajı";
+"self.settings.sound_menu.sounds.wire_ping" = "Wire Pingi";
 
 // By popular demand
-"self.settings.popular_demand.title" = "By popular demand";
-"self.settings.popular_demand.send_button.title" = "Send Button";
-"self.settings.popular_demand.send_button.footer" = "Disable to send via the return key.";
+"self.settings.popular_demand.title" = "Yoğun talep üzerine";
+"self.settings.popular_demand.send_button.title" = "Gönder butonu";
+"self.settings.popular_demand.send_button.footer" = "Giriş (Enter) tuşu ile göndermeyi devre dışı bırak.";
 
 // Sound alerts (TO BE UPDPATED)
-"self.settings.sound_menu.title" = "Sound Alerts";
-"self.settings.sound_menu.no_sounds.title" = "None";
-"self.settings.sound_menu.all_sounds.title" = "All";
-"self.settings.sound_menu.mute_while_talking.title" = "First message, pings, calls";
+"self.settings.sound_menu.title" = "Sesli Uyarılar";
+"self.settings.sound_menu.no_sounds.title" = "Hiçbiri";
+"self.settings.sound_menu.all_sounds.title" = "Hepsi";
+"self.settings.sound_menu.mute_while_talking.title" = "İlk mesaj, seslenmeler, aramalar";
 
 // Developer options
-"self.settings.developer_options.title" = "Developer Options";
-"self.settings.apns_logging.title" = "APNS Logging";
+"self.settings.developer_options.title" = "Geliştiri Seçenekleri";
+"self.settings.apns_logging.title" = "APNS Günlüğü";
 
 // Privacy (visibility) options
-"self.settings.options_menu.title" = "Options";
+"self.settings.options_menu.title" = "Seçenekler";
 
-"self.settings.privacy_contacts_section.title" = "Contacts";
-"self.settings.privacy_contacts_menu.settings_button.title" = "Open Contacts Settings";
-"self.settings.privacy_contacts_menu.description_disabled.title" = "This helps you connect with others. We anonymize all the information and do not share it with anyone else. Allow access via Settings > Privacy > Contacts.";
+"self.settings.privacy_contacts_section.title" = "Kişiler";
+"self.settings.privacy_contacts_menu.settings_button.title" = "Rehber Ayarlarını açın";
+"self.settings.privacy_contacts_menu.description_disabled.title" = "Kişilerinizi paylaşmak, başkalarına bağlanmanızı kolaylaştırır. Biz size ait tüm bilgileri gizler ve başkalarıyla paylaşmayız. Ayarlar > Gizlilik > Kişiler'den bu erişimi aktifleştirebilirsiniz.";
 
-"self.settings.privacy_analytics_menu.devices.title" = "Devices";
+"self.settings.privacy_analytics_menu.devices.title" = "Cihazlar";
 
-"self.settings.privacy_analytics_section.title" = "Usage and Crash Reports";
-"self.settings.privacy_analytics_menu.description.title" = "Make Wire better by sending anonymous information.\n";
+"self.settings.privacy_analytics_section.title" = "Kullanım ve kilitlenme raporları";
+"self.settings.privacy_analytics_menu.description.title" = "Anonim bilgiler göndererek Wire'ın daha iyi olmasını sağlayabilirsiniz.\n";
 
-"self.settings.privacy.clear_history.title" = "Clear History";
-"self.settings.privacy.clear_history.subtitle" = "This will permanently erase the content of all your conversations.";
+"self.settings.privacy.clear_history.title" = "Geçmişi Temizle";
+"self.settings.privacy.clear_history.subtitle" = "Bu kalıcı olarak tüm konuşmalarınıza içeriğinizi silecektir.";
 
-"self.settings.advanced.title" = "Advanced";
-"self.settings.advanced.troubleshooting.title" = "Troubleshooting";
-"self.settings.advanced.troubleshooting.submit_debug.title" = "Calling Debug Report";
-"self.settings.advanced.troubleshooting.submit_debug.subtitle" = "This information helps Wire Support diagnose calling problems.";
-"self.settings.advanced.reset_push_token.title" = "Reset Push Notifications Token";
-"self.settings.advanced.reset_push_token.subtitle" = "If you experience problems with push notifications, Wire Support may ask you to reset this token.";
-"self.settings.advanced.reset_push_token_alert.title" = "Push token has been reset";
-"self.settings.advanced.reset_push_token_alert.message" = "Notifications will be restored in a few seconds.";
-"self.settings.advanced.version_technical_details.title" = "Version Technical Details";
+"self.settings.advanced.title" = "Gelişmiş";
+"self.settings.advanced.troubleshooting.title" = "Sorun giderme";
+"self.settings.advanced.troubleshooting.submit_debug.title" = "Rapor çağırılıyor";
+"self.settings.advanced.troubleshooting.submit_debug.subtitle" = "Bu bilgiler Wire Destek Ekibi'nin, arama sorunlarınızı teşhis etmesine yardımcı olur.";
+"self.settings.advanced.reset_push_token.title" = "Bildirim Sıfırlama Belirteci";
+"self.settings.advanced.reset_push_token.subtitle" = "Eğer anlık bildirimler ile sorun yaşıyorsanız, Wire Destek sizden jetonu sıfırlamanızı isteyebilir.";
+"self.settings.advanced.reset_push_token_alert.title" = "Anlık Belirteş sıfırlandı";
+"self.settings.advanced.reset_push_token_alert.message" = "Bildirimleri birkaç saniye içinde geri yüklenecektir.";
+"self.settings.advanced.version_technical_details.title" = "Versiyonun Teknik Ayrıntıları";
 
 // Technical Report
-"self.settings.technical_report_section.title" = "Technical Report";
-"self.settings.technical_report.send_report" = "Send report to Wire";
+"self.settings.technical_report_section.title" = "Teknik Destek";
+"self.settings.technical_report.send_report" = "Raporu Wire'a gönder";
 "self.settings.technical_report.mail.recipient" = "callingsupport@wire.com";
-"self.settings.technical_report.mail.subject" = "Wire Calling Report";
-"self.settings.technical_report.include_log" = "Include detailed log";
+"self.settings.technical_report.mail.subject" = "Rapor çağırılıyor";
+"self.settings.technical_report.include_log" = "Detaylı günlüğü ekle";
 
 // Password reset
-"self.settings.password_reset_menu.title" = "Reset Password";
+"self.settings.password_reset_menu.title" = "Parolayı Sıfırla";
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // System status
-"system_status_bar.no_internet.title" = "No Internet";
-"system_status_bar.no_internet.explanation" = "There seems to be a problem with your Internet connection. Please make sure it’s working.";
-"system_status_bar.poor_connectivity.title" = "Slow Internet, can’t call now";
-"system_status_bar.poor_connectivity.explanation" = "We can’t guarantee voice quality. Connect to Wi-Fi or try changing your location.";
+"system_status_bar.no_internet.title" = "İnternet Bağlantısı Yok";
+"system_status_bar.no_internet.explanation" = "İnternet bağlantınızla ilgili bir sorun var gibi görünüyor. Lütfen çalıştığından emin olun.";
+"system_status_bar.poor_connectivity.title" = "İnternetim yavaş, şuan arayamıyorum";
+"system_status_bar.poor_connectivity.explanation" = "Ses kalitesi garanti edemiyoruz. Wi-Fİ'a bağlanın veya konumunuzu değiştirmeyi deneyin.";
 
 // Common connections on profile view
-"profile_other.common_connections" = "You both know";
+"profile_other.common_connections" = "Ortak tanıdıklarınız";
 
 // View user profile and options menu
-"name.placeholder" = "Your full name";
-"name.guidance.tooshort" = "At least 2 characters";
-"name.guidance.toolong" = "Too many characters";
+"name.placeholder" = "Tam adınız";
+"name.guidance.tooshort" = "En az 2 karakter";
+"name.guidance.toolong" = "Çok fazla karakter";
 
-"email.placeholder" = "Email";
+"email.placeholder" = "E-posta";
 
-"password.placeholder" = "Password";
-"password.guidance.tooshort" = "At least 8 characters";
-"password.guidance.toolong" = "Too many characters";
+"password.placeholder" = "Parola";
+"password.guidance.tooshort" = "En az 8 karakter";
+"password.guidance.toolong" = "Çok fazla karakter";
 
-"registration.title" = "Registration";
-"registration.close_email_invitation_button.email_title" = "Use another email";
-"registration.close_email_invitation_button.phone_title" = "Register by phone";
-"registration.close_phone_invitation_button.email_title" = "Register by email";
-"registration.close_phone_invitation_button.phone_title" = "Use another phone";
+"registration.title" = "Kayıt";
+"registration.close_email_invitation_button.email_title" = "Başka bir e-posta kullanın";
+"registration.close_email_invitation_button.phone_title" = "Telefon ile kaydol";
+"registration.close_phone_invitation_button.email_title" = "E-posta ile kaydol";
+"registration.close_phone_invitation_button.phone_title" = "Başka bir telefon kullan";
 
-"registration.enter_phone_number.title" = "Edit phone number";
-"registration.enter_phone_number.placeholder" = "Phone number";
+"registration.enter_phone_number.title" = "Telefon numarası edüzenleyin";
+"registration.enter_phone_number.placeholder" = "Telefon numarası";
 
-"registration.verify_phone_number.instructions" = "Enter the verification code we sent to %@";
-"registration.verify_phone_number.resend" = "Resend";
-"registration.verify_phone_number.resend_placeholder" = "No code showing up?\nYou can request a new one in %.0f seconds";
+"registration.verify_phone_number.instructions" = "%@'na gönderdiğimiz doğrulama kodunu girin";
+"registration.verify_phone_number.resend" = "Yeniden gönder";
+"registration.verify_phone_number.resend_placeholder" = "Görünürde kod yok mu?\n%.0f saniye içerisinde yenisini isteyebilirsin";
 
-"registration.verify_email.instructions" = "We sent an email to %@.\n Follow the link to verify your address.";
-"registration.verify_email.resend.instructions" = "Didn't get the message?";
-"registration.verify_email.resend.button_title" = "Re-send";
+"registration.verify_email.instructions" = "%@ adresine e-posta gönderdik. \n Adresi doğrulamak için bağlantıyı takip edin.";
+"registration.verify_email.resend.instructions" = "E-posta gelmedi mi?";
+"registration.verify_email.resend.button_title" = "Yeniden gönder";
 
-"registration.select_picture.subtitle" = "Wire is so much nicer with a picture.";
-"registration.select_picture.button_title" = "Choose your own";
-"registration.keep_picture.button_title" = "Keep this one";
-"registration.camera_action.title" = "Take photo";
-"registration.photo_gallery_action.title" = "Choose Photo";
-"registration.cancel_action.title" = "Cancel";
+"registration.select_picture.subtitle" = "Wire bir fotoğrafla çok daha iyi.";
+"registration.select_picture.button_title" = "Kendininkini seç";
+"registration.keep_picture.button_title" = "Bunu sakla";
+"registration.camera_action.title" = "Fotoğraf çek";
+"registration.photo_gallery_action.title" = "Fotoğraf Seçin";
+"registration.cancel_action.title" = "İptal";
 
-"registration.no_history.hero" = "It’s the first time you’re using Wire on this device.";
-"registration.no_history.subtitle" = "For privacy reasons, your conversation history will not appear here.";
-"registration.no_history.got_it" = "OK";
+"registration.no_history.hero" = "Wire'ı bu aygıtta ilk defa kullanıyorsunuz.";
+"registration.no_history.subtitle" = "Gizlilik nedenleriyle, konuşma geçmişiniz burada görünmeyecek.";
+"registration.no_history.got_it" = "TAMAM";
 
-"registration.no_history.logged_out.hero" = "You've used Wire on this device before.";
-"registration.no_history.logged_out.subtitle" = "Messages sent in the meantime will not appear.";
-"registration.no_history.logged_out.got_it" = "OK";
+"registration.no_history.logged_out.hero" = "Daha önce bu aygıtta Wire kullanmışsınız.";
+"registration.no_history.logged_out.subtitle" = "Bu sürede gönderilen mesajlar gözükmeyecektir.";
+"registration.no_history.logged_out.got_it" = "TAMAM";
 
-"registration.enter_name.title" = "Edit Name";
-"registration.enter_name.hero" = "What should we call you?";
-"registration.enter_name.placeholder" = "Your full name";
+"registration.enter_name.title" = "Adı Düzenle";
+"registration.enter_name.hero" = "Size nasıl seslenmeliyiz?";
+"registration.enter_name.placeholder" = "Tam adınız";
 
-"registration.terms_of_use.title" = "Welcome to Wire.";
-"registration.terms_of_use.terms" = "By continuing you agree to the Wire Terms of Use.";
-"registration.terms_of_use.terms.link" = "Terms of Use";
-"registration.terms_of_use.agree" = "I agree";
+"registration.terms_of_use.title" = "Wire'a hoş geldiniz.";
+"registration.terms_of_use.terms" = "Devam ederek Wire Kullanım Şartlarını kabul ediyorsunuz.";
+"registration.terms_of_use.terms.link" = "Kullanım Şartları";
+"registration.terms_of_use.agree" = "Kabul ediyorum";
 
-"registration.email_flow.title" = "Register by Email";
-"registration.email_flow.email_step.title" = "Edit Details";
+"registration.email_flow.title" = "E-posta ile kaydol";
+"registration.email_flow.email_step.title" = "Ayrıntıları Düzenle";
 
-"registration.country_select.title" = "Country";
+"registration.country_select.title" = "Ülke";
 
-"registration.share_contacts.hero.title" = "Find people on Wire";
-"registration.share_contacts.hero.paragraph"  = "Share your contacts so we can connect you with others. We anonymize all information and do not share it with anyone else.";
-"registration.share_contacts.find_friends_button.title" = "Share contacts";
-"registration.share_contacts.skip_button.title" = "Not now";
+"registration.share_contacts.hero.title" = "Wire'da yeni insanlar keşfedin";
+"registration.share_contacts.hero.paragraph" = "Kişilerinizi paylaşın ki sizi başkalarına bağlayabilelim. Tüm bilgilerinizi gizler ve kimseyle paylaşmayız.";
+"registration.share_contacts.find_friends_button.title" = "Kişileri paylaş";
+"registration.share_contacts.skip_button.title" = "Şimdi değil";
 
-"registration.address_book_access_denied.hero.title" = "Wire does not have access to your contacts.";
-"registration.address_book_access_denied.hero.paragraph1" = "Wire helps find your friends if you share your contacts.";
-"registration.address_book_access_denied.hero.paragraph2" = "To enable access tap Settings and turn on Contacts.";
-"registration.address_book_access_denied.settings_button.title" = "Settings";
-"registration.address_book_access_denied.maybe_later_button.title" = "Maybe later";
+"registration.address_book_access_denied.hero.title" = "Wire'ın kişilerinize erişimi yoktur.";
+"registration.address_book_access_denied.hero.paragraph1" = "Eğer kişilerinizi paylaşırsanız Wire arkadaşlarınızı bulmanıza yardım eder.";
+"registration.address_book_access_denied.hero.paragraph2" = "Erişim sağlamak için Ayarlara girip Kişileri açın.";
+"registration.address_book_access_denied.settings_button.title" = "Ayarlar";
+"registration.address_book_access_denied.maybe_later_button.title" = "Belki sonra";
 
-"registration.push_access_denied.hero.title" = "Never miss a call or a message.";
-"registration.push_access_denied.hero.paragraph1" = "Enable Notifications in Settings.";
-"registration.push_access_denied.settings_button.title" = "Go to Settings";
-"registration.push_access_denied.maybe_later_button.title" = "Maybe later";
+"registration.push_access_denied.hero.title" = "Asla bir arama veya mesaj kaçırmayın.";
+"registration.push_access_denied.hero.paragraph1" = "Ayarlardan Bildirimleri Etkinleştir.";
+"registration.push_access_denied.settings_button.title" = "Ayarlara git";
+"registration.push_access_denied.maybe_later_button.title" = "Belki sonra";
 
-"registration.signin.title" = "Log In";
+"registration.signin.title" = "Oturum Aç";
 "registration.signin.too_many_devices.title" = "";
-"registration.signin.too_many_devices.subtitle" = "Remove one of your other devices to start using Wire on this one.";
-"registration.signin.too_many_devices.manage_button.title" = "Manage devices";
-"registration.signin.too_many_devices.sign_out_button.title" = "Log out";
-"registration.signin.email_button.title" = "Email";
-"registration.signin.phone_button.title" = "Phone";
+"registration.signin.too_many_devices.subtitle" = "Wire'ı bu cihazda kullanmak için diğer cihazlarınızdan birini silin.";
+"registration.signin.too_many_devices.manage_button.title" = "Cihazları yönet";
+"registration.signin.too_many_devices.sign_out_button.title" = "Çıkış yap";
+"registration.signin.email_button.title" = "E-posta";
+"registration.signin.phone_button.title" = "Telefon";
 
-"registration.devices.title" = "Devices";
-"registration.devices.active_list_header" = "Active";
-"registration.devices.current_list_header" = "Current";
-"registration.devices.active_list_subtitle" = "If you don’t recognize a device above, remove it and reset your password.";
-"registration.devices.activated_in" = "Activated in";
+"registration.devices.title" = "Cihazlar";
+"registration.devices.active_list_header" = "Etkin";
+"registration.devices.current_list_header" = "Şu anki";
+"registration.devices.active_list_subtitle" = "Yukarıdaki cihazı tanımıyorsanız, onu silin ve parolanızı sıfırlayın.";
+"registration.devices.activated_in" = "Etkinleştirildi";
 "registration.devices.id" = "ID:";
 
-"signin.forgot_password" = "Forgot password?";
+"signin.forgot_password" = "Şifrenizi mi unuttunuz?";
 
-"registration.add_phone_number.hero.title" = "Add phone number";
-"registration.add_phone_number.hero.paragraph" = "This helps us find people you may know. We never share it.";
-"registration.add_phone_number.skip_button.title" = "Not now";
+"registration.add_phone_number.hero.title" = "Telefon numarası ekleyin";
+"registration.add_phone_number.hero.paragraph" = "Bu bildiğiniz insanlar bulmamıza yardımcı olur. Asla paylaşmayız.";
+"registration.add_phone_number.skip_button.title" = "Şimdi değil";
 
-"registration.add_email_password.hero.title" = "Add your email and password.";
-"registration.add_email_password.hero.paragraph" = "This lets you use Wire on multiple devices.";
+"registration.add_email_password.hero.title" = "E-posta adresinizi ve parolanızı ekleyin.";
+"registration.add_email_password.hero.paragraph" = "Birden çok cihazda Wire kullanmanıza imkan tanır.";
 
-"registration.email_invitation.title" = "Invitation";
-"registration.email_invitation.hero.title" = "Hello, %@";
-"registration.email_invitation.hero.paragraph" = "Choose a password to create your account.";
+"registration.email_invitation.title" = "Davetiye";
+"registration.email_invitation.hero.title" = "Merhaba, %@";
+"registration.email_invitation.hero.paragraph" = "Hesabınızı oluşturmak için bir parola seçin.";
 
-"registration.phone_invitation.title" = "Invitation";
-"registration.phone_invitation.hero.title" = "Hello, %@";
-"registration.phone_invitation.hero.paragraph" = "You are one step away from creating your account.";
+"registration.phone_invitation.title" = "Davetiye";
+"registration.phone_invitation.hero.title" = "Merhaba, %@";
+"registration.phone_invitation.hero.paragraph" = "Hesabınızı oluşturmanıza bir adım kaldı.";
 
-"error.name_and_email" = "Please enter your full name and a valid email address";
-"error.full_name" = "Please enter your full name";
-"error.email" = "Please enter a valid email address";
-"error.input.too_long" = "Input too long";
-"error.input.too_short" = "Input too short";
-"error.email.invalid" = "Please enter a valid email address";
-"error.phone.invalid" = "Please enter a valid phone number";
+"error.name_and_email" = "Lütfen tam adınız ile geçerli bir e-posta adresi giriniz";
+"error.full_name" = "Lütfen tam adınızı girin";
+"error.email" = "Lütfen geçerli bir e-posta adresi girin";
+"error.input.too_long" = "Giriş çok uzun";
+"error.input.too_short" = "Giriş çok kısa";
+"error.email.invalid" = "Lütfen geçerli bir e-posta adresi girin";
+"error.phone.invalid" = "Lütfen geçerli bir telefon numarası girin";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // ZMUserSessionErrorCode mapping. Used during registration and profile edit
-"error.user.unkown_error" = "Something went wrong, please try again";
-"error.user.needs_credentials" = "Please verify your details and try again.";
-"error.user.invalid_credentials" = "Please verify your details and try again.";
-"error.user.account_pending_activation" = "The account you are trying access is pending activation. Please verify your details.";
-"error.user.network_error" = "There seems to be a problem with your network. Please try again later.";
-"error.user.email_is_taken" = "The email address you provided has already been registered. Please try again.";
-"error.user.phone_is_taken" = "The phone number you provided has already been registered. Please try again.";
-"error.user.phone_code_invalid" = "Please enter a valid code";
-"error.user.phone_code_too_many" = "We already sent you a code via SMS. Tap Resend after 10 minutes to get a new one.";
-"error.user.registration_unknown_error" = "Something went wrong. Please try again.";
-"error.user.device_deleted_remotely" = "You have been logged out from another device.";
+"error.user.unkown_error" = "Bir şeyler ters gitti, lütfen tekrar deneyin";
+"error.user.needs_credentials" = "Lütfen bilgilerinizi doğrulayın ve yeniden deneyin.";
+"error.user.invalid_credentials" = "Lütfen bilgilerinizi doğrulayın ve yeniden deneyin.";
+"error.user.account_pending_activation" = "Ulaşmaya çalıştığınız hesap aktivosyan beklemesindedir. Lütfen bilgilerinizi doğrulayınız.";
+"error.user.network_error" = "Ağınızda problem var gibi gözüküyor. Lütfen daha sonra yeniden deneyin.";
+"error.user.email_is_taken" = "Yazdığınız e-posta adresi zaten kayıtlı. Lütfen tekrar deneyin.";
+"error.user.phone_is_taken" = "Verdiğiniz telefon numarası zaten kayıtlı görünüyor. Lütfen yeniden deneyin.";
+"error.user.phone_code_invalid" = "Lütfen geçerli bir kod girin";
+"error.user.phone_code_too_many" = "Size SMS ile bir kod zaten gönderdik. Yenisini almak için 10 dakika sonra Yeniden Gönder'e basın.";
+"error.user.registration_unknown_error" = "Bir şeyler ters gitti, lütfen tekrar deneyin.";
+"error.user.device_deleted_remotely" = "Başka bir cihaz tarafından oturumunuz kapatıldı.";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Those are caught by the UI without involving the SE validation. Basically very similar to ZMUserSessionErrorCode onces
-"error.updating_password" = "Couldn't update your password.";
+"error.updating_password" = "Parolanızı güncelleştiremedik.";
 
-"error.group_call.too_many_members_in_conversation.title" = "Too many people to call";
-"error.group_call.too_many_members_in_conversation" = "Calls work in conversations with up to %d people.";
-"error.group_call.too_many_participants_in_the_call.title" = "The call is full";
-"error.group_call.too_many_participants_in_the_call" = "There’s only room for %d people in here.";
-"error.call.gsm_ongoing.title" = "Cellular call";
-"error.call.gsm_ongoing" = "Please cancel the cellular call before calling on Wire.";
-"error.call.general.title" = "Call error";
-"error.call.general" = "Please try calling again in several minutes.";
-"error.call.slow_connection.title" = "Slow connection";
-"error.call.slow_connection" = "You might experience issues during the call";
-"error.call.slow_connection.call_anyway" = "Call anyway";
+"error.group_call.too_many_members_in_conversation.title" = "Aramak için çok insan var";
+"error.group_call.too_many_members_in_conversation" = "Aramalar %d kişiye kadar yapılabilir.";
+"error.group_call.too_many_participants_in_the_call.title" = "Çağrı dolu";
+"error.group_call.too_many_participants_in_the_call" = "Burda sadece %d kişiye yer var.";
+"error.call.gsm_ongoing.title" = "Hücresel arama";
+"error.call.gsm_ongoing" = "Lütfen Wire üzerinden arama yapmadan önce hücresel aramayı kapatın.";
+"error.call.general.title" = "Arama hatası";
+"error.call.general" = "Lütfen aramayı birkaç dakika sonra tekrar deneyin.";
+"error.call.slow_connection.title" = "Yavaş bağlantı";
+"error.call.slow_connection" = "Arama sırasında sorunlarla karşılaşabilirsiniz";
+"error.call.slow_connection.call_anyway" = "Yine de ara";
 
-"error.invite.no_email_provider" = "Please configure your email client to be able to send the invites via email";
-"error.invite.no_messaging_provider" = "Please configure your SMS to be able to send the invites via SMS";
+"error.invite.no_email_provider" = "Lütfen e-posta ile davet göndermek için e-posta istemcinizi yapılandırın";
+"error.invite.no_messaging_provider" = "Lütfen SMS göndermek için SMS'inizi yapılandırın";
 
-"sketchpad.initial_hint" = "Tap color to change brush size\nPress and hold to fill an area\nShake to remove a photo";
+"sketchpad.initial_hint" = "Fırça boyutunu değiştirmek için renge dokunun\nBir alanı doldurmak için basılı tutun\nFotoğrafı silmek için sallayın";
 
-"migration.please_wait_message" = "One moment, please";
+"migration.please_wait_message" = "Bir dakika, lütfen";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Those are used by the backend to localize APNS
-"push.notification.new_user" = "%@ joined Wire";
-"push.notification.new_message" = "New message";
+"push.notification.new_user" = "%@ Wire'a katıldı";
+"push.notification.new_message" = "Yeni Mesaj";
 
 
-//Force Update
-"force.update.title" = "Update necessary";
-"force.update.message" = "You are missing out on new features.\nGet the latest version of Wire in the App Store.";
-"force.update.ok_button" = "Go to App Store";
+// Force Update
+"force.update.title" = "Güncelleme gerekli";
+"force.update.message" = "Yeni özellikleri kaçırıyorsun.\nApp Store'dan Wire'ın en güncel versiyonunu indir.";
+"force.update.ok_button" = "App Store'a git";
 
 // Third Party
-"giphy.conversation.message" = "%@ · via giphy.com";
-"giphy.conversation.random_message" = "via giphy.com";
-"giphy.error.no_more_results" = "no more gifs";
-"giphy.error.no_result" = "no gif found";
+"giphy.conversation.message" = "%@ · giphy.com aracılığıyla";
+"giphy.conversation.random_message" = "giphy.com aracılığıyla";
+"giphy.error.no_more_results" = "daha fazla gif yok";
+"giphy.error.no_result" = "gif bulunamadı";
 
-"giphy.confirm" = "send";
-"giphy.cancel" = "cancel";
-"giphy.search_placeholder" = "Search giphy";
+"giphy.confirm" = "gönder";
+"giphy.cancel" = "iptal";
+"giphy.search_placeholder" = "Giphy'de ara";
 
-"invite_banner.title" = "Bring your friends to Wire!";
-"invite_banner.message" = "Enjoy calls, messages, sketches, GIFs and more in private or with groups.";
-"invite_banner.invite_button_title" = "Invite more people";
+"invite_banner.title" = "Arkadaşlarını Wire'a getir!";
+"invite_banner.message" = "Aramaların, mesajların, çizimlerin, GIF'lerin ve daha fazlasının özel olarak veya gruplarda tadını çıkar.";
+"invite_banner.invite_button_title" = "Daha fazla kişi davet et";

--- a/Wire-iOS/Resources/tr.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/tr.lproj/Localizable.strings
@@ -1,0 +1,712 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+"general.ok" = "OK";
+"general.cancel" = "Cancel";
+"general.open_settings" = "Open Wire Settings";
+
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++
+// People picker/start UI
+"peoplepicker.search_placeholder" = "Search by name or email";
+"peoplepicker.header.top_people" = "Top people";
+"peoplepicker.button.create_conversation" = "Create group";
+"peoplepicker.button.add_to_conversation" = "Add";
+"peoplepicker.header.conversations" = "Groups";
+"peoplepicker.header.send_invitation" = "Invite";
+"peoplepicker.header.contacts" = "Connections";
+"peoplepicker.header.directory" = "Connect";
+"peoplepicker.title.create_conversation" = "Create group";
+"peoplepicker.title.add_to_conversation" = "Add people";
+
+"peoplepicker.no_contacts_title" = "No Contacts.";
+
+"peoplepicker.no_matching_results_title" = "No results.";
+"peoplepicker.no_matching_results_message" = "Enter a full email address.";
+
+"peoplepicker.no_matching_results.action.send_invite" = "Send an invitation";
+"peoplepicker.no_matching_results.action.share_contacts" = "Share contacts";
+
+"peoplepicker.no_matching_results_provide_valid_email" = "Please enter a valid email address";
+"peoplepicker.no_matching_results_after_address_book_upload_title" = "No results.";
+/* This sentence ends with button title, contained in peoplepicker.no_matching_results_after_address_book_upload_button */
+"peoplepicker.no_matching_results_after_address_book_upload_message" = "Enter a full email address or";
+/*  */
+"peoplepicker.no_matching_results_after_address_book_upload_button" = "share contacts";
+
+"peoplepicker.share_contacts.no_results.title" = "Find people by name or email address";
+
+"peoplepicker.send_invitation.dialog.title" = "Invitation sent";
+"peoplepicker.send_invitation.dialog.message" = "It can be used for 2 weeks. Send a new one if it expires.";
+"peoplepicker.send_invitation.dialog.ok" = "OK";
+
+"peoplepicker.invite_more_people" = "Invite more people";
+"peoplepicker.quick-action.open-conversation" = "Open";
+"peoplepicker.quick-action.create-conversation" = "Create group";
+
+// Contacts UI
+"contacts_ui.search_placeholder" = "Search by name";
+"contacts_ui.invite_others" = "Invite others";
+"contacts_ui.name_in_contacts" = "%@ in address book";
+"contacts_ui.connection_request" = "Requested to connect";
+"contacts_ui.action_button.invite" = "Invite";
+"contacts_ui.action_button.open" = "Open";
+"contacts_ui.invite_sheet.cancel_button_title" = "Cancel";
+"contacts_ui.notification.invitation_sent" = "Invitation sent";
+"contacts_ui.notification.invitation_failed" = "Failed to send invitation";
+"contacts_ui.title" = "Invite people";
+
+"contacts_ui.no_contact.title" = "No active conversations\n";
+"contacts_ui.no_contact.message" = "Tap contacts to start a conversation";
+
+// Conversation List Bottom Bar
+"bottom_bar.contacts_button.title" = "contacts";
+
+// Archived List
+"archived_list.title" = "archive";
+
+// Add contact tool tip
+"tool_tip.contacts.title" = "Conversations start here";
+"tool_tip.contacts.message" = "Start a conversation or invite more people to join. Call, message and share in private or with groups.";
+
+// "Knows" subtitle in cell: "Knows Indrek", "Knows Indrek and Jane", "Knows Indrek and 5 others"
+"peoplepicker.suggested.knows_one" = "Knows %@";
+"peoplepicker.suggested.knows_two" = "Knows %@ and %@";
+"peoplepicker.hide_search_result" = "Hide";
+"peoplepicker.hide_search_result_progress" = "Hiding…";
+
+"send_invitation.subject" = "Connect with me on Wire";
+"send_invitation.text" = "I’m on Wire. Search for %@\nor visit https://get.wire.com to connect with me.";
+"send_invitation_no_email.text" = "I’m on Wire. Visit https://get.wire.com to connect with me.";
+
+"send_personal_invitation.text" = "I’m on Wire, talk to you there. https://get.wire.com";
+
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++x
+// In-app notifications (chat heads)
+"notifications.shared_a_photo" = "shared a picture";
+"notifications.pinged" = "pinged";
+"notifications.sent_file" = "shared a file";
+"notifications.sent_location" = "shared a location";
+"notifications.sent_video" = "shared a video";
+"notifications.sent_audio" = "shared an audio";
+"notifications.in_conversation" = "%@ - %@";
+"notifications.this_conversation" = "%@ in this conversation";
+
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++
+// List (labels) - Needs to be revised with updated guidance
+"list.archived_conversations" = "ARCHIVE";
+"list.archived_conversations_close" = "Close archive";
+
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++
+// Conversation
+"conversation.invite_more_people.title" = "Spread the word!";
+"conversation.invite_more_people.description" = "Add people to this conversation";
+"conversation.invite_more_people.explanation_url" = "https://support.wire.com";
+"conversation.invite_more_people.button_title" = "Add People";
+
+// Conversation names
+"conversation.displayname.emptygroup" = "Empty group conversation";
+
+"conversation.input_bar.verified" = "Verified";
+"conversation.input_bar.placeholder" = "Type a message";
+
+"conversation.input_bar.audio_message.tooltip.pull_send" = "Swipe up to send";
+"conversation.input_bar.audio_message.tooltip.tap_send" = "Tap to send";
+"conversation.input_bar.audio_message.too_long.title" = "Recording Stopped";
+"conversation.input_bar.audio_message.too_long.message" = "Audio messages are limited to %@. Send this message?";
+"conversation.input_bar.audio_message.send" = "Send";
+
+"conversation.input_bar.audio_message.keyboard.record_tip" = "Tap to record\nYou can  %@  it after that";
+"conversation.input_bar.audio_message.keyboard.filter_tip" = "Choose a filter above";
+
+// Image confirmation dialogue
+"image_confirmer.confirm" = "OK";
+"image_confirmer.cancel" = "Cancel";
+"image.add_sketch" = "Add a sketch";
+"image.edit_image" = "Edit image";
+
+// Camera access
+"camera_access.denied" = "Wire needs access to the Camera.";
+"camera_access.denied.instruction" = "";
+"camera_access.denied.open_settings" = "Enable it in Wire Settings";
+
+// Camera Controls
+"camera_controls.aeaf_lock" = "AE/AF Lock";
+
+// Location
+"location.send_button.title" = "Send";
+"location.unauthorized_alert.title" = "Enable Location Services";
+"location.unauthorized_alert.message" = "To send your location, enable Location Services and allow Wire to access your location.";
+"location.unauthorized_alert.cancel" = "Cancel";
+"location.unauthorized_alert.settings" = "Settings";
+
+// Twitter
+"twitter_status.on_twitter" = "%@ on Twitter";
+
+// System messages
+"content.system.continued_conversation" = "Start a conversation with %@";
+
+"content.system.other_started_conversation" = "%@ started a conversation with %@";
+"content.system.you_started_conversation" = "You started a conversation with %@";
+
+"content.system.you_added_participant" = "You added %@";
+"content.system.other_added_participant" = "%@ added %@";
+"content.system.other_added_you" = "%@ added you";
+
+"content.system.participants_you" = "You";
+"content.system.participants_1_other" = "%@ and %@";
+"content.system.other_left" = "%@ left";
+"content.system.you_left" = "You left";
+"content.system.other_removed_other" = "%@ removed %@";
+"content.system.other_removed_you" = "%@ removed you";
+"content.system.you_removed_other" = "You removed %@";
+"content.system.other_renamed_conv" = "%@ renamed the conversation";
+"content.system.you_renamed_conv" = "You renamed the conversation";
+"content.system.other_renamed_conv_to_nothing" = "%@ removed the conversation name";
+"content.system.you_renamed_conv_to_nothing" = "You removed the conversation name";
+"content.system.pending_message_timestamp" = "Sending…";
+"content.system.message_sent_timestamp" = "Sent";
+"content.system.message_delivered_timestamp" = "Delivered";
+"content.system.failedtosend_message_timestamp" = "Sending failed.";
+"content.system.failedtosend_message_timestamp_resend" = "Resend";
+"content.system.like_tooltip" = "Tap to like";
+"content.system.deleted_message_prefix_timestamp" = "Deleted on %@";
+"content.system.edited_message_prefix_timestamp" = "Edited on %@";
+"content.system.connecting_to" = "Connecting to %@.\nStart a conversation";
+"content.system.connected_to" = "Connected to %@\nStart a conversation";
+"content.system.other_wanted_to_talk" = "%@ called";
+"content.system.you_wanted_to_talk" = "You called";
+
+"content.system.you_started" = "You";
+"content.system.this_device" = "this device";
+
+"content.system.reactivated_device" = "You started using %@ again. Messages sent in the meantime will not appear here";
+
+"content.system.new_device" = "a new device";
+"content.system.started_using" = "started using";
+"content.system.is_verified" = "All fingerprints are verified";
+
+"content.system.unverified" = "%@ unverified one of %@"; //example "You unverified one of Jule's devices"
+"content.system.your_devices" = "your devices";
+"content.system.other_devices" = "%@'s devices";
+
+"content.system.missing_messages.title" = "You haven't used this device for a while. Some messages may not appear here.";
+"content.system.missing_messages.subtitle_start" = "Meanwhile,";
+
+"content.system.cannot_decrypt" = "A message from %@ was not received.";
+
+"content.system.cannot_decrypt.you_part" = "you";
+"content.system.cannot_decrypt.why_part" = "Why?";
+
+"content.system.cannot_decrypt.identity" = "%@ device identity changed. Undelivered message.";
+"content.system.cannot_decrypt.identity.you_part" = "Your";
+"content.system.cannot_decrypt.identity.otherUser_part" = "%@'s"; // posessive apostrophe - might differ in different languages
+"content.system.cannot_decrypt.identity.why_part" = "Learn More";
+
+"content.file.uploading" = "Uploading…";
+"content.file.downloading" = "Downloading…";
+"content.file.upload_failed" = "Upload failed";
+"content.file.upload_cancelled" = "Upload cancelled";
+"content.file.upload_video" = "Videos";
+"content.file.take_video" = "Record a video";
+
+"content.file.save_video" = "Save";
+"content.file.save_audio" = "Save";
+"content.image.save_image" = "Save";
+
+"content.message.delete" = "Delete";
+
+"content.message.like" = "Like";
+"content.message.unlike" = "Unlike";
+
+"content.reactions_list.likers" = "Liked by";
+
+"content.file.too_big" = "You can send files up to %@";
+// Someone pinged
+"content.ping.text" = "%1$@ PINGED";
+
+// Current user pinged
+"content.ping.you.text" = "YOU PINGED";
+
+// Inline Player
+"content.player.unable_to_play" = "UNABLE TO PLAY TRACK";
+
+// Connecting (NEW IMPLEMENTATION, REVIEW LATER)
+"connection_request.title" = "Connect to %@"; //check UPPERCASE implementation in code
+"missive.connection_request.default_message" = "Hi %@,\nLet’s connect on Wire.\n%@";
+
+"connection_request.send_button_title" = "Connect";
+"inbox.connection_request.connect_button_title" = "Connect";
+"inbox.connection_request.ignore_button_title" = "Ignore";
+
+// Voice
+"voice.status.one_to_one.incoming" = "%@\nCalling";
+"voice.status.group_call.incoming" = "%@\nRinging";
+"voice.status.one_to_one.outgoing" = "%@\nRinging";
+"voice.status.joining" = "%@\nConnecting";
+"voice.status.video_not_available" = "Video turned off";
+"voice.status.low_connection" = "Bad connection";
+"voice.network_error.title" = "No Internet Connection";
+"voice.network_error.body" = "You must be online to call. Check your connection and try again.";
+"voice.alert.call_in_progress.title" = "Call in progress";
+"voice.alert.call_in_progress.message" = "Another of your devices is already participating in the call";
+"voice.alert.call_in_progress.confirm" = "Ok";
+"voice.accept_button.title" = "Accept";
+"voice.decline_button.title" = "Decline";
+"voice.hang_up_button.title" = "Hang Up";
+"voice.mute_button.title" = "Mute";
+"voice.video_button.title" = "Video";
+"voice.speaker_button.title" = "Speaker";
+
+"voice.alert.microphone_warning.title" = "Wire needs access to the Microphone.";
+"voice.alert.microphone_warning.explanation" = "Enable it in Wire Settings.";
+
+"voice.alert.camera_warning.title" = "Wire needs access to the Camera.";
+"voice.alert.camera_warning.explanation" = "Go to Settings and allow Wire to access the camera.";
+
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++
+// Profile and Participants
+
+"participants.add_people_button_title" = "Add people";
+
+// Meta Menu
+"meta.menu.rename" = "Rename";
+"meta.menu.leave" = "Leave";
+"meta.menu.archive" = "Archive";
+"meta.menu.unarchive" = "Unarchive";
+"meta.menu.delete" = "Delete";
+"meta.menu.silence.mute" = "Mute";
+"meta.menu.silence.unmute" = "Unmute";
+"meta.menu.cancel" = "Cancel";
+"meta.menu.cancel_connection_request" = "Cancel Request";
+
+// Delete conversation
+"meta.menu.delete_content.dialog_title" = "Delete content?";
+"meta.menu.delete_content.dialog_message" = "This will clear the conversation history and remove it from the list.";
+"meta.menu.delete_content.leave_as_well_message" = "Also leave the conversation";
+"meta.menu.delete_content.button_cancel" = "Cancel";
+"meta.menu.delete_content.button_delete" = "Delete";
+
+// Leave conversation
+"meta.leave_conversation_dialog_title" = "Leave conversation?";
+"meta.leave_conversation_dialog_message" = "The participants will be notified and the conversation will be removed from your list.";
+"meta.leave_conversation.delete_content_as_well_message" = "Also delete the content";
+"meta.leave_conversation_button_cancel" = "Cancel";
+"meta.leave_conversation_button_leave" = "Leave";
+
+// Conversation Degraded (security level lowered)
+"meta.degraded.degradation_reason_message.singular" = "%@ started using a new device.";
+"meta.degraded.degradation_reason_message.plural" = "%@ started using new devices.";
+"meta.degraded.dialog_message" = "Do you still want to send your message?";
+"meta.degraded.show_device_button" = "Show device";
+"meta.degraded.send_anyway_button" = "Send anyway";
+
+// Remove from conversation dialogue
+"profile.remove_dialog_title" = "Remove?";
+"profile.remove_dialog_message" = "%@ won’t be able to send or receive messages in this conversation.";
+"profile.remove_dialog_button_cancel" = "Cancel";
+"profile.remove_dialog_button_remove" = "Remove";
+
+// Block dialog
+"profile.block_dialog.title" = "Block?";
+"profile.block_dialog.message" = "%@ won’t be able to find or contact you on Wire.";
+"profile.block_dialog.button_cancel" = "Cancel";
+"profile.block_dialog.button_block" = "Block";
+
+// Delete message dialog
+"message.delete_dialog.message" = "This cannot be undone.";
+"message.delete_dialog.action.cancel" = "Cancel";
+"message.delete_dialog.action.hide" = "Delete for Me";
+"message.delete_dialog.action.delete" = "Delete for Everyone";
+
+// Edit message
+"message.menu.edit.title" = "Edit";
+
+// Accept connection request
+"profile.connection_request_dialog.title" = "Accept?";
+"profile.connection_request_dialog.message" = "This will connect you and open the conversation with %@.";
+"profile.connection_request_dialog.button_cancel" = "Ignore";
+"profile.connection_request_dialog.button_connect" = "Connect";
+
+// Cancel connection request
+"profile.cancel_connection_request_dialog.title" = "Cancel Request?";
+"profile.cancel_connection_request_dialog.message" = "Remove connection request to %@.";
+"profile.cancel_connection_request_dialog.button_no" = "No";
+"profile.cancel_connection_request_dialog.button_yes" = "Yes";
+
+// Unblock button
+"profile.unblock_button_title" = "Unblock";
+
+"profile.cancel_connection_button_title" = "CANCEL REQUEST";
+"profile.connection_request_state.blocked" = "BLOCKED";
+"profile.create_conversation_button_title" = "Create group";
+"profile.open_conversation_button_title" = "Open conversation";
+
+// User Details
+"profile.details.title" = "Details";
+
+// Device list
+"profile.devices.title" = "Devices";
+"profile.devices.fingerprint_message_unencrypted" = "%@ is using an old version of Wire. No devices are shown here.";
+"profile.devices.fingerprint_message" = "Wire gives every device a unique fingerprint. Compare them with %@ and verify your conversation. Why verify conversations?";
+"profile.devices.fingerprint_message.link" = "Why verify conversations?";
+
+// Device detail
+"profile.devices.detail.verify_message" = "Verify that this matches the fingerprint shown on %@'s device.";
+"profile.devices.detail.verify_message.link" = "How do I do that?";
+"profile.devices.detail.show_my_device.title" = "Show my device fingerprint";
+"device.verified" = "Verified";
+"device.not_verified" = "Not Verified";
+"device.class.desktop" = "Desktop";
+"device.class.tablet" = "Tablet";
+"device.class.phone" = "Phone";
+"profile.devices.detail.reset_session.title" = "Reset Session";
+
+// General strings
+"general.confirm" = "OK";
+
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++
+// Self profile
+
+// Options menu contents
+"self.settings" = "Settings";
+"self.help_center" = "Support";
+"self.help_center.support_website" = "Wire Support Website";
+"self.help_center.contact_support" = "Contact Support";
+"self.about" = "About";
+"self.sign_out" = "Log Out";
+"self.report_abuse" = "Report Misuse";
+
+"self.add_phone_number" = "Add phone number";
+"self.add_email_password" = "Add email address and password";
+
+// About screen
+"about.tos.title"="Terms of Use";
+"about.privacy.title"="Privacy Policy";
+"about.license.title" = "License Information";
+"about.website.title"="Wire Website";
+"about.copyright.title"="© Wire Swiss GmbH";
+
+// Self new devices
+"self.new_device_alert.title" = "You have connected %@ to your Wire account";
+"self.new_device_alert.title_prefix.tablet" = "a tablet";
+"self.new_device_alert.title_prefix.phone" = "a phone";
+"self.new_device_alert.title_prefix.devices" = "%d devices";
+"self.new_device_alert.message" = "%@\n\nIf you didn’t do this, remove the device and reset your password.";
+"self.new_device_alert.message_plural" = "%@\n\nIf you didn’t do this, remove those devices and reset your password.";
+"self.new_device_alert.manage_devices" = "Manage devices";
+"self.new_device_alert.trust_devices" = "OK";
+
+// Settings - Account details
+"self.settings.account_section" = "Account";
+
+"self.settings.account_details_group.title" = "Info";
+
+"self.settings.account_section.name.title" = "Name";
+"self.settings.account_section.email.title" = "Email";
+"self.settings.account_section.phone.title" = "Phone";
+
+"self.settings.account_details_group.footer" = "People can find you with these details.";
+
+"self.settings.account_details.remove_device.title" = "Remove Device";
+"self.settings.account_details.key_fingerprint.title" = "Key Fingerprint";
+"self.settings.account_details.remove_device.message" = "Your password is required to remove the device";
+"self.settings.account_details.remove_device.password" = "Password";
+"self.settings.account_details.remove_device.password.error" = "Wrong password";
+
+"self.settings.account_appearance_group.title" = "Appearance";
+"self.settings.account_picture_group.picture" = "Picture";
+"self.settings.account_picture_group.color" = "Color";
+
+"self.settings.account_picture_group.theme" = "Dark Theme";
+
+"self.settings.device_details.fingerprint.subtitle" = "Wire gives every device a unique fingerprint. Compare them and verify your devices and conversations.";
+"self.settings.device_details.reset_session.subtitle" = "If fingerprints don’t match, reset the session to generate new encryption keys on both sides.";
+"self.settings.device_details.remove_device.subtitle" = "Remove this device if you have stopped using it. Your message history will be erased and you will be logged out.";
+"self.settings.device_details.reset_session.success" = "The session has been reset";
+
+"self.settings.account_details.actions.title" = "Actions";
+
+"self.settings.account_details.delete_account.title" = "Delete Account";
+
+"self.settings.account_details.delete_account.alert.title" = "Delete Account";
+"self.settings.account_details.delete_account.alert.message" = "We will send you a message via email or SMS. Follow the link to permanently delete your account.";
+
+
+// Chat alerts
+"self.settings.notifications.push_notification.title" = "Notifications";
+"self.settings.notifications.push_notification.toogle" = "Message Previews";
+"self.settings.notifications.push_notification.footer" = "Sender name and message on the lock screen and in Notification Center.";
+
+"self.settings.notifications.chat_alerts.toggle" = "Message Banners";
+"self.settings.notifications.chat_alerts.footer" = "New messages in other conversations.";
+
+"self.settings.sound_menu.sounds.title" = "Sounds";
+"self.settings.sound_menu.ringtone.title" = "Ringtone";
+"self.settings.sound_menu.message.title" = "Text Tone";
+"self.settings.sound_menu.ping.title" = "Ping";
+"self.settings.sound_menu.ringtones.title" = "Ringtones";
+"self.settings.sound_menu.sounds.wire_sound" = "Wire";
+
+"self.settings.sound_menu.sounds.wire_call" = "Wire Call";
+"self.settings.sound_menu.sounds.wire_message" = "Wire Message";
+"self.settings.sound_menu.sounds.wire_ping" = "Wire Ping";
+
+// By popular demand
+"self.settings.popular_demand.title" = "By popular demand";
+"self.settings.popular_demand.send_button.title" = "Send Button";
+"self.settings.popular_demand.send_button.footer" = "Disable to send via the return key.";
+
+// Sound alerts (TO BE UPDPATED)
+"self.settings.sound_menu.title" = "Sound Alerts";
+"self.settings.sound_menu.no_sounds.title" = "None";
+"self.settings.sound_menu.all_sounds.title" = "All";
+"self.settings.sound_menu.mute_while_talking.title" = "First message, pings, calls";
+
+// Developer options
+"self.settings.developer_options.title" = "Developer Options";
+"self.settings.apns_logging.title" = "APNS Logging";
+
+// Privacy (visibility) options
+"self.settings.options_menu.title" = "Options";
+
+"self.settings.privacy_contacts_section.title" = "Contacts";
+"self.settings.privacy_contacts_menu.settings_button.title" = "Open Contacts Settings";
+"self.settings.privacy_contacts_menu.description_disabled.title" = "This helps you connect with others. We anonymize all the information and do not share it with anyone else. Allow access via Settings > Privacy > Contacts.";
+
+"self.settings.privacy_analytics_menu.devices.title" = "Devices";
+
+"self.settings.privacy_analytics_section.title" = "Usage and Crash Reports";
+"self.settings.privacy_analytics_menu.description.title" = "Make Wire better by sending anonymous information.\n";
+
+"self.settings.privacy.clear_history.title" = "Clear History";
+"self.settings.privacy.clear_history.subtitle" = "This will permanently erase the content of all your conversations.";
+
+"self.settings.advanced.title" = "Advanced";
+"self.settings.advanced.troubleshooting.title" = "Troubleshooting";
+"self.settings.advanced.troubleshooting.submit_debug.title" = "Calling Debug Report";
+"self.settings.advanced.troubleshooting.submit_debug.subtitle" = "This information helps Wire Support diagnose calling problems.";
+"self.settings.advanced.reset_push_token.title" = "Reset Push Notifications Token";
+"self.settings.advanced.reset_push_token.subtitle" = "If you experience problems with push notifications, Wire Support may ask you to reset this token.";
+"self.settings.advanced.reset_push_token_alert.title" = "Push token has been reset";
+"self.settings.advanced.reset_push_token_alert.message" = "Notifications will be restored in a few seconds.";
+"self.settings.advanced.version_technical_details.title" = "Version Technical Details";
+
+// Technical Report
+"self.settings.technical_report_section.title" = "Technical Report";
+"self.settings.technical_report.send_report" = "Send report to Wire";
+"self.settings.technical_report.mail.recipient" = "callingsupport@wire.com";
+"self.settings.technical_report.mail.subject" = "Wire Calling Report";
+"self.settings.technical_report.include_log" = "Include detailed log";
+
+// Password reset
+"self.settings.password_reset_menu.title" = "Reset Password";
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++
+// System status
+"system_status_bar.no_internet.title" = "No Internet";
+"system_status_bar.no_internet.explanation" = "There seems to be a problem with your Internet connection. Please make sure it’s working.";
+"system_status_bar.poor_connectivity.title" = "Slow Internet, can’t call now";
+"system_status_bar.poor_connectivity.explanation" = "We can’t guarantee voice quality. Connect to Wi-Fi or try changing your location.";
+
+// Common connections on profile view
+"profile_other.common_connections" = "You both know";
+
+// View user profile and options menu
+"name.placeholder" = "Your full name";
+"name.guidance.tooshort" = "At least 2 characters";
+"name.guidance.toolong" = "Too many characters";
+
+"email.placeholder" = "Email";
+
+"password.placeholder" = "Password";
+"password.guidance.tooshort" = "At least 8 characters";
+"password.guidance.toolong" = "Too many characters";
+
+"registration.title" = "Registration";
+"registration.close_email_invitation_button.email_title" = "Use another email";
+"registration.close_email_invitation_button.phone_title" = "Register by phone";
+"registration.close_phone_invitation_button.email_title" = "Register by email";
+"registration.close_phone_invitation_button.phone_title" = "Use another phone";
+
+"registration.enter_phone_number.title" = "Edit phone number";
+"registration.enter_phone_number.placeholder" = "Phone number";
+
+"registration.verify_phone_number.instructions" = "Enter the verification code we sent to %@";
+"registration.verify_phone_number.resend" = "Resend";
+"registration.verify_phone_number.resend_placeholder" = "No code showing up?\nYou can request a new one in %.0f seconds";
+
+"registration.verify_email.instructions" = "We sent an email to %@.\n Follow the link to verify your address.";
+"registration.verify_email.resend.instructions" = "Didn't get the message?";
+"registration.verify_email.resend.button_title" = "Re-send";
+
+"registration.select_picture.subtitle" = "Wire is so much nicer with a picture.";
+"registration.select_picture.button_title" = "Choose your own";
+"registration.keep_picture.button_title" = "Keep this one";
+"registration.camera_action.title" = "Take photo";
+"registration.photo_gallery_action.title" = "Choose Photo";
+"registration.cancel_action.title" = "Cancel";
+
+"registration.no_history.hero" = "It’s the first time you’re using Wire on this device.";
+"registration.no_history.subtitle" = "For privacy reasons, your conversation history will not appear here.";
+"registration.no_history.got_it" = "OK";
+
+"registration.no_history.logged_out.hero" = "You've used Wire on this device before.";
+"registration.no_history.logged_out.subtitle" = "Messages sent in the meantime will not appear.";
+"registration.no_history.logged_out.got_it" = "OK";
+
+"registration.enter_name.title" = "Edit Name";
+"registration.enter_name.hero" = "What should we call you?";
+"registration.enter_name.placeholder" = "Your full name";
+
+"registration.terms_of_use.title" = "Welcome to Wire.";
+"registration.terms_of_use.terms" = "By continuing you agree to the Wire Terms of Use.";
+"registration.terms_of_use.terms.link" = "Terms of Use";
+"registration.terms_of_use.agree" = "I agree";
+
+"registration.email_flow.title" = "Register by Email";
+"registration.email_flow.email_step.title" = "Edit Details";
+
+"registration.country_select.title" = "Country";
+
+"registration.share_contacts.hero.title" = "Find people on Wire";
+"registration.share_contacts.hero.paragraph"  = "Share your contacts so we can connect you with others. We anonymize all information and do not share it with anyone else.";
+"registration.share_contacts.find_friends_button.title" = "Share contacts";
+"registration.share_contacts.skip_button.title" = "Not now";
+
+"registration.address_book_access_denied.hero.title" = "Wire does not have access to your contacts.";
+"registration.address_book_access_denied.hero.paragraph1" = "Wire helps find your friends if you share your contacts.";
+"registration.address_book_access_denied.hero.paragraph2" = "To enable access tap Settings and turn on Contacts.";
+"registration.address_book_access_denied.settings_button.title" = "Settings";
+"registration.address_book_access_denied.maybe_later_button.title" = "Maybe later";
+
+"registration.push_access_denied.hero.title" = "Never miss a call or a message.";
+"registration.push_access_denied.hero.paragraph1" = "Enable Notifications in Settings.";
+"registration.push_access_denied.settings_button.title" = "Go to Settings";
+"registration.push_access_denied.maybe_later_button.title" = "Maybe later";
+
+"registration.signin.title" = "Log In";
+"registration.signin.too_many_devices.title" = "";
+"registration.signin.too_many_devices.subtitle" = "Remove one of your other devices to start using Wire on this one.";
+"registration.signin.too_many_devices.manage_button.title" = "Manage devices";
+"registration.signin.too_many_devices.sign_out_button.title" = "Log out";
+"registration.signin.email_button.title" = "Email";
+"registration.signin.phone_button.title" = "Phone";
+
+"registration.devices.title" = "Devices";
+"registration.devices.active_list_header" = "Active";
+"registration.devices.current_list_header" = "Current";
+"registration.devices.active_list_subtitle" = "If you don’t recognize a device above, remove it and reset your password.";
+"registration.devices.activated_in" = "Activated in";
+"registration.devices.id" = "ID:";
+
+"signin.forgot_password" = "Forgot password?";
+
+"registration.add_phone_number.hero.title" = "Add phone number";
+"registration.add_phone_number.hero.paragraph" = "This helps us find people you may know. We never share it.";
+"registration.add_phone_number.skip_button.title" = "Not now";
+
+"registration.add_email_password.hero.title" = "Add your email and password.";
+"registration.add_email_password.hero.paragraph" = "This lets you use Wire on multiple devices.";
+
+"registration.email_invitation.title" = "Invitation";
+"registration.email_invitation.hero.title" = "Hello, %@";
+"registration.email_invitation.hero.paragraph" = "Choose a password to create your account.";
+
+"registration.phone_invitation.title" = "Invitation";
+"registration.phone_invitation.hero.title" = "Hello, %@";
+"registration.phone_invitation.hero.paragraph" = "You are one step away from creating your account.";
+
+"error.name_and_email" = "Please enter your full name and a valid email address";
+"error.full_name" = "Please enter your full name";
+"error.email" = "Please enter a valid email address";
+"error.input.too_long" = "Input too long";
+"error.input.too_short" = "Input too short";
+"error.email.invalid" = "Please enter a valid email address";
+"error.phone.invalid" = "Please enter a valid phone number";
+
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++
+// ZMUserSessionErrorCode mapping. Used during registration and profile edit
+"error.user.unkown_error" = "Something went wrong, please try again";
+"error.user.needs_credentials" = "Please verify your details and try again.";
+"error.user.invalid_credentials" = "Please verify your details and try again.";
+"error.user.account_pending_activation" = "The account you are trying access is pending activation. Please verify your details.";
+"error.user.network_error" = "There seems to be a problem with your network. Please try again later.";
+"error.user.email_is_taken" = "The email address you provided has already been registered. Please try again.";
+"error.user.phone_is_taken" = "The phone number you provided has already been registered. Please try again.";
+"error.user.phone_code_invalid" = "Please enter a valid code";
+"error.user.phone_code_too_many" = "We already sent you a code via SMS. Tap Resend after 10 minutes to get a new one.";
+"error.user.registration_unknown_error" = "Something went wrong. Please try again.";
+"error.user.device_deleted_remotely" = "You have been logged out from another device.";
+
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++
+// Those are caught by the UI without involving the SE validation. Basically very similar to ZMUserSessionErrorCode onces
+"error.updating_password" = "Couldn't update your password.";
+
+"error.group_call.too_many_members_in_conversation.title" = "Too many people to call";
+"error.group_call.too_many_members_in_conversation" = "Calls work in conversations with up to %d people.";
+"error.group_call.too_many_participants_in_the_call.title" = "The call is full";
+"error.group_call.too_many_participants_in_the_call" = "There’s only room for %d people in here.";
+"error.call.gsm_ongoing.title" = "Cellular call";
+"error.call.gsm_ongoing" = "Please cancel the cellular call before calling on Wire.";
+"error.call.general.title" = "Call error";
+"error.call.general" = "Please try calling again in several minutes.";
+"error.call.slow_connection.title" = "Slow connection";
+"error.call.slow_connection" = "You might experience issues during the call";
+"error.call.slow_connection.call_anyway" = "Call anyway";
+
+"error.invite.no_email_provider" = "Please configure your email client to be able to send the invites via email";
+"error.invite.no_messaging_provider" = "Please configure your SMS to be able to send the invites via SMS";
+
+"sketchpad.initial_hint" = "Tap color to change brush size\nPress and hold to fill an area\nShake to remove a photo";
+
+"migration.please_wait_message" = "One moment, please";
+
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++
+// Those are used by the backend to localize APNS
+"push.notification.new_user" = "%@ joined Wire";
+"push.notification.new_message" = "New message";
+
+
+//Force Update
+"force.update.title" = "Update necessary";
+"force.update.message" = "You are missing out on new features.\nGet the latest version of Wire in the App Store.";
+"force.update.ok_button" = "Go to App Store";
+
+// Third Party
+"giphy.conversation.message" = "%@ · via giphy.com";
+"giphy.conversation.random_message" = "via giphy.com";
+"giphy.error.no_more_results" = "no more gifs";
+"giphy.error.no_result" = "no gif found";
+
+"giphy.confirm" = "send";
+"giphy.cancel" = "cancel";
+"giphy.search_placeholder" = "Search giphy";
+
+"invite_banner.title" = "Bring your friends to Wire!";
+"invite_banner.message" = "Enjoy calls, messages, sketches, GIFs and more in private or with groups.";
+"invite_banner.invite_button_title" = "Invite more people";

--- a/Wire-iOS/Resources/tr.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/tr.lproj/Localizable.strings
@@ -128,6 +128,7 @@
 
 "conversation.input_bar.verified" = "Doğrulandı";
 "conversation.input_bar.placeholder" = "Bir mesaj yazın";
+"conversation.input_bar.placeholder_ephemeral" = "Timed message";
 
 "conversation.input_bar.audio_message.tooltip.pull_send" = "Göndermek için kaydırın";
 "conversation.input_bar.audio_message.tooltip.tap_send" = "Göndermek için tıkla";
@@ -161,6 +162,10 @@
 
 // Twitter
 "twitter_status.on_twitter" = "%@ Twitter'da";
+
+// Ephemeral message
+"input.ephemeral.timeout.none" = "Off";
+"input.ephemeral.title" = "Set a timer for temporary messages";
 
 // System messages
 "content.system.continued_conversation" = "%@ ile bir konuşma başlat";
@@ -221,6 +226,8 @@
 "content.system.cannot_decrypt.identity.you_part" = "Senin";
 "content.system.cannot_decrypt.identity.otherUser_part" = "%@'nin"; // posessive apostrophe - might differ in different languages
 "content.system.cannot_decrypt.identity.why_part" = "Daha Fazla";
+"content.system.cannot_decrypt.otherDevice_part" = "(cihaz %@)"; // example " (device d1b23c54f34a)".
+// Full sentence: "A message from %@ was not received. [...] (device d1b23c54f34a). This is a debug information.
 
 "content.file.uploading" = "Yükleniyor…";
 "content.file.downloading" = "İndiriliyor…";

--- a/Wire-iOS/Resources/tr.lproj/Localizable.stringsdict
+++ b/Wire-iOS/Resources/tr.lproj/Localizable.stringsdict
@@ -1,0 +1,191 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+        <key>self.new_device_alert.title_prefix.devices</key>
+        <dict>
+            <key>NSStringLocalizedFormatKey</key>
+            <string>%#@device_count@</string>
+            <key>device_count</key>
+            <dict>
+                <key>NSStringFormatSpecTypeKey</key>
+                <string>NSStringPluralRuleType</string>
+                <key>NSStringFormatValueTypeKey</key>
+                <string>lu</string>
+                <key>zero</key>
+                <string></string>
+                <key>one</key>
+                <string>a device</string>
+                <key>few</key>
+                <string>%lu devices</string>
+                <key>many</key>
+                <string>%lu devices</string>
+                <key>other</key>
+                <string>%lu devices</string>
+            </dict>
+        </dict>
+		<key>participants.people.count</key>
+		<dict>
+			<key>NSStringLocalizedFormatKey</key>
+			<string>%#@lu_number_of_people@</string>
+			<key>lu_number_of_people</key>
+			<dict>
+				<key>NSStringFormatSpecTypeKey</key>
+				<string>NSStringPluralRuleType</string>
+				<key>NSStringFormatValueTypeKey</key>
+				<string>lu</string>
+				<key>zero</key>
+				<string>No people</string>
+				<key>one</key>
+				<string>One person</string>
+				<key>few</key>
+				<string>%lu people</string>
+				<key>many</key>
+				<string>%lu people</string>
+				<key>other</key>
+				<string>%lu people</string>
+			</dict>
+		</dict>
+        <key>content.system.missing_messages.subtitle_added</key>
+        <dict>
+            <key>NSStringLocalizedFormatKey</key>
+            <string>%@ %#@lu_number_of_users@ been added</string>
+            <key>lu_number_of_users</key>
+            <dict>
+                <key>NSStringFormatSpecTypeKey</key>
+                <string>NSStringPluralRuleType</string>
+                <key>NSStringFormatValueTypeKey</key>
+                <string>lu</string>
+                <key>zero</key>
+                <string></string>
+                <key>one</key>
+                <string>has</string>
+                <key>other</key>
+                <string>have</string>
+            </dict>
+        </dict>
+        <key>content.system.missing_messages.subtitle_removed</key>
+        <dict>
+            <key>NSStringLocalizedFormatKey</key>
+            <string>%@ %#@lu_number_of_users@ been removed</string>
+            <key>lu_number_of_users</key>
+            <dict>
+                <key>NSStringFormatSpecTypeKey</key>
+                <string>NSStringPluralRuleType</string>
+                <key>NSStringFormatValueTypeKey</key>
+                <string>lu</string>
+                <key>zero</key>
+                <string></string>
+                <key>one</key>
+                <string>has</string>
+                <key>other</key>
+                <string>have</string>
+            </dict>
+        </dict>
+		<key>list.connect_request.people_waiting</key>
+		<dict>
+			<key>NSStringLocalizedFormatKey</key>
+			<string>%#@d_number_of_people@ waiting</string>
+			<key>d_number_of_people</key>
+			<dict>
+				<key>NSStringFormatSpecTypeKey</key>
+				<string>NSStringPluralRuleType</string>
+				<key>NSStringFormatValueTypeKey</key>
+				<string>d</string>
+				<key>zero</key>
+				<string></string>
+				<key>one</key>
+				<string>One person</string>
+				<key>few</key>
+				<string>%d people</string>
+				<key>many</key>
+				<string>%d people</string>
+				<key>other</key>
+				<string>%d people</string>
+			</dict>
+		</dict>
+		<key>content.system.participants_n_others</key>
+		<dict>
+			<key>NSStringLocalizedFormatKey</key>
+			<string>%@ %#@and_number_of_others@</string>
+			<key>and_number_of_others</key>
+			<dict>
+				<key>NSStringFormatSpecTypeKey</key>
+				<string>NSStringPluralRuleType</string>
+				<key>NSStringFormatValueTypeKey</key>
+				<string>d</string>
+				<key>zero</key>
+				<string/>
+				<key>one</key>
+				<string>and one more</string>
+				<key>few</key>
+				<string>and %d others</string>
+				<key>many</key>
+				<string>and %d others</string>
+				<key>other</key>
+				<string>and %d others</string>
+			</dict>
+		</dict>
+		<key>peoplepicker.suggested.knows_more</key>
+		<dict>
+			<key>NSStringLocalizedFormatKey</key>
+			<string>Knows %@ and %#@d_number_of_others@</string>
+			<key>d_number_of_others</key>
+			<dict>
+				<key>NSStringFormatSpecTypeKey</key>
+				<string>NSStringPluralRuleType</string>
+				<key>NSStringFormatValueTypeKey</key>
+				<string>d</string>
+				<key>few</key>
+				<string>%d others</string>
+				<key>many</key>
+				<string>%d others</string>
+				<key>other</key>
+				<string>%d others</string>
+			</dict>
+		</dict>
+        <key>content.system.people_started_using</key>
+        <dict>
+            <key>NSStringLocalizedFormatKey</key>
+            <string>%@ %#@d_number_of_others@ started using %#@d_new_devices@</string>
+            <key>d_number_of_others</key>
+            <dict>
+                <key>NSStringFormatSpecTypeKey</key>
+                <string>NSStringPluralRuleType</string>
+                <key>NSStringFormatValueTypeKey</key>
+                <string>d</string>
+                <key>one</key>
+                <string></string>
+                <key>other</key>
+                <string>and %d others</string>
+            </dict>
+            <key>d_new_devices</key>
+            <dict>
+                <key>NSStringFormatSpecTypeKey</key>
+                <string>NSStringPluralRuleType</string>
+                <key>NSStringFormatValueTypeKey</key>
+                <string>d</string>
+                <key>one</key>
+                <string>a new device</string>
+                <key>other</key>
+                <string>new devices</string>
+            </dict>
+        </dict>
+        <key>content.system.new_devices</key>
+        <dict>
+            <key>NSStringLocalizedFormatKey</key>
+            <string>%#@d_new_devices@</string>
+            <key>d_new_devices</key>
+            <dict>
+                <key>NSStringFormatSpecTypeKey</key>
+                <string>NSStringPluralRuleType</string>
+                <key>NSStringFormatValueTypeKey</key>
+                <string>d</string>
+                <key>one</key>
+                <string>a new device</string>
+                <key>other</key>
+                <string>new devices</string>
+            </dict>
+        </dict>
+	</dict>
+</plist>

--- a/Wire-iOS/Resources/tr.lproj/Localizable.stringsdict
+++ b/Wire-iOS/Resources/tr.lproj/Localizable.stringsdict
@@ -15,13 +15,13 @@
                 <key>zero</key>
                 <string></string>
                 <key>one</key>
-                <string>a device</string>
+                <string>bir cihaz</string>
                 <key>few</key>
-                <string>%lu devices</string>
+                <string>%lu cihaz</string>
                 <key>many</key>
-                <string>%lu devices</string>
+                <string>%lu cihaz</string>
                 <key>other</key>
-                <string>%lu devices</string>
+                <string>%lu cihaz</string>
             </dict>
         </dict>
 		<key>participants.people.count</key>
@@ -35,21 +35,21 @@
 				<key>NSStringFormatValueTypeKey</key>
 				<string>lu</string>
 				<key>zero</key>
-				<string>No people</string>
+				<string>Hiç kimse</string>
 				<key>one</key>
-				<string>One person</string>
+				<string>Bir kişi</string>
 				<key>few</key>
-				<string>%lu people</string>
+				<string>%lu kişi</string>
 				<key>many</key>
-				<string>%lu people</string>
+				<string>%lu kişi</string>
 				<key>other</key>
-				<string>%lu people</string>
+				<string>%lu kişi</string>
 			</dict>
 		</dict>
         <key>content.system.missing_messages.subtitle_added</key>
         <dict>
             <key>NSStringLocalizedFormatKey</key>
-            <string>%@ %#@lu_number_of_users@ been added</string>
+            <string>%@ %#@lu_number_of_users@ kişi eklendi</string>
             <key>lu_number_of_users</key>
             <dict>
                 <key>NSStringFormatSpecTypeKey</key>
@@ -59,15 +59,15 @@
                 <key>zero</key>
                 <string></string>
                 <key>one</key>
-                <string>has</string>
+                <string> </string>
                 <key>other</key>
-                <string>have</string>
+                <string> </string>
             </dict>
         </dict>
         <key>content.system.missing_messages.subtitle_removed</key>
         <dict>
             <key>NSStringLocalizedFormatKey</key>
-            <string>%@ %#@lu_number_of_users@ been removed</string>
+            <string>%@ %#@lu_number_of_users@ kişi silindi</string>
             <key>lu_number_of_users</key>
             <dict>
                 <key>NSStringFormatSpecTypeKey</key>
@@ -77,15 +77,15 @@
                 <key>zero</key>
                 <string></string>
                 <key>one</key>
-                <string>has</string>
+                <string> </string>
                 <key>other</key>
-                <string>have</string>
+                <string> </string>
             </dict>
         </dict>
 		<key>list.connect_request.people_waiting</key>
 		<dict>
 			<key>NSStringLocalizedFormatKey</key>
-			<string>%#@d_number_of_people@ waiting</string>
+			<string>%#@d_number_of_people@ bekliyor</string>
 			<key>d_number_of_people</key>
 			<dict>
 				<key>NSStringFormatSpecTypeKey</key>
@@ -95,13 +95,13 @@
 				<key>zero</key>
 				<string></string>
 				<key>one</key>
-				<string>One person</string>
+				<string>Bir kişi</string>
 				<key>few</key>
-				<string>%d people</string>
+				<string>%d kişi</string>
 				<key>many</key>
-				<string>%d people</string>
+				<string>%d kişi</string>
 				<key>other</key>
-				<string>%d people</string>
+				<string>%d kişi</string>
 			</dict>
 		</dict>
 		<key>content.system.participants_n_others</key>
@@ -117,19 +117,19 @@
 				<key>zero</key>
 				<string/>
 				<key>one</key>
-				<string>and one more</string>
+				<string>ve bir kişi daha</string>
 				<key>few</key>
-				<string>and %d others</string>
+				<string>ve %d kişiyi</string>
 				<key>many</key>
-				<string>and %d others</string>
+				<string>ve %d kişi daha</string>
 				<key>other</key>
-				<string>and %d others</string>
+				<string>ve %d kişi daha</string>
 			</dict>
 		</dict>
 		<key>peoplepicker.suggested.knows_more</key>
 		<dict>
 			<key>NSStringLocalizedFormatKey</key>
-			<string>Knows %@ and %#@d_number_of_others@</string>
+			<string>%@ ve %#@d_number_of_others@ daha tanıyor</string>
 			<key>d_number_of_others</key>
 			<dict>
 				<key>NSStringFormatSpecTypeKey</key>
@@ -137,17 +137,17 @@
 				<key>NSStringFormatValueTypeKey</key>
 				<string>d</string>
 				<key>few</key>
-				<string>%d others</string>
+				<string>%d diğerleri</string>
 				<key>many</key>
-				<string>%d others</string>
+				<string>%d diğerleri</string>
 				<key>other</key>
-				<string>%d others</string>
+				<string>%d diğerleri</string>
 			</dict>
 		</dict>
         <key>content.system.people_started_using</key>
         <dict>
             <key>NSStringLocalizedFormatKey</key>
-            <string>%@ %#@d_number_of_others@ started using %#@d_new_devices@</string>
+            <string>%@ %#@d_number_of_others@ kişi %#@d_new_devices@ kullanmaya başladı</string>
             <key>d_number_of_others</key>
             <dict>
                 <key>NSStringFormatSpecTypeKey</key>
@@ -157,7 +157,7 @@
                 <key>one</key>
                 <string></string>
                 <key>other</key>
-                <string>and %d others</string>
+                <string>ve %d kişi daha</string>
             </dict>
             <key>d_new_devices</key>
             <dict>
@@ -166,9 +166,9 @@
                 <key>NSStringFormatValueTypeKey</key>
                 <string>d</string>
                 <key>one</key>
-                <string>a new device</string>
+                <string>yeni bir cihaz</string>
                 <key>other</key>
-                <string>new devices</string>
+                <string>yeni cihazlar</string>
             </dict>
         </dict>
         <key>content.system.new_devices</key>
@@ -182,9 +182,9 @@
                 <key>NSStringFormatValueTypeKey</key>
                 <string>d</string>
                 <key>one</key>
-                <string>a new device</string>
+                <string>yeni bir cihaz</string>
                 <key>other</key>
-                <string>new devices</string>
+                <string>yeni cihazlar</string>
             </dict>
         </dict>
 	</dict>

--- a/Wire-iOS/Resources/uk.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/uk.lproj/Localizable.strings
@@ -128,6 +128,7 @@
 
 "conversation.input_bar.verified" = "Верифікований";
 "conversation.input_bar.placeholder" = "Напишіть повідомлення";
+"conversation.input_bar.placeholder_ephemeral" = "Timed message";
 
 "conversation.input_bar.audio_message.tooltip.pull_send" = "Проведіть вгору для надсилання";
 "conversation.input_bar.audio_message.tooltip.tap_send" = "Торкніться для надсилання";
@@ -161,6 +162,10 @@
 
 // Twitter
 "twitter_status.on_twitter" = "%@ в Twitter";
+
+// Ephemeral message
+"input.ephemeral.timeout.none" = "Off";
+"input.ephemeral.title" = "Set a timer for temporary messages";
 
 // System messages
 "content.system.continued_conversation" = "Почати розмову з %@";
@@ -221,6 +226,8 @@
 "content.system.cannot_decrypt.identity.you_part" = "Ваш";
 "content.system.cannot_decrypt.identity.otherUser_part" = "%@"; // posessive apostrophe - might differ in different languages
 "content.system.cannot_decrypt.identity.why_part" = "Дізнатися більше";
+"content.system.cannot_decrypt.otherDevice_part" = "(device %@)"; // example " (device d1b23c54f34a)".
+// Full sentence: "A message from %@ was not received. [...] (device d1b23c54f34a). This is a debug information.
 
 "content.file.uploading" = "Завантаження…";
 "content.file.downloading" = "Скачування…";
@@ -255,7 +262,7 @@
 "missive.connection_request.default_message" = "Привіт %@,\nдавай спілкуватися в Wire.\n%@";
 
 "connection_request.send_button_title" = "Додати";
-"inbox.connection_request.connect_button_title" = "Додати";
+"inbox.connection_request.connect_button_title" = "Додати до контактів";
 "inbox.connection_request.ignore_button_title" = "Ігнорувати";
 
 // Voice
@@ -598,7 +605,7 @@
 "registration.address_book_access_denied.hero.title" = "Wire не має доступу до ваших контактів.";
 "registration.address_book_access_denied.hero.paragraph1" = "Wire допоможе вам знайти ваших друзів, якщо ви поділитесь контактами.";
 "registration.address_book_access_denied.hero.paragraph2" = "Щоб дозволити доступ перейдіть в Налаштування та торкніться до переключателя біля пункту Контакти.";
-"registration.address_book_access_denied.settings_button.title" = "Налаштування";
+"registration.address_book_access_denied.settings_button.title" = "Параметри";
 "registration.address_book_access_denied.maybe_later_button.title" = "Можливо, пізніше";
 
 "registration.push_access_denied.hero.title" = "Не пропустіть жодного дзвінка або повідомлення.";

--- a/Wire-iOS/Resources/uk.lproj/Localizable.stringsdict
+++ b/Wire-iOS/Resources/uk.lproj/Localizable.stringsdict
@@ -79,7 +79,7 @@
                 <key>one</key>
                 <string> </string>
                 <key>other</key>
-                <string>додано</string>
+                <string> </string>
             </dict>
         </dict>
 		<key>list.connect_request.people_waiting</key>


### PR DESCRIPTION
What in this PR:
- Adding support for new languages: Japanese, Italian, Dutch, Turkish
- Small improvements to already existing strings
- Placeholder strings (in English) for ephemeral messaging, will be localised for next release
