### PR TITLE
Crash on no message

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransferCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransferCell.swift
@@ -127,7 +127,7 @@ public final class FileTransferCell: ConversationCell {
         
         var additionalItems = [UIMenuItem]()
         
-        if let fileMessageData = message.fileMessageData,
+        if let message = message, let fileMessageData = message.fileMessageData,
             let _ = fileMessageData.fileURL {
             additionalItems.append(contentsOf: [
                 .open(with: #selector(open)),

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -880,9 +880,11 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
 {
     if (self.messagePresenter.waitingForFileDownload) {
         id<ZMConversationMessage> selectedMessage = self.conversationMessageWindowTableViewAdapter.selectedMessage;
-        if (([Message isVideoMessage:selectedMessage] ||
+        if (selectedMessage &&
+            ([Message isVideoMessage:selectedMessage] ||
              [Message isAudioMessage:selectedMessage] ||
-             [Message isFileTransferMessage:selectedMessage]) && selectedMessage.fileMessageData.transferState == ZMFileTransferStateDownloaded) {
+             [Message isFileTransferMessage:selectedMessage])
+            && selectedMessage.fileMessageData.transferState == ZMFileTransferStateDownloaded) {
             if ([self wr_isVisible]) {
                 NSUInteger indexOfFileMessage = [[[self messageWindow] messages] indexOfObject:selectedMessage];
                 
@@ -913,6 +915,11 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
 
 - (void)conversationWindowDidChange:(MessageWindowChangeInfo *)note
 {
+    // Clear selectedMessage if it is going to be deleted.
+    if ([note.deletedObjects containsObject:self.conversationMessageWindowTableViewAdapter.selectedMessage]) {
+        self.conversationMessageWindowTableViewAdapter.selectedMessage = nil;
+    }
+    
     if (note.insertedIndexes.count == 0) {
         return;
     }


### PR DESCRIPTION
I manged to isolate the error better.
When tapping on a message, some information will be displayed under the message (e.g. "Tap ❤️ to like" suggestion). When this happens, the message is stored as "selected message". If I later delete that message, the "stored message" was not set to nil, and then accessed and used when the conversation window changes, causing a crash. 

This would happen only for file messages, as `[Message isVideoMessage:]` was previously not crashing with `nil` values, but it does now because we are using a non-optional in Swift somewhere down the code. This PR fixes it by checking that the message is not `nil` before accessing it.

