### PR TITLE
Add option to set a accessibilityLabel on UISwitch cells in settings

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Options.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Options.swift
@@ -118,7 +118,11 @@ extension SettingsCellDescriptorFactory {
             cellDescriptors.append(callKitSection)
         }
         
-        let VBRDescriptor = SettingsPropertyToggleCellDescriptor(settingsProperty: settingsPropertyFactory.property(.callingConstantBitRate), inverse: true)
+        let VBRDescriptor = SettingsPropertyToggleCellDescriptor(
+            settingsProperty: settingsPropertyFactory.property(.callingConstantBitRate),
+            inverse: true,
+            switchAccessibilityLabel: "VBRSwitch"
+        )
         let VBRDescription = "self.settings.vbr.description".localized
         let VBRSection = SettingsSectionDescriptor(cellDescriptors: [VBRDescriptor], header: .none, footer: VBRDescription, visibilityAction: .none)
         cellDescriptors.append(VBRSection)

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Options.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Options.swift
@@ -121,7 +121,7 @@ extension SettingsCellDescriptorFactory {
         let VBRDescriptor = SettingsPropertyToggleCellDescriptor(
             settingsProperty: settingsPropertyFactory.property(.callingConstantBitRate),
             inverse: true,
-            switchAccessibilityLabel: "VBRSwitch"
+            identifier: "VBRSwitch"
         )
         let VBRDescription = "self.settings.vbr.description".localized
         let VBRSection = SettingsSectionDescriptor(cellDescriptors: [VBRDescriptor], header: .none, footer: VBRDescription, visibilityAction: .none)

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsPropertyToggleCellDescriptor.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsPropertyToggleCellDescriptor.swift
@@ -32,14 +32,16 @@ class SettingsPropertyToggleCellDescriptor: SettingsPropertyCellDescriptorType {
         }
     }
     let identifier: String?
+    let switchAccessibilityLabel: String?
     var visible: Bool = true
     weak var group: SettingsGroupCellDescriptorType?
     var settingsProperty: SettingsProperty
     
-    init(settingsProperty: SettingsProperty, inverse: Bool = false, identifier: String? = .none) {
+    init(settingsProperty: SettingsProperty, inverse: Bool = false, identifier: String? = .none, switchAccessibilityLabel: String? = .none) {
         self.settingsProperty = settingsProperty
         self.inverse = inverse
         self.identifier = identifier
+        self.switchAccessibilityLabel = switchAccessibilityLabel
     }
     
     func featureCell(_ cell: SettingsCellType) {
@@ -58,6 +60,7 @@ class SettingsPropertyToggleCellDescriptor: SettingsPropertyCellDescriptorType {
             }
             
             toggleCell.switchView.isOn = boolValue
+            toggleCell.switchView.accessibilityLabel = switchAccessibilityLabel
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsPropertyToggleCellDescriptor.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsPropertyToggleCellDescriptor.swift
@@ -32,16 +32,14 @@ class SettingsPropertyToggleCellDescriptor: SettingsPropertyCellDescriptorType {
         }
     }
     let identifier: String?
-    let switchAccessibilityLabel: String?
     var visible: Bool = true
     weak var group: SettingsGroupCellDescriptorType?
     var settingsProperty: SettingsProperty
     
-    init(settingsProperty: SettingsProperty, inverse: Bool = false, identifier: String? = .none, switchAccessibilityLabel: String? = .none) {
+    init(settingsProperty: SettingsProperty, inverse: Bool = false, identifier: String? = .none) {
         self.settingsProperty = settingsProperty
         self.inverse = inverse
         self.identifier = identifier
-        self.switchAccessibilityLabel = switchAccessibilityLabel
     }
     
     func featureCell(_ cell: SettingsCellType) {
@@ -60,7 +58,7 @@ class SettingsPropertyToggleCellDescriptor: SettingsPropertyCellDescriptorType {
             }
             
             toggleCell.switchView.isOn = boolValue
-            toggleCell.switchView.accessibilityLabel = switchAccessibilityLabel
+            toggleCell.switchView.accessibilityLabel = identifier
         }
     }
     


### PR DESCRIPTION
# What's in this PR?

* As requested by automation this adds an `accessibilityLabel` to the VBR switch in settings.