### PR TITLE
Enable data detectors in conversation content

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Views/LinkInteractionTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/LinkInteractionTextView.swift
@@ -77,4 +77,17 @@ extension LinkInteractionTextView: UITextViewDelegate {
         return false
     }
     
+    public func textView(_ textView: UITextView, shouldInteractWith textAttachment: NSTextAttachment, in characterRange: NSRange) -> Bool {
+        return true
+    }
+    
+    @available(iOS 10.0, *)
+    public func textView(_ textView: UITextView, shouldInteractWith textAttachment: NSTextAttachment, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
+        return true
+    }
+    
+    @available(iOS 10.0, *)
+    public func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
+        return true
+    }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/TextMessageCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/TextMessageCell.m
@@ -96,7 +96,6 @@
     [self.messageContentView addSubview:self.messageTextView];
 
     ColorScheme *scheme = ColorScheme.defaultColorScheme;
-    self.messageTextView.dataDetectorTypes = UIDataDetectorTypeNone;
     self.messageTextView.editable = NO;
     self.messageTextView.selectable = YES;
     self.messageTextView.backgroundColor = [scheme colorWithName:ColorSchemeColorBackground];
@@ -106,6 +105,7 @@
     self.messageTextView.userInteractionEnabled = YES;
     self.messageTextView.accessibilityIdentifier = @"Message";
     self.messageTextView.accessibilityElementsHidden = NO;
+    self.messageTextView.dataDetectorTypes = UIDataDetectorTypeAll;
 
     self.linkAttachmentContainer = [[UIView alloc] init];
     self.linkAttachmentContainer.translatesAutoresizingMaskIntoConstraints = NO;
@@ -423,7 +423,6 @@
 {
     [self showMenu];
 }
-
 
 @end
 


### PR DESCRIPTION
# Feature

iOS allows the automatic detection of many data types in the text:
```
    UIDataDetectorTypePhoneNumber                                        = 1 << 0, // Phone number detection
    UIDataDetectorTypeLink                                               = 1 << 1, // URL detection
    UIDataDetectorTypeAddress NS_ENUM_AVAILABLE_IOS(4_0)                 = 1 << 2, // Street address detection
    UIDataDetectorTypeCalendarEvent NS_ENUM_AVAILABLE_IOS(4_0)           = 1 << 3, // Event detection
    UIDataDetectorTypeShipmentTrackingNumber NS_ENUM_AVAILABLE_IOS(10_0) = 1 << 4, // Shipment tracking number detection
    UIDataDetectorTypeFlightNumber NS_ENUM_AVAILABLE_IOS(10_0)           = 1 << 5, // Flight number detection
    UIDataDetectorTypeLookupSuggestion NS_ENUM_AVAILABLE_IOS(10_0)       = 1 << 6, // Information users may want to look up
```

The feature also enables automatic Peek & pop for the detected types.