### PR TITLE
Right to left: keeping the same conversation list toolbar buttons order

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -423,12 +423,20 @@
 
 - (void)updateRightNavigationItemsButtons
 {
-    self.navigationItem.rightBarButtonItems = [self rightNavigationItemsForConversation:self.conversation];
+    if ([UIApplication isLeftToRightLayout]) {
+        self.navigationItem.rightBarButtonItems = [self rightNavigationItemsForConversation:self.conversation];
+    } else {
+        self.navigationItem.rightBarButtonItems = [self leftNavigationItemsForConversation:self.conversation];
+    }
 }
 
 - (void)updateLeftNavigationBarItems
 {
-    self.navigationItem.leftBarButtonItems = [self leftNavigationItemsForConversation:self.conversation];
+    if ([UIApplication isLeftToRightLayout]) {
+        self.navigationItem.leftBarButtonItems = [self leftNavigationItemsForConversation:self.conversation];
+    } else {
+        self.navigationItem.leftBarButtonItems = [self rightNavigationItemsForConversation:self.conversation];
+    }
 }
 
 - (UIViewController *)participantsController

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -423,6 +423,7 @@
 
 - (void)updateRightNavigationItemsButtons
 {
+    // FIXME: iOS8 - we can use UIView's semanticContentAttribute on navigation bar
     if ([UIApplication isLeftToRightLayout]) {
         self.navigationItem.rightBarButtonItems = [self rightNavigationItemsForConversation:self.conversation];
     } else {
@@ -432,6 +433,7 @@
 
 - (void)updateLeftNavigationBarItems
 {
+    // FIXME: iOS8 - we can use UIView's semanticContentAttribute on navigation bar
     if ([UIApplication isLeftToRightLayout]) {
         self.navigationItem.leftBarButtonItems = [self leftNavigationItemsForConversation:self.conversation];
     } else {


### PR DESCRIPTION
Even with RTL layout we have the conversations list opening on the same side, so it makes sense to keep the toolbar buttons in the same order as well.