### PR TITLE
Insert missing tracking call when opening one-on-one conversation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+StartUI.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+StartUI.m
@@ -56,6 +56,7 @@
                 if (users.count == 1) {
                     ZMUser *user = users.anyObject;
                     conversation = user.oneToOneConversation;
+                    [Analytics.shared tagOpenedExistingConversationWithType:conversation.conversationType];
                     [[ZClientViewController sharedZClientViewController] selectConversation:conversation
                                                                                 focusOnView:YES
                                                                                    animated:YES];


### PR DESCRIPTION
# What's in this PR?

* Opening a 1-on-1 conversation was not tracked (see [#7675](https://wearezeta.atlassian.net/browse/ZIOS-7675)).