### PR TITLE
Adjust empty label visuals in drafts list

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -910,7 +910,7 @@
 
 "compose.drafts.title" = "Messages";
 "compose.drafts.empty.title" = "No messages";
-"compose.drafts.empty.subtitle" = "Tap + to compose one.";
+"compose.drafts.empty.subtitle" = "Tap + to compose one";
 "compose.drafts.compose.title" = "Write a message";
 "compose.drafts.compose.subject.placeholder" = "Tap to set a subject";
 

--- a/Wire-iOS/Sources/UserInterface/DraftListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/DraftListViewController.swift
@@ -60,10 +60,14 @@ final class DraftListViewController: CoreDataTableViewController<MessageDraft, D
     }
 
     private func setupEmptyLabel() {
-        let title = "compose.drafts.empty.title".localized && FontSpec(.normal, .semibold).font!
-        let subtitle = "compose.drafts.empty.subtitle".localized && FontSpec(.normal, .none).font!
-        emptyLabel.attributedText = (title + "\n\n" + subtitle) && ColorScheme.default().color(withName: ColorSchemeColorTextDimmed)
-        emptyLabel.textAlignment = .center
+        let paragraphStyle = NSParagraphStyle.default.mutableCopy() as! NSMutableParagraphStyle
+        paragraphStyle.alignment = .center
+        paragraphStyle.paragraphSpacing = 4
+        let paragraphAttributes = [NSParagraphStyleAttributeName: paragraphStyle]
+        let color = ColorScheme.default().color(withName: ColorSchemeColorTextDimmed)
+        let title = "compose.drafts.empty.title".localized.uppercased() && FontSpec(.small, .semibold).font!
+        let subtitle = "compose.drafts.empty.subtitle".localized.uppercased() && FontSpec(.small, .light).font!
+        emptyLabel.attributedText = (title + "\n" + subtitle) && color && paragraphAttributes
         emptyLabel.numberOfLines = 0
         view.addSubview(emptyLabel)
         view.backgroundColor = ColorScheme.default().color(withName: ColorSchemeColorBackground)

--- a/Wire-iOS/Sources/UserInterface/DraftsRootViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/DraftsRootViewController.swift
@@ -56,9 +56,9 @@ final class DraftsRootViewController: UISplitViewController {
         UIApplication.shared.wr_updateStatusBarForCurrentControllerAnimated(true)
     }
 
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        UIApplication.shared.wr_updateStatusBarForCurrentControllerAnimated(false)
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        UIApplication.shared.setStatusBarStyle(.lightContent, animated: animated)
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {


### PR DESCRIPTION
# What's in this PR?

* Adjust empty label visuals in drafts list.
* Fix status bar style change timing when dismissing `DraftsRootViewController`.