### PR TITLE
Fix user avatar tap not working anymore

### DIFF
--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/ProfilePresenter.m
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/ProfilePresenter.m
@@ -123,7 +123,7 @@
 
 - (void)profileViewControllerWantsToBeDismissed:(ProfileViewController *)profileViewController completion:(dispatch_block_t)completion
 {
-    [self.controllerToPresentOn dismissViewControllerAnimated:YES completion:^{
+    [profileViewController dismissViewControllerAnimated:YES completion:^{
         if (completion != nil) {
             completion();
         }

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.m
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.m
@@ -504,8 +504,8 @@ static NSUInteger const StartUIInitiallyShowsKeyboardConversationThreshold = 10;
     UICollectionViewCell *cell = [self.startUIView.collectionView cellForItemAtIndexPath:indexPath];
     
     [self.profilePresenter presentProfileViewControllerForUser:bareUser
-                                                  inController:self.parentViewController 
-                                                      fromRect:[self.parentViewController.view convertRect:cell.bounds fromView:cell] 
+                                                  inController:self
+                                                      fromRect:[self.view convertRect:cell.bounds fromView:cell]
                                                      onDismiss:^{
         if (IS_IPAD) {
             [self.startUIView.collectionView reloadItemsAtIndexPaths:self.startUIView.collectionView.indexPathsForVisibleItems];

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileDetailsViewController.h
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileDetailsViewController.h
@@ -29,7 +29,6 @@
 
 @protocol ProfileDetailsViewControllerDelegate <NSObject>
 
-- (void)profileDetailsViewController:(ProfileDetailsViewController *)profileDetailsViewController didTapOnCommonConnection:(ZMUser *)connection;
 - (void)profileDetailsViewController:(ProfileDetailsViewController *)profileDetailsViewController didSelectConversation:(ZMConversation *)conversation;
 - (void)profileDetailsViewController:(ProfileDetailsViewController *)profileDetailsViewController didPresentAddContactsViewController:(AddContactsViewController *)addContactsViewController;
 - (void)profileDetailsViewController:(ProfileDetailsViewController *)profileDetailsViewController wantsToBeDismissedWithCompletion:(dispatch_block_t)completion;

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.m
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.m
@@ -292,15 +292,6 @@ typedef NS_ENUM(NSUInteger, ProfileViewControllerTabBarIndex) {
 
 @implementation ProfileViewController (ProfileDetailsViewControllerDelegate)
 
-- (void)profileDetailsViewController:(ProfileDetailsViewController *)profileDetailsViewController didTapOnCommonConnection:(ZMUser *)connection
-{
-    ProfileViewController *commonProfileController = [[ProfileViewController alloc] initWithUser:connection context:ProfileViewControllerContextCommonConnection];
-    commonProfileController.delegate = self;
-    commonProfileController.navigationControllerDelegate = self.navigationControllerDelegate;
-    self.navigationControllerDelegate.tapLocation = self.view.center;
-    [self.navigationController pushViewController:commonProfileController animated:YES];
-}
-
 - (void)profileDetailsViewController:(ProfileDetailsViewController *)profileDetailsViewController didSelectConversation:(ZMConversation *)conversation
 {
     if ([self.delegate respondsToSelector:@selector(profileViewController:wantsToNavigateToConversation:)]) {


### PR DESCRIPTION
# What's in this PR?

* Tapping user avatars in the search UI was broken with https://github.com/wireapp/wire-ios/pull/439 when the change was made to present the search UI, archive list etc instead of adding them as child view controller. Due to this change the `parentViewController` property was nil and we failed to present the controller.
* Remove some unused code as the common connections have been removed from the `ProfileDetailViewController`.