### PR TITLE
Reload conversation title view on connection state changes

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -935,7 +935,7 @@
         [self updateOutgoingConnectionVisibility];
     }
     
-    if (note.nameChanged || note.securityLevelChanged) {
+    if (note.nameChanged || note.securityLevelChanged || note.connectionStateChanged) {
         [self setupNavigatiomItem];
     }
 }


### PR DESCRIPTION
# What's in this PR?

* The `ConversationTitleView` does not display the downwards arrow anymore if the conversation is not connected (and the user interaction is disabled), but it was not reloaded when the connection gets established.