### PR TITLE
store last opened conversation per account

### DIFF
--- a/Wire-iOS Tests/Settings/SettingsPropertyTests.swift
+++ b/Wire-iOS Tests/Settings/SettingsPropertyTests.swift
@@ -171,4 +171,48 @@ class SettingsPropertyTests: XCTestCase {
         try? saveAndCheck(property, value: 2)
     }
     
+    // MARK: - Accounts
+    
+    func testThatIntegerUserDefaultsSettingForAccountSave() {
+        // given
+        let settings = Settings()
+        let account = Account(userName: "bob", userIdentifier: UUID())
+        let key = "IntegerKey"
+        XCTAssertNil(settings.value(for: key, in: account))
+        
+        // when
+        settings.setValue(42, for: key, in: account)
+        
+        // then
+        let result: Int? = settings.value(for: key, in: account)
+        XCTAssertEqual(result, 42)
+    }
+    
+    func testThatBoolUserDefaultsSettingForAccountSave() {
+        // given
+        let settings = Settings()
+        let account = Account(userName: "bob", userIdentifier: UUID())
+        let key = "BooleanKey"
+        XCTAssertNil(settings.value(for: key, in: account))
+        
+        // when
+        settings.setValue(true, for: key, in: account)
+        
+        // then
+        let result: Bool? = settings.value(for: key, in: account)
+        XCTAssertEqual(result, true)
+    }
+    
+    func testThatSharedSettingIsMigratedToAccount() {
+        // given
+        let settings = Settings()
+        let account = Account(userName: "bob", userIdentifier: UUID())
+        let key = "IntegerKey"
+        settings.defaults().setValue(42, forKey: key)
+        
+        // when & then
+        let result: Int? = settings.value(for: key, in: account)
+        XCTAssertNil(settings.defaults().object(forKey: key))
+        XCTAssertEqual(result, 42)
+    }
 }

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -938,6 +938,7 @@
 		EE4332491F1A67E500096D90 /* PopUpIconButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4332481F1A67E500096D90 /* PopUpIconButton.swift */; };
 		EE43324B1F1A785800096D90 /* PopUpIconButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE43324A1F1A785800096D90 /* PopUpIconButtonView.swift */; };
 		EE6067041F23BC33001CAC97 /* MarklightTextViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6067031F23BC33001CAC97 /* MarklightTextViewTests.swift */; };
+		EEB8A2D01F628D1100958881 /* Settings+Account.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB8A2CF1F628D1100958881 /* Settings+Account.swift */; };
 		EEF28EEA1F1613DA007642E2 /* MarkdownBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF28EE91F1613DA007642E2 /* MarkdownBarView.swift */; };
 		EEF28EED1F16692A007642E2 /* InputBarSecondaryButtonsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF28EEC1F16692A007642E2 /* InputBarSecondaryButtonsView.swift */; };
 		EEF28EEF1F168039007642E2 /* ConversationInputBarViewController+Markdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF28EEE1F168039007642E2 /* ConversationInputBarViewController+Markdown.swift */; };
@@ -2446,6 +2447,7 @@
 		EE4332481F1A67E500096D90 /* PopUpIconButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PopUpIconButton.swift; sourceTree = "<group>"; };
 		EE43324A1F1A785800096D90 /* PopUpIconButtonView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PopUpIconButtonView.swift; sourceTree = "<group>"; };
 		EE6067031F23BC33001CAC97 /* MarklightTextViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarklightTextViewTests.swift; sourceTree = "<group>"; };
+		EEB8A2CF1F628D1100958881 /* Settings+Account.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Settings+Account.swift"; sourceTree = "<group>"; };
 		EEF28EE91F1613DA007642E2 /* MarkdownBarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MarkdownBarView.swift; path = ../../MarkdownBarView.swift; sourceTree = "<group>"; };
 		EEF28EEC1F16692A007642E2 /* InputBarSecondaryButtonsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InputBarSecondaryButtonsView.swift; sourceTree = "<group>"; };
 		EEF28EEE1F168039007642E2 /* ConversationInputBarViewController+Markdown.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ConversationInputBarViewController+Markdown.swift"; sourceTree = "<group>"; };
@@ -3572,6 +3574,7 @@
 				871BC33C1D34F94200DF0793 /* Settings.h */,
 				871BC33D1D34F94200DF0793 /* Settings.m */,
 				549D55AB1DBE03990035EB66 /* Settings+Logging.swift */,
+				EEB8A2CF1F628D1100958881 /* Settings+Account.swift */,
 				871BC33E1D34F94200DF0793 /* Soundcloud */,
 				871BC3481D34F94200DF0793 /* WRFunctions.h */,
 				871BC3491D34F94200DF0793 /* WRFunctions.m */,
@@ -6210,6 +6213,7 @@
 				871BC28B1D34F8F800DF0793 /* UIResponder+FirstResponder.m in Sources */,
 				871BC23A1D34F8F800DF0793 /* KeyboardFrameObserver+iOS.m in Sources */,
 				8F41CFC9199297C600E3B032 /* Message+UI.m in Sources */,
+				EEB8A2D01F628D1100958881 /* Settings+Account.swift in Sources */,
 				BF5C37981C0E0D9C00EA11E3 /* ParticipantsDeviceHeaderView.m in Sources */,
 				870A8C6B1CF719C400874B16 /* RecordingDotView.swift in Sources */,
 				BFBB03081D61AF8D0065AF4F /* InputBarEditView.swift in Sources */,

--- a/Wire-iOS/Sources/Components/Settings+Account.swift
+++ b/Wire-iOS/Sources/Components/Settings+Account.swift
@@ -30,8 +30,11 @@ extension Settings {
         return self.defaults().value(forKey: account.userDefaultsKey()) as? [String: Any] ?? [:]
     }
     
+    /// Returns the value associated with the given account for the given key,
+    /// or nil if it doesn't exist.
+    ///
     func value<T>(for key: String, in account: Account) -> T? {
-        // Attemt to migrate the shared value
+        // Attempt to migrate the shared value
         if let rootValue = self.defaults().value(forKey: key) {
             setValue(rootValue, for: key, in: account)
             self.defaults().setValue(nil, forKey: key)
@@ -42,6 +45,8 @@ extension Settings {
         return accountPayload[key] as? T
     }
     
+    /// Sets the value associated with the given account for the given key.
+    ///
     func setValue<T>(_ value: T?, for key: String, in account: Account) {
         var accountPayload = self.payload(for: account)
         accountPayload[key] = value

--- a/Wire-iOS/Sources/Components/Settings+Account.swift
+++ b/Wire-iOS/Sources/Components/Settings+Account.swift
@@ -1,0 +1,67 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import Foundation
+
+extension Account {
+    func userDefaultsKey() -> String {
+        return "account_\(self.userIdentifier.transportString())"
+    }
+}
+
+extension Settings {
+    private func payload(for account: Account) -> [String: Any] {
+        return self.defaults().value(forKey: account.userDefaultsKey()) as? [String: Any] ?? [:]
+    }
+    
+    func value<T>(for key: String, in account: Account) -> T? {
+        // Attemt to migrate the shared value
+        if let rootValue = self.defaults().value(forKey: key) {
+            setValue(rootValue, for: key, in: account)
+            self.defaults().setValue(nil, forKey: key)
+            self.defaults().synchronize()
+        }
+        
+        var accountPayload = self.payload(for: account)
+        return accountPayload[key] as? T
+    }
+    
+    func setValue<T>(_ value: T?, for key: String, in account: Account) {
+        var accountPayload = self.payload(for: account)
+        accountPayload[key] = value
+        self.defaults().setValue(accountPayload, forKey: account.userDefaultsKey())
+    }
+    
+    func lastViewedConversation(for account: Account) -> ZMConversation? {
+        guard let conversationID: String = self.value(for: UserDefaultLastViewedConversation, in: account) else {
+            return nil
+        }
+        
+        let conversationURI = URL(string: conversationID)
+        let session = ZMUserSession.shared()
+        let objectID = ZMManagedObject.objectID(forURIRepresentation: conversationURI, inUserSession: session)
+        return ZMConversation.existingObject(with: objectID, inUserSession: session)
+    }
+
+    func setLastViewed(conversation: ZMConversation, for account: Account) {
+        let conversationURI = conversation.objectID.uriRepresentation()
+        self.setValue(conversationURI.absoluteString, for: UserDefaultLastViewedConversation, in: account)
+        self.defaults().synchronize()
+    }
+}

--- a/Wire-iOS/Sources/Components/Settings.h
+++ b/Wire-iOS/Sources/Components/Settings.h
@@ -100,7 +100,6 @@ extern NSString * const UserDefaultDisableLinkPreviews;
 @property (nonatomic, readonly) BOOL skipFirstTimeUseChecks;
 @property (nonatomic) NSDate *lastPushAlertDate;
 
-@property (nonatomic) ZMConversation *lastViewedConversation;
 @property (nonatomic) SettingsLastScreen lastViewedScreen;
 @property (nonatomic) AVCaptureFlashMode preferredFlashMode;
 @property (nonatomic) CameraControllerCamera preferredCamera;

--- a/Wire-iOS/Sources/Components/Settings.h
+++ b/Wire-iOS/Sources/Components/Settings.h
@@ -125,6 +125,7 @@ extern NSString * const UserDefaultDisableLinkPreviews;
 
 - (void)updateAVSCallingConstantBitRateValue;
 
+- (NSUserDefaults *)defaults;
 @end
 
 

--- a/Wire-iOS/Sources/Components/Settings.m
+++ b/Wire-iOS/Sources/Components/Settings.m
@@ -72,7 +72,6 @@ NSString * const UserDefaultDisableLinkPreviews = @"DisableLinkPreviews";
 @interface Settings ()
 
 @property (strong, readonly, nonatomic) NSUserDefaults *defaults;
-@property (nonatomic, strong) ZMConversation *lastViewedConversationInternal;
 @property (nonatomic) BOOL shouldSend500Messages;
 @property (nonatomic) NSTimeInterval maxRecordingDurationDebug;
 @property (nonatomic) ZMEmailCredentials *automationTestEmailCredentials;
@@ -220,29 +219,6 @@ NSString * const UserDefaultDisableLinkPreviews = @"DisableLinkPreviews";
 - (void)setLastPushAlertDate:(NSDate *)lastPushAlertDate
 {
     [self.defaults setObject:lastPushAlertDate forKey:UserDefaultLastPushAlertDate];
-    [self.defaults synchronize];
-}
-
-- (ZMConversation *)lastViewedConversation
-{
-    if (self.lastViewedConversationInternal == nil) {
-        NSString *convString = [self.defaults objectForKey:UserDefaultLastViewedConversation];
-        NSURL *rememberedConvUrl = [NSURL URLWithString:convString];
-        
-        ZMUserSession *session = [ZMUserSession sharedSession];
-        NSManagedObjectID *objectID = [ZMManagedObject objectIDForURIRepresentation:rememberedConvUrl inUserSession:session];
-        
-        ZMConversation *conversation = [ZMConversation existingObjectWithID:objectID inUserSession:session];
-        self.lastViewedConversationInternal = conversation;
-    }
-    return self.lastViewedConversationInternal;
-}
-
-- (void)setLastViewedConversation:(ZMConversation *)lastViewedConversation
-{
-    self.lastViewedConversationInternal = lastViewedConversation;
-    NSURL *selectedConversationURI = [lastViewedConversation.objectID URIRepresentation];
-    [self.defaults setObject:[selectedConversationURI absoluteString] forKey:UserDefaultLastViewedConversation];
     [self.defaults synchronize];
 }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -341,7 +341,8 @@
         // We are presenting the conversation screen so mark it as the last viewed screen,
         // but only if we are acutally focused (otherwise we would be shown on the next launch)
         [Settings sharedSettings].lastViewedScreen = SettingsLastScreenConversation;
-        [Settings sharedSettings].lastViewedConversation = self.conversation;
+        Account *currentAccount = SessionManager.shared.accountManager.selectedAccount;
+        [[Settings sharedSettings] setLastViewedWithConversation:self.conversation for:currentAccount];
     }
 
     self.contentViewController.searchQueries = self.collectionController.currentTextSearchQuery;

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
@@ -595,13 +595,16 @@
 {
     BOOL stateRestored = NO;
 
+    Account *currentAccount = SessionManager.shared.accountManager.selectedAccount;
+    
     SettingsLastScreen lastViewedScreen = [Settings sharedSettings].lastViewedScreen;
     switch (lastViewedScreen) {
             
         case SettingsLastScreenList: {
             
             [self transitionToListAnimated:NO completion:nil];
-            ZMConversation *conversation = [Settings sharedSettings].lastViewedConversation;
+            
+            ZMConversation *conversation = [[Settings sharedSettings] lastViewedConversationFor:currentAccount];
             if (conversation != nil) {
                 // Select the last viewed conversation without giving it focus
                 [self selectConversation:conversation];
@@ -620,7 +623,7 @@
         }
         case SettingsLastScreenConversation: {
             
-            ZMConversation *conversation = [Settings sharedSettings].lastViewedConversation;
+            ZMConversation *conversation = [[Settings sharedSettings] lastViewedConversationFor:currentAccount];
             if (conversation != nil) {
                 [self selectConversation:conversation
                              focusOnView:YES 


### PR DESCRIPTION
Currently all the settings are general and saved in user defaults. The last viewed conversation is also the part of those settings. We need to save the last viewed conversation per account.