### PR TITLE
Fix audio message temporary urls for users with non latin names

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Helpers/NSString+Filename.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/NSString+Filename.swift
@@ -23,12 +23,12 @@ extension NSString {
     
     fileprivate static let dateFormatter : DateFormatter = {
         let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy MM dd hh.mm.ss"
+        formatter.dateFormat = "yyyy-MM-dd-hh.mm.ss"
         return formatter
     }()
-    
+
     static func filenameForSelfUser() -> NSString {
-        let filename = "\(ZMUser.selfUser().name!) \(dateFormatter.string(from: Date()))"
-        return filename.replacingOccurrences(of: " ", with: "-") as NSString
+        let identifier = ZMUser.selfUser().remoteIdentifier?.transportString() ?? ""
+        return "\(identifier)-\(dateFormatter.string(from: Date()))" as NSString
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Helpers/NSString+Filename.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/NSString+Filename.swift
@@ -27,8 +27,15 @@ extension NSString {
         return formatter
     }()
 
+    static private let transforms = [kCFStringTransformStripCombiningMarks, kCFStringTransformToLatin, kCFStringTransformToUnicodeName]
+
+    var normalizedFilename: String {
+        let ref = NSMutableString(string: self) as CFMutableString
+        type(of: self).transforms.forEach { CFStringTransform(ref, nil, $0, false) }
+        return (ref as String).replacingOccurrences(of: " ", with: "-")
+    }
+
     static func filenameForSelfUser() -> NSString {
-        let identifier = ZMUser.selfUser().remoteIdentifier?.transportString() ?? ""
-        return "\(identifier)-\(dateFormatter.string(from: Date()))" as NSString
+        return "\(ZMUser.selfUser().name!.normalizedFilename)-\(dateFormatter.string(from: Date()))" as NSString
     }
 }


### PR DESCRIPTION
# What's in this PR?

* Audio messages were temporarily stored in a file with a name created from the users name, this logic didn't work for users with emoji in their name (or other non-latin characters I assume). This PR fixes this issue and uses the `remoteIdentifier` instead of the users name.
