### PR TITLE
Do not rely on UIApplication.sharedApplication.delegate value

### DIFF
--- a/Wire-iOS/Sources/AppDelegate.m
+++ b/Wire-iOS/Sources/AppDelegate.m
@@ -55,6 +55,8 @@
 #import "StopWatch.h"
 
 
+static AppDelegate *sharedAppDelegate = nil;
+
 
 @interface AppDelegate (NetworkAvailabilityObserver) <ZMNetworkAvailabilityObserver>
 
@@ -90,7 +92,7 @@
 
 + (instancetype)sharedAppDelegate;
 {
-    return (AppDelegate *) [UIApplication sharedApplication].delegate;
+    return sharedAppDelegate;
 }
 
 - (void)dealloc
@@ -102,7 +104,8 @@
 - (instancetype)init
 {
     self = [super init];
-        if (self) {
+    if (self) {
+        sharedAppDelegate = self;
         self.appController = [[AppController alloc] init];
     }
     return self;
@@ -110,7 +113,6 @@
 
 - (BOOL)application:(UIApplication *)application willFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-
     DDLogInfo(@"application:willFinishLaunchingWithOptions %@ (applicationState = %ld)", launchOptions, (long)application.applicationState);
     
     [self setupLogging];


### PR DESCRIPTION
# Issue

After changing to localytics auto integration the app's UIApplication.sharedApplication.delegate is replaced with Localytics multicast delegates wrapper. This forwards all messages to our app delegate, but still can potentially bring issues with being not the AppDelegate we as developer expect from UIApplication.sharedApplication.delegate. 

Solution is to save the reference to the original app delegate to the static variable and return it's value in `sharedAppDelegate`.