### PR TITLE
Adjust ephemeral timeout formatting

### DIFF
--- a/Wire-iOS Tests/Mocks/MockUser.m
+++ b/Wire-iOS Tests/Mocks/MockUser.m
@@ -60,6 +60,16 @@ static id<ZMBareUser> mockSelfUser = nil;
     mockSelfUser = newMockUser;
 }
 
+- (BOOL)isTeamMember
+{
+    return NO;
+}
+
+- (BOOL)isGuestInConversation:(ZMConversation *)conversation
+{
+    return NO;
+}
+
 + (ZMUser<ZMEditableUser> *)selfUserInUserSession:(ZMUserSession *)session
 {
     return mockSelfUser ? : (id)self.mockSelfUser;

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -802,6 +802,7 @@
 		BF5C379B1C0E0E8700EA11E3 /* ParticipantDeviceCell.m in Sources */ = {isa = PBXBuildFile; fileRef = BF5C379A1C0E0E8700EA11E3 /* ParticipantDeviceCell.m */; };
 		BF606D6F1CAA8A78002BAC94 /* ConversationListBottomBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF606D6E1CAA8A78002BAC94 /* ConversationListBottomBar.swift */; };
 		BF606D731CAA9EEE002BAC94 /* ConversationListBottomBarTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BF606D721CAA9EEE002BAC94 /* ConversationListBottomBarTests.m */; };
+		BF69C6C31F0CEBC500649C55 /* EphemeralTimeoutFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF69C6C21F0CEBC500649C55 /* EphemeralTimeoutFormatter.swift */; };
 		BF6EC9061EB1FC3D009D9A69 /* URL+Backup.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF6EC9051EB1FC3D009D9A69 /* URL+Backup.swift */; };
 		BF6EC90A1EB1FD0C009D9A69 /* ExtensionBackupExcluder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF6EC9091EB1FD0C009D9A69 /* ExtensionBackupExcluder.swift */; };
 		BF732A731D9C14C7003077DB /* emoji_activities.plist in Resources */ = {isa = PBXBuildFile; fileRef = BF732A6B1D9C14C7003077DB /* emoji_activities.plist */; };
@@ -2274,6 +2275,7 @@
 		BF5C379A1C0E0E8700EA11E3 /* ParticipantDeviceCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ParticipantDeviceCell.m; sourceTree = "<group>"; };
 		BF606D6E1CAA8A78002BAC94 /* ConversationListBottomBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ConversationListBottomBar.swift; path = ../Conversation/ConversationListBottomBar.swift; sourceTree = "<group>"; };
 		BF606D721CAA9EEE002BAC94 /* ConversationListBottomBarTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ConversationListBottomBarTests.m; sourceTree = "<group>"; };
+		BF69C6C21F0CEBC500649C55 /* EphemeralTimeoutFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EphemeralTimeoutFormatter.swift; sourceTree = "<group>"; };
 		BF6EC9051EB1FC3D009D9A69 /* URL+Backup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "URL+Backup.swift"; sourceTree = "<group>"; };
 		BF6EC9091EB1FD0C009D9A69 /* ExtensionBackupExcluder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtensionBackupExcluder.swift; sourceTree = "<group>"; };
 		BF732A6B1D9C14C7003077DB /* emoji_activities.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = emoji_activities.plist; sourceTree = "<group>"; };
@@ -3685,6 +3687,7 @@
 				BF5090571DE3469700A5FEE0 /* UIView+LayoutMargins.swift */,
 				87DE06B01D256CF50009411F /* DeviceProximityListener.swift */,
 				875F89111D6DCD2C00D8748E /* MessageToolboxView.swift */,
+				BF69C6C21F0CEBC500649C55 /* EphemeralTimeoutFormatter.swift */,
 				875F89131D6DD6D000D8748E /* ReactionsView.swift */,
 				87CB36B91D74782B007AB4E5 /* LikeButton.swift */,
 				87A773CE1DD0B48400ACAA73 /* ObfuscationView.swift */,
@@ -6161,6 +6164,7 @@
 				87DCF48E1D34E9BA00BB420F /* ContactsDataSource.m in Sources */,
 				8710673E1C0DC5570035603B /* SettingsCellDescriptorFactory.swift in Sources */,
 				87DE06B11D256CF50009411F /* DeviceProximityListener.swift in Sources */,
+				BF69C6C31F0CEBC500649C55 /* EphemeralTimeoutFormatter.swift in Sources */,
 				871BC26E1D34F8F800DF0793 /* PassthroughWindow.m in Sources */,
 				871BC2201D34F8F800DF0793 /* ActionSheetAlertView.m in Sources */,
 				16B2DE2E1CCFB3B0000D7C30 /* InputBar.swift in Sources */,

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -272,6 +272,7 @@
 "content.system.connected_to" = "Connected to %@\nStart a conversation";
 "content.system.other_wanted_to_talk" = "%@ called";
 "content.system.you_wanted_to_talk" = "You called";
+"content.system.ephemeral_time_remaining" = "%@ left";
 
 "content.system.you_started" = "You";
 "content.system.this_device" = "this device";

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/EphemeralTimeoutFormatter.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/EphemeralTimeoutFormatter.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
+// Copyright (C) 2017 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/EphemeralTimeoutFormatter.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/EphemeralTimeoutFormatter.swift
@@ -1,0 +1,54 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+class EphemeralTimeoutFormatter {
+
+    private let secondsFormatter: DateComponentsFormatter = {
+        let formatter = DateComponentsFormatter()
+        formatter.unitsStyle = .full
+        formatter.allowedUnits = .second
+        formatter.zeroFormattingBehavior = .dropAll
+        return formatter
+    }()
+
+    func string(from interval: TimeInterval) -> String? {
+        return timeString(from: interval).map {
+            "content.system.ephemeral_time_remaining".localized(args: $0)
+        }
+    }
+
+    private func timeString(from interval: TimeInterval) -> String? {
+        // DateComponentsFormatter ZeroFormattingBehavior.pad unfortunately does
+        // not add a leading 0 to the first unit (e.g. 5:21 instead of 05:21), which
+        // is the reason we need to fallback to manual formatting here.
+        let total = Int(round(interval))
+        let min = (total / 60) % 60
+        let hour = total / 3600
+        let sec = total % 60
+
+        if interval <= 60 {
+            return secondsFormatter.string(from: interval + 1) // We need to add one second to start with the correct value
+        } else if interval <= 3600 {
+            return String(format: "%02u:%02u", min, sec)
+        } else {
+            return String(format: "%02u:%02u:%02u", hour, min, sec)
+        }
+    }
+    
+}

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/EphemeralTimeoutFormatter.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/EphemeralTimeoutFormatter.swift
@@ -38,9 +38,9 @@ class EphemeralTimeoutFormatter {
         // not add a leading 0 to the first unit (e.g. 5:21 instead of 05:21), which
         // is the reason we need to fallback to manual formatting here.
         let (hour, min, sec) = interval.decomposed()
-        if interval <= 60 {
+        if interval < 60 {
             return secondsFormatter.string(from: interval + 1) // We need to add one second to start with the correct value
-        } else if interval <= 3600 {
+        } else if interval < 3600 {
             return String(format: "%02u:%02u", min, sec)
         } else {
             return String(format: "%02u:%02u:%02u", hour, min, sec)

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/EphemeralTimeoutFormatter.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/EphemeralTimeoutFormatter.swift
@@ -37,11 +37,7 @@ class EphemeralTimeoutFormatter {
         // DateComponentsFormatter ZeroFormattingBehavior.pad unfortunately does
         // not add a leading 0 to the first unit (e.g. 5:21 instead of 05:21), which
         // is the reason we need to fallback to manual formatting here.
-        let total = Int(round(interval))
-        let min = (total / 60) % 60
-        let hour = total / 3600
-        let sec = total % 60
-
+        let (hour, min, sec) = interval.decomposed()
         if interval <= 60 {
             return secondsFormatter.string(from: interval + 1) // We need to add one second to start with the correct value
         } else if interval <= 3600 {
@@ -51,4 +47,13 @@ class EphemeralTimeoutFormatter {
         }
     }
     
+}
+
+fileprivate extension TimeInterval {
+
+    func decomposed() -> (hour: Int, min: Int, sec: Int) {
+        let total = Int(rounded())
+        return (total / 3600, (total / 60) % 60, total % 60)
+    }
+
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
@@ -297,7 +297,7 @@ extension ZMSystemMessageData {
 
         let showDestructionTimer = message.isEphemeral && !message.isObfuscated && nil != message.destructionDate
         if let destructionDate = message.destructionDate, showDestructionTimer {
-            let remaining = destructionDate.timeIntervalSinceNow
+            let remaining = destructionDate.timeIntervalSinceNow + 1 // We need to add one second to start with the correct value
             deliveryStateString = MessageToolboxView.ephemeralTimeFormatter.string(from: remaining)
         }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
@@ -65,13 +65,7 @@ extension ZMSystemMessageData {
     fileprivate static let resendLink = URL(string: "settings://resend-message")!
     fileprivate static let deleteLink = URL(string: "settings://delete-message")!
 
-    private static let ephemeralTimeFormatter: DateComponentsFormatter = {
-        let formatter = DateComponentsFormatter()
-        formatter.unitsStyle = .full
-        formatter.allowedUnits = [.day, .hour, .minute, .second]
-        formatter.zeroFormattingBehavior = .dropAll
-        return formatter
-    }()
+    private static let ephemeralTimeFormatter = EphemeralTimeoutFormatter()
 
     open let statusLabel = TTTAttributedLabel(frame: CGRect.zero)
     open let reactionsView = ReactionsView()
@@ -303,7 +297,7 @@ extension ZMSystemMessageData {
 
         let showDestructionTimer = message.isEphemeral && !message.isObfuscated && nil != message.destructionDate
         if let destructionDate = message.destructionDate, showDestructionTimer {
-            let remaining = destructionDate.timeIntervalSinceNow + 1 // We need to add one second to start with the correct value
+            let remaining = destructionDate.timeIntervalSinceNow
             deliveryStateString = MessageToolboxView.ephemeralTimeFormatter.string(from: remaining)
         }
 


### PR DESCRIPTION
# What's in this PR?

Adjust ephemeral timeout formatting. Unfortunately `ZeroFormattingBehavior.pad`  does not add a leading 0 to the first unit (e.g. 5:21 instead of 05:21), which is the reason we need to fallback to manual formatting in some cases.