### PR TITLE
Fix truncated copy in Link Previews setting

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -718,7 +718,7 @@
 "self.settings.privacy_security.lock_cancelled.description" = "Unlock Wire with Touch ID or Passcode";
 "self.settings.privacy_security.lock_cancelled.action" = "Unlock";
 
-"self.settings.privacy_security.disable_link_previews.title" = "Create Previews For Links You Send";
+"self.settings.privacy_security.disable_link_previews.title" = "Create Link Previews";
 "self.settings.privacy_security.disable_link_previews.footer" = "Previews may still be shown for links from other people.";
 
 "self.settings.privacy_analytics_menu.devices.title" = "Devices";


### PR DESCRIPTION
On smaller screens (such as iPhone 5s), the current copy is cut off:

![wire-settings-copy-truncated](https://user-images.githubusercontent.com/129995/30032544-d21055ca-9196-11e7-84e9-ddc2a9bcb381.png)

The explanatory text below provides enough context that we can do without the extra words in the setting itself.