### PR TITLE
Remove .bool case from SettingsPropertyValue

### DIFF
--- a/Wire-iOS Tests/Settings/SettingsPropertyTests.swift
+++ b/Wire-iOS Tests/Settings/SettingsPropertyTests.swift
@@ -101,7 +101,7 @@ class SettingsPropertyTests: XCTestCase {
         // given
         let property = SettingsUserDefaultsProperty(propertyName: SettingsPropertyName.chatHeadsDisabled, userDefaultsKey: UserDefaultChatHeadsDisabled, userDefaults: self.userDefaults)
         // when & then
-        try! XCTAssertTrue(self.saveAndCheck(property, value: true))
+        try! self.saveAndCheck(property, value: NSNumber(value: true))
     }
     
     func testThatNamePropertySetsValue() {

--- a/Wire-iOS Tests/Settings/SettingsPropertyTests.swift
+++ b/Wire-iOS Tests/Settings/SettingsPropertyTests.swift
@@ -65,14 +65,26 @@ class ZMMockCrashlogManager: CrashlogManager {
 class SettingsPropertyTests: XCTestCase {
     let userDefaults: UserDefaults = UserDefaults.standard
     
-    func saveAndCheck<T: Any>( _ property: SettingsProperty, value: T) throws -> Bool where T: Equatable {
+    func saveAndCheck<T>(_ property: SettingsProperty, value: T, file: String = #file, line: UInt = #line) throws where T: Equatable {
         var property = property
         try property << value
         if let readValue : T = property.rawValue() as? T {
-            return value == readValue
+            if value != readValue {
+                recordFailure(
+                    withDescription: "Wrong property value, read \(readValue) but expected \(value)",
+                    inFile: file,
+                    atLine: line,
+                    expected: true
+                )
+            }
         }
         else {
-            return false
+            recordFailure(
+                withDescription: "Unable to read property value",
+                inFile: file,
+                atLine: line,
+                expected: true
+            )
         }
     }
     
@@ -82,7 +94,7 @@ class SettingsPropertyTests: XCTestCase {
         // given
         let property = SettingsUserDefaultsProperty(propertyName: SettingsPropertyName.darkMode, userDefaultsKey: UserDefaultColorScheme, userDefaults: self.userDefaults)
         // when & then
-        try! XCTAssertTrue(self.saveAndCheck(property, value: "light"))
+        try! self.saveAndCheck(property, value: "light")
     }
     
     func testThatBoolUserDefaultsSettingSave() {
@@ -103,7 +115,7 @@ class SettingsPropertyTests: XCTestCase {
         
         let property = factory.property(SettingsPropertyName.profileName)
         // when & then
-        try! XCTAssertTrue(self.saveAndCheck(property, value: "Test"))
+        try! self.saveAndCheck(property, value: "Test")
     }
     
     func testThatSoundLevelPropertySetsValue() {
@@ -117,7 +129,7 @@ class SettingsPropertyTests: XCTestCase {
         
         let property = factory.property(SettingsPropertyName.soundAlerts)
         // when & then
-        try! XCTAssertTrue(self.saveAndCheck(property, value: 1))
+        try! self.saveAndCheck(property, value: 1)
     }
     
     func testThatAnalyticsPropertySetsValue() {
@@ -132,7 +144,7 @@ class SettingsPropertyTests: XCTestCase {
         
         let property = factory.property(SettingsPropertyName.analyticsOptOut)
         // when & then
-        try! XCTAssertTrue(self.saveAndCheck(property, value: true))
+        try! self.saveAndCheck(property, value: true)
     }
     
     func testThatIntegerBlockSettingSave() {
@@ -146,7 +158,22 @@ class SettingsPropertyTests: XCTestCase {
 
         let property = factory.property(SettingsPropertyName.soundAlerts)
         // when & then
-        try! XCTAssertTrue(self.saveAndCheck(property, value: 1))
+        try! self.saveAndCheck(property, value: 1)
+    }
+
+    func testThatItCanSetAIntegerUserDefaultsSettingsPropertyLargerThanOne() {
+        // given
+        let factory = SettingsPropertyFactory(
+            userDefaults: userDefaults,
+            analytics: ZMMockAnalytics(),
+            mediaManager: ZMMockAVSMediaManager(),
+            userSession : MockZMUserSession(),
+            selfUser: MockZMEditableUser()
+        )
+
+        let property = factory.property(.tweetOpeningOption)
+        // when & then
+        try? saveAndCheck(property, value: 2)
     }
     
 }

--- a/Wire-iOS/Sources/Components/Settings/SettingsProperty.swift
+++ b/Wire-iOS/Sources/Components/Settings/SettingsProperty.swift
@@ -89,21 +89,33 @@ enum SettingsPropertyName: String, CustomStringConvertible {
 }
 
 enum SettingsPropertyValue: Equatable {
-    case number(value: Int)
+    case number(value: NSNumber)
     case string(value: Swift.String)
-    case bool(value: Swift.Bool)
     case none
-    
+
+    init(_ bool: Bool) {
+        self = .number(value: NSNumber(value: bool))
+    }
+
+    init(_ uint: UInt) {
+        self = .number(value: NSNumber(value: uint))
+    }
+
+    init(_ int: Int) {
+        self = .number(value: NSNumber(value: int))
+    }
+
+    init(_ int: Int16) {
+        self = .number(value: NSNumber(value: int))
+    }
+
     static func propertyValue(_ object: Any?) -> SettingsPropertyValue {
         switch(object) {
-        case let intValue as Int:
-            return SettingsPropertyValue.number(value: intValue)
+        case let number as NSNumber:
+            return SettingsPropertyValue.number(value: number)
             
         case let stringValue as Swift.String:
             return SettingsPropertyValue.string(value: stringValue)
-            
-        case let boolValue as Swift.Bool:
-            return SettingsPropertyValue.bool(value: boolValue)
             
         default:
             return .none
@@ -116,8 +128,6 @@ enum SettingsPropertyValue: Equatable {
             return value as AnyObject?
         case .string(let value):
             return value as AnyObject?
-        case .bool(let value):
-            return value as AnyObject?
         case .none:
             return .none
         }
@@ -126,22 +136,10 @@ enum SettingsPropertyValue: Equatable {
 
 func ==(a: SettingsPropertyValue, b: SettingsPropertyValue) -> Bool {
     switch (a, b) {
-    case (.string(let a), .string(let b)) where a == b: return true
-    case (.number(let a), .number(let b)) where a == b: return true
-    case (.bool(let a), .bool(let b)) where a == b: return true
+    case (.string(let a), .string(let b)): return a == b
+    case (.number(let a), .number(let b)): return a == b
     case (.none, .none): return true
-    
-    case (.number(let a), .bool(let b)) where ((a == 0) && (b == false)) || ((a > 0) && (b == true)): return true
-    case (.bool(let a), .number(let b)) where ((a == false) && (b == 0)) || ((a == true) && (b > 0)): return true
-        
     default: return false
-    }
-}
-
-// To enable simple Bool creation
-extension Bool {
-    init<T : Integer>(_ integer: T){
-        self.init(integer != 0)
     }
 }
 
@@ -203,8 +201,6 @@ class SettingsUserDefaultsProperty : SettingsProperty {
     
     internal func value() -> SettingsPropertyValue {
         switch self.userDefaults.object(forKey: self.userDefaultsKey) as AnyObject? {
-        case let boolValue as Bool:
-            return SettingsPropertyValue.propertyValue(boolValue as AnyObject?)
         case let numberValue as NSNumber:
             return SettingsPropertyValue.propertyValue(numberValue.intValue as AnyObject?)
         case let stringValue as String:

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Options.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Options.swift
@@ -75,15 +75,15 @@ extension SettingsCellDescriptorFactory {
             let soundAlertProperty = self.settingsPropertyFactory.property(.soundAlerts)
 
             let allAlerts = SettingsPropertySelectValueCellDescriptor(settingsProperty: soundAlertProperty,
-                                                                      value: SettingsPropertyValue.number(value: Int(AVSIntensityLevel.full.rawValue)),
+                                                                      value: SettingsPropertyValue(AVSIntensityLevel.full.rawValue),
                                                                       title: "self.settings.sound_menu.all_sounds.title".localized)
 
             let someAlerts = SettingsPropertySelectValueCellDescriptor(settingsProperty: soundAlertProperty,
-                                                                       value: SettingsPropertyValue.number(value: Int(AVSIntensityLevel.some.rawValue)),
+                                                                       value: SettingsPropertyValue(AVSIntensityLevel.some.rawValue),
                                                                        title: "self.settings.sound_menu.mute_while_talking.title".localized)
 
             let noneAlerts = SettingsPropertySelectValueCellDescriptor(settingsProperty: soundAlertProperty,
-                                                                       value: SettingsPropertyValue.number(value: Int(AVSIntensityLevel.none.rawValue)),
+                                                                       value: SettingsPropertyValue(AVSIntensityLevel.none.rawValue),
                                                                        title: "self.settings.sound_menu.no_sounds.title".localized)
 
             let alertsSection = SettingsSectionDescriptor(cellDescriptors: [allAlerts, someAlerts, noneAlerts], header: titleLabel, footer: .none)
@@ -176,7 +176,7 @@ extension SettingsCellDescriptorFactory {
 
             return SettingsPropertySelectValueCellDescriptor(
                 settingsProperty: property,
-                value: .number(value: option.rawValue),
+                value: SettingsPropertyValue(option.rawValue),
                 title: option.displayString
             )
         }
@@ -195,7 +195,7 @@ extension SettingsCellDescriptorFactory {
 
             return SettingsPropertySelectValueCellDescriptor(
                 settingsProperty: property,
-                value: .number(value: option.rawValue),
+                value: SettingsPropertyValue(option.rawValue),
                 title: option.displayString
             )
         }
@@ -214,7 +214,7 @@ extension SettingsCellDescriptorFactory {
 
             return SettingsPropertySelectValueCellDescriptor(
                 settingsProperty: property,
-                value: .number(value: option.rawValue),
+                value: SettingsPropertyValue(option.rawValue),
                 title: option.displayString
             )
         }

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
@@ -187,7 +187,7 @@ import Foundation
             
             return SettingsPropertySelectValueCellDescriptor(
                 settingsProperty: property,
-                value: .number(value: Int(option.rawValue)),
+                value: SettingsPropertyValue(option.rawValue),
                 title: option.displayString
             )
         }
@@ -274,7 +274,7 @@ import Foundation
     
     func colorsSubgroup() -> SettingsSectionDescriptorType {
         let cellDescriptors = ZMAccentColor.all().map { (color) -> SettingsCellDescriptorType in
-            let value = SettingsPropertyValue.number(value: Int(color.rawValue))
+            let value = SettingsPropertyValue(color.rawValue)
             return SettingsPropertySelectValueCellDescriptor(settingsProperty: self.settingsPropertyFactory.property(.accentColor), value: value, title: "", identifier: .none, selectAction: { _ in
                 
                 }, backgroundColor: color.color) as SettingsCellDescriptorType

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsPropertyToggleCellDescriptor.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsPropertyToggleCellDescriptor.swift
@@ -82,7 +82,7 @@ class SettingsPropertyToggleCellDescriptor: SettingsPropertyCellDescriptorType {
         }
         
         do {
-            try self.settingsProperty << SettingsPropertyValue.bool(value: valueToSet)
+            try self.settingsProperty << SettingsPropertyValue(valueToSet)
         }
         catch(let e) {
             DDLogError("Cannot set property: \(e)")

--- a/Wire-iOS/Sources/UserInterface/Settings/LinkOpening/LinkOpener.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/LinkOpening/LinkOpener.swift
@@ -22,7 +22,7 @@ import Foundation
 
 public extension NSURL {
 
-    @objc func open() -> Bool {
+    @discardableResult @objc func open() -> Bool {
         return (self as URL).open()
     }
 

--- a/Wire-iOS/Sources/UserInterface/Settings/SettingsCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/SettingsCell.swift
@@ -232,7 +232,7 @@ class SettingsToggleCell: SettingsTableCell {
     }
     
     func onSwitchChanged(_ sender: UIResponder) {
-        self.descriptor?.select(SettingsPropertyValue.bool(value: self.switchView.isOn))
+        self.descriptor?.select(SettingsPropertyValue(self.switchView.isOn))
     }
 }
 


### PR DESCRIPTION
# What's in this PR?

* When retrieving a value from the UserDefaults we were losing the type information, specifically if the value we set represents a `Bool` or for example an `Int`, this lead to bugs (e.g. [#8005](https://wearezeta.atlassian.net/browse/ZIOS-8005)).
* We now store all numbers and booleans as `NSNumbers`, the `.bool` case has been removed from the `SettingsPropertyValue`.
* Convenience initializers have been added to the `SettingsPropertyValue` to create a new value using an `Int`, `Bool` or `UInt`, this avoids duplicated `NSNumber` wrapping on the caller side.
* A test to catch the bug storing an integer value higher than 1 has been added, before this change retrieving the value would result in a `true` / `1` being returned.
* Add `@discardableResult` to `open()` method on `URL` to remove warning.