### PR TITLE
Fix view snapshot inset

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.m
@@ -204,7 +204,9 @@
     }
     snapshotBackgroundView.translatesAutoresizingMaskIntoConstraints = NO;
     [self.view addSubview:snapshotBackgroundView];
-    [snapshotBackgroundView autoPinEdgeToSuperviewEdge:ALEdgeTop];
+
+    const CGFloat topBarHeight = CGRectGetMaxY(self.navigationController.navigationBar.frame);
+    [snapshotBackgroundView autoPinEdgeToSuperviewEdge:ALEdgeTop withInset:-topBarHeight];
     [snapshotBackgroundView autoPinEdgeToSuperviewEdge:ALEdgeLeading];
     [snapshotBackgroundView autoSetDimensionsToSize:[[UIScreen mainScreen] bounds].size];
     snapshotBackgroundView.alpha = 0;


### PR DESCRIPTION
# What's in this PR?

Since the introduction of `ConversationImagesViewController` the snapshot view background used by `FullscreenImageViewController` as not properly aligned anymore, leading to a visual glitch when flicking away images as it is not presented in a `UINavigationController`.