### PR TITLE
Recreate sharing session on each share extension launch

### DIFF
--- a/Wire-iOS Share Extension/SendableBatchObserver.swift
+++ b/Wire-iOS Share Extension/SendableBatchObserver.swift
@@ -37,6 +37,8 @@ public final class SendableBatchObserver: SendableObserver {
         observers.forEach { (sendable, token) in
             sendable.remove(token)
         }
+
+        observers = []
     }
 
     public var allSendablesSent: Bool {


### PR DESCRIPTION
# What's in this PR?

* Fix memory leaks.
* Reload `SharingSession` on each share extension start to ensure the conversation list is up to date (otherwise we would need to store and merge the change notifications from the main app into the extension which would be a lot).

#### This PR depends on:
- [ ] A new release of `wire-ios-share-engine` after https://github.com/wireapp/wire-ios-share-engine/pull/12 has been merged.