### PR TITLE
Removed unnecessary sorting

### DIFF
--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
@@ -270,7 +270,6 @@
 - (void)hideIncomingContactRequestsWithCompletion:(dispatch_block_t)completion
 {
     NSArray *conversationsList = [SessionObjectCache sharedCache].conversationList;
-    conversationsList = [conversationsList sortedArrayUsingDescriptors:@[[NSSortDescriptor sortDescriptorWithKey:@"lastModifiedDate" ascending:NO]]];
     if (conversationsList.count == 0) {
         return;
     } else {


### PR DESCRIPTION
# Issue

The conversation list was extra sorted to pick the latest conversation by last date. This is not correct since the list is already sorted by last modified date.