### PR TITLE
Messages are already ordered by descending timeStamp

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
@@ -172,7 +172,7 @@ extension CollectionsViewController: AssetCollectionDelegate {
     public func assetCollectionDidFetch(collection: ZMCollection, messages: [CategoryMatch : [ZMMessage]], hasMore: Bool) {
         
         for messageCategory in messages {
-            let conversationMessages = messageCategory.value.reversed() as [ZMConversationMessage]
+            let conversationMessages = messageCategory.value as [ZMConversationMessage]
             
             if messageCategory.key.including.contains(.image) {
                 self.imageMessages.append(contentsOf: conversationMessages)


### PR DESCRIPTION
Messages are already ordered by timestamp in a descending order. They do not need to be resorted in the UI.