### PR TITLE
Fix AddParticipantsViewController when creating a new group conversation from one-to-one

### DIFF
--- a/Wire-iOS/Sources/Helpers/syncengine/ZMConversation+Additions.m
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMConversation+Additions.m
@@ -67,7 +67,7 @@
         [listOfPeople addObject:self.connectedUser];
         ZMConversation *conversation = [ZMConversation insertGroupConversationIntoUserSession:[ZMUserSession sharedSession]
                                                                              withParticipants:listOfPeople
-                                        inTeam:activeTeam];
+                                                                                       inTeam:activeTeam];
         AnalyticsGroupConversationEvent *event = [AnalyticsGroupConversationEvent eventForCreatedGroupWithContext:CreatedGroupContextConversation
                                                                                                  participantCount:conversation.activeParticipants.count];
         [[Analytics shared] tagEventObject:event];

--- a/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
@@ -94,11 +94,15 @@ public class AddParticipantsViewController : UIViewController {
         
         confirmButton.addTarget(self, action: #selector(searchHeaderViewControllerDidConfirmAction(_:)), for: .touchUpInside)
         
-        searchResultsViewController.filterConversation = conversation
+        searchResultsViewController.filterConversation = conversation.conversationType == .group ? conversation : nil
         searchResultsViewController.mode = .list
         searchResultsViewController.searchContactList()
         
         userSelection.add(observer: self)
+        
+        if conversation.conversationType == .oneOnOne, let connectedUser = conversation.connectedUser {
+            userSelection.add(connectedUser)
+        }
     }
 
     override public func viewDidLoad() {
@@ -114,6 +118,7 @@ public class AddParticipantsViewController : UIViewController {
         searchResultsViewController.searchResultsView?.emptyResultView = emptyResultLabel
         
         createConstraints()
+        updateConfirmButtonVisibility()
     }
     
     func createConstraints() {


### PR DESCRIPTION
When creating a new group conversation from a one-to-one we should not filter out the existing participants. We also pre-select the one-to-one user.