### PR TITLE
Show more helpful error messages when login fails

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Registration/EmailSignInViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/EmailSignInViewController.m
@@ -345,7 +345,18 @@
         self.passwordField.rightAccessoryView = RegistrationTextFieldRightAccessoryViewGuidanceDot;
     }
     
-    if (error.code != ZMUserSessionNeedsPasswordToRegisterClient &&
+    if (error.code == ZMUserSessionUnkownError) {
+        NSString *email = self.emailField.text;
+        NSString *password = self.passwordField.text;
+        
+        if (![ZMUser validateEmailAddress:&email error:nil]) {
+            [self showAlertForError:[NSError errorWithDomain:ZMUserSessionErrorDomain code:ZMUserSessionInvalidEmail userInfo:nil]];
+        } else if (![ZMUser validatePassword:&password error:nil]) {
+            [self showAlertForError:[NSError errorWithDomain:ZMUserSessionErrorDomain code:ZMUserSessionInvalidCredentials userInfo:nil]];
+        } else {
+            [self showAlertForError:error];
+        }
+    } else if (error.code != ZMUserSessionNeedsPasswordToRegisterClient &&
         error.code != ZMUserSessionCanNotRegisterMoreClients &&
         error.code != ZMUserSessionNeedsToRegisterEmailToRegisterClient) {
 


### PR DESCRIPTION
We are intentionally not validating the login credentials to avoid the situation were a user can't login because the validation rules changed after he/she his/her account. However since the backend only gives us a 400 bad request response if the validation rules doesn't pass we were showing a very generic "something went wrong" error message.

To fix this we now validate the credentials on receiving this error in order to display a more helpful error message.

https://wearezeta.atlassian.net/browse/ZIOS-8822