### PR TITLE
Show contact search from address book

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsDataSource.m
+++ b/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsDataSource.m
@@ -97,7 +97,9 @@ NS_ASSUME_NONNULL_END
 - (void)didReceiveSearchResult:(ZMSearchResult *)result forToken:(ZMSearchToken)searchToken
 {
     if ([searchToken isEqual:self.currentSearchToken]) {
-        self.ungroupedSearchResults = result.usersInContacts;
+        NSMutableArray *matches = [result.usersInContacts mutableCopy];
+        [matches addObjectsFromArray:result.usersInDirectory];
+        self.ungroupedSearchResults = matches;
         
         if ([self.delegate respondsToSelector:@selector(dataSource:didReceiveSearchResult:)]) {
             [self.delegate dataSource:self didReceiveSearchResult:self.ungroupedSearchResults];


### PR DESCRIPTION
# Reason for this pull request
Contact search results from SE are in the "non-connected" users (otherwise they would already be displayed as a user); the UI was expecting them to be in "connected". This PR changes that.