### PR TITLE
Filter out self client from clients list (if any)

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
@@ -75,7 +75,7 @@ import CocoaLumberjackSwift
         self.title = NSLocalizedString("registration.devices.title", comment:"")
         self.edgesForExtendedLayout = []
 
-        self.initalizeProperties(clientsList ?? Array(ZMUser.selfUser().clients))
+        self.initalizeProperties(clientsList ?? Array(ZMUser.selfUser().clients.filter { !$0.isSelfClient() } ))
 
         self.clientsObserverToken = ZMUserSession.shared()?.add(self)
         self.userObserverToken = UserChangeInfo.add(observer: self, forBareUser: ZMUser.selfUser())
@@ -122,8 +122,8 @@ import CocoaLumberjackSwift
             self.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: UIBarButtonSystemItem.cancel, target: self, action: #selector(ClientListViewController.backPressed(_:)))
         }
         
-        if let rootViewController = self.navigationController?.viewControllers.first
-            , self.isEqual(rootViewController) {
+        if let rootViewController = self.navigationController?.viewControllers.first,
+            self.isEqual(rootViewController) {
                 self.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(ClientListViewController.backPressed(_:)))
         }
     }
@@ -210,7 +210,7 @@ import CocoaLumberjackSwift
     func finishedFetching(_ userClients: [UserClient]!) {
         self.showLoadingView = false
         
-        self.clients = userClients
+        self.clients = userClients.filter { !$0.isSelfClient() }
     }
     
     func failedToFetchClientsWithError(_ error: Error!) {


### PR DESCRIPTION
- Issue happens when the clients list is visible for the significant time (slow network).
- User is able to delete the self client, which leads to crash.