### PR TITLE
Fix crash after selecting your handle

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController.m
@@ -130,6 +130,11 @@
 {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     [ZMUserSession removeInitalSyncCompletionObserver:self];
+    [self removeUserProfileObserver];
+}
+
+- (void)removeUserProfileObserver
+{
     [self.userProfile removeObserverWithToken:self.userProfileObserverToken];
 }
 


### PR DESCRIPTION
We were crashing because were trying to call a method for de-registering a user profile observer which had been removed.

`Fix:` restore method.

https://wearezeta.atlassian.net/browse/ZIOS-8830