### PR TITLE
Show everything archived label and update bottom bar archived state

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -77,6 +77,9 @@
 "contacts_ui.no_contact.title" = "No active conversations\n";
 "contacts_ui.no_contact.message" = "Tap people to start a conversation";
 
+"contacts_ui.no_contact.archived.title" = "Everything archived";
+
+
 // Conversation List Indicator
 "conversation_list.right_accessory.join_button.title" = "Join";
 


### PR DESCRIPTION
# What's in this PR?

* Show "everything archived" label and update bottom bar archived state when active team changes.