### PR TITLE
Fix a regression which lead to the draft message text being reset

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Editing.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Editing.swift
@@ -28,7 +28,7 @@ extension ConversationInputBarViewController {
     func sendEditedMessageAndUpdateState(withText text: String) {
         delegate.conversationInputBarViewControllerDidFinishEditing?(editingMessage, withText: text)
         editingMessage = nil
-        inputBar.inputBarState = .writing(ephemeral: conversation.destructionEnabled)
+        updateWritingState()
     }
     
     func editMessage(_ message: ZMConversationMessage) {
@@ -53,7 +53,8 @@ extension ConversationInputBarViewController {
         ZMUserSession.shared().enqueueChanges {
             self.conversation.draftMessageText = ""
         }
-        inputBar.inputBarState = .writing(ephemeral: conversation.destructionEnabled)
+        updateWritingState()
+
         NotificationCenter.default.removeObserver(
             self,
             name: NSNotification.Name(rawValue: endEditingNotificationName),
@@ -63,6 +64,12 @@ extension ConversationInputBarViewController {
     
     static func endEditingMessage() {
         NotificationCenter.default.post(name: NSNotification.Name(rawValue: endEditingNotificationName), object: nil)
+    }
+
+    public func updateWritingState() {
+        guard nil == editingMessage else { return }
+        inputBar.inputBarState = .writing(ephemeral: conversation.destructionEnabled)
+        updateRightAccessoryView()
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Ephemeral.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Ephemeral.swift
@@ -44,11 +44,6 @@ extension ConversationInputBarViewController {
         }
     }
 
-    public func updateWritingState() {
-        guard nil == editingMessage else { return }
-        inputBar.inputBarState = .writing(ephemeral: conversation.destructionEnabled)
-    }
-
     public func updateEphemeralIndicatorButtonTitle(_ button: ButtonWithLargerHitArea) {
         let title = conversation.destructionTimeout.shortDisplayString
         button.setTitle(title, for: .normal)


### PR DESCRIPTION
# What's in this PR?

* The conversation draft message text was reset for all input bar state changes, but it should only be reset in case the user finished to cancelled an edit.
* This also fixes an issue in which the right accessory view visibility was not updated in some cases (e.g. after finishing an edit).