### PR TITLE
Fix/chat heads

### DIFF
--- a/Wire-iOS/Resources/Magic/misc.plist
+++ b/Wire-iOS/Resources/Magic/misc.plist
@@ -258,47 +258,6 @@
 	</dict>
 	<key>notifications</key>
 	<dict>
-		<key>container_inset_top</key>
-		<integer>16</integer>
-		<key>container_inset_left</key>
-		<integer>16</integer>
-		<key>container_inset_right</key>
-		<integer>16</integer>
-		<key>corner_radius</key>
-		<integer>6</integer>
-		<key>image_diameter</key>
-		<real>28</real>
-		<key>content_padding</key>
-		<integer>10</integer>
-		<key>title_label_font_regular</key>
-		<dict>
-			<key>font</key>
-			<string>System-Regular</string>
-			<key>size</key>
-			<integer>14</integer>
-		</dict>
-		<key>title_label_font_medium</key>
-		<dict>
-			<key>font</key>
-			<string>System-Medium</string>
-			<key>size</key>
-			<integer>14</integer>
-		</dict>
-		<key>subtitle_label_font</key>
-		<dict>
-			<key>font</key>
-			<string>System-Regular</string>
-			<key>size</key>
-			<string>12</string>
-		</dict>
-		<key>dismiss_delay_duration</key>
-		<integer>5</integer>
-		<key>animation_container_inset</key>
-		<integer>48</integer>
-		<key>animation_text_inset</key>
-		<integer>8</integer>
-		<key>gesture_threshold</key>
-		<integer>75</integer>
 		<key>user_initials_font</key>
 		<dict>
 			<key>font</key>

--- a/Wire-iOS/Sources/UserInterface/Overlay/InAppNotifications/ChatHeadView.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/InAppNotifications/ChatHeadView.swift
@@ -156,8 +156,8 @@ class ChatHeadView: UIView {
     
     private func titleText() -> NSAttributedString {
 
-        let regularFont: [String: AnyObject] = [NSFontAttributeName: FontSpec(.normal, .regular).font!]
-        let mediumFont: [String: AnyObject] = [NSFontAttributeName: FontSpec(.normal, .medium).font!]
+        let regularFont: [String: AnyObject] = [NSFontAttributeName: FontSpec(.medium, .regular).font!.withSize(14)]
+        let mediumFont: [String: AnyObject] = [NSFontAttributeName: FontSpec(.medium, .medium).font!.withSize(14)]
         
         if let teamName = teamName, !isActiveAccount {
             let result = NSMutableAttributedString(string: "in ", attributes: regularFont)
@@ -202,7 +202,7 @@ class ChatHeadView: UIView {
     }
 
     private func messageFont() -> UIFont {
-        let font = FontSpec(.normal, .regular).font!
+        let font = FontSpec(.medium, .regular).font!
         
         if message.isEphemeral {
             return UIFont(name: "RedactedScript-Regular", size: font.pointSize)!

--- a/Wire-iOS/Sources/UserInterface/Overlay/InAppNotifications/ChatHeadView.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/InAppNotifications/ChatHeadView.swift
@@ -35,19 +35,14 @@ class ChatHeadView: UIView {
     private let senderName: String
     private let teamName: String?
     
+    private let imageDiameter: CGFloat = 28
+    private let padding: CGFloat = 10
+    
     public var onSelect: ((ZMConversationMessage) -> Void)?
     
     override var intrinsicContentSize: CGSize {
-        let height = magicFloat("image_diameter") + 2 * magicFloat("content_padding")
+        let height = imageDiameter + 2 * padding
         return CGSize(width: UIViewNoIntrinsicMetric, height: height)
-    }
-
-    private let magicFloat: (String) -> CGFloat = {
-        return WAZUIMagic.cgFloat(forIdentifier: "notifications.\($0)")
-    }
-    
-    private let magicFont: (String) -> UIFont = {
-        return UIFont(magicIdentifier: "notifications.\($0)")
     }
     
     private func color(withName name: String) -> UIColor {
@@ -74,7 +69,7 @@ class ChatHeadView: UIView {
     
     private func setup() {
         backgroundColor = color(withName: ColorSchemeColorChatHeadBackground)
-        layer.cornerRadius = magicFloat("corner_radius")
+        layer.cornerRadius = 6
         layer.borderWidth = 0.5
         layer.borderColor = color(withName: ColorSchemeColorChatHeadBorder).cgColor
         
@@ -125,9 +120,6 @@ class ChatHeadView: UIView {
     }
     
     private func createConstraints() {
-        
-        let imageDiameter = magicFloat("image_diameter")
-        let padding = magicFloat("content_padding")
         
         constrain(labelContainer, titleLabel, subtitleLabel) { container, titleLabel, subtitleLabel in
             titleLabel.leading == container.leading

--- a/Wire-iOS/Sources/UserInterface/Overlay/InAppNotifications/ChatHeadView.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/InAppNotifications/ChatHeadView.swift
@@ -27,18 +27,17 @@ class ChatHeadView: UIView {
     private var subtitleLabel: UILabel!
     private var labelContainer: UIView!
     
-    private let isActiveAccount: Bool
-    private let isOneToOneConversation: Bool
-    
+    private let account: Account
     private let message: ZMConversationMessage
     private let conversationName: String
     private let senderName: String
     private let teamName: String?
+    private let isOneToOneConversation: Bool
     
     private let imageDiameter: CGFloat = 28
     private let padding: CGFloat = 10
     
-    public var onSelect: ((ZMConversationMessage) -> Void)?
+    public var onSelect: ((ZMConversationMessage, Account) -> Void)?
     
     override var intrinsicContentSize: CGSize {
         let height = imageDiameter + 2 * padding
@@ -51,11 +50,11 @@ class ChatHeadView: UIView {
     
     init(message: ZMConversationMessage, account: Account) {
         
+        self.account = account
         self.message = message
         self.conversationName = message.conversation?.displayName ?? ""
         self.senderName = message.sender?.displayName ?? ""
         self.teamName = account.teamName
-        self.isActiveAccount = account == SessionManager.shared?.accountManager.selectedAccount
         self.isOneToOneConversation = message.conversation?.conversationType == .oneOnOne
         super.init(frame: .zero)
         setup()
@@ -151,7 +150,7 @@ class ChatHeadView: UIView {
         let regularFont: [String: AnyObject] = [NSFontAttributeName: FontSpec(.medium, .regular).font!.withSize(14)]
         let mediumFont: [String: AnyObject] = [NSFontAttributeName: FontSpec(.medium, .medium).font!.withSize(14)]
         
-        if let teamName = teamName, !isActiveAccount {
+        if let teamName = teamName, !account.isActive {
             let result = NSMutableAttributedString(string: "in ", attributes: regularFont)
             result.append(NSAttributedString(string: teamName, attributes: mediumFont))
             
@@ -168,7 +167,7 @@ class ChatHeadView: UIView {
     
     private func subtitleText() -> String {
         let content = messageText()
-        return (isActiveAccount && isOneToOneConversation) ? content : "\(senderName): \(content)"
+        return (account.isActive && isOneToOneConversation) ? content : "\(senderName): \(content)"
     }
     
     private func messageText() -> String {
@@ -206,7 +205,7 @@ class ChatHeadView: UIView {
     
     @objc private func didTapInAppNotification(_ gestureRecognizer: UITapGestureRecognizer) {
         if let onSelect = onSelect, gestureRecognizer.state == .recognized {
-            onSelect(message)
+            onSelect(message, account)
         }
     }
 }

--- a/WireExtensionComponents/Utilities/ColorScheme.m
+++ b/WireExtensionComponents/Utilities/ColorScheme.m
@@ -217,6 +217,8 @@ static NSString* light(NSString *colorString) {
     UIColor *white = [UIColor whiteColor];
     UIColor *white97 = [UIColor colorWithWhite:0.97 alpha:1];
     UIColor *white98 = [UIColor colorWithWhite:0.98 alpha:1];
+    UIColor *white90 = [UIColor colorWithWhite:0.9 alpha:1];
+    UIColor *white60 = [UIColor colorWithWhite:0.6 alpha:1];
     UIColor *whiteAlpha16 = [UIColor wr_colorFromString:@"rgb(255, 255, 255, 0.16)"];
     UIColor *whiteAlpha24 = [UIColor wr_colorFromString:@"rgb(255, 255, 255, 0.24)"];
     UIColor *whiteAlpha40 = [UIColor wr_colorFromString:@"rgb(255, 255, 255, 0.40)"];
@@ -238,10 +240,6 @@ static NSString* light(NSString *colorString) {
     UIColor *lightGraphiteAlpha24 = [UIColor wr_colorFromString:@"rgb(141, 152, 159, 0.24)"];
     UIColor *lightGraphiteAlpha48 = [UIColor wr_colorFromString:@"rgb(141, 152, 159, 0.48)"];
     UIColor *lightGraphiteAlpha64 = [UIColor wr_colorFromString:@"rgb(141, 152, 159, 0.64)"];
-    UIColor *chatHeadSubtitleTextLight = [UIColor wr_colorFromString:@"rgb(153, 153, 153)"]; // TODO check color this is
-    UIColor *chatHeadBGDark = [UIColor wr_colorFromString:@"rgb(67, 71, 74)"]; // TODO check color this is
-    UIColor *chatHeadBorderLight = [UIColor wr_colorFromString:@"rgb(230, 230, 230)"]; // TODO check color this is
-    
     
     NSMutableDictionary *lightColors = [NSMutableDictionary dictionaryWithDictionary:
                                 @{ ColorSchemeColorAccent: accentColor,
@@ -265,9 +263,9 @@ static NSString* light(NSString *colorString) {
                                    ColorSchemeColorIconBackgroundSelectedNoAccent: graphite,
                                    ColorSchemeColorPopUpButtonOverlayShadow: blackAlpha24,
                                    ColorSchemeColorChatHeadBackground: white,
-                                   ColorSchemeColorChatHeadBorder: chatHeadBorderLight,
+                                   ColorSchemeColorChatHeadBorder: white90,
                                    ColorSchemeColorChatHeadTitleText: graphite,
-                                   ColorSchemeColorChatHeadSubtitleText: chatHeadSubtitleTextLight,
+                                   ColorSchemeColorChatHeadSubtitleText: white60,
                                    ColorSchemeColorButtonHighlighted: whiteAlpha24,
                                    ColorSchemeColorButtonEmptyText: accentColor,
                                    ColorSchemeColorTabNormal: blackAlpha48,
@@ -319,8 +317,8 @@ static NSString* light(NSString *colorString) {
                                   ColorSchemeColorIconBackgroundSelected: white,
                                   ColorSchemeColorIconBackgroundSelectedNoAccent: white,
                                   ColorSchemeColorPopUpButtonOverlayShadow: black,
-                                  ColorSchemeColorChatHeadBackground: chatHeadBGDark,
-                                  ColorSchemeColorChatHeadBorder: chatHeadBGDark,
+                                  ColorSchemeColorChatHeadBackground: graphite,
+                                  ColorSchemeColorChatHeadBorder: graphite,
                                   ColorSchemeColorChatHeadTitleText: white,
                                   ColorSchemeColorChatHeadSubtitleText: whiteAlpha40,
                                   ColorSchemeColorButtonHighlighted: blackAlpha24,


### PR DESCRIPTION
## What's in this PR?
- general refactoring: removing `magic`, updating `ColorScheme`
- Added account switching when tapping on chat head for inactive account

## Todo:
- Chat heads for calls
- Snapshot tests
- possible bug: sometimes don't receive notifications from one account after switching