### PR TITLE
Fixed menu with block for team accounts

### DIFF
--- a/Wire-iOS/Sources/Helpers/syncengine/ZMConversation+Actions.m
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMConversation+Actions.m
@@ -49,10 +49,12 @@ NSString * const ConversationActionUnblockUser = @"ConversationActionUnblockUser
 {
     NSMutableOrderedSet *actions = [NSMutableOrderedSet orderedSet];
 
-    if (self.connectedUser.isBlocked) {
-        [actions addObject:ConversationActionUnblockUser];
-    } else {
-        [actions addObject:ConversationActionBlockUser];
+    if (nil == self.team) {
+        if (self.connectedUser.isBlocked) {
+            [actions addObject:ConversationActionUnblockUser];
+        } else {
+            [actions addObject:ConversationActionBlockUser];
+        }
     }
 
     [actions addObjectsFromArray:[self availableActionsForConversation].array];

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileDetailsViewController.m
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileDetailsViewController.m
@@ -202,18 +202,18 @@ typedef NS_ENUM(NSUInteger, ProfileUserAction) {
         footerView = sendConnectionRequestFooterView;
     }
     else {
-        ProfileFooterView *userActionsfooterView = [[ProfileFooterView alloc] init];
-        userActionsfooterView.translatesAutoresizingMaskIntoConstraints = NO;
+        ProfileFooterView *userActionsFooterView = [[ProfileFooterView alloc] init];
+        userActionsFooterView.translatesAutoresizingMaskIntoConstraints = NO;
         [[Analytics shared]tagScreen:@"OTHER_USER_PROFILE"];
         
-        [userActionsfooterView setIconTypeForLeftButton:[self iconTypeForUserAction:[self leftButtonAction]]];
-        [userActionsfooterView setIconTypeForRightButton:[self iconTypeForUserAction:[self rightButtonAction]]];
-        [userActionsfooterView.leftButton setTitle:[[self buttonTextForUserAction:[self leftButtonAction]] uppercasedWithCurrentLocale] forState:UIControlStateNormal];
+        [userActionsFooterView setIconTypeForLeftButton:[self iconTypeForUserAction:[self leftButtonAction]]];
+        [userActionsFooterView setIconTypeForRightButton:[self iconTypeForUserAction:[self rightButtonAction]]];
+        [userActionsFooterView.leftButton setTitle:[[self buttonTextForUserAction:[self leftButtonAction]] uppercasedWithCurrentLocale] forState:UIControlStateNormal];
         
-        [userActionsfooterView.leftButton addTarget:self action:@selector(performLeftButtonAction:) forControlEvents:UIControlEventTouchUpInside];
-        [userActionsfooterView.rightButton addTarget:self action:@selector(performRightButtonAction:) forControlEvents:UIControlEventTouchUpInside];
+        [userActionsFooterView.leftButton addTarget:self action:@selector(performLeftButtonAction:) forControlEvents:UIControlEventTouchUpInside];
+        [userActionsFooterView.rightButton addTarget:self action:@selector(performRightButtonAction:) forControlEvents:UIControlEventTouchUpInside];
         
-        footerView = userActionsfooterView;
+        footerView = userActionsFooterView;
     }
     
     [self.view addSubview:footerView];
@@ -347,6 +347,9 @@ typedef NS_ENUM(NSUInteger, ProfileUserAction) {
         else {
             return ProfileUserActionPresentMenu;
         }
+    }
+    else if (nil != user.team) {
+        return ProfileUserActionPresentMenu;
     }
     else {
         return ProfileUserActionNone;


### PR DESCRIPTION
# Issues fixed

1. The team account does not have the "..." right footer button in the profile view.
2. The team account does have the block button in the context menu, it should be removed since there is no connection between the team users, and the block therefore is not possible from the BE perspective.