### PR TITLE
Adding missing copy string for new file in conversation list for muted conversation

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.stringsdict
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.stringsdict
@@ -331,5 +331,21 @@
                 <string>%d missed calls</string>
             </dict>
         </dict>
+        <key>conversation.silenced.status.message.file</key>
+        <dict>
+            <key>NSStringLocalizedFormatKey</key>
+            <string>%#@d_number_of_new@</string>
+            <key>d_number_of_new</key>
+            <dict>
+                <key>NSStringFormatSpecTypeKey</key>
+                <string>NSStringPluralRuleType</string>
+                <key>NSStringFormatValueTypeKey</key>
+                <string>d</string>
+                <key>one</key>
+                <string>new file</string>
+                <key>other</key>
+                <string>%d new files</string>
+            </dict>
+        </dict>
     </dict>
 </plist>


### PR DESCRIPTION
New conversation list was missing copy string for received new file transfer for muted conversations