### PR TITLE
Localisation for release 2.28

### DIFF
--- a/Wire-iOS Share Extension/ar.lproj/Localizable.strings
+++ b/Wire-iOS Share Extension/ar.lproj/Localizable.strings
@@ -1,27 +1,27 @@
-//
+// 
 // Wire
 // Copyright (C) 2016 Wire Swiss GmbH
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-//
-
-
+// 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Share Extension
 
 
+
+
 "share_extension.conversation_selection.title" = "Conversation:";
-"share_extension.send_button.title" = "Send";
+"share_extension.send_button.title" = "إرسال";
 "share_extension.conversation_selection.empty.value" = "Choose";
-"share_extension.input.placeholder" = "Type a message";
+"share_extension.input.placeholder" = "اكتب الرسالة";

--- a/Wire-iOS Share Extension/da.lproj/Localizable.strings
+++ b/Wire-iOS Share Extension/da.lproj/Localizable.strings
@@ -1,27 +1,27 @@
-//
+// 
 // Wire
 // Copyright (C) 2016 Wire Swiss GmbH
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-//
-
-
+// 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Share Extension
+
+
 
 
 "share_extension.conversation_selection.title" = "Conversation:";
 "share_extension.send_button.title" = "Send";
 "share_extension.conversation_selection.empty.value" = "Choose";
-"share_extension.input.placeholder" = "Type a message";
+"share_extension.input.placeholder" = "Skriv en besked";

--- a/Wire-iOS Share Extension/de.lproj/Localizable.strings
+++ b/Wire-iOS Share Extension/de.lproj/Localizable.strings
@@ -1,27 +1,27 @@
-//
+// 
 // Wire
 // Copyright (C) 2016 Wire Swiss GmbH
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-//
-
-
+// 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Share Extension
 
 
-"share_extension.conversation_selection.title" = "Conversation:";
-"share_extension.send_button.title" = "Send";
-"share_extension.conversation_selection.empty.value" = "Choose";
-"share_extension.input.placeholder" = "Type a message";
+
+
+"share_extension.conversation_selection.title" = "Unterhaltung:";
+"share_extension.send_button.title" = "Senden";
+"share_extension.conversation_selection.empty.value" = "Auswählen";
+"share_extension.input.placeholder" = "Schreibe eine Nachricht";

--- a/Wire-iOS Share Extension/es.lproj/Localizable.strings
+++ b/Wire-iOS Share Extension/es.lproj/Localizable.strings
@@ -1,27 +1,27 @@
-//
+// 
 // Wire
 // Copyright (C) 2016 Wire Swiss GmbH
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-//
-
-
+// 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Share Extension
 
 
+
+
 "share_extension.conversation_selection.title" = "Conversation:";
-"share_extension.send_button.title" = "Send";
+"share_extension.send_button.title" = "Enviar";
 "share_extension.conversation_selection.empty.value" = "Choose";
-"share_extension.input.placeholder" = "Type a message";
+"share_extension.input.placeholder" = "Escriba un mensaje";

--- a/Wire-iOS Share Extension/et.lproj/Localizable.strings
+++ b/Wire-iOS Share Extension/et.lproj/Localizable.strings
@@ -1,27 +1,27 @@
-//
+// 
 // Wire
 // Copyright (C) 2016 Wire Swiss GmbH
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-//
-
-
+// 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Share Extension
 
 
-"share_extension.conversation_selection.title" = "Conversation:";
-"share_extension.send_button.title" = "Send";
-"share_extension.conversation_selection.empty.value" = "Choose";
-"share_extension.input.placeholder" = "Type a message";
+
+
+"share_extension.conversation_selection.title" = "Vestlus:";
+"share_extension.send_button.title" = "Saada";
+"share_extension.conversation_selection.empty.value" = "Vali";
+"share_extension.input.placeholder" = "Kirjuta sõnum";

--- a/Wire-iOS Share Extension/fr.lproj/Localizable.strings
+++ b/Wire-iOS Share Extension/fr.lproj/Localizable.strings
@@ -1,27 +1,27 @@
-//
+// 
 // Wire
 // Copyright (C) 2016 Wire Swiss GmbH
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-//
-
-
+// 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Share Extension
 
 
-"share_extension.conversation_selection.title" = "Conversation:";
-"share_extension.send_button.title" = "Send";
-"share_extension.conversation_selection.empty.value" = "Choose";
-"share_extension.input.placeholder" = "Type a message";
+
+
+"share_extension.conversation_selection.title" = "Conversation :";
+"share_extension.send_button.title" = "Envoyer";
+"share_extension.conversation_selection.empty.value" = "Selectionnez";
+"share_extension.input.placeholder" = "Écrivez un message";

--- a/Wire-iOS Share Extension/it.lproj/Localizable.strings
+++ b/Wire-iOS Share Extension/it.lproj/Localizable.strings
@@ -1,27 +1,27 @@
-//
+// 
 // Wire
 // Copyright (C) 2016 Wire Swiss GmbH
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-//
-
-
+// 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Share Extension
 
 
-"share_extension.conversation_selection.title" = "Conversation:";
-"share_extension.send_button.title" = "Send";
-"share_extension.conversation_selection.empty.value" = "Choose";
-"share_extension.input.placeholder" = "Type a message";
+
+
+"share_extension.conversation_selection.title" = "Conversazione:";
+"share_extension.send_button.title" = "Invia";
+"share_extension.conversation_selection.empty.value" = "Scegli";
+"share_extension.input.placeholder" = "Digita un messaggio";

--- a/Wire-iOS Share Extension/ja.lproj/Localizable.strings
+++ b/Wire-iOS Share Extension/ja.lproj/Localizable.strings
@@ -21,7 +21,7 @@
 
 
 
-"share_extension.conversation_selection.title" = "Conversation:";
+"share_extension.conversation_selection.title" = "会話";
 "share_extension.send_button.title" = "送信";
-"share_extension.conversation_selection.empty.value" = "Choose";
+"share_extension.conversation_selection.empty.value" = "選択する";
 "share_extension.input.placeholder" = "メッセージを入力";

--- a/Wire-iOS Share Extension/ja.lproj/Localizable.strings
+++ b/Wire-iOS Share Extension/ja.lproj/Localizable.strings
@@ -1,27 +1,27 @@
-//
+// 
 // Wire
 // Copyright (C) 2016 Wire Swiss GmbH
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-//
-
-
+// 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Share Extension
 
 
+
+
 "share_extension.conversation_selection.title" = "Conversation:";
-"share_extension.send_button.title" = "Send";
+"share_extension.send_button.title" = "送信";
 "share_extension.conversation_selection.empty.value" = "Choose";
-"share_extension.input.placeholder" = "Type a message";
+"share_extension.input.placeholder" = "メッセージを入力";

--- a/Wire-iOS Share Extension/nl.lproj/Localizable.strings
+++ b/Wire-iOS Share Extension/nl.lproj/Localizable.strings
@@ -1,27 +1,27 @@
-//
+// 
 // Wire
 // Copyright (C) 2016 Wire Swiss GmbH
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-//
-
-
+// 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Share Extension
 
 
+
+
 "share_extension.conversation_selection.title" = "Conversation:";
-"share_extension.send_button.title" = "Send";
+"share_extension.send_button.title" = "Stuur";
 "share_extension.conversation_selection.empty.value" = "Choose";
-"share_extension.input.placeholder" = "Type a message";
+"share_extension.input.placeholder" = "Typ een bericht";

--- a/Wire-iOS Share Extension/pt-BR.lproj/Localizable.strings
+++ b/Wire-iOS Share Extension/pt-BR.lproj/Localizable.strings
@@ -1,27 +1,27 @@
-//
+// 
 // Wire
 // Copyright (C) 2016 Wire Swiss GmbH
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-//
-
-
+// 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Share Extension
 
 
+
+
 "share_extension.conversation_selection.title" = "Conversation:";
-"share_extension.send_button.title" = "Send";
+"share_extension.send_button.title" = "Enviar";
 "share_extension.conversation_selection.empty.value" = "Choose";
-"share_extension.input.placeholder" = "Type a message";
+"share_extension.input.placeholder" = "Digite uma mensagem";

--- a/Wire-iOS Share Extension/ru.lproj/Localizable.strings
+++ b/Wire-iOS Share Extension/ru.lproj/Localizable.strings
@@ -1,27 +1,27 @@
-//
+// 
 // Wire
 // Copyright (C) 2016 Wire Swiss GmbH
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-//
-
-
+// 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Share Extension
 
 
-"share_extension.conversation_selection.title" = "Conversation:";
-"share_extension.send_button.title" = "Send";
-"share_extension.conversation_selection.empty.value" = "Choose";
-"share_extension.input.placeholder" = "Type a message";
+
+
+"share_extension.conversation_selection.title" = "Разговор:";
+"share_extension.send_button.title" = "Отправить";
+"share_extension.conversation_selection.empty.value" = "Выбрать";
+"share_extension.input.placeholder" = "Наберите сообщение";

--- a/Wire-iOS Share Extension/sl.lproj/Localizable.strings
+++ b/Wire-iOS Share Extension/sl.lproj/Localizable.strings
@@ -1,27 +1,27 @@
-//
+// 
 // Wire
 // Copyright (C) 2016 Wire Swiss GmbH
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-//
-
-
+// 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Share Extension
 
 
+
+
 "share_extension.conversation_selection.title" = "Conversation:";
-"share_extension.send_button.title" = "Send";
+"share_extension.send_button.title" = "Pošlji";
 "share_extension.conversation_selection.empty.value" = "Choose";
-"share_extension.input.placeholder" = "Type a message";
+"share_extension.input.placeholder" = "Napiši sporočilo";

--- a/Wire-iOS Share Extension/sl.lproj/Localizable.strings
+++ b/Wire-iOS Share Extension/sl.lproj/Localizable.strings
@@ -21,7 +21,7 @@
 
 
 
-"share_extension.conversation_selection.title" = "Conversation:";
+"share_extension.conversation_selection.title" = "Pogovor:";
 "share_extension.send_button.title" = "Pošlji";
-"share_extension.conversation_selection.empty.value" = "Choose";
+"share_extension.conversation_selection.empty.value" = "Izberi";
 "share_extension.input.placeholder" = "Napiši sporočilo";

--- a/Wire-iOS Share Extension/tr.lproj/Localizable.strings
+++ b/Wire-iOS Share Extension/tr.lproj/Localizable.strings
@@ -1,27 +1,27 @@
-//
+// 
 // Wire
 // Copyright (C) 2016 Wire Swiss GmbH
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-//
-
-
+// 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Share Extension
 
 
-"share_extension.conversation_selection.title" = "Conversation:";
-"share_extension.send_button.title" = "Send";
-"share_extension.conversation_selection.empty.value" = "Choose";
-"share_extension.input.placeholder" = "Type a message";
+
+
+"share_extension.conversation_selection.title" = "Konuşma:";
+"share_extension.send_button.title" = "Gönder";
+"share_extension.conversation_selection.empty.value" = "Seç";
+"share_extension.input.placeholder" = "Bir mesaj yazın";

--- a/Wire-iOS Share Extension/uk.lproj/Localizable.strings
+++ b/Wire-iOS Share Extension/uk.lproj/Localizable.strings
@@ -1,27 +1,27 @@
-//
+// 
 // Wire
 // Copyright (C) 2016 Wire Swiss GmbH
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-//
-
-
+// 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Share Extension
 
 
-"share_extension.conversation_selection.title" = "Conversation:";
-"share_extension.send_button.title" = "Send";
-"share_extension.conversation_selection.empty.value" = "Choose";
-"share_extension.input.placeholder" = "Type a message";
+
+
+"share_extension.conversation_selection.title" = "Розмова:";
+"share_extension.send_button.title" = "Надіслати";
+"share_extension.conversation_selection.empty.value" = "Вибрати";
+"share_extension.input.placeholder" = "Напишіть повідомлення";

--- a/Wire-iOS Share Extension/zh-Hans.lproj/Localizable.strings
+++ b/Wire-iOS Share Extension/zh-Hans.lproj/Localizable.strings
@@ -1,27 +1,27 @@
-//
+// 
 // Wire
 // Copyright (C) 2016 Wire Swiss GmbH
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-//
-
-
+// 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Share Extension
 
 
-"share_extension.conversation_selection.title" = "Conversation:";
-"share_extension.send_button.title" = "Send";
-"share_extension.conversation_selection.empty.value" = "Choose";
-"share_extension.input.placeholder" = "Type a message";
+
+
+"share_extension.conversation_selection.title" = "对话：";
+"share_extension.send_button.title" = "发送";
+"share_extension.conversation_selection.empty.value" = "选择";
+"share_extension.input.placeholder" = "键入一条消息";

--- a/Wire-iOS/Resources/ar.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/ar.lproj/Localizable.strings
@@ -97,10 +97,10 @@
 "peoplepicker.hide_search_result_progress" = "جارٍ الإخفاء…";
 
 "send_invitation.subject" = "تواصل معي على Wire";
-"send_invitation.text" = "أنا أستخدم Wire, ابحث عن %@ أو زُر wire.com/download.";
-"send_invitation_no_email.text" = "أنا أستخدم Wire. لِج https://get.wire.com لتتواصل معي.";
+"send_invitation.text" = "أنا أستخدم Wire, ابحث عن %@ أو لِج get.wire.com.";
+"send_invitation_no_email.text" = "أنا أستخدم Wire. لِج get.wire.com لتتواصل معي.";
 
-"send_personal_invitation.text" = "أنا أستخدم Wire، تحدث معي هُناك. https://get.wire.com";
+"send_personal_invitation.text" = "أنا أستخدم Wire، تحدث معي هُناك: get.wire.com.";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++x
@@ -215,7 +215,7 @@
 "content.system.you_started" = "أنت";
 "content.system.this_device" = "هذا الجهاز";
 
-"content.system.reactivated_device" = "بدأت استخدام %@ مرة أخرى. الرسائل المُرسلة في ذاك الحين لن تُعرض هنا";
+"content.system.reactivated_device" = "بدأت استخدام %@ مرة أخرى. الرسائل المُرسلة في ذاك الحين لن تُعرض هنا.";
 
 "content.system.new_device" = "جهاز جديد";
 "content.system.started_using" = "بدأت استخدام";
@@ -256,7 +256,7 @@
 "content.message.like" = "اعجاب";
 "content.message.unlike" = "إلغاء إعجابي";
 "content.message.forward" = "أرسل";
-"content.message.go_to_conversation" = "إظهار في المُحادثة";
+"content.message.go_to_conversation" = "إظهار";
 "content.message.forward.to" = "إرسال إلى...";
 
 "content.reactions_list.likers" = "إعجاب من  ";
@@ -781,5 +781,5 @@
 "collections.section.files.title" = "ملفّات";
 "collections.section.videos.title" = "مقاطع فيديو";
 "collections.section.links.title" = "روابط";
-"collections.section.all.button" = "الكل ←";
-"collections.section.no_items" = "لا توجد عناصر في المكتبة";
+"collections.section.all.button" = "عرض كل %d ←";
+"collections.section.no_items" = "لا توجد عناصر في المختارات";

--- a/Wire-iOS/Resources/da.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/da.lproj/Localizable.strings
@@ -97,10 +97,10 @@
 "peoplepicker.hide_search_result_progress" = "Skjuler…";
 
 "send_invitation.subject" = "Forbind dig med mig på Wire";
-"send_invitation.text" = "Jeg bruger Wire. Søg efter %@ eller besøg get.wire.com";
-"send_invitation_no_email.text" = "Jeg er på Wire. Besøg https://get.wire.com for at forbinde dig med mig.";
+"send_invitation.text" = "I’m on Wire, search for %@ or visit get.wire.com.";
+"send_invitation_no_email.text" = "I’m on Wire. Visit get.wire.com to connect with me.";
 
-"send_personal_invitation.text" = "Jeg er på Wire, vi tales ved derinde. https://get.wire.com";
+"send_personal_invitation.text" = "I’m on Wire, talk to you there: get.wire.com.";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++x
@@ -215,7 +215,7 @@
 "content.system.you_started" = "Dig";
 "content.system.this_device" = "denne enhed";
 
-"content.system.reactivated_device" = "Du begyndte at bruge %@ igen. Beskeder der sendes, vises i mellemtiden ikke her";
+"content.system.reactivated_device" = "You started using %@ again. Messages sent in the meantime will not appear here.";
 
 "content.system.new_device" = "en ny enhed";
 "content.system.started_using" = "er begyndt at bruge";
@@ -256,7 +256,7 @@
 "content.message.like" = "Synes om";
 "content.message.unlike" = "Synes ikke godt om";
 "content.message.forward" = "Videresend";
-"content.message.go_to_conversation" = "Vis i samtale";
+"content.message.go_to_conversation" = "Reveal";
 "content.message.forward.to" = "Send til...";
 
 "content.reactions_list.likers" = "Synes godt af";
@@ -781,5 +781,5 @@
 "collections.section.files.title" = "Filer";
 "collections.section.videos.title" = "Videoer";
 "collections.section.links.title" = "Links";
-"collections.section.all.button" = "Alle %d →";
-"collections.section.no_items" = "Ingen elementer i biblioteket";
+"collections.section.all.button" = "Show all %d →";
+"collections.section.no_items" = "No items in collection";

--- a/Wire-iOS/Resources/da.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/da.lproj/Localizable.strings
@@ -97,10 +97,10 @@
 "peoplepicker.hide_search_result_progress" = "Skjuler…";
 
 "send_invitation.subject" = "Forbind dig med mig på Wire";
-"send_invitation.text" = "I’m on Wire, search for %@ or visit get.wire.com.";
-"send_invitation_no_email.text" = "I’m on Wire. Visit get.wire.com to connect with me.";
+"send_invitation.text" = "Jeg bruger Wire. Søg efter %@ eller besøg get.wire.com.";
+"send_invitation_no_email.text" = "Jeg er på Wire. Besøg get.wire.com for at forbinde dig med mig.";
 
-"send_personal_invitation.text" = "I’m on Wire, talk to you there: get.wire.com.";
+"send_personal_invitation.text" = "Jeg er på Wire, vi tales ved derinde: get.wire.com.";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++x
@@ -215,7 +215,7 @@
 "content.system.you_started" = "Dig";
 "content.system.this_device" = "denne enhed";
 
-"content.system.reactivated_device" = "You started using %@ again. Messages sent in the meantime will not appear here.";
+"content.system.reactivated_device" = "Du begyndte at bruge %@ igen. Beskeder der sendes, vises i mellemtiden ikke her.";
 
 "content.system.new_device" = "en ny enhed";
 "content.system.started_using" = "er begyndt at bruge";

--- a/Wire-iOS/Resources/de.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/de.lproj/Localizable.strings
@@ -97,10 +97,10 @@
 "peoplepicker.hide_search_result_progress" = "löschen…";
 
 "send_invitation.subject" = "Füge mich auf Wire als Kontakt hinzu";
-"send_invitation.text" = "Ich benutze Wire. Suche nach %@ oder gehe auf wire.com/download.";
-"send_invitation_no_email.text" = "Ich bin bei Wire. Gehe auf https://get.wire.com, um mich als Kontakt hinzuzufügen.";
+"send_invitation.text" = "Ich benutze Wire. Suche nach %@ oder gehe auf wire.com.";
+"send_invitation_no_email.text" = "Ich bin bei Wire. Gehe auf get.wire.com, um mich als Kontakt hinzuzufügen.";
 
-"send_personal_invitation.text" = "Lass uns zu Wire wechseln: https://get.wire.com";
+"send_personal_invitation.text" = "Lass uns zu Wire wechseln: get.wire.com.";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++x
@@ -215,7 +215,7 @@
 "content.system.you_started" = "Du";
 "content.system.this_device" = "dieses Gerät";
 
-"content.system.reactivated_device" = "Du hast %@ eine Weile nicht benutzt. Nachrichten, die in der Zwischenzeit gesendet wurden, werden nicht angezeigt";
+"content.system.reactivated_device" = "Du hast %@ eine Weile nicht benutzt. Nachrichten, die in der Zwischenzeit gesendet wurden, werden nicht angezeigt.";
 
 "content.system.new_device" = "ein neues Gerät";
 "content.system.started_using" = "benutzt";
@@ -256,7 +256,7 @@
 "content.message.like" = "Gefällt mir";
 "content.message.unlike" = "Gefällt mir nicht mehr";
 "content.message.forward" = "Weiterleiten";
-"content.message.go_to_conversation" = "In Unterhaltung anzeigen";
+"content.message.go_to_conversation" = "Öffnen";
 "content.message.forward.to" = "Senden an...";
 
 "content.reactions_list.likers" = "Gefällt";
@@ -781,5 +781,5 @@
 "collections.section.files.title" = "Dokumente";
 "collections.section.videos.title" = "Videos";
 "collections.section.links.title" = "Links";
-"collections.section.all.button" = "Alle %d →";
-"collections.section.no_items" = "Keine Objekte in der Sammlung";
+"collections.section.all.button" = "Zeige alle %d →";
+"collections.section.no_items" = "Keine Elemente in dieser Sammlung";

--- a/Wire-iOS/Resources/de.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/de.lproj/Localizable.strings
@@ -97,7 +97,7 @@
 "peoplepicker.hide_search_result_progress" = "löschen…";
 
 "send_invitation.subject" = "Füge mich auf Wire als Kontakt hinzu";
-"send_invitation.text" = "Ich benutze Wire. Suche nach %@ oder gehe auf wire.com.";
+"send_invitation.text" = "Ich benutze Wire. Suche nach %@ oder gehe auf get.wire.com.";
 "send_invitation_no_email.text" = "Ich bin bei Wire. Gehe auf get.wire.com, um mich als Kontakt hinzuzufügen.";
 
 "send_personal_invitation.text" = "Lass uns zu Wire wechseln: get.wire.com.";

--- a/Wire-iOS/Resources/es.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/es.lproj/Localizable.strings
@@ -76,11 +76,11 @@
 "contacts_ui.no_contact.message" = "Toque sobre contactos para iniciar una conversación";
 
 // Conversation List Bottom Bar
-"bottom_bar.contacts_button.title" = "people";
+"bottom_bar.contacts_button.title" = "personas";
 
 
 // Profile Header View
-"conversation.connection_view.in_address_book" = "in Contacts";
+"conversation.connection_view.in_address_book" = "En los contactos";
 
 
 // Archived List
@@ -97,10 +97,10 @@
 "peoplepicker.hide_search_result_progress" = "Ocultando…";
 
 "send_invitation.subject" = "Conectar conmigo en Wire";
-"send_invitation.text" = "Estoy en Wire, búscame como %@ o visita wire.com/download.";
-"send_invitation_no_email.text" = "Estoy en Wire. Visita https://get.wire.com para conectar conmigo.";
+"send_invitation.text" = "I’m on Wire, search for %@ or visit get.wire.com.";
+"send_invitation_no_email.text" = "I’m on Wire. Visit get.wire.com to connect with me.";
 
-"send_personal_invitation.text" = "Estoy en Wire, te hablo por allí. https://get.wire.com";
+"send_personal_invitation.text" = "I’m on Wire, talk to you there: get.wire.com.";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++x
@@ -148,7 +148,7 @@
 "conversation.call.many_participants_confirmation.message" = "Esto llamará a %d personas";
 "conversation.call.many_participants_confirmation.call" = "Llamar";
 
-"conversation.connection_view.in_address_book" = "in Contacts";
+"conversation.connection_view.in_address_book" = "En los contactos";
 
 // Image confirmation dialogue
 "image_confirmer.confirm" = "OK";
@@ -215,7 +215,7 @@
 "content.system.you_started" = "Tú";
 "content.system.this_device" = "este dispositivo";
 
-"content.system.reactivated_device" = "Se comenzó a utilizar %@ otra vez. Por el momento los mensajes enviados no aparecerán aquí";
+"content.system.reactivated_device" = "You started using %@ again. Messages sent in the meantime will not appear here.";
 
 "content.system.new_device" = "un nuevo dispositivo";
 "content.system.started_using" = "comenzaste a utilizar";
@@ -256,7 +256,7 @@
 "content.message.like" = "Me gusta";
 "content.message.unlike" = "Ya no me gusta";
 "content.message.forward" = "Hacia adelante";
-"content.message.go_to_conversation" = "Show in conversation";
+"content.message.go_to_conversation" = "Reveal";
 "content.message.forward.to" = "Enviar a...";
 
 "content.reactions_list.likers" = "Le ha gustado a";
@@ -777,9 +777,9 @@
 "invite_banner.invite_button_title" = "Invitar a más gente";
 
 // Collections
-"collections.section.images.title" = "Pictures";
-"collections.section.files.title" = "Files";
+"collections.section.images.title" = "Fotos";
+"collections.section.files.title" = "Ficheros";
 "collections.section.videos.title" = "Videos";
-"collections.section.links.title" = "Links";
-"collections.section.all.button" = "All %d →";
-"collections.section.no_items" = "No items in library";
+"collections.section.links.title" = "Enlaces";
+"collections.section.all.button" = "Show all %d →";
+"collections.section.no_items" = "No items in collection";

--- a/Wire-iOS/Resources/es.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/es.lproj/Localizable.strings
@@ -97,10 +97,10 @@
 "peoplepicker.hide_search_result_progress" = "Ocultando…";
 
 "send_invitation.subject" = "Conectar conmigo en Wire";
-"send_invitation.text" = "I’m on Wire, search for %@ or visit get.wire.com.";
-"send_invitation_no_email.text" = "I’m on Wire. Visit get.wire.com to connect with me.";
+"send_invitation.text" = "Estoy en Wire, búscame como %@ o visita get.wire.com.";
+"send_invitation_no_email.text" = "Estoy en Wire. Visita get.wire.com para conectar conmigo.";
 
-"send_personal_invitation.text" = "I’m on Wire, talk to you there: get.wire.com.";
+"send_personal_invitation.text" = "Estoy en Wire, te hablo por allí: get.wire.com.";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++x
@@ -215,7 +215,7 @@
 "content.system.you_started" = "Tú";
 "content.system.this_device" = "este dispositivo";
 
-"content.system.reactivated_device" = "You started using %@ again. Messages sent in the meantime will not appear here.";
+"content.system.reactivated_device" = "Se comenzó a utilizar %@ otra vez. Por el momento los mensajes enviados no aparecerán aquí.";
 
 "content.system.new_device" = "un nuevo dispositivo";
 "content.system.started_using" = "comenzaste a utilizar";

--- a/Wire-iOS/Resources/es.lproj/Localizable.stringsdict
+++ b/Wire-iOS/Resources/es.lproj/Localizable.stringsdict
@@ -200,7 +200,7 @@
                 <key>one</key>
                 <string>person</string>
                 <key>other</key>
-                <string>people</string>
+                <string>personas</string>
             </dict>
         </dict>
 	</dict>

--- a/Wire-iOS/Resources/et.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/et.lproj/Localizable.strings
@@ -96,11 +96,11 @@
 "peoplepicker.hide_search_result" = "Peida";
 "peoplepicker.hide_search_result_progress" = "Peidetakse…";
 
-"send_invitation.subject" = "Suhtleme Wire kaudu";
-"send_invitation.text" = "Ma kasutan Wire’t, otsi %@ või külasta wire.com/download.";
-"send_invitation_no_email.text" = "Ma kasutan Wire’t. Külasta https://get.wire.com et minuga suhelda.";
+"send_invitation.subject" = "Tule Wire'isse, suhtleme seal edasi";
+"send_invitation.text" = "Kasutan nüüd Wire'it, otsi mu kasutajanime %@, või kui sul seda äppi veel pole, siis tõmba siit: get.wire.com.";
+"send_invitation_no_email.text" = "Ma kasutan nüüd Wire’t. Külasta get.wire.com, et edasi suhelda.";
 
-"send_personal_invitation.text" = "Ma kasutan Wire’t, räägime seal. https://get.wire.com";
+"send_personal_invitation.text" = "Ma kasutan Wire’t, räägime seal edasi: get.wire.com.";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++x
@@ -244,7 +244,7 @@
 "content.file.downloading" = "Allalaadimine…";
 "content.file.upload_failed" = "Üleslaadimine ebaõnnestus";
 "content.file.upload_cancelled" = "Üleslaadimine katkestati";
-"content.file.upload_video" = "Videos";
+"content.file.upload_video" = "Videod";
 "content.file.take_video" = "Salvesta video";
 
 "content.file.save_video" = "Salvesta";
@@ -256,7 +256,7 @@
 "content.message.like" = "Meeldib";
 "content.message.unlike" = "Ei meeldi";
 "content.message.forward" = "Edasta";
-"content.message.go_to_conversation" = "Näita vestluses";
+"content.message.go_to_conversation" = "Näita";
 "content.message.forward.to" = "Saada...";
 
 "content.reactions_list.likers" = "Neile meeldib";
@@ -273,7 +273,7 @@
 
 // Connecting (NEW IMPLEMENTATION, REVIEW LATER)
 "connection_request.title" = "Ühendu kasutajaga %@"; // check UPPERCASE implementation in code
-"missive.connection_request.default_message" = "Hei, %@.\nSuhtleme Wire’s.\n%@";
+"missive.connection_request.default_message" = "Hei, %@.\nSuhtleme Wire's edasi.\n%@";
 
 "connection_request.send_button_title" = "Lisa kontakt";
 "inbox.connection_request.connect_button_title" = "Lisa kontakt";
@@ -493,7 +493,7 @@
 "self.settings.notifications.push_notification.toogle" = "Sõnumi eelvaade";
 "self.settings.notifications.push_notification.footer" = "Saatja nimi ja sõnum näidatakse lukustuskuval ja ”Notification Center”-is.";
 
-"self.settings.notifications.chat_alerts.toggle" = "Sõnumi Bännerid";
+"self.settings.notifications.chat_alerts.toggle" = "Sõnumi bännerid";
 "self.settings.notifications.chat_alerts.footer" = "Näitab saabuvaid sõnumeid, kui sul mõni teine vestlus avatud.";
 
 "self.settings.sound_menu.sounds.title" = "Helid";
@@ -536,7 +536,7 @@
 
 // Sound alerts (TO BE UPDPATED)
 "self.settings.sound_menu.title" = "Heli seadistus";
-"self.settings.sound_menu.no_sounds.title" = "Vaigista kõik";
+"self.settings.sound_menu.no_sounds.title" = "Puudub";
 "self.settings.sound_menu.all_sounds.title" = "Kõik";
 "self.settings.sound_menu.mute_while_talking.title" = "Esimene sõnum, ping, kõne";
 
@@ -779,7 +779,7 @@
 // Collections
 "collections.section.images.title" = "Pildid";
 "collections.section.files.title" = "Failid";
-"collections.section.videos.title" = "Videos";
+"collections.section.videos.title" = "Videod";
 "collections.section.links.title" = "Lingid";
-"collections.section.all.button" = "Kõik %d →";
-"collections.section.no_items" = "Pole midagi näidata.";
+"collections.section.all.button" = "Näita kõik: %d →";
+"collections.section.no_items" = "Kogumik on tühi";

--- a/Wire-iOS/Resources/fr.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/fr.lproj/Localizable.strings
@@ -97,10 +97,10 @@
 "peoplepicker.hide_search_result_progress" = "Masquage…";
 
 "send_invitation.subject" = "Connectez-vous avec moi sur Wire";
-"send_invitation.text" = "Je suis sur Wire, recherchez %@ ou visitez wire.com/download.";
-"send_invitation_no_email.text" = "Je suis sur Wire. Visitez https://get.wire.com afin de vous connecter avec moi.";
+"send_invitation.text" = "Je suis sur Wire, recherchez %@ ou visitez get.wire.com.";
+"send_invitation_no_email.text" = "Je suis sur Wire. Visitez get.wire.com pour vous connecter avec moi.";
 
-"send_personal_invitation.text" = "Je suis sur Wire, rejoignez-moi là. https://get.wire.com";
+"send_personal_invitation.text" = "Je suis sur Wire, on se parle là : https://get.wire.com.";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++x
@@ -215,7 +215,7 @@
 "content.system.you_started" = "Vous";
 "content.system.this_device" = "cet appareil";
 
-"content.system.reactivated_device" = "Vous avez commencé à utiliser %@ de nouveau. Les messages envoyés dans l’intervalle n’apparaîtront pas ici";
+"content.system.reactivated_device" = "Vous avez recommencé à utiliser %@. Les messages envoyés auparavant n’apparaîtront pas ici.";
 
 "content.system.new_device" = "un nouvel appareil";
 "content.system.started_using" = "a commencé à utiliser";
@@ -256,7 +256,7 @@
 "content.message.like" = "J'aime";
 "content.message.unlike" = "Je n'aime plus";
 "content.message.forward" = "Faire suivre";
-"content.message.go_to_conversation" = "Afficher dans la conversation";
+"content.message.go_to_conversation" = "Révéler";
 "content.message.forward.to" = "Envoyer à ...";
 
 "content.reactions_list.likers" = "Aimé par";
@@ -781,5 +781,5 @@
 "collections.section.files.title" = "Fichiers";
 "collections.section.videos.title" = "Vidéos";
 "collections.section.links.title" = "Liens";
-"collections.section.all.button" = "Tous %d →";
+"collections.section.all.button" = "Afficher toutes les %d →";
 "collections.section.no_items" = "Aucun élément dans la bibliothèque";

--- a/Wire-iOS/Resources/it.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/it.lproj/Localizable.strings
@@ -97,7 +97,7 @@
 "peoplepicker.hide_search_result_progress" = "Nascondendo…";
 
 "send_invitation.subject" = "Connettiti con me su Wire";
-"send_invitation.text" = "Sono su Wire, cerca %@ o visita get.wire.com";
+"send_invitation.text" = "Sono su Wire, cerca %@ o visita get.wire.com.";
 "send_invitation_no_email.text" = "Sono su Wire. Visita get.wire.com per connetterti con me.";
 
 "send_personal_invitation.text" = "Sono su Wire, ci sentiamo lì. get.wire.com";

--- a/Wire-iOS/Resources/it.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/it.lproj/Localizable.strings
@@ -97,10 +97,10 @@
 "peoplepicker.hide_search_result_progress" = "Nascondendo…";
 
 "send_invitation.subject" = "Connettiti con me su Wire";
-"send_invitation.text" = "Sono su Wire, cerca %@ o visita wire.com/download.";
-"send_invitation_no_email.text" = "Sono su Wire. Visita https://get.wire.com per connetterti con me.";
+"send_invitation.text" = "Sono su Wire, cerca %@ o visita get.wire.com";
+"send_invitation_no_email.text" = "Sono su Wire. Visita get.wire.com per connetterti con me.";
 
-"send_personal_invitation.text" = "Sono su wire, ci sentiamo lì. https://get.wire.com";
+"send_personal_invitation.text" = "Sono su Wire, ci sentiamo lì. get.wire.com";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++x
@@ -215,7 +215,7 @@
 "content.system.you_started" = "Tu";
 "content.system.this_device" = "questo dispositivo";
 
-"content.system.reactivated_device" = "Hai iniziato a utilizzare %@ nuovamente. I messaggi inviati nel frattempo non verranno visualizzato qui";
+"content.system.reactivated_device" = "Hai iniziato a utilizzare %@ nuovamente. I messaggi inviati nel frattempo non verranno visualizzato qui.";
 
 "content.system.new_device" = "un nuovo dispositivo";
 "content.system.started_using" = "iniziato ad utilizzare";
@@ -256,7 +256,7 @@
 "content.message.like" = "Mi piace";
 "content.message.unlike" = "Non mi piace più";
 "content.message.forward" = "Inoltra";
-"content.message.go_to_conversation" = "Show in conversation";
+"content.message.go_to_conversation" = "Mostra";
 "content.message.forward.to" = "Invia a...";
 
 "content.reactions_list.likers" = "Piace a";
@@ -781,5 +781,5 @@
 "collections.section.files.title" = "Allegati";
 "collections.section.videos.title" = "Video";
 "collections.section.links.title" = "Link";
-"collections.section.all.button" = "Tutti →";
-"collections.section.no_items" = "Nessun elemento nella libreria";
+"collections.section.all.button" = "Mostra tutti %d →";
+"collections.section.no_items" = "Nessun elemento nella raccolta";

--- a/Wire-iOS/Resources/ja.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/ja.lproj/Localizable.strings
@@ -97,10 +97,10 @@
 "peoplepicker.hide_search_result_progress" = "隠しています...";
 
 "send_invitation.subject" = "Wireで繋がります";
-"send_invitation.text" = "私はWireにいます。%@ で検索するか、wire.com/download にアクセスしてください。";
-"send_invitation_no_email.text" = "私はWireにいます。https://get.wire. から、私とつながりましょう。";
+"send_invitation.text" = "私はWireにいます。%@ で検索するか、get.wire.com. にアクセスしてください";
+"send_invitation_no_email.text" = "私はWireにいます。https://get.wire.com にアクセスして私とつながりましょう。";
 
-"send_personal_invitation.text" = "私は Wire にいます。Wireで話しましょう。https://get.wire.com";
+"send_personal_invitation.text" = "私は Wire にいます。Wireで話しましょう。get.wire.com";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++x
@@ -215,7 +215,7 @@
 "content.system.you_started" = "あなた";
 "content.system.this_device" = "このデバイス";
 
-"content.system.reactivated_device" = "あなたは%@を再び利用しています。いままでのメッセージはここには表示されません。";
+"content.system.reactivated_device" = "あなたは %@ を再び利用しています。いままでのメッセージはここには表示されません。";
 
 "content.system.new_device" = "新しいデバイス";
 "content.system.started_using" = "使用を始めます";
@@ -256,7 +256,7 @@
 "content.message.like" = "いいね！";
 "content.message.unlike" = "いいね！を取消す";
 "content.message.forward" = "転送";
-"content.message.go_to_conversation" = "Show in conversation";
+"content.message.go_to_conversation" = "開く";
 "content.message.forward.to" = "…に送信";
 
 "content.reactions_list.likers" = "いいね！しました";
@@ -330,7 +330,7 @@
 
 // Leave conversation
 "meta.leave_conversation_dialog_title" = "会話から退室しますか？";
-"meta.leave_conversation_dialog_message" = "参加者に通知され、あなたのリストから会話が削除されます。";
+"meta.leave_conversation_dialog_message" = "参加者に通知されたうえで、あなたのリストから会話が削除されます。";
 "meta.leave_conversation.delete_content_as_well_message" = "コンテンツも削除されます";
 "meta.leave_conversation_button_cancel" = "キャンセル";
 "meta.leave_conversation_button_leave" = "離れる";
@@ -705,7 +705,7 @@
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Username takeover screen
-"registration.select_handle.takeover.title" = "ユーザーネームはここです";
+"registration.select_handle.takeover.title" = "ユーザーネームがここに";
 "registration.select_handle.takeover.subtitle" = "Wireでのユーザーネームを選ぶ";
 "registration.select_handle.takeover.subtitle_link" = "もっと知る";
 
@@ -781,5 +781,5 @@
 "collections.section.files.title" = "ファイル";
 "collections.section.videos.title" = "ビデオ";
 "collections.section.links.title" = "リンク";
-"collections.section.all.button" = "すべて→";
-"collections.section.no_items" = "ライブラリにはなにもありません";
+"collections.section.all.button" = "全てを表示 %d →";
+"collections.section.no_items" = "コレクションにアイテムがありません。";

--- a/Wire-iOS/Resources/nl.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/nl.lproj/Localizable.strings
@@ -97,10 +97,10 @@
 "peoplepicker.hide_search_result_progress" = "Verbergen…";
 
 "send_invitation.subject" = "Verbind met mij op Wire";
-"send_invitation.text" = "Ik gebruik Wire, zoek voor %@ of bezoek wire.com/download.";
-"send_invitation_no_email.text" = "Ik gebruik Wire. Ga naar https://get.wire.com om met mij te verbinden.";
+"send_invitation.text" = "Ik gebruik Wire, zoek naar %@ of bezoek get.wire.com.";
+"send_invitation_no_email.text" = "Ik gebruik Wire. Ga naar get.wire.com om met mij te verbinden.";
 
-"send_personal_invitation.text" = "Ik ben op Wire, praat met mij daar. https://get.wire.com";
+"send_personal_invitation.text" = "Ik ben op Wire, praat met mij daar: get.wire.com.";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++x
@@ -215,7 +215,7 @@
 "content.system.you_started" = "Jij";
 "content.system.this_device" = "dit apparaat";
 
-"content.system.reactivated_device" = "Je bent %@ weer gaan gebruiken. Berichten die in de tussentijd verzonden zijn worden hier niet getoond";
+"content.system.reactivated_device" = "Je bent %@ weer gaan gebruiken. Berichten die in de tussentijd verzonden zijn worden hier niet getoond.";
 
 "content.system.new_device" = "een nieuw apparaat";
 "content.system.started_using" = "begon met het gebruik van";
@@ -256,7 +256,7 @@
 "content.message.like" = "Vind ik leuk";
 "content.message.unlike" = "Vind ik niet leuk";
 "content.message.forward" = "Doorsturen";
-"content.message.go_to_conversation" = "Open gesprek";
+"content.message.go_to_conversation" = "Tonen";
 "content.message.forward.to" = "Verzenden naar...";
 
 "content.reactions_list.likers" = "Leuk gevonden door";
@@ -781,5 +781,5 @@
 "collections.section.files.title" = "Bestanden";
 "collections.section.videos.title" = "Video's";
 "collections.section.links.title" = "Links";
-"collections.section.all.button" = "Alles %d →";
-"collections.section.no_items" = "Geen items in bibliotheek";
+"collections.section.all.button" = "Toon alle %d →";
+"collections.section.no_items" = "Geen items in de verzameling";

--- a/Wire-iOS/Resources/pt-BR.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/pt-BR.lproj/Localizable.strings
@@ -97,10 +97,10 @@
 "peoplepicker.hide_search_result_progress" = "Escondendo...";
 
 "send_invitation.subject" = "Conecte-se comigo no Wire";
-"send_invitation.text" = "Eu estou no Wire, pesquise por %@ ou visite wire.com/download.";
-"send_invitation_no_email.text" = "Estou no Wire. Visite https://get.wire.com para se conectar comigo.";
+"send_invitation.text" = "I’m on Wire, search for %@ or visit get.wire.com.";
+"send_invitation_no_email.text" = "I’m on Wire. Visit get.wire.com to connect with me.";
 
-"send_personal_invitation.text" = "Estou no Wire, falo com você lá. https://get.wire.com";
+"send_personal_invitation.text" = "I’m on Wire, talk to you there: get.wire.com.";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++x
@@ -215,7 +215,7 @@
 "content.system.you_started" = "Você";
 "content.system.this_device" = "este dispositivo";
 
-"content.system.reactivated_device" = "Você começou a usar o %@ novamente. Mensagens enviadas entretanto não aparecerão aqui";
+"content.system.reactivated_device" = "You started using %@ again. Messages sent in the meantime will not appear here.";
 
 "content.system.new_device" = "um novo dispositivo";
 "content.system.started_using" = "começou a usar";
@@ -256,7 +256,7 @@
 "content.message.like" = "Curtir";
 "content.message.unlike" = "Descurtir";
 "content.message.forward" = "Encaminhar";
-"content.message.go_to_conversation" = "Show in conversation";
+"content.message.go_to_conversation" = "Reveal";
 "content.message.forward.to" = "Enviar para...";
 
 "content.reactions_list.likers" = "Curtido por";
@@ -781,5 +781,5 @@
 "collections.section.files.title" = "Arquivos";
 "collections.section.videos.title" = "Vídeos";
 "collections.section.links.title" = "Links";
-"collections.section.all.button" = "Todos %d →";
-"collections.section.no_items" = "Não há itens na biblioteca";
+"collections.section.all.button" = "Show all %d →";
+"collections.section.no_items" = "No items in collection";

--- a/Wire-iOS/Resources/pt-BR.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/pt-BR.lproj/Localizable.strings
@@ -97,10 +97,10 @@
 "peoplepicker.hide_search_result_progress" = "Escondendo...";
 
 "send_invitation.subject" = "Conecte-se comigo no Wire";
-"send_invitation.text" = "I’m on Wire, search for %@ or visit get.wire.com.";
-"send_invitation_no_email.text" = "I’m on Wire. Visit get.wire.com to connect with me.";
+"send_invitation.text" = "Eu estou no Wire, pesquise por %@ ou visite get.wire.com.";
+"send_invitation_no_email.text" = "Estou no Wire. Visite get.wire.com para se conectar comigo.";
 
-"send_personal_invitation.text" = "I’m on Wire, talk to you there: get.wire.com.";
+"send_personal_invitation.text" = "Estou no Wire, falo com você lá. get.wire.com.";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++x

--- a/Wire-iOS/Resources/pt-BR.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/pt-BR.lproj/Localizable.strings
@@ -215,7 +215,7 @@
 "content.system.you_started" = "Você";
 "content.system.this_device" = "este dispositivo";
 
-"content.system.reactivated_device" = "You started using %@ again. Messages sent in the meantime will not appear here.";
+"content.system.reactivated_device" = "Você começou a usar o %@ novamente. Mensagens enviadas entretanto não aparecerão aqui.";
 
 "content.system.new_device" = "um novo dispositivo";
 "content.system.started_using" = "começou a usar";

--- a/Wire-iOS/Resources/ru.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/ru.lproj/Localizable.strings
@@ -97,10 +97,10 @@
 "peoplepicker.hide_search_result_progress" = "Прячу…";
 
 "send_invitation.subject" = "Добавь меня в Wire";
-"send_invitation.text" = "Я в Wire, ищи %@ или зайди на wire.com/download.";
-"send_invitation_no_email.text" = "Я уже в Wire. Посетите https://get.wire.com, чтобы добавить меня.";
+"send_invitation.text" = "Я в Wire, ищи %@ или зайди на get.wire.com.";
+"send_invitation_no_email.text" = "Я уже в Wire. Посетите get.wire.com, чтобы добавить меня.";
 
-"send_personal_invitation.text" = "Я в Wire, поговорим там https://get.wire.com";
+"send_personal_invitation.text" = "Я в Wire, поговорим там get.wire.com.";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++x
@@ -215,7 +215,7 @@
 "content.system.you_started" = "Вы";
 "content.system.this_device" = "это устройство";
 
-"content.system.reactivated_device" = "Вы начали использовать %@ снова. Сообщения, отправленные ранее, не будут отображаться здесь";
+"content.system.reactivated_device" = "Вы начали использовать %@ снова. Сообщения, отправленные ранее, не будут отображаться здесь.";
 
 "content.system.new_device" = "новое устройство";
 "content.system.started_using" = "начал(-а) использовать";
@@ -781,5 +781,5 @@
 "collections.section.files.title" = "Файлы";
 "collections.section.videos.title" = "Видео";
 "collections.section.links.title" = "Ссылки";
-"collections.section.all.button" = "Все %d →";
-"collections.section.no_items" = "Нет элементов в библиотеке";
+"collections.section.all.button" = "Показать все %d →";
+"collections.section.no_items" = "Ничего нет";

--- a/Wire-iOS/Resources/sl.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/sl.lproj/Localizable.strings
@@ -97,10 +97,10 @@
 "peoplepicker.hide_search_result_progress" = "Skrivanje…";
 
 "send_invitation.subject" = "Poveži se z mano na Wire";
-"send_invitation.text" = "Sem na Wire, poišči %@ ali obišči wire.com/download.";
-"send_invitation_no_email.text" = "Sem na Wire. Obišči https://get.wire.com za povezavo z mano.";
+"send_invitation.text" = "Sem na Wire, poišči %@ ali obišči get.wire.com.";
+"send_invitation_no_email.text" = "Sem na Wire. Obišči get.wire.com za povezavo z mano.";
 
-"send_personal_invitation.text" = "Sem na Wire, se slišiva tam. https://get.wire.com";
+"send_personal_invitation.text" = "Sem na Wire, se slišiva tam: get.wire.com.";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++x
@@ -215,7 +215,7 @@
 "content.system.you_started" = "Ti";
 "content.system.this_device" = "ta naprava";
 
-"content.system.reactivated_device" = "Spet ste začeli z uporabo %@. Sporočila poslana medtem ne bodo prikazana tukaj";
+"content.system.reactivated_device" = "Spet ste začeli z uporabo %@. Sporočila poslana medtem ne bodo prikazana tukaj.";
 
 "content.system.new_device" = "nova naprava";
 "content.system.started_using" = "začel(-a) uporabljati";
@@ -256,7 +256,7 @@
 "content.message.like" = "Všeč mi je";
 "content.message.unlike" = "Ni mi všeč";
 "content.message.forward" = "Posreduj";
-"content.message.go_to_conversation" = "Pokaži v pogovoru";
+"content.message.go_to_conversation" = "Razkrij";
 "content.message.forward.to" = "Pošlji...";
 
 "content.reactions_list.likers" = "Všečkali so";
@@ -781,5 +781,5 @@
 "collections.section.files.title" = "Zbirke";
 "collections.section.videos.title" = "Video posnetki";
 "collections.section.links.title" = "Povezave";
-"collections.section.all.button" = "Vse %d →";
-"collections.section.no_items" = "Ni predmetov v knjižnici";
+"collections.section.all.button" = "Prikaži vse %d →";
+"collections.section.no_items" = "Ni predmetov v zbirki";

--- a/Wire-iOS/Resources/tr.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/tr.lproj/Localizable.strings
@@ -97,10 +97,10 @@
 "peoplepicker.hide_search_result_progress" = "Gizleniyor…";
 
 "send_invitation.subject" = "Wire'da bana bağlan";
-"send_invitation.text" = "Wire'dayım, %@ olarak arat ya da wire.com/download bu adresi ziyaret et.";
-"send_invitation_no_email.text" = "Wire'dayım. %@ olarak ara ya da bana bağlanmak için https://get.wire.com adresini ziyaret et.";
+"send_invitation.text" = "Wire'dayım, %@ olarak arat ya da get.wire.com adresini ziyaret et.";
+"send_invitation_no_email.text" = "Wire'dayım. get.wire.com 'u ziyaret ederek bana bağlanabilirsin.";
 
-"send_personal_invitation.text" = "Wire kullanıyorum, buradan görüşelim: https://get.wire.com";
+"send_personal_invitation.text" = "Wire kullanıyorum, buradan görüşelim: get.wire.com.";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++x
@@ -215,7 +215,7 @@
 "content.system.you_started" = "Sen";
 "content.system.this_device" = "bu cihaz";
 
-"content.system.reactivated_device" = "Tekrar %@ kullanmaya başladın. Bu sırada gönderilmiş mesajlar burada gözükmeyecek";
+"content.system.reactivated_device" = "Tekrar %@ kullanmaya başladın. Bu sırada gönderilmiş mesajlar burada gözükmeyecek.";
 
 "content.system.new_device" = "yeni bir cihaz";
 "content.system.started_using" = "kullanmaya başladı";
@@ -256,7 +256,7 @@
 "content.message.like" = "Beğen";
 "content.message.unlike" = "Beğenme";
 "content.message.forward" = "İlet";
-"content.message.go_to_conversation" = "Show in conversation";
+"content.message.go_to_conversation" = "Göster";
 "content.message.forward.to" = "Şuraya gönder...";
 
 "content.reactions_list.likers" = "Beğenen";
@@ -781,5 +781,5 @@
 "collections.section.files.title" = "Dosyalar";
 "collections.section.videos.title" = "Videolar";
 "collections.section.links.title" = "Bağlantılar";
-"collections.section.all.button" = "Hepsi %d →";
-"collections.section.no_items" = "Kütüphanede hiç içerk yok";
+"collections.section.all.button" = "Tüm %dleri göster →";
+"collections.section.no_items" = "Koleksiyonda hiçbir şey yok";

--- a/Wire-iOS/Resources/uk.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/uk.lproj/Localizable.strings
@@ -97,10 +97,10 @@
 "peoplepicker.hide_search_result_progress" = "Приховування…";
 
 "send_invitation.subject" = "Додай мене в Wire";
-"send_invitation.text" = "Я в Wire, шукайте %@ або відвідайте wire.com/download.";
-"send_invitation_no_email.text" = "Я уже в Wire. Відвідайте https://get.wire.com, щоб додати мене.";
+"send_invitation.text" = "Я в Wire. Шукайте мене як %@ або відвідайте get.wire.com.";
+"send_invitation_no_email.text" = "Я уже в Wire. Відвідайте get.wire.com, щоб додати мене.";
 
-"send_personal_invitation.text" = "Я уже в Wire, порозмовляємо там. https://get.wire.com";
+"send_personal_invitation.text" = "Я уже в Wire, порозмовляємо там: get.wire.com.";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++x
@@ -215,7 +215,7 @@
 "content.system.you_started" = "Ви";
 "content.system.this_device" = "цей пристрій";
 
-"content.system.reactivated_device" = "Ви почали використовувати %@ знову. Повідомлення, надіслані поки ви не користувалися ним, не з'являться тут";
+"content.system.reactivated_device" = "Ви почали використовувати %@ знову. Повідомлення, надіслані поки ви не користувалися ним, не з'являться тут.";
 
 "content.system.new_device" = "новий пристрій";
 "content.system.started_using" = "почали використовувати";
@@ -256,7 +256,7 @@
 "content.message.like" = "Подобається";
 "content.message.unlike" = "Не подобається";
 "content.message.forward" = "Переслати";
-"content.message.go_to_conversation" = "Show in conversation";
+"content.message.go_to_conversation" = "Показати в розмові";
 "content.message.forward.to" = "Переслати в...";
 
 "content.reactions_list.likers" = "Сподобалося";
@@ -781,5 +781,5 @@
 "collections.section.files.title" = "Файли";
 "collections.section.videos.title" = "Відео";
 "collections.section.links.title" = "Посилання";
-"collections.section.all.button" = "Всі %d →";
-"collections.section.no_items" = "В бібліотеці відсутні елементи";
+"collections.section.all.button" = "Show all %d →";
+"collections.section.no_items" = "Колекція порожня";

--- a/Wire-iOS/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/zh-Hans.lproj/Localizable.strings
@@ -97,10 +97,10 @@
 "peoplepicker.hide_search_result_progress" = "躲藏......";
 
 "send_invitation.subject" = "和我Wire上成为好友吧";
-"send_invitation.text" = "我在Wire, 搜索 %@ 或访问 wire.com/download.";
-"send_invitation_no_email.text" = "我在Wire上。访问 https://get.wire.com 与我联系。";
+"send_invitation.text" = "我在使用Wire，搜索%@或者访问get.wire.com 。";
+"send_invitation_no_email.text" = "我在使用Wire。访问 get.wire.com 来添加我为好友。";
 
-"send_personal_invitation.text" = "我在使用Wire和你交谈。https://get.wire.com";
+"send_personal_invitation.text" = "我在使用Wire，让我们在这里聊天吧： get.wire.com.";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++x
@@ -215,7 +215,7 @@
 "content.system.you_started" = "你";
 "content.system.this_device" = "此设备";
 
-"content.system.reactivated_device" = "你开始再次使用 %@。在此期间的发送的信息不会出现在这里";
+"content.system.reactivated_device" = "您再次开始使用%@。在此期间发送的信息将不会在这里显示。";
 
 "content.system.new_device" = "一个新设备";
 "content.system.started_using" = "开始使用";
@@ -256,7 +256,7 @@
 "content.message.like" = "赞";
 "content.message.unlike" = "取消赞";
 "content.message.forward" = "转发";
-"content.message.go_to_conversation" = "在对话中显示";
+"content.message.go_to_conversation" = "显示";
 "content.message.forward.to" = "发送给...";
 
 "content.reactions_list.likers" = "被赞";
@@ -781,5 +781,5 @@
 "collections.section.files.title" = "文件";
 "collections.section.videos.title" = "视频";
 "collections.section.links.title" = "链接";
-"collections.section.all.button" = "所有 →";
-"collections.section.no_items" = "没有任何条目";
+"collections.section.all.button" = "显示全部 %d →";
+"collections.section.no_items" = "在资源库中什么都没有";


### PR DESCRIPTION
What's in this PR:

- Added localisation files and strings for share extension:.
- Added localisation for collection.
- Removed protocol from invite links.
- Other updated strings from Crowdin. Some of them fall back to English because base string changed and there's no updated translation yet.

