### PR TITLE
Disable double tap to like image

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.h
@@ -97,6 +97,7 @@ typedef void (^SelectedMenuBlock)(BOOL selected, BOOL animated);
 
 @property (nonatomic) AnalyticsTracker *analyticsTracker;
 @property (nonatomic) UILongPressGestureRecognizer *longPressGestureRecognizer;
+@property (nonatomic, readonly) UITapGestureRecognizer *doubleTapGestureRecognizer;
 
 - (void)configureForMessage:(id<ZMConversationMessage>)message layoutProperties:(ConversationCellLayoutProperties *)layoutProperties;
 /// Update cell due since the message content has changed. Return True if the change requires the cell to be re-sized.

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
@@ -65,7 +65,7 @@ const NSTimeInterval ConversationCellSelectionAnimationDuration = 0.33;
 
 @property (nonatomic) AccentColorChangeHandler *accentColorChangeHandler;
 
-@property (nonatomic) UITapGestureRecognizer *doubleTapGestureRecognizer;
+@property (nonatomic, readwrite) UITapGestureRecognizer *doubleTapGestureRecognizer;
 
 @property (nonatomic, readwrite) ConversationCellLayoutProperties *layoutProperties;
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ImageMessageCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ImageMessageCell.m
@@ -86,6 +86,7 @@ static const CGFloat ImageToolbarMinimumSize = 192;
 {
     if (self = [super initWithStyle:style reuseIdentifier:reuseIdentifier]) {
         _autoStretchVertically = YES;
+        self.doubleTapGestureRecognizer.enabled = NO;
         [self createImageMessageViews];
         [self createConstraints];
         


### PR DESCRIPTION
# Issue

Elderly people and regular users are liking images when they want to look at them.