### PR TITLE
Share cryptobox button

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
@@ -231,6 +231,8 @@ import Foundation
         developerCellDescriptors.append(findUnreadConvoButton)
         let shareDatabase = SettingsShareDatabaseCellDescriptor()
         developerCellDescriptors.append(shareDatabase)
+        let shareCryptobox = SettingsShareCryptoboxCellDescriptor()
+        developerCellDescriptors.append(shareCryptobox)
         let reloadUIButton = SettingsButtonCellDescriptor(title: "Reload user interface", isDestructive: false, selectAction: SettingsCellDescriptorFactory.reloadUserInterface)
         developerCellDescriptors.append(reloadUIButton)
         

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsShareDatabaseCellDescriptor.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsShareDatabaseCellDescriptor.swift
@@ -50,3 +50,26 @@ class SettingsShareDatabaseCellDescriptor : SettingsButtonCellDescriptor {
     }
     
 }
+
+class SettingsShareCryptoboxCellDescriptor : SettingsButtonCellDescriptor {
+    
+    let documentDelegate : DocumentDelegate
+    
+    init() {
+        let documentDelegate = DocumentDelegate()
+        self.documentDelegate = documentDelegate
+        
+        super.init(title: "Share Cryptobox", isDestructive: false) { _ in
+            let fileURL = ZMUserSession.shared()!.managedObjectContext.zm_storeURL!.deletingLastPathComponent().deletingLastPathComponent().appendingPathComponent("otr")
+            let archiveURL = fileURL.appendingPathExtension("zip")
+            
+            SSZipArchive.createZipFile(atPath: archiveURL.path, withContentsOfDirectory: fileURL.path)
+            
+            let shareDatabaseDocumentController = UIDocumentInteractionController(url: archiveURL)
+            shareDatabaseDocumentController.delegate = documentDelegate
+            shareDatabaseDocumentController.presentPreview(animated: true)
+        }
+        
+    }
+    
+}


### PR DESCRIPTION
Debug button that would be only visible on the builds with the developer menu. Archives the current cryptobox state and sends it with the iOS integrated email client.