### PR TITLE
Make fingerprint copyable in fingerprint cell

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/FingerprintTableViewCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/FingerprintTableViewCell.swift
@@ -22,9 +22,9 @@ import Cartography
 import Classy
 
 class FingerprintTableViewCell: UITableViewCell {
-    let titleLabel: UILabel
-    let fingerprintLabel: UILabel
-    let spinner: UIActivityIndicatorView
+    let titleLabel = UILabel()
+    let fingerprintLabel = CopyableLabel()
+    let spinner = UIActivityIndicatorView(activityIndicatorStyle: .gray)
     
     var fingerprintLabelFont: UIFont? {
         didSet {
@@ -44,15 +44,8 @@ class FingerprintTableViewCell: UITableViewCell {
     }
     
     override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
-        self.titleLabel = UILabel(frame: CGRect.zero)
-        self.titleLabel.translatesAutoresizingMaskIntoConstraints = false
         self.titleLabel.text = NSLocalizedString("self.settings.account_details.key_fingerprint.title", comment: "")
-        self.fingerprintLabel = UILabel(frame: CGRect.zero)
-        self.fingerprintLabel.translatesAutoresizingMaskIntoConstraints = false
         self.fingerprintLabel.numberOfLines = 0
-        
-        self.spinner = UIActivityIndicatorView(activityIndicatorStyle: .gray)
-        self.spinner.translatesAutoresizingMaskIntoConstraints = false
         self.spinner.hidesWhenStopped = true
         
         super.init(style: style, reuseIdentifier: reuseIdentifier)

--- a/Wire-iOS/Sources/UserInterface/Settings/SettingsTechnicalReportViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/SettingsTechnicalReportViewController.swift
@@ -90,7 +90,7 @@ class SettingsTechnicalReportViewController: UITableViewController, MFMailCompos
         let report = ZMVoiceChannel.voiceChannelDebugInformation()
         
         guard MFMailComposeViewController.canSendMail() else {
-            let activityViewController = UIActivityViewController(activityItems: [report], applicationActivities: nil)
+            let activityViewController = UIActivityViewController(activityItems: [report as Any], applicationActivities: nil)
             activityViewController.popoverPresentationController?.sourceView = sendReportCell.textLabel
             guard let bounds = sendReportCell.textLabel?.bounds else { return }
             activityViewController.popoverPresentationController?.sourceRect = bounds


### PR DESCRIPTION
# What's in this PR?

* d57732f Use `CopyableLabel` in `FingerprintTableViewCell` (this change was missed in https://github.com/wireapp/wire-ios/pull/623).
* 7f202ba Fix warning introduced with new Swift version.