### PR TITLE
Conversation list update fixes

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ArchivedListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ArchivedListViewController.swift
@@ -36,25 +36,16 @@ import Cartography
     let cellReuseIdentifier = "ConversationListCellArchivedIdentifier"
     let swipeIdentifier = "ArchivedList"
     let viewModel = ArchivedListViewModel()
-    var initialSyncCompleted: Bool = false
     
     weak var delegate: ArchivedListViewControllerDelegate?
     
     required init() {
         super.init(nibName: nil, bundle: nil)
-        ZMUserSession.addInitalSyncCompletionObserver(self)
         viewModel.delegate = self
         createViews()
         createConstraints()
-        if let initialSyncCompleted = ZMUserSession.shared()?.initialSyncOnceCompleted {
-            self.initialSyncCompleted = initialSyncCompleted.boolValue
-        }
     }
     
-    deinit {
-        ZMUserSession.removeInitalSyncCompletionObserver(self)
-    }
-
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -127,29 +118,16 @@ extension ArchivedListViewController: UICollectionViewDataSource {
     
 }
 
-// MARK: - ZMInitialSyncCompletionObserver
-
-extension ArchivedListViewController: ZMInitialSyncCompletionObserver {
-    
-    func initialSyncCompleted(_ notification: Notification!) {
-        initialSyncCompleted = true
-        collectionView.reloadData()
-    }
-    
-}
-
 // MARK: - ArchivedListViewModelDelegate
 
 extension ArchivedListViewController: ArchivedListViewModelDelegate {
     internal func archivedListViewModel(_ model: ArchivedListViewModel, didUpdateArchivedConversationsWithChange change: ConversationListChangeInfo, applyChangesClosure: @escaping () -> ()) {
   
-        guard initialSyncCompleted else { return }
         applyChangesClosure()
         collectionView.reloadData()
     }
     
     func archivedListViewModel(_ model: ArchivedListViewModel, didUpdateConversationWithChange change: ConversationChangeInfo) {
-        guard initialSyncCompleted else { return }
         guard change.isArchivedChanged || change.conversationListIndicatorChanged || change.nameChanged ||
             change.unreadCountChanged || change.connectionStateChanged || change.isSilencedChanged else { return }
         for case let cell as ConversationListCell in collectionView.visibleCells where cell.conversation == change.conversation {

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController.m
@@ -88,9 +88,6 @@
 
 @end
 
-@interface ConversationListViewController (InitialSyncObserver) <ZMInitialSyncCompletionObserver>
-@end
-
 
 
 @interface ConversationListViewController () <UIGestureRecognizerDelegate>
@@ -148,7 +145,6 @@
 {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     [self removeUserProfileObserver];
-    [ZMUserSession removeInitalSyncCompletionObserver:self];
 }
 
 - (void)removeUserProfileObserver
@@ -178,7 +174,6 @@
     self.conversationListContainer.backgroundColor = [UIColor clearColor];
     [self.contentContainer addSubview:self.conversationListContainer];
 
-    [ZMUserSession addInitalSyncCompletionObserver:self];
     self.initialSyncCompleted = ZMUserSession.sharedSession.initialSyncOnceCompleted.boolValue;
 
     [self createNoConversationLabel];

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/Model/ConversationListViewModel.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/Model/ConversationListViewModel.m
@@ -247,6 +247,10 @@ void debugLogUpdate (ConversationListChangeInfo *note);
             if (changedIndexes.requiresReload) {
                 [self reloadConversationListViewModel];
             } else {
+                // We need to capture the state of `newConversationList` to make sure that we are updating the value
+                // of the list to the exact new state.
+                // It is important to keep the data source of the collection view consistent, since
+                // any inconsistency in the delta update would make it throw an exception.
                 dispatch_block_t modelUpdates = ^{ [self updateSection:SectionIndexConversations
                                                              withItems:newConversationList]; };
                 [self.delegate listViewModel:self didUpdateSection:SectionIndexConversations usingBlock:modelUpdates withChangedIndexes:changedIndexes];

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/Model/ConversationListViewModel.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/Model/ConversationListViewModel.m
@@ -74,16 +74,25 @@ void debugLogUpdate (ConversationListChangeInfo *note);
 }
 
 /**
- * This updates a specific section in the model, by copying the contents locally.  Passing in a value of SectionIndexAll
- * updates all sections.  The reason why we need to keep local copies of the lists is that
- * we get separate notifications for each list, which means that an update to one can render the
- * collection view out of sync with the datasource
+ * This updates a specific section in the model, by copying the contents locally. 
+ * Passing in a value of SectionIndexAll updates all sections. The reason why we need to keep
+ * local copies of the lists is that we get separate notifications for each list, 
+ * which means that an update to one can render the collection view out of sync with the datasource.
  */
 - (void)updateSection:(SectionIndex)sectionIndex
 {
+    [self updateSection:sectionIndex withItems:nil];
+}
+
+- (void)updateSection:(SectionIndex)sectionIndex withItems:(NSArray *)items
+{
+    if (sectionIndex == SectionIndexAll && items != nil) {
+        NSAssert(true, @"Update for all sections with proposed items is not allowed.");
+    }
+    
     if (sectionIndex == SectionIndexContactRequests || sectionIndex == SectionIndexAll) {
         if ([SessionObjectCache sharedCache].pendingConnectionRequests.count > 0) {
-            self.inbox = @[self.contactRequestsItem];
+            self.inbox = items ? : @[self.contactRequestsItem];
         }
         else {
             self.inbox = @[];
@@ -92,7 +101,7 @@ void debugLogUpdate (ConversationListChangeInfo *note);
 
     if (sectionIndex == SectionIndexConversations || sectionIndex == SectionIndexAll) {
         // Make a new copy of the conversation list
-        self.conversations = [SessionObjectCache sharedCache].conversationList;
+        self.conversations = items ? : [SessionObjectCache sharedCache].conversationList;
     }
     
     
@@ -220,7 +229,7 @@ void debugLogUpdate (ConversationListChangeInfo *note);
             [self reloadConversationListViewModel];
         } else {
             NSArray *oldConversationList = [self.aggregatedItems sectionAtIndex:SectionIndexConversations];
-            NSArray *newConversationList = [SessionObjectCache sharedCache].conversationList.asArray;
+            NSArray *newConversationList = [[SessionObjectCache sharedCache].conversationList.asArray copy];
 
             if ([oldConversationList isEqualToArray:newConversationList]) {
                 return;
@@ -238,7 +247,8 @@ void debugLogUpdate (ConversationListChangeInfo *note);
             if (changedIndexes.requiresReload) {
                 [self reloadConversationListViewModel];
             } else {
-                dispatch_block_t modelUpdates = ^{ [self updateSection:SectionIndexConversations]; };
+                dispatch_block_t modelUpdates = ^{ [self updateSection:SectionIndexConversations
+                                                             withItems:newConversationList]; };
                 [self.delegate listViewModel:self didUpdateSection:SectionIndexConversations usingBlock:modelUpdates withChangedIndexes:changedIndexes];
             }
         }


### PR DESCRIPTION
- Capture the list state that was used to calculate the update to use in the collection view data source.
- Removed the check for initial sync completed (this most likely caused the crash on automation).