### PR TITLE
Fix: empty conversation label stays visible after team deletion

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+Handles.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+Handles.swift
@@ -137,8 +137,10 @@ extension ConversationListViewController: UserProfileUpdateObserver {
 extension ConversationListViewController: ZMUserObserver {
 
     public func userDidChange(_ note: UserChangeInfo) {
-        guard nil != ZMUser.selfUser().handle && note.handleChanged else { return }
-        removeUsernameTakeover()
+        if ZMUser.selfUser().handle != nil && note.handleChanged {
+            removeUsernameTakeover()
+        } else if note.teamsChanged {
+            updateNoConversationVisibility()
+        }
     }
-
 }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController.h
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController.h
@@ -57,4 +57,6 @@ typedef NS_ENUM(NSUInteger, ConversationListState) {
 - (void)presentPeoplePickerAnimated:(BOOL)animated;
 - (void)dismissPeoplePickerWithCompletionBlock:(dispatch_block_t)block;
 
+- (void)updateNoConversationVisibility;
+
 @end


### PR DESCRIPTION
Had to listen for user changes and update the label when teams change.