### PR TITLE
Respect isShowingUnreadDot property when showing separators

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCellBurstTimestampView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCellBurstTimestampView.swift
@@ -44,7 +44,7 @@ import Cartography
 
     public var isSeparatorHidden: Bool = false {
         didSet {
-            leftSeparator.isHidden = isSeparatorHidden
+            leftSeparator.isHidden = isSeparatorHidden || isShowingUnreadDot
             rightSeparator.isHidden = isSeparatorHidden
         }
     }


### PR DESCRIPTION
# What's in this PR?

* Respect `isShowingUnreadDot` property when showing separators.
* When `isSeparatorHidden` was set to `false` after `isShowingUnreadDot` was set to `tue` the state of the view was inconsistent.

<img width="412" alt="screen shot 2017-03-30 at 10 02 56" src="https://cloud.githubusercontent.com/assets/4603353/24493707/15c77548-1530-11e7-91a3-b19f891a8ee7.png">
