### PR TITLE
Set input bar hidden instead of collapsing it

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -933,6 +933,7 @@
     if (note.participantsChanged || note.connectionStateChanged) {
         [self updateNavigationItemsButtons];
         [self updateOutgoingConnectionVisibility];
+        [self.contentViewController updateTableViewHeaderView];
     }
     
     if (note.nameChanged || note.securityLevelChanged || note.connectionStateChanged) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -132,7 +132,6 @@
 @property (nonatomic) UIGestureRecognizer *singleTapGestureRecognizer;
 
 @property (nonatomic) UserImageView *authorImageView;
-@property (nonatomic) NSLayoutConstraint *collapseViewConstraint;
 @property (nonatomic) TypingIndicatorView *typingIndicatorView;
 
 @property (nonatomic) InputBar *inputBar;
@@ -532,14 +531,7 @@
 
 - (void)updateInputBarVisibility
 {
-    if (self.conversation.isReadOnly && self.inputBar.superview != nil) {
-        [self.inputBar removeFromSuperview];
-        self.collapseViewConstraint = [self.view autoSetDimension:ALDimensionHeight toSize:0];
-    } else if (! self.conversation.isReadOnly && self.inputBar.superview == nil) {
-        [self.view removeConstraint:self.collapseViewConstraint];
-        [self.view addSubview:self.inputBar];
-        [self.inputBar autoPinEdgesToSuperviewEdges];
-    }
+    self.view.hidden = self.conversation.isReadOnly;
 }
 
 #pragma mark - Input views handling


### PR DESCRIPTION
# What's in this PR?

* This fixes [#7734](https://wearezeta.atlassian.net/browse/ZIOS-7734), a jumping `UserConnectionView` when an outgoing connection request gets accepted. 
* Hide the input bar view controller instead of collapsing it.
* There was an issue with the username label jumping up once an outgoing connection request got accepted, which was caused by the input bar height being expanded and thus the table view size decreasing. As the table header view is actually a footer view and attached to the bottom (as we use an upside down table view) we need to create the view in the correct size for it to appear with the image in the center. Thus the header moved up once the table view size decreased.