### PR TITLE
Fixed swift type infer performance

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -6268,6 +6268,7 @@
 					"$(inherited)",
 					"-l\"avsobjc\"",
 				);
+				OTHER_SWIFT_FLAGS = "-Xfrontend -warn-long-function-bodies=1000";
 				PRODUCT_NAME = Wire;
 				PROVISIONING_PROFILE_SPECIFIER = "${PROVISIONING_PROFILE_SPECIFIER_APP}";
 				SWIFT_OBJC_BRIDGING_HEADER = "$(TARGET_NAME)/WireBridgingHeader.h";

--- a/Wire-iOS/Sources/UserInterface/Components/Views/LinkInteractionTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/LinkInteractionTextView.swift
@@ -58,11 +58,15 @@ import UIKit
 extension LinkInteractionTextView: UITextViewDelegate {
     
     public func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange) -> Bool {
-        let beganLongPressRecognizers = gestureRecognizers?.flatMap {
-            $0 as? UILongPressGestureRecognizer
-        }.filter {
-            $0.state == .began
-        } ?? []
+        let beganLongPressRecognizers: [UILongPressGestureRecognizer] = gestureRecognizers?.flatMap { (recognizer: AnyObject) -> (UILongPressGestureRecognizer?) in
+            
+            if let recognizer = recognizer as? UILongPressGestureRecognizer, recognizer.state == .began {
+                return recognizer
+            }
+            else {
+                return .none
+            }
+            } ?? []
 
         for recognizer in beganLongPressRecognizers {
             interactionDelegate?.textView(self, didLongPressLink: recognizer)

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/AudioMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/AudioMessageCell.swift
@@ -103,7 +103,7 @@ public final class AudioMessageCell: ConversationCell {
     }
     
     open func createConstraints() {
-        constrain(self.messageContentView, self.containerView, self.playButton, self.timeLabel, self.authorLabel) { messageContentView, containerView, playButton, timeLabel, authorLabel in
+        constrain(self.messageContentView, self.containerView, self.playButton, self.timeLabel, self.authorLabel) { (messageContentView: LayoutProxy, containerView: LayoutProxy, playButton: LayoutProxy, timeLabel: LayoutProxy, authorLabel: LayoutProxy) -> () in
             containerView.left == authorLabel.left
             containerView.right == messageContentView.rightMargin
             containerView.top == messageContentView.top

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/IconSystemCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/IconSystemCell.swift
@@ -80,7 +80,7 @@ open class IconSystemCell: ConversationCell, TTTAttributedLabelDelegate {
         if !self.initialIconConstraintsCreated {
             
             let inset: CGFloat = 16
-            constrain(self.leftIconContainer, self.leftIconView, self.labelView, self.messageContentView, self.authorLabel) { leftIconContainer, leftIconView, labelView, messageContentView, authorLabel in
+            constrain(self.leftIconContainer, self.leftIconView, self.labelView, self.messageContentView, self.authorLabel) { (leftIconContainer: LayoutProxy, leftIconView: LayoutProxy, labelView: LayoutProxy, messageContentView: LayoutProxy, authorLabel: LayoutProxy) -> () in
                 leftIconContainer.leading == messageContentView.leading
                 leftIconContainer.trailing == authorLabel.leading
                 leftIconContainer.top == messageContentView.top + inset
@@ -96,7 +96,7 @@ open class IconSystemCell: ConversationCell, TTTAttributedLabelDelegate {
                 messageContentView.height >= 32
             }
             
-            constrain(self.lineView, self.contentView, self.labelView, self.messageContentView) { lineView, contentView, labelView, messageContentView in
+            constrain(self.lineView, self.contentView, self.labelView, self.messageContentView) { (lineView: LayoutProxy, contentView: LayoutProxy, labelView: LayoutProxy, messageContentView: LayoutProxy) -> () in
                 lineView.leading == labelView.trailing + 16
                 lineView.height == 0.5
                 lineView.trailing == contentView.trailing

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ArticleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ArticleView.swift
@@ -117,7 +117,7 @@ class ArticleView: UIView {
     func setupConstraints(_ imagePlaceholder: Bool) {
         let imageHeight : CGFloat = imagePlaceholder ? self.imageHeight : 0
         
-        constrain(self, messageLabel, authorLabel, imageView, obfuscationView) { container, messageLabel, authorLabel, imageView, obfuscationView in
+        constrain(self, messageLabel, authorLabel, imageView, obfuscationView) { (container: LayoutProxy, messageLabel: LayoutProxy, authorLabel: LayoutProxy, imageView: LayoutProxy, obfuscationView: LayoutProxy) -> () in
             imageView.left == container.left
             imageView.top == container.top
             imageView.right == container.right

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
@@ -148,16 +148,16 @@ extension ConversationContentViewController: UIAdaptivePresentationControllerDel
     @objc public func showForwardFor(message: ZMConversationMessage, fromCell: ConversationCell) {
         self.view.window!.endEditing(true)
         
-        let conversations = SessionObjectCache.shared().allConversations.map { $0 as! ZMConversation }.filter {
-            ($0.conversationType == .oneOnOne || $0.conversationType == .group) &&
-                $0.isSelfAnActiveMember &&
-                $0 != message.conversation!
+        let conversations: [ZMConversation] = SessionObjectCache.shared().allConversations.map { $0 as! ZMConversation }.filter { (conversation: ZMConversation) -> (Bool) in
+            return (conversation.conversationType == .oneOnOne || conversation.conversationType == .group) &&
+                    conversation.isSelfAnActiveMember &&
+                    conversation != message.conversation!
         }
         
-        let shareViewController = ShareViewController(shareable: message as! ZMMessage, destinations: conversations)
+        let shareViewController: ShareViewController<ZMConversation, ZMMessage> = ShareViewController(shareable: message as! ZMMessage, destinations: conversations)
         
-        let displayInPopover = self.traitCollection.horizontalSizeClass == .regular &&
-                               self.traitCollection.horizontalSizeClass == .regular
+        let displayInPopover: Bool = self.traitCollection.horizontalSizeClass == .regular &&
+                                     self.traitCollection.horizontalSizeClass == .regular
                 
         if displayInPopover {
             shareViewController.showPreview = false
@@ -175,7 +175,7 @@ extension ConversationContentViewController: UIAdaptivePresentationControllerDel
         
         shareViewController.presentationController?.delegate = self
         
-        shareViewController.onDismiss = { shareController in
+        shareViewController.onDismiss = { (shareController: ShareViewController<ZMConversation, ZMMessage>) -> () in
             shareController.presentingViewController?.dismiss(animated: true) {
                 UIApplication.shared.wr_updateStatusBarForCurrentControllerAnimated(true)
             }

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationRootViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationRootViewController.swift
@@ -67,7 +67,7 @@ import Cartography
         self.view.addSubview(navigationSeparator)
         self.view.addSubview(self.contentView)
         
-        constrain(self.customNavBar, self.navigationSeparator, self.view, self.contentView, conversationViewController.view) { customNavBar, navigationSeparator, view, contentView, conversationViewControllerView in
+        constrain(self.customNavBar, self.navigationSeparator, self.view, self.contentView, conversationViewController.view) { (customNavBar: LayoutProxy, navigationSeparator: LayoutProxy, view: LayoutProxy, contentView: LayoutProxy, conversationViewControllerView: LayoutProxy) -> () in
             navigationSeparator.height == 0.5
             navigationSeparator.left == customNavBar.left
             navigationSeparator.top == customNavBar.bottom - 1

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordViewController.swift
@@ -161,7 +161,7 @@ private let margin = (CGFloat(WAZUIMagic.float(forIdentifier: "content.left_marg
     func createConstraints() {
         let button = buttonOverlay.audioButton
 
-        constrain(view, bottomContainerView, topContainerView, button) { view, bottomContainer, topContainer, overlayButton in
+        constrain(view, bottomContainerView, topContainerView, button) { (view: LayoutProxy, bottomContainer: LayoutProxy, topContainer: LayoutProxy, overlayButton: LayoutProxy) -> () in
             bottomContainer.height == 56
             bottomContainer.left == view.left
             bottomContainer.right == view.right
@@ -175,26 +175,26 @@ private let margin = (CGFloat(WAZUIMagic.float(forIdentifier: "content.left_marg
             topContainer.bottom == bottomContainer.top
         }
         
-        constrain(topContainerView, topTooltipLabel, buttonOverlay) { topContainer, topTooltip, overlay in
+        constrain(topContainerView, topTooltipLabel, buttonOverlay) { (topContainer: LayoutProxy, topTooltip: LayoutProxy, overlay: LayoutProxy) -> () in
             topContainer.centerY == topTooltip.centerY
             topTooltip.right == overlay.left - 12
         }
         
-        constrain(bottomContainerView, buttonOverlay, topSeparator) { container, overlay, separator in
+        constrain(bottomContainerView, buttonOverlay, topSeparator) { (container: LayoutProxy, overlay: LayoutProxy, separator: LayoutProxy) -> () in
             separator.height == 0.5
             separator.right == overlay.left - 8
             separator.left == container.left + 16
             separator.top == container.top
         }
         
-        self.recordingDotViewHidden = constrain(bottomContainerView, timeLabel) { container, timeLabel in
+        self.recordingDotViewHidden = constrain(bottomContainerView, timeLabel) { (container: LayoutProxy, timeLabel: LayoutProxy) -> () in
             timeLabel.centerY == container.centerY
             timeLabel.left == container.left + margin
         }
         
         self.recordingDotViewHidden?.active = false
         
-        self.recordingDotViewVisible = constrain(bottomContainerView, timeLabel, recordingDotView) { container, timeLabel, recordingDotView in
+        self.recordingDotViewVisible = constrain(bottomContainerView, timeLabel, recordingDotView) { (container: LayoutProxy, timeLabel: LayoutProxy, recordingDotView: LayoutProxy) -> () in
             
             timeLabel.centerY == container.centerY
             timeLabel.left == recordingDotView.right + 24
@@ -208,14 +208,14 @@ private let margin = (CGFloat(WAZUIMagic.float(forIdentifier: "content.left_marg
         self.recordingDotViewVisible?.active = true
         
         
-        constrain(bottomContainerView, buttonOverlay, rightSeparator) { container, overlay, rightSeparator in
+        constrain(bottomContainerView, buttonOverlay, rightSeparator) { (container: LayoutProxy, overlay: LayoutProxy, rightSeparator: LayoutProxy) -> () in
             rightSeparator.right == container.right
             rightSeparator.left == overlay.right + 8
             rightSeparator.top == container.top
             rightSeparator.height == 0.5
         }
         
-        constrain(bottomContainerView, timeLabel, audioPreviewView, cancelButton, buttonOverlay) { container, timeLabel, previewView, cancelButton, overlay in
+        constrain(bottomContainerView, timeLabel, audioPreviewView, cancelButton, buttonOverlay) { (container: LayoutProxy, timeLabel: LayoutProxy, previewView: LayoutProxy, cancelButton: LayoutProxy, overlay: LayoutProxy) -> () in
             previewView.left == timeLabel.right + 8
             previewView.top == container.top + 12
             previewView.bottom == container.bottom - 12

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/Emoji/EmojiSectionViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/Emoji/EmojiSectionViewController.swift
@@ -127,13 +127,13 @@ class EmojiSectionViewController: UIViewController {
         let fullSpacing = (view.bounds.width - 2 * inset) - iconSize
         let padding = fullSpacing / (count - 1)
 
-        constrain(view, sectionButtons.first!) { view, firstButton in
+        constrain(view, sectionButtons.first!) { (view: LayoutProxy, firstButton: LayoutProxy) -> () in
             firstButton.leading == view.leading + inset
             view.height == iconSize + inset
         }
         
         sectionButtons.enumerated().dropFirst().forEach { idx, button in
-            constrain(button, sectionButtons[idx - 1], view) { button, previous, view in
+            constrain(button, sectionButtons[idx - 1], view) { (button: LayoutProxy, previous: LayoutProxy, view: LayoutProxy) -> () in
                 button.centerX == previous.centerX + padding
             }
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarButtonsView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarButtonsView.swift
@@ -166,18 +166,19 @@ public final class InputBarButtonsView: UIView {
             }
         }
         
-        var previous = buttons.first!
-        for current in buttons.dropFirst() {
+        var previous: UIView = buttons.first!
+        for current: UIView in buttons.dropFirst() {
             let isFirstButton = previous == buttons.first
             let isLastButton = rowIsFull && current == buttons.last
+            let offset = constants.iconSize / 2 + constants.buttonMargin
             
-            constrain(previous, current) { previous, current in
+            constrain(previous, current) { (previous: LayoutProxy, current: LayoutProxy) -> () in
                 previous.trailing == current.leading
                 
                 if (isFirstButton) {
-                    previous.width == current.width * 0.5 + constants.iconSize / 2 + constants.buttonMargin
+                    previous.width == current.width * 0.5 + offset
                 } else if (isLastButton) {
-                    current.width == previous.width * 0.5 + constants.iconSize / 2 + constants.buttonMargin
+                    current.width == previous.width * 0.5 + offset
                 } else {
                     current.width == previous.width
                 }

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Views/ProfileHeaderView.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Views/ProfileHeaderView.swift
@@ -74,14 +74,14 @@ final class ProfileHeaderView: UIView {
         let topMargin = WAZUIMagic.cgFloat(forIdentifier: "profile_temp.content_top_margin")
         let horizontalMargin = WAZUIMagic.cgFloat(forIdentifier: "profile_temp.content_left_margin")
 
-        constrain(self, detailView) { view, detailView in
+        constrain(self, detailView) { (view: LayoutProxy, detailView: LayoutProxy) -> () in
             detailView.top == view.top + topMargin
             detailView.leading == view.leading + horizontalMargin + 32
             detailView.trailing == view.trailing - (horizontalMargin + 32)
             detailView.bottom == view.bottom - 12
         }
 
-        constrain(self, dismissButton, verifiedImageView, detailView.titleLabel) { view, dismiss, verified, title in
+        constrain(self, dismissButton, verifiedImageView, detailView.titleLabel) { (view: LayoutProxy, dismiss: LayoutProxy, verified: LayoutProxy, title: LayoutProxy) -> () in
             dismiss.top == view.top + 24
             dismiss.width == dismiss.height
             dismiss.width == 32


### PR DESCRIPTION
# Issue

It comes out that inferring type for swiftc is a very challenging task sometimes. This unfortunately significantly decreases the overall compilation speed of the project, making it challenging to change the sources and run the app quickly.

# Investigation

The swiftc option to warn about functions that are taking too long to compile is used: `-Xfrontend -warn-long-function-bodies=1000` where 1000 is the duration in milliseconds that is minimum required to generate the warning. The option is set only for debug builds, so the new code can be checked against compiler performance.

# Possible issues

The compilation on different computers can take different time, but as option is set only on debug configuration, the issues should not disrupt CI (but make it faster). On the other hand, the developers supposed to have the computers fast enough.

# Interesting facts

Generics and inferred block parameter types seems to be the most challenging ones for swift. Basically every Cartography's `constrain` call increase compilation time on 200-600 ms if the closure types are to be inferred.

# Future steps

Current limit (1 second) is chosen to cut the most horrible parts (worst one took 52 seconds to compile). Would be great to set the limit on 100 ms. 


