### PR TITLE
Fix join call button not appearing and disappearing in some scenarios

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
@@ -147,7 +147,8 @@ public extension ConversationViewController {
     
     public func rightNavigationItems(forConversation conversation: ZMConversation) -> [UIBarButtonItem] {
         guard !conversation.isReadOnly else { return [] }
-        if conversation.conversationListIndicator == .inactiveCall {
+
+        if conversation.canJoinCall {
             return [UIBarButtonItem(customView: joinCallButton)]
         }
 
@@ -237,8 +238,7 @@ public extension ConversationViewController {
     }
 
     private dynamic func joinCallButtonTapped(_sender: UIBarButtonItem) {
-        guard conversation.voiceChannel?.state == .incomingCallInactive
-           || conversation.voiceChannel?.state == .incomingCall else { return }
+        guard conversation.canJoinCall else { return }
 
         // This will result in joining an ongoing call.
         conversation.acceptIncomingCall()
@@ -310,4 +310,15 @@ extension ConversationViewController: CollectionsViewControllerDelegate {
             break
         }
     }
+}
+
+
+extension ZMConversation {
+
+    /// Whether there is an incoming or inactive incoming call that can be joined.
+    var canJoinCall: Bool {
+        guard let state = voiceChannel?.state else { return false }
+        return state == .incomingCallInactive || state == .incomingCall
+    }
+
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -845,12 +845,13 @@
 
 - (void)callCenterDidFailToJoinVoiceChannelWithError:(NSError *)error conversation:(ZMConversation *)conversation
 {
+    [self updateRightNavigationItemsButtons];
     [self showAlertForError:error];
 }
 
 - (void)callCenterDidEndCallWithReason:(VoiceChannelV2CallEndReason)reason conversation:(ZMConversation *)conversation callingProtocol:(enum CallingProtocol)callingProtocol
 {
-    
+    [self updateRightNavigationItemsButtons];
 }
 
 @end


### PR DESCRIPTION
# What's in this PR?

* The join call button was not properly updated when a call was terminated or even started while on the conversation screen.