### PR TITLE
Wrap resign- / becomeFIrstResponder in performWithoutAnimation block

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Helpers/UITextView+Autocorrect.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UITextView+Autocorrect.swift
@@ -22,7 +22,9 @@ import UIKit
 extension UITextView {
     // Autocorrects the last word, if necessary.
     func autocorrectLastWord() {
-        resignFirstResponder()
-        becomeFirstResponder()
+        UITextView.performWithoutAnimation {
+            resignFirstResponder()
+            becomeFirstResponder()
+        }
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Helpers/UITextView+Autocorrect.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UITextView+Autocorrect.swift
@@ -22,7 +22,7 @@ import UIKit
 extension UITextView {
     // Autocorrects the last word, if necessary.
     func autocorrectLastWord() {
-        UITextView.performWithoutAnimation {
+        UIView.performWithoutAnimation {
             resignFirstResponder()
             becomeFirstResponder()
         }


### PR DESCRIPTION
# What's in this PR?

* Wrap `resignFirstResponder` and `becomeFirstResponder` in `UITextView.performWithoutAnimation` block.