### PR TITLE
Remove warning popup about concurrent calls

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -288,9 +288,6 @@
 "voice.status.low_connection" = "Bad connection";
 "voice.network_error.title" = "No Internet Connection";
 "voice.network_error.body" = "You must be online to call. Check your connection and try again.";
-"voice.alert.call_in_progress.title" = "Call in progress";
-"voice.alert.call_in_progress.message" = "Another of your devices is already participating in the call";
-"voice.alert.call_in_progress.confirm" = "Ok";
 "voice.accept_button.title" = "Accept";
 "voice.decline_button.title" = "Decline";
 "voice.hang_up_button.title" = "Hang Up";

--- a/Wire-iOS/Sources/Helpers/syncengine/ZMConversation+Additions.m
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMConversation+Additions.m
@@ -287,13 +287,6 @@
 
 - (void)joinVoiceChannelWithVideo:(BOOL)video completionHandler:(void(^)(BOOL joined))completion
 {
-    if ([self warnAboutCallInProgress]) {
-        if (completion != nil) {
-            completion(NO);
-        }
-        return;
-    }
-
     if ([self warnAboutNoInternetConnection]) {
         if (completion != nil) {
             completion(NO);
@@ -321,6 +314,8 @@
 - (void)joinVoiceChannelWithoutAskingForPermissionWithVideo:(BOOL)video completionHandler:(void(^)(BOOL joined))completion
 {
     [self leaveOtherActiveCallsWithCompletionHandler:^{
+        DDLogError(@"joining call");
+        
         VoiceChannelV2State voiceChannelState = self.voiceChannel.state;
         VoiceChannelV2ConnectionState connectionState = self.voiceChannel.selfUserConnectionState;
 
@@ -416,19 +411,6 @@
                                                                                            message:NSLocalizedString(@"voice.network_error.body", "<voice failed because of network>")
                                                                                  cancelButtonTitle:NSLocalizedString(@"general.ok", "ok string")];
         [[AppDelegate sharedAppDelegate].notificationsWindow.rootViewController presentViewController:noInternetConnectionAlert animated:YES completion:nil];
-        return YES;
-    }
-    return NO;
-}
-
-- (BOOL)warnAboutCallInProgress
-{
-    if ([AppDelegate sharedAppDelegate].notificationWindowController.voiceChannelController.voiceChannelIsJoined) {
-
-        UIAlertController *callInProgressAlert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"voice.alert.call_in_progress.title", @"Calling in progress")
-                                                                                     message:NSLocalizedString(@"voice.alert.call_in_progress.message", @"Another device already in call")
-                                                                           cancelButtonTitle:NSLocalizedString(@"general.ok", @"ok")];
-        [[AppDelegate sharedAppDelegate].notificationsWindow.rootViewController presentViewController:callInProgressAlert animated:YES completion:nil];
         return YES;
     }
     return NO;

--- a/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelController.h
+++ b/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelController.h
@@ -23,9 +23,6 @@
 
 @interface VoiceChannelController : UIViewController
 
-/// Returns YES if the user currently connected / connecting to any voice channel.
-@property (nonatomic, readonly) BOOL voiceChannelIsJoined;
-
 /// Returns YES if any voice channel activity is happening
 @property (nonatomic, readonly) BOOL voiceChannelIsActive;
 

--- a/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelController.m
+++ b/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelController.m
@@ -57,16 +57,6 @@
     return YES;
 }
 
-- (BOOL)voiceChannelIsJoined
-{
-    if (self.activeCallConversation == nil) {
-        return NO;
-    }
-    
-    VoiceChannelV2State voiceChannelState = self.activeCallConversation.voiceChannel.state;
-    return voiceChannelState == VoiceChannelV2StateSelfIsJoiningActiveChannel || voiceChannelState == VoiceChannelV2StateSelfConnectedToActiveChannel;
-}
-
 - (BOOL)voiceChannelIsActive
 {
     return self.activeCallConversation != nil;

--- a/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelOverlayController.m
+++ b/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelOverlayController.m
@@ -327,20 +327,10 @@
     return overlayState;
 }
 
-- (void)leaveConnectedVoiceChannels
-{
-    [[ZMUserSession sharedSession] enqueueChanges:^{
-        for (ZMConversation *conversation in [WireCallCenter activeCallConversationsInUserSession:[ZMUserSession sharedSession]]) {
-            [conversation.voiceChannel leaveWithUserSession:[ZMUserSession sharedSession]];
-        }
-    }];
-}
-
 - (void)joinCurrentVoiceChannel
 {
-    [self leaveConnectedVoiceChannels];
-    [self resetAudioState];
     DDLogVoice(@"UI: Accept button tap");
+    [self resetAudioState];
     [self.conversation acceptIncomingCall];
 }
 


### PR DESCRIPTION
This popup was preventing you from making a while in a call when the call
UI was not fullscreen.