### PR TITLE
Delay reporting new device token until user session is initialized

### DIFF
--- a/Wire-iOS/Sources/AppDelegate.m
+++ b/Wire-iOS/Sources/AppDelegate.m
@@ -342,7 +342,9 @@ static AppDelegate *sharedAppDelegate = nil;
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)newDeviceToken
 {
     DDLogWarn(@"Received APNS token: %@", newDeviceToken);
-    [[ZMUserSession sharedSession] application:application didRegisterForRemoteNotificationsWithDeviceToken:newDeviceToken];
+    [self.appController performAfterUserSessionIsInitialized:^{
+        [[ZMUserSession sharedSession] application:application didRegisterForRemoteNotificationsWithDeviceToken:newDeviceToken];
+    }];
 }
 
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error


### PR DESCRIPTION
We call `registerForRemoteNotifications` before we are authenticated during registration, so it's possible that's will get a deviceToken before the `ZMUserSession` exists. Attempting access the user session before it exists will result in assert (crash). We can avoid this by wrapping the code in a `performAfterUserSessionIsInitialized `.


---
https://wearezeta.atlassian.net/browse/ZIOS-8823