### PR TITLE
Open images and files by one tap

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ImageMessageCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ImageMessageCell.m
@@ -508,11 +508,6 @@ static const CGFloat ImageToolbarMinimumSize = 192;
     [[UIPasteboard generalPasteboard] setMediaAsset:[self.fullImageView mediaAsset]];
 }
 
-// @override from ConversationCell
-- (void)didDoubleTapMessage:(id)sender
-{
-}
-
 - (void)setSelectedByMenu:(BOOL)selected animated:(BOOL)animated
 {
     DDLogDebug(@"Setting selected: %@ animated: %@", @(selected), @(animated));

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ImageMessageCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ImageMessageCell.m
@@ -511,7 +511,6 @@ static const CGFloat ImageToolbarMinimumSize = 192;
 // @override from ConversationCell
 - (void)didDoubleTapMessage:(id)sender
 {
-    [self.delegate conversationCell:self didSelectAction:MessageActionPresent];
 }
 
 - (void)setSelectedByMenu:(BOOL)selected animated:(BOOL)animated

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Private.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Private.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ConversationContentViewController ()
 
 /// The cell whose tools are expanded in the UI. Setting this automatically triggers the expanding in the UI.
-@property (nonatomic, strong, readwrite, nullable) id<ZMConversationMessage>messageWithExpandedTools;
+@property (nonatomic, strong, readwrite, nullable) id<ZMConversationMessage> messageWithExpandedTools;
 
 @property (nonatomic) ZMConversationMessageWindow *messageWindow;
 @property (nonatomic) MessagePresenter* messagePresenter;
@@ -57,6 +57,5 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ConversationContentViewController (MessageActionResponder) <MessageActionResponder>
 
 @end
-
 
 NS_ASSUME_NONNULL_END

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -725,7 +725,19 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
 }
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
-{    
+{
+    id<ZMConversationMessage>message = [self.messageWindow.messages objectAtIndex:indexPath.row];
+    BOOL isFile = [Message isFileTransferMessage:message] &&
+                 ![Message isVideoMessage:message] &&
+                 ![Message isAudioMessage:message];
+    
+    BOOL isImage = [Message isImageMessage:message];
+    
+    if (isFile || isImage) {
+        [self wantsToPerformAction:MessageActionPresent
+                        forMessage:message
+                              cell:[tableView cellForRowAtIndexPath:indexPath]];
+    }
     // Make table view to update cells with animation
     [tableView beginUpdates];
     [tableView endUpdates];


### PR DESCRIPTION
- With the current design it is hard to understand that tapping on file icon opens it
- Already working like that in collection
- It was decided to unify with images too: now tapping on image once is opening it