### PR TITLE
Do not rotate the camera feed on the iPhone

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraCell.swift
@@ -167,11 +167,12 @@ open class CameraCell: UICollectionViewCell, Reusable {
             newOrientation = .portrait;
         }
         
-        if let connection = cameraController.previewLayer.connection , connection.isVideoOrientationSupported {
-            connection.videoOrientation = newOrientation
-        }
-        
         if UIDevice.current.userInterfaceIdiom == .pad {
+            if let connection = cameraController.previewLayer.connection,
+                connection.isVideoOrientationSupported {
+                connection.videoOrientation = newOrientation
+            }
+            
             cameraController.snapshotVideoOrientation = newOrientation
         }
         else {


### PR DESCRIPTION
- The camera feed follows the device physical orientation (since it's attached to the device physically :) )
- The UI orientation is fixed to portrait on the iPhone, and it is rotating on the iPad
- We have to rotate the video feed only on the iPad to compensate the UI rotation