### PR TITLE
Fix missing rounded corners when cells are presented initially

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/AudioMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/AudioMessageCell.swift
@@ -88,6 +88,9 @@ public final class AudioMessageCell: ConversationCell {
         self.audioPlayerProgressObserver = KeyValueObserver.observe(audioTrackPlayer, keyPath: "progress", target: self, selector: #selector(audioProgressChanged(_:)), options: [.initial, .new])
         
         self.audioPlayerStateObserver = KeyValueObserver.observe(audioTrackPlayer, keyPath: "state", target: self, selector: #selector(audioPlayerStateChanged(_:)), options: [.initial, .new])
+
+        setNeedsLayout()
+        layoutIfNeeded()
     }
     
     deinit {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransferCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransferCell.swift
@@ -77,6 +77,9 @@ public final class FileTransferCell: ConversationCell {
         var currentElements = self.accessibilityElements ?? []
         currentElements.append(contentsOf: [topLabel, bottomLabel, fileTypeIconView, actionButton, likeButton, messageToolboxView])
         self.accessibilityElements = currentElements
+
+        setNeedsLayout()
+        layoutIfNeeded()
     }
     
     public required init?(coder aDecoder: NSCoder) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/VideoMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/VideoMessageCell.swift
@@ -86,6 +86,9 @@ public final class VideoMessageCell: ConversationCell {
         var currentElements = self.accessibilityElements ?? []
         currentElements.append(contentsOf: [previewImageView, playButton, timeLabel, progressView, likeButton, messageToolboxView])
         self.accessibilityElements = currentElements
+
+        setNeedsLayout()
+        layoutIfNeeded()
     }
     
     public required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
# What's in this PR?

* There was an issue with the rounded corners of several cells not being present when the cells are shown for the first time.
* `layoutSubViews` is not called the first time a cell is created, which is why we need to call `setNeedsLayout()` and `layoutIfNeeded()` manually in the initializers of `AudioMessageCell`, `FileTransferCell` and `VideoMessageCell`.