### PR TITLE
Fix analytics event not being triggered on phones

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationList+Handles.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationList+Handles.swift
@@ -41,10 +41,10 @@ extension ConversationListViewController {
             takeover.edges == view.edges
         }
 
+        Analytics.shared()?.tag(UserNameEvent.Takeover.shown)
+
         guard traitCollection.userInterfaceIdiom == .pad else { return }
         ZClientViewController.shared().loadPlaceholderConversationController(animated: false)
-
-        Analytics.shared()?.tag(UserNameEvent.Takeover.shown)
     }
 
     func removeUsernameTakeover() {


### PR DESCRIPTION
# What's in this PR?

* There was a bug preventing the takeover screen event to be tracked on non `.pad` devices, guard considered harmful.