### PR TITLE
Exclude whole library dir from backup

### DIFF
--- a/Wire-iOS/Sources/Managers/FileBackupExcluder.swift
+++ b/Wire-iOS/Sources/Managers/FileBackupExcluder.swift
@@ -34,7 +34,10 @@ public extension URL {
 
 final internal class FileBackupExcluder: NSObject {
     typealias FileInDirectory = (NSFileManager.SearchPathDirectory, String)
-    private static let filesToExclude: [FileInDirectory] = [(.libraryDirectory, "Preferences/com.apple.EmojiCache.plist")]
+    private static let filesToExclude: [FileInDirectory] = [
+        (.libraryDirectory, "Preferences/com.apple.EmojiCache.plist"),
+        (.libraryDirectory, ".")
+    ]
     
     deinit {
         NotificationCenter.default.removeObserver(self)


### PR DESCRIPTION
# What's in this PR?

* Try to exclude the whole Library directory from the iCloud backup. We currently exclude all relevant folders manually. 