### PR TITLE
Fix/markdown emoji zios 8862

### DIFF
--- a/Wire-iOS Tests/MarklightTextViewTests.swift
+++ b/Wire-iOS Tests/MarklightTextViewTests.swift
@@ -302,14 +302,44 @@ class MarklightTextViewTests: XCTestCase {
     // MARK: - Emoji
     
     func testThatItStripsMarkdownSyntaxForMarkdownContainingOnlyEmojis() {
-        XCTFail()
+        
+        let emojiStrings = ["😂", "😂       👩🏻‍🏫  ", "  😂  👩🏻‍🏫    🐵  ", "😂👩🏻‍🏫", "   🐵🐵🐵  ", "👩🏻‍🎤  🐵🐵", "👨🏻‍🍳 👨🏻‍🍳 👨🏻‍🍳"]
+        
+        emojiStrings.forEach { emojiStr in
+            
+            var stringsToTest = [String]()
+            ["# ", "## ", "### "].forEach { stringsToTest.append("\($0)\(emojiStr)") }
+            ["*", "_", "**", "__", "`"].forEach { stringsToTest.append("\($0)\(emojiStr)\($0)") }
+            
+            for str in stringsToTest {
+                // given
+                sut.text = ""
+                sut.insertText(str)
+                
+                // then
+                XCTAssertEqual(sut.preparedText, emojiStr.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines))
+            }
+        }
     }
     
     func testThatItStripsMarkdownSyntaxForNestedMarkdownContainingOnlyEmojis() {
-        XCTFail()
+        
+        // given
+        sut.text = ""
+        sut.insertText("# ** _😂_ 👩🏻‍🏫 _🐵🐵_ **")
+        
+        // then
+        XCTAssertEqual(sut.preparedText, "😂 👩🏻‍🏫 🐵🐵")
     }
     
     func testThatItDoesNotStripMarkdownForListItemsContainingOnlyEmojis() {
-        XCTFail()
+        
+        // given
+        let str = ["1. 😂", "2. 👩🏻‍🏫😂", "- 🐵", "* 👩🏻‍🎤👩🏻‍🎤", "+ 👨🏻‍🍳 👨🏻‍🍳 👨🏻‍🍳"].joined(separator: "\n")
+        sut.text = ""
+        sut.insertText(str)
+        
+        // then
+        XCTAssertEqual(sut.preparedText, str)
     }
 }

--- a/Wire-iOS Tests/MarklightTextViewTests.swift
+++ b/Wire-iOS Tests/MarklightTextViewTests.swift
@@ -34,7 +34,7 @@ class MarklightTextViewTests: XCTestCase {
         super.tearDown()
     }
     
-    // MARK: Syntax Insertions
+    // MARK: - Syntax Insertions
     
     func testThatItInsertsH1HeaderSyntax() {
         // given
@@ -124,7 +124,7 @@ class MarklightTextViewTests: XCTestCase {
         XCTAssertEqual(sut.text, "- example")
     }
     
-    // MARK: Syntax Deletions
+    // MARK: - Syntax Deletions
     
     func testThatItDeletesH1HeaderSyntax() {
         // given
@@ -297,5 +297,37 @@ class MarklightTextViewTests: XCTestCase {
         
         // then
         XCTAssertEqual(result, "")
+    }
+    
+    // MARK: - Emoji
+    
+    func testThatItStripsMarkdownSyntaxForMarkdownContainingOnlyEmojis() {
+        XCTFail()
+    }
+    
+    func testThatItStripsMarkdownSyntaxForNestedMarkdownContainingOnlyEmojis() {
+        XCTFail()
+    }
+    
+    func testThatItDoesNotStripMarkdownForListItemsContainingOnlyEmojis() {
+        XCTFail()
+    }
+    
+    // MARK: - Range Calculations
+    
+    func testThatItCalculatesRangesForEmptyMarkdown() {
+        XCTFail()
+    }
+    
+    func testThatItCalculatesRangesForLeadingAndTrailingWhiteSpaceInMarkdown() {
+        XCTFail()
+    }
+    
+    func testThatItCalculatesRangesOfMarkdownContainingOnlyEmojis() {
+        XCTFail()
+    }
+    
+    func testThatItFlattensRanges() {
+        XCTFail()
     }
 }

--- a/Wire-iOS Tests/MarklightTextViewTests.swift
+++ b/Wire-iOS Tests/MarklightTextViewTests.swift
@@ -312,22 +312,4 @@ class MarklightTextViewTests: XCTestCase {
     func testThatItDoesNotStripMarkdownForListItemsContainingOnlyEmojis() {
         XCTFail()
     }
-    
-    // MARK: - Range Calculations
-    
-    func testThatItCalculatesRangesForEmptyMarkdown() {
-        XCTFail()
-    }
-    
-    func testThatItCalculatesRangesForLeadingAndTrailingWhiteSpaceInMarkdown() {
-        XCTFail()
-    }
-    
-    func testThatItCalculatesRangesOfMarkdownContainingOnlyEmojis() {
-        XCTFail()
-    }
-    
-    func testThatItFlattensRanges() {
-        XCTFail()
-    }
 }


### PR DESCRIPTION
## Problems
- when sending markdown that only contains emojis, the emojis are rendered as normal text size, however they should appear large.
- trying to add an emoji to header or list markdown causes the app to crash

## Solutions:
- before sending the message, we search the string for any markdown that contains only emojis and whitespace, then we strip the markdown syntax from this token
- the app was crashing because of incompatibilities between Swift `String` ranges and `NSRange`; an emoji that is considered to be of length 1 by `String` is considered to be of length 2 by `NSString`. Thus, when the text contains at least one emoji and we convert an `NSRange` to a `String` range, we sometime encounter an out of bounds error. The solution is rely on casting the `String` to an `NSString` when deleting characters or extracting substrings.

NOTE: Swift 4 closes the bridge between these range incompatibilities, so I will refactor this code once we migrate.