### PR TITLE
Start UI: not possible to make a call to person without existing conversation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+StartUI.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+StartUI.m
@@ -117,16 +117,22 @@
     if (call) {
         [self dismissPeoplePickerWithCompletionBlock:^{
             if (users.count == 1) {
+                __block ZMConversation *conversation = nil;
                 ZMUser *user = users.anyObject;
-                [[ZClientViewController sharedZClientViewController] selectConversation:[user oneToOneConversationInTeam:activeTeam]
-                                                                            focusOnView:YES
-                                                                               animated:YES];
-                if (videoCall) {
-                    [[user oneToOneConversationInTeam:activeTeam] startVideoCallWithCompletionHandler:nil];
-                }
-                else {
-                    [[user oneToOneConversationInTeam:activeTeam] startAudioCallWithCompletionHandler:nil];
-                }
+
+                [[ZMUserSession sharedSession] enqueueChanges:^{
+                    conversation = [user oneToOneConversationInTeam:activeTeam];
+                } completionHandler:^{
+                    [[ZClientViewController sharedZClientViewController] selectConversation:conversation
+                                                                                focusOnView:YES
+                                                                                   animated:YES];
+                    if (videoCall) {
+                        [conversation startVideoCallWithCompletionHandler:nil];
+                    }
+                    else {
+                        [conversation startAudioCallWithCompletionHandler:nil];
+                    }
+                }];
             }
             else if (users.count > 1) {
                 

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIQuickActionsBar.h
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIQuickActionsBar.h
@@ -30,6 +30,7 @@ typedef NS_ENUM(NSUInteger, StartUIQuickActionBarMode)
     StartUIQuickActionBarModeInvite,
     StartUIQuickActionBarModeCreateConversation,
     StartUIQuickActionBarModeOpenConversation,
+    StartUIQuickActionBarModeOpenGroupConversation
 };
 
 

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIQuickActionsBar.m
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIQuickActionsBar.m
@@ -127,10 +127,10 @@
     self.conversationButton.hidden = (mode == StartUIQuickActionBarModeInvite);
     self.cameraButton.hidden = (mode == StartUIQuickActionBarModeInvite);
     self.callButton.hidden = (mode == StartUIQuickActionBarModeInvite);
-    self.videoCallButton.hidden = (mode != StartUIQuickActionBarModeOpenConversation);
+    self.videoCallButton.hidden = (mode != StartUIQuickActionBarModeOpenConversation) ;
 
     NSString *conversationButtonTitle = @"";
-    if (mode == StartUIQuickActionBarModeOpenConversation) {
+    if (mode == StartUIQuickActionBarModeOpenConversation || mode == StartUIQuickActionBarModeOpenGroupConversation) {
         conversationButtonTitle = NSLocalizedString(@"peoplepicker.quick-action.open-conversation", @"");
     } else if (mode == StartUIQuickActionBarModeCreateConversation) {
         conversationButtonTitle = NSLocalizedString(@"peoplepicker.quick-action.create-conversation", @"");

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.m
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.m
@@ -192,7 +192,11 @@ static NSUInteger const StartUIInitiallyShowsKeyboardConversationThreshold = 10;
     }
     else if (self.userSelection.users.count == 1) {
         self.startUIView.quickActionsBar.hidden = NO;
-        self.startUIView.quickActionsBar.mode = StartUIQuickActionBarModeOpenConversation;
+        if ([[ZMUser selfUser] activeTeam] != nil) { // When in a team we always open group conversations
+            self.startUIView.quickActionsBar.mode = StartUIQuickActionBarModeOpenGroupConversation;
+        } else {
+            self.startUIView.quickActionsBar.mode = StartUIQuickActionBarModeOpenConversation;
+        }
     }
     else {
         self.startUIView.quickActionsBar.hidden = NO;


### PR DESCRIPTION
The fix is to initiate the call only after the conversation is created. However, @typfel found that there is a race condition because the conversation needs to exist remotely for this to work.

This PR partly fixes the issue, more robust fix coming soon.