### PR TITLE
Fix for showing the top bar together with username overlay

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+TopBar.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+TopBar.swift
@@ -82,7 +82,7 @@ extension ConversationListViewController {
         
         self.topBar = ConversationListTopBar()
         
-        self.view.addSubview(self.topBar)
+        self.contentContainer.addSubview(self.topBar)
         self.updateSpaces()
         self.topBar.rightView = settingsButton
     }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController.m
@@ -383,15 +383,15 @@
 
 - (void)createViewConstraints
 {
-    [self.conversationListContainer autoPinEdgesToSuperviewEdges];
+    [self.conversationListContainer autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsZero excludingEdge:ALEdgeTop];
     
     [self.bottomBarController.view autoPinEdgeToSuperviewEdge:ALEdgeLeft];
     [self.bottomBarController.view autoPinEdgeToSuperviewEdge:ALEdgeRight];
     self.bottomBarBottomOffset = [self.bottomBarController.view autoPinEdgeToSuperviewEdge:ALEdgeBottom];
     
-    [self.topBar autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsMake(20, 0, 0, 0) excludingEdge:ALEdgeBottom];
-    [self.topBar autoPinEdge:ALEdgeBottom toEdge:ALEdgeTop ofView:self.contentContainer];
-    [self.contentContainer autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsZero excludingEdge:ALEdgeTop];
+    [self.topBar autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsZero excludingEdge:ALEdgeBottom];
+    [self.topBar autoPinEdge:ALEdgeBottom toEdge:ALEdgeTop ofView:self.conversationListContainer];
+    [self.contentContainer autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsMake(20, 0, 0, 0)];
     
     [self.noConversationLabel autoCenterInSuperview];
     [self.noConversationLabel autoSetDimension:ALDimensionHeight toSize:120.0f];


### PR DESCRIPTION
- The top bar was not added to intended `contentContainer` view.