### PR TITLE
Fixed rotation bugs for collections

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
@@ -130,6 +130,38 @@ final public class CollectionsViewController: UIViewController {
         self.updateNoElementsState()
     }
     
+    override public var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        if self.traitCollection.horizontalSizeClass == .regular {
+            return .all
+        }
+        else {
+            return .portrait
+        }
+    }
+    
+    override public var shouldAutorotate: Bool {
+        if self.traitCollection.horizontalSizeClass == .regular {
+            return true
+        }
+        else {
+            return false
+        }
+    }
+    
+    override public func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        self.contentView.collectionViewLayout.invalidateLayout()
+        self.contentView.collectionView.reloadData()
+    }
+    
+    override public var prefersStatusBarHidden: Bool {
+        return false
+    }
+    
+    open override var preferredStatusBarStyle : UIStatusBarStyle {
+        return ColorScheme.default().variant == .dark ? .lightContent : .default
+    }
+    
     private func updateNoElementsState() {
         if self.fetchingDone && self.inOverviewMode && self.totalNumberOfElements() == 0 {
             self.contentView.noItemsInLibrary = true
@@ -147,15 +179,6 @@ final public class CollectionsViewController: UIViewController {
             let backButton = CollectionsView.backButton()
             backButton.addTarget(self, action: #selector(CollectionsViewController.backButtonPressed(_:)), for: .touchUpInside)
             self.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: backButton)
-        }
-    }
-    
-    open override var preferredStatusBarStyle : UIStatusBarStyle {
-        switch ColorScheme.default().variant {
-        case .light:
-            return .default
-        case .dark:
-            return .lightContent
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/RotationAwareNavigationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/RotationAwareNavigationController.swift
@@ -46,4 +46,22 @@ class RotationAwareNavigationController: UINavigationController {
             return super.preferredInterfaceOrientationForPresentation
         }
     }
+    
+    override var prefersStatusBarHidden: Bool {
+        if let topController = self.viewControllers.last {
+            return topController.prefersStatusBarHidden
+        }
+        else {
+            return super.prefersStatusBarHidden
+        }
+    }
+    
+    open override var preferredStatusBarStyle : UIStatusBarStyle {
+        if let topController = self.viewControllers.last {
+            return topController.preferredStatusBarStyle
+        }
+        else {
+            return super.preferredStatusBarStyle
+        }
+    }
 }


### PR DESCRIPTION
# Issue

- Collections view used to rotate on iPhone
- Collections view has a broken layout after rotation
- On dark theme the status bar color is not correct