### PR TITLE
Fix too small bottom insets for ephemeral chatheads

### DIFF
--- a/Wire-iOS/Resources/Magic/misc.plist
+++ b/Wire-iOS/Resources/Magic/misc.plist
@@ -329,6 +329,8 @@
 		<integer>4</integer>
 		<key>bottom_label_inset</key>
 		<integer>5</integer>
+		<key>ephemeral_bottom_label_inset</key>
+		<integer>8</integer>
 		<key>animation_inset_container</key>
 		<integer>48</integer>
 		<key>animation_inset_text</key>

--- a/Wire-iOS/Sources/UserInterface/Overlay/InAppNotifications/ChatHeadView.m
+++ b/Wire-iOS/Sources/UserInterface/Overlay/InAppNotifications/ChatHeadView.m
@@ -198,6 +198,7 @@
 
         CGFloat topLabelInset = [WAZUIMagic cgFloatForIdentifier:@"notifications.top_label_inset"];
         CGFloat bottomLabelInset = [WAZUIMagic cgFloatForIdentifier:@"notifications.bottom_label_inset"];
+        CGFloat ephemeralBottomLabelInset = [WAZUIMagic cgFloatForIdentifier:@"notifications.ephemeral_bottom_label_inset"];
 
         [self.userImageView autoSetDimension:ALDimensionHeight toSize:tileDiameter];
         [self.userImageView autoAlignAxisToSuperviewAxis:ALAxisHorizontal];
@@ -210,7 +211,9 @@
 
         self.messageLabelLeftConstraint = [self.messageLabel autoPinEdge:ALEdgeLeft toEdge:ALEdgeRight ofView:self.userImageView withOffset:tileToContentGap + self.imageToTextInset];
         self.messageLabelRightConstraint = [self.messageLabel autoPinEdgeToSuperviewEdge:ALEdgeRight withInset:[WAZUIMagic cgFloatForIdentifier:@"notifications.corner_radius"] - self.imageToTextInset];
-        [self.messageLabel autoPinEdgeToSuperviewEdge:ALEdgeBottom withInset:bottomLabelInset];
+
+        CGFloat bottomInset = self.message.isEphemeral ? ephemeralBottomLabelInset : bottomLabelInset;
+        [self.messageLabel autoPinEdgeToSuperviewEdge:ALEdgeBottom withInset:bottomInset];
     }
 
     [super updateConstraints];


### PR DESCRIPTION
# What's in this PR?

* Fix too small bottom insets for ephemeral catheads using the redacted font 