### PR TITLE
Hide temporary user clients when registering a new device and hit client limit

### DIFF
--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
@@ -391,7 +391,7 @@
 - (void)openClientListScreenForUser:(ZMUser *)user
 {
     if (user.isSelfUser) {
-        ClientListViewController *clientListViewController = [[ClientListViewController alloc] initWithClientsList:user.clients.allObjects credentials:nil detailedView:YES];
+        ClientListViewController *clientListViewController = [[ClientListViewController alloc] initWithClientsList:user.clients.allObjects credentials:nil detailedView:YES showTemporary:YES];
         clientListViewController.view.backgroundColor = [UIColor blackColor];
         clientListViewController.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(dismissClientListController:)];
         UINavigationController *navWrapperController = [[SettingsStyleNavigationController alloc] initWithRootViewController:clientListViewController];

--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientUnregisterFlowViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientUnregisterFlowViewController.swift
@@ -128,7 +128,7 @@ class ClientUnregisterFlowViewController: FormFlowViewController, FormStepDelega
     // MARK: - FormStepDelegate
     
     func didCompleteFormStep(_ viewController: UIViewController!) {
-        let clientsListController = ClientListViewController(clientsList: self.clients, credentials: self.credentials)
+        let clientsListController = ClientListViewController(clientsList: self.clients, credentials: self.credentials, showTemporary: false)
         clientsListController.view.backgroundColor = UIColor.black
         if self.traitCollection.userInterfaceIdiom == .pad {
             let navigationController = UINavigationController(rootViewController: clientsListController)


### PR DESCRIPTION
# What's in this PR?

* When registering a new client with already the maximum number of clients registered we were showing the list of clients to let the user choose one to delete it. In this we included temporary devices as well, but the deletion of a users temporary client does not allow them to register a new, non-temporary one, as the limit of 7 clients is only counting the non-temporary ones.
