### PR TITLE
Fixed annoying bugs with animations during the registration

### DIFF
--- a/Wire-iOS/Sources/Components/Constants.h
+++ b/Wire-iOS/Sources/Components/Constants.h
@@ -43,10 +43,6 @@ FOUNDATION_EXPORT NSString *const UserPrefKeyAccentColorTipCompleted;
 #define IS_IPHONE_6 (IS_IPHONE && [[UIScreen mainScreen] nativeBounds].size.height == 1334.0)
 #define IS_IPHONE_6_PLUS_OR_BIGGER (IS_IPHONE && [[UIScreen mainScreen] nativeBounds].size.height >= 1920.0f)
 
-#define IS_OS_8_OR_LATER    ([[[UIDevice currentDevice] systemVersion] floatValue] >= 8.0)
-#define IS_ZOOMED_IPHONE_6 (IS_IPHONE && [[UIScreen mainScreen] bounds].size.height == 568.0 && IS_OS_8_OR_LATER && [UIScreen mainScreen].nativeScale > [UIScreen mainScreen].scale)
-#define IS_ZOOMED_IPHONE_6_PLUS (IS_IPHONE && [[UIScreen mainScreen] bounds].size.height == 667.0 && IS_OS_8_OR_LATER && [UIScreen mainScreen].nativeScale < [UIScreen mainScreen].scale)
-
 #define IS_IPAD ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad)
 #define IS_IPAD_LANDSCAPE_LAYOUT (([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad) && UIInterfaceOrientationIsLandscape([UIApplication sharedApplication].statusBarOrientation))
 #define IS_IPAD_PORTRAIT_LAYOUT (([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad) && UIInterfaceOrientationIsPortrait([UIApplication sharedApplication].statusBarOrientation))

--- a/Wire-iOS/Sources/UserInterface/Registration/EmailSignInViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/EmailSignInViewController.m
@@ -236,9 +236,11 @@
     
     self.navigationController.showLoadingView = YES;
     
-    [self.analyticsTracker tagRequestedEmailLogin];
-    
-    [[UnauthenticatedSession sharedSession] loginWithCredentials:credentials];
+    dispatch_async(dispatch_get_main_queue(), ^{        
+        [self.analyticsTracker tagRequestedEmailLogin];
+        
+        [[UnauthenticatedSession sharedSession] loginWithCredentials:credentials];
+    });
 }
 
 - (IBAction)resetPassword:(id)sender
@@ -330,7 +332,7 @@
 - (void)authenticationDidSucceed
 {
     [self.analyticsTracker tagEmailLogin];
-    self.navigationController.showLoadingView = NO;
+    // Not necessary to remove the loading view, since the controller would not be used any more.
 }
 
 - (void)authenticationDidFail:(NSError *)error

--- a/Wire-iOS/Sources/UserInterface/Registration/NoHistoryViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/NoHistoryViewController.m
@@ -46,6 +46,9 @@
     [self createOKButton];
     
     [self createViewConstraints];
+    
+    // Layout first to avoid the initial layout animation during the presentation. 
+    [self.view layoutIfNeeded];
 }
 
 - (void)createContentView

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTextField.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTextField.m
@@ -63,7 +63,13 @@ static const CGFloat GuidanceDotViewWidth = 40;
         self.font = [UIFont fontWithMagicIdentifier:@"style.text.normal.font_spec"];
         self.textColor = [UIColor colorWithMagicIdentifier:@"style.color.static_foreground.normal"];
         self.textInsets = UIEdgeInsetsMake(0, 8, 0, 8);
-        self.placeholderInsets = UIEdgeInsetsMake(8, 8, 0, 8);
+        if ([[[UIDevice currentDevice] systemVersion] floatValue] < 11.0) {
+            // Placeholder frame calculation is changed in iOS 11, therefore the TOP inset is not necessary
+            self.placeholderInsets = UIEdgeInsetsMake(8, 8, 0, 8);
+        }
+        else {
+            self.placeholderInsets = UIEdgeInsetsMake(0, 8, 0, 8);
+        }
         self.keyboardAppearance = UIKeyboardAppearanceDark;
         self.autocorrectionType = UITextAutocorrectionTypeNo;
         self.contentVerticalAlignment = UIControlContentVerticalAlignmentCenter;

--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientUnregisterFlowViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientUnregisterFlowViewController.swift
@@ -64,13 +64,15 @@ class ClientUnregisterFlowViewController: FormFlowViewController, FormStepDelega
         self.popTransition = PopTransition()
         self.pushTransition = PushTransition()
     
-        self.setupBackgroundImageView()
-        
-        self.setupNavigationController()
-        
-        self.createConstraints()
-    
-        self.view?.isOpaque = false
+        UIView.performWithoutAnimation {            
+            self.setupBackgroundImageView()
+            
+            self.setupNavigationController()
+            
+            self.createConstraints()
+            
+            self.view?.isOpaque = false
+        }
     }
     
     override func viewWillDisappear(_ animated: Bool) {

--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientUnregisterInvitationViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientUnregisterInvitationViewController.swift
@@ -36,6 +36,9 @@ class ClientUnregisterInvitationViewController: RegistrationStepViewController {
         self.createDeleteDevicesButton()
         self.createSignOutButton()
         self.createConstraints()
+        
+        // Layout first to avoid the initial layout animation during the presentation.
+        self.view.layoutIfNeeded()
     }
     
     fileprivate func createContainerView() {


### PR DESCRIPTION
# Issues fixed

1. On iOS11, the placeholder on the input fields was collapsed vertically.
2. Implicit animation from zero frames on manage devices and you are using the device first time screens.
3. Spinner disappearing on email sign in screen.