### PR TITLE
Dismiss ProfileDetailViewController after removing user from conversation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileDetailsViewController.m
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileDetailsViewController.m
@@ -407,6 +407,8 @@ typedef NS_ENUM(NSUInteger, ProfileUserAction) {
             
             [[ZMUserSession sharedSession] enqueueChanges:^{
                 [self.conversation removeParticipant:[self fullUser]];
+            } completionHandler:^{
+                [self.delegate profileDetailsViewController:self wantsToBeDismissedWithCompletion:nil];
             }];
         }];
     }];


### PR DESCRIPTION
# What's in this PR?

* Dismiss ProfileDetailViewController after removing user from conversation.