### PR TITLE
Cancel fetchRequests when closing the Collection VC

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
@@ -160,6 +160,7 @@ final public class CollectionsViewController: UIViewController {
     }
     
     @objc func closeButtonPressed(_ button: UIButton) {
+        collection.assetCollection.tearDown() // Cancel fetchRequests
         self.onDismiss?(self)
     }
     


### PR DESCRIPTION
We need to call tearDown on the AssetCollection to avoid ongoing fetchRequests which might be blocking sync tasks.