### PR TITLE
Change share extension copy and add wire logo

### DIFF
--- a/Wire-iOS Share Extension/Base.lproj/Localizable.strings
+++ b/Wire-iOS Share Extension/Base.lproj/Localizable.strings
@@ -22,5 +22,6 @@
 
 
 "share_extension.conversation_selection.title" = "Share to:";
+"share_extension.send_button.title" = "Send";
 "share_extension.conversation_selection.empty.value" = "None";
 "share_extension.input.placeholder" = "Type something…";

--- a/Wire-iOS Share Extension/ShareViewController.swift
+++ b/Wire-iOS Share Extension/ShareViewController.swift
@@ -42,11 +42,7 @@ class ShareViewController: SLComposeServiceViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
-        if let rightButtonBarItem = navigationController?.navigationBar.items?.first?.rightBarButtonItem {
-            rightButtonBarItem.action = #selector(appendPostTapped)
-        }
-        
+        self.setupNavigationBar()
         self.appendURLIfNeeded()
     }
     
@@ -56,6 +52,13 @@ class ShareViewController: SLComposeServiceViewController {
     
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+    }
+
+    private func setupNavigationBar() {
+        guard let item = navigationController?.navigationBar.items?.first else { return }
+        item.rightBarButtonItem?.action = #selector(appendPostTapped)
+        item.rightBarButtonItem?.title = "share_extension.send_button.title".localized
+        item.titleView = UIImageView(image: UIImage(forLogoWith: .black, iconSize: .small))
     }
 
     deinit {


### PR DESCRIPTION
# What's in this PR?

* Change post button title and add Wire logo to the navigation bar in the share extension.

![simulator screen shot 12 01 2017 11 59 10](https://cloud.githubusercontent.com/assets/4603353/21887291/ac039cf6-d8bf-11e6-9557-689d5f4080be.png)
