### PR TITLE
Fix crash when showing menu for file cell

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
@@ -552,7 +552,12 @@ const NSTimeInterval ConversationCellSelectionAnimationDuration = 0.33;
 
     if ([Message messageCanBeLiked:self.message]) {
         UIMenuItem *likeItem = [UIMenuItem likeItemForMessage:self.message action:@selector(likeMessage:)];
-        [items insertObject:likeItem atIndex:menuConfigurationProperties.likeItemIndex];
+        
+        if (items.count > 0) {
+            [items insertObject:likeItem atIndex:menuConfigurationProperties.likeItemIndex];
+        } else {
+            [items addObject:likeItem];
+        }
     }
 
     if (self.message.canBeDeleted) {


### PR DESCRIPTION
It was crashing when showing the menu for a not downloaded file message because then
there are no additional actions and we try to put the like action at index 1. The fix
is to add a check if the actions list is empty.