### PR TITLE
Add console provider for analytics that can be enabled by command line

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -816,6 +816,7 @@
 		BFE57B4B1D52335A00CB0806 /* ConversationPreviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE57B4A1D52335A00CB0806 /* ConversationPreviewViewController.swift */; };
 		BFEA26591D410F9F000D0ED5 /* audio_sample.m4a in Resources */ = {isa = PBXBuildFile; fileRef = BFEA26581D410F9F000D0ED5 /* audio_sample.m4a */; };
 		BFFD439E1DE47FFA00505C8C /* UIView+RightToLeft.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFFD439D1DE47FFA00505C8C /* UIView+RightToLeft.swift */; };
+		CE2402811E0A992200665A91 /* AnalyticsConsoleProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2402801E0A992200665A91 /* AnalyticsConsoleProvider.swift */; };
 		CE3FBF1E1CE22B4900ED087A /* DeleteMessageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CE3FBF1D1CE22B4900ED087A /* DeleteMessageTests.m */; };
 		CEC0FE3B1C4FBF120093BF0D /* ConversationIgnoredDeviceCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC0FE3A1C4FBF120093BF0D /* ConversationIgnoredDeviceCell.swift */; };
 		CED176471D0074610005234F /* ConversationParticipantsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED176461D0074610005234F /* ConversationParticipantsCell.swift */; };
@@ -2167,6 +2168,7 @@
 		BFFD439D1DE47FFA00505C8C /* UIView+RightToLeft.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+RightToLeft.swift"; sourceTree = "<group>"; };
 		C88A846215D617F8CCFBEB80 /* libPods-Wire-iOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Wire-iOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CC9C38FFEE2CB1B4A68D125E /* libPods-Wire-iOS-Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Wire-iOS-Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		CE2402801E0A992200665A91 /* AnalyticsConsoleProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnalyticsConsoleProvider.swift; sourceTree = "<group>"; };
 		CE3FBF1D1CE22B4900ED087A /* DeleteMessageTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DeleteMessageTests.m; sourceTree = "<group>"; };
 		CEC0FE3A1C4FBF120093BF0D /* ConversationIgnoredDeviceCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConversationIgnoredDeviceCell.swift; sourceTree = "<group>"; };
 		CED176461D0074610005234F /* ConversationParticipantsCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConversationParticipantsCell.swift; sourceTree = "<group>"; };
@@ -2825,6 +2827,7 @@
 				871BBFB71D34F56300DF0793 /* AnalyticsVoiceChannelTracker.m */,
 				871BBFB81D34F56300DF0793 /* Application+runDuration.h */,
 				871BBFB91D34F56300DF0793 /* Application+runDuration.m */,
+				CE2402801E0A992200665A91 /* AnalyticsConsoleProvider.swift */,
 				871BBFBD1D34F56300DF0793 /* Clusterizers */,
 				871BBFC31D34F56300DF0793 /* Events */,
 				871BBFE31D34F56300DF0793 /* FileTransfer */,
@@ -5485,6 +5488,7 @@
 				DBDA83911ADFB3F2000AD57D /* RegistrationPhoneFlowViewController.m in Sources */,
 				DB29BD411AE1094E00DCEF6D /* EmailSignInViewController.m in Sources */,
 				871BC36A1D34F94200DF0793 /* YoutubeService.m in Sources */,
+				CE2402811E0A992200665A91 /* AnalyticsConsoleProvider.swift in Sources */,
 				871BC28F1D34F8F800DF0793 /* UIView+Borders.m in Sources */,
 				871BC24A1D34F8F800DF0793 /* UIFont+MagicAccess.m in Sources */,
 				87F61D1C1CD379EC00670794 /* CircularProgressView.swift in Sources */,

--- a/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
+++ b/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
@@ -112,6 +112,10 @@
             argument = "-ZMBackendEnvironmentType edge"
             isEnabled = "NO">
          </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-ConsoleAnalytics"
+            isEnabled = "NO">
+         </CommandLineArgument>
       </CommandLineArguments>
       <EnvironmentVariables>
          <EnvironmentVariable

--- a/Wire-iOS/Sources/Analytics/Analytics+iOS.h
+++ b/Wire-iOS/Sources/Analytics/Analytics+iOS.h
@@ -21,9 +21,10 @@
 #import "Analytics.h"
 
 
-
+extern NSString * _Nonnull const ZMConsoleAnalyticsArgumentKey;
 @interface Analytics (iOS)
 
++ (void)setConsoleAnayltics:(BOOL)shouldUseConsoleAnalytics;
 + (instancetype __nullable)shared;
 
 @end

--- a/Wire-iOS/Sources/Analytics/Analytics+iOS.m
+++ b/Wire-iOS/Sources/Analytics/Analytics+iOS.m
@@ -22,13 +22,31 @@
 #import "AnalyticsLocalyticsProvider.h"
 #import <AVSFlowManager.h>
 #import "Settings.h"
+#import "Wire-Swift.h"
 
 
+static BOOL useConsoleAnalytics = NO;
+NSString * const ZMConsoleAnalyticsArgumentKey = @"-ConsoleAnalytics";
 @implementation Analytics (iOS)
+
++ (void)setConsoleAnayltics:(BOOL)shouldUseConsoleAnalytics;
+{
+    useConsoleAnalytics = shouldUseConsoleAnalytics;
+}
+
 
 + (instancetype)shared
 {
     static Analytics *sharedAnalytics = nil;
+    
+    if (useConsoleAnalytics) {
+        static dispatch_once_t onceToken;
+        dispatch_once(&onceToken, ^{
+            sharedAnalytics = [[Analytics alloc] initWithProvider:[AnalyticsConsoleProvider new]];
+        });
+        return sharedAnalytics;
+    }
+    
     BOOL useAnalytics = USE_ANALYTICS;
     // Don’t track events in debug configuration.
     if (useAnalytics && ![[Settings sharedSettings] disableAnalytics]) {

--- a/Wire-iOS/Sources/Analytics/AnalyticsConsoleProvider.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsConsoleProvider.swift
@@ -1,0 +1,108 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import ZMCSystem
+
+fileprivate let tag = "<ANALYTICS>:"
+@objc class AnalyticsConsoleProvider : NSObject {
+    
+    let zmLog = ZMSLog(tag: tag)
+    var optedOut = false
+    
+    override init() {
+        super.init()
+        ZMSLog.set(level: .info, tag: tag)
+    }
+}
+
+extension AnalyticsConsoleProvider : AnalyticsProvider {
+
+    public var isOptedOut : Bool {
+        
+        get {
+            return optedOut
+        }
+        
+        set {
+            zmLog.info("Setting Opted out: \(newValue)")
+            optedOut = newValue
+        }
+    }
+    
+    func tagScreen(_ screen: String!) {
+        zmLog.info("Tagging Screen: \(screen ?? "")")
+    }
+    
+    func tagEvent(_ event: String!) {
+        tagEvent(event, attributes: [:])
+    }
+    
+    func tagEvent(_ event: String!, attributes: [AnyHashable : Any]! = [:]) {
+        tagEvent(event, attributes: attributes, customerValueIncrease: nil)
+    }
+    
+    func tagEvent(_ event: String!, attributes: [AnyHashable : Any]! = [:], customerValueIncrease: NSNumber!) {
+        var string = "Tagging Event: \(event ?? "")"
+        if !attributes.isEmpty {
+            let keyValues = attributes.map({ (key, value) -> (String, Any) in
+                return (key as! String, value)
+            })
+            string.append("\n Attributes: \(keyValues)")
+        }
+        
+        if customerValueIncrease != nil {
+            string.append("\n Customer Value Increase: \(customerValueIncrease)")
+        }
+        zmLog.info(string)
+    }
+    
+    func setCustomerID(_ customerID: String!) {
+        zmLog.info("Setting Customer ID: \(customerID ?? "" )")
+    }
+    
+    func setPushToken(_ token: Data!) {
+        zmLog.info("Setting push token: \(token ?? Data() )")
+    }
+    
+    func setCustomDimension(_ dimension: Int32, value: String!) {
+        zmLog.info("Setting Custom Dimension: \(dimension) Value: \(value ?? "" )")
+    }
+    
+    func upload() {
+        zmLog.info("Uploading")
+    }
+    
+    func resume(handler resumeHandler: ResumeHandlerBlock!) {
+        //no-op
+    }
+    
+    func handleRemoteNotification(_ userInfo: [AnyHashable : Any]!) {
+        //no-op
+    }
+    
+    func handleOpen(_ url: URL!) -> Bool {
+        zmLog.info("Opening URL: \(url)")
+        return false
+    }
+    
+    func close() {
+        zmLog.info("Closing")
+    }
+}
+

--- a/Wire-iOS/Sources/AppDelegate.m
+++ b/Wire-iOS/Sources/AppDelegate.m
@@ -129,6 +129,17 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
     DDLogInfo(@"application:didFinishLaunchingWithOptions START %@ (applicationState = %ld)", launchOptions, (long)application.applicationState);
+    
+    BOOL containsConsoleAnalytics = [[[NSProcessInfo processInfo] arguments] indexOfObjectPassingTest:^BOOL(NSString * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+        if ([obj isEqualToString:ZMConsoleAnalyticsArgumentKey]) {
+            *stop = YES;
+            return YES;
+        }
+        return NO;
+    }] != NSNotFound;
+    
+    
+    [Analytics setConsoleAnayltics:containsConsoleAnalytics];
     [Analytics shared]; // preload analytics to listen to some notifications in time
 
     [[NSNotificationCenter defaultCenter] addObserver:self


### PR DESCRIPTION
**What's in this PR**
This PR adds a new analytics provider that will simply log in the console the requests sent to analytics. Used for debugging purposes.
Insert `-ConsoleAnalytics` as command line argument to force enable console logging.