### PR TITLE
Add check if address book access status changed and upload if it became available

### DIFF
--- a/Wire-iOS/Sources/AppController.h
+++ b/Wire-iOS/Sources/AppController.h
@@ -53,5 +53,6 @@ FOUNDATION_EXPORT NSString *const ZMUserSessionDidBecomeAvailableNotification;
 @property (nonatomic, readonly) MediaPlaybackManager *mediaPlaybackManager;
 
 - (void)performAfterUserSessionIsInitialized:(dispatch_block_t)block;
+- (void)uploadAddressBookIfNeeded;
 
 @end

--- a/Wire-iOS/Sources/AppController.m
+++ b/Wire-iOS/Sources/AppController.m
@@ -126,6 +126,15 @@ NSString *const ZMUserSessionDidBecomeAvailableNotification = @"ZMUserSessionDid
     self.enteringForeground = YES;
     [self loadAppropriateController];
     self.enteringForeground = NO;
+
+    [self uploadAddressBookIfNeeded];
+}
+
+- (void)uploadAddressBookIfNeeded
+{
+    BOOL addressBookDidBecomeGranted = [AddressBookHelper.sharedHelper accessStatusDidChangeToGranted];
+    [AddressBookHelper.sharedHelper startRemoteSearchWithCheckingIfEnoughTimeSinceLast:!addressBookDidBecomeGranted];
+    [AddressBookHelper.sharedHelper persistCurrentAccessStatus];
 }
 
 - (void)applicationDidBecomeActive:(UIApplication *)application

--- a/Wire-iOS/Sources/AppDelegate.m
+++ b/Wire-iOS/Sources/AppDelegate.m
@@ -429,7 +429,7 @@
         [[self zetaUserSession] checkIfLoggedInWithCallback:^(BOOL isLoggedIn) {
             if (note.networkState == ZMNetworkStateOnline && isLoggedIn && self.addressBookUploadShouldBeChecked) {
                 self.addressBookUploadShouldBeChecked = NO;
-                [AddressBookHelper.sharedHelper startRemoteSearchWithCheckingIfEnoughTimeSinceLast:YES];
+                [self.appController uploadAddressBookIfNeeded];
             }
         }];
     });


### PR DESCRIPTION
# What's in this PR?

* We now persist the last address book authorisation status so we can check if it changed on app start.
* If the status changed and became available we upload the address book immediately.
* We also check if we should upload the address book every time the application enters the foreground and not only on network reachability changes.