### PR TITLE
Display an icon for files when sharing

### DIFF
--- a/Wire-iOS Share Extension/ShareViewController.swift
+++ b/Wire-iOS Share Extension/ShareViewController.swift
@@ -103,6 +103,12 @@ class ShareViewController: SLComposeServiceViewController {
         }
     }
     
+    
+    /// Display a preview image
+    override func loadPreviewView() -> UIView! {
+        let parentView : UIView? = super.loadPreviewView()
+        return parentView ?? UIImageView(image: UIImage(for: .document, iconSize: .large, color: UIColor.black))
+    }
 
     /// If there is a URL attachment, copy the text of the URL attachment into the text field
     private func appendURLIfNeeded() {

--- a/Wire-iOS Share Extension/ShareViewController.swift
+++ b/Wire-iOS Share Extension/ShareViewController.swift
@@ -106,8 +106,17 @@ class ShareViewController: SLComposeServiceViewController {
     
     /// Display a preview image
     override func loadPreviewView() -> UIView! {
-        let parentView : UIView? = super.loadPreviewView()
-        return parentView ?? UIImageView(image: UIImage(for: .document, iconSize: .large, color: UIColor.black))
+        if let parentView = super.loadPreviewView() {
+            return parentView
+        }
+        let hasURL = self.attachments.first(where: { $0.hasItemConformingToTypeIdentifier(kUTTypeURL as String) }) != nil
+        let hasEmptyText = self.textView.text.isEmpty
+        // I can not ask if it's a http:// or file://, because it's an async operation, so I rely on the fact that 
+        // if it has no image, it has a URL and it has text, it must be a file
+        if  hasURL && hasEmptyText {
+            return UIImageView(image: UIImage(for: .document, iconSize: .large, color: UIColor.black))
+        }
+        return nil
     }
 
     /// If there is a URL attachment, copy the text of the URL attachment into the text field


### PR DESCRIPTION
# Reason for this pull request
When sharing a file, there is no title and no icon. We want to display an icon instead.

# Changes
When there is no icon, `super.loadPreviewView()` will return `nil`. So I just display the icon every time the preview is `nil`, we have no text and there is a URL. 
I can not check that the URL is a `file://` (which would be safer) because this is an async operation that will run on the main thread on the next run loop, and the `loadPreviewView()` must return synchronously.