### PR TITLE
Fix/app rotation

### DIFF
--- a/Wire-iOS/Sources/AppDelegate.m
+++ b/Wire-iOS/Sources/AppDelegate.m
@@ -73,7 +73,6 @@ static AppDelegate *sharedAppDelegate = nil;
     self = [super init];
     if (self) {
         sharedAppDelegate = self;
-        self.rootViewController = [[AppRootViewController alloc] init];
     }
     return self;
 }
@@ -105,6 +104,10 @@ static AppDelegate *sharedAppDelegate = nil;
     DDLogInfo(@"Wire-ios version %@ (%@)",
               [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"],
               [[[NSBundle mainBundle] infoDictionary] objectForKey:(NSString *) kCFBundleVersionKey]);
+    
+    // Note: if we instantiate the root view controller (& windows) any earlier,
+    // the windows will not receive any info about device orientation.
+    self.rootViewController = [[AppRootViewController alloc] init];
     
     return YES;
 }

--- a/Wire-iOS/Sources/UserInterface/Overlay/NotificationWindowRootViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Overlay/NotificationWindowRootViewController.m
@@ -124,12 +124,22 @@
 
 - (BOOL)shouldAutorotate
 {
-    return YES;
+    // guard against a stack overflow
+    if (self != UIApplication.sharedApplication.wr_topmostViewController) {
+        return UIApplication.sharedApplication.wr_topmostViewController.supportedInterfaceOrientations;
+    } else {
+        return YES;
+    }
 }
 
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations
 {
-    return [UIViewController wr_supportedInterfaceOrientations];
+    // guard against a stack overflow
+    if (self != UIApplication.sharedApplication.wr_topmostViewController) {
+        return UIApplication.sharedApplication.wr_topmostViewController.supportedInterfaceOrientations;
+    } else {
+        return [UIViewController wr_supportedInterfaceOrientations];
+    }
 }
 
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator

--- a/Wire-iOS/Sources/UserInterface/Overlay/NotificationWindowRootViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Overlay/NotificationWindowRootViewController.m
@@ -120,16 +120,16 @@
     [self.voiceChannelController.view autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsZero];
 }
 
-#pragma mark - Rotation handling (should match up with roort)
+#pragma mark - Rotation handling (should match up with root)
 
 - (BOOL)shouldAutorotate
 {
-    return UIApplication.sharedApplication.wr_topmostViewController.shouldAutorotate;
+    return YES;
 }
 
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations
 {
-    return UIApplication.sharedApplication.wr_topmostViewController.supportedInterfaceOrientations;
+    return [UIViewController wr_supportedInterfaceOrientations];
 }
 
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator


### PR DESCRIPTION
## Problem
The app was not able to rotate when viewing fullscreen images.

## Cause
The app was in fact not receiving any device rotation information (including `UIDeviceOrientationNotification`'s) from the system. The problem seemed to result in the recent changes to the root view controller instantiation with the introduction of the new `AppRootViewController` class. All window and root view controller objects are managed by this class, and this class was first created in the `AppDelegate`'s initializer. After much trial and error, we discovered that although the view controller hierarchy appeared to be properly constructed, the windows were not receiving any information regarding the device's orientation, and concluded that the windows were being created too early.

## Solution
Simply delaying the instantiation of `RootViewController` to the `application:WillFinishLaunchingWithOptions:` method solved the problem. Furthermore, the rotation handling of the `NotificationWindowRootViewController` needed to be updated to match exactly the `RootViewController`.