### PR TITLE
VoiceOver: initial changes to make the app usable with screen reader

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -93,6 +93,7 @@
 "conversation.connection_view.in_address_book" = "in Contacts";
 
 // Conversation list voiceover accessibility
+"conversation_list.voiceover.open_conversation.hint" = "Open conversation";
 "conversation_list.voiceover.status.pending_connection" = "pending";
 "conversation_list.voiceover.status.active_call" = "active call";
 "conversation_list.voiceover.status.missed_call" = "missed call";

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -129,6 +129,8 @@
 "list.archived_conversations" = "ARCHIVE";
 "list.archived_conversations_close" = "Close archive";
 
+"conversation.voiceover.verified" = "verified";
+
 "conversation.status.call" = "Ongoing call";
 "conversation.status.typing" = "Typing a message…";
 "conversation.status.typing.group" = "%@: typing a message…";

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -92,7 +92,15 @@
 // Profile Header View
 "conversation.connection_view.in_address_book" = "in Contacts";
 
-
+// Conversation list voiceover accessibility
+"conversation_list.voiceover.status.pending_connection" = "pending";
+"conversation_list.voiceover.status.active_call" = "active call";
+"conversation_list.voiceover.status.missed_call" = "missed call";
+"conversation_list.voiceover.status.pause_media" = "pause media";
+"conversation_list.voiceover.status.play_media" = "play media";
+"conversation_list.voiceover.status.silenced" = "silenced";
+"conversation_list.voiceover.status.typing" = "typing";
+"conversation_list.voiceover.status.ping" = "ping";
 
 // Archived List
 "archived_list.title" = "archive";

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -515,6 +515,9 @@
 "self.about" = "About";
 "self.sign_out" = "Log Out";
 "self.report_abuse" = "Report Misuse";
+"self.voiceover.label" = "Profile";
+"self.voiceover.hint" = "Open profile and settings";
+"self.new-device.voiceover.label" = "Profile, new devices added";
 
 "self.add_phone_number" = "Add phone number";
 "self.add_email_password" = "Add email address and password";

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -101,6 +101,14 @@
 "conversation_list.voiceover.status.silenced" = "silenced";
 "conversation_list.voiceover.status.typing" = "typing";
 "conversation_list.voiceover.status.ping" = "ping";
+"conversation_list.voiceover.bottom_bar.archived_button.label" = "archived";
+"conversation_list.voiceover.bottom_bar.archived_button.hint" = "list of archived conversations";
+"conversation_list.voiceover.bottom_bar.contacts_button.label" = "contacts";
+"conversation_list.voiceover.bottom_bar.contacts_button.hint" = "search for people on Wire";
+"conversation_list.voiceover.bottom_bar.compose_button.label" = "compose";
+"conversation_list.voiceover.bottom_bar.compose_button.hint" = "compose messages and save for later";
+"conversation_list.voiceover.bottom_bar.camera_button.label" = "camera";
+"conversation_list.voiceover.bottom_bar.camera_button.hint" = "take picture and send quickly";
 
 // Archived List
 "archived_list.title" = "archive";

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -214,6 +214,7 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
     }
 
     [self scrollToLastUnreadMessageIfNeeded];
+    UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, nil);
 }
 
 - (void)viewWillDisappear:(BOOL)animated

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationListBottomBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationListBottomBar.swift
@@ -77,18 +77,27 @@ import Cartography
         archivedButton.setIcon(.archive, with: .tiny, for: UIControlState())
         archivedButton.addTarget(self, action: #selector(archivedButtonTapped), for: .touchUpInside)
         archivedButton.accessibilityIdentifier = "bottomBarArchivedButton"
+        archivedButton.accessibilityLabel = "conversation_list.voiceover.bottom_bar.archived_button.label".localized
+        archivedButton.accessibilityHint = "conversation_list.voiceover.bottom_bar.archived_button.hint".localized
+
 
         plusButton.setIcon(.plus, with: .tiny, for: .normal)
         plusButton.addTarget(self, action: #selector(plusButtonTapped), for: .touchUpInside)
         plusButton.accessibilityIdentifier = "bottomBarPlusButton"
+        plusButton.accessibilityLabel = "conversation_list.voiceover.bottom_bar.contacts_button.label".localized
+        plusButton.accessibilityHint = "conversation_list.voiceover.bottom_bar.contacts_button.hint".localized
 
         composeButton.setIcon(.compose, with: .tiny, for: .normal)
         composeButton.addTarget(self, action: #selector(composeButtonTapped), for: .touchUpInside)
         composeButton.accessibilityIdentifier = "bottomBarComposeButton"
+        composeButton.accessibilityLabel = "conversation_list.voiceover.bottom_bar.compose_button.label".localized
+        composeButton.accessibilityHint = "conversation_list.voiceover.bottom_bar.compose_button.hint".localized
 
         cameraButton.setIcon(.cameraLens, with: .tiny, for: .normal)
         cameraButton.addTarget(self, action: #selector(cameraButtonTapped), for: .touchUpInside)
         cameraButton.accessibilityIdentifier = "bottomBarCameraButton"
+        cameraButton.accessibilityLabel = "conversation_list.voiceover.bottom_bar.camera_button.label".localized
+        cameraButton.accessibilityHint = "conversation_list.voiceover.bottom_bar.camera_button.hint".localized
 
         addSubviews()
         [separator, archivedButton].forEach{ $0.isHidden = true }

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationTitleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationTitleView.swift
@@ -86,8 +86,10 @@ public final class ConversationTitleView: UIView {
     private func updateAccessibilityValue(_ conversation: ZMConversation) {
         if conversation.securityLevel == .secure {
             self.accessibilityLabel = conversation.displayName.uppercased() + ", " + "conversation.voiceover.verified".localized
+            self.accessibilityIdentifier = conversation.displayName.uppercased() + " - verified fingerprints"
         } else {
             self.accessibilityLabel = conversation.displayName.uppercased()
+            self.accessibilityIdentifier = conversation.displayName.uppercased()
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationTitleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationTitleView.swift
@@ -31,7 +31,8 @@ public final class ConversationTitleView: UIView {
     init(conversation: ZMConversation, interactive: Bool = true) {
         super.init(frame: CGRect.zero)
         self.isAccessibilityElement = true
-        self.accessibilityLabel = "Name"
+        self.accessibilityLabel = conversation.displayName
+        self.accessibilityIdentifier = "Name"
         createViews(conversation)
         CASStyler.default().styleItem(self)
 
@@ -83,8 +84,11 @@ public final class ConversationTitleView: UIView {
     }
     
     private func updateAccessibilityValue(_ conversation: ZMConversation) {
-        let verifiedString = (conversation.securityLevel == .secure) ? " - verified fingerprints" : ""
-        self.accessibilityValue = conversation.displayName.uppercased() + verifiedString
+        if conversation.securityLevel == .secure {
+            self.accessibilityLabel = conversation.displayName.uppercased() + ", " + "conversation.voiceover.verified".localized
+        } else {
+            self.accessibilityLabel = conversation.displayName.uppercased()
+        }
     }
     
     private func createConstraints(_ hasAttachment: Bool) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -551,6 +551,12 @@
 
 #pragma mark - Application Events & Notifications
 
+- (BOOL)accessibilityPerformEscape
+{
+    [self openConversationList];
+    return YES;
+}
+
 - (void)onBackButtonPressed:(UIButton *)backButton
 {
     [self openConversationList];

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListTopBar.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListTopBar.swift
@@ -112,6 +112,7 @@ final class ConversationListTopBar: TopBar {
                 titleLabel.textColor = ColorScheme.default().color(withName: ColorSchemeColorTextForeground,
                                                                    variant: .dark)
                 titleLabel.text = "list.title".localized.uppercased()
+                titleLabel.accessibilityTraits = UIAccessibilityTraitHeader
                 titleLabel.setContentCompressionResistancePriority(UILayoutPriorityRequired, for: .horizontal)
                 titleLabel.setContentCompressionResistancePriority(UILayoutPriorityRequired, for: .vertical)
                 titleLabel.setContentHuggingPriority(UILayoutPriorityRequired, for: .horizontal)

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+TopBar.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+TopBar.swift
@@ -35,7 +35,9 @@ extension ConversationListViewController {
         if let imageView = profileButton.imageView, let user = ZMUser.selfUser() {
             let newDevicesDot = NewDevicesDot(user: user)
             profileButton.addSubview(newDevicesDot)
-            profileButton.accessibilityLabel = "self.new-device.voiceover.label".localized
+            if user.clientsRequiringUserAttention.count > 0 {
+                profileButton.accessibilityLabel = "self.new-device.voiceover.label".localized
+            }
             
             constrain(newDevicesDot, imageView) { newDevicesDot, imageView in
                 newDevicesDot.top == imageView.top - 3

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+TopBar.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+TopBar.swift
@@ -29,10 +29,13 @@ extension ConversationListViewController {
         profileButton.addTarget(self, action: #selector(presentSettings), for: .touchUpInside)
         profileButton.accessibilityIdentifier = "bottomBarSettingsButton"
         profileButton.setIconColor(.white, for: .normal)
+        profileButton.accessibilityLabel = "self.voiceover.label".localized
+        profileButton.accessibilityHint = "self.voiceover.hint".localized
         
         if let imageView = profileButton.imageView, let user = ZMUser.selfUser() {
             let newDevicesDot = NewDevicesDot(user: user)
             profileButton.addSubview(newDevicesDot)
+            profileButton.accessibilityLabel = "self.new-device.voiceover.label".localized
             
             constrain(newDevicesDot, imageView) { newDevicesDot, imageView in
                 newDevicesDot.top == imageView.top - 3

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListAccessoryView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListAccessoryView.swift
@@ -86,11 +86,11 @@ final internal class ConversationListAccessoryView: UIView {
         switch self.icon {
         case .pendingConnection:
             iconView.image = UIImage(for: .clock, fontSize: iconSize, color: .white)
-            self.accessibilityValue = "pending connection"
+            self.accessibilityValue = "conversation_list.voiceover.status.pending_connection".localized
             return iconView
         case .activeCall(true):
             iconView.image = UIImage(for: .phone, fontSize: iconSize, color: .white)
-            self.accessibilityValue = "active call"
+            self.accessibilityValue = "conversation_list.voiceover.status.active_call".localized
             return iconView
         case .activeCall(false):
             textLabel.text = "conversation_list.right_accessory.join_button.title".localized.uppercased()
@@ -98,24 +98,24 @@ final internal class ConversationListAccessoryView: UIView {
             return textLabel
         case .missedCall:
             iconView.image = UIImage(for: .endCall, fontSize: iconSize, color: .black)
-            self.accessibilityValue = "missed call"
+            self.accessibilityValue = "conversation_list.voiceover.status.missed_call".localized
             return iconView
         case .playingMedia:
             if let mediaPlayer = self.mediaPlaybackManager.activeMediaPlayer, mediaPlayer.state == .playing {
                 iconView.image = UIImage(for: .pause, fontSize: iconSize, color: .white)
-                self.accessibilityValue = "pause media"
+                self.accessibilityValue = "conversation_list.voiceover.status.pause_media".localized
             }
             else {
                 iconView.image = UIImage(for: .play, fontSize: iconSize, color: .white)
-                self.accessibilityValue = "play media"
+                self.accessibilityValue = "conversation_list.voiceover.status.play_media".localized
             }
             return iconView
         case .silenced:
             iconView.image = UIImage(for: .bellWithStrikethrough, fontSize: iconSize, color: .white)
-            self.accessibilityValue = "silenced"
+            self.accessibilityValue = "conversation_list.voiceover.status.silenced".localized
             return iconView
         case .typing:
-            self.accessibilityValue = "typing"
+            self.accessibilityValue = "conversation_list.voiceover.status.typing".localized
             return .none
         case .unreadMessages(let count):
             textLabel.text = String(count)
@@ -123,7 +123,7 @@ final internal class ConversationListAccessoryView: UIView {
             return textLabel
         case .unreadPing:
             iconView.image = UIImage(for: .ping, fontSize: iconSize, color: .black)
-            self.accessibilityValue = "ping"
+            self.accessibilityValue = "conversation_list.voiceover.status.ping".localized
             return iconView
         default:
             return .none

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListAccessoryView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListAccessoryView.swift
@@ -87,10 +87,12 @@ final internal class ConversationListAccessoryView: UIView {
         case .pendingConnection:
             iconView.image = UIImage(for: .clock, fontSize: iconSize, color: .white)
             self.accessibilityValue = "conversation_list.voiceover.status.pending_connection".localized
+            self.accessibilityIdentifier = "pending"
             return iconView
         case .activeCall(true):
             iconView.image = UIImage(for: .phone, fontSize: iconSize, color: .white)
             self.accessibilityValue = "conversation_list.voiceover.status.active_call".localized
+            self.accessibilityIdentifier = "active call"
             return iconView
         case .activeCall(false):
             textLabel.text = "conversation_list.right_accessory.join_button.title".localized.uppercased()
@@ -99,23 +101,28 @@ final internal class ConversationListAccessoryView: UIView {
         case .missedCall:
             iconView.image = UIImage(for: .endCall, fontSize: iconSize, color: .black)
             self.accessibilityValue = "conversation_list.voiceover.status.missed_call".localized
+            self.accessibilityIdentifier = "missed call"
             return iconView
         case .playingMedia:
             if let mediaPlayer = self.mediaPlaybackManager.activeMediaPlayer, mediaPlayer.state == .playing {
                 iconView.image = UIImage(for: .pause, fontSize: iconSize, color: .white)
                 self.accessibilityValue = "conversation_list.voiceover.status.pause_media".localized
+                self.accessibilityIdentifier = "pause media"
             }
             else {
                 iconView.image = UIImage(for: .play, fontSize: iconSize, color: .white)
                 self.accessibilityValue = "conversation_list.voiceover.status.play_media".localized
+                self.accessibilityIdentifier = "play media"
             }
             return iconView
         case .silenced:
             iconView.image = UIImage(for: .bellWithStrikethrough, fontSize: iconSize, color: .white)
             self.accessibilityValue = "conversation_list.voiceover.status.silenced".localized
+            self.accessibilityIdentifier = "silenced"
             return iconView
         case .typing:
             self.accessibilityValue = "conversation_list.voiceover.status.typing".localized
+            self.accessibilityIdentifier = "typing"
             return .none
         case .unreadMessages(let count):
             textLabel.text = String(count)
@@ -124,6 +131,7 @@ final internal class ConversationListAccessoryView: UIView {
         case .unreadPing:
             iconView.image = UIImage(for: .ping, fontSize: iconSize, color: .black)
             self.accessibilityValue = "conversation_list.voiceover.status.ping".localized
+            self.accessibilityIdentifier = "ping"
             return iconView
         default:
             return .none

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListCell.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListCell.m
@@ -105,6 +105,8 @@ static const NSTimeInterval OverscrollRatio = 2.5;
     if (![[Settings sharedSettings] disableAVS]) {
         [AVSMediaManagerClientChangeNotification addObserver:self];
     }
+    
+    self.isAccessibilityElement = NO;
 }
 
 - (void)setVisualDrawerOffset:(CGFloat)visualDrawerOffset updateUI:(BOOL)doUpdate

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListItemView+Update.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListItemView+Update.swift
@@ -26,6 +26,7 @@ extension ConversationListItemView {
     internal func configure(with title: String, subtitle: NSAttributedString) {
         self.titleText = title
         self.subtitleAttributedText = subtitle
+        self.accessibilityContentsDidChange()
     }
     
     internal func configure(with title: String, subtitle: NSAttributedString, users: [ZMUser]) {
@@ -34,6 +35,7 @@ extension ConversationListItemView {
         self.rightAccessory.icon = .pendingConnection
         self.avatarView.conversation = .none
         self.avatarView.users = users
+        self.accessibilityContentsDidChange()
     }
     
     @objc(updateForConversation:)

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListItemView.h
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListItemView.h
@@ -41,5 +41,6 @@ FOUNDATION_EXPORT NSString * const ConversationListItemDidScrollNotification;
 @property (nonatomic, assign) CGFloat visualDrawerOffset;
 
 - (void)setVisualDrawerOffset:(CGFloat)visualDrawerOffset notify:(BOOL)notify;
+- (void)accessibilityContentsDidChange;
 
 @end

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListItemView.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListItemView.m
@@ -98,7 +98,7 @@ NSString * const ConversationListItemDidScrollNotification = @"ConversationListI
     [self.avatarContainer addSubview:self.avatarView];
 
     self.rightAccessory = [[ConversationListAccessoryView alloc] initWithMediaPlaybackManager:[AppDelegate sharedAppDelegate].mediaPlaybackManager];
-    self.rightAccessory.accessibilityLabel = @"status";
+    self.rightAccessory.accessibilityIdentifier = @"status";
     [self addSubview:self.rightAccessory];
 
     [self createSubtitleField];
@@ -131,7 +131,7 @@ NSString * const ConversationListItemDidScrollNotification = @"ConversationListI
 {
     self.subtitleField = [[UILabel alloc] initForAutoLayout];
     self.subtitleField.textColor = [UIColor colorWithWhite:1.0f alpha:0.64f];
-    self.subtitleField.accessibilityLabel = @"Conversation status";
+    self.subtitleField.accessibilityIdentifier = @"Conversation status";
     self.subtitleField.numberOfLines = 1;
     [self.labelsContainer addSubview:self.subtitleField];
 }
@@ -221,7 +221,7 @@ NSString * const ConversationListItemDidScrollNotification = @"ConversationListI
 - (void)accessibilityContentsDidChange
 {
     self.labelsContainer.accessibilityLabel = self.titleField.text;
-    self.labelsContainer.accessibilityHint = @"Open conversation";
+    self.labelsContainer.accessibilityHint = NSLocalizedString(@"conversation_list.voiceover.open_conversation.hint", nil);
     self.labelsContainer.accessibilityValue = self.subtitleField.text;
 }
 

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListItemView.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListItemView.m
@@ -81,6 +81,8 @@ NSString * const ConversationListItemDidScrollNotification = @"ConversationListI
 {
     self.labelsContainer = [[UIView alloc] initForAutoLayout];
     [self addSubview:self.labelsContainer];
+    self.labelsContainer.isAccessibilityElement = YES;
+    self.labelsContainer.accessibilityTraits = UIAccessibilityTraitButton;
     
     self.titleField = [[UILabel alloc] initForAutoLayout];
     self.titleField.numberOfLines = 1;
@@ -122,6 +124,7 @@ NSString * const ConversationListItemDidScrollNotification = @"ConversationListI
                                              selector:@selector(otherConversationListItemDidScroll:)
                                                  name:ConversationListItemDidScrollNotification
                                                object:nil];
+    self.isAccessibilityElement = NO;
 }
 
 - (void)createSubtitleField
@@ -213,6 +216,13 @@ NSString * const ConversationListItemDidScrollNotification = @"ConversationListI
 - (void)updateAppearance
 {
     self.titleField.text = self.titleText;
+}
+
+- (void)accessibilityContentsDidChange
+{
+    self.labelsContainer.accessibilityLabel = self.titleField.text;
+    self.labelsContainer.accessibilityHint = @"Open conversation";
+    self.labelsContainer.accessibilityValue = self.subtitleField.text;
 }
 
 #pragma mark - Observer


### PR DESCRIPTION
Navigating the app using voice over is pretty broken at the moment. We would like to have the basics working so we could improve it in the future.

This PR includes part of the basic flow fixes, mainly focused on conversation list:

* Added descriptive labels for conversations and statuses
* Added labels for profile and all bottom bar buttons
* Supporting "two finger Z" gesture to go back to conversation list
* Notify screen reader that conversation view was opened.