### PR TITLE
Align in-conversation copy w/ conversation list

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.stringsdict
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.stringsdict
@@ -35,7 +35,7 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>lu</string>
 			<key>zero</key>
-			<string>No people</string>
+			<string>Everyone left</string>
 			<key>one</key>
 			<string>One person</string>
 			<key>few</key>


### PR DESCRIPTION
The copy that appears within group conversations when all other users have left the conversation should be consistent with the message that appears in the conversation list:

> Everyone left