### PR TITLE
Fixed crash when conversation list updates with move

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/Model/ConversationListViewModel.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/Model/ConversationListViewModel.m
@@ -230,7 +230,10 @@ void debugLogUpdate (ConversationListChangeInfo *note);
             ZMOrderedSetState *endState = [[ZMOrderedSetState alloc] initWithOrderedSet:[NSOrderedSet orderedSetWithArray:newConversationList]];
             ZMOrderedSetState *updatedState = [[ZMOrderedSetState alloc] initWithOrderedSet:[NSOrderedSet orderedSet]];
             
-            ZMChangedIndexes *changedIndexes = [[ZMChangedIndexes alloc] initWithStartState:startState endState:endState updatedState:updatedState];
+            ZMChangedIndexes *changedIndexes = [[ZMChangedIndexes alloc] initWithStartState:startState
+                                                                                   endState:endState
+                                                                               updatedState:updatedState
+                                                                                   moveType:ZMSetChangeMoveTypeUICollectionView];
             
             if (changedIndexes.requiresReload) {
                 [self reloadConversationListViewModel];


### PR DESCRIPTION
- We used to calculate the changeset for UITableView (default value of moveType is NSTableView).