### PR TITLE
Align invitation copy

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -100,9 +100,6 @@
 "send_invitation.text" = "I’m on Wire, search for %@ or visit get.wire.com";
 "send_invitation_no_email.text" = "I’m on Wire, search for %@ or visit get.wire.com";
 
-"send_personal_invitation.text" = "I’m on Wire, search for %@ or visit get.wire.com";
-
-
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++x
 // In-app notifications (chat heads)
 "notifications.shared_a_photo" = "shared a picture";

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -98,7 +98,7 @@
 
 "send_invitation.subject" = "Connect with me on Wire";
 "send_invitation.text" = "I’m on Wire, search for %@ or visit get.wire.com";
-"send_invitation_no_email.text" = "I’m on Wire, search for %@ or visit get.wire.com";
+"send_invitation_no_email.text" = "I’m on Wire. Visit get.wire.com to connect with me.";
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++x
 // In-app notifications (chat heads)

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -97,10 +97,10 @@
 "peoplepicker.hide_search_result_progress" = "Hiding…";
 
 "send_invitation.subject" = "Connect with me on Wire";
-"send_invitation.text" = "I’m on Wire, search for %@ or visit get.wire.com.";
-"send_invitation_no_email.text" = "I’m on Wire. Visit get.wire.com to connect with me.";
+"send_invitation.text" = "I’m on Wire, search for %@ or visit get.wire.com";
+"send_invitation_no_email.text" = "I’m on Wire, search for %@ or visit get.wire.com";
 
-"send_personal_invitation.text" = "I’m on Wire, talk to you there: get.wire.com.";
+"send_personal_invitation.text" = "I’m on Wire, search for %@ or visit get.wire.com";
 
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++x

--- a/Wire-iOS/Sources/UserInterface/ContactsUI/ZMAddressBookContact+LocalInvitation.swift
+++ b/Wire-iOS/Sources/UserInterface/ContactsUI/ZMAddressBookContact+LocalInvitation.swift
@@ -44,7 +44,8 @@ extension ZMAddressBookContact {
         let composeController = MFMailComposeViewController()
         composeController.mailComposeDelegate = EmailInvitePresenter.sharedInstance
         composeController.modalPresentationStyle = .formSheet
-        composeController.setMessageBody("send_personal_invitation.text".localized, isHTML: false)
+
+        composeController.setMessageBody(invitationBody(), isHTML: false)
         composeController.setToRecipients([email])
         ZClientViewController.shared().present(composeController, animated: true, completion: .none)
     }
@@ -57,8 +58,16 @@ extension ZMAddressBookContact {
         let composeController = MFMessageComposeViewController()
         composeController.messageComposeDelegate = EmailInvitePresenter.sharedInstance
         composeController.modalPresentationStyle = .formSheet
-        composeController.body = "send_personal_invitation.text".localized
+        composeController.body = invitationBody()
         composeController.recipients = [phoneNumber]
         ZClientViewController.shared().present(composeController, animated: true, completion: .none)
+    }
+
+    private func invitationBody() -> String {
+        if let handle = ZMUser.selfUser(inUserSession: ZMUserSession.shared()).handle {
+            return "send_invitation.text".localized(args: "@" + handle)
+        } else {
+            return "send_invitation_no_email.text".localized
+        }
     }
 }

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/InviteActionSheet/ShareItemProvider.m
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/InviteActionSheet/ShareItemProvider.m
@@ -67,8 +67,6 @@ NSString *ActivityToAnalyticsString(NSString *activity) {
     if (nil != fullSelfUser.handle) {
         NSString *displayHandle = [NSString stringWithFormat:@"@%@", fullSelfUser.handle];
         return [NSString stringWithFormat:NSLocalizedString(@"send_invitation.text", @""), displayHandle];
-    } else if (fullSelfUser.emailAddress.length > 0) {
-        return [NSString stringWithFormat:NSLocalizedString(@"send_invitation.text", @""), fullSelfUser.emailAddress];
     }
 
     return NSLocalizedString(@"send_invitation_no_email.text", @"");


### PR DESCRIPTION
* Use most recent (username) variant for all three
* Drop trailing punctuation per YV preference