### PR TITLE
Fix: registration analytics events not fired correctly

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationEmailFlowViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationEmailFlowViewController.m
@@ -206,7 +206,7 @@
 
 #pragma mark - ZMAuthenticationObserver
 
-- (void)authenticationDidSucceed
+- (void)clientRegistrationDidSucceed
 {
     [self.analyticsTracker tagRegistrationSucceded];
     [self presentProfilePictureStep];

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPhoneFlowViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPhoneFlowViewController.m
@@ -220,7 +220,7 @@
 
 #pragma mark - ZMAuthenticationObserver
 
-- (void)authenticationDidSucceed
+- (void)clientRegistrationDidSucceed
 {
     self.showLoadingView = NO;
     [self.analyticsTracker tagRegistrationSucceded];


### PR DESCRIPTION
The original issue was that there were 2 identical events fired when registering with phone number, but after some refactoring the events were not fired at all.

Using new client registration notification to signal that registration is complete.