### PR TITLE
Disable text view workaround i os 8

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
@@ -341,7 +341,7 @@ final class AudioMessageView: UIView, TransferView {
     
     // MARK: - Actions
     
-    open func onActionButtonPressed(_ sender: UIButton) {
+    dynamic private func onActionButtonPressed(_ sender: UIButton) {
         
         guard let fileMessage = self.fileMessage, let fileMessageData = fileMessage.fileMessageData else { return }
         
@@ -370,14 +370,14 @@ final class AudioMessageView: UIView, TransferView {
     
     // MARK: - Audio state observer
     
-    @objc private func audioProgressChanged(_ change: NSDictionary) {
+    dynamic private func audioProgressChanged(_ change: NSDictionary) {
         if self.isOwnTrackPlayingInAudioPlayer() {
             self.updateActivePlayerProgressAnimated(false)
             self.updateTimeLabel()
         }
     }
     
-    @objc private func audioPlayerStateChanged(_ change: NSDictionary) {
+    dynamic private func audioPlayerStateChanged(_ change: NSDictionary) {
         if self.isOwnTrackPlayingInAudioPlayer() {
             self.updateActivePlayButton()
             self.updateActivePlayerProgressAnimated(false)

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
@@ -138,8 +138,12 @@ private struct InputBarConstants {
         
     override public func didMoveToWindow() {
         super.didMoveToWindow()
-        textView.isScrollEnabled = false
-        textView.isScrollEnabled = true
+        // This is a workaround for UITextView truncating long contents.
+        // However, this breaks the text view on iOS 8 ¯\_(ツ)_/¯.
+        if #available(iOS 9, *) {
+            textView.isScrollEnabled = false
+            textView.isScrollEnabled = true
+        }
         startCursorBlinkAnimation()
     }
     


### PR DESCRIPTION
# What's in this PR?

* https://github.com/wireapp/wire-ios/pull/764 added a workaround to fix `UITextView` truncating its content. However, this workaround broke the text view on iOS 8. This PR makes the workaround conditional.
* This PR also fixes the access control modifiers in `AudioMessageView`.