### PR TITLE
Check for correct voice channel state and enqueue changes

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListCell.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListCell.m
@@ -191,7 +191,7 @@ static const NSTimeInterval OverscrollRatio = 2.5;
         [self toggleMediaPlayer];
     }
     else if (self.conversation.voiceChannel.state == VoiceChannelV2StateIncomingCallInactive) {
-        [self.conversation startAudioCallWithCompletionHandler:nil];
+        [self.conversation acceptIncomingCall];
     }
 }
     

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListCell.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListCell.m
@@ -190,10 +190,10 @@ static const NSTimeInterval OverscrollRatio = 2.5;
         mediaPlaybackManager.activeMediaPlayer.sourceMessage.conversation == self.conversation) {
         [self toggleMediaPlayer];
     }
-    else {
-        if (self.conversation.voiceChannel.state == VoiceChannelV2StateIncomingCall) {
+    else if (self.conversation.voiceChannel.state == VoiceChannelV2StateIncomingCallInactive) {
+        [ZMUserSession.sharedSession enqueueChanges:^{
             (void)[self.conversation.voiceChannel joinWithVideo:NO userSession:[ZMUserSession sharedSession]];
-        }
+        }];
     }
 }
     

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListCell.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListCell.m
@@ -191,9 +191,7 @@ static const NSTimeInterval OverscrollRatio = 2.5;
         [self toggleMediaPlayer];
     }
     else if (self.conversation.voiceChannel.state == VoiceChannelV2StateIncomingCallInactive) {
-        [ZMUserSession.sharedSession enqueueChanges:^{
-            (void)[self.conversation.voiceChannel joinWithVideo:NO userSession:[ZMUserSession sharedSession]];
-        }];
+        [self.conversation startAudioCallWithCompletionHandler:nil];
     }
 }
     


### PR DESCRIPTION
# What's in this PR?

* We were checking for the wrong voice channel state. 
* Warp the call to join the ongoing call in an `enqueueChanges` block.