### PR TITLE
Fix optional strings in audio message tracking

### DIFF
--- a/Wire-iOS/Sources/Analytics/Events/Analytics+MediaActionEvents.swift
+++ b/Wire-iOS/Sources/Analytics/Events/Analytics+MediaActionEvents.swift
@@ -334,9 +334,11 @@ public extension Analytics {
     
     /// User plays an audio message
     @objc public func tagPlayedAudioMessage(_ duration: TimeInterval, extensionString: String) {
-        let attributes = ["duration": videoDurationClusterizer.clusterizeTimeInterval(duration),
-                          "duration_actual": type(of: self).stringFromTimeInterval(duration),
-                          "type": extensionString]
+        let attributes: [String: String] = [
+            "duration": videoDurationClusterizer.clusterizeTimeInterval(duration),
+            "duration_actual": type(of: self).stringFromTimeInterval(duration),
+            "type": extensionString
+        ]
         tagEvent(conversationMediaPlayedAudioMessageEventName, attributes: attributes)
     }
     


### PR DESCRIPTION
# What's in this PR?

* The type of the attributes dictionary was `[String: String?]` which resulted in `"Optional(\"31-60\")"` values being tracked.