### PR TITLE
Fix conversation list inset calculation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListTopBar.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListTopBar.swift
@@ -22,7 +22,11 @@ import WireExtensionComponents
 
 final class ConversationListTopBar: TopBar {
     private var teamsView: TeamSelectorView? = .none
-    public weak var contentScrollView: UIScrollView? = .none
+    public weak var contentScrollView: UIScrollView? = .none {
+        didSet {
+            self.setShowTeams(to: self.showTeams)
+        }
+    }
     
     private var selfUserObserverToken: NSObjectProtocol!
     private var applicationDidBecomeActiveToken: NSObjectProtocol!

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController.m
@@ -169,11 +169,11 @@
     [ZMUserSession addInitalSyncCompletionObserver:self];
     self.initialSyncCompleted = ZMUserSession.sharedSession.initialSyncOnceCompleted.boolValue;
 
-    [self createTopBar];
     [self createNoConversationLabel];
     [self createListContentController];
     [self createBottomBarController];
-    
+    [self createTopBar];
+
     [self createViewConstraints];
     [self.listContentController.collectionView scrollRectToVisible:CGRectMake(0, 0, self.view.bounds.size.width, 1) animated:NO];
     


### PR DESCRIPTION
- The inset is bigger when team selector is visible.
- Property was nil at the time of the `ConversationListTopBar` creation.