### PR TITLE
Track button taps instead of waiting for BE results

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationList+Handles.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationList+Handles.swift
@@ -99,15 +99,14 @@ extension ConversationListViewController: UserNameTakeOverViewControllerDelegate
     }
 
     private func tagEvent(for action: UserNameTakeOverViewControllerAction) {
-        guard let event = event(for: action) else { return }
-        Analytics.shared()?.tag(event)
+        Analytics.shared()?.tag(event(for: action))
     }
 
-    private func event(for action: UserNameTakeOverViewControllerAction) -> UserNameEvent.Takeover? {
+    private func event(for action: UserNameTakeOverViewControllerAction) -> UserNameEvent.Takeover {
         switch action {
         case .chooseOwn(_): return .openedSettings
         case .learnMore: return .openedFAQ
-        default: return nil
+        case .keepSuggestion(_): return .keepSuggested(success: true)
         }
     }
 
@@ -117,26 +116,19 @@ extension ConversationListViewController: UserNameTakeOverViewControllerDelegate
 extension ConversationListViewController: UserProfileUpdateObserver {
 
     public func didFailToSetHandle() {
-        tagDidSetHandle(successfully: false)
         openChangeHandleViewController(with: "")
     }
 
     public func didFailToSetHandleBecauseExisting() {
-        tagDidSetHandle(successfully: false)
         openChangeHandleViewController(with: "")
     }
 
     public func didSetHandle() {
-        tagDidSetHandle(successfully: true)
         removeUsernameTakeover()
     }
 
     public func didFindHandleSuggestion(handle: String) {
         showUsernameTakeover(with: handle)
-    }
-
-    private func tagDidSetHandle(successfully: Bool) {
-        Analytics.shared()?.tag(UserNameEvent.Takeover.keepSuggested(success: successfully))
     }
 
 }


### PR DESCRIPTION
# What's in this PR?

* We were tracking the result of a tap on the `"Keep suggested"` button on the takeover view controller when we receive the callback from sync-engine. When selecting choose own we do not remove the observer as we want to dismiss the controller once a different username has been chosen, this lead to non matching tracking numbers as the keep suggested event was tracked in this case as well.
* The intention of the user is more important so we now track the button taps directly.