### PR TITLE
Use original link per default in the link preview

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ArticleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ArticleView.swift
@@ -255,10 +255,10 @@ extension LinkPreview {
     var openableURL: NSURL? {
         let application = UIApplication.shared
 
-        if let permanentURL = permanentURL, application.canOpenURL(permanentURL) {
-            return permanentURL as NSURL?
-        } else if let originalURL = NSURL(string: originalURLString), application.canOpenURL(originalURL as URL) {
+        if let originalURL = NSURL(string: originalURLString), application.canOpenURL(originalURL as URL) {
             return originalURL
+        } else if let permanentURL = permanentURL, application.canOpenURL(permanentURL) {
+            return permanentURL as NSURL?
         }
 
         return nil


### PR DESCRIPTION
- Link preview permanent URL could be redirecting to the incorrect location, for example
     - Malicious websites.
     - iframes (we use the outer frame html as the link preview source).
     - Websites with broken but present link previews.
