### PR TITLE
Update avs-versions

### DIFF
--- a/avs-versions
+++ b/avs-versions
@@ -17,4 +17,4 @@
 # along with this program. If not, see http://www.gnu.org/licenses/.
 #
 
-export APPSTORE_AVS_VERSION=3.2.43
+export APPSTORE_AVS_VERSION=3.3.13


### PR DESCRIPTION
Update avs to 3.3.13

New APIs: 
wcall: void wcall_network_changed(void) used to trigger roaming event
Mediamanager: (void)setUiStartsAudio:(BOOL)ui_starts_audio. Should be set when call kit is used. Then AVS will not start the audio before the audio session is active