### PR TITLE
Phone number removal

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -504,6 +504,9 @@
 "self.settings.account_section.phone_number.change.save" = "Save";
 "self.settings.account_section.phone_number.change.remove" = "Remove Phone number";
 
+"self.settings.account_section.phone_number.change.remove.message" = "Do you really want to remove your phone?";
+"self.settings.account_section.phone_number.change.remove.action" = "Remove";
+
 "self.settings.account_section.phone_number.change.verify.save" = "Save";
 "self.settings.account_section.phone_number.change.verify.title" = "Verify phone";
 "self.settings.account_section.phone_number.change.verify.description" = "Enter the verification code we sent to %@.";

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -502,6 +502,7 @@
 
 "self.settings.account_section.phone_number.change.title" = "Phone number";
 "self.settings.account_section.phone_number.change.save" = "Save";
+"self.settings.account_section.phone_number.change.remove" = "Remove Phone number";
 
 "self.settings.account_section.phone_number.change.verify.save" = "Save";
 "self.settings.account_section.phone_number.change.verify.title" = "Verify phone";

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -757,7 +757,7 @@
 "error.user.phone_code_too_many" = "We already sent you a code via SMS. Tap Resend after 10 minutes to get a new one.";
 "error.user.registration_unknown_error" = "Something went wrong. Please try again.";
 "error.user.device_deleted_remotely" = "You have been logged out from another device.";
-
+"error.user.last_identity_cant_be_deleted" = "You need to have both an email and phone number to be able to remove one of them";
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Those are caught by the UI without involving the SE validation. Basically very similar to ZMUserSessionErrorCode onces

--- a/Wire-iOS/Sources/UserInterface/Helpers/UIViewController+Errors.m
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UIViewController+Errors.m
@@ -99,6 +99,9 @@
             case ZMUserSessionClientDeletedRemotely:
                 message = NSLocalizedString(@"error.user.device_deleted_remotely", @"");
                 break;
+            case ZMUserSessionLastUserIdentityCantBeDeleted:
+                message = NSLocalizedString(@"error.user.last_identity_cant_be_deleted", @"");
+                break;
                 
             default:
             case ZMUserSessionUnkownError:

--- a/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ChangePhoneViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ChangePhoneViewController.swift
@@ -220,9 +220,21 @@ final class ChangePhoneViewController: SettingsBaseTableViewController {
         case .phoneNumber:
             break
         case .remove:
-            userProfile?.requestPhoneNumberRemoval()
-            updateSaveButtonState(enabled: false)
-            showLoadingView = true
+            let alert = UIAlertController(
+                title: "self.settings.account_section.phone_number.change.remove.message".localized,
+                message: nil,
+                preferredStyle: .actionSheet
+            )
+            
+            alert.addAction(.init(title: "general.cancel".localized, style: .cancel, handler: nil))
+            alert.addAction(.init(title: "self.settings.account_section.phone_number.change.remove.action".localized, style: .destructive) { [weak self] _ in
+                guard let `self` = self else { return }
+                self.userProfile?.requestPhoneNumberRemoval()
+                self.updateSaveButtonState(enabled: false)
+                self.showLoadingView = true
+            })
+
+            present(alert, animated: true, completion: nil)
         }
         tableView.deselectRow(at: indexPath, animated: false)
     }


### PR DESCRIPTION
## What's in this PR?

Adding ability to remove phone number if you have both email and phone in your profile.

This is part of the functionality needed for #665, split into a separate PR to make it smaller.

- [x] Depends on https://github.com/wireapp/wire-ios-sync-engine/pull/251 