### PR TITLE
Fix links without previews not opening in third party applications

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Views/LinkInteractionTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/LinkInteractionTextView.swift
@@ -66,7 +66,7 @@ extension LinkInteractionTextView: UITextViewDelegate {
             else {
                 return .none
             }
-            } ?? []
+        } ?? []
 
         if beganLongPressRecognizers.count > 0 {
             interactionDelegate?.textViewDidLongPress(self)
@@ -93,11 +93,13 @@ extension LinkInteractionTextView: UITextViewDelegate {
     
     @available(iOS 10.0, *)
     public func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
-        if interaction == .presentActions {
+        switch interaction {
+        case .invokeDefaultAction:
+            return !(interactionDelegate?.textView(self, open: URL) ?? false)
+        case .presentActions:
             interactionDelegate?.textViewDidLongPress(self)
             return false
-        }
-        else {
+        default:
             return true
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Settings/LinkOpening/BrowserOpening.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/LinkOpening/BrowserOpening.swift
@@ -17,6 +17,9 @@
 //
 
 
+private let log = ZMSLog(tag: "link opening")
+
+
 enum BrowserOpeningOption: Int, LinkOpeningOption {
 
     case safari, chrome, firefox
@@ -46,14 +49,19 @@ enum BrowserOpeningOption: Int, LinkOpeningOption {
 extension URL {
 
     func openAsLink() -> Bool {
+        log.debug("Trying to open \"\(self)\" in thrid party browser")
         let saved = BrowserOpeningOption(rawValue: Settings.shared().browserLinkOpeningOptionRawValue) ?? .safari
+        log.debug("Saved option to open a regular link: \(saved.displayString)")
+
         switch saved {
         case .safari: return false
         case .chrome:
             guard let url = chromeURL else { return false }
+            log.debug("Trying to open chrome app using \"\(url)\"")
             return UIApplication.shared.openURL(url)
         case .firefox:
             guard let url = firefoxURL else { return false }
+            log.debug("Trying to open firefox app using \"\(url)\"")
             return UIApplication.shared.openURL(url)
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Settings/LinkOpening/LinkOpener.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/LinkOpening/LinkOpener.swift
@@ -20,6 +20,9 @@
 import Foundation
 
 
+private let log = ZMSLog(tag: "link opening")
+
+
 public extension NSURL {
 
     @discardableResult @objc func open() -> Bool {
@@ -36,6 +39,7 @@ public extension URL {
             return true
         }
         else {
+            log.debug("Did not open \"\(self)\" in a twitter application or third party browser.")
             if UIApplication.shared.canOpenURL(self) {
                 UIApplication.shared.openURL(self)
                 return true

--- a/Wire-iOS/Sources/UserInterface/Settings/LinkOpening/MapOpening.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/LinkOpening/MapOpening.swift
@@ -17,6 +17,9 @@
 //
 
 
+private let log = ZMSLog(tag: "link opening")
+
+
 enum MapsOpeningOption: Int, LinkOpeningOption {
 
     case apple, google
@@ -45,7 +48,10 @@ enum MapsOpeningOption: Int, LinkOpeningOption {
 extension URL {
 
     public func openAsLocation() -> Bool {
+        log.debug("Trying to open \"\(self)\" as location")
         let saved = MapsOpeningOption(rawValue: Settings.shared().mapsLinkOpeningOptionRawValue) ?? .apple
+        log.debug("Saved option to open a location: \(saved.displayString)")
+
         switch saved {
         case .apple: return false
         case .google:

--- a/Wire-iOS/Sources/UserInterface/Settings/LinkOpening/TweetOpening.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/LinkOpening/TweetOpening.swift
@@ -17,6 +17,9 @@
 //
 
 
+private let log = ZMSLog(tag: "link opening")
+
+
 enum TweetOpeningOption: Int, LinkOpeningOption {
 
     case none, tweetbot, twitterrific
@@ -47,15 +50,20 @@ enum TweetOpeningOption: Int, LinkOpeningOption {
 extension URL {
 
     func openAsTweet() -> Bool {
+        log.debug("Trying to open \"\(self)\" as tweet, isTweet: \(isTweet)")
         guard isTweet else { return false }
         let saved = TweetOpeningOption(rawValue: Settings.shared().twitterLinkOpeningOptionRawValue) ?? .none
+        log.debug("Saved option to open a tweet: \(saved.displayString)")
+
         switch saved {
         case .none: return false
         case .tweetbot:
             guard let url = tweetbotURL else { return false }
+            log.debug("Trying to open tweetbot app using \"\(url)\"")
             return UIApplication.shared.openURL(url)
         case .twitterrific:
             guard let url = twitterrificURL else { return false }
+            log.debug("Trying to open twitterific app using \"\(url)\"")
             return UIApplication.shared.openURL(url)
         }
     }


### PR DESCRIPTION
# What's in this PR?

* When we enabled data detectors in `LinkInteractionTextView` the behaviour when tapping on a link was broken. The text view no longer asked its delegate to open a link but instead opened it by itself, which means opening it using Safari.
* Also added some debug logs to the link opening logic which can be enabled using the `"link opening"` log tag.