### PR TITLE
Add an option to delete ephemeral message

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
@@ -516,7 +516,8 @@ static const CGFloat BurstContainerExpandedHeight = 40;
 
 - (void)showMenu;
 {
-    if (self.message.isEphemeral) {
+    // ephemeral message's only possibility is to be deleted
+    if (self.message.isEphemeral && !self.message.canBeDeleted) {
         return;
     }
 
@@ -553,18 +554,22 @@ static const CGFloat BurstContainerExpandedHeight = 40;
     UIMenuController *menuController = UIMenuController.sharedMenuController;
     
     NSMutableArray <UIMenuItem *> *items = [NSMutableArray array];
-    [items addObjectsFromArray:menuConfigurationProperties.additionalItems];
-
-    if ([Message messageCanBeLiked:self.message]) {
-        UIMenuItem *likeItem = [UIMenuItem likeItemForMessage:self.message action:@selector(likeMessage:)];
+    
+    if (!self.message.isEphemeral) {
+        [items addObjectsFromArray:menuConfigurationProperties.additionalItems];
         
-        if (items.count > 0) {
-            [items insertObject:likeItem atIndex:menuConfigurationProperties.likeItemIndex];
-        } else {
-            [items addObject:likeItem];
+        if ([Message messageCanBeLiked:self.message]) {
+            UIMenuItem *likeItem = [UIMenuItem likeItemForMessage:self.message action:@selector(likeMessage:)];
+            
+            if (items.count > 0) {
+                [items insertObject:likeItem atIndex:menuConfigurationProperties.likeItemIndex];
+            } else {
+                [items addObject:likeItem];
+            }
         }
     }
 
+    // at this point, if message is ephemeral, then this will always be true
     if (self.message.canBeDeleted) {
         UIMenuItem *deleteItem = [UIMenuItem deleteItemWithAction:@selector(deleteMessage:)];
         [items addObject:deleteItem];
@@ -600,6 +605,10 @@ static const CGFloat BurstContainerExpandedHeight = 40;
     
     if (action == @selector(likeMessage:)) {
         return YES;
+    }
+    
+    if (action == @selector(copy:) && self.message.isEphemeral) {
+        return NO;
     }
     
     return [super canPerformAction:action withSender:sender];

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ImageMessageCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ImageMessageCell.m
@@ -501,7 +501,7 @@ static const CGFloat ImageToolbarMinimumSize = 192;
         return NO;
     }
     else if (action == @selector(copy:) || action == @selector(saveImage) || action == @selector(forward:)) {
-        return self.fullImageView.image != nil;
+        return !self.message.isEphemeral && self.fullImageView.image != nil;
     }
     else if (action == @selector(paste:)) {
         return NO;

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/LocationMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/LocationMessageCell.swift
@@ -184,7 +184,7 @@ public final class LocationMessageCell: ConversationCell {
         case #selector(cut), #selector(paste), #selector(select), #selector(selectAll):
             return false
         case #selector(copy(_:)), #selector(forward(_:)):
-            return true
+            return !self.message.isEphemeral
         default:
             return super.canPerformAction(action, withSender: sender)
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/TextMessageCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/TextMessageCell.m
@@ -305,7 +305,7 @@
         return NO;
     }
     else if (action == @selector(copy:)) {
-        return self.messageTextView.text != nil;
+        return !self.message.isEphemeral && self.messageTextView.text != nil;
     }
     else if (action == @selector(paste:)) {
         return NO;


### PR DESCRIPTION
## What's new?

We now allow ephemeral messages to be deleted prematurely by long pressing on the ephemeral message. This reveals the usual action menu, however the only item it will contain is `delete`.