### PR TITLE
Fixed bug with dismissing settings as the result of color selection

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.m
@@ -435,7 +435,11 @@ NSString *SplitLayoutObservableDidChangeToLayoutSizeNotification = @"SplitLayout
         return;
     }
     
-    [self.rightViewController dismissViewControllerAnimated:NO completion:nil];
+    // To determine if self.rightViewController.presentedViewController is actually presented over it, or is it
+    // presented over one of it's parents.
+    if (self.rightViewController.presentedViewController.presentingViewController == self.rightViewController) {
+        [self.rightViewController dismissViewControllerAnimated:NO completion:nil];
+    }
     
     UIViewController *removedViewController = self.rightViewController;
     

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
@@ -176,8 +176,12 @@ public extension ConversationViewController {
             UIApplication.shared.wr_updateStatusBarForCurrentControllerAnimated(true)
         })
         
-        collections.onDismiss = { _ in
-            ZClientViewController.shared().dismiss(animated: true, completion: {
+        collections.onDismiss = { [weak self] _ in
+            guard let `self` = self, let collectionController = self.collectionController else {
+                return
+            }
+
+            collectionController.dismiss(animated: true, completion: {
                 UIApplication.shared.wr_updateStatusBarForCurrentControllerAnimated(true)
             })
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
@@ -167,21 +167,25 @@ public extension ConversationViewController {
         let collections = CollectionsViewController(conversation: conversation)
         collections.delegate = self
         
+        self.collectionController = collections
+        
         let navigationController = collections.wrap(inNavigationControllerClass: RotationAwareNavigationController.self)
         navigationController.transitioningDelegate = self.conversationDetailsTransitioningDelegate
 
-        self.parent?.present(navigationController, animated: true, completion: {
+        ZClientViewController.shared().present(navigationController, animated: true, completion: {
             UIApplication.shared.wr_updateStatusBarForCurrentControllerAnimated(true)
         })
         
-        collections.onDismiss = {[weak self] _ in
-            guard let `self` = self else {
-                return
-            }
-            
-            self.parent?.dismiss(animated: true, completion: { 
+        collections.onDismiss = { _ in
+            ZClientViewController.shared().dismiss(animated: true, completion: {
                 UIApplication.shared.wr_updateStatusBarForCurrentControllerAnimated(true)
             })
+        }
+    }
+    
+    internal func dismissCollectionIfNecessary() {
+        if let _ = self.collectionController {
+            ZClientViewController.shared().dismiss(animated: false)
         }
     }
 }
@@ -190,7 +194,7 @@ extension ConversationViewController: CollectionsViewControllerDelegate {
     public func collectionsViewController(_ viewController: CollectionsViewController, performAction action: MessageAction, onMessage message: ZMConversationMessage) {
         switch action {
         case .forward:
-            self.parent?.dismiss(animated: true) {
+            ZClientViewController.shared().dismiss(animated: true) {
                 self.contentViewController.scroll(to: message) {[weak self] cell in
                     guard let `self` = self else {
                         return
@@ -201,7 +205,7 @@ extension ConversationViewController: CollectionsViewControllerDelegate {
             
             
         case .showInConversation:
-            self.parent?.dismiss(animated: true) { [weak self] in
+            ZClientViewController.shared().dismiss(animated: true) { [weak self] in
                 guard let `self` = self else {
                     return
                 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
@@ -185,7 +185,7 @@ public extension ConversationViewController {
     
     internal func dismissCollectionIfNecessary() {
         if let _ = self.collectionController {
-            ZClientViewController.shared().dismiss(animated: false)
+            self.collectionController.dismiss(animated: false)
         }
     }
 }
@@ -194,7 +194,7 @@ extension ConversationViewController: CollectionsViewControllerDelegate {
     public func collectionsViewController(_ viewController: CollectionsViewController, performAction action: MessageAction, onMessage message: ZMConversationMessage) {
         switch action {
         case .forward:
-            ZClientViewController.shared().dismiss(animated: true) {
+            viewController.dismiss(animated: true) {
                 self.contentViewController.scroll(to: message) {[weak self] cell in
                     guard let `self` = self else {
                         return
@@ -205,7 +205,7 @@ extension ConversationViewController: CollectionsViewControllerDelegate {
             
             
         case .showInConversation:
-            ZClientViewController.shared().dismiss(animated: true) { [weak self] in
+            viewController.dismiss(animated: true) { [weak self] in
                 guard let `self` = self else {
                     return
                 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+Private.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+Private.h
@@ -24,6 +24,7 @@
 
 @class ConversationInputBarViewController;
 @class ConversationDetailsTransitioningDelegate;
+@class CollectionsViewController;
 
 @interface ConversationViewController (Private)
 
@@ -32,6 +33,7 @@
 @property (nonatomic, readonly) UIViewController *participantsController;
 @property (nonatomic, readonly) AnalyticsTracker *analyticsTracker;
 @property (nonatomic, readonly) ConversationDetailsTransitioningDelegate *conversationDetailsTransitioningDelegate;
+@property (nonatomic, weak)     CollectionsViewController *collectionController;
 
 - (void)onBackButtonPressed:(UIButton *)backButton;
 @end

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -141,6 +141,7 @@
 
 @property (nonatomic) BOOL isAppearing;
 @property (nonatomic) ConversationTitleView *titleView;
+@property (nonatomic, weak) CollectionsViewController *collectionController;
 
 @end
 
@@ -150,6 +151,8 @@
 
 - (void)dealloc
 {
+    [self dismissCollectionIfNecessary];
+    
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     [self.conversation.voiceChannel removeVoiceChannelStateObserverForToken:self.voiceChannelStateObserverToken];
 
@@ -366,11 +369,6 @@
     return YES;
 }
 
-- (void)didReceiveMemoryWarning
-{
-    [super didReceiveMemoryWarning];
-}
-
 - (void)openConversationList
 {
     BOOL leftControllerRevealed = self.parentViewController.wr_splitViewController.leftViewControllerRevealed;
@@ -399,7 +397,6 @@
         self.conversationObserverToken = [self.conversation addConversationObserver:self];
     }
 }
-
 
 - (void)setupNavigatiomItem
 {


### PR DESCRIPTION
# Issue

When user selects accent color on iPad, the whole settings controller is dismissed.

# Investigation

Recently in SplitViewController was added the code to dismiss the modal controllers over the right controller when the right controller is changed. For some reason, when anything is presented over the app the right controller also says that it is presented over it. When the accent color changes we reload the conversation controller, which triggers the dismissal of the controller that is presented over the right controller. iOS dismisses the settings, so the user is getting confused.

# Solution

I changed the conversation controller so it would keep track on it's own about the presented collection controller and dismiss it if it's being deallocated.