### PR TITLE
Also end typing when view disappears or user scrolls

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -824,6 +824,9 @@
 
 - (void)textViewDidEndEditing:(UITextView *)textView
 {
+    if (textView.text.length > 0) {
+        [self.conversation setIsTyping:NO];
+    }
     [[ZMUserSession sharedSession] enqueueChanges:^{
         self.conversation.draftMessageText = textView.text;
     }];


### PR DESCRIPTION
This is called when the view disappears as well as when the textView stops being first responder (e.g. when the user scrolls in the list)