### PR TITLE
make opening of data detected links responsibility of textview

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Views/LinkInteractionTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/LinkInteractionTextView.swift
@@ -72,7 +72,8 @@ extension LinkInteractionTextView: UITextViewDelegate {
             return false
         }
         
-        return !(interactionDelegate?.textView(self, open: URL) ?? false)
+        // data detector links should be handled by the system
+        return URL.scheme == "x-apple-data-detectors" || !(interactionDelegate?.textView(self, open: URL) ?? false)
     }
     
     public func textView(_ textView: UITextView, shouldInteractWith textAttachment: NSTextAttachment, in characterRange: NSRange) -> Bool {
@@ -94,7 +95,8 @@ extension LinkInteractionTextView: UITextViewDelegate {
     public func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
         switch interaction {
         case .invokeDefaultAction:
-            return !(interactionDelegate?.textView(self, open: URL) ?? false)
+            // data detector links should be handle by the system
+            return URL.scheme == "x-apple-data-detectors" || !(interactionDelegate?.textView(self, open: URL) ?? false)
         case .presentActions:
             interactionDelegate?.textViewDidLongPress(self)
             return false


### PR DESCRIPTION
## Problem
If Safari is not set as the preferred browser, opening a location address (e.g. 123 Example St) would open in the 3rd party browser with an error message, instead of in the `Maps` application.

## Solution
When tapping on a link within the `UITextView` we check to see if the link is a data detected link, i.e. `URL.scheme == "x-apple-data-detectors`. If so, we bypass the `interactionDelegate` and allow the system to handle the link.

## Note
The location link will always open in the default Apple `Maps` application, even if the user has set `Google Maps` as the preferred application. I did some investigation into how I could extract the location data from the URL but it appears this is done at a hidden level, unless anyone has some ideas?