### PR TITLE
Add input bar send and emoji button improvements

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -352,7 +352,7 @@
     CGFloat edgeLength = 28;
     [self.sendButton autoSetDimensionsToSize:CGSizeMake(edgeLength, edgeLength)];
     CGFloat rightInset = ([WAZUIMagic cgFloatForIdentifier:@"content.left_margin"] - edgeLength) / 2;
-    [self.sendButton autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsMake(14, 0, 0, rightInset - 16) excludingEdge:ALEdgeBottom];
+    [self.sendButton autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsMake(0, 0, 14, rightInset - 16) excludingEdge:ALEdgeTop];
 }
 
 - (void)createEphemeralIndicatorButton
@@ -383,7 +383,7 @@
 
     [self.inputBar.leftAccessoryView addSubview:self.emojiButton];
     [self.emojiButton autoAlignAxisToSuperviewAxis:ALAxisVertical];
-    [self.emojiButton autoPinEdgeToSuperviewEdge:ALEdgeTop withInset:14];
+    [self.emojiButton autoPinEdgeToSuperviewEdge:ALEdgeBottom withInset:14];
     [self.emojiButton autoSetDimensionsToSize:CGSizeMake(senderDiameter, senderDiameter)];
 }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -347,12 +347,15 @@
     self.sendButton.adjustsImageWhenHighlighted = NO;
     self.sendButton.adjustBackgroundImageWhenHighlighted = YES;
     self.sendButton.cas_styleClass = @"send-button";
+    self.sendButton.hitAreaPadding = CGSizeMake(30, 30);
 
     [self.inputBar.rightAccessoryView addSubview:self.sendButton];
     CGFloat edgeLength = 28;
     [self.sendButton autoSetDimensionsToSize:CGSizeMake(edgeLength, edgeLength)];
+    [self.sendButton autoPinEdgeToSuperviewEdge:ALEdgeLeading];
+    [self.sendButton autoPinEdgeToSuperviewEdge:ALEdgeBottom withInset:14];
     CGFloat rightInset = ([WAZUIMagic cgFloatForIdentifier:@"content.left_margin"] - edgeLength) / 2;
-    [self.sendButton autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsMake(0, 0, 14, rightInset - 16) excludingEdge:ALEdgeTop];
+    [self.sendButton autoPinEdgeToSuperviewEdge:ALEdgeTrailing withInset:rightInset relation:NSLayoutRelationGreaterThanOrEqual];
 }
 
 - (void)createEphemeralIndicatorButton

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
@@ -204,7 +204,7 @@ private struct InputBarConstants {
             leftAccessoryView.bottom == buttonContainer.top
             leftAccessoryView.width == constants.contentLeftMargin
 
-            rightAccessoryView.trailing == rightAccessoryView.superview!.trailing - 16
+            rightAccessoryView.trailing == rightAccessoryView.superview!.trailing
             rightAccessoryView.top == rightAccessoryView.superview!.top
             rightAccessoryView.width == 0 ~ LayoutPriority(750)
             rightAccessoryView.bottom == buttonContainer.top

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
@@ -212,7 +212,8 @@ private struct InputBarConstants {
             buttonContainer.top == textView.bottom
             textView.top == textView.superview!.top
             textView.leading == leftAccessoryView.trailing
-            textView.trailing == rightAccessoryView.leading
+            textView.trailing <= textView.superview!.trailing - 16
+            textView.trailing == rightAccessoryView.leading ~ LayoutPriority(750)
             textView.height >= 56
             textView.height <= 120 ~ LayoutPriority(750)
 


### PR DESCRIPTION
# What's in this PR?

* Align emoji and send button sticky to the bottom instead of to the top of the input bar.
* Increase the hit area of the send button to the right.