### PR TITLE
fix/request to open view

### DIFF
--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -36,6 +36,8 @@ class AppRootViewController : UIViewController {
     fileprivate let transitionQueue : DispatchQueue = DispatchQueue(label: "transitionQueue")
     fileprivate var isClassyInitialized = false
     
+    fileprivate var performWhenRequestsToOpenViewsDelegateAvailable: ((ZMRequestsToOpenViewsDelegate)->())?
+    
     
     
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
@@ -113,6 +115,7 @@ class AppRootViewController : UIViewController {
         { sessionManager in
             self.sessionManager = sessionManager
             self.sessionManager?.localMessageNotificationResponder = self
+            self.sessionManager?.requestToOpenViewDelegate = self
             sessionManager.updateCallNotificationStyleFromSettings()
         }
     }
@@ -182,7 +185,13 @@ class AppRootViewController : UIViewController {
         }
         
         if let viewController = viewController {
-            transition(to: viewController, animated: true, completionHandler: completionHandler)
+            transition(to: viewController, animated: true) {
+                if viewController.conforms(to: ZMRequestsToOpenViewsDelegate.self) {
+                    self.performWhenRequestsToOpenViewsDelegateAvailable?(viewController as! ZMRequestsToOpenViewsDelegate)
+                    self.performWhenRequestsToOpenViewsDelegateAvailable = nil
+                }
+                completionHandler?()
+            }
         } else {
             completionHandler?()
         }
@@ -349,6 +358,29 @@ extension AppRootViewController : AppStateControllerDelegate {
         enqueueTransition(to: appState)
     }
     
+}
+
+// MARK: - RequestToOpenViewsDelegate
+
+extension AppRootViewController : ZMRequestsToOpenViewsDelegate {
+    
+    public func showConversationList(for userSession: ZMUserSession!) {
+        performWhenRequestsToOpenViewsDelegateAvailable = { delegate in
+            delegate.showConversationList(for: userSession)
+        }
+    }
+    
+    public func userSession(_ userSession: ZMUserSession!, show conversation: ZMConversation!) {
+        performWhenRequestsToOpenViewsDelegateAvailable = { delegate in
+            delegate.userSession(userSession, show: conversation)
+        }
+    }
+    
+    public func userSession(_ userSession: ZMUserSession!, show message: ZMMessage!, in conversation: ZMConversation!) {
+        performWhenRequestsToOpenViewsDelegateAvailable = { delegate in
+            delegate.userSession(userSession, show: message, in: conversation)
+        }
+    }
 }
 
 // MARK: - Application Icon Badge Number

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
@@ -117,7 +117,6 @@
         self.proximityMonitorManager = [ProximityMonitorManager new];
         self.mediaPlaybackManager = [[MediaPlaybackManager alloc] initWithName:@"conversationMedia"];
         self.messageCountTracker = [[LegacyMessageTracker alloc] initWithManagedObjectContext:ZMUserSession.sharedSession.syncManagedObjectContext];
-        [[SessionManager shared] setRequestToOpenViewDelegate:self];
 
         [AVSProvider.shared.mediaManager registerMedia:self.mediaPlaybackManager withOptions:@{ @"media" : @"external "}];
         
@@ -180,6 +179,9 @@
     }
     
     self.userObserverToken = [UserChangeInfo addObserver:self forUser:[ZMUser selfUser] userSession:[ZMUserSession sharedSession]];
+    
+    // set delegate here b/c it may trigger loading of other views
+    [[SessionManager shared] setRequestToOpenViewDelegate:self];
 }
 
 - (void)createBackgroundViewController

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
@@ -179,9 +179,6 @@
     }
     
     self.userObserverToken = [UserChangeInfo addObserver:self forUser:[ZMUser selfUser] userSession:[ZMUserSession sharedSession]];
-    
-    // set delegate here b/c it may trigger loading of other views
-    [[SessionManager shared] setRequestToOpenViewDelegate:self];
 }
 
 - (void)createBackgroundViewController


### PR DESCRIPTION
## Fix
`ZClientViewController` was not responding to `SessionManager`s request to open a conversation.

## Solution
- Make `AppRootViewController` the `ZMRequestsToOpenViewsDelegate` for `SessionManager` and store the invoked delegate method as a closure.
- When a transition to a new view controller is complete, invoke the stored closure if the view controller conforms to `ZMRequestsToOpenViewsDelegate`.