### PR TITLE
Make back button bigger & update the collections icon

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
@@ -23,68 +23,76 @@ import Cartography
 
 public extension ConversationViewController {
     
-    func barButtonItem(withType type: ZetaIconType, target: AnyObject?, action: Selector, accessibilityIdentifier: String?, imageEdgeInsets: UIEdgeInsets = .zero) -> UIBarButtonItem {
+    func barButtonItem(withType type: ZetaIconType, target: AnyObject?, action: Selector, accessibilityIdentifier: String?, width: CGFloat = 30, imageEdgeInsets: UIEdgeInsets = .zero) -> IconButton {
         let button = IconButton.iconButtonDefault()
         button.setIcon(type, with: .tiny, for: .normal)
-        button.frame = CGRect(x: 0, y: 0, width: 30, height: 20)
+        button.frame = CGRect(x: 0, y: 0, width: width, height: 20)
         button.addTarget(target, action: action, for: .touchUpInside)
         button.accessibilityIdentifier = accessibilityIdentifier
         button.imageEdgeInsets = imageEdgeInsets
-        return UIBarButtonItem(customView: button)
+        return button
     }
     
-    var audioCallBarButtonItem: UIBarButtonItem {
+    var audioCallBarButtonItem: IconButton {
         let button = barButtonItem(withType: .callAudio,
                                    target: self,
                                    action: #selector(ConversationViewController.voiceCallItemTapped(_:)),
                                    accessibilityIdentifier: "audioCallBarButton",
+                                   width: 38,
                                    imageEdgeInsets: UIEdgeInsetsMake(0, 0, 0, -16))
         return button
     }
     
-    var videoCallBarButtonItem: UIBarButtonItem {
+    var videoCallBarButtonItem: IconButton {
         let button = barButtonItem(withType: .callVideo,
                                    target: self,
                                    action: #selector(ConversationViewController.videoCallItemTapped(_:)),
                                    accessibilityIdentifier: "videoCallBarButton",
+                                   width: 30,
                                    imageEdgeInsets: UIEdgeInsetsMake(0, 0, 0, -16))
         return button
     }
     
-    var backBarButtonItem: UIBarButtonItem {
+    var backBarButtonItem: IconButton {
         let leftButtonIcon: ZetaIconType = (self.parent?.wr_splitViewController?.layoutSize == .compact) ? .backArrow : .hamburger
         
         return barButtonItem(withType: leftButtonIcon,
                              target: self,
                              action: #selector(ConversationViewController.onBackButtonPressed(_:)),
                              accessibilityIdentifier: "ConversationBackButton",
+                             width: 38,
                              imageEdgeInsets: UIEdgeInsetsMake(0, -16, 0, 0))
     }
     
-    var collectionsBarButtonItem: UIBarButtonItem {
+    var collectionsBarButtonItem: IconButton {
         return barButtonItem(withType: .library,
                              target: self,
                              action: #selector(ConversationViewController.onCollectionButtonPressed(_:)),
                              accessibilityIdentifier: "collection",
-                             imageEdgeInsets: UIEdgeInsetsMake(0, -16, 0, 0))
+                             width: 30,
+                             imageEdgeInsets: UIEdgeInsetsMake(0, -8, 0, 0))
     }
     
     public func rightNavigationItems(forConversation conversation: ZMConversation) -> [UIBarButtonItem] {
         guard !conversation.isReadOnly else { return [] }
         if conversation.conversationType == .oneOnOne {
-            return [audioCallBarButtonItem, videoCallBarButtonItem]
+            return [UIBarButtonItem(customView: audioCallBarButtonItem), UIBarButtonItem(customView: videoCallBarButtonItem)]
         }
 
-        return [audioCallBarButtonItem]
+        return [UIBarButtonItem(customView: audioCallBarButtonItem)]
     }
     
     public func leftNavigationItems(forConversation conversation: ZMConversation) -> [UIBarButtonItem] {
         var items: [UIBarButtonItem] = []
         
         if self.parent?.wr_splitViewController?.layoutSize != .regularLandscape {
-            items.append(backBarButtonItem)
+            let backButton = backBarButtonItem
+            backButton.hitAreaPadding = CGSize(width: 28, height: 20)
+            items.append(UIBarButtonItem(customView: backButton))
         }
-        items.append(collectionsBarButtonItem)
+        let collectionsButton = collectionsBarButtonItem
+        collectionsButton.hitAreaPadding = CGSize(width: 0, height: 20)
+        items.append(UIBarButtonItem(customView: collectionsButton))
         return items
     }
     

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
@@ -49,7 +49,7 @@ public extension ConversationViewController {
                                    action: #selector(ConversationViewController.videoCallItemTapped(_:)),
                                    accessibilityIdentifier: "videoCallBarButton",
                                    width: 30,
-                                   imageEdgeInsets: UIEdgeInsetsMake(0, 0, 0, -16))
+                                   imageEdgeInsets: UIEdgeInsetsMake(0, 0, 0, -8))
         return button
     }
     

--- a/WireExtensionComponents/Icons/Autogenerated/WireStyleKit.h
+++ b/WireExtensionComponents/Icons/Autogenerated/WireStyleKit.h
@@ -16,6 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
+
 #import <UIKit/UIKit.h>
 
 

--- a/WireExtensionComponents/Icons/Autogenerated/WireStyleKit.m
+++ b/WireExtensionComponents/Icons/Autogenerated/WireStyleKit.m
@@ -4185,29 +4185,35 @@ static UIImage* _imageOfShieldnotverified = nil;
 + (void)drawIcon_0x260_32ptWithColor: (UIColor*)color
 {
 
-    //// Bezier Drawing
-    UIBezierPath* bezierPath = [UIBezierPath bezierPath];
-    [bezierPath moveToPoint: CGPointMake(0, 0)];
-    [bezierPath addLineToPoint: CGPointMake(7.96, 0)];
-    [bezierPath addLineToPoint: CGPointMake(7.96, 64)];
-    [bezierPath addLineToPoint: CGPointMake(0, 64)];
-    [bezierPath addLineToPoint: CGPointMake(0, 0)];
-    [bezierPath closePath];
-    [bezierPath moveToPoint: CGPointMake(15.93, 0)];
-    [bezierPath addLineToPoint: CGPointMake(23.89, 0)];
-    [bezierPath addLineToPoint: CGPointMake(23.89, 64)];
-    [bezierPath addLineToPoint: CGPointMake(15.93, 64)];
-    [bezierPath addLineToPoint: CGPointMake(15.93, 0)];
-    [bezierPath closePath];
-    [bezierPath moveToPoint: CGPointMake(29.86, 5.38)];
-    [bezierPath addLineToPoint: CGPointMake(37.08, 2)];
-    [bezierPath addLineToPoint: CGPointMake(64, 60)];
-    [bezierPath addLineToPoint: CGPointMake(56.78, 63.38)];
-    [bezierPath addLineToPoint: CGPointMake(29.86, 5.38)];
-    [bezierPath closePath];
-    bezierPath.usesEvenOddFillRule = YES;
+    //// Collection Drawing
+    UIBezierPath* collectionPath = [UIBezierPath bezierPath];
+    [collectionPath moveToPoint: CGPointMake(0.02, 27.98)];
+    [collectionPath addCurveToPoint: CGPointMake(3.67, 24) controlPoint1: CGPointMake(-0.2, 25.78) controlPoint2: CGPointMake(1.42, 24)];
+    [collectionPath addLineToPoint: CGPointMake(60.33, 24)];
+    [collectionPath addCurveToPoint: CGPointMake(63.98, 27.98) controlPoint1: CGPointMake(62.57, 24) controlPoint2: CGPointMake(64.2, 25.77)];
+    [collectionPath addLineToPoint: CGPointMake(60.33, 64)];
+    [collectionPath addLineToPoint: CGPointMake(3.67, 64)];
+    [collectionPath addLineToPoint: CGPointMake(0.02, 27.98)];
+    [collectionPath closePath];
+    [collectionPath moveToPoint: CGPointMake(3.67, 15)];
+    [collectionPath addCurveToPoint: CGPointMake(6.71, 12) controlPoint1: CGPointMake(3.67, 13.34) controlPoint2: CGPointMake(5.01, 12)];
+    [collectionPath addLineToPoint: CGPointMake(57.29, 12)];
+    [collectionPath addCurveToPoint: CGPointMake(60.33, 15) controlPoint1: CGPointMake(58.97, 12) controlPoint2: CGPointMake(60.33, 13.33)];
+    [collectionPath addLineToPoint: CGPointMake(60.33, 18)];
+    [collectionPath addLineToPoint: CGPointMake(3.67, 18)];
+    [collectionPath addLineToPoint: CGPointMake(3.67, 15)];
+    [collectionPath closePath];
+    [collectionPath moveToPoint: CGPointMake(7.71, 3)];
+    [collectionPath addCurveToPoint: CGPointMake(10.75, 0) controlPoint1: CGPointMake(7.71, 1.34) controlPoint2: CGPointMake(9.06, 0)];
+    [collectionPath addLineToPoint: CGPointMake(53.25, 0)];
+    [collectionPath addCurveToPoint: CGPointMake(56.29, 3) controlPoint1: CGPointMake(54.93, 0) controlPoint2: CGPointMake(56.29, 1.33)];
+    [collectionPath addLineToPoint: CGPointMake(56.29, 6)];
+    [collectionPath addLineToPoint: CGPointMake(7.71, 6)];
+    [collectionPath addLineToPoint: CGPointMake(7.71, 3)];
+    [collectionPath closePath];
+    collectionPath.usesEvenOddFillRule = YES;
     [color setFill];
-    [bezierPath fill];
+    [collectionPath fill];
 }
 
 + (void)drawMissedcallWithAccent: (UIColor*)accent


### PR DESCRIPTION
# Issue

With the new collections icon, some people are accidentally clicking the collections button instead of the back button. 

# Solution

Initial approach is to increase the tap area of the back button and move it a little bit to the right.