### PR TITLE
Remove reference to inactive participants and use conversation type instead of participants count

### DIFF
--- a/Wire-iOS/Sources/Helpers/syncengine/ZMConversation+Additions.h
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMConversation+Additions.h
@@ -25,7 +25,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ZMConversation (Additions)
 
-- (NSUInteger)participantsCount;
 - (nullable id<ZMConversationMessage>)firstTextMessage;
 - (nullable id<ZMConversationMessage>)lastTextMessage;
 - (nullable id<ZMConversationMessage>)lastMessageSentByUser:(ZMUser *)user limit:(NSUInteger)limit;

--- a/Wire-iOS/Sources/Helpers/syncengine/ZMConversation+Additions.m
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMConversation+Additions.m
@@ -46,11 +46,6 @@
 
 @implementation ZMConversation (Additions)
 
-- (NSUInteger)participantsCount
-{
-    return self.activeParticipants.count + self.inactiveParticipants.count;
-}
-
 - (ZMConversation *)addParticipants:(NSSet *)participants
 {
     if (! participants || participants.count == 0) {

--- a/Wire-iOS/Sources/UserInterface/Overlay/InAppNotifications/ChatHeadView.m
+++ b/Wire-iOS/Sources/UserInterface/Overlay/InAppNotifications/ChatHeadView.m
@@ -125,7 +125,7 @@
 {
     NSString *nameString = [[self.message.sender displayName] uppercasedWithCurrentLocale];
 
-    if (self.message.conversation.participantsCount == 2) { // 1 to 1 conversation
+    if (self.message.conversation.conversationType == ZMConversationTypeOneOnOne) { // 1 to 1 conversation
         return nameString;
     }
     else if ([self isMessageInCurrentConversation]) {

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.m
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.m
@@ -664,7 +664,7 @@ static NSUInteger const StartUIInitiallyShowsKeyboardConversationThreshold = 10;
             [self presentProfileViewControllerForUser:user atIndexPath:indexPath];
         }
         else {
-            if (conversation.participantsCount != 2) { // double tap condition
+            if (conversation.conversationType == ZMConversationTypeGroup) { // double tap condition
                 if ([self.delegate respondsToSelector:@selector(startUI:didSelectConversation:)]) {
                     [self.delegate startUI:self didSelectConversation:modelObject];
                 }


### PR DESCRIPTION
# Reason for this pull request
We are removing `inactiveParticipants` from data model.

# Changes
Do not rely on participant count to know if a conversation is one to one or group.