### PR TITLE
Show sender if previous message is ping

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ZMConversationMessageWindow+Formatting.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ZMConversationMessageWindow+Formatting.m
@@ -91,7 +91,9 @@ static NSTimeInterval const BurstSeparatorTimeDifference = 60 * 45; // 45 minute
     }
     
     if (!systemMessage) {
-        return ![self isPreviousSenderSameForMessage:message] || message.updatedAt != nil;
+        return  ![self isPreviousSenderSameForMessage:message]
+              || [Message isKnockMessage:[self messagePreviousToMessage:message]]
+              || message.updatedAt != nil;
     }
     
     return NO;

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ZMConversationMessageWindow+Formatting.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ZMConversationMessageWindow+Formatting.m
@@ -91,9 +91,14 @@ static NSTimeInterval const BurstSeparatorTimeDifference = 60 * 45; // 45 minute
     }
     
     if (!systemMessage) {
-        return  ![self isPreviousSenderSameForMessage:message]
-              || [Message isKnockMessage:[self messagePreviousToMessage:message]]
-              || message.updatedAt != nil;
+        if (![self isPreviousSenderSameForMessage:message] || message.updatedAt != nil) {
+            return YES;
+        }
+
+        id <ZMConversationMessage> previousMessage = [self messagePreviousToMessage:message];
+        if (nil != previousMessage) {
+            return [Message isKnockMessage:previousMessage];
+        }
     }
     
     return NO;


### PR DESCRIPTION
# What's in this PR?

* The ping cell no longer shows the author image, which is why we now always show it in case the previous message is a ping.