### PR TITLE
Show name instead of displayName property in username takeover

### DIFF
--- a/Wire-iOS Tests/UserNameTakeOverViewControllerTests.swift
+++ b/Wire-iOS Tests/UserNameTakeOverViewControllerTests.swift
@@ -31,7 +31,7 @@ class UserNameTakeOverViewControllerTests: ZMSnapshotTestCase {
     }
 
     func testThatItRendersCorrectInitally() {
-        let sut = UserNameTakeOverViewController(suggestedHandle: "joseluis4839", displayName: "Jose Luis")
+        let sut = UserNameTakeOverViewController(suggestedHandle: "joseluis4839", name: "Jose Luis")
         verify(view: sut.prepareForSnapshots())
     }
 

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationList+Handles.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationList+Handles.swift
@@ -29,7 +29,7 @@ extension ConversationListViewController {
     func showUsernameTakeover(with handle: String) {
         guard let selfUser = ZMUser.selfUser(), nil == selfUser.handle || debugOverrideShowTakeover else { return }
         guard nil == usernameTakeoverViewController else { return }
-        usernameTakeoverViewController = UserNameTakeOverViewController(suggestedHandle: handle, displayName: selfUser.displayName)
+        usernameTakeoverViewController = UserNameTakeOverViewController(suggestedHandle: handle, name: selfUser.name)
         usernameTakeoverViewController.delegate = self
 
         addChildViewController(usernameTakeoverViewController)

--- a/Wire-iOS/Sources/UserInterface/ConversationList/UserNameTakeOverViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/UserNameTakeOverViewController.swift
@@ -48,16 +48,16 @@ final class UserNameTakeOverViewController: UIViewController {
     private let contentView = UIView()
     private let topContainer = UIView()
     private let suggestedHandle: String
-    private let displayName: String
+    private let name: String
 
     private let learnMore = "registration.select_handle.takeover.subtitle_link".localized
     fileprivate let learnMoreURL = URL(string:"action://learn-more")!
 
     weak var delegate: UserNameTakeOverViewControllerDelegate?
 
-    init(suggestedHandle: String, displayName: String) {
+    init(suggestedHandle: String, name: String) {
         self.suggestedHandle = suggestedHandle
-        self.displayName = displayName
+        self.name = name
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -77,7 +77,7 @@ final class UserNameTakeOverViewController: UIViewController {
         view.addSubview(contentView)
         [displayNameLabel, suggestedHandleLabel].forEach(topContainer.addSubview)
         [topContainer, titleLabel, subtitleLabel, chooseOwnButton, keepSuggestedButton].forEach(contentView.addSubview)
-        displayNameLabel.text = displayName
+        displayNameLabel.text = name
         suggestedHandleLabel.text = "@" + suggestedHandle
         displayNameLabel.textAlignment = .center
         suggestedHandleLabel.textAlignment = .center


### PR DESCRIPTION
# What's in this PR?

* The wrong name was used in the `UserNameTakeOverViewController`.