### PR TITLE
Only check the last line of `carthage version` output

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -33,7 +33,7 @@ hash carthage 2>/dev/null || die "Can't find Carthage, please install from https
 hash xcodebuild 2>/dev/null || die "Can't find Xcode, please install from the App Store"
 hash gem 2>/dev/null || die "Can't find Ruby (gem), please install from https://www.ruby-lang.org/en/"
 
-version=`carthage version`
+version=`carthage version | tail -n 1`
 CARTHAGE_VERSION=( ${version//./ } )
 version=`xcodebuild -version | head -n 1 | sed "s/Xcode //"`
 XCODE_VERSION=( ${version//./ } )


### PR DESCRIPTION
# What's in this PR?

A new Carthage version was just released, when running `carthage version` and the installed version is not the current one it will print something like:

```
*** Please update to the latest Carthage version: 0.21.0. You currently are on 0.20.1
0.20.1
```

Which our `./setup.sh` did not parse correctly.