### PR TITLE
Enable pingback logs for internal builds

### DIFF
--- a/WireExtensionComponents/Utilities/DeveloperMenuState+Debugging.swift
+++ b/WireExtensionComponents/Utilities/DeveloperMenuState+Debugging.swift
@@ -27,7 +27,7 @@ extension DeveloperMenuState {
     }
     
     private static func enableLogsForMessageSendingDebugging() {
-        ["Network", "Dependencies", "State machine"].forEach {
+        ["Network", "Dependencies", "State machine", "Pingback"].forEach {
             ZMSLog.set(level: .debug, tag: $0)
         }
     }


### PR DESCRIPTION
# What's in this PR?

* Enable pingback logs by default for internal builds.