### PR TITLE
Use conversation based user displayNames for message sender names

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
@@ -417,7 +417,7 @@ const NSTimeInterval ConversationCellSelectionAnimationDuration = 0.33;
 
 - (void)updateSenderAndSenderImage:(id<ZMConversationMessage>)message
 {
-    self.authorLabel.text = message.sender.displayName.uppercaseString;
+    self.authorLabel.text = [message.sender displayNameInConversation:message.conversation].uppercaseString;
     self.authorImageView.user = message.sender;
 }
 


### PR DESCRIPTION
A conversation's participants' displayNames are now calculated on the fly for each conversation.
There is still a bug: the selfUser currently shows their fullName. Will be fixed tomorrow.

Names in the reaction list should still always be givenNames.