### PR TITLE
Fix crash when switching the account with keyboard up

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter.m
@@ -317,7 +317,9 @@ static NSString *const ConversationUnknownMessageCellId     = @"conversationUnkn
     conversationCell.delegate = self.conversationCellDelegate;
     conversationCell.analyticsTracker = self.analyticsTracker;
     
-    [self configureConversationCell:conversationCell withMessage:message];
+    if (nil != [ZMUserSession sharedSession]) {
+        [self configureConversationCell:conversationCell withMessage:message];
+    }
     
     return cell;
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter.m
@@ -317,6 +317,7 @@ static NSString *const ConversationUnknownMessageCellId     = @"conversationUnkn
     conversationCell.delegate = self.conversationCellDelegate;
     conversationCell.analyticsTracker = self.analyticsTracker;
     
+    // Configuration of the cell is not possible when `ZMUserSession` is not available. 
     if (nil != [ZMUserSession sharedSession]) {
         [self configureConversationCell:conversationCell withMessage:message];
     }


### PR DESCRIPTION
- Issue happens when the `SessionManager` tries to swap the acounts, and keyboard is dismissed. - The dismissal of the keyboard triggers the reload of the table view content when the `UserSession` is not active any more.