### PR TITLE
Fix share extension sending cancellation

### DIFF
--- a/Wire-iOS Share Extension/SendableBatchObserver.swift
+++ b/Wire-iOS Share Extension/SendableBatchObserver.swift
@@ -22,7 +22,7 @@ import WireShareEngine
 
 public final class SendableBatchObserver: SendableObserver {
 
-    private let sendables: [Sendable]
+    public let sendables: [Sendable]
     private var observers = [(Sendable, SendableObserverToken)]()
 
     public var sentHandler: (() -> Void)?

--- a/Wire-iOS Share Extension/SendingProgressViewController.swift
+++ b/Wire-iOS Share Extension/SendingProgressViewController.swift
@@ -26,7 +26,6 @@ class SendingProgressViewController : UIViewController {
     var cancelHandler : (() -> Void)?
     
     private var progressLabel = UILabel()
-    private var observers : [(Sendable, SendableObserverToken)] = []
     
     var progress: Float = 0 {
         didSet {
@@ -60,11 +59,6 @@ class SendingProgressViewController : UIViewController {
     }
     
     func onCancelTapped() {
-        observers.filter {
-            $0.0.deliveryState != .sent && $0.0.deliveryState != .delivered
-            }.forEach {
-                $0.0.cancel()
-        }
         cancelHandler?()
     }
 

--- a/Wire-iOS Share Extension/ShareViewController.swift
+++ b/Wire-iOS Share Extension/ShareViewController.swift
@@ -140,7 +140,14 @@ class ShareViewController: SLComposeServiceViewController {
         let progressSendingViewController = SendingProgressViewController()
         
         progressSendingViewController.cancelHandler = { [weak self] in
-            self?.cancel()
+            guard let `self` = self else { return }
+            self.observer?.sendables.filter {
+                $0.deliveryState != .sent && $0.deliveryState != .delivered
+            }.forEach {
+                $0.cancel()
+            }
+
+            self.cancel()
         }
 
         progressViewController = progressSendingViewController

--- a/Wire-iOS Share Extension/ShareViewController.swift
+++ b/Wire-iOS Share Extension/ShareViewController.swift
@@ -141,10 +141,15 @@ class ShareViewController: SLComposeServiceViewController {
         
         progressSendingViewController.cancelHandler = { [weak self] in
             guard let `self` = self else { return }
-            self.observer?.sendables.filter {
+
+            let sendablesToCancel = self.observer?.sendables.lazy.filter {
                 $0.deliveryState != .sent && $0.deliveryState != .delivered
-            }.forEach {
-                $0.cancel()
+            }
+
+            globSharingSession?.enqueue {
+                sendablesToCancel?.forEach {
+                    $0.cancel()
+                }
             }
 
             self.cancel()


### PR DESCRIPTION
# What's in this PR?

* Share extension sending cancellation broke due to changes made in https://github.com/wireapp/wire-ios/pull/550, this PR fixes this.