### PR TITLE
Fix crash on updating profile picture

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelOverlay.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelOverlay.swift
@@ -222,6 +222,7 @@ class VoiceChannelOverlay: UIView {
     }
     
     deinit {
+        EAGLContext.setCurrent(nil) // workaround for ZIOS-8718
         NotificationCenter.default.removeObserver(self)
         cancelHideControlsAfterElapsedTime()
     }


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/ZIOS-8718

https://rink.hockeyapp.net/manage/apps/42908/crashes/search?per_page=10&query=cmethod%3AdesaturatedImageWithContext%2A&type=groups

This crash seems similar to https://forums.developer.apple.com/thread/21884 where an `EAGLContext` is not properly shutdown (`AVSVideoView`) which leads to a crash on the following `EAGLContext setCurrentContext:` which in this case is done by `CIContext`.