### PR TITLE
Add tracking calls to username takeover screen and username settings

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -761,6 +761,7 @@
 		BF7ED2D81DF1A30C003A4397 /* IncomingConnectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7ED2D71DF1A30C003A4397 /* IncomingConnectionView.swift */; };
 		BF7ED2DA1DF1B5ED003A4397 /* OutgoingConnectionBottomBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7ED2D91DF1B5ED003A4397 /* OutgoingConnectionBottomBar.swift */; };
 		BF7ED2DC1DF1D1CF003A4397 /* IncomingConnectionViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7ED2DB1DF1D1CF003A4397 /* IncomingConnectionViewTests.swift */; };
+		BF7ED2DE1DF59974003A4397 /* Analytics+Usernames.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7ED2DD1DF59974003A4397 /* Analytics+Usernames.swift */; };
 		BF7EF5451D953B3F003E3999 /* Date+Format.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7EF5441D953B3F003E3999 /* Date+Format.swift */; };
 		BF8042271BFC741F004CD789 /* NSURL+WireURLs.m in Sources */ = {isa = PBXBuildFile; fileRef = BF8042261BFC741F004CD789 /* NSURL+WireURLs.m */; };
 		BF808B4D1DE5AD1600718076 /* SettingsCellDescriptorFactory+Account.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF808B4C1DE5AD1600718076 /* SettingsCellDescriptorFactory+Account.swift */; };
@@ -2099,6 +2100,7 @@
 		BF7ED2D71DF1A30C003A4397 /* IncomingConnectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IncomingConnectionView.swift; sourceTree = "<group>"; };
 		BF7ED2D91DF1B5ED003A4397 /* OutgoingConnectionBottomBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OutgoingConnectionBottomBar.swift; sourceTree = "<group>"; };
 		BF7ED2DB1DF1D1CF003A4397 /* IncomingConnectionViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IncomingConnectionViewTests.swift; sourceTree = "<group>"; };
+		BF7ED2DD1DF59974003A4397 /* Analytics+Usernames.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Analytics+Usernames.swift"; sourceTree = "<group>"; };
 		BF7EF5441D953B3F003E3999 /* Date+Format.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Date+Format.swift"; sourceTree = "<group>"; };
 		BF8042251BFC741F004CD789 /* NSURL+WireURLs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURL+WireURLs.h"; sourceTree = "<group>"; };
 		BF8042261BFC741F004CD789 /* NSURL+WireURLs.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURL+WireURLs.m"; sourceTree = "<group>"; };
@@ -2855,6 +2857,7 @@
 				F93D58421D7D9184003AE972 /* Analytics+ConversationEvents.swift */,
 				871BBFC81D34F56300DF0793 /* Analytics+MediaActionEvents.swift */,
 				BFCF31DE1DA64AD40039B3DC /* Analytics+SendButton.swift */,
+				BF7ED2DD1DF59974003A4397 /* Analytics+Usernames.swift */,
 				BFCF31E01DA64B970039B3DC /* Analytics+EmojiKeyboard.swift */,
 				871BBFC91D34F56300DF0793 /* Analytics+Navigation.h */,
 				871BBFCA1D34F56300DF0793 /* Analytics+Navigation.m */,
@@ -5703,6 +5706,7 @@
 				871BC3631D34F94200DF0793 /* SoundcloudAudioTrack.m in Sources */,
 				8744489D1C22FCE500E7B947 /* LinkAttachmentCache.m in Sources */,
 				870815881BF4EAD100D321BC /* SettingsTableViewController.swift in Sources */,
+				BF7ED2DE1DF59974003A4397 /* Analytics+Usernames.swift in Sources */,
 				871BC2241D34F8F800DF0793 /* BottomOverlayViewController.m in Sources */,
 				16063D021BDA6BF50097F62C /* GroupConversationHeader.m in Sources */,
 				871BC28D1D34F8F800DF0793 /* UITableView+RowCount.m in Sources */,

--- a/Wire-iOS/Sources/Analytics/Events/Analytics+Usernames.swift
+++ b/Wire-iOS/Sources/Analytics/Events/Analytics+Usernames.swift
@@ -1,0 +1,77 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+typealias UserNameLength = Int
+
+
+protocol Event {
+    var name: String { get }
+    var attributes: [AnyHashable: Any]? { get }
+}
+
+extension Event {
+    var attributes: [AnyHashable: Any]? {
+        return nil
+    }
+}
+
+enum UserNameEvent {
+
+    enum Settings: Event {
+        case enteredUsername(withLength: UserNameLength)
+        case setUsername(withLength: UserNameLength)
+
+        var name: String {
+            switch self {
+            case .enteredUsername(_): return "settings.entered_username" // when user enters an attempt to set username
+            case .setUsername(_): return "settings.set_username" // when username was successfully set
+            }
+        }
+
+        var attributes: [AnyHashable : Any]? {
+            switch self {
+            case .enteredUsername(let length): return ["length": length]
+            case .setUsername(let length): return ["length": length]
+            }
+        }
+    }
+
+    enum Takeover: Event {
+        case shown, openedSettings, openedFAQ, keepSuggested
+
+        var name: String {
+            switch self {
+            case .shown: return "onboarding.seen_username_screen"
+            case .keepSuggested: return "onboarding.kept_generated_username"
+            case .openedSettings: return "onboarding.opened_username_settings" // when user taps button to choose his own username
+            case .openedFAQ: return "onboarding.opened_username_faq"
+            }
+        }
+    }
+
+}
+
+
+extension Analytics {
+
+    func tag(_ event: Event) {
+        tagEvent(event.name, attributes: event.attributes)
+    }
+    
+}

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationList+Handles.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationList+Handles.swift
@@ -43,6 +43,8 @@ extension ConversationListViewController {
 
         guard traitCollection.userInterfaceIdiom == .pad else { return }
         ZClientViewController.shared().loadPlaceholderConversationController(animated: false)
+
+        Analytics.shared()?.tag(UserNameEvent.Takeover.shown)
     }
 
     func removeUsernameTakeover() {
@@ -85,10 +87,27 @@ extension ConversationListViewController {
 extension ConversationListViewController: UserNameTakeOverViewControllerDelegate {
 
     func takeOverViewController(_ viewController: UserNameTakeOverViewController, didPerformAction action: UserNameTakeOverViewControllerAction) {
+        tagEvent(for: action)
+        perform(action)
+    }
+
+    private func perform(_ action: UserNameTakeOverViewControllerAction) {
         switch action {
         case .chooseOwn(let suggested): openChangeHandleViewController(with: suggested)
         case .keepSuggestion(let suggested): setSuggested(handle: suggested)
         case .learnMore: URL(string: "https://wire.com/support/username/")?.open()
+        }
+    }
+
+    private func tagEvent(for action: UserNameTakeOverViewControllerAction) {
+        Analytics.shared()?.tag(event(for: action))
+    }
+
+    private func event(for action: UserNameTakeOverViewControllerAction) -> UserNameEvent.Takeover {
+        switch action {
+        case .chooseOwn(_): return .openedSettings
+        case .learnMore: return .openedFAQ
+        case .keepSuggestion(_): return .keepSuggested
         }
     }
 

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/ChangeHandleViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/ChangeHandleViewController.swift
@@ -229,6 +229,7 @@ final class ChangeHandleViewController: SettingsBaseTableViewController {
 
     func saveButtonTapped(sender: UIBarButtonItem) {
         guard let handleToSet = state.newHandle else { return }
+        Analytics.shared()?.tag(UserNameEvent.Settings.enteredUsername(withLength: handleToSet.characters.count))
         userProfile?.requestSettingHandle(handle: handleToSet)
         showLoadingView = true
     }
@@ -330,6 +331,7 @@ extension ChangeHandleViewController: UserProfileUpdateObserver {
     func didSetHandle() {
         showLoadingView = false
         state.availability = .taken
+        Analytics.shared()?.tag(UserNameEvent.Settings.setUsername(withLength: state.newHandle?.characters.count ?? 0))
         guard popOnSuccess else { return }
         _ = navigationController?.popViewController(animated: true)
     }


### PR DESCRIPTION
# What's in this PR?

* Add analytics calls to the username takeover and the username screen in settings.
* This implements the first half of [#7675](https://wearezeta.atlassian.net/browse/ZIOS-7675).