### PR TITLE
Fix tappable title view in outgoing connection request

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConnectRequests/UserConnectionView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConnectRequests/UserConnectionView.swift
@@ -114,8 +114,7 @@ public final class UserConnectionView: UIView, Copyable {
             labelContainer.centerX == selfView.centerX
             labelContainer.top == selfView.top
             labelContainer.left >= selfView.left
-            labelContainer.bottom <= userImageView.top
-            
+
             userImageView.center == selfView.center
             userImageView.left >= selfView.left + 54
             userImageView.width == userImageView.height
@@ -132,7 +131,6 @@ public final class UserConnectionView: UIView, Copyable {
                 $0.leading == labelContainer.leading
                 $0.trailing == labelContainer.trailing
             }
-
         }
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationTitleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationTitleView.swift
@@ -47,9 +47,13 @@ public final class ConversationTitleView: UIView {
     private func configure(_ conversation: ZMConversation) {
         guard let font = titleFont, let color = titleColor, let selectedColor = titleColorSelected else { return }
         let title = conversation.displayName.uppercased() && font
+        let tappable = conversation.relatedConnectionState != .sent
         
         let titleWithColor: (UIColor) -> NSAttributedString = {
-            var attributed = (title + "  " + NSAttributedString(attachment: .downArrow(color: $0)))
+            var attributed = title
+            if tappable {
+                attributed += "  " + NSAttributedString(attachment: .downArrow(color: $0))
+            }
             if conversation.securityLevel == .secure {
                 attributed = NSAttributedString(attachment: .verifiedShield()) + "  " + attributed
             }
@@ -59,6 +63,7 @@ public final class ConversationTitleView: UIView {
         titleButton.setAttributedTitle(titleWithColor(color), for: UIControlState())
         titleButton.setAttributedTitle(titleWithColor(selectedColor), for: .highlighted)
         titleButton.sizeToFit()
+        titleButton.isEnabled = tappable
         updateAccessibilityValue(conversation)
         setNeedsLayout()
         layoutIfNeeded()


### PR DESCRIPTION
# What's in this PR?

* The `ConversationTitleView` was showing the downwards arrow and was tappable in case of an outgoing connection request, which should not be the case as the presented profile detail view will display the same information.