### PR TITLE
Open team oneOnOne and set team in userImageView

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarSendController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarSendController.m
@@ -127,7 +127,7 @@
         
         ZMUser *user = (ZMUser *) participant;
         
-        ZMConversation *conversation = [ZMConversation existingOneOnOneConversationWithUser:user inUserSession:[ZMUserSession sharedSession]];
+        ZMConversation *conversation = [user oneToOneConversationInTeam:ZMUser.selfUser.activeTeam];
         [[ZMUserSession sharedSession] enqueueChanges:^{
             [conversation appendKnock];
             [[Analytics shared] tagMediaActionCompleted:ConversationMediaActionPing inConversation:self.conversation];

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileDetailsViewController.m
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileDetailsViewController.m
@@ -142,6 +142,7 @@ typedef NS_ENUM(NSUInteger, ProfileUserAction) {
     self.userImageView.userSession = [ZMUserSession sharedSession];
     self.userImageView.translatesAutoresizingMaskIntoConstraints = NO;
     self.userImageView.size = UserImageViewSizeBig;
+    self.userImageView.team = ZMUser.selfUser.activeTeam;
     self.userImageView.user = self.bareUser;
     [self.userImageViewContainer addSubview:self.userImageView];
 }
@@ -528,7 +529,7 @@ typedef NS_ENUM(NSUInteger, ProfileUserAction) {
     ZMConversation __block *conversation = nil;
     
     [[ZMUserSession sharedSession] enqueueChanges:^{
-        conversation = [ZMConversation existingOneOnOneConversationWithUser:self.fullUser inUserSession:[ZMUserSession sharedSession]];
+        conversation = [self.fullUser oneToOneConversationInTeam:ZMUser.selfUser.activeTeam];
     } completionHandler:^{
         [self.delegate profileDetailsViewController:self didSelectConversation:conversation];
     }];


### PR DESCRIPTION
`[ZMConversation existingOneOnOneConversationWithUser:inUserSession]` should not be used anymore. It also does the same as [user oneOnOneConversationInTeam:].

Also fixed: Profile image in detail view was still grey because team was not set.