### PR TITLE
Call Overlay: fix failing tests

### DIFF
--- a/Wire-iOS/Resources/Classy/stylesheet.cas
+++ b/Wire-iOS/Resources/Classy/stylesheet.cas
@@ -106,7 +106,7 @@ VoiceChannelOverlay {
         }
     }
     
-    callButton: @{
+    makeDegradedCallButton: @{
         iconButton: @{
             backgroundImageColor[state:normal]: $color-accent-green;
             iconColor[state:normal]: white;


### PR DESCRIPTION
Snapshot tests failed because call button lost its background color ¯\\\_(ツ)_/¯