### PR TITLE
Use ephemeral color for send button when in ephemeral mode

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -768,6 +768,7 @@
 		BFAF4CB91CEDE82400780537 /* NumberHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFAF4CB81CEDE82400780537 /* NumberHelper.swift */; };
 		BFBB03061D5DF4CB0065AF4F /* InputBarButtonsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFBB03051D5DF4CB0065AF4F /* InputBarButtonsView.swift */; };
 		BFBB03081D61AF8D0065AF4F /* InputBarEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFBB03071D61AF8D0065AF4F /* InputBarEditView.swift */; };
+		BFBDDBC61DB0D51C00BEED02 /* ConversationInputBarButtonState.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFBDDBC51DB0D51C00BEED02 /* ConversationInputBarButtonState.swift */; };
 		BFC914921D1814AF001F068B /* LocationMessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFC914911D1814AF001F068B /* LocationMessageCell.swift */; };
 		BFC9149B1D181BE7001F068B /* LocationMessageCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFC914991D181B7C001F068B /* LocationMessageCellTests.swift */; };
 		BFCF31D51D9E91880039B3DC /* RecentlyUsedEmojis.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFCF31D41D9E91880039B3DC /* RecentlyUsedEmojis.swift */; };
@@ -2061,6 +2062,7 @@
 		BFAF4CB81CEDE82400780537 /* NumberHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NumberHelper.swift; sourceTree = "<group>"; };
 		BFBB03051D5DF4CB0065AF4F /* InputBarButtonsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InputBarButtonsView.swift; sourceTree = "<group>"; };
 		BFBB03071D61AF8D0065AF4F /* InputBarEditView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InputBarEditView.swift; sourceTree = "<group>"; };
+		BFBDDBC51DB0D51C00BEED02 /* ConversationInputBarButtonState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConversationInputBarButtonState.swift; sourceTree = "<group>"; };
 		BFC914911D1814AF001F068B /* LocationMessageCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationMessageCell.swift; sourceTree = "<group>"; };
 		BFC914991D181B7C001F068B /* LocationMessageCellTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationMessageCellTests.swift; sourceTree = "<group>"; };
 		BFCF31D41D9E91880039B3DC /* RecentlyUsedEmojis.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RecentlyUsedEmojis.swift; path = Emoji/RecentlyUsedEmojis.swift; sourceTree = "<group>"; };
@@ -4186,6 +4188,7 @@
 				8FC851B9199245760008B66B /* ConversationInputBarViewController.m */,
 				BF8EE5551D62FBCD00B0D6D7 /* ConversationInputBarViewController+Editing.swift */,
 				BF2A74701CEB466A002608BF /* ConversationInputBarViewController+Audio.swift */,
+				BFBDDBC51DB0D51C00BEED02 /* ConversationInputBarButtonState.swift */,
 				BF0BDF6C1DA6794E003C61DE /* ConversationInputBarViewController+Ephemeral.swift */,
 				BF0BDF7F1DAB8923003C61DE /* EphemeralKeyboardViewController.swift */,
 				BF732A691D9C114D003077DB /* Emoji */,
@@ -5551,6 +5554,7 @@
 				874448851C22FC6200E7B947 /* ConversationVerifiedCell.swift in Sources */,
 				874D0EB31D3E6D77003DF418 /* ConversationInputBarViewController+Camera.swift in Sources */,
 				871BC2561D34F8F800DF0793 /* PopTransition.m in Sources */,
+				BFBDDBC61DB0D51C00BEED02 /* ConversationInputBarButtonState.swift in Sources */,
 				875F89141D6DD6D000D8748E /* ReactionsView.swift in Sources */,
 				87DCF4F41D34EA4500BB420F /* StartUIView.m in Sources */,
 				871BC27A1D34F8F800DF0793 /* WebLinkTextView.m in Sources */,

--- a/Wire-iOS/Resources/Classy/stylesheet.cas
+++ b/Wire-iOS/Resources/Classy/stylesheet.cas
@@ -912,7 +912,7 @@ IconButton.send-button {
 
 ConversationInputBarViewController {
 
-    ephemeralSendButton: @{
+    ephemeralIndicatorButton: @{
         borderColor: $color-ephemeral;
         titleColor: $color-ephemeral;
         titleLabel: @{

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
@@ -247,8 +247,10 @@ const NSTimeInterval ConversationCellSelectionAnimationDuration = 0.33;
 
     if ([self.delegate respondsToSelector:@selector(conversationCellShouldStartDestructionTimer:)] &&
         [self.delegate conversationCellShouldStartDestructionTimer:self]) {
-        [self.message startSelfDestructionIfNeeded];
-        [self startCountdownAnimationIfNeeded:self.message];
+        [self updateCountdownView];
+        if ([self.message startSelfDestructionIfNeeded]) {
+            [self startCountdownAnimationIfNeeded:self.message];
+        }
     }
 
     [self.messageContentView bringSubviewToFront:self.countdownContainerView];
@@ -614,8 +616,9 @@ const NSTimeInterval ConversationCellSelectionAnimationDuration = 0.33;
 
     if ([self.delegate respondsToSelector:@selector(conversationCellShouldStartDestructionTimer:)] &&
         [self.delegate conversationCellShouldStartDestructionTimer:self]) {
-        [self.message startSelfDestructionIfNeeded];
-        [self startCountdownAnimationIfNeeded:self.message];
+        if ([self.message startSelfDestructionIfNeeded]) {
+            [self startCountdownAnimationIfNeeded:self.message];
+        }
     }
 
     [self updateToolboxVisibilityAnimated:change.reactionsChanged];
@@ -653,7 +656,7 @@ const NSTimeInterval ConversationCellSelectionAnimationDuration = 0.33;
         return;
     }
 
-    if (!self.countdownContainerView.hidden) {
+    if (!self.countdownContainerView.hidden && nil != self.message.destructionDate) {
         CGFloat fraction = self.message.destructionDate.timeIntervalSinceNow / self.message.deletionTimeout;
         [self.countdownView updateWithFraction:fraction];
         [self.messageToolboxView updateTimestamp:self.message];

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarButtonState.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarButtonState.swift
@@ -1,0 +1,61 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+
+private let disableEphemeralSending = false
+
+
+public final class ConversationInputBarButtonState: NSObject {
+
+    public var sendButtonHidden: Bool {
+        return !hasText || editing || (Settings.shared().disableSendButton && mode != .emojiInput)
+    }
+
+    public var hourglassButtonHidden: Bool {
+        return hasText || conversationType != .oneOnOne || editing || ephemeral || disableEphemeralSending
+    }
+
+    public var ephemeralIndicatorButtonHidden: Bool {
+        return hasText || conversationType != .oneOnOne || editing || !ephemeral || disableEphemeralSending
+    }
+
+    private var hasText: Bool {
+        return textLength != 0
+    }
+
+    private var ephemeral: Bool {
+        return destructionTimeout != 0
+    }
+
+    private var textLength: Int = 0
+    private var editing: Bool = false
+    private var destructionTimeout: TimeInterval = 0
+    private var conversationType: ZMConversationType = .oneOnOne
+    private var mode: ConversationInputBarViewControllerMode = .textInput
+
+    public func update(textLength: Int, editing: Bool, destructionTimeout: TimeInterval, conversationType: ZMConversationType, mode: ConversationInputBarViewControllerMode) {
+        self.textLength = textLength
+        self.editing = editing
+        self.destructionTimeout = destructionTimeout
+        self.conversationType = conversationType
+        self.mode = mode
+    }
+
+}

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Ephemeral.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Ephemeral.swift
@@ -27,15 +27,15 @@ extension ConversationInputBarViewController {
         ephemeralKeyboardViewController?.delegate = self
     }
 
-    public func configureHourglassButton(_ button: IconButton) {
-        button.addTarget(self, action: #selector(hourglassButtonPressed), for: .touchUpInside)
+    public func configureEphemeralKeyboardButton(_ button: IconButton) {
+        button.addTarget(self, action: #selector(ephemeralKeyboardButtonTapped), for: .touchUpInside)
     }
 
-    public func hourglassButtonPressed(_ sender: IconButton) {
-        dismissEphemeralKeyboard()
+    public func ephemeralKeyboardButtonTapped(_ sender: IconButton) {
+        updateEphemeralKeyboardVisibility()
     }
 
-    fileprivate func dismissEphemeralKeyboard() {
+    fileprivate func updateEphemeralKeyboardVisibility() {
         if mode != .timeoutConfguration {
             mode = .timeoutConfguration
             inputBar.textView.becomeFirstResponder()
@@ -49,7 +49,7 @@ extension ConversationInputBarViewController {
         inputBar.inputBarState = .writing(ephemeral: conversation.destructionEnabled)
     }
 
-    public func updateEphemeralSendButtonTitle(_ button: ButtonWithLargerHitArea) {
+    public func updateEphemeralIndicatorButtonTitle(_ button: ButtonWithLargerHitArea) {
         let title = conversation.destructionTimeout.shortDisplayString
         button.setTitle(title, for: .normal)
     }
@@ -59,13 +59,14 @@ extension ConversationInputBarViewController {
 extension ConversationInputBarViewController: EphemeralKeyboardViewControllerDelegate {
 
     func ephemeralKeyboardWantsToBeDismissed(_ keyboard: EphemeralKeyboardViewController) {
-        dismissEphemeralKeyboard()
+        updateEphemeralKeyboardVisibility()
     }
 
     func ephemeralKeyboard(_ keyboard: EphemeralKeyboardViewController, didSelectMessageTimeout timeout: ZMConversationMessageDestructionTimeout) {
         inputBar.inputBarState = .writing(ephemeral: timeout != .none)
         ZMUserSession.shared().enqueueChanges {
             self.conversation.updateMessageDestructionTimeout(timeout)
+            self.updateRightAccessoryView()
         }
     }
 

--- a/WireExtensionComponents/Views/Buttons/IconButton.h
+++ b/WireExtensionComponents/Views/Buttons/IconButton.h
@@ -28,6 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) CGFloat borderWidth;
 @property (nonatomic) BOOL adjustsTitleWhenHighlighted;
 @property (nonatomic) BOOL adjustsBorderColorWhenHighlighted;
+@property (nonatomic) BOOL adjustBackgroundImageWhenHighlighted;
 @property (nonatomic) CGFloat titleImageSpacing;
 
 

--- a/WireExtensionComponents/Views/Buttons/IconButton.m
+++ b/WireExtensionComponents/Views/Buttons/IconButton.m
@@ -203,6 +203,9 @@
 - (void)setBackgroundImageColor:(UIColor *)color forState:(UIControlState)state
 {
     [self setBackgroundImage:[UIImage singlePixelImageWithColor:color] forState:state];
+    if (self.adjustBackgroundImageWhenHighlighted && (state & UIControlStateNormal) == UIControlStateNormal) {
+        [self setBackgroundImage:[UIImage singlePixelImageWithColor:[color mix:UIColor.blackColor amount:0.4]] forState:UIControlStateHighlighted];
+    }
 }
 
 - (void)setIcon:(ZetaIconType)icon withSize:(ZetaIconSize)iconSize forState:(UIControlState)state


### PR DESCRIPTION
# What's in this PR?

* Use ephemeral color for send button when in ephemeral mode
* Extract button hide logic into a separate class to declutter the `ConversationInputBarViewController` a bit.
* Add a flag to `IconButton` to adjust the backgroundImage when highlighted.
* The hourglass is now only shown when in not in ephemeral mode and no text is in the input bar, the destruction time indicator is shown when no text is in the input bar but when in ephemeral mode.
* This also includes some fixes to the destruction countdown being shown before the actual timer did start which resulted in it being shown with a fraction of 0 initially.