### PR TITLE
Tear down linkAttachmentController when message gets obfuscated or deleted

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/TextMessageCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/TextMessageCell.m
@@ -151,6 +151,13 @@
     [self.countdownContainerView autoPinEdge:ALEdgeTop toEdge:ALEdgeTop ofView:self.messageTextView];
 }
 
+- (void)willDeleteMessage
+{
+    // If we have a linkattachment which is playing we need to stop
+    [self.linkAttachmentViewController tearDown];
+    [super willDeleteMessage];
+}
+
 - (void)updateTextMessageConstraintConstants
 {
     BOOL hasLinkAttachment = self.linkAttachment || self.linkAttachmentView;
@@ -243,6 +250,12 @@
 /// Overriden from the super class cell
 - (BOOL)updateForMessage:(MessageChangeInfo *)change
 {
+    if (change.isObfuscatedChanged) {
+        // We need to tear down the attachment controller before super is called,
+        // as the attachment will already be set to `nil` otherwise
+        [self.linkAttachmentViewController tearDown];
+    }
+
     BOOL needsLayout = [super updateForMessage:change];
 
     if (change.linkPreviewChanged && self.linkAttachmentView == nil) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter.m
@@ -114,7 +114,11 @@ static NSString *const ConversationMessageDeletedCellId     = @"conversationMess
     BOOL initialContentLoad = self.messageWindow.messages.count == change.insertedIndexes.count && change.deletedIndexes.count == 0;
     BOOL updateOnlyChange = change.insertedIndexes.count == 0 && change.deletedIndexes.count == 0 && change.movedIndexPairs.count == 0;
     BOOL insertionAtTop = change.insertedIndexes.count > 0 && change.insertedIndexes.lastIndex == self.messageWindow.messages.count - 1;
-    
+
+    if (change.deletedIndexes.count) {
+        [self willDeleteMessagesAtIndexPaths:[change.deletedIndexes indexPaths]];
+    }
+
     if (initialContentLoad || insertionAtTop) {
         [self.tableView reloadData];
     }
@@ -122,7 +126,6 @@ static NSString *const ConversationMessageDeletedCellId     = @"conversationMess
         [self.tableView beginUpdates];
         
         if (change.deletedIndexes.count) {
-            [self willDeleteMessagesAtIndexPaths:[change.deletedIndexes indexPaths]];
             [self.tableView deleteRowsAtIndexPaths:[change.deletedIndexes indexPaths] withRowAnimation:UITableViewRowAnimationFade];
         }
         


### PR DESCRIPTION
# What's in this PR?

* Tear down linkAttachmentController when message gets obfuscated or deleted
* This only applies if the message is in the view port, if the user scrolled the message out of the viewport we do not receive any change notifications and thus can not stop playing attachments, this is only an issue for Soundcloud link attachments as Vimeo and YouTube play fullscreen.