### PR TITLE
Wrap file sending with performChanges

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Files.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Files.m
@@ -265,12 +265,13 @@ const NSTimeInterval ConversationUploadMaxVideoDuration = 4.0f * 60.0f; // 4 min
             completion();
         }
         else {
-            [ZMUserSession.sharedSession performChanges:^{
-                [self.analyticsTracker tagInitiatedFileUploadWithSize:[attributes[NSFileSize] unsignedLongLongValue]
-                                                        fileExtension:[url pathExtension]
-                                                              context:FileTransferContextApp];
-                
-                [FileMetaDataGenerator metadataForFileAtURL:url UTI:url.UTI name:url.lastPathComponent completion:^(ZMFileMetadata * _Nonnull metadata) {
+            [self.analyticsTracker tagInitiatedFileUploadWithSize:[attributes[NSFileSize] unsignedLongLongValue]
+                                                    fileExtension:[url pathExtension]
+                                                          context:FileTransferContextApp];
+            
+            [FileMetaDataGenerator metadataForFileAtURL:url UTI:url.UTI name:url.lastPathComponent completion:^(ZMFileMetadata * _Nonnull metadata) {
+                [ZMUserSession.sharedSession performChanges:^{
+
                     id<ZMConversationMessage> message = [self.conversation appendMessageWithFileMetadata:metadata
                                                                                                 version3:Settings.sharedSettings.sendV3Assets];
                     


### PR DESCRIPTION
- So the observers can see the new file message

@evr3n this would most likely fix automation for files/video/audio sending