### PR TITLE
Add more right-to-left layout adjustments

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -800,6 +800,7 @@
 		BFE49C321C0F39590061C16F /* NSString+FingerprintTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BFE49C311C0F39580061C16F /* NSString+FingerprintTests.m */; };
 		BFE57B4B1D52335A00CB0806 /* ConversationPreviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE57B4A1D52335A00CB0806 /* ConversationPreviewViewController.swift */; };
 		BFEA26591D410F9F000D0ED5 /* audio_sample.m4a in Resources */ = {isa = PBXBuildFile; fileRef = BFEA26581D410F9F000D0ED5 /* audio_sample.m4a */; };
+		BFFD439E1DE47FFA00505C8C /* UIView+RightToLeft.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFFD439D1DE47FFA00505C8C /* UIView+RightToLeft.swift */; };
 		CE3FBF1E1CE22B4900ED087A /* DeleteMessageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CE3FBF1D1CE22B4900ED087A /* DeleteMessageTests.m */; };
 		CEC0FE3B1C4FBF120093BF0D /* ConversationIgnoredDeviceCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC0FE3A1C4FBF120093BF0D /* ConversationIgnoredDeviceCell.swift */; };
 		CED176471D0074610005234F /* ConversationParticipantsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED176461D0074610005234F /* ConversationParticipantsCell.swift */; };
@@ -2137,6 +2138,7 @@
 		BFE57B451D51FDE800CB0806 /* ImageMessageCell+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ImageMessageCell+Internal.h"; sourceTree = "<group>"; };
 		BFE57B4A1D52335A00CB0806 /* ConversationPreviewViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConversationPreviewViewController.swift; sourceTree = "<group>"; };
 		BFEA26581D410F9F000D0ED5 /* audio_sample.m4a */ = {isa = PBXFileReference; lastKnownFileType = file; path = audio_sample.m4a; sourceTree = "<group>"; };
+		BFFD439D1DE47FFA00505C8C /* UIView+RightToLeft.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+RightToLeft.swift"; sourceTree = "<group>"; };
 		C88A846215D617F8CCFBEB80 /* libPods-Wire-iOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Wire-iOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CC9C38FFEE2CB1B4A68D125E /* libPods-Wire-iOS-Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Wire-iOS-Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CE3FBF1D1CE22B4900ED087A /* DeleteMessageTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DeleteMessageTests.m; sourceTree = "<group>"; };
@@ -3223,6 +3225,7 @@
 				871BC2001D34F8F800DF0793 /* UIColor+WR_ColorScheme.m */,
 				871BC2011D34F8F800DF0793 /* UIFont+MonoSpaced.swift */,
 				871BC2021D34F8F800DF0793 /* UIImage+Dotted.swift */,
+				BFFD439D1DE47FFA00505C8C /* UIView+RightToLeft.swift */,
 				871BC2031D34F8F800DF0793 /* UIImage+Transform.h */,
 				871BC2041D34F8F800DF0793 /* UIImage+Transform.m */,
 				871BC2051D34F8F800DF0793 /* UIImagePickerController+GetImage.h */,
@@ -5476,6 +5479,7 @@
 				8F8914391A9F2A510056AB0C /* TopItemsView.m in Sources */,
 				871BC26C1D34F8F800DF0793 /* GapLoadingBar.m in Sources */,
 				8FC8543D199245770008B66B /* ConnectRequestsViewController.m in Sources */,
+				BFFD439E1DE47FFA00505C8C /* UIView+RightToLeft.swift in Sources */,
 				871BC2511D34F8F800DF0793 /* MediaPreviewData.m in Sources */,
 				DB7FEC921B8729AD00BA72DE /* ConversationInputBarSendController.m in Sources */,
 				8744D5BE1C41D6C2000F8F93 /* SettingsClientViewController.swift in Sources */,

--- a/Wire-iOS/Sources/UserInterface/Components/Transitions/PopTransition.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Transitions/PopTransition.m
@@ -44,16 +44,19 @@
     
     CGAffineTransform offscreenRight = CGAffineTransformMakeTranslation(initialFrameFromViewController.size.width, 0);
     CGAffineTransform offscreenLeft = CGAffineTransformMakeTranslation(-initialFrameFromViewController.size.width, 0);
-    
+
+    CGAffineTransform toViewStartTransform = self.rightToLeft ? offscreenRight : offscreenLeft;
+    CGAffineTransform fromViewEndTransform = self.rightToLeft ? offscreenLeft : offscreenRight;
+
     fromView.frame = initialFrameFromViewController;
     toView.frame = finalFrameToViewController;
-    toView.transform = offscreenLeft;
+    toView.transform = toViewStartTransform;
     
     [containerView addSubview:toView];
     [containerView addSubview:fromView];
     
     dispatch_block_t animation = ^{
-        fromView.transform = offscreenRight;
+        fromView.transform = fromViewEndTransform;
         toView.transform = CGAffineTransformIdentity;
     };
     
@@ -71,6 +74,11 @@
                      completion:^(){
                          completion(YES);
                      }];
+}
+
+- (BOOL)rightToLeft
+{
+    return UIApplication.sharedApplication.userInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft;
 }
 
 @end

--- a/Wire-iOS/Sources/UserInterface/Components/Transitions/PushTransition.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Transitions/PushTransition.m
@@ -42,16 +42,19 @@
     
     CGAffineTransform offscreenRight = CGAffineTransformMakeTranslation(initialFrameFromViewController.size.width, 0);
     CGAffineTransform offscreenLeft = CGAffineTransformMakeTranslation(-initialFrameFromViewController.size.width, 0);
+
+    CGAffineTransform toViewStartTransform = self.rightToLeft ? offscreenLeft : offscreenRight;
+    CGAffineTransform fromViewEndTransform = self.rightToLeft ? offscreenRight : offscreenLeft;
     
     fromView.frame = initialFrameFromViewController;
     toView.frame = finalFrameToViewController;
-    toView.transform = offscreenRight;
+    toView.transform = toViewStartTransform;
     
     [containerView addSubview:toView];
     [containerView addSubview:fromView];
     
     dispatch_block_t animation = ^{
-        fromView.transform = offscreenLeft;
+        fromView.transform = fromViewEndTransform;
         toView.transform = CGAffineTransformIdentity;
     };
     
@@ -69,6 +72,11 @@
                      completion:^(){
                          completion(YES);
                      }];
+}
+
+- (BOOL)rightToLeft
+{
+    return UIApplication.sharedApplication.userInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft;
 }
 
 @end

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
@@ -301,8 +301,8 @@ const NSTimeInterval ConversationCellSelectionAnimationDuration = 0.33;
     
     [self.messageToolboxView autoSetDimension:ALDimensionHeight toSize:0 relation:NSLayoutRelationGreaterThanOrEqual];
     [self.messageToolboxView autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.messageContentView];
-    [self.messageToolboxView autoPinEdgeToSuperviewEdge:ALEdgeRight];
-    [self.messageToolboxView autoPinEdgeToSuperviewEdge:ALEdgeLeft];
+    [self.messageToolboxView autoPinEdgeToSuperviewEdge:ALEdgeTrailing];
+    [self.messageToolboxView autoPinEdgeToSuperviewEdge:ALEdgeLeading];
     [self.messageToolboxView autoPinEdgeToSuperviewEdge:ALEdgeBottom];
     
     [self.likeButton autoAlignAxis:ALAxisHorizontal toSameAxisOfView:self.messageToolboxView];

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
@@ -134,7 +134,7 @@ extension ZMConversationMessage {
             reactionsView.centerY == selfView.centerY
             
             likeTooltipArrow.centerY == statusLabel.centerY
-            likeTooltipArrow.trailing == selfView.trailingMargin - 8
+            likeTooltipArrow.trailing == selfView.leadingMargin - 8
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
@@ -121,20 +121,20 @@ extension ZMConversationMessage {
     
     private func createConstraints() {
         constrain(self, reactionsView, statusLabel, labelClipView, likeTooltipArrow) { selfView, reactionsView, statusLabel, labelClipView, likeTooltipArrow in
-            labelClipView.left == selfView.leftMargin
+            labelClipView.leading == selfView.leadingMargin
             labelClipView.centerY == selfView.centerY
-            labelClipView.right == selfView.rightMargin
+            labelClipView.trailing == selfView.trailingMargin
             
-            statusLabel.left == labelClipView.left
+            statusLabel.leading == labelClipView.leading
             statusLabel.top == labelClipView.top
             statusLabel.bottom == labelClipView.bottom
-            statusLabel.right <= reactionsView.left
+            statusLabel.trailing <= reactionsView.leading
             
-            reactionsView.right == selfView.rightMargin
+            reactionsView.trailing == selfView.trailingMargin
             reactionsView.centerY == selfView.centerY
             
             likeTooltipArrow.centerY == statusLabel.centerY
-            likeTooltipArrow.right == selfView.leftMargin - 8
+            likeTooltipArrow.trailing == selfView.trailingMargin - 8
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
@@ -100,10 +100,15 @@ open class CameraKeyboardViewController: UIViewController {
     override open func viewDidLoad() {
         super.viewDidLoad()
         
+        setupViews()
+        createConstraints()
+    }
+
+    private func setupViews() {
         self.createCollectionView()
-        
+
         self.view.backgroundColor = UIColor.white
-        
+
         self.goBackButton.translatesAutoresizingMaskIntoConstraints = false
         self.goBackButton.backgroundColor = UIColor(white: 0, alpha: 0.88)
         self.goBackButton.circular = true
@@ -111,7 +116,8 @@ open class CameraKeyboardViewController: UIViewController {
         self.goBackButton.setIconColor(UIColor.white, for: UIControlState())
         self.goBackButton.accessibilityIdentifier = "goBackButton"
         self.goBackButton.addTarget(self, action: #selector(goBackPressed(_:)), for: .touchUpInside)
-        
+        self.goBackButton.applyRTLTransformIfNeeded()
+
         self.cameraRollButton.translatesAutoresizingMaskIntoConstraints = false
         self.cameraRollButton.backgroundColor = UIColor(white: 0, alpha: 0.88)
         self.cameraRollButton.circular = true
@@ -119,20 +125,22 @@ open class CameraKeyboardViewController: UIViewController {
         self.cameraRollButton.setIconColor(UIColor.white, for: UIControlState())
         self.cameraRollButton.accessibilityIdentifier = "cameraRollButton"
         self.cameraRollButton.addTarget(self, action: #selector(openCameraRollPressed(_:)), for: .touchUpInside)
-        
+
         [self.collectionView, self.goBackButton, self.cameraRollButton].forEach(self.view.addSubview)
-        
+    }
+
+    private func createConstraints() {
         constrain(self.view, self.collectionView, self.goBackButton, self.cameraRollButton) { view, collectionView, goBackButton, cameraRollButton in
             collectionView.edges == view.edges
-            
+
             goBackButton.width == 36
             goBackButton.height == goBackButton.width
-            goBackButton.left == view.left + self.sideMargin
+            goBackButton.leading == view.leading + self.sideMargin
             goBackButton.bottom == view.bottom - 18
-            
+
             cameraRollButton.width == 36
             cameraRollButton.height == goBackButton.width
-            cameraRollButton.right == view.right - self.sideMargin
+            cameraRollButton.trailing == view.trailing - self.sideMargin
             cameraRollButton.centerY == goBackButton.centerY
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
@@ -181,6 +181,7 @@ private struct InputBarConstants {
         textView.accessibilityIdentifier = "inputField"
         updatePlaceholder()
         textView.lineFragmentPadding = 0
+        textView.textAlignment = .natural
         textView.textContainerInset = UIEdgeInsetsMake(inputBarVerticalInset / 2, 0, inputBarVerticalInset / 2, 4)
         textView.placeholderTextContainerInset = UIEdgeInsetsMake(21, 10, 21, 0)
         textView.keyboardType = .default

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController.m
@@ -514,8 +514,8 @@
 
     [self.listContentController.view autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.topItemsController.view];
     [self.listContentController.view autoPinEdge:ALEdgeBottom toEdge:ALEdgeTop ofView:self.bottomBarController.view];
-    [self.listContentController.view autoPinEdgeToSuperviewEdge:ALEdgeLeft];
-    [self.listContentController.view autoPinEdgeToSuperviewEdge:ALEdgeRight];
+    [self.listContentController.view autoPinEdgeToSuperviewEdge:ALEdgeLeading];
+    [self.listContentController.view autoPinEdgeToSuperviewEdge:ALEdgeTrailing];
 }
 
 - (void)updateTopItemsInset

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListCell.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListCell.m
@@ -158,8 +158,8 @@ static const NSTimeInterval IgnoreOverscrollTimeInterval = 0.1;
         [self.animatedListView autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsZero];
 
         [NSLayoutConstraint autoSetPriority:UILayoutPriorityDefaultLow forConstraints:^{
-            [self.animatedListView autoPinEdgeToSuperviewEdge:ALEdgeLeft withInset:leftMarginConvList];
-            self.archiveRightMarginConstraint = [self.animatedListView autoPinEdgeToSuperviewEdge:ALEdgeRight withInset:leftMarginConvList / 2.0f];
+            [self.animatedListView autoPinEdgeToSuperviewEdge:ALEdgeLeading withInset:leftMarginConvList];
+            self.archiveRightMarginConstraint = [self.animatedListView autoPinEdgeToSuperviewEdge:ALEdgeTrailing withInset:leftMarginConvList / 2.0f];
         }];
     }
 

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListItemView.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListItemView.m
@@ -43,7 +43,6 @@ NSString * const ConversationListItemDidScrollNotification = @"ConversationListI
 @property (nonatomic, strong) UIView *lineView;
 
 @property (nonatomic, assign) BOOL enableSubtitles;
-@property (nonatomic, assign) BOOL hasCreatedInitialConstraints;
 
 @property (nonatomic, strong) NSLayoutConstraint *titleBottomMarginConstraint;
 @property (nonatomic, strong) NSLayoutConstraint *rightAccessoryWidthConstraint;
@@ -97,6 +96,8 @@ NSString * const ConversationListItemDidScrollNotification = @"ConversationListI
         [self createSubtitleField];
     }
 
+    [self createConstraints];
+
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(otherConversationListItemDidScroll:)
                                                  name:ConversationListItemDidScrollNotification
@@ -120,38 +121,32 @@ NSString * const ConversationListItemDidScrollNotification = @"ConversationListI
     [self addSubview:self.lineView];
 }
 
-- (void)updateConstraints
+- (void)createConstraints
 {
-    if (! self.hasCreatedInitialConstraints) {
-        self.hasCreatedInitialConstraints = YES;
-        
-        CGFloat leftMargin = [WAZUIMagic floatForIdentifier:@"list.left_margin"];
-        [self.statusIndicator autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsZero excludingEdge:ALEdgeRight];
-        [self.statusIndicator autoPinEdge:ALEdgeRight toEdge:ALEdgeLeft ofView:self.titleField];
-        
-        [self.titleField autoPinEdge:ALEdgeLeft toEdge:ALEdgeLeft ofView:self withOffset:leftMargin];
-        [self.titleField autoPinEdge:ALEdgeRight toEdge:ALEdgeLeft ofView:self.rightAccessory withOffset:0.0];
-        self.titleBottomMarginConstraint = [self.titleField autoPinEdgeToSuperviewEdge:ALEdgeBottom withInset:18.0f];
+    CGFloat leftMargin = [WAZUIMagic floatForIdentifier:@"list.left_margin"];
+    [self.statusIndicator autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsZero excludingEdge:ALEdgeTrailing];
+    [self.statusIndicator autoPinEdge:ALEdgeTrailing toEdge:ALEdgeLeading ofView:self.titleField];
 
-        [self.rightAccessory autoPinEdgeToSuperviewEdge:ALEdgeRight withInset:18.0];
-        [self.rightAccessory autoAlignAxisToSuperviewAxis:ALAxisHorizontal];
-        [self.rightAccessory autoSetDimension:ALDimensionHeight toSize:28.0f];
-        self.rightAccessoryWidthConstraint = [self.rightAccessory autoSetDimension:ALDimensionWidth toSize:0.0f];
-        [self updateRightAccessoryWidth];
-        
-        if (self.enableSubtitles) {
-            [self.subtitleField autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.titleField withOffset:2];
-            [self.subtitleField autoPinEdge:ALEdgeLeft toEdge:ALEdgeLeft ofView:self.titleField];
-            [self.subtitleField autoPinEdge:ALEdgeRight toEdge:ALEdgeRight ofView:self.titleField];
-            
-            [self.lineView autoSetDimension:ALDimensionHeight toSize:1.0];
-            [self.lineView autoPinEdgeToSuperviewEdge:ALEdgeBottom];
-            [self.lineView autoPinEdge:ALEdgeRight toEdge:ALEdgeRight ofView:self withOffset:-35.0];
-            [self.lineView autoPinEdge:ALEdgeLeft toEdge:ALEdgeLeft ofView:self.titleField];
-        }
+    [self.titleField autoPinEdge:ALEdgeLeading toEdge:ALEdgeLeading ofView:self withOffset:leftMargin];
+    [self.titleField autoPinEdge:ALEdgeTrailing toEdge:ALEdgeLeading ofView:self.rightAccessory withOffset:0.0];
+    self.titleBottomMarginConstraint = [self.titleField autoPinEdgeToSuperviewEdge:ALEdgeBottom withInset:18.0f];
+
+    [self.rightAccessory autoPinEdgeToSuperviewEdge:ALEdgeTrailing withInset:18.0];
+    [self.rightAccessory autoAlignAxisToSuperviewAxis:ALAxisHorizontal];
+    [self.rightAccessory autoSetDimension:ALDimensionHeight toSize:28.0f];
+    self.rightAccessoryWidthConstraint = [self.rightAccessory autoSetDimension:ALDimensionWidth toSize:0.0f];
+    [self updateRightAccessoryWidth];
+
+    if (self.enableSubtitles) {
+        [self.subtitleField autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.titleField withOffset:2];
+        [self.subtitleField autoPinEdge:ALEdgeLeading toEdge:ALEdgeLeading ofView:self.titleField];
+        [self.subtitleField autoPinEdge:ALEdgeTrailing toEdge:ALEdgeTrailing ofView:self.titleField];
+
+        [self.lineView autoSetDimension:ALDimensionHeight toSize:1.0];
+        [self.lineView autoPinEdgeToSuperviewEdge:ALEdgeBottom];
+        [self.lineView autoPinEdge:ALEdgeTrailing toEdge:ALEdgeTrailing ofView:self withOffset:-35.0];
+        [self.lineView autoPinEdge:ALEdgeLeading toEdge:ALEdgeLeading ofView:self.titleField];
     }
-    
-    [super updateConstraints];
 }
 
 - (void)setTitleText:(NSString *)titleText

--- a/Wire-iOS/Sources/UserInterface/ConversationList/SearchView/SearchViewController.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/SearchView/SearchViewController.m
@@ -66,7 +66,7 @@
     CGFloat rightMargin = [WAZUIMagic cgFloatForIdentifier:@"people_picker.search_results_mode.person_tile_right_margin"];
     [self.searchView autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsZero];
     
-    [self.cancelButton autoPinEdgeToSuperviewEdge:ALEdgeRight withInset:rightMargin - 10];
+    [self.cancelButton autoPinEdgeToSuperviewEdge:ALEdgeTrailing withInset:rightMargin - 10];
     [self.cancelButton autoAlignAxis:ALAxisHorizontal toSameAxisOfView:self.peopleInputController.view];
     [self.cancelButton autoMatchDimension:ALDimensionWidth toDimension:ALDimensionHeight ofView:self.cancelButton];
     [self.cancelButton autoSetDimension:ALDimensionWidth toSize:30];

--- a/Wire-iOS/Sources/UserInterface/Helpers/UIView+RightToLeft.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UIView+RightToLeft.swift
@@ -1,0 +1,43 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import UIKit
+
+fileprivate extension CGAffineTransform {
+
+    static var verticallyMirrored: CGAffineTransform {
+        return CGAffineTransform(scaleX: -1, y: 1)
+    }
+
+}
+
+public extension UIView {
+
+    func applyRTLTransformIfNeeded() {
+        transform = isRightToLeft ? .verticallyMirrored : .identity
+    }
+
+    var isRightToLeft: Bool {
+        if #available(iOS 9.0, *) {
+            return UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) == .rightToLeft
+        } else {
+            return UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft
+        }
+    }
+    
+}

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/Cells/SearchResultCell.m
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/Cells/SearchResultCell.m
@@ -149,14 +149,14 @@
         [self.hideButton autoPinEdgeToSuperviewEdge:ALEdgeTop];
         [self.hideButton autoPinEdgeToSuperviewEdge:ALEdgeBottom];
         [NSLayoutConstraint autoSetPriority:UILayoutPriorityDefaultLow forConstraints:^{
-            [self.hideButton autoPinEdgeToSuperviewEdge:ALEdgeLeft withInset:leftMargin];
-            [self.hideButton autoPinEdgeToSuperviewEdge:ALEdgeRight withInset:nameAvatarMargin];
+            [self.hideButton autoPinEdgeToSuperviewEdge:ALEdgeLeading withInset:leftMargin];
+            [self.hideButton autoPinEdgeToSuperviewEdge:ALEdgeTrailing withInset:nameAvatarMargin];
         }];
         [self.hideButton autoSetDimension:ALDimensionWidth toSize:64 relation:NSLayoutRelationGreaterThanOrEqual];
 
         [self.subtitleLabel autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.nameLabel];
-        [self.subtitleLabel autoPinEdge:ALEdgeLeft toEdge:ALEdgeRight ofView:self.avatarContainer withOffset:[WAZUIMagic cgFloatForIdentifier:@"people_picker.search_results_mode.tile_name_horizontal_spacing"]];
-        self.subtitleRightMarginConstraint = [self.subtitleLabel autoPinEdge:ALEdgeRight toEdge:ALEdgeRight ofView:self.swipeView withOffset:- rightMargin];
+        [self.subtitleLabel autoPinEdge:ALEdgeLeading toEdge:ALEdgeTrailing ofView:self.avatarContainer withOffset:[WAZUIMagic cgFloatForIdentifier:@"people_picker.search_results_mode.tile_name_horizontal_spacing"]];
+        self.subtitleRightMarginConstraint = [self.subtitleLabel autoPinEdge:ALEdgeTrailing toEdge:ALEdgeTrailing ofView:self.swipeView withOffset:- rightMargin];
 
         self.nameLabelTopConstraint = [self.nameLabel autoPinEdge:ALEdgeTop toEdge:ALEdgeTop ofView:self.swipeView withOffset:9.0f];
         self.nameLabelVerticalConstraint = [self.nameLabel autoAlignAxis:ALAxisHorizontal toSameAxisOfView:self.avatarContainer];
@@ -170,21 +170,21 @@
             self.nameLabelTopConstraint.active = YES;
         }
         
-        [self.nameLabel autoPinEdge:ALEdgeLeft toEdge:ALEdgeRight ofView:self.avatarContainer withOffset:nameAvatarMargin];
-        self.nameRightMarginConstraint = [self.nameLabel autoPinEdge:ALEdgeRight toEdge:ALEdgeRight ofView:self.swipeView withOffset:- rightMargin];
+        [self.nameLabel autoPinEdge:ALEdgeLeading toEdge:ALEdgeTrailing ofView:self.avatarContainer withOffset:nameAvatarMargin];
+        self.nameRightMarginConstraint = [self.nameLabel autoPinEdge:ALEdgeTrailing toEdge:ALEdgeTrailing ofView:self.swipeView withOffset:- rightMargin];
 
         self.avatarViewSizeConstraint = [self.avatarContainer autoSetDimension:ALDimensionWidth toSize:80];
         [self.avatarContainer autoMatchDimension:ALDimensionWidth toDimension:ALDimensionHeight ofView:self.avatarContainer];
-        [self.avatarContainer autoPinEdge:ALEdgeLeft toEdge:ALEdgeLeft ofView:self.swipeView withOffset:leftMargin];
+        [self.avatarContainer autoPinEdge:ALEdgeLeading toEdge:ALEdgeLeading ofView:self.swipeView withOffset:leftMargin];
         [self.avatarContainer autoAlignAxisToSuperviewMarginAxis:ALAxisHorizontal];
 
         self.conversationImageViewSize = [self.conversationImageView autoSetDimension:ALDimensionWidth toSize:80];
         [self.conversationImageView autoMatchDimension:ALDimensionWidth toDimension:ALDimensionHeight ofView:self.conversationImageView];
-        [self.conversationImageView autoPinEdge:ALEdgeLeft toEdge:ALEdgeLeft ofView:self.swipeView withOffset:[WAZUIMagic cgFloatForIdentifier:@"people_picker.search_results_mode.person_tile_left_margin"]];
+        [self.conversationImageView autoPinEdge:ALEdgeLeading toEdge:ALEdgeLeading ofView:self.swipeView withOffset:[WAZUIMagic cgFloatForIdentifier:@"people_picker.search_results_mode.person_tile_left_margin"]];
         [self.conversationImageView autoPinEdgeToSuperviewEdge:ALEdgeTop];
 
         [self.instantConnectButton autoAlignAxis:ALAxisHorizontal toSameAxisOfView:self.avatarContainer];
-        [self.instantConnectButton autoPinEdgeToSuperviewEdge:ALEdgeRight withInset:0];
+        [self.instantConnectButton autoPinEdgeToSuperviewEdge:ALEdgeTrailing withInset:0];
         [self.instantConnectButton autoSetDimensionsToSize:CGSizeMake(64, 64)];
 
         self.initialConstraintsCreated = YES;

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/Cells/SearchSectionHeaderView.m
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/Cells/SearchSectionHeaderView.m
@@ -67,7 +67,7 @@ NSString *const PeoplePickerHeaderReuseIdentifier = @"PeoplePickerHeaderReuseIde
 {
     [self.titleField autoPinEdgeToSuperviewEdge:ALEdgeBottom withInset:10.0f];
     CGFloat leftInset = [WAZUIMagic floatForIdentifier:@"people_picker.top_conversations_mode.left_padding"];
-    [self.titleField autoPinEdgeToSuperviewEdge:ALEdgeLeft withInset:leftInset];
+    [self.titleField autoPinEdgeToSuperviewEdge:ALEdgeLeading withInset:leftInset];
 }
 
 - (void)setTitle:(NSString *)title

--- a/WireExtensionComponents/Views/TextView.m
+++ b/WireExtensionComponents/Views/TextView.m
@@ -77,7 +77,7 @@
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(textChanged:) name:UITextViewTextDidChangeNotification object:self];
     self.placeholderTextColor = [UIColor lightGrayColor];
     self.placeholderTextContainerInset = self.textContainerInset;
-    self.placeholderTextAlignment = NSTextAlignmentLeft;
+    self.placeholderTextAlignment = NSTextAlignmentNatural;
     
     if ([AutomationHelper.sharedHelper disableAutocorrection]) {
         self.autocorrectionType = UITextAutocorrectionTypeNo;


### PR DESCRIPTION
# What's in this PR?

**As follow up on https://github.com/wireapp/wire-ios/pull/416 this PR adds more adjustments for right-to-left languages:**

* `MessageToolboxView` is now correctly mirrored.
* The transitions in settings are adjusted for RTL.
* Some layout adjustments to controls in `CameraKeyboardViewController`.
* Mirror the conversation list correctly (indicator was clipped).
* Update input fields and their placeholders to use the correct text alignment.