### PR TITLE
Force sort conversation list on coming back from background

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/Model/ConversationListViewModel.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/Model/ConversationListViewModel.m
@@ -257,6 +257,7 @@ void debugLogUpdate (ConversationListChangeInfo *note);
 
 - (void)applicationWillEnterForeground:(NSNotification *)note
 {
+    [SessionObjectCache.sharedCache.conversationList resort];
     [self reloadConversationListViewModel];
 }
 


### PR DESCRIPTION
This will cause sorting in many cases where this is not needed, but is guaranteed to fix the order