### PR TITLE
The conversation title view was truncated when initially verifying all clients

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationTitleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationTitleView.swift
@@ -24,7 +24,7 @@ public final class ConversationTitleView: UIView {
     
     var titleColor, titleColorSelected: UIColor?
     var titleFont: UIFont?
-    var titleButton = UIButton()
+    let titleButton = UIButton()
     public var tapHandler: ((UIButton) -> Void)? = nil
     
     init(conversation: ZMConversation) {
@@ -44,7 +44,7 @@ public final class ConversationTitleView: UIView {
         addSubview(titleButton)
     }
     
-    func configure(_ conversation: ZMConversation) {
+    private func configure(_ conversation: ZMConversation) {
         guard let font = titleFont, let color = titleColor, let selectedColor = titleColorSelected else { return }
         let title = conversation.displayName.uppercased() && font
         

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -876,12 +876,8 @@
         [self updateNavigationItemsButtons];
     }
     
-    if (note.nameChanged) {
+    if (note.nameChanged || note.securityLevelChanged) {
         [self setupNavigatiomItem];
-    }
-
-    if (note.securityLevelChanged) {
-        [self.titleView configure:self.conversation];
     }
 }
 


### PR DESCRIPTION
# What's in this PR?

* As `UINavigationItem` doesn't really play nicely with auto layout we are now just recreating the title view when the security status changes.