### PR TITLE
Fix for clipping message with multiline link preview title

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/TextMessageCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/TextMessageCell.m
@@ -211,6 +211,8 @@
         ArticleView *articleView = [[ArticleView alloc] initWithImagePlaceholder:textMesssageData.hasImageData];
         articleView.imageHeight = self.smallLinkAttachments ? 0 : 144;
         if (self.smallLinkAttachments) {
+            articleView.messageLabel.numberOfLines = 1;
+            articleView.authorLabel.numberOfLines = 1;
             [articleView autoSetDimension:ALDimensionHeight toSize:70];
         }
         articleView.translatesAutoresizingMaskIntoConstraints = NO;

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/TextMessageCell+Internal.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/TextMessageCell+Internal.h
@@ -20,5 +20,6 @@
 
 @interface TextMessageCell ()
 @property (nonatomic) LinkInteractionTextView *messageTextView;
+// Using @c smallLinkAttachments = YES imply that the cell is not going to be re-used.
 @property (nonatomic) BOOL smallLinkAttachments;
 @end


### PR DESCRIPTION
# Issue

Link preview with multiple lines is cut because of link preview view height collapse. Fix is to force labels to be one-line in this case.