### PR TITLE
Do not collapse the add participants view in popover

### DIFF
--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsView.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsView.swift
@@ -28,7 +28,7 @@ class SearchResultsView : UIView {
     let accessoryContainer = UIView()
     var lastLayoutBounds : CGRect = CGRect.zero
     var accessoryViewBottomOffsetConstraint : NSLayoutConstraint?
-    var isIgnoringKeyboard : Bool = false
+    var isContainedInPopover : Bool = false
     
     deinit {
         NotificationCenter.default.removeObserver(self)
@@ -122,7 +122,7 @@ class SearchResultsView : UIView {
     }
     
     func keyboardFrameDidChange(notification: Notification) {
-        guard !isIgnoringKeyboard else {
+        guard !isContainedInPopover else {
             return
         }
         

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsView.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsView.swift
@@ -28,6 +28,7 @@ class SearchResultsView : UIView {
     let accessoryContainer = UIView()
     var lastLayoutBounds : CGRect = CGRect.zero
     var accessoryViewBottomOffsetConstraint : NSLayoutConstraint?
+    var isIgnoringKeyboard : Bool = false
     
     deinit {
         NotificationCenter.default.removeObserver(self)
@@ -121,6 +122,10 @@ class SearchResultsView : UIView {
     }
     
     func keyboardFrameDidChange(notification: Notification) {
+        guard !isIgnoringKeyboard else {
+            return
+        }
+        
         let firstResponder = UIResponder.wr_currentFirst()
         let inputAccessoryHeight = firstResponder?.inputAccessoryView?.bounds.size.height ?? 0
         

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
@@ -161,7 +161,7 @@ public class SearchResultsViewController : UIViewController {
     
     public override func loadView() {
         searchResultsView  = SearchResultsView()
-        searchResultsView?.isIgnoringKeyboard = isContainedInPopover()
+        searchResultsView?.isContainedInPopover = isContainedInPopover()
         view = searchResultsView
     }
     

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
@@ -45,6 +45,49 @@ public enum SearchResultsViewControllerSection : Int {
     case directory
 }
 
+
+
+extension UIViewController {
+    class ControllerHierarchyIterator: IteratorProtocol {
+        private var current: UIViewController
+        
+        init(controller: UIViewController) {
+            current = controller
+        }
+        
+        func next() -> UIViewController? {
+            var candidate: UIViewController? = .none
+            if let controller = current.navigationController {
+                candidate = controller
+            }
+            else if let controller = current.presentingViewController {
+                candidate = controller
+            }
+            else if let controller = current.parent {
+                candidate = controller
+            }
+            if let candidate = candidate {
+                current = candidate
+            }
+            return candidate
+        }
+    }
+    
+    func isContainedInPopover() -> Bool {
+        var hierarchy = ControllerHierarchyIterator(controller: self)
+        
+        return hierarchy.any {
+            if let arrowDirection = $0.popoverPresentationController?.arrowDirection,
+                arrowDirection != .unknown {
+                return true
+            }
+            else {
+                return false
+            }
+        }
+    }
+}
+
 public class SearchResultsViewController : UIViewController {
     
     var searchResultsView : SearchResultsView?
@@ -118,6 +161,7 @@ public class SearchResultsViewController : UIViewController {
     
     public override func loadView() {
         searchResultsView  = SearchResultsView()
+        searchResultsView?.isIgnoringKeyboard = isContainedInPopover()
         view = searchResultsView
     }
     


### PR DESCRIPTION
# Issue

We collapse the view when the keyboard is shown in order to be able to scroll to the end of the list. Issue happens on iPad where the higher level view is collapsed by the iOS, so we are collapsing it twice.

# Solution

Check if the view controller is currently presented in popover by checking is any parent has a valid `arrowDirection` on it's `popoverPresentationController`.