### PR TITLE
Append file messages on the correct queue when forwarding

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
@@ -50,11 +50,12 @@ func forward(_ message: ZMMessage, to: [AnyObject]) {
         }
     }
     else if Message.isVideoMessage(message) || Message.isAudioMessage(message) || Message.isFileTransferMessage(message) {
-        ZMUserSession.shared()?.performChanges {
             FileMetaDataGenerator.metadataForFileAtURL(message.fileMessageData!.fileURL, UTI: message.fileMessageData!.fileURL.UTI(), name: message.fileMessageData!.fileURL.lastPathComponent) { fileMetadata in
-                forEachNonEphemeral(in: conversations) { _ = $0.appendMessage(with: fileMetadata) }
+
+                ZMUserSession.shared()?.performChanges {
+                        forEachNonEphemeral(in: conversations) { _ = $0.appendMessage(with: fileMetadata) }
+                    }
             }
-        }
     }
     else if Message.isLocationMessage(message) {
         let locationData = LocationData.locationData(withLatitude: message.locationMessageData!.latitude, longitude: message.locationMessageData!.longitude, name: message.locationMessageData!.name, zoomLevel: message.locationMessageData!.zoomLevel)


### PR DESCRIPTION
# What's in this PR?

* We were dispatching to a different thread inside of a `ZMUserSession.performChanges`, which lead to the message being appended on the wrong queue.