### PR TITLE
Play ringing from me, do not play from them on CallKit

### DIFF
--- a/Wire-iOS/Sources/Managers/SoundEventListener.m
+++ b/Wire-iOS/Sources/Managers/SoundEventListener.m
@@ -57,9 +57,7 @@ static NSTimeInterval const SoundEventListenerIgnoreTimeForPushStart = 2.0;
 {
     self = [super init];
     if (self) {
-        if (![ZMUserSession useCallKit]) {
-            self.voiceChannelStateObserverToken = [ZMVoiceChannel addGlobalVoiceChannelStateObserver:self inUserSession:[ZMUserSession sharedSession]];
-        }
+        self.voiceChannelStateObserverToken = [ZMVoiceChannel addGlobalVoiceChannelStateObserver:self inUserSession:[ZMUserSession sharedSession]];
         self.unreadMessageObserverToken = [ZMMessageNotification addNewMessagesObserver:self inUserSession:[ZMUserSession sharedSession]];
         self.unreadKnockMessageObserverToken = [ZMMessageNotification addNewKnocksObserver:self inUserSession:[ZMUserSession sharedSession]];
         [ZMCallEndedNotification addCallEndObserver:self];
@@ -202,7 +200,7 @@ static NSTimeInterval const SoundEventListenerIgnoreTimeForPushStart = 2.0;
             break;
         }
         case ZMVoiceChannelStateIncomingCall: {
-            if (! change.voiceChannel.conversation.isSilenced) {
+            if (![ZMUserSession useCallKit] && ! change.voiceChannel.conversation.isSilenced) {
                 
                 BOOL otherVoiceChannelIsActive = NO;
                 


### PR DESCRIPTION
# Issue

We where not observing the call states in SoundEventListener in case we are using CallKit, because in this case iOS plays the incoming call sound. Now we observe it, but explicitly do not play incoming call and play other sound events.