### PR TITLE
Layout fixes for right to left languages

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -872,6 +872,7 @@
 		F127BD571E262E9F0093B2F1 /* CollectionsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F127BD561E262E9F0093B2F1 /* CollectionsViewControllerTests.swift */; };
 		F127BD5A1E2667170093B2F1 /* MockCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = F127BD581E265FB40093B2F1 /* MockCollection.swift */; };
 		F186A5E41E2FACF5005611C6 /* CGFloat+Hairline.swift in Sources */ = {isa = PBXBuildFile; fileRef = F186A5E31E2FACF5005611C6 /* CGFloat+Hairline.swift */; };
+		F194AD7A1E3F3BBC00B0049B /* UIApplication+RTL.swift in Sources */ = {isa = PBXBuildFile; fileRef = F194AD791E3F3BBC00B0049B /* UIApplication+RTL.swift */; };
 		F195EB9D1E2F75BC00712118 /* FeedbackOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F195EB9C1E2F75BC00712118 /* FeedbackOverlayView.swift */; };
 		F93D58431D7D9184003AE972 /* Analytics+ConversationEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93D58421D7D9184003AE972 /* Analytics+ConversationEvents.swift */; };
 		F93D58451D7DA865003AE972 /* ZMConversation+Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93D58441D7DA865003AE972 /* ZMConversation+Analytics.swift */; };
@@ -2319,6 +2320,7 @@
 		F127BD561E262E9F0093B2F1 /* CollectionsViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionsViewControllerTests.swift; sourceTree = "<group>"; };
 		F127BD581E265FB40093B2F1 /* MockCollection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockCollection.swift; sourceTree = "<group>"; };
 		F186A5E31E2FACF5005611C6 /* CGFloat+Hairline.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CGFloat+Hairline.swift"; sourceTree = "<group>"; };
+		F194AD791E3F3BBC00B0049B /* UIApplication+RTL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIApplication+RTL.swift"; sourceTree = "<group>"; };
 		F195EB9C1E2F75BC00712118 /* FeedbackOverlayView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeedbackOverlayView.swift; sourceTree = "<group>"; };
 		F93D58421D7D9184003AE972 /* Analytics+ConversationEvents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Analytics+ConversationEvents.swift"; sourceTree = "<group>"; };
 		F93D58441D7DA865003AE972 /* ZMConversation+Analytics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMConversation+Analytics.swift"; sourceTree = "<group>"; };
@@ -4189,6 +4191,7 @@
 				BFAF4CB81CEDE82400780537 /* NumberHelper.swift */,
 				8719FD661C88802C005FBEC0 /* Delay.swift */,
 				8719FD681C888044005FBEC0 /* NSData+MD5.swift */,
+				F194AD791E3F3BBC00B0049B /* UIApplication+RTL.swift */,
 				1693D9661CEDB26200D1F13C /* UIApplication+Permissions.h */,
 				1693D9671CEDB26200D1F13C /* UIApplication+Permissions.m */,
 				871BC0241D34F5D200DF0793 /* EmoticonSubstitutionConfiguration.h */,
@@ -5577,6 +5580,7 @@
 				BA8DC27C1B5FF5CF00103262 /* SketchColorPickerController.m in Sources */,
 				871BC2871D34F8F800DF0793 /* UIFont+MonoSpaced.swift in Sources */,
 				87DCF4DF1D34EA4500BB420F /* SearchSectionHeaderView.m in Sources */,
+				F194AD7A1E3F3BBC00B0049B /* UIApplication+RTL.swift in Sources */,
 				871BC2351D34F8F800DF0793 /* GiphyNavigationBar.m in Sources */,
 				87F280AA1D080E8400F813CA /* AVSMediaManager+CustomSounds.swift in Sources */,
 				873C5FE71C10426A00D5132A /* ClientListViewController.swift in Sources */,

--- a/Wire-iOS/Sources/Helpers/UIApplication+RTL.swift
+++ b/Wire-iOS/Sources/Helpers/UIApplication+RTL.swift
@@ -1,0 +1,25 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import UIKit
+
+extension UIApplication {
+    @objc static var isLeftToRightLayout: Bool {
+        return UIApplication.shared.userInterfaceLayoutDirection == .leftToRight
+    }
+}

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationListBottomBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationListBottomBar.swift
@@ -132,18 +132,18 @@ import Cartography
             view.height == heightConstant ~ 750
             
             separator.height == 0.5
-            separator.left == view.left
-            separator.right == view.right
+            separator.leading == view.leading
+            separator.trailing == view.trailing
             separator.top == view.top
         }
         
         constrain(view, contactsButtonContainer, contactsButton) { view, container, contactsButton in
-            container.left == view.left
+            container.leading == view.leading
             container.top == view.top
             container.bottom == view.bottom
             
-            contactsButton.left == container.left + 18
-            contactsButton.right == container.right - 18
+            contactsButton.leading == container.leading + 18
+            contactsButton.trailing == container.trailing - 18
             contactsButton.centerY == container.centerY
         }
         
@@ -152,18 +152,18 @@ import Cartography
             container.top == view.top
             container.bottom == view.bottom
             
-            archivedButton.left == container.left + 18
-            archivedButton.right == container.right - 18
+            archivedButton.leading == container.leading + 18
+            archivedButton.trailing == container.trailing - 18
             archivedButton.centerY == container.centerY
         }
         
         constrain(view, settingsButtonContainer, settingsButton) { view, container, settingsButton in
-            container.right == view.right
+            container.trailing == view.trailing
             container.top == view.top
             container.bottom == view.bottom
             
-            settingsButton.right == container.right - 24
-            settingsButton.left == container.left + 24
+            settingsButton.trailing == container.trailing - 24
+            settingsButton.leading == container.leading + 24
             settingsButton.centerY == container.centerY
         }
         
@@ -173,7 +173,7 @@ import Cartography
         
         constrain(indicator, settingsImageView) { indicator, imageView in
             indicator.top == imageView.top - 3
-            indicator.right == imageView.right + 3
+            indicator.trailing == imageView.trailing + 3
             indicator.width == 8
             indicator.height == 8
         }

--- a/Wire-iOS/Sources/UserInterface/Registration/CountryCode/Country.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/CountryCode/Country.m
@@ -34,7 +34,13 @@ NS_ASSUME_NONNULL_BEGIN
         return [Country countryWithISO:carrier.isoCountryCode];
     } else {
         NSString *localeIdentifier = [[NSLocale currentLocale] localeIdentifier];
-        NSString *ISO = [localeIdentifier substringFromIndex:[localeIdentifier rangeOfString:@"_"].location + 1];
+        NSString *ISO;
+        NSRange underscore = [localeIdentifier rangeOfString:@"_"];
+        if (underscore.location != NSNotFound) {
+            ISO = [localeIdentifier substringFromIndex:underscore.location + 1];
+        } else {
+            ISO = localeIdentifier;
+        }
         return [Country countryWithISO:ISO.lowercaseString];
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Registration/CountryCodeView.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/CountryCodeView.m
@@ -67,7 +67,7 @@
         
         [self.button autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsZero];
         [self.separatorLine autoSetDimension:ALDimensionWidth toSize:1];
-        [self.separatorLine autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsZero excludingEdge:ALEdgeLeft];
+        [self.separatorLine autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsZero excludingEdge:ALEdgeLeading];
     }
     
     [super updateConstraints];

--- a/Wire-iOS/Sources/UserInterface/Registration/GuidanceLabel.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/GuidanceLabel.m
@@ -33,7 +33,7 @@
         self.font = [UIFont fontWithMagicIdentifier:@"style.text.small.font_spec_bold"];
         self.textColor = [UIColor whiteColor];
         self.numberOfLines = 0;
-        self.textAlignment = NSTextAlignmentLeft;
+        self.textAlignment = NSTextAlignmentNatural;
     }
     
     return self;

--- a/Wire-iOS/Sources/UserInterface/Registration/NavigationController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/NavigationController.m
@@ -77,7 +77,10 @@
 {
     self.backButton = [[IconButton alloc] initForAutoLayout];
     self.backButton.cas_styleClass = @"navigation";
-    [self.backButton setIcon:ZetaIconTypeChevronLeft withSize:ZetaIconSizeSmall forState:UIControlStateNormal];
+    
+    ZetaIconType iconType = [UIApplication isLeftToRightLayout] ? ZetaIconTypeChevronLeft : ZetaIconTypeChevronRight;
+
+    [self.backButton setIcon:iconType withSize:ZetaIconSizeSmall forState:UIControlStateNormal];
     self.backButton.accessibilityIdentifier = @"BackToWelcomeButton";
     [self.view addSubview:self.backButton];
 
@@ -118,20 +121,20 @@
         
         [self.logoImageView autoSetDimensionsToSize:CGSizeMake(76, 22)];
         [self.logoImageView autoPinEdgeToSuperviewEdge:ALEdgeTop withInset:35];
-        [self.logoImageView autoPinEdgeToSuperviewEdge:ALEdgeLeft withInset:26];
+        [self.logoImageView autoPinEdgeToSuperviewEdge:ALEdgeLeading withInset:26];
         
         [self.backButton autoSetDimension:ALDimensionHeight toSize:32];
         [self.backButton autoSetDimension:ALDimensionWidth toSize:32 relation:NSLayoutRelationGreaterThanOrEqual];
         [self.backButton autoPinEdgeToSuperviewEdge:ALEdgeTop withInset:32];
-        [self.backButton autoPinEdgeToSuperviewEdge:ALEdgeLeft withInset:28];
+        [self.backButton autoPinEdgeToSuperviewEdge:ALEdgeLeading withInset:28];
         
         [self.rightTitledButton autoSetDimension:ALDimensionHeight toSize:28];
         [self.rightTitledButton autoPinEdgeToSuperviewEdge:ALEdgeTop withInset:32];
-        [self.rightTitledButton autoPinEdgeToSuperviewEdge:ALEdgeRight withInset:28];
+        [self.rightTitledButton autoPinEdgeToSuperviewEdge:ALEdgeTrailing withInset:28];
         
         [self.rightIconedButton autoSetDimensionsToSize:CGSizeMake(32, 32)];
         [self.rightIconedButton autoPinEdgeToSuperviewEdge:ALEdgeTop withInset:32];
-        [self.rightIconedButton autoPinEdgeToSuperviewEdge:ALEdgeRight withInset:28];
+        [self.rightIconedButton autoPinEdgeToSuperviewEdge:ALEdgeTrailing withInset:28];
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Registration/PhoneNumberStepViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/PhoneNumberStepViewController.m
@@ -139,12 +139,12 @@
         [NSLayoutConstraint autoSetPriority:UILayoutPriorityDefaultLow forConstraints:^{            
             [self.heroLabel autoPinEdgeToSuperviewEdge:ALEdgeTop withInset:75 relation:NSLayoutRelationGreaterThanOrEqual];
         }];
-        [self.heroLabel autoPinEdgeToSuperviewEdge:ALEdgeLeft withInset:28];
-        [self.heroLabel autoPinEdgeToSuperviewEdge:ALEdgeRight withInset:28];
+        [self.heroLabel autoPinEdgeToSuperviewEdge:ALEdgeLeading withInset:28];
+        [self.heroLabel autoPinEdgeToSuperviewEdge:ALEdgeTrailing withInset:28];
         
         [self.phoneNumberViewController.view autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.heroLabel withOffset:24];
-        [self.phoneNumberViewController.view autoPinEdgeToSuperviewEdge:ALEdgeLeft withInset:28];
-        [self.phoneNumberViewController.view autoPinEdgeToSuperviewEdge:ALEdgeRight withInset:28];
+        [self.phoneNumberViewController.view autoPinEdgeToSuperviewEdge:ALEdgeLeading withInset:28];
+        [self.phoneNumberViewController.view autoPinEdgeToSuperviewEdge:ALEdgeTrailing withInset:28];
         [self.phoneNumberViewController.view autoPinEdgeToSuperviewEdge:ALEdgeBottom withInset:51];
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Registration/PhoneNumberViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/PhoneNumberViewController.m
@@ -87,7 +87,8 @@ static CGFloat PhoneNumberFieldTopMargin = 16;
     [self.selectCountryButton setTitleColor:[UIColor colorWithMagicIdentifier:@"style.color.static_foreground.normal"] forState:UIControlStateNormal];
     [self.selectCountryButton setTitleColor:[UIColor colorWithMagicIdentifier:@"style.color.static_foreground.faded"] forState:UIControlStateHighlighted];
     
-    UIImage *icon = [UIImage imageForIcon:ZetaIconTypeChevronRight iconSize:ZetaIconSizeSmall color:UIColor.whiteColor];
+    ZetaIconType iconType = [UIApplication isLeftToRightLayout] ? ZetaIconTypeChevronRight : ZetaIconTypeChevronLeft;
+    UIImage *icon = [UIImage imageForIcon:iconType iconSize:ZetaIconSizeSmall color:UIColor.whiteColor];
     self.selectCountryButtonIcon = [[UIImageView alloc] initWithImage:icon];
     self.selectCountryButtonIcon.translatesAutoresizingMaskIntoConstraints = NO;
     [self.selectCountryButton addSubview:self.selectCountryButtonIcon];

--- a/Wire-iOS/Sources/UserInterface/Registration/PhoneNumberViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/PhoneNumberViewController.m
@@ -29,6 +29,7 @@
 #import "WAZUIMagicIOS.h"
 #import "UIImage+ZetaIconsNeue.h"
 #import "zmessaging+iOS.h"
+#import "Wire-Swift.h"
 
 #import "AnalyticsTracker+Navigation.h"
 
@@ -80,7 +81,8 @@ static CGFloat PhoneNumberFieldTopMargin = 16;
 - (void)createSelectCountryButton
 {
     self.selectCountryButton = [UIButton buttonWithType:UIButtonTypeCustom];
-    self.selectCountryButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeft;
+    self.selectCountryButton.contentHorizontalAlignment = [UIApplication isLeftToRightLayout] ? UIControlContentHorizontalAlignmentLeft : UIControlContentHorizontalAlignmentRight;
+    
     self.selectCountryButton.titleLabel.font = [UIFont fontWithMagicIdentifier:@"style.text.normal.font_spec"];
     [self.selectCountryButton setTitleColor:[UIColor colorWithMagicIdentifier:@"style.color.static_foreground.normal"] forState:UIControlStateNormal];
     [self.selectCountryButton setTitleColor:[UIColor colorWithMagicIdentifier:@"style.color.static_foreground.faded"] forState:UIControlStateHighlighted];

--- a/Wire-iOS/Sources/UserInterface/Registration/PhoneNumberViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/PhoneNumberViewController.m
@@ -138,14 +138,14 @@ static CGFloat PhoneNumberFieldTopMargin = 16;
         
         self.initialConstraintsCreated = YES;
         
-        [self.selectCountryButtonIcon autoPinEdgeToSuperviewEdge:ALEdgeRight withInset:0];
+        [self.selectCountryButtonIcon autoPinEdgeToSuperviewEdge:ALEdgeTrailing withInset:0];
         [self.selectCountryButtonIcon autoAlignAxisToSuperviewAxis:ALAxisHorizontal];
-        [self.selectCountryButton.titleLabel autoPinEdge:ALEdgeRight toEdge:ALEdgeLeft ofView:self.selectCountryButtonIcon withOffset:0 relation:NSLayoutRelationLessThanOrEqual];
+        [self.selectCountryButton.titleLabel autoPinEdge:ALEdgeTrailing toEdge:ALEdgeLeading ofView:self.selectCountryButtonIcon withOffset:0 relation:NSLayoutRelationLessThanOrEqual];
         
         [self.selectCountryButton autoPinEdgeToSuperviewEdge:ALEdgeTop];
-        [self.selectCountryButton autoPinEdgeToSuperviewEdge:ALEdgeLeft];
+        [self.selectCountryButton autoPinEdgeToSuperviewEdge:ALEdgeLeading];
         
-        [self.selectCountryButton autoPinEdgeToSuperviewEdge:ALEdgeRight withInset:10];
+        [self.selectCountryButton autoPinEdgeToSuperviewEdge:ALEdgeTrailing withInset:10];
 
         self.selectCountryButtonHeightConstraint = [self.selectCountryButton autoSetDimension:ALDimensionHeight toSize:SelectCountryButtonHeight];
         

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTextField.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTextField.m
@@ -173,7 +173,11 @@ static const CGFloat GuidanceDotViewWidth = 40;
 
     // In case the text content should be center-aligned, we need to inset the text with the right accessory view size on the left
     if (self.rightAccessoryView != RegistrationTextFieldRightAccessoryViewNone && self.textAlignment == NSTextAlignmentCenter) {
-        textRect = UIEdgeInsetsInsetRect(textRect, UIEdgeInsetsMake(0, [self rightViewRectForBounds:bounds].size.width, 0, 0));
+        if ([UIApplication isLeftToRightLayout]) {
+            textRect = UIEdgeInsetsInsetRect(textRect, UIEdgeInsetsMake(0, [self rightViewRectForBounds:bounds].size.width, 0, 0));
+        } else {
+            textRect = UIEdgeInsetsInsetRect(textRect, UIEdgeInsetsMake(0, 0, 0, [self leftViewRectForBounds:bounds].size.width));
+        }
     }
 
     return UIEdgeInsetsInsetRect(textRect, self.textInsets);

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTextField.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTextField.m
@@ -177,8 +177,27 @@ static const CGFloat GuidanceDotViewWidth = 40;
     return UIEdgeInsetsInsetRect(textRect, self.textInsets);
 }
 
+- (CGRect)rightViewRectForBounds:(CGRect)bounds
+{
+    BOOL leftToRight = [UIApplication sharedApplication].userInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionLeftToRight;
+    if (leftToRight) {
+        return [self rightAccessoryViewRectForBounds:bounds leftToRight:leftToRight];
+    } else {
+        return [self leftAccessoryViewRectForBounds:bounds leftToRight:leftToRight];
+    }
+}
+
 - (CGRect)leftViewRectForBounds:(CGRect)bounds
 {
+    BOOL leftToRight = [UIApplication sharedApplication].userInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionLeftToRight;
+    if (leftToRight) {
+        return [self leftAccessoryViewRectForBounds:bounds leftToRight:leftToRight];
+    } else {
+        return [self rightAccessoryViewRectForBounds:bounds leftToRight:leftToRight];
+    }
+}
+
+- (CGRect)leftAccessoryViewRectForBounds:(CGRect)bounds leftToRight:(BOOL)leftToRight {
     CGRect leftViewRect;
     
     switch (self.leftAccessoryView) {
@@ -187,15 +206,18 @@ static const CGFloat GuidanceDotViewWidth = 40;
             break;
             
         case RegistrationTextFieldLeftAccessoryViewCountryCode:
-            leftViewRect = CGRectMake(bounds.origin.x, bounds.origin.y, CountryCodeViewWidth, bounds.size.height);
+            if (leftToRight) {
+                leftViewRect = CGRectMake(bounds.origin.x, bounds.origin.y, CountryCodeViewWidth, bounds.size.height);
+            } else {
+                leftViewRect = CGRectMake(CGRectGetMaxX(bounds) - CountryCodeViewWidth, bounds.origin.y, CountryCodeViewWidth, bounds.size.height);
+            }
             break;
     }
     
     return leftViewRect;
 }
 
-- (CGRect)rightViewRectForBounds:(CGRect)bounds
-{
+- (CGRect)rightAccessoryViewRectForBounds:(CGRect)bounds leftToRight:(BOOL)leftToRight {
     CGRect rightViewRect;
     
     switch (self.rightAccessoryView) {
@@ -204,15 +226,27 @@ static const CGFloat GuidanceDotViewWidth = 40;
             break;
             
         case RegistrationTextFieldRightAccessoryViewGuidanceDot:
-            rightViewRect = CGRectMake(CGRectGetMaxX(bounds) - GuidanceDotViewWidth, bounds.origin.y, GuidanceDotViewWidth, bounds.size.height);
+            if (leftToRight) {
+                rightViewRect = CGRectMake(CGRectGetMaxX(bounds) - GuidanceDotViewWidth, bounds.origin.y, GuidanceDotViewWidth, bounds.size.height);
+            } else {
+                rightViewRect = CGRectMake(bounds.origin.x, bounds.origin.y, GuidanceDotViewWidth, bounds.size.height);
+            }
             break;
             
         case RegistrationTextFieldRightAccessoryViewConfirmButton:
-            rightViewRect = CGRectMake(CGRectGetMaxX(bounds) - ConfirmButtonWidth, bounds.origin.y, ConfirmButtonWidth, bounds.size.height);
+            if (leftToRight) {
+                rightViewRect = CGRectMake(CGRectGetMaxX(bounds) - ConfirmButtonWidth, bounds.origin.y, ConfirmButtonWidth, bounds.size.height);
+            } else {
+                rightViewRect = CGRectMake(bounds.origin.x, bounds.origin.y, ConfirmButtonWidth, bounds.size.height);
+            }
             break;
-        
+            
         case RegistrationTextFieldRightAccessoryViewCustom:
-            rightViewRect = CGRectMake(CGRectGetMaxX(bounds) - self.customRightView.intrinsicContentSize.width, bounds.origin.y, self.customRightView.intrinsicContentSize.width, bounds.size.height);
+            if (leftToRight) {
+                rightViewRect = CGRectMake(CGRectGetMaxX(bounds) - self.customRightView.intrinsicContentSize.width, bounds.origin.y, self.customRightView.intrinsicContentSize.width, bounds.size.height);
+            } else {
+                rightViewRect = CGRectMake(bounds.origin.x, bounds.origin.y, self.customRightView.intrinsicContentSize.width, bounds.size.height);
+            }
             break;
     }
     

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTextField.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTextField.m
@@ -28,6 +28,7 @@
 #import "CountryCodeView.h"
 
 #import "NSAttributedString+Wire.h"
+#import "Wire-Swift.h"
 
 static const CGFloat ConfirmButtonWidth = 40;
 static const CGFloat CountryCodeViewWidth = 60;
@@ -78,7 +79,8 @@ static const CGFloat GuidanceDotViewWidth = 40;
 {
     self.confirmButton = [[IconButton alloc] init];
     [self.confirmButton setBackgroundImageColor:[UIColor whiteColor] forState:UIControlStateNormal];
-    [self.confirmButton setIcon:ZetaIconTypeChevronRight withSize:ZetaIconSizeSmall forState:UIControlStateNormal];
+    ZetaIconType iconType = [UIApplication isLeftToRightLayout] ? ZetaIconTypeChevronRight : ZetaIconTypeChevronLeft;
+    [self.confirmButton setIcon:iconType withSize:ZetaIconSizeSmall forState:UIControlStateNormal];
     [self.confirmButton setIconColor:[UIColor colorWithMagicIdentifier:@"style.color.foreground.normal"] forState:UIControlStateNormal];
     self.confirmButton.accessibilityIdentifier= @"RegistrationConfirmButton";
 }

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTextField.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTextField.m
@@ -185,7 +185,7 @@ static const CGFloat GuidanceDotViewWidth = 40;
 
 - (CGRect)rightViewRectForBounds:(CGRect)bounds
 {
-    BOOL leftToRight = [UIApplication sharedApplication].userInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionLeftToRight;
+    BOOL leftToRight = [UIApplication isLeftToRightLayout];
     if (leftToRight) {
         return [self rightAccessoryViewRectForBounds:bounds leftToRight:leftToRight];
     } else {
@@ -195,7 +195,7 @@ static const CGFloat GuidanceDotViewWidth = 40;
 
 - (CGRect)leftViewRectForBounds:(CGRect)bounds
 {
-    BOOL leftToRight = [UIApplication sharedApplication].userInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionLeftToRight;
+    BOOL leftToRight = [UIApplication isLeftToRightLayout];
     if (leftToRight) {
         return [self leftAccessoryViewRectForBounds:bounds leftToRight:leftToRight];
     } else {

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/Cells/SearchResultCell.m
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/Cells/SearchResultCell.m
@@ -99,7 +99,7 @@
 
         self.nameLabel = [[UILabel alloc] initForAutoLayout];
         self.nameLabel.lineBreakMode = NSLineBreakByTruncatingTail;
-        self.nameLabel.textAlignment = NSTextAlignmentLeft;
+        self.nameLabel.textAlignment = NSTextAlignmentNatural;
         [self.swipeView addSubview:self.nameLabel];
 
         self.subtitleLabel = [[UILabel alloc] initForAutoLayout];

--- a/WireExtensionComponents/Views/Buttons/IconButton.m
+++ b/WireExtensionComponents/Views/Buttons/IconButton.m
@@ -190,9 +190,17 @@
 {
     _titleImageSpacing = titleImageSpacing;
     
-    CGFloat inset = titleImageSpacing / 2.0f;
-    self.imageEdgeInsets = UIEdgeInsetsMake(self.imageEdgeInsets.top, -inset, self.imageEdgeInsets.bottom, inset);
-    self.titleEdgeInsets = UIEdgeInsetsMake(self.titleEdgeInsets.top, inset, self.titleEdgeInsets.bottom, -inset);
+    BOOL isLeftToRight = YES;
+    if ([[UIView class] respondsToSelector:@selector(userInterfaceLayoutDirectionForSemanticContentAttribute:)]) {
+        isLeftToRight = [UIView userInterfaceLayoutDirectionForSemanticContentAttribute: UISemanticContentAttributeUnspecified] == UIUserInterfaceLayoutDirectionLeftToRight;
+    }
+    
+    CGFloat inset = titleImageSpacing / 2.0f ;
+    CGFloat leftInset = isLeftToRight ? -inset : inset;
+    CGFloat rightInset = isLeftToRight ? inset : -inset;
+    
+    self.imageEdgeInsets = UIEdgeInsetsMake(self.imageEdgeInsets.top, leftInset, self.imageEdgeInsets.bottom, rightInset);
+    self.titleEdgeInsets = UIEdgeInsetsMake(self.titleEdgeInsets.top, rightInset, self.titleEdgeInsets.bottom, leftInset);
 
     CGFloat horizontal = inset + horizontalMargin;
     self.contentEdgeInsets = UIEdgeInsetsMake(self.contentEdgeInsets.top, horizontal, self.contentEdgeInsets.bottom, horizontal);


### PR DESCRIPTION
## What's in this PR?

Several fixes for layout issues in RTL languages:

* Registration and login fields had problems, especially the phone number input.
* Arrows in registration screens were pointing the wrong way
* Contacts list button from the conversation list screen was overlapping the label
* Contact name in the contacts list had wrong alignment


