### PR TITLE
Update visible voice channel overlays when coming on screen

### DIFF
--- a/Wire-iOS/Sources/Analytics/AnalyticsConversationListObserver.m
+++ b/Wire-iOS/Sources/Analytics/AnalyticsConversationListObserver.m
@@ -119,7 +119,7 @@ const NSTimeInterval PermantentConversationListObserverObservationFinalTime = 20
     else if ([currentNetworkType isEqualToString:CTRadioAccessTechnologyLTE]) {
         networkType = @"4G";
     }
-    else if ([NetworkStatus sharedStatus].reachability == ServerReachabilityOK){
+    else if ([NetworkStatus sharedStatus].reachability == ServerReachabilityOK) {
         networkType = @"wifi";
     }
     

--- a/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelController.m
+++ b/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelController.m
@@ -40,7 +40,7 @@
 
 @implementation VoiceChannelController
 
-- (void)loadView{
+- (void)loadView {
     self.view = [[PassthroughTouchesView alloc] init];
 }
 
@@ -51,9 +51,21 @@
     self.voiceChannelObserverToken = [VoiceChannelRouter addStateObserver:self userSession:[ZMUserSession sharedSession]];
 }
 
+- (void)viewDidAppear:(BOOL)animated
+{
+    [super viewDidAppear:animated];
+    [self updateOverlays];
+}
+
 - (BOOL)prefersStatusBarHidden
 {
     return YES;
+}
+
+- (void)updateOverlays
+{
+    [self updateActiveCallConversation];
+    [self updateVoiceChannelOverlays];
 }
 
 - (BOOL)voiceChannelIsActive
@@ -193,8 +205,7 @@
 - (void)callCenterDidChangeVoiceChannelState:(VoiceChannelV2State)voiceChannelState conversation:(ZMConversation *)conversation callingProtocol:(enum CallingProtocol)callingProtocol
 {
     DDLogVoice(@"SE: Voice channel state change to %d (%@)", voiceChannelState, StringFromVoiceChannelV2State(voiceChannelState));
-    [self updateActiveCallConversation];
-    [self updateVoiceChannelOverlays];
+    [self updateOverlays];
 }
 
 - (void)callCenterDidFailToJoinVoiceChannelWithError:(NSError *)error conversation:(ZMConversation *)conversation


### PR DESCRIPTION
# What's in this PR?

* There were some recent changes to the calling threading, which most likely broke the voice channel overlay in some rare cases. When using CallKit and accepting a video call form the lock screen no overlay was visible when returning to the application. 
* This PR adds a call to check for the current overlay state to ensure the UI overlay logic is not dependent on the calling order / notifications from SE.
* However this PR does not fix the fact that there are notifications that are not received in this special case, which could be related to the threading changes or the general fact that the UI might not yet be loaded at the point when the notifications are fired.