### PR TITLE
React to fingerprint update

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/SettingsClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/SettingsClientViewController.swift
@@ -62,7 +62,7 @@ class SettingsClientViewController: UIViewController, UITableViewDelegate, UITab
         self.userClientToken = userClient.addObserver(self)
         if userClient.fingerprint == .none {
             ZMUserSession.shared()?.enqueueChanges({ () -> Void in
-                userClient.markForFetchingPreKeys()
+                userClient.fetchFingerprintOrPrekeys()
             })
         }
         self.title = userClient.deviceClass?.capitalized(with: NSLocale.current)

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileClientViewController.swift
@@ -90,7 +90,7 @@ class ProfileClientViewController: UIViewController {
         self.userClientToken = userClient.addObserver(self)
         if userClient.fingerprint == .none {
             ZMUserSession.shared()?.enqueueChanges({ () -> Void in
-                self.userClient.markForFetchingPreKeys()
+                self.userClient.fetchFingerprintOrPrekeys()
             })
         }
         self.updateFingerprintLabel()
@@ -368,10 +368,8 @@ class ProfileClientViewController: UIViewController {
 extension ProfileClientViewController: UserClientObserver {
 
     func userClientDidChange(_ changeInfo: UserClientChangeInfo) {
-        if changeInfo.fingerprintChanged {
-            self.updateFingerprintLabel()
-        }
-
+        self.updateFingerprintLabel()
+        
         // This means the fingerprint is acquired
         if self.resetSessionPending && self.userClient.fingerprint != .none {
             let alert = UIAlertController(title: "", message: NSLocalizedString("self.settings.device_details.reset_session.success", comment: ""), preferredStyle: .alert)


### PR DESCRIPTION
# Issue

Apparently in current observer system there is a bug that causes the `changeInfo.fingerprintChanged` not to be initialized. As far as I know the change flags are going away anyway so the code is updated to reload fingerprint for any `UserClient` update.

Also updated to new method name `markForFetchingPreKeys` -> `fetchFingerprintOrPrekeys`