### PR TITLE
Do not show loading if devices list is available

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
@@ -75,13 +75,15 @@ import CocoaLumberjackSwift
         self.title = NSLocalizedString("registration.devices.title", comment:"")
         self.edgesForExtendedLayout = []
 
-        self.initalizeProperties(clientsList ?? [])
+        self.initalizeProperties(clientsList ?? Array(ZMUser.selfUser().clients))
 
         self.clientsObserverToken = ZMUserSession.shared()?.add(self)
         self.userObserverToken = UserChangeInfo.add(observer: self, forBareUser: ZMUser.selfUser())
         
         if clientsList == nil {
-            self.showLoadingView = true
+            if clients.isEmpty {
+                self.showLoadingView = true
+            }
             ZMUserSession.shared()?.fetchAllClients()
         }
     }


### PR DESCRIPTION
- If there is at least one device in the list then the loading spinner would not be initially displayed.