### PR TITLE
Fix adding locale to an URL

### DIFF
--- a/Wire-iOS Tests/NSURLWireLocaleTests.m
+++ b/Wire-iOS Tests/NSURLWireLocaleTests.m
@@ -77,4 +77,21 @@
     XCTAssertFalse([URL.absoluteString containsString:@"&&"]);
 }
 
+- (void)testThatLocaleParameterGetAppendedRightWithOtherParametersNoAndCharacter
+{
+    // given
+    NSURL *URL = [NSURL URLWithString:@"http://wire.com?test=1"];
+    
+    // when
+    NSURL *localizedURL = [URL wr_URLByAppendingLocaleParameter];
+    NSString *URLResult = [localizedURL absoluteString];
+    
+    // then
+    XCTAssertNotNil(URLResult);
+    BOOL contains = [URLResult containsString:[NSString stringWithFormat:@"&%@=", WireParameterKeyLocale]];
+    XCTAssertTrue(contains);
+    XCTAssertTrue([URLResult containsString:@"test=1"]);
+    XCTAssertFalse([URL.absoluteString containsString:@"&&"]);
+}
+
 @end

--- a/Wire-iOS/Sources/Helpers/NSURL+WireLocale.m
+++ b/Wire-iOS/Sources/Helpers/NSURL+WireLocale.m
@@ -28,10 +28,14 @@ NSString *const WireParameterKeyLocale = @"hl";
 - (instancetype)wr_URLByAppendingLocaleParameter
 {
     NSURLComponents *components = [[NSURLComponents alloc] initWithURL:self resolvingAgainstBaseURL:NO];
+    
     NSLocale *locale = [NSLocale currentLocale];
-    NSString *localeQueryString = [NSString stringWithFormat:@"%@=%@", WireParameterKeyLocale, [locale localeIdentifier]];
-    NSString *tmpQuery = (nil == components.query) ? @"": components.query;
-    components.query = [tmpQuery hasSuffix:@"&"] ? [tmpQuery stringByAppendingFormat:@"&%@", localeQueryString]: [tmpQuery stringByAppendingString:localeQueryString];
+    NSURLQueryItem *localeQueryItem = [[NSURLQueryItem alloc] initWithName:WireParameterKeyLocale value:[locale localeIdentifier]];
+    
+    NSMutableArray *newQueryItems = [[NSMutableArray alloc] initWithArray:components.queryItems];
+    [newQueryItems addObject:localeQueryItem];
+    
+    components.queryItems = newQueryItems;
     return components.URL;
 }
 


### PR DESCRIPTION
- Before we where adding the parameters per hand.
- `NSURLQueryItem` is very nice.