### PR TITLE
Un-hide video view if we later discover that we are in video call

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelOverlay.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelOverlay.swift
@@ -701,6 +701,8 @@ extension VoiceChannelOverlay {
         videoButton.isSelected = videoButton.isEnabled && outgoingVideoActive
         
         if isVideoCall {
+            videoView?.isHidden = false
+            videoPreview?.isHidden = false
             videoViewFullscreen = !connected
         } else {
             videoView?.isHidden = true


### PR DESCRIPTION
`wcall_is_video_call` is not reliable until AVS has processed the start of the call on their thread.