### PR TITLE
Share extension: show archived conversations in the list

### DIFF
--- a/Wire-iOS Share Extension/ShareViewController.swift
+++ b/Wire-iOS Share Extension/ShareViewController.swift
@@ -156,7 +156,8 @@ class ShareViewController: SLComposeServiceViewController {
     private func selectConversation() {
         guard let sharingSession = globSharingSession else { return }
 
-        let conversationSelectionViewController = ConversationSelectionViewController(conversations: sharingSession.writeableNonArchivedConversations)
+        let allConversations = sharingSession.writeableNonArchivedConversations + sharingSession.writebleArchivedConversations
+        let conversationSelectionViewController = ConversationSelectionViewController(conversations: allConversations)
         
         conversationSelectionViewController.selectionHandler = { [weak self] conversation in
             self?.conversationItem?.value = conversation.name


### PR DESCRIPTION
Archived conversations were not listed in conversations list and it was not possible to share to them.