### PR TITLE
Re-add removed call to reload conversation lists when entering foreground

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/Model/ConversationListViewModel.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/Model/ConversationListViewModel.m
@@ -287,9 +287,9 @@ void debugLogUpdate (ConversationListChangeInfo *note);
 
 - (void)applicationWillEnterForeground:(NSNotification *)note
 {
+    [ZMConversationList refetchAllListsInUserSession:ZMUserSession.sharedSession];
     [self reloadConversationListViewModel];
 }
-
 
 - (void)conversationInsideList:(ZMConversationList *)list didChange:(ConversationChangeInfo *)changeInfo;
 {


### PR DESCRIPTION
# What's in this PR?

* Re-add removed call to reload conversation lists when entering foreground.
* The call was removed by accident when removing the `SessionObjectCache` (https://github.com/wireapp/wire-ios/pull/1031/commits/5326251ff3242a91ab610198ec6b55d224903ed8#diff-c400ceedcde8d0bf071098407ee787c8L309).