### PR TITLE
Markdown/design fix

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Views/MarklightTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/MarklightTextView.swift
@@ -74,13 +74,17 @@ public class MarklightTextView: NextResponderTextView {
 
     class func defaultMarkdownStyle() -> MarklightStyle {
         
+        let defaultFont = FontSpec(.normal, .light).font!
         let colorScheme = ColorScheme.default()
         let style = MarklightStyle()
+        
         style.syntaxAttributes = [NSForegroundColorAttributeName: colorScheme.accentColor]
+        style.italicAttributes = [NSFontAttributeName: defaultFont.setItalic()]
         style.codeAttributes[NSForegroundColorAttributeName] = colorScheme.color(withName: ColorSchemeColorTextForeground)
         style.blockQuoteAttributes[NSForegroundColorAttributeName] = colorScheme.color(withName: ColorSchemeColorTextForeground)
         style.fontTextStyle = UIFontTextStyle.subheadline.rawValue
         style.hideSyntax = false
+        
         return style
     }
     

--- a/Wire-iOS/Sources/UserInterface/Components/Views/MarklightTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/MarklightTextView.swift
@@ -79,7 +79,7 @@ public class MarklightTextView: NextResponderTextView {
         let style = MarklightStyle()
         
         style.syntaxAttributes = [NSForegroundColorAttributeName: colorScheme.accentColor]
-        style.italicAttributes = [NSFontAttributeName: defaultFont.setItalic()]
+        style.italicAttributes = [NSFontAttributeName: defaultFont.italicFont()]
         style.codeAttributes[NSForegroundColorAttributeName] = colorScheme.color(withName: ColorSchemeColorTextForeground)
         style.blockQuoteAttributes[NSForegroundColorAttributeName] = colorScheme.color(withName: ColorSchemeColorTextForeground)
         style.fontTextStyle = UIFontTextStyle.subheadline.rawValue

--- a/Wire-iOS/Sources/UserInterface/Components/Views/PopUpIconButtonView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/PopUpIconButtonView.swift
@@ -32,10 +32,8 @@ class PopUpIconButtonView: UIView {
     private let upperRect: CGRect
     private let itemWidth: CGFloat
     
-    private let selectionColor = ColorScheme.default().accentColor
-    private let normalIconColor = ColorScheme.default().color(withName: ColorSchemeColorIconNormal)
+    private let color = ColorScheme.default().color(withName:)
     private let expandDirection: PopUpIconButtonExpandDirection
-    
     
     init(withButton button: PopUpIconButton) {
         self.button = button
@@ -89,29 +87,31 @@ class PopUpIconButtonView: UIView {
         context.saveGState()
         
         // overlay shadow
-        let color = UIColor.gray.cgColor
+        let shadowColor = color(ColorSchemeColorPopUpButtonOverlayShadow).cgColor
         let offset = CGSize(width: 0.0, height: 2.0)
         let blurRadius: CGFloat = 4.0
-        context.setShadow(offset: offset, blur: blurRadius, color: color)
+        context.setShadow(offset: offset, blur: blurRadius, color: shadowColor)
         
         // overlay fill
-        UIColor.white.set()
+        color(ColorSchemeColorBarBackground).set()
         path.fill()
         
         context.restoreGState()
         
         // button icon
-        if let buttonImage = button.imageView?.image {
+        if let imageView = button.imageView {
             // rect in window coordinates
-            let imageRect = button.imageView!.convert(button.imageView!.bounds, to: nil)
-            buttonImage.draw(in: imageRect)
+            let imageRect = imageView.convert(button.imageView!.bounds, to: nil)
+            let image = UIImage(for: button.iconType(for: .normal), iconSize: .tiny, color: color(ColorSchemeColorIconNormal))!
+            image.draw(in: imageRect)
         }
         
         // item icons
         if let buttonImageView = button.imageView {
             for (index, icon) in button.itemIcons.enumerated() {
                 let itemRect = rectForItem(icon)!
-                let image = UIImage(for: icon, iconSize: .medium, color: index == selectedIndex ? selectionColor : normalIconColor)!
+                let iconColor = index == selectedIndex ? color(ColorSchemeColorAccent) : color(ColorSchemeColorIconNormal)
+                let image = UIImage(for: icon, iconSize: .medium, color: iconColor)!
                 // rect in window coordinates
                 var imageRect = buttonImageView.convert(buttonImageView.bounds, to: nil)
                 // center image in item rect

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/Message+Formatting.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/Message+Formatting.m
@@ -181,6 +181,9 @@ static inline NSDataDetector *linkDataDetector(void)
         paragraphStyle.paragraphSpacingBefore = 24.0;
         paragraphStyle.paragraphSpacing = 12.0;
         
+        UIFont *italicFont = [[UIFont systemFontOfSize:16.0 weight:UIFontWeightLight] setItalic];
+        style.italicAttributes = @{NSFontAttributeName: italicFont};
+        
         NSMutableDictionary *h1HeaderAttributes = [[NSMutableDictionary alloc] initWithDictionary:style.h1HeadingAttributes];
         [h1HeaderAttributes setValue:paragraphStyle forKey:NSParagraphStyleAttributeName];
         style.h1HeadingAttributes = h1HeaderAttributes;

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/Message+Formatting.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/Message+Formatting.m
@@ -181,7 +181,7 @@ static inline NSDataDetector *linkDataDetector(void)
         paragraphStyle.paragraphSpacingBefore = 24.0;
         paragraphStyle.paragraphSpacing = 12.0;
         
-        UIFont *italicFont = [[UIFont systemFontOfSize:16.0 weight:UIFontWeightLight] setItalic];
+        UIFont *italicFont = [[UIFont systemFontOfSize:16.0 weight:UIFontWeightLight] italicFont];
         style.italicAttributes = @{NSFontAttributeName: italicFont};
         
         NSMutableDictionary *h1HeaderAttributes = [[NSMutableDictionary alloc] initWithDictionary:style.h1HeadingAttributes];

--- a/WireExtensionComponents/Utilities/ColorScheme.h
+++ b/WireExtensionComponents/Utilities/ColorScheme.h
@@ -41,6 +41,8 @@ extern NSString * const ColorSchemeColorIconBackgroundSelectedNoAccent;
 extern NSString * const ColorSchemeColorIconShadow;
 extern NSString * const ColorSchemeColorIconHighlight;
 
+extern NSString * const ColorSchemeColorPopUpButtonOverlayShadow;
+
 extern NSString * const ColorSchemeColorTabNormal;
 extern NSString * const ColorSchemeColorTabSelected;
 extern NSString * const ColorSchemeColorTabHighlighted;

--- a/WireExtensionComponents/Utilities/ColorScheme.m
+++ b/WireExtensionComponents/Utilities/ColorScheme.m
@@ -45,6 +45,8 @@ NSString * const ColorSchemeColorIconHighlighted = @"icon-highlighted";
 NSString * const ColorSchemeColorIconBackgroundSelected = @"icon-background-selected";
 NSString * const ColorSchemeColorIconBackgroundSelectedNoAccent = @"icon-background-selected-no-accent";
 
+NSString * const ColorSchemeColorPopUpButtonOverlayShadow = @"popup-button-overlay-shadow";
+
 NSString * const ColorSchemeColorButtonHighlighted = @"button-highlighted";
 NSString * const ColorSchemeColorButtonEmptyText = @"button-empty-text";
 
@@ -253,6 +255,7 @@ static NSString* light(NSString *colorString) {
                                    ColorSchemeColorIconHighlight: white,
                                    ColorSchemeColorIconBackgroundSelected: accentColor,
                                    ColorSchemeColorIconBackgroundSelectedNoAccent: graphite,
+                                   ColorSchemeColorPopUpButtonOverlayShadow: blackAlpha24,
                                    ColorSchemeColorButtonHighlighted: whiteAlpha24,
                                    ColorSchemeColorButtonEmptyText: accentColor,
                                    ColorSchemeColorTabNormal: blackAlpha48,
@@ -303,6 +306,7 @@ static NSString* light(NSString *colorString) {
                                   ColorSchemeColorIconHighlight: whiteAlpha16,
                                   ColorSchemeColorIconBackgroundSelected: white,
                                   ColorSchemeColorIconBackgroundSelectedNoAccent: white,
+                                  ColorSchemeColorPopUpButtonOverlayShadow: black,
                                   ColorSchemeColorButtonHighlighted: blackAlpha24,
                                   ColorSchemeColorButtonEmptyText: white,
                                   ColorSchemeColorTabNormal: lightGraphite,

--- a/WireExtensionComponents/Utilities/FontScheme.swift
+++ b/WireExtensionComponents/Utilities/FontScheme.swift
@@ -95,7 +95,7 @@ extension UIFont {
         return fontDescriptor.symbolicTraits.contains(.traitItalic)
     }
     
-    public func setItalic() -> UIFont {
+    public func italicFont() -> UIFont {
         
         if isItalic {
             return self

--- a/WireExtensionComponents/Utilities/FontScheme.swift
+++ b/WireExtensionComponents/Utilities/FontScheme.swift
@@ -90,6 +90,28 @@ extension UIFont {
     }
 }
 
+extension UIFont {
+    public var isItalic: Bool {
+        return fontDescriptor.symbolicTraits.contains(.traitItalic)
+    }
+    
+    public func setItalic() -> UIFont {
+        
+        if isItalic {
+            return self
+        } else {
+            var symbolicTraits = fontDescriptor.symbolicTraits
+            symbolicTraits.insert([.traitItalic])
+            
+            if let newFontDescriptor = fontDescriptor.withSymbolicTraits(symbolicTraits) {
+                return UIFont(descriptor: newFontDescriptor, size: pointSize)
+            } else {
+                return self
+            }
+        }
+    }
+}
+
 public struct FontSpec {
     public let size: FontSize
     public let weight: FontWeight?


### PR DESCRIPTION
## What's in this PR?

Some minor design fixes for the markdown feature.

### Fixed:
- italic font weight should be `light`
- header popup button overlay renders incorrect color for dark mode