### PR TITLE
Inverse images order in fullscreen images view

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/MessagePresenter+ConversationImages.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/MessagePresenter+ConversationImages.swift
@@ -29,7 +29,8 @@ extension MessagePresenter {
         
         let collection = AssetCollectionWrapper(conversation: conversation, matchingCategories: [imagesCategoryMatch])
         
-        let imagesController = ConversationImagesViewController(collection: collection, initialMessage: message)
+        let imagesController = ConversationImagesViewController(collection: collection, initialMessage: message, inverse: true)
+        
         if (UIDevice.current.userInterfaceIdiom == .phone) {
             imagesController.modalPresentationStyle = .fullScreen;
             imagesController.snapshotBackgroundView = UIScreen.main.snapshotView(afterScreenUpdates: true)


### PR DESCRIPTION
When the swiping view is opened from the conversation the images order must be inverted to match the logical images stream direction (top-down to left-right).