### PR TITLE
Fix: video permissions dialog is shown on audio calls

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelOverlay.h
+++ b/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelOverlay.h
@@ -82,13 +82,9 @@ FOUNDATION_EXPORT NSString *StringFromVoiceChannelOverlayState(VoiceChannelOverl
 @property (nonatomic) ZMUser *selfUser;
 
 @property (nonatomic) CameraPreviewView *cameraPreviewView;
-@property (nonatomic) BOOL videoViewFullscreen;
 
 @property (nonatomic) UICollectionView *participantsCollectionView;
 @property (nonatomic) VoiceChannelCollectionViewLayout *participantsCollectionViewLayout;
-
-@property (nonatomic) AVSVideoPreview *videoPreview;
-@property (nonatomic) AVSVideoView *videoView;
 
 @property (nonatomic) UIView *contentContainer;
 @property (nonatomic) UIView *avatarContainer;

--- a/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelOverlay.m
+++ b/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelOverlay.m
@@ -21,8 +21,6 @@
 #import <PureLayout/PureLayout.h>
 @import Classy;
 @import WireExtensionComponents;
-#import <avs/AVSVideoView.h>
-#import <avs/AVSVideoPreview.h>
 
 #import "VoiceChannelOverlay.h"
 #import "VoiceChannelOverlayController.h"
@@ -88,39 +86,6 @@ static NSString *NotNilString(NSString *string) {
 {
     UIPanGestureRecognizer *videoFeedPan = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(onCameraPreviewPan:)];
     [self.cameraPreviewView addGestureRecognizer:videoFeedPan];
-}
-
-- (void)setVideoViewFullscreen:(BOOL)videoViewFullscreen
-{
-    [self createVideoPreviewIfNeeded];
-
-    if (_videoViewFullscreen == videoViewFullscreen) {
-        return;
-    }
-    DDLogVoice(@"videoViewFullScreen: %d -> %d", _videoViewFullscreen, videoViewFullscreen);
-    _videoViewFullscreen = videoViewFullscreen;
-    if (_videoViewFullscreen) {
-        self.videoPreview.frame = self.bounds;
-        [self insertSubview:self.videoPreview aboveSubview:self.videoView];
-    }
-    else {
-        self.videoPreview.frame = self.cameraPreviewView.videoFeedContainer.bounds;
-        [self.cameraPreviewView.videoFeedContainer addSubview:self.videoPreview];
-    }
-}
-
-- (void)createVideoPreviewIfNeeded
-{
-    if (![[Settings sharedSettings] disableAVS] && nil == self.videoPreview) {
-        // Preview view is moving from one subview to another. We cannot use constraints because renderer break if the view
-        // is removed from hierarchy and immediately being added to the new superview (we need that to reapply constraints)
-        // therefore we use @c autoresizingMask here
-        self.videoPreview = [[AVSVideoPreview alloc] initWithFrame:self.bounds];
-        self.videoPreview.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-        self.videoPreview.userInteractionEnabled = NO;
-        self.videoPreview.backgroundColor = [UIColor clearColor];
-        [self insertSubview:self.videoPreview aboveSubview:self.videoView];
-    }
 }
 
 - (void)setLowBandwidth:(BOOL)lowBandwidth

--- a/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelOverlay.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelOverlay.swift
@@ -35,6 +35,21 @@ let GroupCallAvatarLabelHeight: CGFloat = 30.0;
     var shieldOverlay: DegradationOverlayView!
     var degradationTopConstraint: NSLayoutConstraint!
     var degradationBottomConstraint: NSLayoutConstraint!
+    var videoView: AVSVideoView!
+    var videoPreview: AVSVideoPreview!
+    
+    var videoViewFullscreen: Bool = true {
+        didSet {
+            createVideoPreviewIfNeeded()
+            if videoViewFullscreen {
+                videoPreview.frame = bounds
+                insertSubview(videoPreview, aboveSubview: videoView)
+            } else {
+                videoPreview.frame = cameraPreviewView.videoFeedContainer.bounds
+                cameraPreviewView.videoFeedContainer.addSubview(videoPreview)
+            }
+        }
+    }
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -95,6 +110,19 @@ extension VoiceChannelOverlay {
 }
 
 extension VoiceChannelOverlay {
+    
+    func createVideoPreviewIfNeeded() {
+        if !Settings.shared().disableAVS && videoPreview == nil {
+            // Preview view is moving from one subview to another. We cannot use constraints because renderer break if the view
+            // is removed from hierarchy and immediately being added to the new superview (we need that to reapply constraints)
+            // therefore we use @c autoresizingMask here
+            videoPreview = AVSVideoPreview(frame: bounds)
+            videoPreview.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+            videoPreview.isUserInteractionEnabled = false
+            videoPreview.backgroundColor = .clear
+            insertSubview(videoPreview, aboveSubview: videoView)
+        }
+    }
 
     public func hideControls() {
         controlsHidden = true
@@ -148,8 +176,6 @@ extension VoiceChannelOverlay {
             videoView.backgroundColor = UIColor(patternImage: .dot(9))
             addSubview(videoView)
         }
-
-        videoViewFullscreen = true
         
         shadow = UIView()
         shadow.isUserInteractionEnabled = false


### PR DESCRIPTION
The underlying reason was that the video view is created when setting `videoViewFullscreen = true`. In the Obj-C version it was assigning it to ivar, bypassing the setter.