### PR TITLE
Fix shared user session assumed to be not nil when uploading AB

### DIFF
--- a/Wire-iOS/Sources/AppController.m
+++ b/Wire-iOS/Sources/AppController.m
@@ -127,7 +127,11 @@ NSString *const ZMUserSessionDidBecomeAvailableNotification = @"ZMUserSessionDid
     [self loadAppropriateController];
     self.enteringForeground = NO;
 
-    [self uploadAddressBookIfNeeded];
+    [[self zetaUserSession] checkIfLoggedInWithCallback:^(BOOL isLoggedIn) {
+        if (isLoggedIn) {
+            [self uploadAddressBookIfNeeded];
+        }
+    }];
 }
 
 - (void)uploadAddressBookIfNeeded

--- a/Wire-iOS/Sources/Helpers/sound/AVSMediaManager+CustomSounds.swift
+++ b/Wire-iOS/Sources/Helpers/sound/AVSMediaManager+CustomSounds.swift
@@ -24,7 +24,7 @@ extension AVSMediaManager {
         let settingsPropertyFactory = SettingsPropertyFactory(userDefaults: UserDefaults.standard,
                                                               analytics: Analytics.shared(),
                                                               mediaManager: AVSProvider.shared.mediaManager,
-                                                              userSession: ZMUserSession.shared(),
+                                                              userSession: ZMUserSession.shared()!,
                                                               selfUser: ZMUser.selfUser(),
                                                               crashlogManager: BITHockeyManager.shared())
         return settingsPropertyFactory

--- a/Wire-iOS/Sources/Helpers/syncengine/ZMUserSession+iOS.h
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMUserSession+iOS.h
@@ -19,12 +19,12 @@
 
 #import "zmessaging+iOS.h"
 
-extern NSString * const UserSessionDidRequestAuthenticationNotification;
+extern NSString * __nonnull const UserSessionDidRequestAuthenticationNotification;
 
 @interface ZMUserSession (iOS)
 
-+ (instancetype)sharedSession;
++ (instancetype __nullable)sharedSession;
 
-- (void)loginWithCredentials:(ZMCredentials *)loginCredentials notify:(BOOL)notify;
+- (void)loginWithCredentials:(ZMCredentials * __nonnull)loginCredentials notify:(BOOL)notify;
 
 @end

--- a/Wire-iOS/Sources/Managers/AddressBookHelper.swift
+++ b/Wire-iOS/Sources/Managers/AddressBookHelper.swift
@@ -139,7 +139,7 @@ extension AddressBookHelper {
         self.addressBookSearchPerformedAtLeastOnce = true;
         
         if TARGET_OS_SIMULATOR == 0 || (self.configuration?.shouldPerformAddressBookRemoteSearchEvenOnSimulator ?? false) {
-            ZMUserSession.shared().uploadAddressBook()
+            ZMUserSession.shared()?.uploadAddressBook()
         }
         UserDefaults.standard.set(Date(), forKey: addressBookLastSearchDate)
     }

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
@@ -148,7 +148,7 @@ final public class CollectionsViewController: UIViewController {
     public func perform(_ action: MessageAction, for message: ZMConversationMessage, from view: UIView) {
         switch (action) {
         case .cancel:
-            ZMUserSession.shared().enqueueChanges {
+            ZMUserSession.shared()?.enqueueChanges {
                 message.fileMessageData?.cancelTransfer()
             }
         case .present:

--- a/Wire-iOS/Sources/UserInterface/Conversation/ArchivedListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ArchivedListViewController.swift
@@ -46,7 +46,7 @@ import Cartography
         viewModel.delegate = self
         createViews()
         createConstraints()
-        if let initialSyncCompleted = ZMUserSession.shared().initialSyncOnceCompleted {
+        if let initialSyncCompleted = ZMUserSession.shared()?.initialSyncOnceCompleted {
             self.initialSyncCompleted = initialSyncCompleted.boolValue
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationNewDeviceCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationNewDeviceCell.swift
@@ -73,7 +73,7 @@ class ConversationNewDeviceCell: IconSystemCell {
     
     
     func configureForNewClientOfSelfUser(_ selfUser: ZMUser, clients: [UserClientType], attributes: TextAttributes){
-        let isSelfClient = clients.first?.isEqual(ZMUserSession.shared().selfUserClient()) ?? false
+        let isSelfClient = clients.first?.isEqual(ZMUserSession.shared()?.selfUserClient()) ?? false
         
         let senderName = NSLocalizedString("content.system.you_started", comment: "").uppercased() && attributes.senderAttributes
         let startedUsingString = NSLocalizedString("content.system.started_using", comment: "").uppercased() && attributes.startedUsingAttributes

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
@@ -358,7 +358,7 @@ final class AudioMessageView: UIView, TransferView {
             }
         case .uploaded, .failedDownload:
             self.expectingDownload = true
-            ZMUserSession.shared().enqueueChanges({
+            ZMUserSession.shared()?.enqueueChanges({
                 fileMessage.requestFileDownload()
             })
             

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
@@ -40,17 +40,17 @@ func forward(_ message: ZMMessage, to: [AnyObject]) {
     let conversations = to as! [ZMConversation]
     
     if Message.isTextMessage(message) {
-        ZMUserSession.shared().performChanges {
+        ZMUserSession.shared()?.performChanges {
             forEachNonEphemeral(in: conversations) { _ = $0.appendMessage(withText: message.textMessageData!.messageText) }
         }
     }
     else if Message.isImageMessage(message) {
-        ZMUserSession.shared().performChanges {
+        ZMUserSession.shared()?.performChanges {
             forEachNonEphemeral(in: conversations) { _ = $0.appendMessage(withImageData: message.imageMessageData!.imageData) }
         }
     }
     else if Message.isVideoMessage(message) || Message.isAudioMessage(message) || Message.isFileTransferMessage(message) {
-        ZMUserSession.shared().performChanges {
+        ZMUserSession.shared()?.performChanges {
             FileMetaDataGenerator.metadataForFileAtURL(message.fileMessageData!.fileURL, UTI: message.fileMessageData!.fileURL.UTI()) { fileMetadata in
                 forEachNonEphemeral(in: conversations) { _ = $0.appendMessage(with: fileMetadata) }
             }
@@ -58,7 +58,7 @@ func forward(_ message: ZMMessage, to: [AnyObject]) {
     }
     else if Message.isLocationMessage(message) {
         let locationData = LocationData.locationData(withLatitude: message.locationMessageData!.latitude, longitude: message.locationMessageData!.longitude, name: message.locationMessageData!.name, zoomLevel: message.locationMessageData!.zoomLevel)
-        ZMUserSession.shared().performChanges {
+        ZMUserSession.shared()?.performChanges {
             forEachNonEphemeral(in: conversations) { _ = $0.appendMessage(with: locationData) }
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageDeletion.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageDeletion.swift
@@ -56,7 +56,7 @@ extension ConversationContentViewController {
             if case .delete(let type) = action {
                 self?.trackDelete(message, deletionType:type)
 
-                ZMUserSession.shared().enqueueChanges {
+                ZMUserSession.shared()?.enqueueChanges {
                     switch type {
                     case .local:
                         ZMMessage.hideMessage(message)

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Editing.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Editing.swift
@@ -50,7 +50,7 @@ extension ConversationInputBarViewController {
         guard nil != editingMessage else { return }
         delegate.conversationInputBarViewControllerDidCancelEditing?(editingMessage)
         editingMessage = nil
-        ZMUserSession.shared().enqueueChanges {
+        ZMUserSession.shared()?.enqueueChanges {
             self.conversation.draftMessageText = ""
         }
         updateWritingState()

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Ephemeral.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Ephemeral.swift
@@ -96,7 +96,7 @@ extension ConversationInputBarViewController: EphemeralKeyboardViewControllerDel
 
     func ephemeralKeyboard(_ keyboard: EphemeralKeyboardViewController, didSelectMessageTimeout timeout: ZMConversationMessageDestructionTimeout) {
         inputBar.inputBarState = .writing(ephemeral: timeout != .none)
-        ZMUserSession.shared().enqueueChanges {
+        ZMUserSession.shared()?.enqueueChanges {
             self.conversation.updateMessageDestructionTimeout(timeout: timeout)
             self.updateRightAccessoryView()
             self.updateButtonIconsForEphemeral()

--- a/Wire-iOS/Sources/UserInterface/Settings/AccentColorPickerController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/AccentColorPickerController.swift
@@ -230,7 +230,7 @@ extension AccentColorPickerController: ColorPickerControllerDelegate {
             return
         }
         
-        ZMUserSession.shared().performChanges { 
+        ZMUserSession.shared()?.performChanges {
             ZMUser.selfUser().accentColorValue = self.allAccentColors[colorIndex]
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/ChangeHandleViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/ChangeHandleViewController.swift
@@ -172,7 +172,7 @@ final class ChangeHandleViewController: SettingsBaseTableViewController {
     public var footerFont: UIFont?
     var state: HandleChangeState
     private var footerLabel = UILabel()
-    fileprivate weak var userProfile = ZMUserSession.shared().userProfile
+    fileprivate weak var userProfile = ZMUserSession.shared()?.userProfile
     private var observerToken: AnyObject?
     var popOnSuccess = true
 

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
@@ -177,8 +177,8 @@ extension SettingsCellDescriptorFactory {
             let actionCancel = UIAlertAction(title: "general.cancel".localized, style: .cancel, handler: nil)
             alert.addAction(actionCancel)
             let actionDelete = UIAlertAction(title: "general.ok".localized, style: .destructive) { _ in
-                ZMUserSession.shared().enqueueChanges {
-                    ZMUserSession.shared().initiateUserDeletion()
+                ZMUserSession.shared()?.enqueueChanges {
+                    ZMUserSession.shared()?.initiateUserDeletion()
                 }
             }
             alert.addAction(actionDelete)

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
@@ -122,7 +122,7 @@ import Foundation
         let pushSectionSubtitle = "self.settings.advanced.reset_push_token.subtitle".localized
         
         let pushButton = SettingsExternalScreenCellDescriptor(title: pushTitle, isDestructive: false, presentationStyle: PresentationStyle.modal, presentationAction: { () -> (UIViewController?) in
-            ZMUserSession.shared().resetPushTokens()
+            ZMUserSession.shared()?.resetPushTokens()
             let alert = UIAlertController(title: "self.settings.advanced.reset_push_token_alert.title".localized, message: "self.settings.advanced.reset_push_token_alert.message".localized, preferredStyle: .alert)
             weak var weakAlert = alert;
             alert.addAction(UIAlertAction(title: "general.ok".localized, style: .default, handler: { (alertAction: UIAlertAction) -> Void in

--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
@@ -60,7 +60,7 @@ import CocoaLumberjackSwift
     var userObserverToken : ZMUserObserverOpaqueToken?
         
     required init(clientsList: [UserClient]?, credentials: ZMEmailCredentials? = .none, detailedView: Bool = false, showTemporary: Bool = true) {
-        let selfClient = ZMUserSession.shared().selfUserClient()
+        let selfClient = ZMUserSession.shared()!.selfUserClient()
         self.selfClient = selfClient
         self.detailedView = detailedView
         self.credentials = credentials
@@ -77,12 +77,12 @@ import CocoaLumberjackSwift
 
         self.initalizeProperties(clientsList ?? [])
 
-        self.clientsObserverToken = ZMUserSession.shared().add(self)
+        self.clientsObserverToken = ZMUserSession.shared()!.add(self)
         self.userObserverToken = ZMUser.add(self, forUsers: [ZMUser.selfUser()], in: ZMUserSession.shared())
         
         if clientsList == nil {
             self.showLoadingView = true
-            ZMUserSession.shared().fetchAllClients()
+            ZMUserSession.shared()!.fetchAllClients()
         }
     }
     
@@ -95,7 +95,7 @@ import CocoaLumberjackSwift
     }
     
     deinit {
-        ZMUserSession.shared().removeClientUpdateObserver(self.clientsObserverToken)
+        ZMUserSession.shared()!.removeClientUpdateObserver(self.clientsObserverToken)
         ZMUser.removeObserver(for: self.userObserverToken)
     }
     
@@ -192,7 +192,7 @@ import CocoaLumberjackSwift
     
     func deleteUserClient(_ userClient: UserClient, credentials: ZMEmailCredentials) {
         self.showLoadingView = true
-        ZMUserSession.shared().delete([userClient], with: credentials);
+        ZMUserSession.shared()!.delete([userClient], with: credentials);
     }
 
     func displayError(_ message: String) {

--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
@@ -77,12 +77,12 @@ import CocoaLumberjackSwift
 
         self.initalizeProperties(clientsList ?? [])
 
-        self.clientsObserverToken = ZMUserSession.shared()!.add(self)
+        self.clientsObserverToken = ZMUserSession.shared()?.add(self)
         self.userObserverToken = ZMUser.add(self, forUsers: [ZMUser.selfUser()], in: ZMUserSession.shared())
         
         if clientsList == nil {
             self.showLoadingView = true
-            ZMUserSession.shared()!.fetchAllClients()
+            ZMUserSession.shared()?.fetchAllClients()
         }
     }
     
@@ -95,7 +95,7 @@ import CocoaLumberjackSwift
     }
     
     deinit {
-        ZMUserSession.shared()!.removeClientUpdateObserver(self.clientsObserverToken)
+        ZMUserSession.shared()?.removeClientUpdateObserver(self.clientsObserverToken)
         ZMUser.removeObserver(for: self.userObserverToken)
     }
     
@@ -192,7 +192,7 @@ import CocoaLumberjackSwift
     
     func deleteUserClient(_ userClient: UserClient, credentials: ZMEmailCredentials) {
         self.showLoadingView = true
-        ZMUserSession.shared()!.delete([userClient], with: credentials);
+        ZMUserSession.shared()?.delete([userClient], with: credentials);
     }
 
     func displayError(_ message: String) {

--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientUnregisterFlowViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientUnregisterFlowViewController.swift
@@ -41,7 +41,7 @@ class ClientUnregisterFlowViewController: FormFlowViewController, FormStepDelega
         self.credentials = credentials
         self.delegate = delegate
         super.init(nibName: nil, bundle: nil)
-        self.authToken = ZMUserSession.shared().add(self)
+        self.authToken = ZMUserSession.shared()?.add(self)
     }
     
     required override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
@@ -54,7 +54,7 @@ class ClientUnregisterFlowViewController: FormFlowViewController, FormStepDelega
     
     deinit {
         if let token = self.authToken {
-            ZMUserSession.shared().removeAuthenticationObserver(for: token)
+            ZMUserSession.shared()?.removeAuthenticationObserver(for: token)
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/SettingsClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/SettingsClientViewController.swift
@@ -60,7 +60,7 @@ class SettingsClientViewController: UIViewController, UITableViewDelegate, UITab
 
         self.userClientToken = userClient.addObserver(self)
         if userClient.fingerprint == .none {
-            ZMUserSession.shared()!.enqueueChanges({ () -> Void in
+            ZMUserSession.shared()?.enqueueChanges({ () -> Void in
                 userClient.markForFetchingPreKeys()
             })
         }
@@ -260,7 +260,7 @@ class SettingsClientViewController: UIViewController, UITableViewDelegate, UITab
             
         case .removeDevice:
             if let credentials = self.credentials {
-                ZMUserSession.shared()!.delete([self.userClient], with: credentials)
+                ZMUserSession.shared()?.delete([self.userClient], with: credentials)
                 if let navigationController = self.navigationController {
                     navigationController.popViewController(animated: true)
                 }
@@ -271,7 +271,7 @@ class SettingsClientViewController: UIViewController, UITableViewDelegate, UITab
                     case .left(let passwordString):
                         let newCredentials = ZMEmailCredentials(email: ZMUser.selfUser().emailAddress, password: passwordString)
                         self.credentials = newCredentials
-                        ZMUserSession.shared()!.delete([self.userClient], with: newCredentials)
+                        ZMUserSession.shared()?.delete([self.userClient], with: newCredentials)
                         if let navigationController = self.navigationController {
                             navigationController.popViewController(animated: true)
                         }

--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/SettingsClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/SettingsClientViewController.swift
@@ -60,7 +60,7 @@ class SettingsClientViewController: UIViewController, UITableViewDelegate, UITab
 
         self.userClientToken = userClient.addObserver(self)
         if userClient.fingerprint == .none {
-            ZMUserSession.shared().enqueueChanges({ () -> Void in
+            ZMUserSession.shared()!.enqueueChanges({ () -> Void in
                 userClient.markForFetchingPreKeys()
             })
         }
@@ -134,7 +134,7 @@ class SettingsClientViewController: UIViewController, UITableViewDelegate, UITab
     }
     
     func onVerifiedChanged(_ sender: UISwitch!) {
-        let selfClient = ZMUserSession.shared().selfUserClient()
+        let selfClient = ZMUserSession.shared()!.selfUserClient()
         if(sender.isOn) {
             selfClient?.trustClient(self.userClient)
         } else {
@@ -154,7 +154,7 @@ class SettingsClientViewController: UIViewController, UITableViewDelegate, UITab
     
     func numberOfSections(in tableView: UITableView) -> Int {
         
-        if self.userClient == ZMUserSession.shared().selfUserClient() {
+        if self.userClient == ZMUserSession.shared()!.selfUserClient() {
             return 2
         }
         else {
@@ -169,7 +169,7 @@ class SettingsClientViewController: UIViewController, UITableViewDelegate, UITab
         case .info:
             return 1
         case .fingerprintAndVerify:
-            if self.userClient == ZMUserSession.shared().selfUserClient()  {
+            if self.userClient == ZMUserSession.shared()?.selfUserClient()  {
                 return 1
             }
             else {
@@ -260,7 +260,7 @@ class SettingsClientViewController: UIViewController, UITableViewDelegate, UITab
             
         case .removeDevice:
             if let credentials = self.credentials {
-                ZMUserSession.shared().delete([self.userClient], with: credentials)
+                ZMUserSession.shared()!.delete([self.userClient], with: credentials)
                 if let navigationController = self.navigationController {
                     navigationController.popViewController(animated: true)
                 }
@@ -271,7 +271,7 @@ class SettingsClientViewController: UIViewController, UITableViewDelegate, UITab
                     case .left(let passwordString):
                         let newCredentials = ZMEmailCredentials(email: ZMUser.selfUser().emailAddress, password: passwordString)
                         self.credentials = newCredentials
-                        ZMUserSession.shared().delete([self.userClient], with: newCredentials)
+                        ZMUserSession.shared()!.delete([self.userClient], with: newCredentials)
                         if let navigationController = self.navigationController {
                             navigationController.popViewController(animated: true)
                         }

--- a/Wire-iOS/Sources/UserInterface/Settings/SettingsNavigationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/SettingsNavigationController.swift
@@ -35,7 +35,7 @@ import Foundation
         let settingsPropertyFactory = SettingsPropertyFactory(userDefaults: UserDefaults.standard,
             analytics: Analytics.shared(),
             mediaManager: AVSProvider.shared.mediaManager,
-            userSession: ZMUserSession.shared(),
+            userSession: ZMUserSession.shared()!,
             selfUser: ZMUser.selfUser(),
             crashlogManager: BITHockeyManager.shared())
         
@@ -184,7 +184,7 @@ import Foundation
         
         self.present(newLoginAlertController!, animated:true, completion:.none)
         
-        ZMUserSession.shared().enqueueChanges {
+        ZMUserSession.shared()?.enqueueChanges {
             clients.forEach {
                 $0.needsToNotifyUser = false
             }

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileClientViewController.swift
@@ -88,7 +88,7 @@ class ProfileClientViewController: UIViewController, UserClientObserver, UITextV
         
         self.userClientToken = userClient.addObserver(self)
         if userClient.fingerprint == .none {
-            ZMUserSession.shared().enqueueChanges({ () -> Void in
+            ZMUserSession.shared()?.enqueueChanges({ () -> Void in
                 self.userClient.markForFetchingPreKeys()
             })
         }
@@ -341,7 +341,7 @@ class ProfileClientViewController: UIViewController, UserClientObserver, UITextV
     }
     
     func onShowMyDeviceTapped(_ sender: AnyObject) {
-        let selfClientController = SettingsClientViewController(userClient: ZMUserSession.shared().selfUserClient(), fromConversation:self.fromConversation)
+        let selfClientController = SettingsClientViewController(userClient: ZMUserSession.shared()!.selfUserClient(), fromConversation:self.fromConversation)
         let navigationControllerWrapper = UINavigationController(rootViewController: selfClientController)
         navigationControllerWrapper.modalPresentationStyle = .currentContext
         self.present(navigationControllerWrapper, animated: true, completion: .none)
@@ -349,7 +349,7 @@ class ProfileClientViewController: UIViewController, UserClientObserver, UITextV
     
     func onTrustChanged(_ sender: AnyObject) {
         if let verifiedToggle = self.verifiedToggle {
-            let selfClient = ZMUserSession.shared().selfUserClient()
+            let selfClient = ZMUserSession.shared()!.selfUserClient()
             if(verifiedToggle.isOn) {
                 selfClient?.trustClient(self.userClient)
             } else {


### PR DESCRIPTION
In some cases, the user session could still be nil (e.g. if performing a migration). However it was forced unwrapped in a few cases, e.g. when checking whether to upload the AB.

Now I'm using the user session as optional, and I don't start the AB upload if the session is not there yet