### PR TITLE
Fixes for data detectors

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Views/LinkInteractionTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/LinkInteractionTextView.swift
@@ -22,7 +22,7 @@ import UIKit
 
 @objc public protocol TextViewInteractionDelegate: NSObjectProtocol {
     func textView(_ textView: LinkInteractionTextView, open url: URL) -> Bool
-    func textView(_ textView: LinkInteractionTextView, didLongPressLink recognizer: UILongPressGestureRecognizer)
+    func textViewDidLongPress(_ textView: LinkInteractionTextView)
 }
 
 
@@ -68,8 +68,8 @@ extension LinkInteractionTextView: UITextViewDelegate {
             }
             } ?? []
 
-        for recognizer in beganLongPressRecognizers {
-            interactionDelegate?.textView(self, didLongPressLink: recognizer)
+        if beganLongPressRecognizers.count > 0 {
+            interactionDelegate?.textViewDidLongPress(self)
             return false
         }
         
@@ -82,11 +82,23 @@ extension LinkInteractionTextView: UITextViewDelegate {
     
     @available(iOS 10.0, *)
     public func textView(_ textView: UITextView, shouldInteractWith textAttachment: NSTextAttachment, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
-        return true
+        if interaction == .presentActions {
+            interactionDelegate?.textViewDidLongPress(self)
+            return false
+        }
+        else {
+            return true
+        }
     }
     
     @available(iOS 10.0, *)
     public func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
-        return true
+        if interaction == .presentActions {
+            interactionDelegate?.textViewDidLongPress(self)
+            return false
+        }
+        else {
+            return true
+        }
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Components/Views/LinkInteractionTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/LinkInteractionTextView.swift
@@ -21,7 +21,7 @@ import UIKit
 
 
 @objc public protocol TextViewInteractionDelegate: NSObjectProtocol {
-    func textView(_ textView: LinkInteractionTextView, open url: URL)
+    func textView(_ textView: LinkInteractionTextView, open url: URL) -> Bool
     func textView(_ textView: LinkInteractionTextView, didLongPressLink recognizer: UILongPressGestureRecognizer)
 }
 
@@ -72,9 +72,8 @@ extension LinkInteractionTextView: UITextViewDelegate {
             interactionDelegate?.textView(self, didLongPressLink: recognizer)
             return false
         }
-
-        interactionDelegate?.textView(self, open: URL)
-        return false
+        
+        return !(interactionDelegate?.textView(self, open: URL) ?? false)
     }
     
     public func textView(_ textView: UITextView, shouldInteractWith textAttachment: NSTextAttachment, in characterRange: NSRange) -> Bool {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/TextMessageCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/TextMessageCell.m
@@ -419,7 +419,7 @@
     return [url open];
 }
 
-- (void)textView:(LinkInteractionTextView *)textView didLongPressLink:(UILongPressGestureRecognizer *)recognizer
+- (void)textViewDidLongPress:(LinkInteractionTextView *)textView
 {
     [self showMenu];
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/TextMessageCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/TextMessageCell.m
@@ -404,7 +404,7 @@
 
 #pragma mark - TextViewInteractionDelegate
 
-- (void)textView:(LinkInteractionTextView *)textView open:(NSURL *)url
+- (BOOL)textView:(LinkInteractionTextView *)textView open:(NSURL *)url
 {
     LinkAttachment *linkAttachment = [self.layoutProperties.linkAttachments filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"SELF.URL == %@", url]].lastObject;
     
@@ -416,7 +416,7 @@
                                                          conversationType:self.message.conversation.conversationType];
     }
 
-    [url open];
+    return [url open];
 }
 
 - (void)textView:(LinkInteractionTextView *)textView didLongPressLink:(UILongPressGestureRecognizer *)recognizer

--- a/Wire-iOS/Sources/UserInterface/Settings/LinkOpening/LinkOpener.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/LinkOpening/LinkOpener.swift
@@ -22,21 +22,29 @@ import Foundation
 
 public extension NSURL {
 
-    @objc func open() {
-        (self as URL).open()
+    @objc func open() -> Bool {
+        return (self as URL).open()
     }
 
 }
 
 public extension URL {
 
-    func open() {
-        let openened = openAsTweet() || openAsLink()
-        if !openened {
-            UIApplication.shared.openURL(self)
+    func open() -> Bool {
+        let opened = openAsTweet() || openAsLink()
+        if opened {
+            return true
+        }
+        else {
+            if UIApplication.shared.canOpenURL(self) {
+                UIApplication.shared.openURL(self)
+                return true
+            }
+            else {
+                return false
+            }
         }
     }
-
 }
 
 protocol LinkOpeningOption {


### PR DESCRIPTION
1. Fixed the behavior on iOS 9 when certain kinds of detected elements where not possible to open.

The issue happened when the special iOS internal kind of URL was provided for address and other special types and we tried to open it directly.

2. The issue with iOS integrated menu with "Add to reading list" and other default elements where displayed for long press menu on the URL. Now we display the default menu instead.