### PR TITLE
Changing "Collections" to singular "Collection"

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -777,10 +777,10 @@
 "invite_banner.invite_button_title" = "Invite more people";
 
 // Collections
-"collections.title" = "Collections";
+"collections.title" = "Collection";
 "collections.section.images.title" = "Pictures";
 "collections.section.files.title" = "Files";
 "collections.section.videos.title" = "Videos";
 "collections.section.links.title" = "Links";
 "collections.section.all.button" = "All %d →";
-"collections.section.no_items" = "No items in collections";
+"collections.section.no_items" = "No items in collection";


### PR DESCRIPTION
Unifying copy between platforms, using singular "Collection" everywhere.
CC @priiduzilmer @olivereitalu @Yorgos-V @infotexture 