### PR TITLE
Move Open-In options from advanced to options settings menu

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -487,7 +487,7 @@
 "self.settings.popular_demand.send_button.footer" = "Disable to send via the return key.";
 
 // Open in
-"self.settings.external_apps.header" = "Open Links In";
+"self.settings.external_apps.header" = "Open With";
 
 "self.settings.link_options.twitter.title" = "Tweets";
 "self.settings.link_options.maps.title" = "Locations";
@@ -497,7 +497,7 @@
 "open_link.twitter.option.tweetbot" = "Tweetbot";
 "open_link.twitter.option.twitterrific" = "Twitterrific";
 
-"open_link.maps.option.apple" = "Apple Maps";
+"open_link.maps.option.apple" = "Maps";
 "open_link.maps.option.google" = "Google Maps";
 
 "open_link.browser.option.safari" = "Safari";

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Options.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Options.swift
@@ -102,8 +102,6 @@ extension SettingsCellDescriptorFactory {
         }()
 
         let soundAlertSection = SettingsSectionDescriptor(cellDescriptors: [soundAlert])
-
-
         let soundsHeader = "self.settings.sound_menu.sounds.title".localized
 
         let callSoundProperty = self.settingsPropertyFactory.property(.callSoundName)
@@ -116,6 +114,25 @@ extension SettingsCellDescriptorFactory {
         let pingSoundGroup = self.soundGroupForSetting(pingSoundProperty, title: SettingsPropertyLabelText(pingSoundProperty.propertyName), callSound: false, fallbackSoundName: MediaManagerSoundIncomingKnockSound, defaultSoundTitle: "self.settings.sound_menu.sounds.wire_ping".localized)
 
         let soundsSection = SettingsSectionDescriptor(cellDescriptors: [callSoundGroup, messageSoundGroup, pingSoundGroup], header: soundsHeader)
+
+        var externalAppsDescriptors = [SettingsCellDescriptorType]()
+
+        if BrowserOpeningOption.optionsAvailable {
+            externalAppsDescriptors.append(browserOpeningGroup(for: settingsPropertyFactory.property(.browserOpeningOption)))
+        }
+        if MapsOpeningOption.optionsAvailable {
+            externalAppsDescriptors.append(mapsOpeningGroup(for: settingsPropertyFactory.property(.mapsOpeningOption)))
+        }
+        if TweetOpeningOption.optionsAvailable {
+            externalAppsDescriptors.append(twitterOpeningGroup(for: settingsPropertyFactory.property(.tweetOpeningOption)))
+        }
+
+        let externalAppsSection = SettingsSectionDescriptor(
+            cellDescriptors: externalAppsDescriptors,
+            header: "self.settings.external_apps.header".localized
+        )
+
+
 
         let sendButtonDescriptor = SettingsPropertyToggleCellDescriptor(settingsProperty: settingsPropertyFactory.property(.disableSendButton), inverse: true)
 
@@ -131,6 +148,73 @@ extension SettingsCellDescriptorFactory {
             footer: "self.settings.popular_demand.send_button.footer".localized
         )
 
-        return SettingsGroupCellDescriptor(items: [shareContactsDisabledSection, clearHistorySection, notificationVisibleSection, chatHeadsSection, soundAlertSection, soundsSection, byPopularDemandSection], title: "self.settings.options_menu.title".localized, icon: .settingsOptions)
+        var cellDescriptors = [shareContactsDisabledSection, clearHistorySection, notificationVisibleSection, chatHeadsSection, soundAlertSection, soundsSection]
+
+        if externalAppsDescriptors.count > 0 {
+            cellDescriptors.append(externalAppsSection)
+        }
+
+        cellDescriptors.append(byPopularDemandSection)
+
+        return SettingsGroupCellDescriptor(items: cellDescriptors, title: "self.settings.options_menu.title".localized, icon: .settingsOptions)
     }
+
+    func twitterOpeningGroup(for property: SettingsProperty) -> SettingsCellDescriptorType {
+        let cells = TweetOpeningOption.availableOptions.map { option -> SettingsPropertySelectValueCellDescriptor in
+
+            return SettingsPropertySelectValueCellDescriptor(
+                settingsProperty: property,
+                value: .number(value: option.rawValue),
+                title: option.displayString
+            )
+        }
+
+        let section = SettingsSectionDescriptor(cellDescriptors: cells.map { $0 as SettingsCellDescriptorType })
+        let preview: PreviewGeneratorType = { descriptor in
+            let value = property.value().value() as? Int
+            guard let option = value.flatMap ({ TweetOpeningOption(rawValue: $0) }) else { return .text(TweetOpeningOption.none.displayString) }
+            return .text(option.displayString)
+        }
+        return SettingsGroupCellDescriptor(items: [section], title: SettingsPropertyLabelText(property.propertyName), identifier: nil, previewGenerator: preview)
+    }
+
+    func mapsOpeningGroup(for property: SettingsProperty) -> SettingsCellDescriptorType {
+        let cells = MapsOpeningOption.availableOptions.map { option -> SettingsPropertySelectValueCellDescriptor in
+
+            return SettingsPropertySelectValueCellDescriptor(
+                settingsProperty: property,
+                value: .number(value: option.rawValue),
+                title: option.displayString
+            )
+        }
+
+        let section = SettingsSectionDescriptor(cellDescriptors: cells.map { $0 as SettingsCellDescriptorType })
+        let preview: PreviewGeneratorType = { descriptor in
+            let value = property.value().value() as? Int
+            guard let option = value.flatMap ({ MapsOpeningOption(rawValue: $0) }) else { return .text(MapsOpeningOption.apple.displayString) }
+            return .text(option.displayString)
+        }
+        return SettingsGroupCellDescriptor(items: [section], title: SettingsPropertyLabelText(property.propertyName), identifier: nil, previewGenerator: preview)
+    }
+
+    func browserOpeningGroup(for property: SettingsProperty) -> SettingsCellDescriptorType {
+        let cells = BrowserOpeningOption.availableOptions.map { option -> SettingsPropertySelectValueCellDescriptor in
+
+            return SettingsPropertySelectValueCellDescriptor(
+                settingsProperty: property,
+                value: .number(value: option.rawValue),
+                title: option.displayString
+            )
+        }
+
+        let section = SettingsSectionDescriptor(cellDescriptors: cells.map { $0 as SettingsCellDescriptorType })
+        let preview: PreviewGeneratorType = { descriptor in
+            let value = property.value().value() as? Int
+            guard let option = value.flatMap ({ BrowserOpeningOption(rawValue: $0) }) else { return .text(BrowserOpeningOption.safari.displayString) }
+            return .text(option.displayString)
+        }
+        return SettingsGroupCellDescriptor(items: [section], title: SettingsPropertyLabelText(property.propertyName), identifier: nil, previewGenerator: preview)
+    }
+    
+
 }

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
@@ -173,63 +173,6 @@ import Foundation
         }, icon: .settingsDevices)
     }
 
-    func twitterOpeningGroup(for property: SettingsProperty) -> SettingsCellDescriptorType {
-        let cells = TweetOpeningOption.availableOptions.map { option -> SettingsPropertySelectValueCellDescriptor in
-
-            return SettingsPropertySelectValueCellDescriptor(
-                settingsProperty: property,
-                value: .number(value: option.rawValue),
-                title: option.displayString
-            )
-        }
-
-        let section = SettingsSectionDescriptor(cellDescriptors: cells.map { $0 as SettingsCellDescriptorType })
-        let preview: PreviewGeneratorType = { descriptor in
-            let value = property.value().value() as? Int
-            guard let option = value.flatMap ({ TweetOpeningOption(rawValue: $0) }) else { return .text(TweetOpeningOption.none.displayString) }
-            return .text(option.displayString)
-        }
-        return SettingsGroupCellDescriptor(items: [section], title: SettingsPropertyLabelText(property.propertyName), identifier: nil, previewGenerator: preview)
-    }
-
-    func mapsOpeningGroup(for property: SettingsProperty) -> SettingsCellDescriptorType {
-        let cells = MapsOpeningOption.availableOptions.map { option -> SettingsPropertySelectValueCellDescriptor in
-
-            return SettingsPropertySelectValueCellDescriptor(
-                settingsProperty: property,
-                value: .number(value: option.rawValue),
-                title: option.displayString
-            )
-        }
-
-        let section = SettingsSectionDescriptor(cellDescriptors: cells.map { $0 as SettingsCellDescriptorType })
-        let preview: PreviewGeneratorType = { descriptor in
-            let value = property.value().value() as? Int
-            guard let option = value.flatMap ({ MapsOpeningOption(rawValue: $0) }) else { return .text(MapsOpeningOption.apple.displayString) }
-            return .text(option.displayString)
-        }
-        return SettingsGroupCellDescriptor(items: [section], title: SettingsPropertyLabelText(property.propertyName), identifier: nil, previewGenerator: preview)
-    }
-
-    func browserOpeningGroup(for property: SettingsProperty) -> SettingsCellDescriptorType {
-        let cells = BrowserOpeningOption.availableOptions.map { option -> SettingsPropertySelectValueCellDescriptor in
-
-            return SettingsPropertySelectValueCellDescriptor(
-                settingsProperty: property,
-                value: .number(value: option.rawValue),
-                title: option.displayString
-            )
-        }
-
-        let section = SettingsSectionDescriptor(cellDescriptors: cells.map { $0 as SettingsCellDescriptorType })
-        let preview: PreviewGeneratorType = { descriptor in
-            let value = property.value().value() as? Int
-            guard let option = value.flatMap ({ BrowserOpeningOption(rawValue: $0) }) else { return .text(BrowserOpeningOption.safari.displayString) }
-            return .text(option.displayString)
-        }
-        return SettingsGroupCellDescriptor(items: [section], title: SettingsPropertyLabelText(property.propertyName), identifier: nil, previewGenerator: preview)
-    }
-    
     func soundGroupForSetting(_ settingsProperty: SettingsProperty, title: String, callSound: Bool, fallbackSoundName: String, defaultSoundTitle : String = "self.settings.sound_menu.sounds.wire_sound".localized) -> SettingsCellDescriptorType {
         var items: [ZMSound?] = [.none]
         if callSound {
@@ -275,22 +218,6 @@ import Foundation
     }
 
     func advancedGroup() -> SettingsCellDescriptorType {
-        var externalAppsDescriptors = [SettingsCellDescriptorType]()
-
-        if BrowserOpeningOption.optionsAvailable {
-            externalAppsDescriptors.append(browserOpeningGroup(for: settingsPropertyFactory.property(.browserOpeningOption)))
-        }
-        if MapsOpeningOption.optionsAvailable {
-            externalAppsDescriptors.append(mapsOpeningGroup(for: settingsPropertyFactory.property(.mapsOpeningOption)))
-        }
-        if TweetOpeningOption.optionsAvailable {
-            externalAppsDescriptors.append(twitterOpeningGroup(for: settingsPropertyFactory.property(.tweetOpeningOption)))
-        }
-
-        let externalAppsSection = SettingsSectionDescriptor(
-            cellDescriptors: externalAppsDescriptors,
-            header: "self.settings.external_apps.header".localized
-        )
 
         let sendDataToWire = SettingsPropertyToggleCellDescriptor(settingsProperty: self.settingsPropertyFactory.property(.analyticsOptOut), inverse: true)
         let usageLabel = "self.settings.privacy_analytics_section.title".localized
@@ -332,13 +259,8 @@ import Foundation
 
         let versionSection = SettingsSectionDescriptor(cellDescriptors: [versionCell])
 
-        var advanvedItems = [sendUsageSection, troubleshootingSection, pushSection, versionSection]
-        if externalAppsDescriptors.count > 0 {
-            advanvedItems.insert(externalAppsSection, at: 0)
-        }
-
         return SettingsGroupCellDescriptor(
-            items: advanvedItems,
+            items: [sendUsageSection, troubleshootingSection, pushSection, versionSection],
             title: "self.settings.advanced.title".localized,
             icon: .settingsAdvanced
         )


### PR DESCRIPTION
# What's in this PR?

* Move the "Open-In" options menu from the advanced group into the options group.