### PR TITLE
Move call to scroll to last unread message to viewDidAppear

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -213,6 +213,8 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
         
         [self registerForPreviewingWithDelegate:self sourceView:self.view.superview];
     }
+
+    [self scrollToLastUnreadMessageIfNeeded];
 }
 
 - (void)viewWillDisappear:(BOOL)animated
@@ -221,10 +223,8 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
     [super viewWillDisappear:animated];
 }
 
-- (void)viewDidLayoutSubviews
+- (void)scrollToLastUnreadMessageIfNeeded
 {
-    [super viewDidLayoutSubviews];
-    
     if (! self.hasDoneInitialLayout) {
         self.hasDoneInitialLayout = YES;
         [self updateTableViewHeaderView];


### PR DESCRIPTION
# What's in this PR?

* Conversations were not scrolled to the last unread message when opening them, it seems like placing the call to `scrollToRowAtIndexPath:` from inside ``viewDidLayoutSubviews` was to early. Unfortunately `viewWillAppear` is too early as well, so we will try if there are any visible effects placing it in `viewDidAppear`. If there are any then we need to investigate the underlying issue further (looks like some cell height calculations ore other layout is not fully done yet).