### PR TITLE
Updating Localytics SDK to 4.3.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 def ios_pods
     pod 'GoogleAPIClient/YouTube', '1.0.4', :inhibit_warnings => true
     pod 'CocoaSecurity', '1.2.4', :inhibit_warnings => true
-    pod 'Localytics', '4.2.0', :inhibit_warnings => true
+    pod 'Localytics', '4.3.0', :inhibit_warnings => true
     pod 'NSObject-ObjectMap', :git => 'https://github.com/wireapp/NSObject-ObjectMap', :tag => 'v2.3.1'
     pod 'PureLayout', :git => 'https://github.com/wireapp/PureLayout', :tag => 'v3.0.0'
     pod 'RBBAnimation', :git => 'https://github.com/wireapp/RBBAnimation', :commit => '7dd8d9a3cf610be5f7c1e4459692d555d70704c7'


### PR DESCRIPTION
Updating Localytics SDK to latest available version: 4.3.0
According to their change log there should not be any major functional changes, just improvements to in-app etc messaging.
```
4.3.1: April 5th, 2017

Fixed a bug that caused In-App creatives in test mode to not be approprately responsive.
4.3.0: March 23, 2017

In-App Messaging improvements including:
Per campaign UI modification. Using a callback, a number of properties on the In-app campaign can be modified such as centered In-App aspect ratio, Banner In-App offset from the edges of the screen, full-screen In-App transparency, and dismiss button image, location and visibility.
A new campaign test mode UI including the ability to preview all creatives in an A/B test.
The ability to delay In-App campaigns triggered by "Session Start" and refire them at a later time to avoid conflicts with splash screens or other interstitials.
Additional Javascript callbacks for setting Profiles and identifitying users within custom HTML In-App Messaging creatives.
A new In-App Dimiss button.
In-App Messages can now be triggered or suppressed based on dimensions.
Performance events to manually track impressions and conversions for customers rendering fully custom Push, In-App, Inbox, and Places campaigns.
Places notification trigger methods.
```