### PR TITLE
Set input bar state correctly

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Editing.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Editing.swift
@@ -37,7 +37,8 @@ extension ConversationInputBarViewController {
         editingMessage = message
         updateRightAccessoryView()
 
-        inputBar.inputBarState = .editing(originalText: text)
+        inputBar.setInputBarState(.editing(originalText: text), animated: true)
+
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(endEditingMessageIfNeeded),

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Editing.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Editing.swift
@@ -69,12 +69,7 @@ extension ConversationInputBarViewController {
     @objc(updateWritingStateAnimated:)
     public func updateWritingState(animated: Bool) {
         guard nil == editingMessage else { return }
-        inputBar.updateInputBar(
-            withState: .writing(ephemeral: conversation.destructionEnabled),
-            oldState: inputBar.inputBarState,
-            animated: animated
-        )
-
+        inputBar.setInputBarState(.writing(ephemeral: conversation.destructionEnabled), animated: animated)
         updateRightAccessoryView()
         updateButtonIconsForEphemeral()
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Ephemeral.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Ephemeral.swift
@@ -95,7 +95,8 @@ extension ConversationInputBarViewController: EphemeralKeyboardViewControllerDel
     }
 
     func ephemeralKeyboard(_ keyboard: EphemeralKeyboardViewController, didSelectMessageTimeout timeout: ZMConversationMessageDestructionTimeout) {
-        inputBar.inputBarState = .writing(ephemeral: timeout != .none)
+        inputBar.setInputBarState(.writing(ephemeral: timeout != .none), animated: true)
+
         ZMUserSession.shared()?.enqueueChanges {
             self.conversation.updateMessageDestructionTimeout(timeout: timeout)
             self.updateRightAccessoryView()

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
@@ -106,11 +106,7 @@ private struct InputBarConstants {
         return inputBarState.isEditing
     }
     
-    var inputBarState: InputBarState = .writing(ephemeral: false) {
-        didSet(oldValue) {
-            updateInputBar(withState: inputBarState, oldState: oldValue)
-        }
-    }
+    private var inputBarState: InputBarState = .writing(ephemeral: false)
     
     fileprivate var textIsOverflowing = false {
         didSet {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
@@ -340,7 +340,13 @@ private struct InputBarConstants {
 
     // MARK: - InputBarState
 
-    func updateInputBar(withState state: InputBarState, oldState: InputBarState? = nil, animated: Bool = true) {
+    public func setInputBarState(_ state: InputBarState, animated: Bool) {
+        let oldState = inputBarState
+        inputBarState = state
+        updateInputBar(withState: state, oldState: oldState, animated: animated)
+    }
+
+    private func updateInputBar(withState state: InputBarState, oldState: InputBarState? = nil, animated: Bool = true) {
         updateEditViewState()
         updatePlaceholder()
         rowTopInsetConstraint?.constant = state.isWriting ? -constants.buttonsBarHeight : 0


### PR DESCRIPTION
# What's in this PR?

* Since we removed the animation in https://github.com/wireapp/wire-ios/pull/800 we failed to actually set the input bar state.
* Fixes [8221](https://wearezeta.atlassian.net/browse/ZIOS-8221) and [8243](https://wearezeta.atlassian.net/browse/ZIOS-8243).