### PR TITLE
Fix username not being shown in search results for some users

### DIFF
--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/Cells/SearchResultCell.m
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/Cells/SearchResultCell.m
@@ -390,7 +390,7 @@
 
 - (void)updateSubtitleForCommonConnections:(NSUInteger)connections
 {
-    NSAttributedString *subtitle = [self attributedSubtitleWithConnectionCount:connections];
+    NSAttributedString *subtitle = [self attributedSubtitleWithConnectionCount:connections user:BareUserToUser(self.user)];
 
     if (nil == subtitle) {
         self.subtitleLabel.text = @"";
@@ -403,20 +403,19 @@
     }
 }
 
-- (NSAttributedString *)attributedSubtitleWithConnectionCount:(NSUInteger)connections
+- (NSAttributedString *)attributedSubtitleWithConnectionCount:(NSUInteger)connections user:(ZMUser *)user
 {
     NSMutableAttributedString *subtitle = [[NSMutableAttributedString alloc] init];
-    [subtitle beginEditing];
 
     NSAttributedString *handle;
-    if (nil != self.user.handle && self.user.handle.length > 0) {
+    if (nil != user.handle && user.handle.length > 0) {
         NSDictionary *attributes = @{ NSFontAttributeName: self.class.boldFont, NSForegroundColorAttributeName: self.class.subtitleColor };
-        NSString *displayHandle = [NSString stringWithFormat:@"@%@", self.user.handle];
+        NSString *displayHandle = [NSString stringWithFormat:@"@%@", user.handle];
         handle = [[NSAttributedString alloc] initWithString:displayHandle attributes:attributes];
         [subtitle appendAttributedString:handle];
     }
 
-    NSString *addresBookName = BareUserToUser(self.user).addressBookEntry.cachedName;
+    NSString *addresBookName = user.addressBookEntry.cachedName;
     NSAttributedString *correlation = [self.class.correlationFormatter correlationTextFor:self.user with:connections addressBookName:addresBookName];
     if (nil != correlation) {
         if (nil != handle) {
@@ -426,7 +425,6 @@
         [subtitle appendAttributedString:correlation];
     }
 
-    [subtitle endEditing];
     return subtitle.length != 0 ? [[NSAttributedString alloc] initWithAttributedString:subtitle] : nil;
 }
 


### PR DESCRIPTION
# What's in this PR?

* There was an issue in the `SearchResultsCell` not showing the username in specific cases as we did not use the underlying user of a bare user.