### PR TITLE
Extract batch observing of sendables and delay progress view controller push

### DIFF
--- a/Wire-iOS Share Extension/SendableBatchObserver.swift
+++ b/Wire-iOS Share Extension/SendableBatchObserver.swift
@@ -1,0 +1,81 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireShareEngine
+
+
+public final class SendableBatchObserver: SendableObserver {
+
+    private let sendables: [Sendable]
+    private var observers = [(Sendable, SendableObserverToken)]()
+
+    public var sentHandler: (() -> Void)?
+    public var progressHandler: ((Float) -> Void)?
+
+    init(sendables: [Sendable]) {
+        self.sendables = sendables
+        setupObservers(for: sendables)
+    }
+
+    deinit {
+        observers.forEach { (sendable, token) in
+            sendable.remove(token)
+        }
+    }
+
+    public var allSendablesSent: Bool {
+        return observers.reduce(true) { (result, observer) -> Bool in
+            return result && (observer.0.deliveryState == .sent || observer.0.deliveryState == .delivered)
+        }
+    }
+
+    private func setupObservers(for sendables: [Sendable]) {
+        sendables.forEach {
+            observers.append(($0, ($0.registerObserverToken(self))))
+        }
+    }
+
+    public func onDeliveryChanged() {
+        if allSendablesSent {
+            DispatchQueue.main.async { [weak self] in
+                self?.sentHandler?()
+            }
+        }
+
+        updateProgress()
+    }
+
+    private func updateProgress() {
+        var totalProgress: Float = 0
+
+        observers.forEach { (message, _) in
+            if message.deliveryState == .sent || message.deliveryState == .delivered {
+                totalProgress = totalProgress + 1.0 / Float(observers.count)
+            } else {
+                let messageProgress = (message.deliveryProgress ?? 0)
+                totalProgress = totalProgress +  messageProgress / Float(observers.count)
+            }
+        }
+
+        DispatchQueue.main.async { [weak self] in
+            self?.progressHandler?(totalProgress)
+        }
+    }
+
+}

--- a/Wire-iOS Share Extension/SendingProgressViewController.swift
+++ b/Wire-iOS Share Extension/SendingProgressViewController.swift
@@ -21,47 +21,21 @@ import WireExtensionComponents
 import WireShareEngine
 import Cartography
 
-class SendingProgressViewController : UIViewController, SendableObserver {
-    
-    var sentHandler : (() -> Void)?
+class SendingProgressViewController : UIViewController {
+
     var cancelHandler : (() -> Void)?
     
     private var progressLabel = UILabel()
     private var observers : [(Sendable, SendableObserverToken)] = []
     
-    var totalProgress : Float {
-        var totalProgress : Float = 0.0
-        
-        observers.forEach { (message, _) in
-            if message.deliveryState == .sent || message.deliveryState == .delivered {
-                totalProgress = totalProgress + 1.0 / Float(observers.count)
-            } else {
-                let messageProgress = (message.deliveryProgress ?? 0)
-                totalProgress = totalProgress +  messageProgress / Float(observers.count)
-            }
-        }
-        
-        return totalProgress
-    }
-    
-    var isAllMessagesDelivered : Bool {
-        return observers.reduce(true) { (result, observer) -> Bool in
-            return result && (observer.0.deliveryState == .sent || observer.0.deliveryState == .delivered)
+    var progress: Float = 0 {
+        didSet {
+            progressLabel.text = "\(Int(progress * 100))%"
         }
     }
     
-    init(messages: [Sendable]) {
+    init() {
         super.init(nibName: nil, bundle: nil)
-        
-        messages.forEach {message in
-            observers.append((message, (message.registerObserverToken(self))))
-        }
-    }
-    
-    deinit {
-        observers.forEach { (message, token) in
-            message.remove(token)
-        }
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -93,12 +67,5 @@ class SendingProgressViewController : UIViewController, SendableObserver {
         }
         cancelHandler?()
     }
-    
-    func onDeliveryChanged() {
-        progressLabel.text = "\(Int(self.totalProgress * 100))%"
-        
-        if self.isAllMessagesDelivered {
-            sentHandler?()
-        }
-    }
+
 }

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -740,6 +740,7 @@
 		BF52C15E1CAEC1430037331F /* ArchivedNavigationBarTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BF52C15D1CAEC1430037331F /* ArchivedNavigationBarTests.m */; };
 		BF52C1601CB25FE70037331F /* ArchivedListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF52C15F1CB25FE70037331F /* ArchivedListViewModel.swift */; };
 		BF531D521E266C69002DA3F9 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = BF531D511E266C69002DA3F9 /* Localizable.strings */; };
+		BF531D541E267A50002DA3F9 /* SendableBatchObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF531D531E267A50002DA3F9 /* SendableBatchObserver.swift */; };
 		BF58ABED1D23F00000D5FF14 /* LocationSendViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF58ABEC1D23F00000D5FF14 /* LocationSendViewControllerTests.swift */; };
 		BF58ABEF1D23F3CD00D5FF14 /* ModalTopBarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF58ABEE1D23F3CD00D5FF14 /* ModalTopBarTests.swift */; };
 		BF5C37981C0E0D9C00EA11E3 /* ParticipantsDeviceHeaderView.m in Sources */ = {isa = PBXBuildFile; fileRef = BF5C37971C0E0D9C00EA11E3 /* ParticipantsDeviceHeaderView.m */; };
@@ -2117,6 +2118,7 @@
 		BF52C15D1CAEC1430037331F /* ArchivedNavigationBarTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ArchivedNavigationBarTests.m; sourceTree = "<group>"; };
 		BF52C15F1CB25FE70037331F /* ArchivedListViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArchivedListViewModel.swift; sourceTree = "<group>"; };
 		BF531D511E266C69002DA3F9 /* Localizable.strings */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; path = Localizable.strings; sourceTree = "<group>"; };
+		BF531D531E267A50002DA3F9 /* SendableBatchObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SendableBatchObserver.swift; sourceTree = "<group>"; };
 		BF58ABEC1D23F00000D5FF14 /* LocationSendViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationSendViewControllerTests.swift; sourceTree = "<group>"; };
 		BF58ABEE1D23F3CD00D5FF14 /* ModalTopBarTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModalTopBarTests.swift; sourceTree = "<group>"; };
 		BF5C37961C0E0D9C00EA11E3 /* ParticipantsDeviceHeaderView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ParticipantsDeviceHeaderView.h; sourceTree = "<group>"; };
@@ -2456,6 +2458,7 @@
 				168A16AB1D9597C2005CFA6C /* ShareViewController.swift */,
 				543E0C611E2394E7000E2161 /* ConversationSelectionViewController.swift */,
 				543E0C651E23A72F000E2161 /* SendingProgressViewController.swift */,
+				BF531D531E267A50002DA3F9 /* SendableBatchObserver.swift */,
 				543E0C671E23A7C3000E2161 /* NotSignedInViewController.swift */,
 				BF531D511E266C69002DA3F9 /* Localizable.strings */,
 				165FDC491DD5D447009D75A2 /* NSItemProvider+Helper.h */,
@@ -5328,6 +5331,7 @@
 				543E0C681E23A7C3000E2161 /* NotSignedInViewController.swift in Sources */,
 				168A16AC1D9597C2005CFA6C /* ShareViewController.swift in Sources */,
 				543E0C661E23A72F000E2161 /* SendingProgressViewController.swift in Sources */,
+				BF531D541E267A50002DA3F9 /* SendableBatchObserver.swift in Sources */,
 				543E0C641E2394F4000E2161 /* ConversationSelectionViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
# What's in this PR?

* The batch observation of sendables was done in `SendingProgressViewController`, to clean this code up it is now contained in a separate class responsible for batch observing, the `SendableBatchObserver`.
* The observer is owned by the `ShareViewController`, which now updates the `SendingProgressViewController` on progress changes as well as dismisses the share extension when all messages have been sent.
* There is a new field `progressDisplayDelay` which I experimentally added and which is currently set to 0.5 seconds. The set time will delay the display of the progress and will dismiss the extension without showing the progress if all messages are sent in that time (which in case of 0.5 seconds should be enough for one text message in good network conditions), if they are not sent the usual progress is shown. We should discuss if such behaviour is desirable or not.