### PR TITLE
Conversation views optimisation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/AudioMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/AudioMessageCell.swift
@@ -47,7 +47,7 @@ public final class AudioMessageCell: ConversationCell {
         var currentElements: [Any] = self.accessibilityElements ?? []
         let contentViewAccessibilityElements: [Any] = self.audioMessageView.accessibilityElements ?? []
         currentElements.append(contentsOf: contentViewAccessibilityElements)
-        currentElements.append(contentsOf: [likeButton, messageToolboxView])
+        currentElements.append(contentsOf: [likeButton, toolboxView])
         self.accessibilityElements = currentElements
         
         setNeedsLayout()

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.h
@@ -80,7 +80,7 @@ typedef void (^SelectedMenuBlock)(BOOL selected, BOOL animated);
 @property (nonatomic, readonly) UILabel *authorLabel;
 @property (nonatomic, readonly) UIView *messageContentView;
 @property (nonatomic) LikeButton *likeButton;
-@property (nonatomic, readonly) MessageToolboxView *messageToolboxView;
+@property (nonatomic, readonly) MessageToolboxView *toolboxView;
 @property (nonatomic, readonly) UIView *countdownContainerView;
 @property (nonatomic, strong, readonly) UIView *selectionView;
 @property (nonatomic, readonly) CGRect selectionRect;

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransferCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransferCell.swift
@@ -48,7 +48,7 @@ public final class FileTransferCell: ConversationCell {
         var currentElements: [Any] = self.accessibilityElements ?? []
         let contentViewAccessibilityElements: [Any] = self.fileTransferView.accessibilityElements ?? []
         currentElements.append(contentsOf: contentViewAccessibilityElements)
-        currentElements.append(contentsOf: [likeButton, messageToolboxView])
+        currentElements.append(contentsOf: [likeButton, toolboxView])
         self.accessibilityElements = currentElements
     }
     

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/TextMessageCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/TextMessageCell.m
@@ -69,7 +69,9 @@
 {
     if (self = [super initWithStyle:style reuseIdentifier:reuseIdentifier]) {        
         [self createTextMessageViews];
-        [self createConstraints];
+        [NSLayoutConstraint autoCreateAndInstallConstraints:^{
+            [self createConstraints];
+        }];
     }
     
     return self;

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
@@ -76,21 +76,13 @@ extension ZMConversationMessage {
     fileprivate(set) weak var message: ZMConversationMessage?
     
     fileprivate var forceShowTimestamp: Bool = false
+    private var isConfigured: Bool = false
     
     override init(frame: CGRect) {
         
         super.init(frame: frame)
         self.isAccessibilityElement = true
         self.accessibilityElementsHidden = false
-        
-        CASStyler.default().styleItem(self)
-        
-        setupViews()
-        createConstraints()
-        
-        tapGestureRecogniser = UITapGestureRecognizer(target: self, action: #selector(MessageToolboxView.onTapContent(_:)))
-        tapGestureRecogniser.delegate = self
-        addGestureRecognizer(tapGestureRecogniser)
     }
     
     private func setupViews() {
@@ -147,6 +139,18 @@ extension ZMConversationMessage {
     }
     
     open func configureForMessage(_ message: ZMConversationMessage, forceShowTimestamp: Bool, animated: Bool = false) {
+        if !self.isConfigured {
+            self.isConfigured = true
+            CASStyler.default().styleItem(self)
+            
+            setupViews()
+            createConstraints()
+            
+            tapGestureRecogniser = UITapGestureRecognizer(target: self, action: #selector(MessageToolboxView.onTapContent(_:)))
+            tapGestureRecogniser.delegate = self
+            addGestureRecognizer(tapGestureRecogniser)
+        }
+        
         self.forceShowTimestamp = forceShowTimestamp
         self.message = message
         

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/VideoMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/VideoMessageCell.swift
@@ -44,7 +44,7 @@ public final class VideoMessageCell: ConversationCell {
         var currentElements: [Any] = self.accessibilityElements ?? []
         let contentViewAccessibilityElements: [Any] = self.videoMessageView.accessibilityElements ?? []
         currentElements.append(contentsOf: contentViewAccessibilityElements)
-        currentElements.append(contentsOf: [likeButton, messageToolboxView])
+        currentElements.append(contentsOf: [likeButton, toolboxView])
         self.accessibilityElements = currentElements
 
         setNeedsLayout()

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
@@ -136,7 +136,7 @@ extension ZMMessage: Shareable {
             contentView.edges == cell.edges
         }
 
-        cell.messageToolboxView.isHidden = true
+        cell.toolboxView.isHidden = true
         cell.likeButton.isHidden = true
         cell.isUserInteractionEnabled = false
         cell.setSelected(false, animated: false)


### PR DESCRIPTION
# Optimisations

Apart from renaming messageToolboxView to toolboxView :)

- `MessageToolboxView` content is lazy-loaded, so no unnecessary layout and views loading is performed for every cell
- Countdown view is also lazy-loaded for cells where it is actually needed
- PureLayout constraints are bulk installed. It comes out that it installs every constraint separately and every new constraint installation is making a performance hit.