### PR TITLE
Added dispatch group to image cache

### DIFF
--- a/Wire-iOS Tests/ImageCacheTests.swift
+++ b/Wire-iOS Tests/ImageCacheTests.swift
@@ -1,0 +1,162 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import XCTest
+@testable import Wire
+
+
+class ImageCacheTests: XCTestCase {
+    var sut = ImageCache(name: "TestImageCache")
+    var imageData = try! Data(contentsOf: Bundle(for: ImageCacheTests.self).url(forResource: "unsplash_matterhorn", withExtension: "jpg")!)
+    
+    func testThatItLeavesGroupWhenProcessingOneImage() {
+        // GIVEN
+        var imagesProcessed = 0
+        let groupNotifyExpectation = self.expectation(description: "Group done")
+        
+        self.sut.image(for: imageData, cacheKey: "key", creationBlock: {
+            return UIImage(data: $0)! as Any
+        }) { _ in
+            imagesProcessed = imagesProcessed + 1
+        }
+        
+        // WHEN
+        self.sut.processingGroup.notify(qos: DispatchQoS.default, flags: [], queue: .main) {
+            groupNotifyExpectation.fulfill()
+        }
+        
+        // THEN
+        self.waitForExpectations(timeout: 5) {
+            XCTAssertNil($0)
+        }
+        XCTAssertEqual(imagesProcessed, 1)
+    }
+    
+    func testThatItLeavesGroupWhenProcessingManyImages() {
+        // GIVEN
+        let imagesToProcess = 5
+        var imagesProcessed = 0
+        let groupNotifyExpectation = self.expectation(description: "Group done")
+        
+        for index in 1...imagesToProcess {
+            self.sut.image(for: imageData, cacheKey: "key\(index)", creationBlock: {
+                return UIImage(data: $0)! as Any
+            }) { _ in
+                imagesProcessed = imagesProcessed + 1
+            }
+        }
+        
+        // WHEN
+        self.sut.processingGroup.notify(qos: DispatchQoS.default, flags: [], queue: .main) {
+            groupNotifyExpectation.fulfill()
+        }
+        
+        // THEN
+        self.waitForExpectations(timeout: 5) {
+            XCTAssertNil($0)
+        }
+        XCTAssertEqual(imagesProcessed, imagesToProcess)
+    }
+    
+    func testThatItLeavesGroupAfterLeavingItOnce() {
+        // GIVEN
+        var imagesProcessed = 0
+        let groupNotifyExpectation = self.expectation(description: "Group done once")
+        
+        self.sut.image(for: imageData, cacheKey: "key1", creationBlock: {
+            return UIImage(data: $0)! as Any
+        }) { _ in
+            imagesProcessed = imagesProcessed + 1
+        }
+        
+        // WHEN
+        self.sut.processingGroup.notify(qos: DispatchQoS.default, flags: [], queue: .main) {
+            groupNotifyExpectation.fulfill()
+        }
+        
+        // THEN
+        self.waitForExpectations(timeout: 5) {
+            XCTAssertNil($0)
+        }
+        XCTAssertEqual(imagesProcessed, 1)
+        
+        // AND WHEN
+        self.sut.image(for: imageData, cacheKey: "key2", creationBlock: {
+            return UIImage(data: $0)! as Any
+        }) { _ in
+            imagesProcessed = imagesProcessed + 1
+        }
+        
+        let secondGroupNotifyExpectation = self.expectation(description: "Group done twice")
+        
+        self.sut.processingGroup.notify(qos: DispatchQoS.default, flags: [], queue: .main) {
+            secondGroupNotifyExpectation.fulfill()
+        }
+        
+        // THEN
+        self.waitForExpectations(timeout: 5) {
+            XCTAssertNil($0)
+        }
+        XCTAssertEqual(imagesProcessed, 2)
+    }
+    
+    func testThatItLeavesGroupWhenTwoCallbacksForOneTask() {
+        // GIVEN
+        var imagesProcessedCallbacks = 0
+        let groupNotifyExpectation = self.expectation(description: "Group done")
+        
+        self.sut.image(for: imageData, cacheKey: "key", creationBlock: {
+            return UIImage(data: $0)! as Any
+        }) { _ in
+            imagesProcessedCallbacks = imagesProcessedCallbacks + 1
+        }
+        
+        self.sut.image(for: imageData, cacheKey: "key", creationBlock: {
+            return UIImage(data: $0)! as Any
+        }) { _ in
+            imagesProcessedCallbacks = imagesProcessedCallbacks + 1
+        }
+        
+        // WHEN
+        self.sut.processingGroup.notify(qos: DispatchQoS.default, flags: [], queue: .main) {
+            groupNotifyExpectation.fulfill()
+        }
+        
+        // THEN
+        self.waitForExpectations(timeout: 5) {
+            XCTAssertNil($0)
+        }
+        XCTAssertEqual(imagesProcessedCallbacks, 2)
+    }
+    
+    func testThatItLeavesGroupWhenNoImagesProcessed() {
+        // GIVEN
+        let groupNotifyExpectation = self.expectation(description: "Group done")
+        
+        // WHEN
+        self.sut.processingGroup.notify(qos: DispatchQoS.default, flags: [], queue: .main) {
+            groupNotifyExpectation.fulfill()
+        }
+        
+        // THEN
+        self.waitForExpectations(timeout: 5) {
+            XCTAssertNil($0)
+        }
+    }
+}

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -215,6 +215,7 @@
 		870815881BF4EAD100D321BC /* SettingsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870815871BF4EAD100D321BC /* SettingsTableViewController.swift */; };
 		8708158A1BF4EADE00D321BC /* SettingsNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870815891BF4EADE00D321BC /* SettingsNavigationController.swift */; };
 		8708B8331DDDFF0D00310A53 /* UserConnectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8708B8321DDDFF0D00310A53 /* UserConnectionView.swift */; };
+		870916DC1E2CFFC500D10FA3 /* ImageCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870916DA1E2CFFC100D10FA3 /* ImageCacheTests.swift */; };
 		870A8C6B1CF719C400874B16 /* RecordingDotView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870A8C6A1CF719C400874B16 /* RecordingDotView.swift */; };
 		870C97C31D670C9A00F6FD7D /* NextResponderTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = 870C97C21D670C9A00F6FD7D /* NextResponderTextView.m */; };
 		870DC1EB1C92F5CC005C1DB9 /* AVSLogObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 870DC1EA1C92F5CC005C1DB9 /* AVSLogObserver.m */; };
@@ -1205,6 +1206,7 @@
 		870815871BF4EAD100D321BC /* SettingsTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsTableViewController.swift; sourceTree = "<group>"; };
 		870815891BF4EADE00D321BC /* SettingsNavigationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsNavigationController.swift; sourceTree = "<group>"; };
 		8708B8321DDDFF0D00310A53 /* UserConnectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserConnectionView.swift; sourceTree = "<group>"; };
+		870916DA1E2CFFC100D10FA3 /* ImageCacheTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCacheTests.swift; sourceTree = "<group>"; };
 		870A8C6A1CF719C400874B16 /* RecordingDotView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecordingDotView.swift; sourceTree = "<group>"; };
 		870C97C21D670C9A00F6FD7D /* NextResponderTextView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NextResponderTextView.m; sourceTree = "<group>"; };
 		870C97C41D670CA700F6FD7D /* NextResponderTextView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NextResponderTextView.h; sourceTree = "<group>"; };
@@ -4659,6 +4661,7 @@
 				87CA886F1DE30AD0004101B6 /* UserConnectionViewTests.swift */,
 				BF7ED2DB1DF1D1CF003A4397 /* IncomingConnectionViewTests.swift */,
 				874941CC1DE458DF006CF32B /* CombinationTest.swift */,
+				870916DA1E2CFFC100D10FA3 /* ImageCacheTests.swift */,
 			);
 			path = "Wire-iOS Tests";
 			sourceTree = "<group>";
@@ -6050,6 +6053,7 @@
 				BF808B591DE72B7100718076 /* UserNameTakeOverViewControllerTests.swift in Sources */,
 				BFBAE9E31E041FB7003FCE49 /* ReactionsCellTests.swift in Sources */,
 				8787BDD91BF374420096B1B5 /* SettingsPropertyTests.swift in Sources */,
+				870916DC1E2CFFC500D10FA3 /* ImageCacheTests.swift in Sources */,
 				874941CD1DE458DF006CF32B /* CombinationTest.swift in Sources */,
 				1E8772231B0C8B0F005BDDC6 /* EmoticonSubstitutionConfigurationMocks.m in Sources */,
 				1651F9BC1D352C5700A9FAE8 /* ArticleViewTests.swift in Sources */,

--- a/Wire-iOS/Sources/Components/ImageCache.h
+++ b/Wire-iOS/Sources/Components/ImageCache.h
@@ -23,10 +23,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ImageCache : NSObject
 
-@property (nonatomic, assign) NSUInteger countLimit;
-@property (nonatomic, assign) NSUInteger totalCostLimit;
-@property (nonatomic, assign) NSInteger maxConcurrentOperationCount;
-@property (nonatomic, assign) NSQualityOfService qualityOfService;
+@property (nonatomic) NSUInteger countLimit;
+@property (nonatomic) NSUInteger totalCostLimit;
+@property (nonatomic) NSInteger maxConcurrentOperationCount;
+@property (nonatomic) NSQualityOfService qualityOfService;
+@property (nonatomic, readonly) dispatch_group_t processingGroup;
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithName:(nullable NSString *)name NS_DESIGNATED_INITIALIZER;

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionImageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionImageCell.swift
@@ -23,7 +23,7 @@ import CocoaLumberjackSwift
 import WireExtensionComponents
 
 final public class CollectionImageCell: CollectionCell {
-    static var imageCache: ImageCache {
+    public static var imageCache: ImageCache {
         let cache = ImageCache(name: "CollectionImageCell.imageCache")
         cache.maxConcurrentOperationCount = 4
         cache.totalCostLimit = UInt(1024 * 1024 * 20) // 20 MB


### PR DESCRIPTION
- Possible to observe the end of images loading.
- Useful for writing async UI tests when waiting for the image cache to finish the processing.