### PR TITLE
Fix flickering input bar when opening a conversation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -190,18 +190,21 @@
 
     [self addChildViewController:self.contentViewController];
     [self.view addSubview:self.contentViewController.view];
+    [self.contentViewController didMoveToParentViewController:self];
 
     [self addChildViewController:self.inputBarController];
     [self.view addSubview:self.inputBarController.view];
+    [self.inputBarController didMoveToParentViewController:self];
 
     [self addChildViewController:self.conversationBarController];
     [self.view addSubview:self.conversationBarController.view];
+    [self.conversationBarController didMoveToParentViewController:self];
 
     [self addChildViewController:self.chatHeadsViewController];
     [self.view addSubview:self.chatHeadsViewController.view];
+    [self.chatHeadsViewController didMoveToParentViewController:self];
 
     [self updateOutgoingConnectionVisibility];
-
     self.isAppearing = NO;
 
     [self createConstraints];

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Editing.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Editing.swift
@@ -28,7 +28,7 @@ extension ConversationInputBarViewController {
     func sendEditedMessageAndUpdateState(withText text: String) {
         delegate.conversationInputBarViewControllerDidFinishEditing?(editingMessage, withText: text)
         editingMessage = nil
-        updateWritingState()
+        updateWritingState(animated: true)
     }
     
     func editMessage(_ message: ZMConversationMessage) {
@@ -53,7 +53,7 @@ extension ConversationInputBarViewController {
         ZMUserSession.shared()?.enqueueChanges {
             self.conversation.draftMessageText = ""
         }
-        updateWritingState()
+        updateWritingState(animated: true)
 
         NotificationCenter.default.removeObserver(
             self,
@@ -66,9 +66,15 @@ extension ConversationInputBarViewController {
         NotificationCenter.default.post(name: NSNotification.Name(rawValue: endEditingNotificationName), object: nil)
     }
 
-    public func updateWritingState() {
+    @objc(updateWritingStateAnimated:)
+    public func updateWritingState(animated: Bool) {
         guard nil == editingMessage else { return }
-        inputBar.inputBarState = .writing(ephemeral: conversation.destructionEnabled)
+        inputBar.updateInputBar(
+            withState: .writing(ephemeral: conversation.destructionEnabled),
+            oldState: inputBar.inputBarState,
+            animated: animated
+        )
+
         updateRightAccessoryView()
         updateButtonIconsForEphemeral()
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -215,7 +215,7 @@
     [self updateInputBarVisibility];
     [self updateSeparatorLineVisibility];
     [self updateTypingIndicatorVisibility];
-    [self updateWritingState];
+    [self updateWritingStateAnimated:NO];
     [self updateButtonIconsForEphemeral];
 }
 


### PR DESCRIPTION
# What's in this PR?

* We update the state of the input bar from `viewDidLoad` which is fine, we just shouldn't do it animated.
* This PR also inserts some missing calls to `didMoveToParentViewController` (`addChildViewController` only calls `willMoveToParentViewController` internally).