### PR TITLE
Fix header view moving up on successive connection requests

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConnectionRequestCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConnectionRequestCell.m
@@ -40,7 +40,7 @@
 - (void)createConstraints
 {
     [NSLayoutConstraint autoSetPriority:UILayoutPriorityDefaultHigh forConstraints:^{
-        [self.messageContentView autoSetDimension:ALDimensionHeight toSize:0];
+        [self.messageContentView autoSetDimension:ALDimensionHeight toSize:0.5];
     }];
 }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -266,7 +266,7 @@
 
 - (void)setConversationHeaderView:(UIView *)headerView
 {
-    CGSize fittingSize = CGSizeMake(self.tableView.self.bounds.size.width, self.tableView.bounds.size.height - 20);
+    CGSize fittingSize = CGSizeMake(self.tableView.bounds.size.width, self.tableView.bounds.size.height - 20);
     CGSize requiredSize = [headerView systemLayoutSizeFittingSize:fittingSize withHorizontalFittingPriority:UILayoutPriorityRequired verticalFittingPriority:UILayoutPriorityDefaultLow];
     headerView.frame = CGRectMake(0, 0, requiredSize.width, requiredSize.height);
     self.tableView.tableHeaderView = headerView;


### PR DESCRIPTION
# What's in this PR?

* The height of the `ConnectionRequestCell`, which should neither be used nor inserted anymore was set to 0, which unfortunately will make the table view set it to the default height of 40. We now set it to 0.5 to ensure the header view does not get pushed up (as we use a rotated tableview we actually set the footer view when setting a header view, but as the default position will be scrolled to the bottom the header view will be pushed out of the visible viewport).
* The underlying issue that we still insert connection request system messages into the conversation should be fixed in `wire-ios-sync-engine` which is tracked in [#7737](https://wearezeta.atlassian.net/browse/ZIOS-7737).