### PR TITLE
fix/conversation-list-touch-force-ZIOS-8853

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Views/SwipeMenuCollectionCell.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/SwipeMenuCollectionCell.m
@@ -436,8 +436,17 @@ NSString * const SwipeMenuCollectionCellIDToCloseKey = @"IDToClose";
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
 {
-    // pan recognizer should not recognize simultaneously with any other recognizer
-    return ![gestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]];}
+    // NOTE: in iOS 11 with a force touch enabled device, not allowing the pan recognizer to
+    // work simulatenously with the force touch recognizer produces the correct behaviour.
+    // However in iOS 10 with the same setting, the pan recognizer blocks force touch.
+    // Therefore in iOS 10 we allow simulatneous recognition.
+    if ([[[UIDevice currentDevice] systemVersion] compare:@"11" options:NSNumericSearch] != NSOrderedAscending) {
+        // pan recognizer should not recognize simultaneously with any other recognizer
+        return ![gestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]];
+    } else {
+        return YES;
+    }
+}
 
 @end
 

--- a/Wire-iOS/Sources/UserInterface/Components/Views/SwipeMenuCollectionCell.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/SwipeMenuCollectionCell.m
@@ -423,21 +423,20 @@ NSString * const SwipeMenuCollectionCellIDToCloseKey = @"IDToClose";
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
 {
-    if (gestureRecognizer == self.revealDrawerGestureRecognizer) {
-        return YES;
-    }
-    return NO;
+    // all other recognizers require this pan recognizer to fail
+    return gestureRecognizer == self.revealDrawerGestureRecognizer;
 }
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRequireFailureOfGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
 {
-    return ![gestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]] || ![otherGestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]];
+    // pan recognizer should not be blocked by any other recognizer
+    return ![gestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]];
 }
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
 {
-    return YES;
-}
+    // pan recognizer should not recognize simultaneously with any other recognizer
+    return ![gestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]];}
 
 @end
 

--- a/Wire-iOS/Sources/UserInterface/Components/Views/SwipeMenuCollectionCell.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/SwipeMenuCollectionCell.m
@@ -175,15 +175,6 @@ NSString * const SwipeMenuCollectionCellIDToCloseKey = @"IDToClose";
     switch (pan.state) {
         case UIGestureRecognizerStateBegan:
             
-            // iOS 11 3D TOUCH WORKAROUND:
-            // We need to block force touch on the cell while panning. Since
-            // the force touch gesture recognizers are not exposed in the public
-            // API, we disable all gesture recognizers of the superview
-            // (collectionView), then re-enable when pan is finished.
-            for (UIGestureRecognizer *gr in self.superview.gestureRecognizers) {
-                gr.enabled = [gr isEqual:pan];
-            }
-            
             // reset gesture state
             [self drawerScrollingStarts];
             
@@ -204,12 +195,7 @@ NSString * const SwipeMenuCollectionCellIDToCloseKey = @"IDToClose";
         case UIGestureRecognizerStateEnded:
         case UIGestureRecognizerStateFailed:
         case UIGestureRecognizerStateCancelled:
-        {
-            // re-enable recognizers (see above)
-            for (UIGestureRecognizer *gr in self.superview.gestureRecognizers) {
-                gr.enabled = YES;
-            }
-            
+        {            
             [self drawerScrollingEndedWithOffset:offset.x];
             
             if (offset.x + self.initialDrawerOffset > self.bounds.size.width * self.overscrollFraction) { // overscrolled

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ImageMessageCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ImageMessageCell.m
@@ -468,7 +468,9 @@ static const CGFloat ImageToolbarMinimumSize = 192;
 }
 
 - (void)imageTapped:(id)sender {
-    [self.delegate conversationCell:self didSelectAction:MessageActionPresent];
+    if (!self.message.isObfuscated) {
+        [self.delegate conversationCell:self didSelectAction:MessageActionPresent];
+    }
 }
 
 #pragma mark - Message updates


### PR DESCRIPTION
## Problem
On **iOS 11**, the *peek and pop* touch force gesture is blocking the `UIPanGestureRecognizer` used to reveal a conversation cell's hidden menu.

## Solution
Force touch is managed by gesture recognizers, however these are not exposed on the public level. Previously, this `UIPanGestureRecognizer` required all other non pan gesture recognizers to fail before it can recognize a gesture. It seems that force touch is being recognized first and therefore blocking the pan recognizer. By removing the fail prerequisite, the pan can start to recognize gestures. Furthermore, the pan recognizer should not would simultaneously with any other recognizer, so we adjusted the delegate method appropriately.
