### PR TITLE
Feature/markdown send button

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarButtonState.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarButtonState.swift
@@ -26,7 +26,7 @@ private let disableEphemeralSendingInGroups = false
 public final class ConversationInputBarButtonState: NSObject {
 
     public var sendButtonHidden: Bool {
-        return !hasText || editing || (Settings.shared().disableSendButton && mode != .emojiInput)
+        return !hasText || editing || (Settings.shared().disableSendButton && mode != .emojiInput && !markingDown)
     }
 
     public var hourglassButtonHidden: Bool {
@@ -47,13 +47,15 @@ public final class ConversationInputBarButtonState: NSObject {
 
     private var textLength: Int = 0
     private var editing: Bool = false
+    private var markingDown: Bool = false
     private var destructionTimeout: TimeInterval = 0
     private var conversationType: ZMConversationType = .oneOnOne
     private var mode: ConversationInputBarViewControllerMode = .textInput
 
-    public func update(textLength: Int, editing: Bool, destructionTimeout: TimeInterval, conversationType: ZMConversationType, mode: ConversationInputBarViewControllerMode) {
+    public func update(textLength: Int, editing: Bool, markingDown: Bool, destructionTimeout: TimeInterval, conversationType: ZMConversationType, mode: ConversationInputBarViewControllerMode) {
         self.textLength = textLength
         self.editing = editing
+        self.markingDown = markingDown
         self.destructionTimeout = destructionTimeout
         self.conversationType = conversationType
         self.mode = mode

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Markdown.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Markdown.swift
@@ -52,5 +52,6 @@ extension ConversationInputBarViewController {
         }
         
         updateMarkdownButton()
+        updateRightAccessoryView()
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -458,6 +458,7 @@
 
     [self.sendButtonState updateWithTextLength:trimmed.length
                                        editing:nil != self.editingMessage
+                                   markingDown:self.inputBar.isMarkingDown
                             destructionTimeout:self.conversation.messageDestructionTimeout
                               conversationType:self.conversation.conversationType
                                           mode:self.mode];

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -821,12 +821,8 @@
         [self.inputBar.textView handleNewLine];
     }
     
-    if (!Settings.sharedSettings.disableSendButton) {
-        // The send button is not disabled, we allow newlines and don't send.
-        return YES;
-    }
-
-    if ([text isEqualToString:@"\n"]) {
+    // send only if send key pressed
+    if (textView.returnKeyType == UIReturnKeySend && [text isEqualToString:@"\n"]) {
         [self.inputBar.textView autocorrectLastWord];
         NSString *candidateText = self.inputBar.textView.preparedText;
         [self sendOrEditText:candidateText];

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
@@ -283,7 +283,8 @@ private struct InputBarConstants {
     }
 
     public func updateReturnKey() {
-        textView.returnKeyType = Settings.shared().returnKeyType
+        textView.returnKeyType = isMarkingDown ? .default : Settings.shared().returnKeyType
+        textView.reloadInputViews()
     }
 
     func updatePlaceholder() {
@@ -336,6 +337,7 @@ private struct InputBarConstants {
     private func updateInputBar(withState state: InputBarState, oldState: InputBarState? = nil, animated: Bool = true) {
         updateEditViewState()
         updatePlaceholder()
+        updateReturnKey()
         rowTopInsetConstraint?.constant = state.isWriting ? -constants.buttonsBarHeight : 0
 
         let textViewChanges = {


### PR DESCRIPTION
## Issue
When the send button is disabled in settings, it is impossible to enter a newline and therefore impossible to create markdown lists with more than one item.

## Solution
When markdown is enabled, the send button and return key will always be displayed, bypassing the settings temporarily.