### PR TITLE
Retain MediaPlaybackManager while obsetving it with KVO

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -93,6 +93,7 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
 @property (nonatomic) ConversationMessageWindowTableViewAdapter *conversationMessageWindowTableViewAdapter;
 @property (nonatomic, assign) BOOL wasScrolledToBottomAtStartOfUpdate;
 @property (nonatomic) NSObject *activeMediaPlayerObserver;
+@property (nonatomic) MediaPlaybackManager *mediaPlaybackManager;
 @property (nonatomic) BOOL conversationLoadStopwatchFired;
 @property (nonatomic) NSMutableDictionary *cachedRowHeights;
 @property (nonatomic) BOOL wasFetchingMessages;
@@ -183,8 +184,8 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
 {
     [super viewWillAppear:animated];
     self.onScreen = YES;
-    
-    self.activeMediaPlayerObserver = [KeyValueObserver observeObject:[AppDelegate sharedAppDelegate].mediaPlaybackManager
+    self.mediaPlaybackManager = [AppDelegate sharedAppDelegate].mediaPlaybackManager;
+    self.activeMediaPlayerObserver = [KeyValueObserver observeObject:self.mediaPlaybackManager
                                                              keyPath:@"activeMediaPlayer"
                                                               target:self
                                                             selector:@selector(activeMediaPlayerChanged:)

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController.m
@@ -54,6 +54,7 @@ static NSString * const CellReuseIdConversation = @"CellId";
 @property (nonatomic, strong) ConversationListViewModel *listViewModel;
 
 @property (nonatomic) NSObject *activeMediaPlayerObserver;
+@property (nonatomic) MediaPlaybackManager *mediaPlaybackManager;
 @property (nonatomic) BOOL focusOnNextSelection;
 @property (nonatomic) BOOL animateNextSelection;
 @property (nonatomic, copy) dispatch_block_t selectConversationCompletion;
@@ -121,8 +122,9 @@ static NSString * const CellReuseIdConversation = @"CellId";
     [self updateVisibleCells];
     
     [self scrollToCurrentSelectionAnimated:NO];
-
-    self.activeMediaPlayerObserver = [KeyValueObserver observeObject:AppDelegate.sharedAppDelegate.mediaPlaybackManager
+    
+    self.mediaPlaybackManager = AppDelegate.sharedAppDelegate.mediaPlaybackManager;
+    self.activeMediaPlayerObserver = [KeyValueObserver observeObject:self.mediaPlaybackManager
                                                              keyPath:@"activeMediaPlayer"
                                                               target:self
                                                             selector:@selector(activeMediaPlayerChanged:)];


### PR DESCRIPTION
# Issue

On iOS9 the system is throwing an exception if the object is deallocated while KVO is registered to it.

# Fix

Make sure object is still alive before deallocating the observer.