### PR TITLE
Use immutable attributed strings

### DIFF
--- a/Wire-iOS/Sources/Helpers/UserClient+Fingerprint.swift
+++ b/Wire-iOS/Sources/Helpers/UserClient+Fingerprint.swift
@@ -28,7 +28,7 @@ extension UserClient {
         let attributedRemoteIdentifier = identifier.fingerprintStringWithSpaces().fingerprintString(attributes: attributes,
             boldAttributes:boldAttributes)
         identifierString.append(attributedRemoteIdentifier!)
-        return identifierString
+        return NSAttributedString(attributedString: identifierString)
     }
     
     public func localizedDeviceClass() -> String? {

--- a/Wire-iOS/Sources/Permissions/ShareContactsViewController.m
+++ b/Wire-iOS/Sources/Permissions/ShareContactsViewController.m
@@ -99,7 +99,7 @@
                                      NSFontAttributeName : [UIFont fontWithMagicIdentifier:@"style.text.large.font_spec_thin"] }
                             range:[text rangeOfString:paragraph]];
     
-    return attributedText;
+    return [[NSAttributedString alloc] initWithAttributedString:attributedText];
 }
 
 - (void)createShareContactsButton

--- a/Wire-iOS/Sources/UserInterface/Components/FormGuidance/FormGuidance.m
+++ b/Wire-iOS/Sources/UserInterface/Components/FormGuidance/FormGuidance.m
@@ -152,7 +152,7 @@
             [attributedTitle addAttribute:NSForegroundColorAttributeName value:titleColor range:titleRange];
             [attributedTitle addAttribute:NSForegroundColorAttributeName value:explanationColor range:explanationRange];
 
-            [self setAttributedTitle:attributedTitle forState:UIControlStateNormal];
+            [self setAttributedTitle:[[NSAttributedString alloc] initWithAttributedString:attributedTitle] forState:UIControlStateNormal];
         }
         else if (guidance.title || guidance.explanation) {
             NSString *guidanceText = guidance.title != nil ? guidance.title : guidance.explanation;
@@ -161,7 +161,7 @@
             attributedTitle = [[NSMutableAttributedString alloc] initWithString:guidanceText];
 
             [attributedTitle addAttribute:NSForegroundColorAttributeName value:color range:range];
-            [self setAttributedTitle:attributedTitle forState:UIControlStateNormal];
+            [self setAttributedTitle:[[NSAttributedString alloc] initWithAttributedString:attributedTitle] forState:UIControlStateNormal];
         }
 
         [self setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisVertical];

--- a/Wire-iOS/Sources/UserInterface/Components/Giphy/GiphyNavigationBarController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Giphy/GiphyNavigationBarController.m
@@ -93,7 +93,8 @@
     [attributedTitle addAttribute:NSFontAttributeName value:[UIFont fontWithMagicIdentifier:@"style.text.small.font_spec_bold"] range:titleRange];
     [attributedTitle addAttribute:NSFontAttributeName value:[UIFont fontWithMagicIdentifier:@"style.text.small.font_spec_light"] range:subTitleRange];
 
-    [navBar.centerButton setAttributedTitle:attributedTitle forState:UIControlStateNormal];
+    [navBar.centerButton setAttributedTitle:[[NSAttributedString alloc] initWithAttributedString:attributedTitle]
+                                                                                        forState:UIControlStateNormal];
 }
 
 #pragma mark - Actions

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationIgnoredDeviceCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationIgnoredDeviceCell.swift
@@ -60,7 +60,7 @@ class ConversationIgnoredDeviceCell : IconSystemCell {
                 attributedString.addAttributes([NSFontAttributeName: labelBoldFont, NSForegroundColorAttributeName: labelTextColor], range: youRange)
                 attributedString.addAttributes([NSFontAttributeName: labelFont, NSLinkAttributeName: type(of: self).deviceListLink], range: deviceRange)
                 
-                self.labelView.attributedText = attributedString
+                self.labelView.attributedText = NSAttributedString(attributedString: attributedString)
                 self.labelView.addLinks()
                 self.labelView.accessibilityLabel = self.labelView.attributedText.string
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/Message+Formatting.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/Message+Formatting.m
@@ -183,7 +183,7 @@ static inline NSDataDetector *linkDataDetector(void)
         [attributedString setAttributes:@{NSFontAttributeName: [UIFont systemFontOfSize:40]} range:NSMakeRange(0, attributedString.length)];
     }
     
-    return (nil != markdownStr) ? markdownStr: attributedString;
+    return (nil != markdownStr) ? markdownStr: [[NSAttributedString alloc] initWithAttributedString:attributedString];
 }
 
 @end

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
@@ -319,7 +319,7 @@ extension ZMConversationMessage {
         }
         
         let changeBlock =  {
-            self.statusLabel.attributedText = attributedText
+            self.statusLabel.attributedText = NSAttributedString(attributedString: attributedText)
             self.accessibilityValue = self.statusLabel.attributedText.string
             self.statusLabel.addLinks()
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Headers/GroupConversationHeader.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Headers/GroupConversationHeader.m
@@ -138,7 +138,7 @@
     NSMutableDictionary *explanationAttributes = [self.explanationTextAttributes mutableCopy];
     [explanationAttributes setObject:[NSURL URLWithString:NSLocalizedString(@"conversation.invite_more_people.explanation_url", nil)] forKey:NSLinkAttributeName];
     
-    return attributedString;
+    return [[NSAttributedString alloc] initWithAttributedString:attributedString];
 }
 
 #pragma mark - UITextViewDelegate

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
@@ -180,7 +180,7 @@ import CocoaLumberjackSwift
         style.lineSpacing = 8
        
         attributedTipText.addAttribute(NSParagraphStyleAttributeName, value: style, range: NSMakeRange(0, (attributedTipText.string as NSString).length))
-        self.tipLabel.attributedText = attributedTipText
+        self.tipLabel.attributedText = NSAttributedString(attributedString: attributedTipText)
         self.tipLabel.numberOfLines = 2
         self.tipLabel.font = UIFont(magicIdentifier: "style.text.small.font_spec_light")
         self.tipLabel.textColor = colorScheme.color(withName: ColorSchemeColorTextDimmed)

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController.m
@@ -268,7 +268,7 @@
                         attributes:textAttributes];
     
     self.noConversationLabel = [[UILabel alloc] initForAutoLayout];
-    self.noConversationLabel.attributedText = [[NSAttributedString alloc] initWithString:attributedString];
+    self.noConversationLabel.attributedText = [[NSAttributedString alloc] initWithAttributedString:attributedString];
     self.noConversationLabel.numberOfLines = 0;
     [self.contentContainer addSubview:self.noConversationLabel];
 }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController.m
@@ -268,7 +268,7 @@
                         attributes:textAttributes];
     
     self.noConversationLabel = [[UILabel alloc] initForAutoLayout];
-    self.noConversationLabel.attributedText = [attributedString copy];
+    self.noConversationLabel.attributedText = [[NSAttributedString alloc] initWithString:attributedString];
     self.noConversationLabel.numberOfLines = 0;
     [self.contentContainer addSubview:self.noConversationLabel];
 }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/InviteBannerViewController.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/InviteBannerViewController.m
@@ -95,7 +95,7 @@
     [attributedText addAttributes:@{ NSFontAttributeName: [UIFont fontWithMagicIdentifier:@"style.text.normal.font_spec_medium"] } range:[text rangeOfString:title]];
     [attributedText addAttributes:@{ NSFontAttributeName: [UIFont fontWithMagicIdentifier:@"style.text.normal.font_spec"] } range:[text rangeOfString:paragraph]];
     
-    return attributedText;
+    return [[NSAttributedString alloc] initWithAttributedString:attributedText];
 }
 
 #pragma mark - Actions

--- a/Wire-iOS/Sources/UserInterface/Helpers/NSString+Fingerprint.m
+++ b/Wire-iOS/Sources/UserInterface/Helpers/NSString+Fingerprint.m
@@ -56,7 +56,7 @@
                               bold = !bold;
                           }];
     
-    return mutableFingerprintString;
+    return [[NSAttributedString alloc] initWithAttributedString:mutableFingerprintString];
 }
 
 @end

--- a/Wire-iOS/Sources/UserInterface/Helpers/TextTransform/UILabel+TextTransform.m
+++ b/Wire-iOS/Sources/UserInterface/Helpers/TextTransform/UILabel+TextTransform.m
@@ -122,7 +122,7 @@ SYNTHESIZE_ASC_PRIMITIVE_BLOCK(textTransform, setTextTransform, TextTransform, ^
         [transformedAttributedString setAttributes:attrs range:range];
     }];
     
-    return transformedAttributedString;
+    return [[NSAttributedString alloc] initWithAttributedString:transformedAttributedString];
 }
 
 @end

--- a/Wire-iOS/Sources/UserInterface/Registration/EmailInvitationStepViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/EmailInvitationStepViewController.m
@@ -111,7 +111,7 @@
                                      NSFontAttributeName : [UIFont fontWithMagicIdentifier:@"style.text.large.font_spec_thin"] }
                             range:[text rangeOfString:paragraph]];
     
-    return attributedText;
+    return [[NSAttributedString alloc] initWithAttributedString: attributedText];
 }
 
 - (void)createEmailField

--- a/Wire-iOS/Sources/UserInterface/Registration/EmailVerificationStepViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/EmailVerificationStepViewController.m
@@ -109,7 +109,7 @@
     [attributedText addAttributes:@{NSFontAttributeName : [UIFont fontWithMagicIdentifier:@"style.text.normal.font_spec_bold"]}
                             range:[instructions rangeOfString:self.emailAddress]];
     
-    return attributedText;
+    return [[NSAttributedString alloc] initWithAttributedString:attributedText];
 }
 
 - (void)createResendInstructions

--- a/Wire-iOS/Sources/UserInterface/Registration/TermsOfUseStepViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/TermsOfUseStepViewController.m
@@ -93,7 +93,7 @@
     
     self.termsOfUseText = [[WebLinkTextView alloc] initForAutoLayout];
     self.termsOfUseText.delegate = self;
-    self.termsOfUseText.attributedText = attributedTerms;
+    self.termsOfUseText.attributedText = [[NSAttributedString alloc] initWithAttributedString:attributedTerms];
     
     [self.view addSubview:self.termsOfUseText];
 }

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/Cells/SearchResultCell.m
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/Cells/SearchResultCell.m
@@ -427,7 +427,7 @@
     }
 
     [subtitle endEditing];
-    return subtitle.length != 0 ? subtitle : nil;
+    return subtitle.length != 0 ? [[NSAttributedString alloc] initWithAttributedString:subtitle] : nil;
 }
 
 @end

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIView.m
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIView.m
@@ -220,7 +220,7 @@
         [string appendAttributedString:messageString];
     }
     
-    self.emptyResultView.messageTextView.attributedText = string;
+    self.emptyResultView.messageTextView.attributedText = [[NSAttributedString alloc] initWithAttributedString:string];
     
     [self setEmptyResultsActionView:self.sendInviteActionView visible:self.emptyResultsShowInviteAction];
     [self setEmptyResultsActionView:self.shareContactsActionView visible:self.emptyResultsShowShareContactsAction];

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Views/ParticipantsDeviceHeaderView.m
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Views/ParticipantsDeviceHeaderView.m
@@ -122,7 +122,7 @@
                                                                                        attributes:textAttributes];
 
     [attributedText addAttributes:linkAttributes range:learnMoreLinkRange];
-    return attributedText;
+    return [[NSAttributedString alloc] initWithAttributedString:attributedText];
 }
 
 @end

--- a/WireExtensionComponents/Utilities/AttributedStringOperators.swift
+++ b/WireExtensionComponents/Utilities/AttributedStringOperators.swift
@@ -28,7 +28,7 @@ public func +(left: NSAttributedString, right: NSAttributedString) -> NSAttribut
     let result = NSMutableAttributedString()
     result.append(left)
     result.append(right)
-    return result
+    return NSAttributedString(attributedString: result)
 }
 
 public func +(left: String, right: NSAttributedString) -> NSAttributedString {
@@ -39,7 +39,7 @@ public func +(left: String, right: NSAttributedString) -> NSAttributedString {
     result.append(NSAttributedString(string: left, attributes: attributes))
 
     result.append(right)
-    return result
+    return NSAttributedString(attributedString: result)
 }
 
 public func +(left: NSAttributedString, right: String) -> NSAttributedString {
@@ -49,7 +49,7 @@ public func +(left: NSAttributedString, right: String) -> NSAttributedString {
     let result = NSMutableAttributedString()
     result.append(left)
     result.append(NSAttributedString(string:right, attributes: attributes))
-    return result
+    return NSAttributedString(attributedString: result)
 }
 
 // Concats the lhs and rhs and assigns the result to the lhs
@@ -92,7 +92,7 @@ public func &&(left: NSAttributedString, right: UIFont?) -> NSAttributedString {
     guard let font = right else { return left }
     let result = NSMutableAttributedString(attributedString: left)
     result.addAttributes([NSFontAttributeName: font], range: NSMakeRange(0, result.length))
-    return result
+    return NSAttributedString(attributedString: result)
 }
 
 public func &&(left: String, right: UIColor) -> NSAttributedString {
@@ -103,13 +103,13 @@ public func &&(left: String, right: UIColor) -> NSAttributedString {
 public func &&(left: NSAttributedString, right: UIColor) -> NSAttributedString {
     let result = NSMutableAttributedString(attributedString: left)
     result.addAttributes([NSForegroundColorAttributeName: right], range: NSMakeRange(0, result.length))
-    return result
+    return NSAttributedString(attributedString: result)
 }
 
 public func &&(left: NSAttributedString, right: [String: Any]) -> NSAttributedString {
     let result = NSMutableAttributedString(attributedString: left)
     result.addAttributes(right, range: NSMakeRange(0, result.length))
-    return result
+    return NSAttributedString(attributedString: result)
 }
 
 // MARK: - Helper Functions
@@ -142,13 +142,13 @@ public extension NSAttributedString {
     public func addAttributes(_ attributes: [String: AnyObject], toSubstring substring: String) -> NSAttributedString {
         let mutableSelf = NSMutableAttributedString(attributedString: self)
         mutableSelf.addAttributes(attributes, to: substring)
-        return mutableSelf
+        return NSAttributedString(attributedString: mutableSelf)
     }
     
     public func setAttributes(_ attributes: [String: AnyObject], toSubstring substring: String) -> NSAttributedString {
         let mutableSelf = NSMutableAttributedString(attributedString: self)
         mutableSelf.setAttributes(attributes, range: (string as NSString).range(of: substring))
-        return mutableSelf
+        return NSAttributedString(attributedString: mutableSelf)
     }
 
 }


### PR DESCRIPTION
# Issue

According to the issue that QA detected, the use of mutable attributed strings in the UI with automation causes crashes: http://www.openradar.me/25623858

# Solution

I did not found the particular issue, but it looks like the + and && operators are returning the mutable attributed strings. I updated the implementations to always return the immutable instance, which also seems to be a correct approach.