### PR TITLE
Input bar has layout issue when pinned to superview margins

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -310,7 +310,7 @@
     self.inputBar.textView.delegate = self;
     
     [self.view addSubview:self.inputBar];
-    [self.inputBar autoPinEdgesToSuperviewMarginsExcludingEdge:ALEdgeBottom];
+    [self.inputBar autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsZero excludingEdge:ALEdgeBottom];
     [NSLayoutConstraint autoSetPriority:UILayoutPriorityDefaultLow forConstraints:^{
         [self.inputBar autoPinEdgeToSuperviewEdge:ALEdgeBottom];
     }];


### PR DESCRIPTION
This would become visible only after app comes to foreground, so maybe the margins are added slightly later than we create the view.