### PR TITLE
Re-add initial sync observer to conversation list controller

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController.m
@@ -81,6 +81,9 @@
 @interface ConversationListViewController (PermissionDenied) <PermissionDeniedViewControllerDelegate>
 @end
 
+@interface ConversationListViewController (InitialSyncObserver) <ZMInitialSyncCompletionObserver>
+@end
+
 @interface ConversationListViewController (ConversationListObserver) <ZMConversationListObserver>
 
 - (void)updateArchiveButtonVisibility;
@@ -133,6 +136,7 @@
 - (void)dealloc
 {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
+    [ZMUserSession removeInitalSyncCompletionObserver:self];
     [self removeUserProfileObserver];
 }
 
@@ -163,6 +167,7 @@
     self.conversationListContainer.backgroundColor = [UIColor clearColor];
     [self.contentContainer addSubview:self.conversationListContainer];
 
+    [ZMUserSession addInitalSyncCompletionObserver:self];
     self.initialSyncCompleted = ZMUserSession.sharedSession.initialSyncOnceCompleted.boolValue;
 
     [self createTopBar];
@@ -807,6 +812,7 @@
 }
 
 @end
+
 
 @implementation ConversationListViewController (InitialSyncObserver)
 


### PR DESCRIPTION
# What's in this PR?

* The `ConversationListViewController` somehow no longer was a `ZMInitialSyncCompletionObserver`, which it needs to be in order to only show the username takeover screen once the initial sync is done. This is due to the fact that the user might already have set a username on another device and we need to wait for the user to be refetched.