### PR TITLE
Fixed double method implementation for gestureRecognizerShouldBegin

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController+PullToDismiss.h
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController+PullToDismiss.h
@@ -30,6 +30,8 @@
 @property (nonatomic) CGRect initialImageViewBounds;
 @property (nonatomic) CGPoint initialImageViewCenter;
 @property (nonatomic) CGFloat minimumDismissMagnitude;
+
+@property (nonatomic) UIPanGestureRecognizer *panRecognizer;
 @end
 
 @interface FullscreenImageViewController (PullToDismiss) <UIGestureRecognizerDelegate>

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController+PullToDismiss.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController+PullToDismiss.m
@@ -29,6 +29,11 @@
 
 @end
 
+
+@interface FullscreenImageViewController (PanGestureRecognizerDelegate) <UIGestureRecognizerDelegate>
+@end
+
+
 @implementation FullscreenImageViewController (PullToDismiss)
 
 - (void)dismissingPanGestureRecognizerPanned:(UIPanGestureRecognizer *)panner
@@ -213,13 +218,27 @@
     }
 }
 
-#pragma mark - UIGestureRecognizerDelegate
+@end
+
+
+@implementation FullscreenImageViewController (PanGestureRecognizerDelegate)
 
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
 {
-    // tiny inset threshold
-    return CGRectContainsRect(CGRectInset(self.view.bounds, -10, -10),
-                              [self.view convertRect:self.imageView.bounds fromView:self.imageView]);
+    if (!CGRectContainsRect(CGRectInset(self.view.bounds, -10, -10),
+                            [self.view convertRect:self.imageView.bounds fromView:self.imageView])) {
+        return NO;
+    }
+    
+    if (gestureRecognizer == self.panRecognizer) {
+        CGPoint offset = [self.panRecognizer translationInView:self.view];
+        
+        return fabs(offset.y) > fabs(offset.x);
+    }
+    else {
+        return YES;
+    }
 }
 
 @end
+

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.m
@@ -102,13 +102,9 @@
 @property (nonatomic) CGFloat lastZoomScale;
 
 @property (nonatomic) BOOL forcePortraitMode;
-@property (nonatomic) UIPanGestureRecognizer *panRecognizer;
 
 @property (nonatomic) id messageObserverToken;
 
-@end
-
-@interface FullscreenImageViewController (PanGestureRecognizerDelegate) <UIGestureRecognizerDelegate>
 @end
 
 @implementation FullscreenImageViewController
@@ -634,22 +630,6 @@
         self.loadingSpinner = nil;
         
         [self loadImageAndSetupImageView];
-    }
-}
-
-@end
-
-@implementation FullscreenImageViewController (PanGestureRecognizerDelegate)
-
-- (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
-{
-    if (gestureRecognizer == self.panRecognizer) {
-        CGPoint offset = [self.panRecognizer translationInView:self.view];
-
-        return fabs(offset.y) > fabs(offset.x);
-    }
-    else {
-        return YES;
     }
 }
 


### PR DESCRIPTION
# Issue

The method `gestureRecognizerShouldBegin` was implemented both in `FullscreenImageViewController` class body, and in the extension. Which leads to the undefined behavior.