### PR TITLE
Hide collections button for versions below iOS 8.3

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
@@ -83,6 +83,8 @@ public extension ConversationViewController {
     }
     
     private func shouldShowCollectionsButton() -> Bool {
+        guard #available(iOS 8.3, *) else { return false }
+
         switch self.conversation.conversationType {
         case .group:
             return true


### PR DESCRIPTION
# What's in this PR?

* Disable collections for devices with a OS version below 8.3