### PR TITLE
Set regular tap area on bar buttons to avoid overlap

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Collections/ConversationImagesViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/ConversationImagesViewController.swift
@@ -219,8 +219,10 @@ internal final class ConversationImagesViewController: UIViewController {
         emojiSketchButton.accessibilityLabel = "sketch emoji over image"
         emojiSketchButton.addTarget(self, action: #selector(ConversationImagesViewController.sketchCurrentEmoji(_:)), for: .touchUpInside)
         
+        let buttons = [likeButton, shareButton, sketchButton, emojiSketchButton, copyButton, saveButton, revealButton, deleteButton]
+        buttons.forEach { $0.hitAreaPadding = .zero }
         
-        self.buttonsBar = InputBarButtonsView(buttons: [likeButton, shareButton, sketchButton, emojiSketchButton, copyButton, saveButton, revealButton, deleteButton])
+        self.buttonsBar = InputBarButtonsView(buttons: buttons)
         self.buttonsBar.clipsToBounds = true
         self.buttonsBar.expandRowButton.setIconColor(ColorScheme.default().color(withName: ColorSchemeColorTextForeground), for: .normal)
         self.view.addSubview(self.buttonsBar)


### PR DESCRIPTION
- Issue happens when user clicks on the bottom part of the bar. If all the buttons are having the bigger tap area the bottom invisible row of buttons is receiving the tap.