### PR TITLE
Fix crash when sending a file from iCloud

### DIFF
--- a/Wire-iOS Share Extension/ShareViewController.swift
+++ b/Wire-iOS Share Extension/ShareViewController.swift
@@ -361,9 +361,9 @@ extension ShareViewController {
     
     /// Process data to the right format to be sent
     private func prepareForSending(data: Data, UTIString UTI: String, name: String?, completionHandler: @escaping (URL?, Error?) -> Void) {
-        let fileExtension = UTTypeCopyPreferredTagWithClass(UTI as CFString, kUTTagClassFilenameExtension as CFString)?.takeRetainedValue() as! String
-
-        let fileName = name ?? "\(UUID().uuidString).\(fileExtension)"
+        guard let fileName = nameForFile(withUTI: UTI, name: name) else {
+            return completionHandler(nil, nil)
+        }
         
         let tempDirectory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true).appendingPathComponent(UUID().uuidString) // temp subdir
         if !FileManager.default.fileExists(atPath: tempDirectory.absoluteString) {
@@ -389,6 +389,13 @@ extension ShareViewController {
         } else {
             completionHandler(tempFileURL, nil)
         }
+    }
+
+    private func nameForFile(withUTI UTI: String, name: String?) -> String? {
+        if let fileExtension = UTTypeCopyPreferredTagWithClass(UTI as CFString, kUTTagClassFilenameExtension)?.takeRetainedValue() as? String {
+            return "\(UUID().uuidString).\(fileExtension)"
+        }
+        return name
     }
 }
 


### PR DESCRIPTION
# What's in this PR?

* There was a crash caused by force unwrapping an Optional, as the UTI does not provide information about the file extension in the case of `public.file-url`.