### PR TITLE
Fix crash when changing name

### DIFF
--- a/Wire-iOS/Sources/Components/Settings/SettingsPropertyFactory.swift
+++ b/Wire-iOS/Sources/Components/Settings/SettingsPropertyFactory.swift
@@ -117,10 +117,10 @@ class SettingsPropertyFactory {
                 case .string(let stringValue):
                     var inOutString: NSString? = stringValue as NSString
                     try type(of: self.selfUser).validateName(&inOutString)
-                    
-                    self.userSession?.enqueueChanges({
-                        self.selfUser.name = stringValue
-                    })
+                    let selfUser = self.selfUser
+                    self.userSession?.enqueueChanges {
+                        selfUser.name = stringValue
+                    }
                 default:
                     throw SettingsPropertyError.WrongValue("Incorrect type \(value) for key \(propertyName)")
                 }


### PR DESCRIPTION
## Problem

If when changing name we tap X to exit settings the app crashes. A minor related issue is that after successfully changing name and handle it is not updated in the main account view.

## Solution

* The crash happens because `unowned self` is gone by the time we save changes. The fix is to extract user and use that instead.
* Added observing for name and handle changes