### PR TITLE
Added the key for the itunes connect to indicate no encryption changes

### DIFF
--- a/Wire-iOS/Wire-Info.plist
+++ b/Wire-iOS/Wire-Info.plist
@@ -135,5 +135,7 @@
 	<false/>
 	<key>WireGroupId</key>
 	<string>${WIRE_BUNDLE_ID}</string>
+    <key>ITSAppUsesNonExemptEncryption</key>
+    <false/>
 </dict>
 </plist>


### PR DESCRIPTION
# Issue

Itunes Connect always checks on submission if the app's encryption algorithms are changed. If it's not, they suggest to add this key, so they don't have to ask any more.

The downside is if we actually change the encryption then we have to remove it.