### PR TITLE
Fix: some controllers could be gone while notifications arrive

### DIFF
--- a/Wire-iOS/Sources/AppDelegate+Network.swift
+++ b/Wire-iOS/Sources/AppDelegate+Network.swift
@@ -33,7 +33,7 @@ extension AppDelegate {
     @discardableResult
     @objc(checkNetworkAndFlashIndicatorIfNecessaryAndShowAlert:)
     static func checkNetworkAndFlashIndicatorIfNecessary(showAlert: Bool)  -> Bool {
-        AppDelegate.shared().notificationWindowController?.networkStatusViewController.flashNetworkStatusIfNecessaryAndShowAlert(showAlert)
+        AppDelegate.shared().notificationWindowController?.networkStatusViewController?.flashNetworkStatusIfNecessaryAndShowAlert(showAlert)
         return AppDelegate.shared().sessionManager.serverConnection?.isOffline ?? true
     }
     

--- a/Wire-iOS/Sources/UserInterface/Overlay/InAppNotifications/ChatHeadsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/InAppNotifications/ChatHeadsViewController.swift
@@ -157,7 +157,7 @@ class ChatHeadsViewController: UIViewController {
             return false
         }
         
-        if AppDelegate.shared().notificationWindowController?.voiceChannelController.voiceChannelIsActive ?? false {
+        if AppDelegate.shared().notificationWindowController?.voiceChannelController?.voiceChannelIsActive ?? false {
             return false;
         }
 

--- a/Wire-iOS/Sources/UserInterface/Overlay/NotificationWindowRootViewController.h
+++ b/Wire-iOS/Sources/UserInterface/Overlay/NotificationWindowRootViewController.h
@@ -28,16 +28,16 @@
 
 @interface NotificationWindowRootViewController : UIViewController
 
-@property (nonatomic, readonly) NetworkStatusViewController *networkStatusViewController;
-@property (nonatomic, readonly) VoiceChannelController *voiceChannelController;
-@property (nonatomic, readonly) AppLockViewController *appLockViewController;
-@property (nonatomic, readonly) ChatHeadsViewController *chatHeadsViewController;
+@property (nonatomic, readonly, nullable) NetworkStatusViewController *networkStatusViewController;
+@property (nonatomic, readonly, nullable) VoiceChannelController *voiceChannelController;
+@property (nonatomic, readonly, nullable) AppLockViewController *appLockViewController;
+@property (nonatomic, readonly, nullable) ChatHeadsViewController *chatHeadsViewController;
 
 @property (nonatomic) BOOL showLoadMessages;
 
 @property (nonatomic) BOOL hideNetworkActivityView;
 
 - (void)transitionToLoggedInSession;
-- (void)showLocalNotification:(UILocalNotification*)notification;
+- (void)showLocalNotification:(nonnull UILocalNotification *)notification;
 
 @end


### PR DESCRIPTION
This happens when switching accounts and the UI is torn down, but you still get a new message.