### PR TITLE
Removed add phone screen after email login

### DIFF
--- a/Wire-iOS/Sources/Helpers/syncengine/ZMUser+Additions.h
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMUser+Additions.h
@@ -51,8 +51,6 @@ FOUNDATION_EXPORT ZMUser *BareUserToUser(id bareUser);
 
 + (BOOL)isSelfUserActiveParticipantOfConversation:(ZMConversation *)conversation;
 
-+ (BOOL)selfUserHasIncompleteUserDetails;
-
 /// Just checks if any approval is pending from any side (SelfUser or OtherUser)
 - (BOOL)isPendingApproval;
 

--- a/Wire-iOS/Sources/Helpers/syncengine/ZMUser+Additions.m
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMUser+Additions.m
@@ -97,11 +97,6 @@ ZMUser *BareUserToUser(id bareUser) {
     return (self.isPendingApprovalBySelfUser || self.isPendingApprovalByOtherUser);
 }
 
-+ (BOOL)selfUserHasIncompleteUserDetails;
-{
-    return [[[ZMUser selfUser] emailAddress] length] == 0 || [[[ZMUser selfUser] phoneNumber] length] == 0;
-}
-
 + (ZMAccentColor)pickRandomAcceptableAccentColor
 {
     ZMAccentColor accentColorValue;

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationViewController.m
@@ -262,7 +262,7 @@
         return;
     }
     
-    if (! [[ZMUserSession sharedSession] registeredOnThisDevice] && [ZMUser selfUserHasIncompleteUserDetails]) {
+    if (! [[ZMUserSession sharedSession] registeredOnThisDevice] && [[[ZMUser selfUser] emailAddress] length] == 0) {
         self.rootNavigationController.logoEnabled = NO;
         self.rootNavigationController.backButtonEnabled = NO;
         
@@ -274,22 +274,12 @@
             self.hasPushedPostRegistrationStep = YES;
         }
         
-        if ([[[ZMUser selfUser] phoneNumber] length] == 0) {
-            AddPhoneNumberViewController *addPhoneNumberViewController = [[AddPhoneNumberViewController alloc] init];
-            addPhoneNumberViewController.analyticsTracker = [AnalyticsTracker analyticsTrackerWithContext:AnalyticsContextPostLogin];
-            addPhoneNumberViewController.formStepDelegate = self;
-            addPhoneNumberViewController.skipButtonType = AddPhoneNumberViewControllerSkipButtonTypeSkip;
-            
-            [self.rootNavigationController pushViewController:addPhoneNumberViewController animated:YES];
-        }
-        else if ([[[ZMUser selfUser] emailAddress] length] == 0) {
-            AddEmailPasswordViewController *addEmailPasswordViewController = [[AddEmailPasswordViewController alloc] init];
-            addEmailPasswordViewController.analyticsTracker = [AnalyticsTracker analyticsTrackerWithContext:AnalyticsContextPostLogin];
-            addEmailPasswordViewController.formStepDelegate = self;
-            addEmailPasswordViewController.skipButtonType = AddEmailPasswordViewControllerSkipButtonTypeNone;
-            
-            [self.rootNavigationController pushViewController:addEmailPasswordViewController animated:YES];
-        }
+        AddEmailPasswordViewController *addEmailPasswordViewController = [[AddEmailPasswordViewController alloc] init];
+        addEmailPasswordViewController.analyticsTracker = [AnalyticsTracker analyticsTrackerWithContext:AnalyticsContextPostLogin];
+        addEmailPasswordViewController.formStepDelegate = self;
+        addEmailPasswordViewController.skipButtonType = AddEmailPasswordViewControllerSkipButtonTypeNone;
+        
+        [self.rootNavigationController pushViewController:addEmailPasswordViewController animated:YES];
     }
     else if (! [[ZMUserSession sharedSession] registeredOnThisDevice]) {
         ContextType type = [[ZMUserSession sharedSession] hadHistoryAtLastLogin] ? ContextTypeLoggedOut : ContextTypeNewDevice;


### PR DESCRIPTION
# Issue

The user is asked right now to add the phone if it is not added yet after the email login. This step is obsolete and should be removed.