### PR TITLE
Don't scale down GIFs

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Views/ImageToolbarView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/ImageToolbarView.swift
@@ -42,6 +42,13 @@ class ImageToolbarView: UIView {
             updateButtonConfiguration()
         }
     }
+
+    @objc public var showsSketchButton = true {
+        didSet {
+            guard oldValue != showsSketchButton else { return }
+            updateButtonConfiguration()
+        }
+    }
     
     var isPlacedOnImage : Bool = false {
         didSet {
@@ -77,18 +84,19 @@ class ImageToolbarView: UIView {
     
     func updateButtonConfiguration() {
         buttons.forEach({ $0.removeFromSuperview() })
-        
+        var newButtons = showsSketchButton ? [sketchButton] : []
+
         switch configuration {
         case .cell:
-            buttons = [sketchButton, emojiButton, expandButton]
+            newButtons.append(contentsOf: [emojiButton, expandButton])
         case .compactCell:
-            buttons = [sketchButton, expandButton]
+            newButtons.append(expandButton)
         case .preview:
-            buttons = [sketchButton, emojiButton]
+            newButtons.append(emojiButton)
         }
-        
+
+        buttons = newButtons
         buttons.forEach(buttonContainer.addSubview)
-        
         createButtonConstraints()
     }
     

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ImageMessageCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ImageMessageCell.m
@@ -165,8 +165,6 @@ static const CGFloat ImageToolbarMinimumSize = 192;
     self.fullImageView.translatesAutoresizingMaskIntoConstraints = NO;
     self.fullImageView.contentMode = UIViewContentModeScaleAspectFill;
     self.fullImageView.clipsToBounds = YES;
-    self.fullImageView.layer.borderWidth = UIScreen.hairline;
-    self.fullImageView.layer.borderColor = [UIColor colorWithWhite:0 alpha:0.08].CGColor;
     self.fullImageView.hidden = YES;
     [self.imageViewContainer addSubview:self.fullImageView];
 
@@ -294,7 +292,8 @@ static const CGFloat ImageToolbarMinimumSize = 192;
     // request
     [convMessage requestImageDownload]; // there is no harm in calling this if the full content is already available
 
-    self.originalImageSize = CGSizeApplyAffineTransform(imageMessageData.originalSize, CGAffineTransformMakeScale(0.5, 0.5));
+    const CGFloat scaleFactor = imageMessageData.isAnimatedGIF ? 1 : 0.5;
+    self.originalImageSize = CGSizeApplyAffineTransform(imageMessageData.originalSize, CGAffineTransformMakeScale(scaleFactor, scaleFactor));
     self.imageSize = CGSizeMake(MAX(48, self.originalImageSize.width), MAX(48, self.originalImageSize.height));
     
     if (self.autoStretchVertically) {
@@ -303,6 +302,8 @@ static const CGFloat ImageToolbarMinimumSize = 192;
     else {
         self.fullImageView.contentMode = UIViewContentModeScaleAspectFill;
     }
+
+    [self updateImageBorder];
 
     self.imageToolbarView.showsSketchButton = !imageMessageData.isAnimatedGIF;
     self.imageToolbarView.isPlacedOnImage = [self imageToolbarFitsInsideImage];
@@ -365,6 +366,13 @@ static const CGFloat ImageToolbarMinimumSize = 192;
             self.loadingView.hidden = NO;
         }
     }
+}
+
+- (void)updateImageBorder
+{
+    BOOL showBorder = !self.imageSmallerThanMinimumSize;
+    self.fullImageView.layer.borderWidth = showBorder ? UIScreen.hairline : 0;
+    self.fullImageView.layer.borderColor = [UIColor colorWithWhite:0 alpha:0.08].CGColor;
 }
 
 - (void)setImage:(id<MediaAsset>)image

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ImageMessageCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ImageMessageCell.m
@@ -243,13 +243,15 @@ static const CGFloat ImageToolbarMinimumSize = 192;
             if (! self.imageAspectConstraint) {
                 CGFloat aspectRatio = self.imageSize.height / self.imageSize.width;
                 [NSLayoutConstraint autoSetPriority:ALLayoutPriorityRequired forConstraints:^{
-                    self.imageAspectConstraint = [self.imageViewContainer autoMatchDimension:ALDimensionHeight toDimension:ALDimensionWidth ofView:self.imageViewContainer withMultiplier:aspectRatio];
+                    self.imageAspectConstraint = [self.imageViewContainer autoMatchDimension:ALDimensionHeight
+                                                                                 toDimension:ALDimensionWidth
+                                                                                      ofView:self.imageViewContainer
+                                                                              withMultiplier:aspectRatio];
                 }];
             }
         }
         else {
             self.messageContentView.layoutMargins = UIEdgeInsetsZero;
-            
             self.imageRightConstraint.active = YES;
         }
         
@@ -301,7 +303,8 @@ static const CGFloat ImageToolbarMinimumSize = 192;
     else {
         self.fullImageView.contentMode = UIViewContentModeScaleAspectFill;
     }
-    
+
+    self.imageToolbarView.showsSketchButton = !imageMessageData.isAnimatedGIF;
     self.imageToolbarView.isPlacedOnImage = [self imageToolbarFitsInsideImage];
     self.imageToolbarView.configuration = [self imageToolbarNeedsToBeCompact] ? ImageToolbarConfigurationCompactCell : ImageToolbarConfigurationCell;
     


### PR DESCRIPTION
# What's in this PR?

* Hide sketch button for GIFs.
* Don't scale down GIFs.
* Don't show border for images smaller than 48pt.