### PR TITLE
Check assets v3 setting everywhere

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
@@ -38,6 +38,7 @@ func forEachNonEphemeral(in conversations: [ZMConversation], callback: (ZMConver
 func forward(_ message: ZMMessage, to: [AnyObject]) {
     
     let conversations = to as! [ZMConversation]
+    let v3Assets = ExtensionSettings.shared.useAssetsV3
     
     if message.isText {
         ZMUserSession.shared()?.performChanges {
@@ -46,16 +47,16 @@ func forward(_ message: ZMMessage, to: [AnyObject]) {
     }
     else if message.isImage {
         ZMUserSession.shared()?.performChanges {
-            forEachNonEphemeral(in: conversations) { _ = $0.appendMessage(withImageData: message.imageMessageData!.imageData) }
+            forEachNonEphemeral(in: conversations) { _ = $0.appendMessage(withImageData: message.imageMessageData!.imageData, version3: v3Assets) }
         }
     }
     else if message.isVideo || message.isAudio || message.isFile {
-            FileMetaDataGenerator.metadataForFileAtURL(message.fileMessageData!.fileURL, UTI: message.fileMessageData!.fileURL.UTI(), name: message.fileMessageData!.fileURL.lastPathComponent) { fileMetadata in
-
-                ZMUserSession.shared()?.performChanges {
-                        forEachNonEphemeral(in: conversations) { _ = $0.appendMessage(with: fileMetadata) }
-                    }
+        let url  = message.fileMessageData!.fileURL!
+        FileMetaDataGenerator.metadataForFileAtURL(url, UTI: url.UTI(), name: url.lastPathComponent) { fileMetadata in
+            ZMUserSession.shared()?.performChanges {
+                forEachNonEphemeral(in: conversations) { _ = $0.appendMessage(with: fileMetadata, version3: v3Assets) }
             }
+        }
     }
     else if message.isLocation {
         let locationData = LocationData.locationData(withLatitude: message.locationMessageData!.latitude, longitude: message.locationMessageData!.longitude, name: message.locationMessageData!.name, zoomLevel: message.locationMessageData!.zoomLevel)

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -573,7 +573,7 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
         NSData *imageData = UIImagePNGRepresentation(image);
         
         [[ZMUserSession sharedSession] enqueueChanges:^{
-            [self.conversation appendMessageWithImageData:imageData];
+            [self.conversation appendMessageWithImageData:imageData version3:ExtensionSettings.shared.useAssetsV3];
         } completionHandler:^{
             [[Analytics shared] tagMediaActionCompleted:ConversationMediaActionSketch inConversation:self.conversation];
             [[Analytics shared] tagMediaSentPictureSourceSketchInConversation:self.conversation sketchSource:ConversationMediaSketchSourceImageFullView];

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+StartUI.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+StartUI.m
@@ -185,7 +185,7 @@
                 ZMUser *user = self.startUISelectedUsers.anyObject;
                 
                 [[ZMUserSession sharedSession] enqueueChanges:^{
-                    [user.oneToOneConversation appendMessageWithImageData:imageData];
+                    [user.oneToOneConversation appendMessageWithImageData:imageData version3:ExtensionSettings.shared.useAssetsV3];
                 } completionHandler:^{
                     [[Analytics shared] tagMediaActionCompleted:ConversationMediaActionPhoto inConversation:user.oneToOneConversation];
                     
@@ -204,10 +204,9 @@
                     conversation = [ZMConversation insertGroupConversationIntoUserSession:[ZMUserSession sharedSession]
                                                                          withParticipants:self.startUISelectedUsers.allObjects];
                 } completionHandler:^{
-                    
                     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.3 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
                         [[ZMUserSession sharedSession] enqueueChanges:^{
-                            [conversation appendMessageWithImageData:imageData];
+                            [conversation appendMessageWithImageData:imageData version3:ExtensionSettings.shared.useAssetsV3];
                         } completionHandler:^{
                             [[Analytics shared] tagMediaActionCompleted:ConversationMediaActionPhoto inConversation:conversation];
                             dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.3 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{


### PR DESCRIPTION
# What's in this PR?

* Forwarding and sending from the start UI did not use the asset v3 setting.
* I am removing the assets v3 flag from `wire-ios-data-model` (as well as the strategies used to send v2 assets), but this is still work in progress and requires a lot of tests to be fixed.