### PR TITLE
Fixed swipe back from collections first screen

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
@@ -161,7 +161,7 @@ final public class CollectionsViewController: UIViewController {
         super.viewWillAppear(animated)
         self.setupNavigationItem()
         self.flushLayout()
-
+        
         self.navigationController?.interactivePopGestureRecognizer?.isEnabled = true
         self.navigationController?.interactivePopGestureRecognizer?.delegate = self
     }
@@ -263,10 +263,8 @@ final public class CollectionsViewController: UIViewController {
         return ColorScheme.default().variant == .dark ? .lightContent : .default
     }
     
-    private func updateNoElementsState() {
-        if self.fetchingDone && self.inOverviewMode && self.totalNumberOfElements() == 0 {
-            self.contentView.noItemsInLibrary = true
-        }
+    fileprivate func updateNoElementsState() {
+        self.contentView.noItemsInLibrary = self.fetchingDone && self.inOverviewMode && self.totalNumberOfElements() == 0
     }
     
     private func setupNavigationItem() {
@@ -380,6 +378,7 @@ extension CollectionsViewController: AssetCollectionDelegate {
         }
         
         if self.isViewLoaded {
+            self.updateNoElementsState()
             self.contentView.collectionView.reloadData()
         }
     }
@@ -753,6 +752,11 @@ extension CollectionsViewController: MessageActionResponder {
 
 extension CollectionsViewController: UIGestureRecognizerDelegate {
     public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
-        return true
+        if self.navigationController?.interactivePopGestureRecognizer == gestureRecognizer {
+            return self.navigationController?.viewControllers.count > 1
+        }
+        else {
+            return true
+        }
     }
 }


### PR DESCRIPTION
- Also fixed overlapping collections placeholder, when:

    - Open collections in the empty conversation.
    - Close it.
    - Post asset.
    - Open collections again.