### PR TITLE
Fix crash when using emoji as handle input

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/ChangeHandleViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/ChangeHandleViewController.swift
@@ -158,7 +158,7 @@ struct HandleChangeState {
     /// This function does not update the `HandleChangeState` itself.
     func validate(_ handle: String) throws {
         let subset = CharacterSet(charactersIn: handle).isSubset(of: HandleChangeState.allowedCharacters)
-        guard subset else { throw ValidationError.invalidCharacter }
+        guard subset && handle.isEqualToUnicodeName else { throw ValidationError.invalidCharacter }
         guard handle.characters.count >= HandleChangeState.allowedLength.lowerBound else { throw ValidationError.tooShort }
         guard handle.characters.count <= HandleChangeState.allowedLength.upperBound else { throw ValidationError.tooLong }
         guard handle != currentHandle else { throw ValidationError.sameAsPrevious }
@@ -358,3 +358,16 @@ extension ChangeHandleViewController: UserProfileUpdateObserver {
     }
 }
 
+fileprivate extension String {
+
+    var isEqualToUnicodeName: Bool {
+        if #available(iOS 9, *) {
+            return applyingTransform(.toUnicodeName, reverse: false) == self
+        } else {
+            let ref = NSMutableString(string: self) as CFMutableString
+            CFStringTransform(ref, nil, kCFStringTransformToUnicodeName, false)
+            return ref as String == self
+        }
+    }
+    
+}


### PR DESCRIPTION
# What's in this PR?

* There was a crash when trying to input an emoji as username.
* We now check if the handle, which we already checked to be composed out of the valid characters is equal to its transliteration to Unicode names. As alphanumerics will stay the same in this process but emoji will be transformed in a way like `🐷 → {PIG FACE}` we can know that there is an invalid character.
* I previously tried to make this more generic an detect emoji in a string in general, however as other non-emoji characters are not equal to their Unicode name this does not work (see https://github.com/wireapp/wire-ios-utilities/pull/10 for more information).