### PR TITLE
Fix crash when putting app in background while switching accounts

### DIFF
--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -189,9 +189,22 @@ class AppRootViewController : UIViewController {
         }
     }
     
+    
+    private func dismissModalsFromAllChildren(of viewController: UIViewController?) {
+        guard let viewController = viewController else { return }
+        for child in viewController.childViewControllers {
+            if child.presentedViewController != nil {
+                child.dismiss(animated: false, completion: nil)
+            }
+            dismissModalsFromAllChildren(of: child)
+        }
+    }
+    
     func transition(to viewController : UIViewController, animated : Bool = true, completionHandler: (() -> Void)? = nil) {
         
-        visibleViewController?.dismiss(animated: false, completion: nil)
+        // If we have some modal view controllers presented in any of the (grand)children
+        // of this controller they stay in memory and leak on iOS 10.
+        dismissModalsFromAllChildren(of: visibleViewController)
         visibleViewController?.willMove(toParentViewController: nil)
         
         if let previousViewController = visibleViewController, animated {

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController.m
@@ -112,6 +112,12 @@ static NSString * const CellReuseIdConversation = @"CellId";
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
+
+    // viewWillAppear: can get called also when dismissing the controller above this one.
+    // The user session might not be there anymore in some cases, e.g. when logging out
+    if ([ZMUserSession sharedSession] == nil) {
+        return;
+    }
     [self updateVisibleCells];
     
     [self scrollToCurrentSelectionAnimated:NO];

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
@@ -132,10 +132,10 @@
         [[NSNotificationCenter defaultCenter] postNotificationName:ZMUserSessionDidBecomeAvailableNotification object:nil];
         
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(contentSizeCategoryDidChange:) name:UIContentSizeCategoryDidChangeNotification object:nil];
-        [[NSNotificationCenter defaultCenter]addObserver:self selector:@selector(applicationDidBecomeActive:) name:UIApplicationDidBecomeActiveNotification object:nil];
-        [[NSNotificationCenter defaultCenter]addObserver:self selector:@selector(applicationWillResignActive:) name:UIApplicationWillResignActiveNotification object:nil];
-        [[NSNotificationCenter defaultCenter]addObserver:self selector:@selector(applicationWillEnterForeground:) name:UIApplicationWillEnterForegroundNotification object:nil];
-        [[NSNotificationCenter defaultCenter]addObserver:self selector:@selector(applicationDidEnterBackground:) name:UIApplicationDidEnterBackgroundNotification object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationDidBecomeActive:) name:UIApplicationDidBecomeActiveNotification object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationWillResignActive:) name:UIApplicationWillResignActiveNotification object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationWillEnterForeground:) name:UIApplicationWillEnterForegroundNotification object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationDidEnterBackground:) name:UIApplicationDidEnterBackgroundNotification object:nil];
     }
     return self;
 }


### PR DESCRIPTION
The reason was that ConversationListViewController was leaking after tearing down UI and UserSession. It was listening for app lifecycle notifications and was doing things with user session after coming back from background.