### PR TITLE
Do not leave call when joining

### DIFF
--- a/Wire-iOS/Sources/Helpers/syncengine/ZMConversation+Additions.h
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMConversation+Additions.h
@@ -49,7 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isCallingSupported;
 
 - (void)acceptIncomingCall;
-+ (void)leaveActiveCallsWithCompletionHandler:(nullable void(^)())completionHandler;
+- (void)leaveOtherActiveCallsWithCompletionHandler:(nullable void(^)())completionHandler;
 - (void)startAudioCallWithCompletionHandler:(nullable void(^)(BOOL joined))completion;
 - (void)startVideoCallWithCompletionHandler:(nullable void(^)(BOOL joined))completion;
 

--- a/Wire-iOS/Sources/Helpers/syncengine/ZMConversation+Additions.m
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMConversation+Additions.m
@@ -320,7 +320,7 @@
 
 - (void)joinVoiceChannelWithoutAskingForPermissionWithVideo:(BOOL)video completionHandler:(void(^)(BOOL joined))completion
 {
-    [self.class leaveActiveCallsWithCompletionHandler:^{
+    [self leaveOtherActiveCallsWithCompletionHandler:^{
         ZMVoiceChannelState voiceChannelState = self.voiceChannel.state;
         ZMVoiceChannelConnectionState connectionState = self.voiceChannel.selfUserConnectionState;
 
@@ -359,7 +359,7 @@
     }];
 }
 
-+ (void)leaveActiveCallsWithCompletionHandler:(nullable void(^)())completionHandler
+- (void)leaveOtherActiveCallsWithCompletionHandler:(nullable void(^)())completionHandler
 {
     NSArray *nonIdleConversations = [[SessionObjectCache sharedCache] nonIdleVoiceChannelConversations];
 

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
@@ -346,12 +346,13 @@ import Foundation
     
     func developerGroup() -> SettingsCellDescriptorType {
         let title = "self.settings.developer_options.title".localized
+        var developerCellDescriptors: [SettingsCellDescriptorType] = []
         
         let devController = SettingsExternalScreenCellDescriptor(title: "Logging") { () -> (UIViewController?) in
             return DeveloperOptionsController()
         }
         
-        var developerCellDescriptors: [SettingsCellDescriptorType] = []
+        developerCellDescriptors.append(devController)
         
         let diableAVSSetting = SettingsPropertyToggleCellDescriptor(settingsProperty: self.settingsPropertyFactory.property(.disableAVS))
         developerCellDescriptors.append(diableAVSSetting)
@@ -367,7 +368,7 @@ import Foundation
             developerCellDescriptors.append(callKitDescriptor)
         }
         
-        return SettingsGroupCellDescriptor(items: [SettingsSectionDescriptor(cellDescriptors: [devController, diableAVSSetting, diableUISetting, diableHockeySetting, diableAnalyticsSetting])], title: title, icon: .effectRobot)
+        return SettingsGroupCellDescriptor(items: [SettingsSectionDescriptor(cellDescriptors:developerCellDescriptors)], title: title, icon: .effectRobot)
     }
     
     func helpSection() -> SettingsCellDescriptorType {


### PR DESCRIPTION
# Issus

As the method `leaveActiveCallsWithCompletionHandler` was changed from instance to static, the compiler seemed to ignore the fact that `self` was used in the method:
```
if (conversation == self) {
```

So one more reason to use Swift (it would detect this error on compilation).

# Consequences 

It was impossible to join the call when callkit was disabled or on iOS 9.
