### PR TITLE
Fix crash on returning from background on login screen

### DIFF
--- a/Wire-iOS/Sources/AppController.m
+++ b/Wire-iOS/Sources/AppController.m
@@ -158,14 +158,16 @@ NSString *const ZMUserSessionDidBecomeAvailableNotification = @"ZMUserSessionDid
     self.enteringForeground = YES;
     [self loadAppropriateController];
     self.enteringForeground = NO;
-
-    [[self zetaUserSession] checkIfLoggedInWithCallback:^(BOOL isLoggedIn) {
-        if (isLoggedIn) {
-            [self uploadAddressBookIfNeeded];
-            [self trackShareExtensionEventsIfNeeded];
-            [self.messageCountTracker trackLegacyMessageCount];
-        }
-    }];
+    
+    if (self.sessionManager.isUserSessionActive) {
+        [[self zetaUserSession] checkIfLoggedInWithCallback:^(BOOL isLoggedIn) {
+            if (isLoggedIn) {
+                [self uploadAddressBookIfNeeded];
+                [self trackShareExtensionEventsIfNeeded];
+                [self.messageCountTracker trackLegacyMessageCount];
+            }
+        }];
+    }
 }
 
 - (void)applicationWillResignActive:(UIApplication *)application


### PR DESCRIPTION
We crashed because we were trying to access a non existing user session.

`fix:` add check if user session exists.

https://wearezeta.atlassian.net/browse/ZIOS-8831