### PR TITLE
Fix tracking call for when username takeover is shown

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationList+Handles.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationList+Handles.swift
@@ -41,10 +41,10 @@ extension ConversationListViewController {
             takeover.edges == view.edges
         }
 
+        Analytics.shared()?.tag(UserNameEvent.Takeover.shown)
+
         guard traitCollection.userInterfaceIdiom == .pad else { return }
         ZClientViewController.shared().loadPlaceholderConversationController(animated: false)
-
-        Analytics.shared()?.tag(UserNameEvent.Takeover.shown)
     }
 
     func removeUsernameTakeover() {


### PR DESCRIPTION
# What's in this PR?

* The tracking call was only reached when on iPad