### PR TITLE
Do not cover share button with overlay

### DIFF
--- a/Wire-iOS/Resources/Classy/stylesheet.cas
+++ b/Wire-iOS/Resources/Classy/stylesheet.cas
@@ -1222,7 +1222,7 @@ ActionSheetContainerView.dark {
 
 PeoplePickerEmptyResultsView UITextView {
     font: $font-normal-thin;
-    textColor: $color-text-foreground;
+    textColor: $color-text-foreground-dark;
     editable: NO;
     selectable: NO;
 }

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIView.m
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIView.m
@@ -34,7 +34,6 @@
 @property (nonatomic, strong) PeoplePickerEmptyResultsView *emptyResultView;
 
 @property (nonatomic) CGFloat keyboardHeight;
-@property (nonatomic) NSLayoutConstraint *emptyResultsViewBottomOffset;
 @property (nonatomic) NSLayoutConstraint *actionsBarBottomOffset;
 
 @property (nonatomic) CGRect currentLayoutBounds;
@@ -190,7 +189,7 @@
         [self.emptyResultView autoPinEdgeToSuperviewEdge:ALEdgeRight withInset:0];
         
         [NSLayoutConstraint autoSetPriority:UILayoutPriorityDefaultHigh forConstraints:^{
-            self.emptyResultsViewBottomOffset = [self.emptyResultView autoPinEdgeToSuperviewEdge:ALEdgeBottom withInset:self.keyboardHeight];
+            [self.emptyResultView autoPinEdge:ALEdgeBottom toEdge:ALEdgeBottom ofView:self.collectionView withOffset:self.keyboardHeight];
         }];
     }
     
@@ -308,7 +307,6 @@
                                      // NOTE: we don't attach a input accessory view in the start UI but we do
                                      // in the conversation input bar so we must subtracts its height here.
                                      self.keyboardHeight = keyboardFrameInView.size.height - inputAccessoryViewHeight;
-                                     self.emptyResultsViewBottomOffset.constant = -self.keyboardHeight;
                                      self.actionsBarBottomOffset.constant = -self.keyboardHeight;
                                      [self updateConstraints];
                                      [self layoutIfNeeded];


### PR DESCRIPTION
- The button was covered by the overlay.
- Overlay contained black text over black.