### PR TITLE
Fixed accent color selection when no yellow is shown

### DIFF
--- a/Wire-iOS/Sources/Helpers/syncengine/ZMAccentColor+Additions.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMAccentColor+Additions.swift
@@ -34,4 +34,13 @@ extension ZMAccentColor {
                 .softPink,
                 .violet]
     }
+    
+    static func allSelectable() -> [ZMAccentColor] {
+        return [.strongBlue,
+                .strongLimeGreen,
+                .vividRed,
+                .brightOrange,
+                .softPink,
+                .violet]
+    }
 }

--- a/Wire-iOS/Sources/UserInterface/Settings/AccentColorPickerController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/AccentColorPickerController.swift
@@ -212,13 +212,17 @@ extension ColorPickerController: UITableViewDelegate, UITableViewDataSource {
 
 
 
-open class AccentColorPickerController: ColorPickerController {
+final class AccentColorPickerController: ColorPickerController {
+    fileprivate let allAccentColors: [ZMAccentColor]
+    
+    
     public init() {
-        let allColors = ZMAccentColor.all().filter { $0 != .brightYellow }
+        self.allAccentColors = ZMAccentColor.all().filter { $0 != .brightYellow }
         
-        super.init(colors: allColors.map { $0.color })
+        super.init(colors: self.allAccentColors.map { $0.color })
         self.title = "self.settings.account_picture_group.color".localized.uppercased()
-        if let currentColorIndex = ZMAccentColor.all().index(of: ZMUser.selfUser().accentColorValue) {
+        
+        if let currentColorIndex = self.allAccentColors.index(of: ZMUser.selfUser().accentColorValue) {
             self.currentColor = self.colors[currentColorIndex]
         }
         self.delegate = self
@@ -241,7 +245,7 @@ extension AccentColorPickerController: ColorPickerControllerDelegate {
         }
         
         ZMUserSession.shared().performChanges { 
-            ZMUser.selfUser().accentColorValue = ZMAccentColor.all()[colorIndex]
+            ZMUser.selfUser().accentColorValue = self.allAccentColors[colorIndex]
         }
     }
 

--- a/Wire-iOS/Sources/UserInterface/Settings/AccentColorPickerController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/AccentColorPickerController.swift
@@ -210,14 +210,12 @@ extension ColorPickerController: UITableViewDelegate, UITableViewDataSource {
     }
 }
 
-
-
 final class AccentColorPickerController: ColorPickerController {
     fileprivate let allAccentColors: [ZMAccentColor]
     
     
     public init() {
-        self.allAccentColors = ZMAccentColor.all().filter { $0 != .brightYellow }
+        self.allAccentColors = ZMAccentColor.allSelectable()
         
         super.init(colors: self.allAccentColors.map { $0.color })
         self.title = "self.settings.account_picture_group.color".localized.uppercased()


### PR DESCRIPTION
# Issue

The indexes where not aligned between `ZMAccentColor.all()` array and `self.colors` array.