### PR TITLE
Persist log level switches between runs

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -4762,12 +4762,10 @@
 				TargetAttributes = {
 					1EE85C4F1B5F96FB008E084B = {
 						CreatedOnToolsVersion = 6.4;
-						DevelopmentTeam = W5KEQBF9B5;
 						LastSwiftMigration = 0800;
 					};
 					1EE9DC6F1B5F98AD00E347DF = {
 						CreatedOnToolsVersion = 6.4;
-						DevelopmentTeam = W5KEQBF9B5;
 						SystemCapabilities = {
 							com.apple.Keychain = {
 								enabled = 1;
@@ -4787,7 +4785,6 @@
 					};
 					BACB88501AF7C48900DDCDB0 = {
 						CreatedOnToolsVersion = 6.3;
-						DevelopmentTeam = W5KEQBF9B5;
 						LastSwiftMigration = 0800;
 						TestTargetID = 8F42C537199244A700288E4D;
 					};

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -218,6 +218,7 @@
 		1EFBFF3F1B81FFA50011A94A /* NSItemProvider+Attachments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EFBFF3E1B81FFA50011A94A /* NSItemProvider+Attachments.swift */; };
 		39260D2402C36A8DE422A998 /* libPods-Wire-iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C88A846215D617F8CCFBEB80 /* libPods-Wire-iOS.a */; };
 		5407B8C31A643CCE009090C6 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5407B8C21A643CCE009090C6 /* UIKit.framework */; };
+		549D55AC1DBE03990035EB66 /* Settings+Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 549D55AB1DBE03990035EB66 /* Settings+Logging.swift */; };
 		54AB765C1DB7AB77008D19C8 /* DeveloperOptionsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54AB765B1DB7AB77008D19C8 /* DeveloperOptionsController.swift */; };
 		54F7C27F1D74367E004D8087 /* AddressBookHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F7C27E1D74367E004D8087 /* AddressBookHelper.swift */; };
 		54F7C2831D7467FA004D8087 /* AutomationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4A15D11D4900930051E8BA /* AutomationHelper.swift */; };
@@ -1141,6 +1142,7 @@
 		2729F031D6F030693AF9AEB5 /* Pods-Wire-iOS-Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Wire-iOS-Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Wire-iOS-Tests/Pods-Wire-iOS-Tests.release.xcconfig"; sourceTree = "<group>"; };
 		34FC4EA42010986A36883210 /* Pods-Wire-iOS-Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Wire-iOS-Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Wire-iOS-Tests/Pods-Wire-iOS-Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		5407B8C21A643CCE009090C6 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
+		549D55AB1DBE03990035EB66 /* Settings+Logging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Settings+Logging.swift"; sourceTree = "<group>"; };
 		54AB765B1DB7AB77008D19C8 /* DeveloperOptionsController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeveloperOptionsController.swift; sourceTree = "<group>"; };
 		54F7C27E1D74367E004D8087 /* AddressBookHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddressBookHelper.swift; sourceTree = "<group>"; };
 		54F7C2841D746F3F004D8087 /* AddressBookHelper+Automation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AddressBookHelper+Automation.swift"; sourceTree = "<group>"; };
@@ -3235,6 +3237,7 @@
 				871BC33B1D34F94200DF0793 /* Settings+ColorScheme.m */,
 				871BC33C1D34F94200DF0793 /* Settings.h */,
 				871BC33D1D34F94200DF0793 /* Settings.m */,
+				549D55AB1DBE03990035EB66 /* Settings+Logging.swift */,
 				871BC33E1D34F94200DF0793 /* Soundcloud */,
 				871BC3431D34F94200DF0793 /* Vimeo */,
 				871BC3481D34F94200DF0793 /* WRFunctions.h */,
@@ -4759,10 +4762,12 @@
 				TargetAttributes = {
 					1EE85C4F1B5F96FB008E084B = {
 						CreatedOnToolsVersion = 6.4;
+						DevelopmentTeam = W5KEQBF9B5;
 						LastSwiftMigration = 0800;
 					};
 					1EE9DC6F1B5F98AD00E347DF = {
 						CreatedOnToolsVersion = 6.4;
+						DevelopmentTeam = W5KEQBF9B5;
 						SystemCapabilities = {
 							com.apple.Keychain = {
 								enabled = 1;
@@ -4782,6 +4787,7 @@
 					};
 					BACB88501AF7C48900DDCDB0 = {
 						CreatedOnToolsVersion = 6.3;
+						DevelopmentTeam = W5KEQBF9B5;
 						LastSwiftMigration = 0800;
 						TestTargetID = 8F42C537199244A700288E4D;
 					};
@@ -5330,6 +5336,7 @@
 				8FC8543F199245770008B66B /* IncomingConnectRequestView.m in Sources */,
 				8FC85459199245770008B66B /* InvisibleInputAccessoryView.m in Sources */,
 				8F9E3B8A19D04CAC00FD427A /* SoundEventListener.m in Sources */,
+				549D55AC1DBE03990035EB66 /* Settings+Logging.swift in Sources */,
 				87DCF4F11D34EA4500BB420F /* UIViewController+WR_Invite.m in Sources */,
 				871067401C0DC5570035603B /* SettingsPropertyTextValueCellDescriptor.swift in Sources */,
 				871BC2811D34F8F800DF0793 /* NSString+Fingerprint.m in Sources */,

--- a/Wire-iOS/Sources/Components/Settings+Logging.swift
+++ b/Wire-iOS/Sources/Components/Settings+Logging.swift
@@ -1,9 +1,19 @@
 //
-//  Settings+Logging.swift
-//  Wire-iOS
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
 //
-//  Created by Marco Conti on 24/10/16.
-//  Copyright © 2016 Zeta Project Germany GmbH. All rights reserved.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
 import Foundation

--- a/Wire-iOS/Sources/Components/Settings+Logging.swift
+++ b/Wire-iOS/Sources/Components/Settings+Logging.swift
@@ -1,0 +1,40 @@
+//
+//  Settings+Logging.swift
+//  Wire-iOS
+//
+//  Created by Marco Conti on 24/10/16.
+//  Copyright © 2016 Zeta Project Germany GmbH. All rights reserved.
+//
+
+import Foundation
+import ZMCSystem
+
+private let enabledLogsKey = "WireEnabledZMLogTags"
+
+extension Settings {
+    
+    func set(logTag: String, enabled: Bool) {
+        ZMLogSetLevelForTag(enabled ? .debug : .warn, (logTag as NSString).utf8String!)
+        saveEnabledLogs()
+    }
+    
+    private func saveEnabledLogs() {
+        let enabledLogs = ZMLogGetAllTags().filter { str in
+            let level = ZMLogGetLevelForTag(str as! String)
+            return level == .debug || level == .info
+        } as NSArray
+        
+        UserDefaults.shared().set(enabledLogs, forKey: enabledLogsKey)
+    }
+    
+    @objc public func loadEnabledLogs() {
+        
+        guard let tagsToEnable = UserDefaults.shared().value(forKey: enabledLogsKey) as? Array<NSString> else {
+            return
+        }
+        
+        tagsToEnable.forEach { (tag) in
+            ZMLogSetLevelForTag(.debug, tag.utf8String!)
+        }
+    }
+}

--- a/Wire-iOS/Sources/Components/Settings.m
+++ b/Wire-iOS/Sources/Components/Settings.m
@@ -121,7 +121,7 @@ NSString * const UserDefaultSendButtonDisabled = @"SendButtonDisabled";
     self = [super init];
     if (self) {
         [self restoreLastUsedIntensityLevel];
-
+        [self loadEnabledLogs];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationDidEnterBackground:) name:UIApplicationDidEnterBackgroundNotification object:nil];
     }
     return self;
@@ -445,3 +445,4 @@ NSString * const UserDefaultSendButtonDisabled = @"SendButtonDisabled";
 }
 
 @end
+

--- a/Wire-iOS/Sources/Developer/DeveloperOptionsController.swift
+++ b/Wire-iOS/Sources/Developer/DeveloperOptionsController.swift
@@ -95,7 +95,6 @@ extension DeveloperOptionsController : UITableViewDataSource {
     func switchLogDidChange(sender: AnyObject) {
         let `switch` = sender as! UISwitch
         let logTag = self.allTags[`switch`.tag]
-        let newLevel = `switch`.isOn ? ZMLogLevel_t.debug : ZMLogLevel_t.warn
-        ZMLogSetLevelForTag(newLevel, logTag)
+        Settings.shared().set(logTag: logTag, enabled: `switch`.isOn)
     }
 }


### PR DESCRIPTION
# Reason for this pull request
Need to debug some decryption errors, this will allow testers to set the log on once instead of having to set it every time they restart the app. This will also allow to get logs when we are decrypting the notification stream, which happens immediately and there is no time to switch on the log manually.

# Changes
Save list of log tags that are enabled to user defaults
