### PR TITLE
Remove toggle to disable link preview fetching when sending using share extension

### DIFF
--- a/Wire-iOS Share Extension/UnsentSendable.swift
+++ b/Wire-iOS Share Extension/UnsentSendable.swift
@@ -69,7 +69,6 @@ class UnsentSendableBase {
 class UnsentTextSendable: UnsentSendableBase, UnsentSendable {
 
     private let text: String
-    let fetchPreview = ExtensionSettings.shared.fetchLinkPreview
 
     init(conversation: Conversation, sharingSession: SharingSession, text: String) {
         self.text = text
@@ -79,7 +78,7 @@ class UnsentTextSendable: UnsentSendableBase, UnsentSendable {
     func send(completion: @escaping (Sendable?) -> Void) {
         sharingSession.enqueue { [weak self] in
             guard let `self` = self else { return }
-            completion(self.conversation.appendTextMessage(self.text, fetchLinkPreview: self.fetchPreview))
+            completion(self.conversation.appendTextMessage(self.text, fetchLinkPreview: true))
         }
     }
 

--- a/Wire-iOS/Sources/Components/Settings/SettingsProperty.swift
+++ b/Wire-iOS/Sources/Components/Settings/SettingsProperty.swift
@@ -77,7 +77,6 @@ enum SettingsPropertyName: String, CustomStringConvertible {
     case sendV3Assets = "SendV3Assets"
     case callingProtocolStrategy = "CallingProtcolStrategy"
     case enableBatchCollections = "EnableBatchCollections"
-    case linkPreviewsInShareExtension = "LinkPreviewsInShareExtension"
 
     case lockApp = "lockApp"
     case lockAppLastDate = "lockAppLastDate"

--- a/Wire-iOS/Sources/Components/Settings/SettingsPropertyFactory.swift
+++ b/Wire-iOS/Sources/Components/Settings/SettingsPropertyFactory.swift
@@ -249,17 +249,6 @@ class SettingsPropertyFactory {
                         ZMUserSession.callingProtocolStrategy = callingProtocolStrategy
                     }
             })
-
-        case .linkPreviewsInShareExtension:
-            return SettingsBlockProperty(
-                propertyName: .linkPreviewsInShareExtension,
-                getAction: { _ in return SettingsPropertyValue(ExtensionSettings.shared.fetchLinkPreview) },
-                setAction: { _, value in
-                    switch value {
-                    case .number(value: let number): ExtensionSettings.shared.fetchLinkPreview = number.boolValue
-                    default: throw SettingsPropertyError.WrongValue("Incorrect type \(value) for key \(propertyName)")
-                }
-            })
         case .lockApp:
             return SettingsBlockProperty(
                 propertyName: .lockApp,

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptor.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptor.swift
@@ -262,8 +262,6 @@ func SettingsPropertyLabelText(_ name: SettingsPropertyName) -> String {
         return "Calling protocol"
     case .enableBatchCollections:
         return "Use AssetCollectionBatched"
-    case .linkPreviewsInShareExtension:
-        return "Fetch link previews in share extension"
     case .lockApp:
         return "self.settings.privacy_security.lock_app".localized
     case .lockAppLastDate:

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
@@ -181,7 +181,6 @@ import Foundation
         
         developerCellDescriptors.append(devController)
         
-        
         let callingProtocolSetting = callingProtocolStrategyGroup(for: self.settingsPropertyFactory.property(.callingProtocolStrategy))
         developerCellDescriptors.append(callingProtocolSetting)
         let diableAVSSetting = SettingsPropertyToggleCellDescriptor(settingsProperty: self.settingsPropertyFactory.property(.disableAVS))
@@ -196,8 +195,6 @@ import Foundation
         developerCellDescriptors.append(enableAssetV3Setting)
         let enableBatchCollections = SettingsPropertyToggleCellDescriptor(settingsProperty: self.settingsPropertyFactory.property(.enableBatchCollections))
         developerCellDescriptors.append(enableBatchCollections)
-        let linkPreviewsInShareExtension = SettingsPropertyToggleCellDescriptor(settingsProperty: settingsPropertyFactory.property(.linkPreviewsInShareExtension))
-        developerCellDescriptors.append(linkPreviewsInShareExtension)
         let sendBrokenMessageButton = SettingsButtonCellDescriptor(title: "Send broken message", isDestructive: true, selectAction: sendBrokenMessage)
         developerCellDescriptors.append(sendBrokenMessageButton)
         

--- a/WireExtensionComponents/Utilities/ExtensionSettings.swift
+++ b/WireExtensionComponents/Utilities/ExtensionSettings.swift
@@ -22,19 +22,16 @@ import Foundation
 
 private enum ExtensionSettingsKey: String {
 
-    case fetchLinkPreview = "fetchLinkPreview"
     case disableHockey = "disableHockey"
     case disableCrashAndAnalyticsSharing = "disableCrashAndAnalyticsSharing"
 
     static var all: [ExtensionSettingsKey] {
-        return [.fetchLinkPreview, .disableHockey, .disableCrashAndAnalyticsSharing]
+        return [.disableHockey, .disableCrashAndAnalyticsSharing]
     }
 
     private var defaultValue: Any? {
         switch self {
-        case .fetchLinkPreview: return true
-
-            // In case the user opted out and we did not yet migrate the opt out value
+        // In case the user opted out and we did not yet migrate the opt out value
         // into the shared settings (which is only done from the main app).
         case .disableHockey: return true
         case .disableCrashAndAnalyticsSharing: return true
@@ -76,16 +73,6 @@ public class ExtensionSettings: NSObject {
 
         // As we purposely crash afterwards we manually call synchronize.
         defaults?.synchronize()
-    }
-
-    public var fetchLinkPreview: Bool {
-        get {
-            return defaults?.bool(forKey: ExtensionSettingsKey.fetchLinkPreview.rawValue) ?? false
-        }
-
-        set {
-            defaults?.set(newValue, forKey: ExtensionSettingsKey.fetchLinkPreview.rawValue)
-        }
     }
 
     public var disableHockey: Bool {


### PR DESCRIPTION
# What's in this PR?

* Remove the developer options to disable fetching link previews when sending from the share extension.
