### PR TITLE
Adjust no results and empty screen in search

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Collections/TextSearch/TextSearchViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/TextSearch/TextSearchViewController.swift
@@ -97,8 +97,8 @@ final public class TextSearchViewController: NSObject {
 
         // We hide the results when we either have none or the query is too short
         resultsView.tableView.isHidden = noResults || !validQuery
-        // We only show the no results view if there are no results
-        resultsView.noResultsView.isHidden = !noResults
+        // We only show the no results view if there are no results and a valid query
+        resultsView.noResultsView.isHidden = !noResults || !validQuery
         // If the user did not enter any search query we show the collection again
         resultsView.isHidden = query.isEmpty
 
@@ -132,6 +132,9 @@ extension TextSearchViewController: TextSearchInputViewDelegate {
         }
 
         if query.characters.count < 2 {
+            // We reset the results to avoid showing the previous 
+            // results for a short period for subsequential searches
+            results = []
             resultsView.isLoading = false
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Collections/TextSearch/TextSearchViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/TextSearch/TextSearchViewController.swift
@@ -35,9 +35,7 @@ final public class TextSearchViewController: NSObject {
     
     fileprivate var results: [ZMConversationMessage] = [] {
         didSet {
-            self.resultsView.tableView.isHidden = results.count == 0
-            self.resultsView.noResultsView.isHidden = results.count != 0
-            self.resultsView.tableView.reloadData()
+            reloadResults()
         }
     }
 
@@ -92,6 +90,21 @@ final public class TextSearchViewController: NSObject {
         }
     }
 
+    fileprivate func reloadResults() {
+        let query = searchQuery ?? ""
+        let noResults = results.isEmpty
+        let validQuery = query.characters.count >= 2
+
+        // We hide the results when we either have none or the query is too short
+        resultsView.tableView.isHidden = noResults || !validQuery
+        // We only show the no results view if there are no results
+        resultsView.noResultsView.isHidden = !noResults
+        // If the user did not enter any search query we show the collection again
+        resultsView.isHidden = query.isEmpty
+
+        resultsView.tableView.reloadData()
+    }
+
 }
 
 extension TextSearchViewController: TextSearchQueryDelegate {
@@ -112,13 +125,10 @@ extension TextSearchViewController: TextSearchInputViewDelegate {
     public func searchView(_ searchView: TextSearchInputView, didChangeQueryTo query: String) {
         textSearchQuery?.cancel()
         searchStartedDate = nil
+        reloadResults()
 
-        if query.isEmpty {
-            self.resultsView.isHidden = true
-        }
-        else {
-            self.scheduleSearch()
-            self.resultsView.isHidden = false
+        if !query.isEmpty {
+            scheduleSearch()
         }
 
         if query.characters.count < 2 {


### PR DESCRIPTION
# What's in this PR?

* Adjust when we show the "No Results" screen and when an empty screen is shown in the search.
* Clear the last search when tapping the cancel button or deleting the last valid character.