### PR TITLE
Workaround for call overlay buttons loosing background color

### DIFF
--- a/Wire-iOS/Sources/Managers/ColorSchemeController.m
+++ b/Wire-iOS/Sources/Managers/ColorSchemeController.m
@@ -70,9 +70,12 @@ NSString * const ColorSchemeControllerDidApplyColorSchemeChangeNotification = @"
     if (! note.accentColorValueChanged) {
         return;
     }
-    
-    [[CASStyler defaultStyler] applyDefaultColorSchemeWithAccentColor:[UIColor accentColor]];
-    [self notifyColorSchemeChange];
+    ColorScheme *colorScheme = [ColorScheme defaultColorScheme];
+    UIColor *newAccentColor = [UIColor accentColor];
+    if (![colorScheme.accentColor isEqual:newAccentColor]) {
+        [[CASStyler defaultStyler] applyDefaultColorSchemeWithAccentColor:newAccentColor];
+        [self notifyColorSchemeChange];
+    }
 }
 
 #pragma mark - SettingsColorSchemeDidChangeNotification


### PR DESCRIPTION
The underlying issue seems to be caused by Classy and the reason is unknown. This workaround fixes the problem, but we should find the root cause as well.

N.B. This PR merges to the `release/2.32` branch