### PR TITLE
Add OS version condition to text view workaround

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
@@ -341,7 +341,7 @@ final class AudioMessageView: UIView, TransferView {
     
     // MARK: - Actions
     
-    open func onActionButtonPressed(_ sender: UIButton) {
+    dynamic private func onActionButtonPressed(_ sender: UIButton) {
         
         guard let fileMessage = self.fileMessage, let fileMessageData = fileMessage.fileMessageData else { return }
         
@@ -369,15 +369,15 @@ final class AudioMessageView: UIView, TransferView {
     }
     
     // MARK: - Audio state observer
-    
-    func audioProgressChanged(_ change: NSDictionary) {
+
+    dynamic private func audioProgressChanged(_ change: NSDictionary) {
         if self.isOwnTrackPlayingInAudioPlayer() {
             self.updateActivePlayerProgressAnimated(false)
             self.updateTimeLabel()
         }
     }
-    
-    func audioPlayerStateChanged(_ change: NSDictionary) {
+
+    dynamic private func audioPlayerStateChanged(_ change: NSDictionary) {
         if self.isOwnTrackPlayingInAudioPlayer() {
             self.updateActivePlayButton()
             self.updateActivePlayerProgressAnimated(false)

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
@@ -138,8 +138,12 @@ private struct InputBarConstants {
         
     override public func didMoveToWindow() {
         super.didMoveToWindow()
-        textView.isScrollEnabled = false
-        textView.isScrollEnabled = true
+        // This is a workaround for UITextView truncating long contents.
+        // However, this breaks the text view on iOS 8 ¯\_(ツ)_/¯.
+        if #available(iOS 9, *) {
+            textView.isScrollEnabled = false
+            textView.isScrollEnabled = true
+        }
         startCursorBlinkAnimation()
     }
     


### PR DESCRIPTION
# What's in this PR?

* https://github.com/wireapp/wire-ios/pull/777 against `release/2.31`.
