### PR TITLE
Hide the toolbox before reusing the cell for forwarding

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
@@ -136,7 +136,7 @@ extension ZMMessage: Shareable {
             contentView.edges == cell.edges
         }
 
-        cell.toolboxView.isHidden = true
+        cell.toolboxView.removeFromSuperview()
         cell.likeButton.isHidden = true
         cell.isUserInteractionEnabled = false
         cell.setSelected(false, animated: false)


### PR DESCRIPTION
# Reason for this pull request
Sharing a link with text would freeze the app (stuck in Autolayout)

# Changes
Hide the toolbox before reusing the cell for forwarding
Thanks to Mike for the fix