### PR TITLE
Fix failing property tests

### DIFF
--- a/Wire-iOS/Sources/Components/Settings/SettingsProperty.swift
+++ b/Wire-iOS/Sources/Components/Settings/SettingsProperty.swift
@@ -201,17 +201,14 @@ class SettingsUserDefaultsProperty : SettingsProperty {
     }
     
     internal func value() -> SettingsPropertyValue {
-        let value : AnyObject? = self.userDefaults.object(forKey: self.userDefaultsKey) as AnyObject?
-        if let boolValue = value as? Bool {
+        switch self.userDefaults.object(forKey: self.userDefaultsKey) as AnyObject? {
+        case let boolValue as Bool:
             return SettingsPropertyValue.propertyValue(boolValue as AnyObject?)
-        }
-        if let numberValue = value as? NSNumber {
+        case let numberValue as NSNumber:
             return SettingsPropertyValue.propertyValue(numberValue.intValue as AnyObject?)
-        }
-        else if let stringValue = value as? String {
+        case let stringValue as String:
             return SettingsPropertyValue.propertyValue(stringValue as AnyObject?)
-        }
-        else {
+        default:
             return .none
         }
     }

--- a/Wire-iOS/Sources/Components/Settings/SettingsProperty.swift
+++ b/Wire-iOS/Sources/Components/Settings/SettingsProperty.swift
@@ -202,10 +202,13 @@ class SettingsUserDefaultsProperty : SettingsProperty {
     
     internal func value() -> SettingsPropertyValue {
         let value : AnyObject? = self.userDefaults.object(forKey: self.userDefaultsKey) as AnyObject?
-        if let numberValue : NSNumber = value as? NSNumber {
+        if let boolValue = value as? Bool {
+            return SettingsPropertyValue.propertyValue(boolValue as AnyObject?)
+        }
+        if let numberValue = value as? NSNumber {
             return SettingsPropertyValue.propertyValue(numberValue.intValue as AnyObject?)
         }
-        else if let stringValue : String = value as? String {
+        else if let stringValue = value as? String {
             return SettingsPropertyValue.propertyValue(stringValue as AnyObject?)
         }
         else {

--- a/Wire-iOS/Sources/Components/Settings/SettingsPropertyFactory.swift
+++ b/Wire-iOS/Sources/Components/Settings/SettingsPropertyFactory.swift
@@ -184,7 +184,7 @@ class SettingsPropertyFactory {
         case .analyticsOptOut:
             let getAction : GetAction = { [unowned self] (property: SettingsBlockProperty) -> SettingsPropertyValue in
                 if let analytics = self.analytics {
-                    return SettingsPropertyValue.number(value: Int(analytics.isOptedOut ? 1 : 0))
+                    return .bool(value: analytics.isOptedOut)
                 }
                 else {
                     return .bool(value: false)


### PR DESCRIPTION
# Reason for this pull request
Tests where failing when extracting a property that was set as a boolean, because it was extracted as a number instead.

# Remarks
I just fixed the casting to the right type (number/bool). However the entire SettingsPropertyValue system seems a bit complicated and I think it could be simplified in more concise code. Let's keep it in mind for the future.