### PR TITLE
Add workaround to fix UITextView truncation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
@@ -138,6 +138,8 @@ private struct InputBarConstants {
         
     override public func didMoveToWindow() {
         super.didMoveToWindow()
+        textView.isScrollEnabled = false
+        textView.isScrollEnabled = true
         startCursorBlinkAnimation()
     }
     
@@ -215,7 +217,7 @@ private struct InputBarConstants {
             textView.trailing <= textView.superview!.trailing - 16
             textView.trailing == rightAccessoryView.leading ~ LayoutPriority(750)
             textView.height >= 56
-            textView.height <= 120 ~ LayoutPriority(750)
+            textView.height <= 120 ~ LayoutPriority(1000)
 
             buttonRowSeparator.top == buttonContainer.top
             buttonRowSeparator.leading == buttonRowSeparator.superview!.leading + 16


### PR DESCRIPTION
# What's in this PR?

* Workaround for `UITextView` truncating the text in some cases.
* Fixes https://github.com/wireapp/wire-ios/issues/370.