### PR TITLE
Do not re-create the app lock controller

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
@@ -34,6 +34,7 @@ import HockeySDK.BITHockeyManager
         }
     }
     
+    static let shared = AppLockViewController()
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Wire-iOS/Sources/UserInterface/Overlay/NotificationWindowRootViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Overlay/NotificationWindowRootViewController.m
@@ -34,6 +34,21 @@
 #import "UIViewController+Orientation.h"
 #import "Wire-Swift.h"
 
+@interface UIViewController (Child)
+- (void)wr_removeFromParentViewController;
+@end
+
+@implementation UIViewController (Child)
+
+- (void)wr_removeFromParentViewController
+{
+    [self willMoveToParentViewController:nil];
+    [self.view removeFromSuperview];
+    [self removeFromParentViewController];
+}
+
+@end
+
 @interface NotificationWindowRootViewController ()
 
 @property (nonatomic) NetworkStatusViewController *networkStatusViewController;
@@ -51,6 +66,11 @@
 
 @implementation NotificationWindowRootViewController
 
+- (void)dealloc
+{
+    [self.appLockViewController wr_removeFromParentViewController];
+}
+    
 - (void)loadView
 {
     self.view = [PassthroughTouchesView new];
@@ -59,7 +79,11 @@
     self.networkStatusViewController.view.translatesAutoresizingMaskIntoConstraints = NO;
     [self addViewController:self.networkStatusViewController toView:self.view];
     
-    self.appLockViewController = [[AppLockViewController alloc] init];
+    self.appLockViewController = [AppLockViewController shared];
+    if (nil != self.appLockViewController.parentViewController) {
+        [self.appLockViewController wr_removeFromParentViewController];
+    }
+    
     self.appLockViewController.view.translatesAutoresizingMaskIntoConstraints = NO;
     [self addViewController:self.appLockViewController toView:self.view];
     


### PR DESCRIPTION
- On creation the app lock controller shows itself, but it is an issue since we are re-creating it as the part of the overlay window.
- Keeping the shared instance is OK, since it's not bound to the user.