### PR TITLE
don't open obfuscated image

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ImageMessageCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ImageMessageCell.m
@@ -468,7 +468,9 @@ static const CGFloat ImageToolbarMinimumSize = 192;
 }
 
 - (void)imageTapped:(id)sender {
-    [self.delegate conversationCell:self didSelectAction:MessageActionPresent];
+    if (!self.message.isObfuscated) {
+        [self.delegate conversationCell:self didSelectAction:MessageActionPresent];
+    }
 }
 
 #pragma mark - Message updates


### PR DESCRIPTION
## Problem
Tapping on an obfuscated image presented a blank fullscreen image view controller with a never ending activity indicator

## Solution
When the image is tapped, only invoke the normal delegate method when the image is not obfuscated