### PR TITLE
Invite “people” (not “friends”)

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -619,7 +619,7 @@
 "self.settings.password_reset_menu.title" = "Reset Password";
 
 // Invite from Settings
-"self.settings.invite_friends.title" = "Invite friends";
+"self.settings.invite_friends.title" = "Invite people";
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // System status


### PR DESCRIPTION
Not all people are “friends”, particulary in a business context.

(Aligning this recently-added string with invitation copy that appears elsewhere in the app.)