### PR TITLE
Enable deletion for the selfUser for failed to send messages and in left conversations

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
@@ -541,8 +541,11 @@ const NSTimeInterval ConversationCellSelectionAnimationDuration = 0.33;
         NSString *likeTitleKey = [Message isLikedMessage:self.message] ? @"content.message.unlike" : @"content.message.like";
         UIMenuItem *likeItem = [[UIMenuItem alloc] initWithTitle:NSLocalizedString(likeTitleKey, @"") action:@selector(likeMessage:)];
         [items insertObject:likeItem atIndex:0];
+    }
 
-        UIMenuItem *deleteItem = [[UIMenuItem alloc] initWithTitle:NSLocalizedString(@"content.message.delete", @"") action:@selector(deleteMessage:)];
+    if (self.message.canBeDeleted) {
+        NSString *deleteTitle = NSLocalizedString(@"content.message.delete", @"");
+        UIMenuItem *deleteItem = [[UIMenuItem alloc] initWithTitle:deleteTitle action:@selector(deleteMessage:)];
         [items addObject:deleteItem];
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageDeletion.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageDeletion.swift
@@ -18,6 +18,20 @@
 
 import ZMCDataModel
 
+
+private extension ZMConversationMessage {
+
+    /// Whether the `Delete for everyone` option should be allowed and shown for this message.
+    var canBeDeletedForEveryone: Bool {
+        guard let sender = sender, let conversation = conversation else { return false }
+        return sender.isSelfUser
+            && conversation.isSelfAnActiveMember
+            && (deliveryState == .sent || deliveryState == .delivered)
+    }
+
+}
+
+
 extension ConversationContentViewController {
 
     /**
@@ -28,8 +42,7 @@ extension ConversationContentViewController {
      - parameter message:    The message for which the alert controller should be shown
      */
     func presentDeletionAlertController(forMessage message: ZMConversationMessage, completion: (() -> Void)?) {
-        let showDelete = (message.sender?.isSelfUser ?? false) && conversation.isSelfAnActiveMember
-        let alert = UIAlertController.alertControllerForMessageDeletion(showDelete) { [weak self] action in
+        let alert = UIAlertController.alertControllerForMessageDeletion(message.canBeDeletedForEveryone) { [weak self] action in
             
             // Tracking needs to be called before performing the action, since the content of the message is cleared
             if case .delete(let type) = action {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageDeletion.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageDeletion.swift
@@ -24,9 +24,17 @@ private extension ZMConversationMessage {
     /// Whether the `Delete for everyone` option should be allowed and shown for this message.
     var canBeDeletedForEveryone: Bool {
         guard let sender = sender, let conversation = conversation else { return false }
-        return sender.isSelfUser
-            && conversation.isSelfAnActiveMember
-            && (deliveryState == .sent || deliveryState == .delivered)
+        return sender.isSelfUser && conversation.isSelfAnActiveMember
+    }
+
+    var deletionConfiguration: DeletionConfiguration {
+        // If the message failed to send we only want to show the delete for everyone option,
+        // as we can not be sure that it did not hit the backend before we expired it.
+        if deliveryState == .failedToSend {
+            return .delete
+        }
+
+        return canBeDeletedForEveryone ? .hideAndDelete : .hide
     }
 
 }
@@ -42,7 +50,7 @@ extension ConversationContentViewController {
      - parameter message:    The message for which the alert controller should be shown
      */
     func presentDeletionAlertController(forMessage message: ZMConversationMessage, completion: (() -> Void)?) {
-        let alert = UIAlertController.alertControllerForMessageDeletion(message.canBeDeletedForEveryone) { [weak self] action in
+        let alert = UIAlertController.forMessageDeletion(with: message.deletionConfiguration) { [weak self] action in
             
             // Tracking needs to be called before performing the action, since the content of the message is cleared
             if case .delete(let type) = action {
@@ -95,17 +103,40 @@ private enum AlertAction {
     case delete(DeletionType), cancel
 }
 
+// Used to enforce only valid configurations can be shown.
+// Unfortunately this can not be done with an `OptionSetType`
+// as there is no way to enforce a non-empty option set.
+private enum DeletionConfiguration {
+    case hide, delete, hideAndDelete
+
+    var showHide: Bool {
+        switch self {
+        case .hide, .hideAndDelete: return true
+        case .delete: return false
+        }
+    }
+
+    var showDelete: Bool {
+        switch self {
+        case .delete, .hideAndDelete: return true
+        case .hide: return false
+        }
+    }
+}
+
 private extension UIAlertController {
 
-    static func alertControllerForMessageDeletion(_ showDelete: Bool, selectedAction: @escaping (AlertAction) -> Void) -> UIAlertController {
+    static func forMessageDeletion(with configuration: DeletionConfiguration, selectedAction: @escaping (AlertAction) -> Void) -> UIAlertController {
         let alertTitle = "message.delete_dialog.message".localized
         let alert = UIAlertController(title: alertTitle, message: nil, preferredStyle: .actionSheet)
 
-        let hideTitle = "message.delete_dialog.action.hide".localized
-        let hideAction = UIAlertAction(title: hideTitle, style: .default, handler: { _ in selectedAction(.delete(.local)) })
-        alert.addAction(hideAction)
+        if configuration.showHide {
+            let hideTitle = "message.delete_dialog.action.hide".localized
+            let hideAction = UIAlertAction(title: hideTitle, style: .default, handler: { _ in selectedAction(.delete(.local)) })
+            alert.addAction(hideAction)
+        }
 
-        if showDelete {
+        if configuration.showDelete {
             let deleteTitle = "message.delete_dialog.action.delete".localized
             let deleteForEveryoneAction = UIAlertAction(title: deleteTitle, style: .default, handler: { _ in selectedAction(.delete(.everywhere)) })
             alert.addAction(deleteForEveryoneAction)


### PR DESCRIPTION
# What's in this PR?
* This fixes [#7281](https://wearezeta.atlassian.net/browse/ZIOS-7448) and [#7448](https://wearezeta.atlassian.net/browse/ZIOS-7281).
* There was a bug with the delete for me option not being present if the message failed to send as well as in left conversations. The issue was that we were adding the delete `UIMenuItem` to the menu if a message can be liked. To ensure we do not show a delete for everyone if the message failed to sent an additional check has been added.