### PR TITLE
Fix crash when switching accounts

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Overlay/InAppNotifications/ChatHeadsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/InAppNotifications/ChatHeadsViewController.swift
@@ -119,7 +119,7 @@ class ChatHeadsViewController: UIViewController {
     
     private func shouldDisplay(message: ZMConversationMessage, account: Account) -> Bool {
         
-        let clientVC = ZClientViewController.shared()!
+        guard let clientVC = ZClientViewController.shared() else { return false }
 
         // if current conversation contains message & is visible
         if clientVC.currentConversation === message.conversation && clientVC.isConversationViewVisible {


### PR DESCRIPTION
When switching accounts without notifications enabled the app sometimes crashes. It happens because we try to access ZClientViewController before it was created during switching.