### PR TITLE
Pin line view to xHeight of the first line of text in IconSystemCell

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/IconSystemCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/IconSystemCell.swift
@@ -34,7 +34,14 @@ open class IconSystemCell: ConversationCell, TTTAttributedLabelDelegate {
     
     var labelTextColor: UIColor?
     var labelTextBlendedColor: UIColor?
-    var labelFont: UIFont?
+
+    var lineBaseLineConstraint: NSLayoutConstraint?
+
+    var labelFont: UIFont? {
+        didSet {
+            updateLineBaseLineConstraint()
+        }
+    }
     var labelBoldFont: UIFont?
 
     var verticalInset: CGFloat {
@@ -82,7 +89,6 @@ open class IconSystemCell: ConversationCell, TTTAttributedLabelDelegate {
         constrain(self.leftIconContainer, self.leftIconView, self.labelView, self.messageContentView, self.authorLabel) { (leftIconContainer: LayoutProxy, leftIconView: LayoutProxy, labelView: LayoutProxy, messageContentView: LayoutProxy, authorLabel: LayoutProxy) -> () in
             leftIconContainer.leading == messageContentView.leading
             leftIconContainer.trailing == authorLabel.leading
-            leftIconContainer.top == messageContentView.top + verticalInset
             leftIconContainer.bottom <= messageContentView.bottom
             leftIconContainer.height == leftIconView.height
             leftIconView.center == leftIconContainer.center
@@ -99,8 +105,19 @@ open class IconSystemCell: ConversationCell, TTTAttributedLabelDelegate {
             lineView.leading == labelView.trailing + 16
             lineView.height == .hairline
             lineView.trailing == contentView.trailing
-            lineView.top == messageContentView.top + verticalInset + 8
         }
+
+        updateLineBaseLineConstraint()
+
+        constrain(lineView, labelView, leftIconContainer) { (lineView: LayoutProxy, labelView: LayoutProxy, icon: LayoutProxy) -> () in
+            lineBaseLineConstraint = lineView.centerY == labelView.top + self.labelView.font.median - 2
+            icon.centerY == lineView.centerY
+        }
+    }
+
+    private func updateLineBaseLineConstraint() {
+        guard let font = labelFont else { return }
+        lineBaseLineConstraint?.constant = font.median - 2
     }
 
     open override var canResignFirstResponder: Bool {
@@ -108,4 +125,13 @@ open class IconSystemCell: ConversationCell, TTTAttributedLabelDelegate {
             return false
         }
     }
+}
+
+
+fileprivate extension UIFont {
+
+    var median: CGFloat {
+        return ascender - (xHeight / 2)
+    }
+
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/IconSystemCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/IconSystemCell.swift
@@ -48,6 +48,8 @@ open class IconSystemCell: ConversationCell, TTTAttributedLabelDelegate {
         return 16
     }
 
+    private let lineMedianYOffset: CGFloat = 2
+
     public required override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
 
@@ -110,14 +112,14 @@ open class IconSystemCell: ConversationCell, TTTAttributedLabelDelegate {
         updateLineBaseLineConstraint()
 
         constrain(lineView, labelView, leftIconContainer) { (lineView: LayoutProxy, labelView: LayoutProxy, icon: LayoutProxy) -> () in
-            lineBaseLineConstraint = lineView.centerY == labelView.top + self.labelView.font.median - 2
+            lineBaseLineConstraint = lineView.centerY == labelView.top + self.labelView.font.median - lineMedianYOffset
             icon.centerY == lineView.centerY
         }
     }
 
     private func updateLineBaseLineConstraint() {
         guard let font = labelFont else { return }
-        lineBaseLineConstraint?.constant = font.median - 2
+        lineBaseLineConstraint?.constant = font.median - lineMedianYOffset
     }
 
     open override var canResignFirstResponder: Bool {


### PR DESCRIPTION
# What's in this PR?

* The line to the right of the `UILabel` in `IconSystemCell` was pinned to the top with a hardcoded distance. With dynamic type the font size can change and the label will not be aligned to the center of the first line of text in the label anymore. 
* We now calculate the y-Position of the center of the first line of text to take changing fonts into account.