### PR TITLE
Add keyboard shortcut to send message (⌘⏎)

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -545,6 +545,25 @@
     self.view.hidden = self.conversation.isReadOnly;
 }
 
+#pragma mark - Keyboard Shortcuts
+
+- (NSArray<UIKeyCommand *> *)keyCommands
+{
+    return @[[UIKeyCommand keyCommandWithInput:@"\r" modifierFlags:UIKeyModifierCommand action:@selector(commandReturnPressed)]];
+}
+
+- (BOOL)canBecomeFirstResponder
+{
+    return YES;
+}
+
+- (void)commandReturnPressed
+{
+    if (nil != self.inputBar.textView.text) {
+        [self sendOrEditText:self.inputBar.textView.text];
+    }
+}
+
 #pragma mark - Input views handling
 
 - (void)onSingleTap:(UITapGestureRecognizer *)recognier


### PR DESCRIPTION
# What's in this PR?

I just had to quickly implement the first part of https://github.com/wireapp/wire-ios/issues/1125 as it enhances the usability of Wire on iPad greatly and also makes sending messages on Simulator so much easier.