### PR TITLE
Fix for logical bug in countdown rendering

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
@@ -438,14 +438,16 @@ const NSTimeInterval ConversationCellSelectionAnimationDuration = 0.33;
     
     _countdownContainerViewHidden = countdownContainerViewHidden;
     
-    if (nil == self.countdownView && !countdownContainerViewHidden) {
-        self.countdownView = [[DestructionCountdownView alloc] init];
-        [self.countdownContainerView addSubview:self.countdownView];
-        [self.countdownView autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsMake(2, 2, 2, 2)];
-        self.countdownContainerView.layer.cornerRadius = CGRectGetWidth(self.countdownContainerView.bounds) / 2;
+    if (nil == self.countdownView) {
+        if (!countdownContainerViewHidden) {
+            self.countdownView = [[DestructionCountdownView alloc] init];
+            [self.countdownContainerView addSubview:self.countdownView];
+            [self.countdownView autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsMake(2, 2, 2, 2)];
+            self.countdownContainerView.layer.cornerRadius = CGRectGetWidth(self.countdownContainerView.bounds) / 2;
+        }
     }
-    else if (nil != self.countdownView && countdownContainerViewHidden) {
-        self.countdownContainerView.hidden = YES;
+    else if (self.countdownView) {
+        self.countdownContainerView.hidden = countdownContainerViewHidden;
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
@@ -446,7 +446,7 @@ const NSTimeInterval ConversationCellSelectionAnimationDuration = 0.33;
             self.countdownContainerView.layer.cornerRadius = CGRectGetWidth(self.countdownContainerView.bounds) / 2;
         }
     }
-    else if (self.countdownView) {
+    else {
         self.countdownContainerView.hidden = countdownContainerViewHidden;
     }
 }


### PR DESCRIPTION
Issue happened when

- The counter was loaded once
- The cell gets reused for the new ephemeral message (which is a frequent case)
- Cell does not show the indicator