### PR TITLE
ensure profile image data represents JPEG file

### DIFF
--- a/Wire-iOS Tests/NSData_ImageTypeTests.swift
+++ b/Wire-iOS Tests/NSData_ImageTypeTests.swift
@@ -1,0 +1,41 @@
+//
+//  NSData_ImageTypeTests.swift
+//  Wire-iOS
+//
+//  Created by John Nguyen on 12.09.17.
+//  Copyright © 2017 Zeta Project Germany GmbH. All rights reserved.
+//
+
+import XCTest
+@testable import Wire
+
+class NSData_ImageTypeTests: XCTestCase {
+        
+    func testThatItIdentifiesJPEG() {
+        
+        // given
+        guard let jpeg = UIImageJPEGRepresentation(#imageLiteral(resourceName: "wire-logo-shield"), 1.0) else {
+            XCTFail()
+            return
+        }
+        
+        let sut = NSData(data: jpeg)
+        
+        // then
+        XCTAssertTrue(sut.isJPEG)
+    }
+    
+    func testThatItDoesNotIdentifyJPEG() {
+        
+        // given
+        guard let png = UIImagePNGRepresentation(#imageLiteral(resourceName: "wire-logo-shield")) else {
+            XCTFail()
+            return
+        }
+        
+        let sut = NSData(data: png)
+        
+        // then
+        XCTAssertFalse(sut.isJPEG)
+    }
+}

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -939,6 +939,8 @@
 		EE43324B1F1A785800096D90 /* PopUpIconButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE43324A1F1A785800096D90 /* PopUpIconButtonView.swift */; };
 		EE6067041F23BC33001CAC97 /* MarklightTextViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6067031F23BC33001CAC97 /* MarklightTextViewTests.swift */; };
 		EEB8A2D01F628D1100958881 /* Settings+Account.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB8A2CF1F628D1100958881 /* Settings+Account.swift */; };
+		EEBE8C5C1F681694009D78C9 /* NSData+ImageType.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBE8C5B1F681694009D78C9 /* NSData+ImageType.swift */; };
+		EEBE8C5E1F68171F009D78C9 /* NSData_ImageTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBE8C5D1F68171F009D78C9 /* NSData_ImageTypeTests.swift */; };
 		EEF28EEA1F1613DA007642E2 /* MarkdownBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF28EE91F1613DA007642E2 /* MarkdownBarView.swift */; };
 		EEF28EED1F16692A007642E2 /* InputBarSecondaryButtonsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF28EEC1F16692A007642E2 /* InputBarSecondaryButtonsView.swift */; };
 		EEF28EEF1F168039007642E2 /* ConversationInputBarViewController+Markdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF28EEE1F168039007642E2 /* ConversationInputBarViewController+Markdown.swift */; };
@@ -2448,6 +2450,8 @@
 		EE43324A1F1A785800096D90 /* PopUpIconButtonView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PopUpIconButtonView.swift; sourceTree = "<group>"; };
 		EE6067031F23BC33001CAC97 /* MarklightTextViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarklightTextViewTests.swift; sourceTree = "<group>"; };
 		EEB8A2CF1F628D1100958881 /* Settings+Account.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Settings+Account.swift"; sourceTree = "<group>"; };
+		EEBE8C5B1F681694009D78C9 /* NSData+ImageType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSData+ImageType.swift"; sourceTree = "<group>"; };
+		EEBE8C5D1F68171F009D78C9 /* NSData_ImageTypeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSData_ImageTypeTests.swift; sourceTree = "<group>"; };
 		EEF28EE91F1613DA007642E2 /* MarkdownBarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MarkdownBarView.swift; path = ../../MarkdownBarView.swift; sourceTree = "<group>"; };
 		EEF28EEC1F16692A007642E2 /* InputBarSecondaryButtonsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InputBarSecondaryButtonsView.swift; sourceTree = "<group>"; };
 		EEF28EEE1F168039007642E2 /* ConversationInputBarViewController+Markdown.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ConversationInputBarViewController+Markdown.swift"; sourceTree = "<group>"; };
@@ -4323,6 +4327,7 @@
 				BFAF4CB81CEDE82400780537 /* NumberHelper.swift */,
 				8719FD661C88802C005FBEC0 /* Delay.swift */,
 				8719FD681C888044005FBEC0 /* NSData+MD5.swift */,
+				EEBE8C5B1F681694009D78C9 /* NSData+ImageType.swift */,
 				F194AD791E3F3BBC00B0049B /* UIApplication+RTL.swift */,
 				BF8ECC2C1E570A920015177D /* UIActivityViewController+FileSaving.swift */,
 				1693D9661CEDB26200D1F13C /* UIApplication+Permissions.h */,
@@ -4801,6 +4806,7 @@
 		BACB88521AF7C48900DDCDB0 /* Wire-iOS Tests */ = {
 			isa = PBXGroup;
 			children = (
+				EEBE8C5D1F68171F009D78C9 /* NSData_ImageTypeTests.swift */,
 				EE6067031F23BC33001CAC97 /* MarklightTextViewTests.swift */,
 				F1C9E35E1EADFFB8006438D7 /* TestSetup.swift */,
 				1651F9BA1D352C5300A9FAE8 /* ArticleViewTests.swift */,
@@ -6412,6 +6418,7 @@
 				871BC3561D34F94200DF0793 /* AudioPlaylistViewController.m in Sources */,
 				871BC2491D34F8F800DF0793 /* UIColor+MagicAccess.m in Sources */,
 				871BC1261D34F7B700DF0793 /* ZiphyClient+Convenience.m in Sources */,
+				EEBE8C5C1F681694009D78C9 /* NSData+ImageType.swift in Sources */,
 				F1AA8AD61E5DF36A006A0E68 /* DegradationOverlayView.swift in Sources */,
 				8784D4551E817D13007A6867 /* ConversationListTopBar.swift in Sources */,
 				871BC3521D34F94200DF0793 /* AggregateArray.m in Sources */,
@@ -6440,6 +6447,7 @@
 			files = (
 				BACB88561AF7C48900DDCDB0 /* AggregateArrayTests.m in Sources */,
 				8751A93C1C737D7200C72324 /* IconSystemCellTests.m in Sources */,
+				EEBE8C5E1F68171F009D78C9 /* NSData_ImageTypeTests.swift in Sources */,
 				BFFE943C1E7839D10025AD75 /* ConversationRenamedCellTests.swift in Sources */,
 				BF16FC4C1DAFCA0000FF4325 /* EphemeralKeyboardViewControllerTests.swift in Sources */,
 				BF27AE4E1E9E513400809A2B /* MessageDraftTests.swift in Sources */,

--- a/Wire-iOS/Sources/Helpers/NSData+ImageType.swift
+++ b/Wire-iOS/Sources/Helpers/NSData+ImageType.swift
@@ -1,0 +1,41 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension NSData {
+    var isJPEG: Bool {
+        return (self as Data).isJPEG
+    }
+}
+
+extension Data {
+    var isJPEG: Bool {
+        let array = self.withUnsafeBytes {
+            [UInt8](UnsafeBufferPointer(start: $0, count: 3))
+        }
+        let JPEGHeader: [UInt8] = [0xFF, 0xD8, 0xFF]
+        
+        for i in 0..<JPEGHeader.count {
+            if array[i] != JPEGHeader[i] {
+                return false
+            }
+        }
+        return true
+    }
+}

--- a/Wire-iOS/Sources/Helpers/NSData+ImageType.swift
+++ b/Wire-iOS/Sources/Helpers/NSData+ImageType.swift
@@ -16,6 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
+
 import Foundation
 
 extension NSData {

--- a/Wire-iOS/Sources/UserInterface/Registration/ProfilePictureStepViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/ProfilePictureStepViewController.m
@@ -291,8 +291,10 @@ NSString * const UnsplashRandomImageLowQualityURL = @"https://source.unsplash.co
 - (void)setPictureImageData:(NSData *)imageData
 {
     if (imageData != nil) {
+        // iOS11 uses HEIF image format, but BE expects JPEG
+        NSData *jpegData = UIImageJPEGRepresentation([UIImage imageWithData:imageData], 1.0);
         [AppDelegate checkNetworkAndFlashIndicatorIfNecessary];
-        [[UnauthenticatedSession sharedSession] setProfileImage:imageData];
+        [[UnauthenticatedSession sharedSession] setProfileImage:jpegData];
         [self.formStepDelegate didCompleteFormStep:self];
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Registration/ProfilePictureStepViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/ProfilePictureStepViewController.m
@@ -292,7 +292,7 @@ NSString * const UnsplashRandomImageLowQualityURL = @"https://source.unsplash.co
 {
     if (imageData != nil) {
         // iOS11 uses HEIF image format, but BE expects JPEG
-        NSData *jpegData = UIImageJPEGRepresentation([UIImage imageWithData:imageData], 1.0);
+        NSData *jpegData = imageData.isJPEG ? imageData : UIImageJPEGRepresentation([UIImage imageWithData:imageData], 1.0);
         [AppDelegate checkNetworkAndFlashIndicatorIfNecessary];
         [[UnauthenticatedSession sharedSession] setProfileImage:jpegData];
         [self.formStepDelegate didCompleteFormStep:self];

--- a/Wire-iOS/Sources/UserInterface/Settings/ProfileSelfPictureViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Settings/ProfileSelfPictureViewController.m
@@ -42,6 +42,8 @@
 #import "AnalyticsTracker.h"
 #import "AnalyticsTracker+SelfUser.h"
 
+#import "Wire-Swift.h"
+
 @interface ProfileSelfPictureViewController () <CameraViewControllerDelegate>
 
 @property (nonatomic) ButtonWithLargerHitArea *cameraButton;
@@ -168,8 +170,8 @@
     [self.analyticsTracker tagPictureChanged];
     
     // iOS11 uses HEIF image format, but BE expects JPEG
-    NSData *jpegData = UIImageJPEGRepresentation([UIImage imageWithData:selfImageData], 1.0);
-
+    NSData *jpegData = selfImageData.isJPEG ? selfImageData : UIImageJPEGRepresentation([UIImage imageWithData:selfImageData], 1.0);
+    
     [[ZMUserSession sharedSession] enqueueChanges:^{
         [[ZMUserSession sharedSession].profileUpdate updateImageWithImageData:jpegData];
         [self.delegate bottomOverlayViewControllerBackgroundTapped:self];

--- a/Wire-iOS/Sources/UserInterface/Settings/ProfileSelfPictureViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Settings/ProfileSelfPictureViewController.m
@@ -166,9 +166,12 @@
 - (void)setSelfImageToData:(NSData *)selfImageData
 {
     [self.analyticsTracker tagPictureChanged];
+    
+    // iOS11 uses HEIF image format, but BE expects JPEG
+    NSData *jpegData = UIImageJPEGRepresentation([UIImage imageWithData:selfImageData], 1.0);
 
     [[ZMUserSession sharedSession] enqueueChanges:^{
-        [[ZMUserSession sharedSession].profileUpdate updateImageWithImageData:selfImageData];
+        [[ZMUserSession sharedSession].profileUpdate updateImageWithImageData:jpegData];
         [self.delegate bottomOverlayViewControllerBackgroundTapped:self];
     }];
 }


### PR DESCRIPTION
iOS 11 introduced the new **HEIF** file format for images, however the backend expects the images to be **JPEG** files. As a result, other *non iOS* clients can not render the image correctly.