### PR TITLE
Fix crash when registering with email on iPad

### DIFF
--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
@@ -271,11 +271,13 @@
 {
     AppDelegate *appDelegate = [AppDelegate sharedAppDelegate];
     
-    if ([appDelegate.rootViewController.visibleViewController isKindOfClass:ZClientViewController.class]) {
-        return (ZClientViewController *)appDelegate.rootViewController.visibleViewController;
-    } else {
-        return nil;
+    for (UIViewController *controller in appDelegate.rootViewController.childViewControllers) {
+        if ([controller isKindOfClass:ZClientViewController.class]) {
+            return (ZClientViewController *)controller;
+        }
     }
+    
+    return nil;
 }
 
 - (void)selectConversation:(ZMConversation *)conversation


### PR DESCRIPTION
The reason was that we try to fetch shared ZClientViewController, but it is not in the expected place because the registration controller is being animated out it.