### PR TITLE
Display popup in case of AVS I/O error on internal builds

### DIFF
--- a/Wire-iOS/Sources/Analytics/AnalyticsVoiceChannelTracker.m
+++ b/Wire-iOS/Sources/Analytics/AnalyticsVoiceChannelTracker.m
@@ -20,6 +20,7 @@
 #import "AnalyticsVoiceChannelTracker.h"
 #import "Analytics.h"
 #import "zmessaging+iOS.h"
+#import "DeveloperMenuState.h"
 
 
 @interface AnalyticsVoiceChannelTracker () <VoiceChannelStateObserver>
@@ -83,6 +84,14 @@
 
 - (void)callCenterDidEndCallWithReason:(VoiceChannelV2CallEndReason)reason conversation:(ZMConversation *)conversation callingProtocol:(enum CallingProtocol)callingProtocol
 {
+    if (reason == VoiceChannelV2CallEndReasonInputOutputError && [DeveloperMenuState developerMenuEnabled]) {
+        UIAlertView* view = [[UIAlertView alloc] initWithTitle:@"Calling error"
+                                                       message:@"AVS I/O error"
+                                                      delegate:nil
+                                             cancelButtonTitle:@"OK"
+                                             otherButtonTitles:nil];
+        [view show];
+    }
     [self.analytics tagEndedCallInConversation:conversation
                                          video:self.isVideoCall
                                  initiatedCall:self.initiatedCall


### PR DESCRIPTION
Display popup in case of AVS I/O error on internal builds. We want to monitor how often this happens on internal builds