### PR TITLE
Add first fixes to support RTL languages

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -734,6 +734,7 @@
 		BF4199D71DB794B3006A4C02 /* LinkOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4199D31DB794B3006A4C02 /* LinkOpener.swift */; };
 		BF4199D81DB794B3006A4C02 /* MapOpening.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4199D41DB794B3006A4C02 /* MapOpening.swift */; };
 		BF4199D91DB794B3006A4C02 /* TweetOpening.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4199D51DB794B3006A4C02 /* TweetOpening.swift */; };
+		BF5090581DE3469700A5FEE0 /* UIView+LayoutMargins.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF5090571DE3469700A5FEE0 /* UIView+LayoutMargins.swift */; };
 		BF5127161CC9119400F23DEA /* ZMSnapshotTestCase+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF5127141CC9118F00F23DEA /* ZMSnapshotTestCase+Swift.swift */; };
 		BF515F941D9D1C1900C786FB /* EmojiSectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF515F931D9D1C1900C786FB /* EmojiSectionViewController.swift */; };
 		BF52C1571CAEB9E10037331F /* ArchivedListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF52C1561CAEB9E10037331F /* ArchivedListViewController.swift */; };
@@ -2060,6 +2061,7 @@
 		BF4199D41DB794B3006A4C02 /* MapOpening.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapOpening.swift; sourceTree = "<group>"; };
 		BF4199D51DB794B3006A4C02 /* TweetOpening.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweetOpening.swift; sourceTree = "<group>"; };
 		BF4A15D11D4900930051E8BA /* AutomationHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutomationHelper.swift; sourceTree = "<group>"; };
+		BF5090571DE3469700A5FEE0 /* UIView+LayoutMargins.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+LayoutMargins.swift"; sourceTree = "<group>"; };
 		BF5127141CC9118F00F23DEA /* ZMSnapshotTestCase+Swift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMSnapshotTestCase+Swift.swift"; sourceTree = "<group>"; };
 		BF515F931D9D1C1900C786FB /* EmojiSectionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = EmojiSectionViewController.swift; path = Emoji/EmojiSectionViewController.swift; sourceTree = "<group>"; };
 		BF52C1561CAEB9E10037331F /* ArchivedListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ArchivedListViewController.swift; path = ../Conversation/ArchivedListViewController.swift; sourceTree = "<group>"; };
@@ -3427,6 +3429,7 @@
 				874B5DAF1CEDEBDA0010474C /* FileMessageCellState.swift */,
 				16D68E9A1CEF99C7003AB9E0 /* WaveformProgressView.swift */,
 				BF02CDC21D79A98000C87D38 /* SavableImage.swift */,
+				BF5090571DE3469700A5FEE0 /* UIView+LayoutMargins.swift */,
 				16BEBC3C1D006A6B006FFD3E /* ThreeDotsLoadingView.swift */,
 				87DE06B01D256CF50009411F /* DeviceProximityListener.swift */,
 				875F89111D6DCD2C00D8748E /* MessageToolboxView.swift */,
@@ -5359,6 +5362,7 @@
 				16D453601B69131400675246 /* ConversationListCollectionViewLayout.m in Sources */,
 				87DCF49E1D34E9E600BB420F /* ModalTopBar.swift in Sources */,
 				8FC8549C199245770008B66B /* NetworkStatusViewController.m in Sources */,
+				BF5090581DE3469700A5FEE0 /* UIView+LayoutMargins.swift in Sources */,
 				8F8914131A9F287E0056AB0C /* ConversationListItemView.m in Sources */,
 				16063CEB1BCFCEB70097F62C /* InviteBannerViewController.m in Sources */,
 				1600E2051AD5799400C0DBA8 /* PhoneNumberStepViewController.m in Sources */,

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
@@ -120,10 +120,7 @@ const NSTimeInterval ConversationCellSelectionAnimationDuration = 0.33;
             cell.unreadDotView.backgroundColor = newColor;
         }];
         
-        UIEdgeInsets layoutMargins = UIEdgeInsetsMake(0, [WAZUIMagic floatForIdentifier:@"content.left_margin"],
-                                                      0, [WAZUIMagic floatForIdentifier:@"content.right_margin"]);
-        
-        self.contentLayoutMargins = layoutMargins;
+        self.contentLayoutMargins = self.layoutDirectionAwareLayoutMargins;
     }
     
     return self;
@@ -270,9 +267,9 @@ const NSTimeInterval ConversationCellSelectionAnimationDuration = 0.33;
     self.unreadDotHeightConstraint.active = NO;
     [self.unreadDotView autoMatchDimension:ALDimensionWidth toDimension:ALDimensionHeight ofView:self.unreadDotView];
     [self.unreadDotView autoAlignAxis:ALAxisHorizontal toSameAxisOfView:self.burstTimestampLabel];
-    [self.unreadDotView autoPinEdge:ALEdgeRight toEdge:ALEdgeLeft ofView:self.burstTimestampLabel withOffset:-8];
+    [self.unreadDotView autoPinEdge:ALEdgeTrailing toEdge:ALEdgeLeading ofView:self.burstTimestampLabel withOffset:-8];
     
-    [self.authorLabel autoPinEdgeToSuperviewMargin:ALEdgeLeft];
+    [self.authorLabel autoPinEdgeToSuperviewMargin:ALEdgeLeading];
     self.authorHeightConstraint = [self.authorLabel autoSetDimension:ALDimensionHeight toSize:0];
     [self.authorLabel autoAlignAxis:ALAxisHorizontal toSameAxisOfView:self.authorImageContainer];
     [self.authorLabel setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisVertical];
@@ -286,12 +283,12 @@ const NSTimeInterval ConversationCellSelectionAnimationDuration = 0.33;
     [self.authorImageView autoCenterInSuperview];
     
     self.authorImageTopMarginConstraint = [self.authorImageContainer autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.burstTimestampLabel];
-    [self.authorImageContainer autoPinEdgeToSuperviewEdge:ALEdgeLeft];
-    [self.authorImageContainer autoPinEdge:ALEdgeRight toEdge:ALEdgeLeft ofView:self.authorLabel];
+    [self.authorImageContainer autoPinEdgeToSuperviewEdge:ALEdgeLeading];
+    [self.authorImageContainer autoPinEdge:ALEdgeTrailing toEdge:ALEdgeLeading ofView:self.authorLabel];
     
     [self.messageContentView autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.authorImageView];
-    [self.messageContentView autoPinEdgeToSuperviewEdge:ALEdgeLeft];
-    [self.messageContentView autoPinEdgeToSuperviewEdge:ALEdgeRight];
+    [self.messageContentView autoPinEdgeToSuperviewEdge:ALEdgeLeading];
+    [self.messageContentView autoPinEdgeToSuperviewEdge:ALEdgeTrailing];
     
     [NSLayoutConstraint autoSetPriority:UILayoutPriorityDefaultHigh + 1 forConstraints:^{
         [self.unreadDotView autoSetDimension:ALDimensionHeight toSize:8];
@@ -312,11 +309,12 @@ const NSTimeInterval ConversationCellSelectionAnimationDuration = 0.33;
     [self.likeButton autoAlignAxis:ALAxisVertical toSameAxisOfView:self.authorImageContainer];
 
     [self.countdownView autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsMake(2, 2, 2, 2)];
-    [self.countdownContainerView autoPinEdgeToSuperviewEdge:ALEdgeRight withInset:8];
+    [self.countdownContainerView autoPinEdgeToSuperviewEdge:ALEdgeTrailing withInset:8];
 }
 
 - (void)setContentLayoutMargins:(UIEdgeInsets)contentLayoutMargins
 {
+
     _contentLayoutMargins = contentLayoutMargins;
     
     self.contentView.layoutMargins = contentLayoutMargins;

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/IconSystemCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/IconSystemCell.swift
@@ -81,25 +81,25 @@ open class IconSystemCell: ConversationCell, TTTAttributedLabelDelegate {
             
             let inset: CGFloat = 16
             constrain(self.leftIconContainer, self.leftIconView, self.labelView, self.messageContentView, self.authorLabel) { leftIconContainer, leftIconView, labelView, messageContentView, authorLabel in
-                leftIconContainer.left == messageContentView.left
-                leftIconContainer.right == authorLabel.left
+                leftIconContainer.leading == messageContentView.leading
+                leftIconContainer.trailing == authorLabel.leading
                 leftIconContainer.top == messageContentView.top + inset
                 leftIconContainer.bottom <= messageContentView.bottom
                 leftIconContainer.height == leftIconView.height
                 leftIconView.center == leftIconContainer.center
                 leftIconView.height == 16
                 leftIconView.height == leftIconView.width
-                labelView.left == leftIconContainer.right
+                labelView.leading == leftIconContainer.trailing
                 labelView.top == messageContentView.top + inset + 2
-                labelView.right <= messageContentView.right - 72
+                labelView.trailing <= messageContentView.trailing - 72
                 labelView.bottom <= messageContentView.bottom - inset
                 messageContentView.height >= 32
             }
             
             constrain(self.lineView, self.contentView, self.labelView, self.messageContentView) { lineView, contentView, labelView, messageContentView in
-                lineView.left == labelView.right + 16
+                lineView.leading == labelView.trailing + 16
                 lineView.height == 0.5
-                lineView.right == contentView.right
+                lineView.trailing == contentView.trailing
                 lineView.top == messageContentView.top + inset + 8
             }
             

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/PingCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/PingCell.m
@@ -75,7 +75,7 @@ typedef void (^AnimationBlock)(id, NSInteger);
 - (void)createConstraints
 {
     [self.pingImageView autoAlignAxis:ALAxisHorizontal toSameAxisOfView:self.authorLabel];
-    [self.pingImageView autoPinEdge:ALEdgeLeft toEdge:ALEdgeRight ofView:self.authorLabel withOffset:8];
+    [self.pingImageView autoPinEdge:ALEdgeLeading toEdge:ALEdgeTrailing ofView:self.authorLabel withOffset:8];
     [self.countdownContainerView autoAlignAxis:ALAxisHorizontal toSameAxisOfView:self.pingImageView];
 }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/TextMessageCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/TextMessageCell.m
@@ -127,14 +127,14 @@
 - (void)createConstraints
 {
     [self.messageTextView autoPinEdgeToSuperviewMargin:ALEdgeTop];
-    [self.messageTextView autoPinEdgeToSuperviewMargin:ALEdgeLeft];
-    [self.messageTextView autoPinEdgeToSuperviewMargin:ALEdgeRight];
+    [self.messageTextView autoPinEdgeToSuperviewMargin:ALEdgeLeading];
+    [self.messageTextView autoPinEdgeToSuperviewMargin:ALEdgeTrailing];
     
     self.textViewHeightConstraint = [self.messageTextView autoSetDimension:ALDimensionHeight toSize:0];
     self.textViewHeightConstraint.active = NO;
     
-    [self.linkAttachmentContainer autoPinEdgeToSuperviewEdge:ALEdgeLeft withInset:0];
-    [self.linkAttachmentContainer autoPinEdgeToSuperviewEdge:ALEdgeRight withInset:0];
+    [self.linkAttachmentContainer autoPinEdgeToSuperviewEdge:ALEdgeLeading withInset:0];
+    [self.linkAttachmentContainer autoPinEdgeToSuperviewEdge:ALEdgeTrailing withInset:0];
     self.mediaPlayerTopMarginConstraint = [self.linkAttachmentContainer autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.messageTextView];
     
     [NSLayoutConstraint autoSetPriority:UILayoutPriorityDefaultHigh forConstraints:^{

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/UIView+LayoutMargins.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/UIView+LayoutMargins.swift
@@ -1,0 +1,36 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import UIKit
+
+
+extension ConversationCell {
+
+    var layoutDirectionAwareLayoutMargins: UIEdgeInsets {
+        var left = WAZUIMagic.cgFloat(forIdentifier: "content.left_margin")
+        var right = WAZUIMagic.cgFloat(forIdentifier: "content.right_margin")
+
+        if UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft {
+            (left, right) = (right, left)
+        }
+
+        return UIEdgeInsets(top: 0, left: left, bottom: 0, right: right)
+    }
+
+}

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
@@ -211,13 +211,13 @@ private struct InputBarConstants {
             buttonContainer.top == textView.bottom
             textView.top == textView.superview!.top
             textView.leading == leftAccessoryView.trailing
-            textView.right == rightAccessoryView.left
+            textView.trailing == rightAccessoryView.leading
             textView.height >= 56
             textView.height <= 120 ~ LayoutPriority(750)
 
             buttonRowSeparator.top == buttonContainer.top
-            buttonRowSeparator.left == buttonRowSeparator.superview!.left + 16
-            buttonRowSeparator.right == buttonRowSeparator.superview!.right - 16
+            buttonRowSeparator.leading == buttonRowSeparator.superview!.leading + 16
+            buttonRowSeparator.trailing == buttonRowSeparator.superview!.trailing - 16
             buttonRowSeparator.height == 0.5
         }
         
@@ -235,8 +235,8 @@ private struct InputBarConstants {
         
         constrain(buttonContainer, buttonInnerContainer)  { container, innerContainer in
             container.bottom == container.superview!.bottom
-            container.left == container.superview!.left
-            container.right == container.superview!.right
+            container.leading == container.superview!.leading
+            container.trailing == container.superview!.trailing
             container.height == constants.buttonsBarHeight
 
             innerContainer.leading == container.leading

--- a/Wire-iOS/Sources/UserInterface/Settings/SettingsCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/SettingsCell.swift
@@ -137,7 +137,7 @@ class SettingsTableCell: UITableViewCell, SettingsCellType {
         self.contentView.addSubview(self.iconImageView)
         
         constrain(self.contentView, self.iconImageView) { contentView, iconImageView in
-            iconImageView.left == contentView.left + 24
+            iconImageView.leading == contentView.leading + 24
             iconImageView.width == 16
             iconImageView.height == iconImageView.height
             iconImageView.centerY == contentView.centerY
@@ -150,8 +150,8 @@ class SettingsTableCell: UITableViewCell, SettingsCellType {
         self.contentView.addSubview(self.cellNameLabel)
         
         constrain(self.contentView, self.cellNameLabel, self.iconImageView) { contentView, cellNameLabel, iconImageView in
-            self.cellNameLabelToIconInset = cellNameLabel.left == iconImageView.right + 24
-            cellNameLabel.left == contentView.left + 16 ~ LayoutPriority(750)
+            self.cellNameLabelToIconInset = cellNameLabel.leading == iconImageView.trailing + 24
+            cellNameLabel.leading == contentView.leading + 16 ~ LayoutPriority(750)
             cellNameLabel.top == contentView.top + 12
             cellNameLabel.bottom == contentView.bottom - 12
         }
@@ -164,12 +164,14 @@ class SettingsTableCell: UITableViewCell, SettingsCellType {
         self.valueLabel.textAlignment = .right
         
         self.contentView.addSubview(self.valueLabel)
-        
-        constrain(self.contentView, self.cellNameLabel, self.valueLabel) { contentView, cellNameLabel, valueLabel in
+
+        let trailingBoundaryView = accessoryView ?? contentView
+
+        constrain(self.contentView, self.cellNameLabel, self.valueLabel, trailingBoundaryView) { contentView, cellNameLabel, valueLabel, trailingBoundaryView in
             valueLabel.top == contentView.top - 8
             valueLabel.bottom == contentView.bottom + 8
-            valueLabel.left == cellNameLabel.right + 8
-            valueLabel.right == contentView.right - 16
+            valueLabel.leading >= cellNameLabel.trailing + 8
+            valueLabel.trailing == trailingBoundaryView.trailing - 16
         }
         
         self.imagePreview.clipsToBounds = true
@@ -180,7 +182,7 @@ class SettingsTableCell: UITableViewCell, SettingsCellType {
         constrain(self.contentView, self.imagePreview) { contentView, imagePreview in
             imagePreview.width == imagePreview.height
             imagePreview.height == 24
-            imagePreview.right == contentView.right - 16
+            imagePreview.trailing == contentView.trailing - 16
             imagePreview.centerY == contentView.centerY
         }
         
@@ -276,12 +278,12 @@ class SettingsTextCell: SettingsTableCell, UITextFieldDelegate {
         self.textInput.textAlignment = .right
         self.textInput.textColor = UIColor.lightGray
         self.contentView.addSubview(self.textInput)
-        
-        constrain(self.contentView, self.cellNameLabel, self.textInput) { contentView, cellNameLabel, textInput in
+
+        let trailingBoundaryView = accessoryView ?? contentView
+        constrain(self.contentView, self.textInput, trailingBoundaryView) { contentView, textInput, trailingBoundaryView in
             textInput.top == contentView.top - 8
             textInput.bottom == contentView.bottom + 8
-            textInput.left == cellNameLabel.right + 8
-            textInput.right == contentView.right - 16
+            textInput.trailing == trailingBoundaryView.trailing - 16
         }
     }
     


### PR DESCRIPTION
# What's in this PR?

**This PR contains multiple fixes for layout issues present when using the application on a device with a right-to-left layout direction ([#4822](https://wearezeta.atlassian.net/browse/ZIOS-4822), [#7665](https://wearezeta.atlassian.net/browse/ZIOS-7665))**

* Align text in text messages to the right.
* Fix input bar misalignment and emoji button location.
* Reverse system message cell alignment for RTL languages.
* Update alignment of the cells in settings for RTL languages.

There are still a lot of issues when using a RTL language which are tracked in [#7665](https://wearezeta.atlassian.net/browse/ZIOS-7665).