### PR TITLE
Move ephemeral keyboard into popover on iPad

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -165,7 +165,7 @@
 
 // Ephemeral message
 "input.ephemeral.timeout.none" = "Off";
-"input.ephemeral.title" = "Set a timer for timed messages";
+"input.ephemeral.title" = "Set a timer for temporary messages";
 
 // System messages
 "content.system.continued_conversation" = "Start a conversation with %@";

--- a/Wire-iOS/Resources/Classy/stylesheet.cas
+++ b/Wire-iOS/Resources/Classy/stylesheet.cas
@@ -923,7 +923,7 @@ ConversationInputBarViewController {
         borderWidth: 0.0;
         titleColor: $color-ephemeral;
         titleLabel: @{
-            font: $font-small;
+            font: $font-small-medium;
         }
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Ephemeral.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Ephemeral.swift
@@ -36,12 +36,41 @@ extension ConversationInputBarViewController {
     }
 
     fileprivate func updateEphemeralKeyboardVisibility() {
-        if mode != .timeoutConfguration {
-            mode = .timeoutConfguration
-            inputBar.textView.becomeFirstResponder()
+
+        let showPopover = traitCollection.horizontalSizeClass == .regular
+        let noPopoverPresented = presentedViewController == nil
+        let regularNotPresenting = showPopover && noPopoverPresented
+        let compactNotPresenting = mode != .timeoutConfguration && !showPopover
+
+        // presenting
+        if compactNotPresenting || regularNotPresenting {
+            if showPopover {
+                presentEphemeralControllerAsPopover()
+            } else {
+                // we only want to change the mode when we present a custom keyboard
+                mode = .timeoutConfguration
+            }
+        // dismissing
         } else {
-            mode = .textInput
+            if noPopoverPresented {
+                mode = .textInput
+            } else {
+                ephemeralKeyboardViewController?.dismiss(animated: true, completion: nil)
+                ephemeralKeyboardViewController = nil
+            }
         }
+    }
+
+    private func presentEphemeralControllerAsPopover() {
+        createEphemeralKeyboardViewController()
+        ephemeralKeyboardViewController?.modalPresentationStyle = .popover
+        let popover = ephemeralKeyboardViewController?.popoverPresentationController
+        popover?.sourceRect = ephemeralIndicatorButton.frame
+        popover?.sourceView = ephemeralIndicatorButton
+        popover?.backgroundColor = ephemeralKeyboardViewController?.view.backgroundColor
+        ephemeralKeyboardViewController?.preferredContentSize = CGSize(width: 320, height: 275)
+        guard let controller = ephemeralKeyboardViewController else { return }
+        present(controller, animated: true, completion: nil)
     }
 
     public func updateEphemeralIndicatorButtonTitle(_ button: ButtonWithLargerHitArea) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Ephemeral.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Ephemeral.swift
@@ -49,6 +49,7 @@ extension ConversationInputBarViewController {
             } else {
                 // we only want to change the mode when we present a custom keyboard
                 mode = .timeoutConfguration
+                inputBar.textView.becomeFirstResponder()
             }
         // dismissing
         } else {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.h
@@ -51,6 +51,7 @@ typedef NS_ENUM(NSUInteger, ConversationInputBarViewControllerMode) {
 @interface ConversationInputBarViewController : UIViewController <UIPopoverPresentationControllerDelegate>
 
 @property (nonatomic, readonly) IconButton *photoButton;
+@property (nonatomic, readonly) IconButton *ephemeralIndicatorButton;
 @property (nonatomic, readonly) InputBar *inputBar;
 @property (nonatomic, readonly) ZMConversation *conversation;
 @property (nonatomic, weak) id <ConversationInputBarViewControllerDelegate> delegate;


### PR DESCRIPTION
# What's in this PR?

**These changes are only relevant for sending ephemeral messages (2.20)**

* Update ephemeral timeout indicator font weight.
* Update ephemeral timeout selection keyboard title copy.
* Use popover for ephemeral time selection on devices which are horizontally compact.
