### PR TITLE
Cancel sending when the host application enters the background

### DIFF
--- a/Wire-iOS Share Extension/ShareViewController.swift
+++ b/Wire-iOS Share Extension/ShareViewController.swift
@@ -48,10 +48,16 @@ class ShareViewController: SLComposeServiceViewController {
     
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
+        setupObserver()
     }
     
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+        setupObserver()
+    }
+
+    private func setupObserver() {
+        NotificationCenter.default.addObserver(self, selector: #selector(extensionHostDidEnterBackground), name: .NSExtensionHostDidEnterBackground, object: nil)
     }
 
     private func setupNavigationBar() {
@@ -60,13 +66,23 @@ class ShareViewController: SLComposeServiceViewController {
         item.rightBarButtonItem?.title = "share_extension.send_button.title".localized
         item.titleView = UIImageView(image: UIImage(forLogoWith: .black, iconSize: .small))
     }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationController?.view.backgroundColor = .white
         recreateSharingSession()
     }
-    
+
+    @objc private func extensionHostDidEnterBackground() {
+        postContent?.cancel { [weak self] in
+            self?.cancel()
+        }
+    }
+
     override func presentationAnimationDidFinish() {
         guard let sharingSession = sharingSession, sharingSession.canShare else {
             return presentNotSignedInMessage()


### PR DESCRIPTION
# What's in this PR?

* It was possible to go to the home screen and open the main application while the share extension was still preparing or sending messages, which is undesired as the host app could pick up and send  messages, which are not yet marked as sent, again.
* We now subscribe to the `NSExtensionHostDidEnterBackground` notification in the `init` of the `ShareViewController`. If we receive this notification we ask the `PostContent` to cancel, which will only invoke the completion closure in case a preparing or sending operation is in progress, which is good as in any other case the share extension will not be dismissed and still be present when the user returns to the host application.