### PR TITLE
Enable chatheads for ephemeral messages using the redacted font

### DIFF
--- a/Wire-iOS/Sources/Helpers/syncengine/Message.m
+++ b/Wire-iOS/Sources/Helpers/syncengine/Message.m
@@ -190,8 +190,7 @@
             ! isSenderSelfUser &&
             isMessageUnread &&
             isTimelyMessage &&
-            ! isSystemMessage &&
-            ! message.isEphemeral;
+            ! isSystemMessage;
 }
 
 @end

--- a/Wire-iOS/Sources/UserInterface/Overlay/InAppNotifications/ChatHeadView.m
+++ b/Wire-iOS/Sources/UserInterface/Overlay/InAppNotifications/ChatHeadView.m
@@ -101,7 +101,7 @@
     self.messageLabel.backgroundColor = [UIColor clearColor];
     self.messageLabel.userInteractionEnabled = NO;
     self.messageLabel.text = [self messageText];
-    self.messageLabel.font =  [UIFont fontWithMagicIdentifier:@"style.text.small.font_spec_light"];
+    self.messageLabel.font = [self messageFont];
     self.messageLabel.textColor = [UIColor colorWithMagicIdentifier:@"notifications.text_color"];
     self.messageLabel.lineBreakMode = NSLineBreakByTruncatingTail;
 
@@ -141,6 +141,7 @@
     NSString *result = @"";
 
     if ([Message isTextMessage:self.message]) {
+        
         result = [self.message.textMessageData.messageText stringByResolvingEmoticonShortcuts];
     }
     else if ([Message isImageMessage:self.message]) {
@@ -163,6 +164,17 @@
     }
     
     return result;
+}
+
+- (UIFont *)messageFont
+{
+    UIFont *font = [UIFont fontWithMagicIdentifier:@"style.text.small.font_spec_light"];
+
+    if (self.message.isEphemeral) {
+        return [UIFont fontWithName:@"RedactedScript-Regular" size:font.pointSize];
+    }
+
+    return font;
 }
 
 - (void)didTapInAppNotification:(UITapGestureRecognizer *)tapper


### PR DESCRIPTION
# What's in this PR?

* Enable chatheads for ephemeral messages again, but using the redacted font.