### PR TITLE
Fix showing image placeholder in link previews in text messages cells.

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/TextMessageCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/TextMessageCell.m
@@ -201,8 +201,9 @@
     }
 
     if (linkPreview != nil && nil == self.linkAttachmentViewController && !isGiphy) {
-        ArticleView *articleView = [[ArticleView alloc] initWithImagePlaceholder:textMesssageData.hasImageData];
-        articleView.imageHeight = self.smallLinkAttachments ? 0 : 144;
+        BOOL showImage = !self.smallLinkAttachments && textMesssageData.hasImageData;
+        ArticleView *articleView = [[ArticleView alloc] initWithImagePlaceholder:showImage];
+
         if (self.smallLinkAttachments) {
             articleView.messageLabel.numberOfLines = 1;
             articleView.authorLabel.numberOfLines = 1;


### PR DESCRIPTION
# What's in this PR?

* There was a bug when creating an `ArticleView` in `TextMessageCell`, for forwarding we do not want to show the image, but if there is none and the context is not forwarding we do not want to show one as well.