### PR TITLE
Fixed rotation layout issues

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionHeaderView.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionHeaderView.swift
@@ -95,6 +95,23 @@ import Cartography
         }
     }
     
+    public var desiredWidth: CGFloat = 0
+    public var desiredHeight: CGFloat = 0
+    
+    override open var intrinsicContentSize: CGSize {
+        get {
+            return CGSize(width: self.desiredWidth, height: self.desiredHeight)
+        }
+    }
+    
+    override open func preferredLayoutAttributesFitting(_ layoutAttributes: UICollectionViewLayoutAttributes) -> UICollectionViewLayoutAttributes {
+        var newFrame = layoutAttributes.frame
+        newFrame.size.width = intrinsicContentSize.width
+        newFrame.size.height = intrinsicContentSize.height
+        layoutAttributes.frame = newFrame
+        return layoutAttributes
+    }
+    
     public func didSelect(_ button: UIButton!) {
         self.selectionAction?(self.section)
     }

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionViewLeftAlignedFlowLayout.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionViewLeftAlignedFlowLayout.swift
@@ -21,6 +21,10 @@ import Foundation
 
 // NB: This class assumes that the elements in one section are of the same size.
 final class CollectionViewLeftAlignedFlowLayout: UICollectionViewFlowLayout {
+    override func shouldInvalidateLayout(forBoundsChange newBounds: CGRect) -> Bool {
+        return newBounds.width != self.collectionView?.bounds.size.width
+    }
+    
     override func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
         guard let oldAttributes: [UICollectionViewLayoutAttributes] = super.layoutAttributesForElements(in: rect) else {
             return .none

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionsView.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionsView.swift
@@ -21,8 +21,8 @@ import Foundation
 import Cartography
 
 @objc public final class CollectionsView: UIView {
-    let collectionViewLayout = CollectionViewLeftAlignedFlowLayout()
-    var collectionView: UICollectionView
+    var collectionViewLayout: CollectionViewLeftAlignedFlowLayout!
+    var collectionView: UICollectionView!
     let noItemsLabel = UILabel()
     let noItemsIcon = UIImageView()
     
@@ -34,16 +34,11 @@ import Cartography
     }
     
     override init(frame: CGRect) {
-        self.collectionView = UICollectionView(frame: CGRect.zero, collectionViewLayout: collectionViewLayout)
-
         super.init(frame: frame)
         
-        self.collectionViewLayout.scrollDirection = .vertical
-        self.collectionViewLayout.minimumLineSpacing = 1
-        self.collectionViewLayout.minimumInteritemSpacing = 1
-        self.collectionViewLayout.sectionInset = UIEdgeInsets(top: 24, left: 16, bottom: 8, right: 16)
-        self.collectionViewLayout.estimatedItemSize = CGSize(width: 64, height: 64)
-        self.collectionViewLayout.headerReferenceSize = CGSize(width: 100, height: 32)
+        self.recreateLayout()
+        self.collectionView = UICollectionView(frame: CGRect.zero, collectionViewLayout: self.collectionViewLayout)
+
         self.collectionView.register(CollectionImageCell.self, forCellWithReuseIdentifier: CollectionImageCell.reuseIdentifier)
         self.collectionView.register(CollectionFileCell.self, forCellWithReuseIdentifier: CollectionFileCell.reuseIdentifier)
         self.collectionView.register(CollectionAudioCell.self, forCellWithReuseIdentifier: CollectionAudioCell.reuseIdentifier)
@@ -75,6 +70,17 @@ import Cartography
         self.noItemsLabel.textColor = placeholderColor
         
         self.constrainViews()
+    }
+    
+    private func recreateLayout() {
+        let layout = CollectionViewLeftAlignedFlowLayout()
+        layout.scrollDirection = .vertical
+        layout.minimumLineSpacing = 1
+        layout.minimumInteritemSpacing = 1
+        layout.sectionInset = UIEdgeInsets(top: 0, left: 16, bottom: 8, right: 16)
+        layout.estimatedItemSize = CGSize(width: 64, height: 64)
+        
+        self.collectionViewLayout = layout
     }
     
     public required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
# Problems fixed

- Incorrect initial layout (1)
- Crash on rotation on iPad (2)
- Crash on rotation in detail (picture) view and going back

# Cause of the problem

The issue (1) is related to the fact that we are using the custom transition that lays out the view several times. The layout gets confused for some reason with the section headers (other items are laid out correctly). Before we used to invalidate the collection layout on every layout change, which seem to cause the infinite layout loop on automation.

Second issue is caused by the fact that we have different count of cells in images section in portrait and landscape. Asking the collection view to reload data does not help (it seems to cache the number of cells in the section for some reason). What helps is to reload the sections. Unfortunately this can only happen with the animation, which can be suppressed with `UIView.performWithoutAnimation(_:)`.

Additionally I switched to autolayout the section headers.