### PR TITLE
obey link preview setting within share extension

### DIFF
--- a/Wire-iOS Share Extension/UnsentSendable.swift
+++ b/Wire-iOS Share Extension/UnsentSendable.swift
@@ -78,7 +78,8 @@ class UnsentTextSendable: UnsentSendableBase, UnsentSendable {
     func send(completion: @escaping (Sendable?) -> Void) {
         sharingSession.enqueue { [weak self] in
             guard let `self` = self else { return }
-            completion(self.conversation.appendTextMessage(self.text, fetchLinkPreview: true))
+            let fetchPreview = !ExtensionSettings.shared.disableLinkPreviews
+            completion(self.conversation.appendTextMessage(self.text, fetchLinkPreview: fetchPreview))
         }
     }
 

--- a/Wire-iOS/Sources/Components/Settings.m
+++ b/Wire-iOS/Sources/Components/Settings.m
@@ -169,6 +169,7 @@ NSString * const UserDefaultDisableLinkPreviews = @"DisableLinkPreviews";
     if (! [self.defaults boolForKey:UserDefaultDidMigrateHockeySettingInitially]) {
         ExtensionSettings.shared.disableHockey = self.disableHockey;
         ExtensionSettings.shared.disableCrashAndAnalyticsSharing = self.disableAnalytics;
+        ExtensionSettings.shared.disableLinkPreviews = self.disableLinkPreviews;
         [self.defaults setBool:YES forKey:UserDefaultDidMigrateHockeySettingInitially];
     }
 }
@@ -418,6 +419,8 @@ NSString * const UserDefaultDisableLinkPreviews = @"DisableLinkPreviews";
 - (void)setDisableLinkPreviews:(BOOL)disableLinkPreviews
 {
     [self.defaults setBool:disableLinkPreviews forKey:UserDefaultDisableLinkPreviews];
+    ExtensionSettings.shared.disableLinkPreviews = disableLinkPreviews;
+    [self.defaults synchronize];
 }
 
 #pragma mark - Features disable keys

--- a/WireExtensionComponents/Utilities/ExtensionSettings.swift
+++ b/WireExtensionComponents/Utilities/ExtensionSettings.swift
@@ -24,6 +24,7 @@ private enum ExtensionSettingsKey: String {
 
     case disableHockey = "disableHockey"
     case disableCrashAndAnalyticsSharing = "disableCrashAndAnalyticsSharing"
+    case disableLinkPreviews = "disableLinkPreviews"
 
     static var all: [ExtensionSettingsKey] {
         return [
@@ -38,6 +39,7 @@ private enum ExtensionSettingsKey: String {
         // into the shared settings (which is only done from the main app).
         case .disableHockey: return true
         case .disableCrashAndAnalyticsSharing: return true
+        case .disableLinkPreviews: return false
         }
     }
 
@@ -97,4 +99,13 @@ public class ExtensionSettings: NSObject {
         }
     }
     
+    public var disableLinkPreviews: Bool {
+        get {
+            return defaults?.bool(forKey: ExtensionSettingsKey.disableLinkPreviews.rawValue) ?? false
+        }
+        
+        set {
+            defaults?.set(newValue, forKey: ExtensionSettingsKey.disableLinkPreviews.rawValue)
+        }
+    }
 }


### PR DESCRIPTION
## Fixed:
- disable link preview setting not considered when sharing link from the share extension