### PR TITLE
Added CircleCI integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ Wire-iOS/ComponentsVersions.plist
 /Libraries
 /wire-ios-build-assets
 .bundle/
+SnapshotResults

--- a/Wire-iOS Tests/Info.plist
+++ b/Wire-iOS Tests/Info.plist
@@ -20,5 +20,7 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>NSPrincipalClass</key>
+	<string>Wire_iOS_Tests.TestSetup</string>
 </dict>
 </plist>

--- a/Wire-iOS Tests/TestSetup.swift
+++ b/Wire-iOS Tests/TestSetup.swift
@@ -1,0 +1,34 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import UIKit
+
+/// This class is set as NSPrincipalClass in test suite info.plist
+/// XCTest makes sure to initialise it only once and we can add all global
+/// test setup code here
+class TestSetup: NSObject {
+    override init() {
+        super.init()
+        // The snapshot tests expect to be run with CET time zone
+        // We make sure that is the case if e.g. tests run on cloud CI provider
+        if let timezone = TimeZone(abbreviation: "CET") {
+            NSTimeZone.default = timezone
+        }
+    }
+}

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -950,6 +950,7 @@
 		F195EB9D1E2F75BC00712118 /* FeedbackOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F195EB9C1E2F75BC00712118 /* FeedbackOverlayView.swift */; };
 		F1AA8AD61E5DF36A006A0E68 /* DegradationOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1AA8AD51E5DF36A006A0E68 /* DegradationOverlayView.swift */; };
 		F1B025641E574B3C00900C65 /* VoiceChannelOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1B025631E574B3C00900C65 /* VoiceChannelOverlay.swift */; };
+		F1C9E3601EAE008C006438D7 /* TestSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C9E35E1EADFFB8006438D7 /* TestSetup.swift */; };
 		F93D58431D7D9184003AE972 /* Analytics+ConversationEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93D58421D7D9184003AE972 /* Analytics+ConversationEvents.swift */; };
 		F93D58451D7DA865003AE972 /* ZMConversation+Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93D58441D7DA865003AE972 /* ZMConversation+Analytics.swift */; };
 		F93D58471D7DA876003AE972 /* ZMMessage+Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93D58461D7DA876003AE972 /* ZMMessage+Analytics.swift */; };
@@ -2466,6 +2467,7 @@
 		F195EB9C1E2F75BC00712118 /* FeedbackOverlayView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeedbackOverlayView.swift; sourceTree = "<group>"; };
 		F1AA8AD51E5DF36A006A0E68 /* DegradationOverlayView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DegradationOverlayView.swift; sourceTree = "<group>"; };
 		F1B025631E574B3C00900C65 /* VoiceChannelOverlay.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VoiceChannelOverlay.swift; sourceTree = "<group>"; };
+		F1C9E35E1EADFFB8006438D7 /* TestSetup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSetup.swift; sourceTree = "<group>"; };
 		F93D58421D7D9184003AE972 /* Analytics+ConversationEvents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Analytics+ConversationEvents.swift"; sourceTree = "<group>"; };
 		F93D58441D7DA865003AE972 /* ZMConversation+Analytics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMConversation+Analytics.swift"; sourceTree = "<group>"; };
 		F93D58461D7DA876003AE972 /* ZMMessage+Analytics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMMessage+Analytics.swift"; sourceTree = "<group>"; };
@@ -4821,6 +4823,7 @@
 		BACB88521AF7C48900DDCDB0 /* Wire-iOS Tests */ = {
 			isa = PBXGroup;
 			children = (
+				F1C9E35E1EADFFB8006438D7 /* TestSetup.swift */,
 				1651F9BA1D352C5300A9FAE8 /* ArticleViewTests.swift */,
 				BFAD3A1B1CD1078500F0FBED /* Resources */,
 				BF29C9851C6E357100601EE7 /* ZMSnapshotTestCase.h */,
@@ -6462,6 +6465,7 @@
 				162E8C631CF5D68A004B4F45 /* AudioProcessingTests.swift in Sources */,
 				BF58ABEF1D23F3CD00D5FF14 /* ModalTopBarTests.swift in Sources */,
 				16B2DE301CCFB845000D7C30 /* InputBarTests.swift in Sources */,
+				F1C9E3601EAE008C006438D7 /* TestSetup.swift in Sources */,
 				BFC9149B1D181BE7001F068B /* LocationMessageCellTests.swift in Sources */,
 				16A2026B1B66A0040095BBD1 /* SoundcloudServiceTests.m in Sources */,
 				BF606D731CAA9EEE002BAC94 /* ConversationListBottomBarTests.m in Sources */,

--- a/Wire-iOS.xcodeproj/xcshareddata/xcschemes/ImageNotificationExtension.xcscheme
+++ b/Wire-iOS.xcodeproj/xcshareddata/xcschemes/ImageNotificationExtension.xcscheme
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0820"
+   wasCreatedForAppExtension = "YES"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "87B7DAA01E696E4E005F5140"
+               BuildableName = "ImageNotificationExtension.appex"
+               BlueprintName = "ImageNotificationExtension"
+               ReferencedContainer = "container:Wire-iOS.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      launchAutomaticallySubstyle = "2">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "87B7DAA01E696E4E005F5140"
+            BuildableName = "ImageNotificationExtension.appex"
+            BlueprintName = "ImageNotificationExtension"
+            ReferencedContainer = "container:Wire-iOS.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES"
+      launchAutomaticallySubstyle = "2">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "87B7DAA01E696E4E005F5140"
+            BuildableName = "ImageNotificationExtension.appex"
+            BlueprintName = "ImageNotificationExtension"
+            ReferencedContainer = "container:Wire-iOS.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Wire-iOS.xcodeproj/xcshareddata/xcschemes/NotificationFetchComponents.xcscheme
+++ b/Wire-iOS.xcodeproj/xcshareddata/xcschemes/NotificationFetchComponents.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0820"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BFAD53FA1E6972CC0015C677"
+               BuildableName = "NotificationFetchComponents.framework"
+               BlueprintName = "NotificationFetchComponents"
+               ReferencedContainer = "container:Wire-iOS.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BFAD53FA1E6972CC0015C677"
+            BuildableName = "NotificationFetchComponents.framework"
+            BlueprintName = "NotificationFetchComponents"
+            ReferencedContainer = "container:Wire-iOS.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BFAD53FA1E6972CC0015C677"
+            BuildableName = "NotificationFetchComponents.framework"
+            BlueprintName = "NotificationFetchComponents"
+            ReferencedContainer = "container:Wire-iOS.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
+++ b/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
@@ -134,6 +134,11 @@
             isEnabled = "NO">
          </EnvironmentVariable>
          <EnvironmentVariable
+            key = "IMAGE_DIFF_DIR"
+            value = "$(SOURCE_ROOT)/SnapshotResults"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
             key = "OS_ACTIVITY_MODE"
             value = "disable"
             isEnabled = "YES">

--- a/Wire-iOS.xcodeproj/xcshareddata/xcschemes/WireExtensionComponents.xcscheme
+++ b/Wire-iOS.xcodeproj/xcshareddata/xcschemes/WireExtensionComponents.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0800"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1EE85C4F1B5F96FB008E084B"
+               BuildableName = "WireExtensionComponents.framework"
+               BlueprintName = "WireExtensionComponents"
+               ReferencedContainer = "container:Wire-iOS.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1EE85C4F1B5F96FB008E084B"
+            BuildableName = "WireExtensionComponents.framework"
+            BlueprintName = "WireExtensionComponents"
+            ReferencedContainer = "container:Wire-iOS.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1EE85C4F1B5F96FB008E084B"
+            BuildableName = "WireExtensionComponents.framework"
+            BlueprintName = "WireExtensionComponents"
+            ReferencedContainer = "container:Wire-iOS.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/circle.yml
+++ b/circle.yml
@@ -10,10 +10,7 @@ dependencies:
   cache_directories:
     - Carthage/Build
 
-build:
-  override:
-    - xcodebuild -workspace Wire-iOS.xcworkspace -scheme Wire-iOS build-for-testing -enableCodeCoverage YES -destination "${DESTINATION}" | tee $CIRCLE_ARTIFACTS/xcode_build.log | xcpretty
-
 test:
   override:
+    - xcodebuild -workspace Wire-iOS.xcworkspace -scheme Wire-iOS build-for-testing -enableCodeCoverage YES -destination "${DESTINATION}" | tee $CIRCLE_ARTIFACTS/xcode_build.log | xcpretty
     - xcodebuild -workspace Wire-iOS.xcworkspace -scheme Wire-iOS test-without-building -enableCodeCoverage YES -destination "${DESTINATION}" | tee $CIRCLE_ARTIFACTS/xcode_test.log | xcpretty

--- a/circle.yml
+++ b/circle.yml
@@ -14,8 +14,10 @@ dependencies:
     - ./setup.sh
   cache_directories:
     - Carthage/Build
+    - Libraries
+    - ~/.gem
 
 test:
   override:
     - set -o pipefail && xcodebuild -workspace Wire-iOS.xcworkspace -scheme Wire-iOS build-for-testing -enableCodeCoverage YES -destination "${DESTINATION}" | tee $CIRCLE_ARTIFACTS/xcode_build.log | xcpretty
-    - set -o pipefail && IMAGE_DIFF_DIR=$CIRCLE_ARTIFACTS xcodebuild -workspace Wire-iOS.xcworkspace -scheme Wire-iOS test-without-building -enableCodeCoverage YES -destination "${DESTINATION}" | tee $CIRCLE_ARTIFACTS/xcode_test.log | xcpretty
+    - set -o pipefail && IMAGE_DIFF_DIR="{$CIRCLE_ARTIFACTS}" xcodebuild -workspace Wire-iOS.xcworkspace -scheme Wire-iOS test-without-building -enableCodeCoverage YES -destination "${DESTINATION}" | tee $CIRCLE_ARTIFACTS/xcode_test.log | xcpretty

--- a/circle.yml
+++ b/circle.yml
@@ -5,15 +5,15 @@ machine:
     DESTINATION: platform=iOS Simulator,name=iPhone 6,OS=10.3
 
 dependencies:
-  # override:
-    # - ./setup.sh
+  override:
+    - ./setup.sh
   cache_directories:
     - Carthage/Build
 
 build:
   override:
-    - xcodebuild -workspace Wire-iOS.xcworkspace -scheme Wire-iOS build-for-testing -enableCodeCoverage YES -destination '${DESTINATION}' | tee $CIRCLE_ARTIFACTS/xcode_build.log | xcpretty
+    - xcodebuild -workspace Wire-iOS.xcworkspace -scheme Wire-iOS build-for-testing -enableCodeCoverage YES -destination "${DESTINATION}" | tee $CIRCLE_ARTIFACTS/xcode_build.log | xcpretty
 
 test:
   override:
-    - xcodebuild -workspace Wire-iOS.xcworkspace -scheme Wire-iOS test-without-building -enableCodeCoverage YES -destination '${DESTINATION}' | tee $CIRCLE_ARTIFACTS/xcode_test.log | xcpretty
+    - xcodebuild -workspace Wire-iOS.xcworkspace -scheme Wire-iOS test-without-building -enableCodeCoverage YES -destination "${DESTINATION}" | tee $CIRCLE_ARTIFACTS/xcode_test.log | xcpretty

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ machine:
     DESTINATION: platform=iOS Simulator,name=iPhone 6,OS=10.3
 
 dependencies:
-  override:
+  # override:
     # - ./setup.sh
   cache_directories:
     - Carthage/Build

--- a/circle.yml
+++ b/circle.yml
@@ -4,6 +4,11 @@ machine:
   environment:
     DESTINATION: "platform=iOS Simulator,name=iPhone 6,OS=10.3"
 
+checkout:
+  post:
+    # Preheat cocoapods main repo
+    - bash <(curl -s https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh)
+
 dependencies:
   override:
     - ./setup.sh

--- a/circle.yml
+++ b/circle.yml
@@ -12,5 +12,5 @@ dependencies:
 
 test:
   override:
-    - xcodebuild -workspace Wire-iOS.xcworkspace -scheme Wire-iOS build-for-testing -enableCodeCoverage YES -destination "${DESTINATION}" | tee $CIRCLE_ARTIFACTS/xcode_build.log | xcpretty
-    - xcodebuild -workspace Wire-iOS.xcworkspace -scheme Wire-iOS test-without-building -enableCodeCoverage YES -destination "${DESTINATION}" | tee $CIRCLE_ARTIFACTS/xcode_test.log | xcpretty
+    - set -o pipefail && xcodebuild -workspace Wire-iOS.xcworkspace -scheme Wire-iOS build-for-testing -enableCodeCoverage YES -destination "${DESTINATION}" | tee $CIRCLE_ARTIFACTS/xcode_build.log | xcpretty
+    - set -o pipefail && xcodebuild -workspace Wire-iOS.xcworkspace -scheme Wire-iOS test-without-building -enableCodeCoverage YES -destination "${DESTINATION}" | tee $CIRCLE_ARTIFACTS/xcode_test.log | xcpretty

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   xcode:
     version: "8.3"
   environment:
-    DESTINATION: platform=iOS Simulator,name=iPhone 6,OS=10.3
+    DESTINATION: "platform=iOS Simulator,name=iPhone 6,OS=10.3"
 
 dependencies:
   override:
@@ -13,4 +13,4 @@ dependencies:
 test:
   override:
     - set -o pipefail && xcodebuild -workspace Wire-iOS.xcworkspace -scheme Wire-iOS build-for-testing -enableCodeCoverage YES -destination "${DESTINATION}" | tee $CIRCLE_ARTIFACTS/xcode_build.log | xcpretty
-    - set -o pipefail && xcodebuild -workspace Wire-iOS.xcworkspace -scheme Wire-iOS test-without-building -enableCodeCoverage YES -destination "${DESTINATION}" | tee $CIRCLE_ARTIFACTS/xcode_test.log | xcpretty
+    - set -o pipefail && IMAGE_DIFF_DIR=$CIRCLE_ARTIFACTS xcodebuild -workspace Wire-iOS.xcworkspace -scheme Wire-iOS test-without-building -enableCodeCoverage YES -destination "${DESTINATION}" | tee $CIRCLE_ARTIFACTS/xcode_test.log | xcpretty

--- a/circle.yml
+++ b/circle.yml
@@ -18,7 +18,8 @@ dependencies:
 
 test:
   override:
+    - mkdir -p $CIRCLE_TEST_REPORTS/junit/
     - set -o pipefail && xcodebuild -workspace Wire-iOS.xcworkspace -scheme Wire-iOS build-for-testing -enableCodeCoverage YES -destination "${DESTINATION}" | tee $CIRCLE_ARTIFACTS/xcode_build.log | xcpretty
-    - set -o pipefail && xcodebuild -workspace Wire-iOS.xcworkspace -scheme Wire-iOS test-without-building -enableCodeCoverage YES -destination "${DESTINATION}" | tee $CIRCLE_ARTIFACTS/xcode_test.log | xcpretty
+    - set -o pipefail && xcodebuild -workspace Wire-iOS.xcworkspace -scheme Wire-iOS test-without-building -enableCodeCoverage YES -destination "${DESTINATION}" | tee $CIRCLE_ARTIFACTS/xcode_test.log | xcpretty -r junit --output $CIRCLE_TEST_REPORTS/junit/
   post:
     - if [ -d "SnapshotResults" ]; then cp -R SnapshotResults $CIRCLE_ARTIFACTS/; fi

--- a/circle.yml
+++ b/circle.yml
@@ -2,19 +2,18 @@ machine:
   xcode:
     version: "8.3"
   environment:
-    # Used for compatibility with scripts made for Jenkins
     DESTINATION: platform=iOS Simulator,name=iPhone 6,OS=10.3
 
 dependencies:
   override:
-    - ./setup.sh
+    # - ./setup.sh
   cache_directories:
     - Carthage/Build
 
 build:
   override:
-    - xcodebuild -workspace Wire-iOS.xcworkspace -scheme Wire-iOS build-for-testing -enableCodeCoverage YES -destination '$(DESTINATION)' | xcpretty
+    - xcodebuild -workspace Wire-iOS.xcworkspace -scheme Wire-iOS build-for-testing -enableCodeCoverage YES -destination '${DESTINATION}' | tee $CIRCLE_ARTIFACTS/xcode_build.log | xcpretty
 
 test:
   override:
-    - xcodebuild -workspace Wire-iOS.xcworkspace -scheme Wire-iOS test-without-building -enableCodeCoverage YES -destination '$(DESTINATION)' | xcpretty
+    - xcodebuild -workspace Wire-iOS.xcworkspace -scheme Wire-iOS test-without-building -enableCodeCoverage YES -destination '${DESTINATION}' | tee $CIRCLE_ARTIFACTS/xcode_test.log | xcpretty

--- a/circle.yml
+++ b/circle.yml
@@ -14,10 +14,9 @@ dependencies:
     - ./setup.sh
   cache_directories:
     - Carthage/Build
-    - Libraries
     - ~/.gem
 
 test:
   override:
     - set -o pipefail && xcodebuild -workspace Wire-iOS.xcworkspace -scheme Wire-iOS build-for-testing -enableCodeCoverage YES -destination "${DESTINATION}" | tee $CIRCLE_ARTIFACTS/xcode_build.log | xcpretty
-    - set -o pipefail && IMAGE_DIFF_DIR="{$CIRCLE_ARTIFACTS}" xcodebuild -workspace Wire-iOS.xcworkspace -scheme Wire-iOS test-without-building -enableCodeCoverage YES -destination "${DESTINATION}" | tee $CIRCLE_ARTIFACTS/xcode_test.log | xcpretty
+    - set -o pipefail && xcodebuild -workspace Wire-iOS.xcworkspace -scheme Wire-iOS test-without-building -enableCodeCoverage YES -destination "${DESTINATION}" | tee $CIRCLE_ARTIFACTS/xcode_test.log | xcpretty

--- a/circle.yml
+++ b/circle.yml
@@ -20,3 +20,5 @@ test:
   override:
     - set -o pipefail && xcodebuild -workspace Wire-iOS.xcworkspace -scheme Wire-iOS build-for-testing -enableCodeCoverage YES -destination "${DESTINATION}" | tee $CIRCLE_ARTIFACTS/xcode_build.log | xcpretty
     - set -o pipefail && xcodebuild -workspace Wire-iOS.xcworkspace -scheme Wire-iOS test-without-building -enableCodeCoverage YES -destination "${DESTINATION}" | tee $CIRCLE_ARTIFACTS/xcode_test.log | xcpretty
+  post:
+    - if [ -d "SnapshotResults" ]; then cp -R SnapshotResults $CIRCLE_ARTIFACTS/; fi

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,19 @@
+machine:
+  xcode:
+    version: "8.3"
+  environment:
+    # Used for compatibility with scripts made for Jenkins
+    DESTINATION: "platform=iOS Simulator,name=iPhone 6,OS=10.3" 
+
+dependencies:
+  override:
+    - ./setup.sh
+
+build:
+  override:
+    - xcodebuild -workspace Wire-iOS.xcworkspace -scheme Wire-iOS build-for-testing -enableCodeCoverage YES -destination '$(DESTINATION)' | xcpretty
+
+test:
+  override:
+    - xcodebuild -workspace Wire-iOS.xcworkspace -scheme Wire-iOS test-without-building -enableCodeCoverage YES -destination '$(DESTINATION)' | xcpretty
+    

--- a/circle.yml
+++ b/circle.yml
@@ -3,11 +3,13 @@ machine:
     version: "8.3"
   environment:
     # Used for compatibility with scripts made for Jenkins
-    DESTINATION: "platform=iOS Simulator,name=iPhone 6,OS=10.3" 
+    DESTINATION: platform=iOS Simulator,name=iPhone 6,OS=10.3
 
 dependencies:
   override:
     - ./setup.sh
+  cache_directories:
+    - Carthage/Build
 
 build:
   override:
@@ -16,4 +18,3 @@ build:
 test:
   override:
     - xcodebuild -workspace Wire-iOS.xcworkspace -scheme Wire-iOS test-without-building -enableCodeCoverage YES -destination '$(DESTINATION)' | xcpretty
-    


### PR DESCRIPTION
## What changes were needed to the project?

* Sharing schemes for all extensions
* Added a NSPrincipalClass for test suite. XCTest makes sure it gets initialized only once and it's possible to add all global init code there. Currently it only has default time zone override which makes sure that snapshots are tested with the same timezone as reference images
* Setting a variable so that failed snapshots would be saved to a (git-ignored) folder in the root source directory. This enables us saving it in build artefacts for later inspection.

## Contents of `circle.yml`

* Because the VM instance we get from Circle is completely empty it also doesn't have CocoaPods main repo. This takes around 7-9 mins to download, but we can use a handy script that instead of downloading it with Git from Github gets it from S3 and unzips in the right directory
* `xcodebuild` was split into two steps - `build-for-testing` and `test-without-building` which is the recommended way to run tests and avoid most of the weird race conditions with simulator etc.
* Saving failed snapshots to build artefacts folder. Hopefully in the near future we will be able to add Danger support for it as well.