### PR TITLE
Dismiss overlay when split view changes controller

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.m
@@ -435,6 +435,8 @@ NSString *SplitLayoutObservableDidChangeToLayoutSizeNotification = @"SplitLayout
         return;
     }
     
+    [self.rightViewController dismissViewControllerAnimated:NO completion:nil];
+    
     UIViewController *removedViewController = self.rightViewController;
     
     BOOL transitionDidStart =

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
@@ -242,7 +242,7 @@
 {
     [self.conversationListViewController selectConversation:conversation
                                                 focusOnView:NO
-                                                animated:NO];
+                                                   animated:NO];
 }
 
 - (void)selectConversation:(ZMConversation *)conversation focusOnView:(BOOL)focus animated:(BOOL)animated


### PR DESCRIPTION
When the collection view is open and user selects other conversation with push we would like to close collection together with the old conversation view. This applies more generally to all cases when we change right controller in split view container.