### PR TITLE
Fix account button selection ring and dot

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+TopBar.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+TopBar.swift
@@ -34,7 +34,7 @@ extension ConversationListViewController {
     public func createTopBar() {
         let profileAccountView = self.currentAccountView()
         profileAccountView.selected = false
-        profileAccountView.autoupdate = false
+        profileAccountView.autoupdateSelection = false
         
         let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(presentSettings))
         profileAccountView.addGestureRecognizer(tapGestureRecognizer)

--- a/Wire-iOS/Sources/UserInterface/ConversationList/NewDevicesDot.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/NewDevicesDot.swift
@@ -32,6 +32,7 @@ final class NewDevicesDot: DotView {
     init(user: ZMUser) {
         self.user = user
         super.init(frame: .zero)
+        self.isHidden = true
         self.backgroundColor = user.accentColorValue.color
         userObserverToken = UserChangeInfo.add(observer: self, forBareUser: user)
         self.createClientObservers()

--- a/Wire-iOS/Sources/UserInterface/SelfProfile/AccountView.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/AccountView.swift
@@ -119,7 +119,7 @@ public final class AccountViewFactory {
 }
 
 public class BaseAccountView: UIView, AccountViewType {
-    public var autoupdate: Bool = true
+    public var autoupdateSelection: Bool = true
     
     internal let imageViewContainer = UIView()
     fileprivate let outlineView = UIView()
@@ -217,7 +217,9 @@ public class BaseAccountView: UIView, AccountViewType {
     }
     
     public func update() {
-        self.selected = SessionManager.shared?.accountManager.selectedAccount == self.account
+        if self.autoupdateSelection {
+            self.selected = SessionManager.shared?.accountManager.selectedAccount == self.account
+        }
     }
     
     @objc public func didTap(_ sender: UITapGestureRecognizer!) {
@@ -301,7 +303,6 @@ public final class PersonalAccountView: BaseAccountView {
 
 extension PersonalAccountView {
     override public func userDidChange(_ changeInfo: UserChangeInfo) {
-        guard self.autoupdate else { return }
         super.userDidChange(changeInfo)
         if changeInfo.nameChanged {
             update()
@@ -457,7 +458,6 @@ public final class TeamImageView: UIImageView {
 
 extension TeamAccountView: TeamObserver {
     func teamDidChange(_ changeInfo: TeamChangeInfo) {
-        guard self.autoupdate else { return }
         self.update()
     }
 }


### PR DESCRIPTION
Two issues:

- Initially the new devices dot is briefly visible.
- If the user image is not updating then we cannot see the user image change, so only selection is not updated with the new property `autoupdateSelection`.