### PR TITLE
Do not dismiss image view controller when showing deleting dialog

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
@@ -687,7 +687,8 @@ extension CollectionsViewController: CollectionCellDelegate {
         case .forward, .showInConversation:
             self.delegate?.collectionsViewController(self, performAction: action, onMessage: message)
         case .delete:
-            deletionDialogPresenter?.presentDeletionAlertController(forMessage: message, source: cell) { [weak self] in
+            deletionDialogPresenter?.presentDeletionAlertController(forMessage: message, source: cell) { [weak self] deleted in
+                guard deleted else { return }
                 self?.refetchCollection()
             }
         default:
@@ -738,7 +739,8 @@ extension CollectionsViewController: MessageActionResponder {
         case .forward, .copy, .save, .showInConversation:
             self.delegate?.collectionsViewController(self, performAction: action, onMessage: message)
         case .delete:
-            deletionDialogPresenter?.presentDeletionAlertController(forMessage: message, source: nil) { [weak self] in
+            deletionDialogPresenter?.presentDeletionAlertController(forMessage: message, source: nil) { [weak self] deleted in
+                guard deleted else { return }
                 _ = self?.navigationController?.popViewController(animated: true)
                 self?.refetchCollection()
             }

--- a/Wire-iOS/Sources/UserInterface/Collections/ConversationImagesViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/ConversationImagesViewController.swift
@@ -251,7 +251,7 @@ internal final class ConversationImagesViewController: UIViewController {
         self.messageActionDelegate?.wants(toPerform: .save, for: self.currentMessage)
     }
 
-    @objc public func likeCurrent(_ sender: AnyObject!) {
+    @objc public func likeCurrent() {
         ZMUserSession.shared()?.enqueueChanges({
             self.currentMessage.liked = !self.currentMessage.liked
         }, completionHandler: {
@@ -278,7 +278,10 @@ extension ConversationImagesViewController: MessageActionResponder {
     }
 
     func wants(toPerform action: MessageAction, for message: ZMConversationMessage!) {
-        self.messageActionDelegate?.wants(toPerform: action, for: message)
+        switch action {
+        case .like: likeCurrent()
+        default: self.messageActionDelegate?.wants(toPerform: action, for: message)
+        }
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageDeletion.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageDeletion.swift
@@ -71,9 +71,12 @@ extension CollectionCell: SelectableView {
      or to cancel. An optional completion block can be provided to get notified when an action has been selected.
      The delete everywhere option is only shown if this action is allowed for the input message.
      
-     - parameter message:    The message for which the alert controller should be shown
+     - parameter message: The message for which the alert controller should be shown.
+     - parameter source: The source view used for a potential popover presentation of the dialog.
+     - parameter completion: A completion closure which will be invoked with `true` if a deletion occured and `false` otherwise.
      */
-    @objc public func presentDeletionAlertController(forMessage message: ZMConversationMessage, source: SelectableView?, completion: (() -> Void)?) {
+    @objc public func presentDeletionAlertController(forMessage message: ZMConversationMessage, source: SelectableView?, completion: ((Bool) -> Void)?) {
+        guard !message.hasBeenDeleted else { return }
         let alert = UIAlertController.forMessageDeletion(with: message.deletionConfiguration) { [weak self] (action, alert) in
             
             // Tracking needs to be called before performing the action, since the content of the message is cleared
@@ -88,8 +91,10 @@ extension CollectionCell: SelectableView {
                         ZMMessage.deleteForEveryone(message)
                     }
                 }, completionHandler: {
-                    completion?()
+                    completion?(true)
                 })
+            } else {
+                completion?(false)
             }
 
             alert.dismiss(animated: true, completion: nil)


### PR DESCRIPTION
# What's in this PR?

* We were dismissing the image view controller when deleting an image from the image view controller before the user selected if the message should be deleted for everyone or not.
* The same issue was occurring when linking a message from the same view controller.
* The completion handler of the `DeletionDialogPresenter` was not invoked in case the user selected the cancel option, which lead to the cell in the conversation not being deselected.