### PR TITLE
Bump AVS to 3.5.41. Fall-back for mix-up between group and 1:1 call s…

### DIFF
--- a/avs-versions
+++ b/avs-versions
@@ -17,4 +17,4 @@
 # along with this program. If not, see http://www.gnu.org/licenses/.
 #
 
-export APPSTORE_AVS_VERSION=3.5.40
+export APPSTORE_AVS_VERSION=3.5.41


### PR DESCRIPTION
…cenarios.