### PR TITLE
instead of resorting, recreate conversationlists

### DIFF
--- a/Wire-iOS/Sources/Managers/SessionObjectCache.h
+++ b/Wire-iOS/Sources/Managers/SessionObjectCache.h
@@ -47,5 +47,6 @@
 + (instancetype)sharedCache;
 
 - (instancetype)initWithUserSession:(ZMUserSession *)session;
+- (void)refetchConversationLists;
 
 @end

--- a/Wire-iOS/Sources/Managers/SessionObjectCache.m
+++ b/Wire-iOS/Sources/Managers/SessionObjectCache.m
@@ -62,6 +62,13 @@
     return self;
 }
 
+- (void)refetchConversationLists
+{
+    if (self.userSession != nil) {
+        [ZMConversationList refetchAllListsInUserSession:self.userSession];
+    }
+}
+
 - (ZMConversationList *)conversationList
 {
     if (_conversationList == nil && self.userSession != nil) {        

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/Model/ConversationListViewModel.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/Model/ConversationListViewModel.m
@@ -257,7 +257,7 @@ void debugLogUpdate (ConversationListChangeInfo *note);
 
 - (void)applicationWillEnterForeground:(NSNotification *)note
 {
-    [SessionObjectCache.sharedCache.conversationList resort];
+    [SessionObjectCache.sharedCache refetchConversationLists];
     [self reloadConversationListViewModel];
 }
 


### PR DESCRIPTION
Instead of resorting the list when re-entering the foreground, it should be recreated. Otherwise conversations that were inserted or deleted while the app was in the background may not be included in the list.

Note: This need a new ZMCDataModel release with https://github.com/wireapp/wire-ios-data-model/pull/151
and then retested before merging