### PR TITLE
Conversation status: added participants

### DIFF
--- a/Wire-iOS Tests/ConversationStatusLineTests.swift
+++ b/Wire-iOS Tests/ConversationStatusLineTests.swift
@@ -158,7 +158,7 @@ class ConversationStatusLineTests: CoreDataSnapshotTestCase {
         let otherMessage = ZMSystemMessage.insertNewObject(in: moc)
         otherMessage.systemMessageType = .participantsAdded
         otherMessage.sender = self.otherUser
-        otherMessage.users = Set([self.otherUser])
+        otherMessage.users = Set([self.selfUser])
         otherMessage.addedUsers = Set([self.selfUser])
         sut.sortedAppendMessage(otherMessage)
         sut.lastReadServerTimeStamp = Date.distantPast
@@ -175,7 +175,7 @@ class ConversationStatusLineTests: CoreDataSnapshotTestCase {
         let otherMessage = ZMSystemMessage.insertNewObject(in: moc)
         otherMessage.systemMessageType = .participantsAdded
         otherMessage.sender = self.selfUser
-        otherMessage.users = Set([self.selfUser])
+        otherMessage.users = Set([self.otherUser])
         otherMessage.addedUsers = Set([self.otherUser])
         sut.sortedAppendMessage(otherMessage)
         sut.lastReadServerTimeStamp = Date.distantPast

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ZMConversation+Status.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ZMConversation+Status.swift
@@ -381,11 +381,11 @@ final internal class GroupActivityMatcher: ConversationStatusMatcher {
         else if let message = messages.last,
                 let systemMessage = message.systemMessageData,
                 let sender = message.sender {
-            if systemMessage.addedUsers.contains(where: { $0.isSelfUser }) {
+            if systemMessage.users.contains(where: { $0.isSelfUser }) {
                 return String(format: "conversation.status.you_was_added".localized, sender.displayName(in: conversation))
             }
             else {
-                let usersList = systemMessage.addedUsers.map { $0.displayName(in: conversation) }.joined(separator: ", ")
+                let usersList = systemMessage.users.map { $0.displayName(in: conversation) }.joined(separator: ", ")
                 let sender = sender.isSelfUser ? "conversation.status.you".localized : sender.displayName(in: conversation)
                 return String(format: "conversation.status.added_users".localized, sender!, usersList)
             }
@@ -572,7 +572,7 @@ extension ZMConversation {
         if messagesRequiringAttention.count == 0,
             let lastMessage = self.messages.lastObject as? ZMConversationMessage,
             let systemMessageData = lastMessage.systemMessageData,
-            systemMessageData.systemMessageType == .participantsRemoved {
+            systemMessageData.systemMessageType == .participantsRemoved || systemMessageData.systemMessageType == .participantsAdded {
             messagesRequiringAttention.append(lastMessage)
         }
         


### PR DESCRIPTION
- System message about added participants is marked read automatically.
- The added participants are stored in `users` and not in `addedUsers`.