### PR TITLE
Reuse existing VoiceChannelOverlayController

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelController.m
+++ b/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelController.m
@@ -144,7 +144,9 @@
         
         [self transitionFromViewController:fromController toViewController:toController duration:0.35 options:UIViewAnimationOptionTransitionCrossDissolve animations:^{
             [self.primaryVoiceChannelOverlay.view autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsZero];
-        } completion:nil];
+        } completion:^(BOOL finished) {
+            [fromController removeFromParentViewController];
+        }];
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelController.m
+++ b/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelController.m
@@ -134,19 +134,20 @@
             fromController.blurEffectView.effect = nil;
             fromController.overlayView.alpha = 0;
         } completion:^(BOOL finished) {
-            [fromController.view removeFromSuperview];
-            [fromController removeFromParentViewController];
+            // Remove all view controllers also those from interrupting calls
+            for (VoiceChannelOverlayController *controller in self.childViewControllers) {
+                [controller.view removeFromSuperview];
+                [controller removeFromParentViewController];
+            }
         }];
     }
     else {
-        [fromController willMoveToParentViewController:nil];
         [self addChildViewController:toController];
-        
+        [fromController willMoveToParentViewController:nil];
+
         [self transitionFromViewController:fromController toViewController:toController duration:0.35 options:UIViewAnimationOptionTransitionCrossDissolve animations:^{
             [self.primaryVoiceChannelOverlay.view autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsZero];
-        } completion:^(BOOL finished) {
-            [fromController removeFromParentViewController];
-        }];
+        } completion:nil];
     }
 }
 
@@ -164,6 +165,13 @@
 {
     if (conversation == nil) {
         return nil;
+    }
+    
+    VoiceChannelOverlayController *previousController = [[self.childViewControllers filterWithBlock:^BOOL(VoiceChannelOverlayController* obj){
+                                                              return [obj.conversation isEqual:conversation];
+                                                          }] firstObject];
+    if (nil != previousController) {
+        return previousController;
     }
     
     VoiceChannelOverlayController *controller = [[VoiceChannelOverlayController alloc] initWithConversation:conversation];

--- a/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelController.m
+++ b/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelController.m
@@ -134,20 +134,19 @@
             fromController.blurEffectView.effect = nil;
             fromController.overlayView.alpha = 0;
         } completion:^(BOOL finished) {
-            // Remove all view controllers also those from interrupting calls
-            for (VoiceChannelOverlayController *controller in self.childViewControllers) {
-                [controller.view removeFromSuperview];
-                [controller removeFromParentViewController];
-            }
+            [fromController.view removeFromSuperview];
+            [fromController removeFromParentViewController];
         }];
     }
     else {
-        [self addChildViewController:toController];
         [fromController willMoveToParentViewController:nil];
-
+        [self addChildViewController:toController];
+        
         [self transitionFromViewController:fromController toViewController:toController duration:0.35 options:UIViewAnimationOptionTransitionCrossDissolve animations:^{
             [self.primaryVoiceChannelOverlay.view autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsZero];
-        } completion:nil];
+        } completion:^(BOOL finished) {
+            [fromController removeFromParentViewController];
+        }];
     }
 }
 
@@ -165,13 +164,6 @@
 {
     if (conversation == nil) {
         return nil;
-    }
-    
-    VoiceChannelOverlayController *previousController = [[self.childViewControllers filterWithBlock:^BOOL(VoiceChannelOverlayController* obj){
-                                                              return [obj.conversation isEqual:conversation];
-                                                          }] firstObject];
-    if (nil != previousController) {
-        return previousController;
     }
     
     VoiceChannelOverlayController *controller = [[VoiceChannelOverlayController alloc] initWithConversation:conversation];

--- a/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelOverlayController.m
+++ b/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelOverlayController.m
@@ -128,6 +128,9 @@
     doubleTapGestureRecognizer.numberOfTapsRequired = 2;
     [self.view addGestureRecognizer:doubleTapGestureRecognizer];
     
+    if (self.conversation.voiceChannel.state == VoiceChannelV2StateSelfConnectedToActiveChannel) {
+        [self createParticipantsControllerIfNecessary];
+    }
     [self updateVoiceChannelOverlayStateWithVoiceChannelState:self.conversation.voiceChannel.state];
 }
 

--- a/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelOverlayController.m
+++ b/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelOverlayController.m
@@ -127,10 +127,6 @@
     doubleTapGestureRecognizer.delegate = self;
     doubleTapGestureRecognizer.numberOfTapsRequired = 2;
     [self.view addGestureRecognizer:doubleTapGestureRecognizer];
-    
-    if (self.conversation.voiceChannel.state == VoiceChannelV2StateSelfConnectedToActiveChannel) {
-        [self createParticipantsControllerIfNecessary];
-    }
     [self updateVoiceChannelOverlayStateWithVoiceChannelState:self.conversation.voiceChannel.state];
 }
 

--- a/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelOverlayController.m
+++ b/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelOverlayController.m
@@ -127,6 +127,10 @@
     doubleTapGestureRecognizer.delegate = self;
     doubleTapGestureRecognizer.numberOfTapsRequired = 2;
     [self.view addGestureRecognizer:doubleTapGestureRecognizer];
+    
+    if (self.conversation.voiceChannel.state == VoiceChannelV2StateSelfConnectedToActiveChannel) {
+        [self createParticipantsControllerIfNecessary];
+    }
     [self updateVoiceChannelOverlayStateWithVoiceChannelState:self.conversation.voiceChannel.state];
 }
 


### PR DESCRIPTION
When we receive a call while we are already in a call and reject the new incoming call we are currently creating a new `VoiceChannelOverlayController` for the already ongoing call instead of reusing the old one. Furthermore we never deallocate the previously added `VoiceChannelOverlayController` except the last one we created. This leads to crashes when we receive another call in one of the conversations already observed by the left-over controllers.

This PR includes two changes: 
(1) It removes the previous childViewController
(2) It adds the voiceChannelParticipantController on viewDidLoad when the call is in callState connected