### PR TITLE
Align download links

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -98,9 +98,9 @@
 
 "send_invitation.subject" = "Connect with me on Wire";
 "send_invitation.text" = "I’m on Wire, search for %@ or visit get.wire.com.";
-"send_invitation_no_email.text" = "I’m on Wire. Visit https://get.wire.com to connect with me.";
+"send_invitation_no_email.text" = "I’m on Wire. Visit get.wire.com to connect with me.";
 
-"send_personal_invitation.text" = "I’m on Wire, talk to you there. https://get.wire.com.";
+"send_personal_invitation.text" = "I’m on Wire, talk to you there: get.wire.com.";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++x

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -97,10 +97,10 @@
 "peoplepicker.hide_search_result_progress" = "Hiding…";
 
 "send_invitation.subject" = "Connect with me on Wire";
-"send_invitation.text" = "I’m on Wire, search for %@ or visit wire.com/download.";
+"send_invitation.text" = "I’m on Wire, search for %@ or visit get.wire.com.";
 "send_invitation_no_email.text" = "I’m on Wire. Visit https://get.wire.com to connect with me.";
 
-"send_personal_invitation.text" = "I’m on Wire, talk to you there. https://get.wire.com";
+"send_personal_invitation.text" = "I’m on Wire, talk to you there. https://get.wire.com.";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++x
@@ -215,7 +215,7 @@
 "content.system.you_started" = "You";
 "content.system.this_device" = "this device";
 
-"content.system.reactivated_device" = "You started using %@ again. Messages sent in the meantime will not appear here";
+"content.system.reactivated_device" = "You started using %@ again. Messages sent in the meantime will not appear here.";
 
 "content.system.new_device" = "a new device";
 "content.system.started_using" = "started using";


### PR DESCRIPTION
The ’get.wire.com’ variant is used in more places and offers platform-specific redirects that take users directly to the app stores on supported platforms.