### PR TITLE
Set default accent color in base snapshot test class

### DIFF
--- a/Wire-iOS Tests/ArticleViewTests.swift
+++ b/Wire-iOS Tests/ArticleViewTests.swift
@@ -24,12 +24,7 @@ import WireLinkPreview
 class ArticleViewTests: ZMSnapshotTestCase {
     
     var sut: ArticleView!
-    
-    override func setUp() {
-        super.setUp()
-        accentColor = .vividRed
-    }
-    
+        
     /// MARK - Fixture
     
     func articleWithoutPicture() -> MockTextMessageData {

--- a/Wire-iOS Tests/AudioMessageCellTests.swift
+++ b/Wire-iOS Tests/AudioMessageCellTests.swift
@@ -51,12 +51,7 @@ class AudioMessageCellTests: ZMSnapshotTestCase {
         
         return cell.wrapInTableView()
     }
-    
-    override func setUp() {
-        super.setUp()
-        self.accentColor = .vividRed
-    }
-    
+        
     // MARK : Uploaded (File not downloaded)
     
     func testUploadedCell_fromThisDevice() {

--- a/Wire-iOS Tests/FileTransferCellTests.swift
+++ b/Wire-iOS Tests/FileTransferCellTests.swift
@@ -49,11 +49,6 @@ class FileTransferCellTests: ZMSnapshotTestCase {
       
         return cell.wrapInTableView()
     }
-    
-    override func setUp() {
-        super.setUp()
-        self.accentColor = .vividRed
-    }
    
     func testUploadedCell_fromThisDevice() {
         let cell = self.wrappedCellWithConfig({

--- a/Wire-iOS Tests/InputBar/InputBarTests.swift
+++ b/Wire-iOS Tests/InputBar/InputBarTests.swift
@@ -24,11 +24,6 @@ import Classy
 
 class InputBarTests: ZMSnapshotTestCase {
     
-    override func setUp() {
-        super.setUp()
-        self.accentColor = .vividRed
-    }
-    
     let shortText = "Lorem ipsum dolor"
     let longText = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est"
     let LTRText = "ناك حقيقة مثبتة منذ"

--- a/Wire-iOS Tests/LocationMessageCellTests.swift
+++ b/Wire-iOS Tests/LocationMessageCellTests.swift
@@ -24,11 +24,6 @@ import MapKit
 class LocationMessageCellTests: ZMSnapshotTestCase {
 
     typealias CellConfiguration = (MockMessage) -> Void
-    
-    override func setUp() {
-        super.setUp()
-        accentColor = .vividRed
-    }
 
     func testThatItRendersLocationCellWithAddressCorrect() {
         // This is experimental as the MKMapView might break the snapshot tests,

--- a/Wire-iOS Tests/LocationSendViewControllerTests.swift
+++ b/Wire-iOS Tests/LocationSendViewControllerTests.swift
@@ -26,7 +26,6 @@ class LocationSendViewControllerTests: ZMSnapshotTestCase {
     
     override func setUp() {
         super.setUp()
-        accentColor = .vividRed
         sut = LocationSendViewController()
     }
     

--- a/Wire-iOS Tests/UnknownMessageCellTests.swift
+++ b/Wire-iOS Tests/UnknownMessageCellTests.swift
@@ -46,11 +46,6 @@ class UnknownMessageCellTests: ZMSnapshotTestCase {
         return cell.wrapInTableView()
     }
     
-    override func setUp() {
-        super.setUp()
-        self.accentColor = .vividRed
-    }
-    
     func testCell() {
         verify(view: wrappedCell())
     }

--- a/Wire-iOS Tests/VideoMessageCellTests.swift
+++ b/Wire-iOS Tests/VideoMessageCellTests.swift
@@ -52,12 +52,7 @@ class VideoMessageCellTests: ZMSnapshotTestCase {
  
         return cell.wrapInTableView()
     }
-    
-    override func setUp() {
-        super.setUp()
-        self.accentColor = .vividRed
-    }
-    
+        
     // MARK : Uploaded (File not downloaded)
     
     func testUploadedCell_fromThisDevice() {

--- a/Wire-iOS Tests/ZMSnapshotTestCase.m
+++ b/Wire-iOS Tests/ZMSnapshotTestCase.m
@@ -71,6 +71,7 @@ static NSSet *phoneWidths(void) {
     }
 
     [UIView setAnimationsEnabled:NO];
+    self.accentColor = ZMAccentColorVividRed;
     self.snapshotBackgroundColor = UIColor.clearColor;
     // Enable when the design of the view has changed in order to update the reference snapshots
 #ifdef RECORDING_SNAPSHOTS


### PR DESCRIPTION
Since we no longer have self user in during the snaphot tests we were falling back to the default blue accent color. Since all tests expect the account color to be red I now explicitly set it in `ZMSnapshotTestCase`