### PR TITLE
Use the search user and it's underlying user when presenting profile from search

### DIFF
--- a/Wire-iOS/Sources/Managers/AddressBookHelper.swift
+++ b/Wire-iOS/Sources/Managers/AddressBookHelper.swift
@@ -76,7 +76,7 @@ extension AddressBookHelper {
         // Date check
         let timeSinceLastSearch = Date().timeIntervalSince(lastSearchDate)
         let customTimeLimit : TimeInterval
-        if let timeLimitInConfiguration = self.configuration?.addressBookRemoteSearchTimeInterval , timeLimitInConfiguration > 0 {
+        if let timeLimitInConfiguration = self.configuration?.addressBookRemoteSearchTimeInterval, timeLimitInConfiguration > 0 {
             customTimeLimit = timeLimitInConfiguration
         } else {
             customTimeLimit = self.searchTimeInterval

--- a/Wire-iOS/Sources/UserInterface/ConnectRequests/UserConnectionViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConnectRequests/UserConnectionViewController.swift
@@ -36,10 +36,11 @@ final public class IncomingConnectionViewController: UIViewController, ZMCommonC
         self.userSession = userSession
         self.user = user
         super.init(nibName: .none, bundle: .none)
-        
-        if self.user.totalCommonConnections == 0  && !self.user.isConnected {
-            self.recentSearchToken = self.user.searchCommonContacts(in: self.userSession, with: self)
-        }
+
+        guard !self.user.isConnected else { return }
+        user.refreshData()
+        guard self.user.totalCommonConnections == 0 else { return }
+        self.recentSearchToken = self.user.searchCommonContacts(in: self.userSession, with: self)
     }
 
     required public init?(coder aDecoder: NSCoder) {
@@ -89,9 +90,10 @@ final public class UserConnectionViewController: UIViewController, ZMCommonConta
         self.user = user
         super.init(nibName: .none, bundle: .none)
         
-        if self.user.totalCommonConnections == 0  && !self.user.isConnected {
-            self.recentSearchToken = self.user.searchCommonContacts(in: self.userSession, with: self)
-        }
+        guard !self.user.isConnected else { return }
+        user.refreshData()
+        guard self.user.totalCommonConnections == 0 else { return }
+        self.recentSearchToken = self.user.searchCommonContacts(in: self.userSession, with: self)
     }
     
     required public init?(coder aDecoder: NSCoder) {

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/ProfilePresenter.h
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/ProfilePresenter.h
@@ -19,11 +19,11 @@
 
 #import <Foundation/Foundation.h>
 
-@protocol ZMBareUser;
+@protocol ZMSearchableUser;
 
 @interface ProfilePresenter : NSObject
 @property (nonatomic, assign) BOOL profileOpenedFromPeoplePicker;
 @property (nonatomic, assign) BOOL keyboardPersistedAfterOpeningProfile;
 
-- (void)presentProfileViewControllerForUser:(id<ZMBareUser>)user inController:(UIViewController *)controller fromRect:(CGRect)rect onDismiss:(dispatch_block_t)onDismiss arrowDirection:(UIPopoverArrowDirection)arrowDirection;
+- (void)presentProfileViewControllerForUser:(id<ZMSearchableUser>)user inController:(UIViewController *)controller fromRect:(CGRect)rect onDismiss:(dispatch_block_t)onDismiss arrowDirection:(UIPopoverArrowDirection)arrowDirection;
 @end

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/ProfilePresenter.m
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/ProfilePresenter.m
@@ -92,7 +92,7 @@
     }
 }
 
-- (void)presentProfileViewControllerForUser:(id<ZMBareUser>)user inController:(UIViewController *)controller fromRect:(CGRect)rect onDismiss:(dispatch_block_t)onDismiss arrowDirection:(UIPopoverArrowDirection)arrowDirection
+- (void)presentProfileViewControllerForUser:(id<ZMSearchableUser>)user inController:(UIViewController *)controller fromRect:(CGRect)rect onDismiss:(dispatch_block_t)onDismiss arrowDirection:(UIPopoverArrowDirection)arrowDirection
 {
     self.profileOpenedFromPeoplePicker = YES;
     self.viewToPresentOn = controller.view;

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.m
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.m
@@ -495,7 +495,7 @@ static NSUInteger const StartUIInitiallyShowsKeyboardConversationThreshold = 10;
     [self presentAddressBookUploadDialogue];
 }
 
-- (void)presentProfileViewControllerForUser:(id<ZMBareUser>)bareUser atIndexPath:(NSIndexPath *)indexPath
+- (void)presentProfileViewControllerForUser:(id<ZMSearchableUser>)bareUser atIndexPath:(NSIndexPath *)indexPath
 {
     [self.peopleInputController.tokenField resignFirstResponder];
 
@@ -666,9 +666,9 @@ static NSUInteger const StartUIInitiallyShowsKeyboardConversationThreshold = 10;
             }
         }
         
-    } else if ([modelObject conformsToProtocol:@protocol(ZMBareUser)]) {
-        id<ZMBareUser> bareUser = modelObject;
-        ZMUser *user = BareUserToUser(bareUser);
+    } else if ([modelObject conformsToProtocol:@protocol(ZMSearchableUser)]) {
+        id<ZMSearchableUser> searchableUser = modelObject;
+        ZMUser *user = BareUserToUser(searchableUser);
             
         BOOL isAlreadySelectedUser = [self.selection.selectedUsers containsObject:user];
         
@@ -679,7 +679,7 @@ static NSUInteger const StartUIInitiallyShowsKeyboardConversationThreshold = 10;
             [self.selection addUserToSelectedResults:user];
         }
         else {
-            [self presentProfileViewControllerForUser:bareUser atIndexPath:indexPath];
+            [self presentProfileViewControllerForUser:searchableUser atIndexPath:indexPath];
             [self.startUIView.collectionView deselectItemAtIndexPath:indexPath animated:NO];
         }
     }
@@ -737,8 +737,8 @@ static NSUInteger const StartUIInitiallyShowsKeyboardConversationThreshold = 10;
     }
     else if ([modelObject isKindOfClass:[ZMSearchUser class]]) {
 
-        id<ZMBareUser> bareUser = modelObject;
-        ZMUser *user = BareUserToUser(bareUser);
+        id<ZMSearchableUser> searchableUser = modelObject;
+        ZMUser *user = BareUserToUser(searchableUser);
 
         if (user.isConnected && ! user.isBlocked) {
 
@@ -751,7 +751,7 @@ static NSUInteger const StartUIInitiallyShowsKeyboardConversationThreshold = 10;
             }
         }
         else {
-            [self presentProfileViewControllerForUser:bareUser atIndexPath:indexPath];
+            [self presentProfileViewControllerForUser:searchableUser atIndexPath:indexPath];
 
             if (IS_IPHONE && self.peopleInputController.tokenField.isFirstResponder) {
                 self.peopleInputController.retainSelectedState = YES;

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileHeaderViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileHeaderViewModel.swift
@@ -25,7 +25,7 @@ import UIKit
     let userDetailViewModel: UserNameDetailViewModel
     let style: ProfileHeaderStyle
 
-    init(user: ZMUser?, fallbackName fallback: String, addressBookName: String?, commonConnections: Int, style: ProfileHeaderStyle) {
+    init(user: ZMBareUser?, fallbackName fallback: String, addressBookName: String?, commonConnections: Int, style: ProfileHeaderStyle) {
         self.style = style
         self.userDetailViewModel = UserNameDetailViewModel(
             user: user,

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.h
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.h
@@ -21,7 +21,7 @@
 
 
 
-@protocol ZMBareUser;
+@protocol ZMSearchableUser;
 @class ZMConversation;
 @class ZMUser;
 @class ProfileViewController;
@@ -56,11 +56,11 @@ typedef NS_ENUM(NSInteger, ProfileViewControllerContext) {
 
 @interface ProfileViewController : UIViewController
 
-- (id)initWithUser:(id<ZMBareUser>)user context:(ProfileViewControllerContext)context;
-- (id)initWithUser:(id<ZMBareUser>)user conversation:(ZMConversation *)conversation;
-- (id)initWithUser:(id<ZMBareUser>)user conversation:(ZMConversation *)conversation context:(ProfileViewControllerContext)context;
+- (id)initWithUser:(id<ZMSearchableUser>)user context:(ProfileViewControllerContext)context;
+- (id)initWithUser:(id<ZMSearchableUser>)user conversation:(ZMConversation *)conversation;
+- (id)initWithUser:(id<ZMSearchableUser>)user conversation:(ZMConversation *)conversation context:(ProfileViewControllerContext)context;
 
-@property (nonatomic, readonly) id<ZMBareUser> bareUser;
+@property (nonatomic, readonly) id<ZMSearchableUser> bareUser;
 @property (nonatomic, weak) id<ProfileViewControllerDelegate> delegate;
 @property (nonatomic) ProfileNavigationControllerDelegate *navigationControllerDelegate;
 @property (nonatomic, assign) BOOL shouldDrawTopSeparatorLineDuringPresentation;

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.m
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.m
@@ -183,8 +183,8 @@ typedef NS_ENUM(NSUInteger, ProfileViewControllerTabBarIndex) {
 
 - (void)setupHeader
 {
-    ZMUser *user = [self fullUser];
-    
+    id <ZMBareUser> user = self.bareUser;
+
     ProfileHeaderStyle headerStyle = ProfileHeaderStyleCancelButton;
     if (IS_IPAD) {
         if (self.navigationController.viewControllers.count > 1) {
@@ -195,8 +195,8 @@ typedef NS_ENUM(NSUInteger, ProfileViewControllerTabBarIndex) {
     }
 
     ProfileHeaderViewModel *viewModel = [[ProfileHeaderViewModel alloc] initWithUser:user
-                                                                        fallbackName:self.bareUser.displayName
-                                                                     addressBookName:user.addressBookEntry.cachedName
+                                                                        fallbackName:user.displayName
+                                                                     addressBookName:BareUserToUser(user).addressBookEntry.cachedName
                                                                    commonConnections:user.totalCommonConnections
                                                                                style:headerStyle];
 

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.m
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.m
@@ -61,6 +61,8 @@ typedef NS_ENUM(NSUInteger, ProfileViewControllerTabBarIndex) {
 @interface ProfileViewController (DevicesListDelegate) <ProfileDevicesViewControllerDelegate>
 @end
 
+@interface ProfileViewController (CommonContactsDelegate) <ZMCommonContactsSearchDelegate>
+@end
 
 @interface ProfileViewController (TabBarControllerDelegate) <TabBarControllerDelegate>
 @end
@@ -73,6 +75,7 @@ typedef NS_ENUM(NSUInteger, ProfileViewControllerTabBarIndex) {
 @property (nonatomic, readonly) ZMConversation *conversation;
 
 @property (nonatomic) id <ZMUserObserverOpaqueToken> observerToken;
+@property (nonatomic) id <ZMCommonContactsSearchToken> commonContactsSearchToken;
 @property (nonatomic) ProfileHeaderView *headerView;
 @property (nonatomic) TabBarController *tabsController;
 
@@ -82,12 +85,12 @@ typedef NS_ENUM(NSUInteger, ProfileViewControllerTabBarIndex) {
 
 @implementation ProfileViewController
 
-- (id)initWithUser:(id<ZMBareUser>)user context:(ProfileViewControllerContext)context
+- (id)initWithUser:(id<ZMSearchableUser>)user context:(ProfileViewControllerContext)context
 {
     return [self initWithUser:user conversation:nil context:context];
 }
 
-- (id)initWithUser:(id<ZMBareUser>)user conversation:(ZMConversation *)conversation
+- (id)initWithUser:(id<ZMSearchableUser>)user conversation:(ZMConversation *)conversation
 {
     if (conversation.conversationType == ZMConversationTypeGroup) {
         return [self initWithUser:user conversation:conversation context:ProfileViewControllerContextGroupConversation];
@@ -97,13 +100,16 @@ typedef NS_ENUM(NSUInteger, ProfileViewControllerTabBarIndex) {
     }
 }
 
-- (id)initWithUser:(id<ZMBareUser>)user conversation:(ZMConversation *)conversation context:(ProfileViewControllerContext)context
+- (id)initWithUser:(id<ZMSearchableUser>)user conversation:(ZMConversation *)conversation context:(ProfileViewControllerContext)context
 {
     if (self = [super init]) {
         _bareUser = user;
         _conversation = conversation;
         _context = context;
         _navigationControllerDelegate = [[ProfileNavigationControllerDelegate alloc] init];
+        if (user.totalCommonConnections == 0 && !user.isConnected) {
+            _commonContactsSearchToken = [user searchCommonContactsInUserSession:ZMUserSession.sharedSession withDelegate:self];
+        }
     }
     return self;
 }
@@ -183,8 +189,19 @@ typedef NS_ENUM(NSUInteger, ProfileViewControllerTabBarIndex) {
 
 - (void)setupHeader
 {
-    id <ZMBareUser> user = self.bareUser;
+    id<ZMBareUser> user = self.bareUser;
 
+    ProfileHeaderViewModel *viewModel = [self headerViewModelWithUser:user commonConnections:user.totalCommonConnections];
+    ProfileHeaderView *headerView = [[ProfileHeaderView alloc] initWithViewModel:viewModel];
+    headerView.translatesAutoresizingMaskIntoConstraints = NO;
+    [headerView.dismissButton addTarget:self action:@selector(dismissButtonClicked) forControlEvents:UIControlEventTouchUpInside];
+    
+    [self.view addSubview:headerView];
+    self.headerView = headerView;
+}
+
+- (ProfileHeaderViewModel *)headerViewModelWithUser:(id<ZMBareUser>)user commonConnections:(NSInteger)commonConnections
+{
     ProfileHeaderStyle headerStyle = ProfileHeaderStyleCancelButton;
     if (IS_IPAD) {
         if (self.navigationController.viewControllers.count > 1) {
@@ -194,18 +211,11 @@ typedef NS_ENUM(NSUInteger, ProfileViewControllerTabBarIndex) {
         }
     }
 
-    ProfileHeaderViewModel *viewModel = [[ProfileHeaderViewModel alloc] initWithUser:user
-                                                                        fallbackName:user.displayName
-                                                                     addressBookName:BareUserToUser(user).addressBookEntry.cachedName
-                                                                   commonConnections:user.totalCommonConnections
-                                                                               style:headerStyle];
-
-    ProfileHeaderView *headerView = [[ProfileHeaderView alloc] initWithViewModel:viewModel];
-    headerView.translatesAutoresizingMaskIntoConstraints = NO;
-    [headerView.dismissButton addTarget:self action:@selector(dismissButtonClicked) forControlEvents:UIControlEventTouchUpInside];
-    
-    [self.view addSubview:headerView];
-    self.headerView = headerView;
+    return [[ProfileHeaderViewModel alloc] initWithUser:user
+                                           fallbackName:user.displayName
+                                        addressBookName:BareUserToUser(user).addressBookEntry.cachedName
+                                      commonConnections:commonConnections
+                                                  style:headerStyle];
 }
 
 #pragma mark - User observation
@@ -315,6 +325,7 @@ typedef NS_ENUM(NSUInteger, ProfileViewControllerTabBarIndex) {
 
 @end
 
+
 @implementation ProfileViewController (DevicesListDelegate)
 
 - (void)profileDevicesViewController:(ProfileDevicesViewController *)profileDevicesViewController didTapDetailForClient:(UserClient *)client
@@ -325,6 +336,7 @@ typedef NS_ENUM(NSUInteger, ProfileViewControllerTabBarIndex) {
 
 @end
 
+
 @implementation ProfileViewController (TabBarControllerDelegate)
 
 - (void)tabBarController:(TabBarController *)controller tabBarDidSelectIndex:(NSInteger)index
@@ -333,6 +345,17 @@ typedef NS_ENUM(NSUInteger, ProfileViewControllerTabBarIndex) {
         [[Analytics shared] tagOtherDeviceList];
     }
     [self updateShowVerifiedShield];
+}
+
+@end
+
+
+@implementation ProfileViewController (CommonContactsDelegate)
+
+- (void)didReceiveCommonContactsUsers:(NSOrderedSet *)users forSearchToken:(id<ZMCommonContactsSearchToken>)searchToken
+{
+    ProfileHeaderViewModel *model = [self headerViewModelWithUser:self.bareUser commonConnections:users.count];
+    [self.headerView configureWithViewModel:model];
 }
 
 @end

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Views/ProfileHeaderView.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Views/ProfileHeaderView.swift
@@ -99,7 +99,8 @@ final class ProfileHeaderView: UIView {
         }
     }
 
-    private func configure(with model: ProfileHeaderViewModel) {
+    @objc(configureWithViewModel:)
+    public func configure(with model: ProfileHeaderViewModel) {
         detailView.configure(with: model.userDetailViewModel)
     }
 

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Views/UserNameDetailView.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Views/UserNameDetailView.swift
@@ -40,7 +40,7 @@ fileprivate let textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTe
         self.color = color
     }
 
-    private func addressBookText(for user: ZMSearchableUser, with addressBookName: String) -> NSAttributedString? {
+    private func addressBookText(for user: ZMBareUser, with addressBookName: String) -> NSAttributedString? {
         guard !user.isSelfUser else { return nil }
         let suffix = "conversation.connection_view.in_address_book".localized && lightFont && color
         if addressBookName.lowercased() == user.name.lowercased() {
@@ -51,7 +51,7 @@ fileprivate let textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTe
         return contactName + " " + suffix
     }
 
-    func correlationText(for user: ZMSearchableUser, with count: Int, addressBookName: String?) -> NSAttributedString? {
+    func correlationText(for user: ZMBareUser, with count: Int, addressBookName: String?) -> NSAttributedString? {
         if let name = addressBookName, let addressBook = addressBookText(for: user, with: name) {
             return addressBook
         }
@@ -99,22 +99,22 @@ fileprivate let textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTe
         AddressBookCorrelationFormatter(lightFont: smallLightFont, boldFont: smallBoldFont, color: dimmedColor)
     }()
 
-    init(user: ZMUser?, fallbackName fallback: String, addressBookName: String?, commonConnections: Int) {
+    init(user: ZMBareUser?, fallbackName fallback: String, addressBookName: String?, commonConnections: Int) {
         title = UserNameDetailViewModel.attributedTitle(for: user, fallback: fallback)
         handleText = UserNameDetailViewModel.attributedSubtitle(for: user)
         correlationText = UserNameDetailViewModel.attributedCorrelationText(for: user, with: commonConnections, addressBookName: addressBookName)
     }
 
-    static func attributedTitle(for user: ZMUser?, fallback: String) -> NSAttributedString {
+    static func attributedTitle(for user: ZMBareUser?, fallback: String) -> NSAttributedString {
         return (user?.name ?? fallback) && normalBoldFont && textColor
     }
 
-    static func attributedSubtitle(for user: ZMUser?) -> NSAttributedString? {
+    static func attributedSubtitle(for user: ZMBareUser?) -> NSAttributedString? {
         guard let handle = user?.handle else { return nil }
         return ("@" + handle) && smallBoldFont && dimmedColor
     }
 
-    static func attributedCorrelationText(for user: ZMUser?, with connections: Int, addressBookName: String?) -> NSAttributedString? {
+    static func attributedCorrelationText(for user: ZMBareUser?, with connections: Int, addressBookName: String?) -> NSAttributedString? {
         guard let user = user else { return nil }
         return formatter.correlationText(for: user, with: connections, addressBookName: addressBookName)
     }


### PR DESCRIPTION
# What's in this PR?

* Request refreshing user data when entering a connection view.
* Use a search users underlying user (if there is one) to access an eventual address book entry.
* Use properties from bare user instead of casting it (this was causing a missing username and common connections label when the profile details were opened from search for an unconnected user).