### PR TITLE
Showing the team avatar when switching to team account

### DIFF
--- a/Wire-iOS/Sources/UserInterface/SkeletonViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/SkeletonViewController.swift
@@ -231,7 +231,7 @@ class SkeletonViewController: UIViewController {
     
     public init(from: Account?, to: Account) {
 
-        if let fromUnwrapped = from, to.imageData == nil {
+        if let fromUnwrapped = from, to.imageData == nil, to.teamName == nil {
             account = fromUnwrapped
         }
         else {


### PR DESCRIPTION
Previously it would fallback to the initial user image as teams don’t have image yet.