### PR TITLE
Fix crash in UserImageView (missing UserSession)

### DIFF
--- a/Wire-iOS/Resources/Magic/conversation.plist
+++ b/Wire-iOS/Resources/Magic/conversation.plist
@@ -365,8 +365,6 @@
 		<integer>3</integer>
 		<key>footer_button_size</key>
 		<integer>20</integer>
-		<key>tile_image_diameter</key>
-		<integer>80</integer>
 		<key>name_label_height</key>
 		<integer>12</integer>
 		<key>tile_name_spacing</key>
@@ -380,13 +378,6 @@
 		</array>
 		<key>text_transform</key>
 		<string>UPPER</string>
-		<key>badge_icon_color</key>
-		<array>
-			<integer>1</integer>
-			<integer>1</integer>
-			<integer>1</integer>
-			<integer>1</integer>
-		</array>
 		<key>separator_line_color</key>
 		<array>
 			<integer>1</integer>
@@ -412,8 +403,6 @@
 		<integer>80</integer>
 		<key>tile_height</key>
 		<integer>116</integer>
-		<key>tile_name_vertical_spacing</key>
-		<integer>8</integer>
 		<key>user_initials_font</key>
 		<dict>
 			<key>font</key>

--- a/Wire-iOS/Resources/Magic/people_picker.plist
+++ b/Wire-iOS/Resources/Magic/people_picker.plist
@@ -151,13 +151,6 @@
 					<integer>1</integer>
 					<integer>1</integer>
 				</array>
-				<key>badge_icon_color</key>
-				<array>
-					<integer>1</integer>
-					<integer>1</integer>
-					<integer>1</integer>
-					<integer>1</integer>
-				</array>
 			</dict>
 			<key>context_add_people</key>
 			<dict>
@@ -169,13 +162,6 @@
 					<integer>1</integer>
 				</array>
 				<key>icon_tint_color</key>
-				<array>
-					<integer>1</integer>
-					<integer>1</integer>
-					<integer>1</integer>
-					<integer>1</integer>
-				</array>
-				<key>badge_icon_color</key>
 				<array>
 					<integer>1</integer>
 					<integer>1</integer>
@@ -262,13 +248,6 @@
 					<integer>1</integer>
 					<integer>1</integer>
 				</array>
-				<key>badge_icon_color</key>
-				<array>
-					<integer>1</integer>
-					<integer>1</integer>
-					<integer>1</integer>
-					<integer>1</integer>
-				</array>
 			</dict>
 			<key>context_add_people</key>
 			<dict>
@@ -280,13 +259,6 @@
 					<integer>1</integer>
 				</array>
 				<key>icon_tint_color</key>
-				<array>
-					<integer>1</integer>
-					<integer>1</integer>
-					<integer>1</integer>
-					<integer>1</integer>
-				</array>
-				<key>badge_icon_color</key>
 				<array>
 					<integer>1</integer>
 					<integer>1</integer>

--- a/Wire-iOS/Sources/UserInterface/Collections/TextSearch/TextSearchResultCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/TextSearch/TextSearchResultCell.swift
@@ -69,6 +69,8 @@ internal class SearchResultCountBadge: UIView {
     override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         
+        self.userImageView.userSession = ZMUserSession.shared()
+        
         self.accessibilityIdentifier = "search result cell"
         
         self.contentView.addSubview(self.footerView)

--- a/Wire-iOS/Sources/UserInterface/ConnectRequests/IncomingConnectionView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConnectRequests/IncomingConnectionView.swift
@@ -57,6 +57,7 @@ public final class IncomingConnectionView: UIView {
         self.user = user
         super.init(frame: .zero)
 
+        self.userImageView.userSession = ZMUserSession.shared()
         self.setup()
         self.createConstraints()
     }

--- a/Wire-iOS/Sources/UserInterface/ConnectRequests/UserConnectionView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConnectRequests/UserConnectionView.swift
@@ -54,7 +54,7 @@ public final class UserConnectionView: UIView, Copyable {
     public init(user: ZMUser) {
         self.user = user
         super.init(frame: .zero)
-        
+        self.userImageView.userSession = ZMUserSession.shared()
         self.setup()
         self.createConstraints()
     }

--- a/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsCell.m
+++ b/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsCell.m
@@ -85,6 +85,7 @@ NS_ASSUME_NONNULL_END
 {
     self.selectionStyle = UITableViewCellSelectionStyleNone;
     self.userImageView = [[BadgeUserImageView alloc] initWithMagicPrefix:@"address_book"];
+    self.userImageView.userSession = [ZMUserSession sharedSession];
     self.userImageView.size = UserImageViewSizeTiny;
     self.userImageView.translatesAutoresizingMaskIntoConstraints = NO;
     [self.contentView addSubview:self.userImageView];

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
@@ -168,6 +168,7 @@ static const CGFloat BurstContainerExpandedHeight = 40;
     [self.contentView addSubview:self.authorImageContainer];
     
     self.authorImageView = [[UserImageView alloc] initWithMagicPrefix:@"content.author_image"];
+    self.authorImageView.userSession = [ZMUserSession sharedSession];
     self.authorImageView.translatesAutoresizingMaskIntoConstraints = NO;
     self.authorImageView.delegate = self;
     

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ParticipantsCell/ParticipantsCollectionViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ParticipantsCell/ParticipantsCollectionViewController.swift
@@ -34,6 +34,7 @@ final class ParticipantsUserCell: UICollectionViewCell {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
+        self.imageView.userSession = ZMUserSession.shared()
         backgroundColor = .clear
         addSubview(imageView)
         constrain(self, imageView) { view, image in

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ReactionsView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ReactionsView.swift
@@ -42,6 +42,7 @@ import Cartography
             
             for user in likersToDisplay {
                 let userImage = UserImageView(magicPrefix: "content.reaction")
+                userImage.userSession = ZMUserSession.shared()
                 userImage.user = user
                 constrain(userImage) { userImage in
                     userImage.width == userImage.height

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/MentionsCollectionViewCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/MentionsCollectionViewCell.m
@@ -23,7 +23,7 @@
 #import "UIFont+MagicAccess.h"
 #import <PureLayout/PureLayout.h>
 #import "UserImageView+Magic.h"
-
+#import "zmessaging+iOS.h"
 
 @interface MentionsLabel : UILabel
 
@@ -67,6 +67,7 @@
 -(void)createUserImageView
 {
     self.userImageView = [[UserImageView alloc] initWithMagicPrefix:@"content.author_image"];
+    self.userImageView.userSession = [ZMUserSession sharedSession];
     self.userImageView.translatesAutoresizingMaskIntoConstraints = NO;
     
     [self.contentView addSubview:self.userImageView];

--- a/Wire-iOS/Sources/UserInterface/Conversation/ReactionsList/ReactionCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ReactionsList/ReactionCell.swift
@@ -55,6 +55,8 @@ import Classy
     public override init(frame: CGRect) {
         super.init(frame: frame)
         
+        self.userImageView.userSession = ZMUserSession.shared()
+        
         self.contentView.addSubview(self.userDisplayNameLabel)
         self.contentView.addSubview(self.usernameLabel)
         self.contentView.addSubview(self.userImageView)

--- a/Wire-iOS/Sources/UserInterface/ConversationList/SearchView/SearchView.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/SearchView/SearchView.m
@@ -33,7 +33,7 @@
 #import "UIColor+WAZExtensions.h"
 #import "UIFont+MagicAccess.h"
 
-@interface SearchView () <ZMUserObserver, UserImageViewDelegate>
+@interface SearchView () <ZMUserObserver>
 @property (nonatomic, readwrite) PeopleInputController *peopleInputController;
 @property (nonatomic, readwrite) UIView *lineView;
 

--- a/Wire-iOS/Sources/UserInterface/Overlay/InAppNotifications/ChatHeadView.m
+++ b/Wire-iOS/Sources/UserInterface/Overlay/InAppNotifications/ChatHeadView.m
@@ -106,6 +106,7 @@
     self.messageLabel.lineBreakMode = NSLineBreakByTruncatingTail;
 
     self.userImageView = [[ContrastUserImageView alloc] initWithMagicPrefix:@"notifications"];
+    self.userImageView.userSession = [ZMUserSession sharedSession];
     self.userImageView.userInteractionEnabled = NO;
     self.userImageView.translatesAutoresizingMaskIntoConstraints = NO;
     [self addSubview:self.userImageView];

--- a/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelOverlay.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelOverlay.swift
@@ -210,6 +210,8 @@ class VoiceChannelOverlay: UIView {
     var leaveButtonPinRightConstraint: NSLayoutConstraint?
     
     init(frame: CGRect, callingConversation: ZMConversation) {
+        self.callingUserImage.userSession = ZMUserSession.shared()
+        self.callingTopUserImage.userSession = ZMUserSession.shared()
         self.callingConversation = callingConversation
         self.participantsCollectionViewLayout = VoiceChannelCollectionViewLayout()
         self.participantsCollectionView = UICollectionView(frame: .zero, collectionViewLayout: participantsCollectionViewLayout)

--- a/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelParticipantCell.m
+++ b/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelParticipantCell.m
@@ -79,6 +79,7 @@
     
     if (self) {
         self.userImage = [[VoiceUserImageView alloc] initWithMagicPrefix:@"voice_overlay.user_image_view"];
+        self.userImage.userSession = [ZMUserSession sharedSession];
         self.userImage.translatesAutoresizingMaskIntoConstraints = NO;
         self.userImage.state = VoiceUserImageViewStateTalking;
         [self.contentView addSubview:self.userImage];

--- a/Wire-iOS/Sources/UserInterface/Participants/ParticipantsListCell.h
+++ b/Wire-iOS/Sources/UserInterface/Participants/ParticipantsListCell.h
@@ -19,10 +19,10 @@
 
 #import <UIKit/UIKit.h>
 
-
+@class ZMUser;
 
 @interface ParticipantsListCell : UICollectionViewCell
 
-@property (strong, nonatomic) id representedObject;
+@property (strong, nonatomic) ZMUser* representedObject;
 
 @end

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/Cells/SearchResultCell.m
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/Cells/SearchResultCell.m
@@ -134,6 +134,7 @@
     [self.badgeUserImageView removeFromSuperview];
 
     self.badgeUserImageView = [[BadgeUserImageView alloc] initWithMagicPrefix:@"people_picker.search_results_mode"];
+    self.badgeUserImageView.userSession = [ZMUserSession sharedSession];
     self.badgeUserImageView.size = UserImageViewSizeTiny;
     self.badgeUserImageView.translatesAutoresizingMaskIntoConstraints = NO;
     self.badgeUserImageView.badgeIconSize = ZetaIconSizeTiny;
@@ -208,7 +209,7 @@
     CGFloat squareImageWidth = [WAZUIMagic cgFloatForIdentifier:@"people_picker.search_results_mode.tile_image_diameter"];
     self.avatarViewSizeConstraint.constant = squareImageWidth;
     self.conversationImageViewSize.constant = squareImageWidth;
-    self.badgeUserImageView.badgeColor = [UIColor colorWithMagicIdentifier:@"people_picker.search_results_mode.context_create_conversation.badge_icon_color"];
+    self.badgeUserImageView.badgeColor = [UIColor whiteColor];
 }
 
 - (void)prepareForReuse

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/Cells/TopPeopleCell.m
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/Cells/TopPeopleCell.m
@@ -82,6 +82,7 @@
     [self.badgeUserImageView removeFromSuperview];
 
     self.badgeUserImageView = [[BadgeUserImageView alloc] initWithMagicPrefix:@"people_picker.top_conversations_mode"];
+    self.badgeUserImageView.userSession = [ZMUserSession sharedSession];
     self.badgeUserImageView.size = UserImageViewSizeSmall;
     self.badgeUserImageView.translatesAutoresizingMaskIntoConstraints = NO;
     self.badgeUserImageView.userInteractionEnabled = NO;
@@ -129,7 +130,7 @@
     self.avatarViewSizeConstraint.constant = squareImageWidth;
     self.conversationImageViewSize.constant = squareImageWidth;
     
-    self.badgeUserImageView.badgeColor = [UIColor colorWithMagicIdentifier:@"people_picker.top_conversations_mode.context_add_people.badge_icon_color"];
+    self.badgeUserImageView.badgeColor = [UIColor whiteColor];
 }
 
 - (void)prepareForReuse

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileDetailsViewController.m
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileDetailsViewController.m
@@ -140,6 +140,7 @@ typedef NS_ENUM(NSUInteger, ProfileUserAction) {
     [self.view addSubview:self.userImageViewContainer];
     
     self.userImageView = [[UserImageView alloc] initWithMagicPrefix:@"profile.user_image"];
+    self.userImageView.userSession = [ZMUserSession sharedSession];
     self.userImageView.translatesAutoresizingMaskIntoConstraints = NO;
     self.userImageView.size = UserImageViewSizeBig;
     self.userImageView.user = self.bareUser;

--- a/WireExtensionComponents/Views/UserImageView.h
+++ b/WireExtensionComponents/Views/UserImageView.h
@@ -43,7 +43,7 @@ typedef NS_ENUM(NSUInteger, UserImageViewSize) {
 @interface UserImageView : AvatarImageView <ZMUserObserver>
 
 @property (nonatomic, nullable) id<ZMBareUser, AccentColorProvider> user;
-@property (nonatomic) ZMUserSession *userSession;
+@property (nonatomic, nullable) ZMUserSession *userSession;
 @property (nonatomic) BOOL shouldDesaturate;
 @property (nonatomic) BOOL indicatorEnabled;
 

--- a/WireExtensionComponents/Views/UserImageView.m
+++ b/WireExtensionComponents/Views/UserImageView.m
@@ -184,7 +184,7 @@ static CIContext *ciContext(void)
     if (self.size == UserImageViewSizeBig &&
         self.user.imageMediumData == nil) {
         
-        if ([self.user respondsToSelector:@selector(requestMediumProfileImageInUserSession:)]) {
+        if ([self.user respondsToSelector:@selector(requestMediumProfileImageInUserSession:)] && self.userSession != nil) {
             [(id)self.user requestMediumProfileImageInUserSession:self.userSession];
         }
         return;
@@ -193,7 +193,7 @@ static CIContext *ciContext(void)
     if (self.size != UserImageViewSizeBig &&
         self.user.imageSmallProfileData == nil) {
         
-        if ([self.user respondsToSelector:@selector(requestSmallProfileImageInUserSession:)]) {
+        if ([self.user respondsToSelector:@selector(requestSmallProfileImageInUserSession:)] && self.userSession != nil) {
             [(id)self.user requestSmallProfileImageInUserSession:self.userSession];
         }
         return;


### PR DESCRIPTION
UserSession has to be injected now, since the UserImageView is ported to WireExtensionComponents, and there the user session is not possible to have.