### PR TITLE
iOS9 crash: deallocation order

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -93,6 +93,7 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
 @property (nonatomic) ConversationMessageWindowTableViewAdapter *conversationMessageWindowTableViewAdapter;
 @property (nonatomic, assign) BOOL wasScrolledToBottomAtStartOfUpdate;
 @property (nonatomic) NSObject *activeMediaPlayerObserver;
+@property (nonatomic) MediaPlaybackManager *mediaPlaybackManager;
 @property (nonatomic) BOOL conversationLoadStopwatchFired;
 @property (nonatomic) NSMutableDictionary *cachedRowHeights;
 @property (nonatomic) BOOL wasFetchingMessages;
@@ -183,8 +184,8 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
 {
     [super viewWillAppear:animated];
     self.onScreen = YES;
-    
-    self.activeMediaPlayerObserver = [KeyValueObserver observeObject:[AppDelegate sharedAppDelegate].mediaPlaybackManager
+    self.mediaPlaybackManager = [AppDelegate sharedAppDelegate].mediaPlaybackManager;
+    self.activeMediaPlayerObserver = [KeyValueObserver observeObject:self.mediaPlaybackManager
                                                              keyPath:@"activeMediaPlayer"
                                                               target:self
                                                             selector:@selector(activeMediaPlayerChanged:)

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -126,6 +126,10 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
 
 - (void)dealloc
 {
+    // Observer must be deallocated before `mediaPlaybackManager`
+    self.activeMediaPlayerObserver = nil;
+    self.mediaPlaybackManager = nil;
+    
     if (nil != self.tableView) {
         self.tableView.delegate = nil;
         self.tableView.dataSource = nil;

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController.m
@@ -73,6 +73,9 @@ static NSString * const CellReuseIdConversation = @"CellId";
 
 - (void)dealloc
 {
+    // Observer must be deallocated before `mediaPlaybackManager`
+    self.activeMediaPlayerObserver = nil;
+    self.mediaPlaybackManager = nil;
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController.m
@@ -54,6 +54,7 @@ static NSString * const CellReuseIdConversation = @"CellId";
 @property (nonatomic, strong) ConversationListViewModel *listViewModel;
 
 @property (nonatomic) NSObject *activeMediaPlayerObserver;
+@property (nonatomic) MediaPlaybackManager *mediaPlaybackManager;
 @property (nonatomic) BOOL focusOnNextSelection;
 @property (nonatomic) BOOL animateNextSelection;
 @property (nonatomic, copy) dispatch_block_t selectConversationCompletion;
@@ -121,8 +122,9 @@ static NSString * const CellReuseIdConversation = @"CellId";
     [self updateVisibleCells];
     
     [self scrollToCurrentSelectionAnimated:NO];
-
-    self.activeMediaPlayerObserver = [KeyValueObserver observeObject:AppDelegate.sharedAppDelegate.mediaPlaybackManager
+    
+    self.mediaPlaybackManager = AppDelegate.sharedAppDelegate.mediaPlaybackManager;
+    self.activeMediaPlayerObserver = [KeyValueObserver observeObject:self.mediaPlaybackManager
                                                              keyPath:@"activeMediaPlayer"
                                                               target:self
                                                             selector:@selector(activeMediaPlayerChanged:)];

--- a/Wire-iOS/Sources/UserInterface/Overlay/MediaBar/MediaBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Overlay/MediaBar/MediaBarViewController.m
@@ -41,6 +41,14 @@
 
 @implementation MediaBarViewController
 
+- (void)dealloc
+{
+    // Observer must be deallocated before `mediaPlaybackManager`
+    self.mediaTitleObserver = nil;
+    self.mediaPlaybackStateObserver = nil;
+    self.mediaPlaybackManager = nil;
+}
+
 - (instancetype)initWithMediaPlaybackManager:(MediaPlaybackManager *)mediaPlaybackManager
 {
     self = [super initWithNibName:nil bundle:nil];


### PR DESCRIPTION
Fix to dealloc properties in the correct order, otherwise it still crashes.