### PR TITLE
Logic to exclude emoji cache from the backup

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -453,6 +453,7 @@
 		874D0EB31D3E6D77003DF418 /* ConversationInputBarViewController+Camera.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874D0EB21D3E6D77003DF418 /* ConversationInputBarViewController+Camera.swift */; };
 		874E27CB1E2912860079573D /* ConversationImagesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874E27CA1E2912860079573D /* ConversationImagesViewController.swift */; };
 		87501FB31D40D6490056C042 /* ComponentsVersions.plist in Resources */ = {isa = PBXBuildFile; fileRef = 87501FB21D40D6490056C042 /* ComponentsVersions.plist */; };
+		875060731E5B3D9E005B21C7 /* FileBackupExcluder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 875060721E5B3D9E005B21C7 /* FileBackupExcluder.swift */; };
 		8751A93C1C737D7200C72324 /* IconSystemCellTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8751A93B1C737D7200C72324 /* IconSystemCellTests.m */; };
 		87555C851A85021C00A43E2E /* ChatHeadView.m in Sources */ = {isa = PBXBuildFile; fileRef = 87555C801A85021C00A43E2E /* ChatHeadView.m */; };
 		87555C871A85021C00A43E2E /* ChatHeadsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 87555C841A85021C00A43E2E /* ChatHeadsViewController.m */; };
@@ -1666,6 +1667,7 @@
 		874E27CA1E2912860079573D /* ConversationImagesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConversationImagesViewController.swift; sourceTree = "<group>"; };
 		874E85951BEA0D3C006A7EBF /* Wire-iOS-Tests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Wire-iOS-Tests-Bridging-Header.h"; sourceTree = "<group>"; };
 		87501FB21D40D6490056C042 /* ComponentsVersions.plist */ = {isa = PBXFileReference; lastKnownFileType = file.bplist; name = ComponentsVersions.plist; path = "Wire-iOS/ComponentsVersions.plist"; sourceTree = "<group>"; };
+		875060721E5B3D9E005B21C7 /* FileBackupExcluder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileBackupExcluder.swift; sourceTree = "<group>"; };
 		8751A93B1C737D7200C72324 /* IconSystemCellTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IconSystemCellTests.m; sourceTree = "<group>"; };
 		87555C7F1A85021C00A43E2E /* ChatHeadView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ChatHeadView.h; sourceTree = "<group>"; };
 		87555C801A85021C00A43E2E /* ChatHeadView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ChatHeadView.m; sourceTree = "<group>"; };
@@ -4326,6 +4328,7 @@
 				BA79B0A41B6284D900F23AFB /* SoundEventRulesWatchDog.m */,
 				876113DE1DD1DD19007F5969 /* ColorSchemeController.h */,
 				876113DF1DD1DD19007F5969 /* ColorSchemeController.m */,
+				875060721E5B3D9E005B21C7 /* FileBackupExcluder.swift */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -6032,6 +6035,7 @@
 				16E311C91A5FEAE200FF2C9E /* TextMessageCell.m in Sources */,
 				87B8C3411DF9788B0015EC89 /* MapOpening.swift in Sources */,
 				87DCF4EA1D34EA4500BB420F /* CollectionViewSectionAggregator.m in Sources */,
+				875060731E5B3D9E005B21C7 /* FileBackupExcluder.swift in Sources */,
 				871BC2571D34F8F800DF0793 /* PushTransition.m in Sources */,
 				8744489F1C22FCE500E7B947 /* Message+Formatting.m in Sources */,
 				166390D61DC8AC0C00D7BF1C /* String+Image.swift in Sources */,

--- a/Wire-iOS/Sources/AppController.m
+++ b/Wire-iOS/Sources/AppController.m
@@ -68,6 +68,7 @@ NSString *const ZMUserSessionDidBecomeAvailableNotification = @"ZMUserSessionDid
 @property (nonatomic) NSMutableArray <dispatch_block_t> *blocksToExecute;
 
 @property (nonatomic) ClassyCache *classyCache;
+@property (nonatomic) FileBackupExcluder *fileBackupExcluder;
 
 @end
 
@@ -92,6 +93,7 @@ NSString *const ZMUserSessionDidBecomeAvailableNotification = @"ZMUserSessionDid
         self.blocksToExecute = [NSMutableArray array];
         self.logObserver = [[AVSLogObserver alloc] init];
         self.classyCache = [[ClassyCache alloc] init];
+        self.fileBackupExcluder = [[FileBackupExcluder alloc] init];
         self.groupIdentifier = [NSString stringWithFormat:@"group.%@", NSBundle.mainBundle.bundleIdentifier];
         
         [[NSNotificationCenter defaultCenter] addObserver:self

--- a/Wire-iOS/Sources/Managers/FileBackupExcluder.swift
+++ b/Wire-iOS/Sources/Managers/FileBackupExcluder.swift
@@ -1,0 +1,80 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import CocoaLumberjackSwift
+
+public extension URL {
+    public func wr_excludeFromBackup() throws {
+        var mutableCopy = self
+        var resourceValues = URLResourceValues()
+        resourceValues.isExcludedFromBackup = true
+        try mutableCopy.setResourceValues(resourceValues)
+    }
+    
+    public static func wr_directory(for searchPathDirectory: NSFileManager.SearchPathDirectory) -> URL {
+        return URL(fileURLWithPath: NSSearchPathForDirectoriesInDomains(searchPathDirectory, .userDomainMask, true).first!)
+    }
+}
+
+final internal class FileBackupExcluder: NSObject {
+    typealias FileInDirectory = (NSFileManager.SearchPathDirectory, String)
+    private static let filesToExclude: [FileInDirectory] = [(.libraryDirectory, "Preferences/com.apple.EmojiCache.plist")]
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+    
+    override internal init() {
+        super.init()
+        
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(FileBackupExcluder.applicationWillEnterForeground(_:)),
+                                               name: .UIApplicationWillEnterForeground,
+                                               object: .none)
+        
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(FileBackupExcluder.applicationWillResignActive(_:)),
+                                               name: .UIApplicationWillResignActive,
+                                               object: .none)
+        
+        self.excludeFilesFromBackup()
+    }
+    
+    @objc internal func applicationWillEnterForeground(_ sender: AnyObject!) {
+        self.excludeFilesFromBackup()
+    }
+    
+    @objc internal func applicationWillResignActive(_ sender: AnyObject!) {
+        self.excludeFilesFromBackup()
+    }
+    
+    internal func excludeFilesFromBackup() {
+        do {
+            try type(of: self).filesToExclude.forEach { (directory, path) in
+                let url = URL.wr_directory(for: directory).appendingPathComponent(path)
+                if FileManager.default.fileExists(atPath: url.path) {
+                    try url.wr_excludeFromBackup()
+                }
+            }
+        }
+        catch (let error) {
+            DDLogError("Cannot exclude file from the backup: \(self): \(error)")
+        }
+    }
+}

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/Emoji/RecentlyUsedEmojis.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/Emoji/RecentlyUsedEmojis.swift
@@ -75,15 +75,14 @@ class RecentlyUsedEmojiPeristenceCoordinator {
     }
 
     private static func createDirectoryIfNeeded() {
-        guard var url = directoryURL else { return }
+        guard let url = directoryURL else { return }
         
         do {
             if !FileManager.default.fileExists(atPath: url.path) {
                 try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true, attributes: nil)
             }
-            var values = URLResourceValues()
-            values.isExcludedFromBackup = true
-            try url.setResourceValues(values)
+
+            try url.wr_excludeFromBackup()
         }
         catch (let exception) {
             DDLogError("Error creating \(directoryURL): \(exception)")

--- a/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ConfirmPhoneViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ConfirmPhoneViewController.swift
@@ -212,7 +212,7 @@ final class ConfirmPhoneViewController: SettingsBaseTableViewController {
 
 extension ConfirmPhoneViewController: ZMUserObserver {
     
-    func userDidChange(_ note: ZMCDataModel.UserChangeInfo!) {
+    func userDidChange(_ note: ZMCDataModel.UserChangeInfo) {
         if note.user.isSelfUser {
             // we need to check if the notification really happened because
             // the phone got changed to what we expected


### PR DESCRIPTION
- Logic can be used for other random files that iOS creates