### PR TITLE
Show conversation content search for (ex-)team conversations

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
@@ -150,11 +150,11 @@ public extension ConversationViewController {
             if let connection = conversation.connection,
                 connection.status != .pending && connection.status != .sent {
                 return true
+            } else {
+                return nil != conversation.teamRemoteIdentifier
             }
         default: return false
         }
-        
-        return false
     }
     
     public func leftNavigationItems(forConversation conversation: ZMConversation) -> [UIBarButtonItem] {


### PR DESCRIPTION
# What's in this PR?

* 1-on-1 team conversations should show the conversation content search, as the team might be deleted due to the transition to a multi account setup we check the `teamRemoteIdentifier` instead.