### PR TITLE
Remove edge backend from Titles array to sync it with Values

### DIFF
--- a/Wire-iOS/Resources/Settings.bundle/Root.plist
+++ b/Wire-iOS/Resources/Settings.bundle/Root.plist
@@ -55,7 +55,6 @@
 			<array>
 				<string>Production</string>
 				<string>Staging</string>
-				<string>Edge</string>
 				<string>Default (Depends on build)</string>
 			</array>
 			<key>Values</key>


### PR DESCRIPTION
# What's in this PR?

* `Titles` and `Values` array have to be of the same count in order for the settings entry to appear.