### PR TITLE
Fix conversation list visible in conversation (voiceover)

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.h
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.h
@@ -39,8 +39,6 @@ FOUNDATION_EXPORT NSString *SplitLayoutObservableDidChangeToLayoutSizeNotificati
 
 @protocol SplitViewControllerDelegate <NSObject>
 - (BOOL)splitViewControllerShouldMoveLeftViewController:(SplitViewController *)splitViewController;
-- (void)splitViewControllerWillExpandLeftViewController:(SplitViewController *)splitViewController;
-- (void)splitViewControllerWillCollapseLeftViewController:(SplitViewController *)splitViewController;
 @end
 
 

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.h
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.h
@@ -54,15 +54,12 @@ FOUNDATION_EXPORT NSString *SplitLayoutObservableDidChangeToLayoutSizeNotificati
 @property (nonatomic, nullable) UIViewController *leftViewController;
 @property (nonatomic, nullable) UIViewController *rightViewController;
 
-@property (nonatomic, getter=isLeftViewControllerExpanded) BOOL leftViewControllerExpanded;
 @property (nonatomic, getter=isLeftViewControllerRevealed) BOOL leftViewControllerRevealed;
 
 @property (nonatomic, weak, nullable) id<SplitViewControllerDelegate> delegate;
 
 - (void)setLeftViewController:(nullable UIViewController *)leftViewController animated:(BOOL)animated completion:(nullable dispatch_block_t)completion;
-- (void)setLeftViewController:(nullable UIViewController *)leftViewController animated:(BOOL)animated expanded:(BOOL)expanded completion:(nullable dispatch_block_t)completion;
 - (void)setRightViewController:(nullable UIViewController *)rightViewController animated:(BOOL)animated completion:(nullable dispatch_block_t)completion;
-- (void)setLeftViewControllerExpanded:(BOOL)leftViewControllerIsExpanded animated:(BOOL)animated completion:(nullable dispatch_block_t)completion;
 - (void)setLeftViewControllerRevealed:(BOOL)leftViewControllerIsRevealed animated:(BOOL)animated completion:(nullable dispatch_block_t)completion;
 
 @end

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.m
@@ -566,6 +566,7 @@ NSString *SplitLayoutObservableDidChangeToLayoutSizeNotification = @"SplitLayout
         case UIGestureRecognizerStateBegan:
             [self.leftViewController beginAppearanceTransition:! self.leftViewControllerRevealed animated:YES];
             [self.rightViewController beginAppearanceTransition:self.leftViewControllerRevealed animated:YES];
+            self.leftView.hidden = NO;
             break;
             
         case UIGestureRecognizerStateChanged:

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.m
@@ -158,7 +158,6 @@ NSString *SplitLayoutObservableDidChangeToLayoutSizeNotification = @"SplitLayout
 
 @property (nonatomic) NSLayoutConstraint *sideBySideConstraint;
 @property (nonatomic) NSLayoutConstraint *pinLeftViewOffsetConstraint;
-@property (nonatomic) NSLayoutConstraint *expandLeftViewConstraint;
 
 @property (nonatomic) UIPanGestureRecognizer *horizontalPanner;
 
@@ -215,9 +214,6 @@ NSString *SplitLayoutObservableDidChangeToLayoutSizeNotification = @"SplitLayout
         self.leftViewOffsetConstraint = [self.leftView autoPinEdgeToSuperviewEdge:ALEdgeLeft];
         self.rightViewOffsetConstraint = [self.rightView autoPinEdgeToSuperviewEdge:ALEdgeLeft];
     }];
-    
-    self.expandLeftViewConstraint = [self.leftView autoPinEdgeToSuperviewEdge:ALEdgeRight];
-    self.expandLeftViewConstraint.active = NO;
     
     self.leftViewWidthConstraint = [self.leftView autoSetDimension:ALDimensionWidth toSize:0];
     self.rightViewWidthConstraint = [self.rightView autoSetDimension:ALDimensionWidth toSize:0];
@@ -345,9 +341,7 @@ NSString *SplitLayoutObservableDidChangeToLayoutSizeNotification = @"SplitLayout
     if (self.layoutSize != SplitViewControllerLayoutSizeRegularLandscape) {
         [constraints addObjectsFromArray:@[self.pinLeftViewOffsetConstraint, self.sideBySideConstraint]];
     }
-    
-    [constraints addObjectsFromArray:@[self.expandLeftViewConstraint]];
-    
+        
     return [constraints allObjects];
 }
 

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.m
@@ -333,11 +333,7 @@ NSString *SplitLayoutObservableDidChangeToLayoutSizeNotification = @"SplitLayout
         [constraints addObjectsFromArray:@[self.pinLeftViewOffsetConstraint, self.sideBySideConstraint]];
     }
     
-    if (self.leftViewControllerExpanded) {
-        [constraints addObjectsFromArray:@[self.expandLeftViewConstraint, self.sideBySideConstraint]];
-    } else {
-        [constraints addObjectsFromArray:@[self.leftViewWidthConstraint]];
-    }
+    [constraints addObjectsFromArray:@[self.leftViewWidthConstraint]];
     
     return [constraints allObjects];
 }
@@ -350,32 +346,9 @@ NSString *SplitLayoutObservableDidChangeToLayoutSizeNotification = @"SplitLayout
         [constraints addObjectsFromArray:@[self.pinLeftViewOffsetConstraint, self.sideBySideConstraint]];
     }
     
-    if (self.leftViewControllerExpanded) {
-        [constraints addObjectsFromArray:@[self.leftViewWidthConstraint]];
-    } else {
-        [constraints addObjectsFromArray:@[self.expandLeftViewConstraint]];
-    }
+    [constraints addObjectsFromArray:@[self.expandLeftViewConstraint]];
     
     return [constraints allObjects];
-}
-
-- (void)setLeftViewController:(UIViewController *)leftViewController animated:(BOOL)animated expanded:(BOOL)expanded completion:(nullable dispatch_block_t)completion
-{
-    if (self.traitCollection.userInterfaceIdiom == UIUserInterfaceIdiomPad && self.leftViewControllerExpanded != expanded) {
-        @weakify(self);
-        [self setLeftViewController:nil animated:animated completion:^{
-            @strongify(self);
-            @weakify(self);
-            [self setLeftViewControllerExpanded:expanded animated:animated completion:^{
-                @strongify(self);
-                [self setLeftViewController:leftViewController animated:animated completion:completion];
-            }];
-            
-        }];
-    } else {
-        SplitViewControllerTransition transition = expanded ? SplitViewControllerTransitionPresent : SplitViewControllerTransitionDismiss;
-        [self setLeftViewController:leftViewController animated:animated transition:transition completion:completion];
-    }
 }
 
 - (void)setLeftViewController:(nullable UIViewController *)leftViewController
@@ -504,36 +477,6 @@ NSString *SplitLayoutObservableDidChangeToLayoutSizeNotification = @"SplitLayout
     return YES;
 }
 
-- (void)setLeftViewControllerExpanded:(BOOL)leftViewControllerIsExpanded
-{
-    [self setLeftViewControllerExpanded:leftViewControllerIsExpanded animated:YES completion:nil];
-}
-
-- (void)setLeftViewControllerExpanded:(BOOL)leftViewControllerExpanded animated:(BOOL)animated completion:(nullable dispatch_block_t)completion
-{
-    _leftViewControllerExpanded = leftViewControllerExpanded;
-    
-    if (leftViewControllerExpanded) {
-        if ([self.delegate respondsToSelector:@selector(splitViewControllerWillExpandLeftViewController:)]) {
-            [self.delegate splitViewControllerWillExpandLeftViewController:self];
-        }
-    } else {
-        if ([self.delegate respondsToSelector:@selector(splitViewControllerWillCollapseLeftViewController:)]) {
-            [self.delegate splitViewControllerWillCollapseLeftViewController:self];
-        }
-    }
-    
-    [self updateActiveConstraints];
-    
-    if (animated) {
-        [UIView wr_animateWithEasing:RBBEasingFunctionEaseOutExpo duration:0.35 animations:^{
-            [self.view layoutIfNeeded];
-        } completion:^(BOOL finished) {
-            if (completion != nil) completion();
-        }];
-    }
-}
-
 - (void)setLeftViewControllerRevealed:(BOOL)leftViewControllerIsRevealed
 {
     [self setLeftViewControllerRevealed:leftViewControllerIsRevealed animated:YES completion:nil];
@@ -544,6 +487,8 @@ NSString *SplitLayoutObservableDidChangeToLayoutSizeNotification = @"SplitLayout
     if (animated) {
         [self.view layoutIfNeeded];
     }
+    
+    self.leftView.hidden = NO;
     
     _leftViewControllerRevealed = leftViewControllerRevealed;
     self.openPercentage = leftViewControllerRevealed ? 1 : 0;
@@ -558,7 +503,7 @@ NSString *SplitLayoutObservableDidChangeToLayoutSizeNotification = @"SplitLayout
             [[UIApplication sharedApplication] wr_updateStatusBarForCurrentControllerAnimated:NO];
         }
         
-        [UIView wr_animateWithEasing:RBBEasingFunctionEaseOutExpo duration:0.55 animations:^{
+        [UIView wr_animateWithEasing:RBBEasingFunctionEaseOutExpo duration:0.55f animations:^{
             [self.view layoutIfNeeded];
             if (!leftViewControllerRevealed) {
                 dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.01f * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
@@ -572,7 +517,10 @@ NSString *SplitLayoutObservableDidChangeToLayoutSizeNotification = @"SplitLayout
                 [self.leftViewController endAppearanceTransition];
                 [self.rightViewController endAppearanceTransition];
             }
-          
+            
+            if (self.openPercentage == 0) {
+                self.leftView.hidden = YES;
+            }
         }];
     }
     else {
@@ -591,7 +539,7 @@ NSString *SplitLayoutObservableDidChangeToLayoutSizeNotification = @"SplitLayout
 
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
 {
-    if (self.layoutSize == SplitViewControllerLayoutSizeRegularLandscape || ! [self.delegate splitViewControllerShouldMoveLeftViewController:self] || self.isLeftViewControllerExpanded) {
+    if (self.layoutSize == SplitViewControllerLayoutSizeRegularLandscape || ! [self.delegate splitViewControllerShouldMoveLeftViewController:self]) {
         return NO;
     }
     
@@ -604,7 +552,7 @@ NSString *SplitLayoutObservableDidChangeToLayoutSizeNotification = @"SplitLayout
 
 - (void)onHorizontalPan:(UIPanGestureRecognizer *)gestureRecognizer
 {
-    if (self.layoutSize == SplitViewControllerLayoutSizeRegularLandscape || ! [self.delegate splitViewControllerShouldMoveLeftViewController:self] || self.isLeftViewControllerExpanded) {
+    if (self.layoutSize == SplitViewControllerLayoutSizeRegularLandscape || ! [self.delegate splitViewControllerShouldMoveLeftViewController:self]) {
         return;
     }
     

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
@@ -653,16 +653,6 @@
            (self.conversationListViewController.presentedViewController == nil || splitViewController.isLeftViewControllerRevealed == NO);
 }
 
-- (void)splitViewControllerWillExpandLeftViewController:(SplitViewController *)splitViewController
-{
-    [self.backgroundViewController setForceFullScreen:YES animated:YES];
-}
-
-- (void)splitViewControllerWillCollapseLeftViewController:(SplitViewController *)splitViewController
-{
-    [self.backgroundViewController setForceFullScreen:NO animated:YES];
-}
-
 @end
 
 @implementation ZClientViewController (ZMRequestsToOpenViewsDelegate)

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
@@ -260,7 +260,7 @@
     [stopWatch restartEvent:[NSString stringWithFormat:@"ConversationSelect%@", conversation.displayName]];
     
     @weakify(self);
-    [self.splitViewController setLeftViewController:self.conversationListViewController animated:animated expanded:NO completion:^{
+    [self.splitViewController setLeftViewController:self.conversationListViewController animated:animated completion:^{
         @strongify(self);
         [self.conversationListViewController selectConversation:conversation focusOnView:focus animated:animated completion:completion];
     }];


### PR DESCRIPTION
# Issue

We where not hiding the conv list view when the conversation was open, therefore drawing the voiceover quite useless.

- Also removed "expanded" mode for left view controller when it used to occupy the whole viewport, for example in self profile;