### PR TITLE
Fix flashing black screen on launch

### DIFF
--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -82,6 +82,8 @@ class AppRootViewController : UIViewController {
         
         NotificationCenter.default.addObserver(self, selector: #selector(onContentSizeCategoryChange), name: Notification.Name.UIContentSizeCategoryDidChange, object: nil)
         
+        transition(to: .headless)
+        
         enqueueTransition(to: appStateController.appState)
     }
     


### PR DESCRIPTION
On launch you would see a black screen for 0.5 second because we didn't
configure a view controller on didFinishLaunching. We can fix this by
always configuring the launch controller view controller before any
other view controller.