### PR TITLE
Fix getting stuck when resuming an aborted login

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationViewController.m
@@ -49,7 +49,7 @@
 
 #import "AnalyticsTracker+Registration.h"
 
-@interface RegistrationViewController (PostLoginAuthenticationObserver) <PostLoginAuthenticationObserver>
+@interface RegistrationViewController (UserSessionObserver) <SessionManagerObserver, PostLoginAuthenticationObserver>
 @end
 
 @interface RegistrationViewController () <UINavigationControllerDelegate, FormStepDelegate, ZMInitialSyncCompletionObserver>
@@ -68,6 +68,7 @@
 @property (nonatomic) NSArray<UserClient *>* userClients;
 @property (nonatomic) id initialSyncObserverToken;
 @property (nonatomic) id postLoginToken;
+@property (nonatomic) id sessionCreationObserverToken;
 
 @end
 
@@ -87,6 +88,7 @@
     self.unregisteredUser = [ZMIncompleteRegistrationUser new];
     self.unregisteredUser.accentColorValue = [UIColor indexedAccentColor];
     self.postLoginToken = [PostLoginAuthenticationNotification addObserver:self];
+    self.sessionCreationObserverToken = [[SessionManager shared] addSessionManagerObserver:self];
     
     [self setupBackgroundViewController];
     [self setupNavigationController];
@@ -295,7 +297,11 @@
 
 #pragma mark - Session observer
 
-@implementation RegistrationViewController (PostLoginAuthenticationObserver)
+@implementation RegistrationViewController (UserSessionObserver)
+
+- (void)sessionManagerCreatedWithUserSession:(ZMUserSession *)userSession {
+    self.initialSyncObserverToken = [ZMUserSession addInitialSyncCompletionObserver:self userSession:[ZMUserSession sharedSession]];
+}
 
 - (void)clientRegistrationDidSucceedWithAccountId:(NSUUID * _Nonnull)accountId
 {

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationViewController.m
@@ -49,7 +49,7 @@
 
 #import "AnalyticsTracker+Registration.h"
 
-@interface RegistrationViewController (SessionManagerObserver) <SessionManagerObserver>
+@interface RegistrationViewController (PostLoginAuthenticationObserver) <PostLoginAuthenticationObserver>
 @end
 
 @interface RegistrationViewController () <UINavigationControllerDelegate, FormStepDelegate, ZMInitialSyncCompletionObserver>
@@ -67,7 +67,7 @@
 @property (nonatomic) BOOL hasPushedPostRegistrationStep;
 @property (nonatomic) NSArray<UserClient *>* userClients;
 @property (nonatomic) id initialSyncObserverToken;
-@property (nonatomic) id sessionCreationObserverToken;
+@property (nonatomic) id postLoginToken;
 
 @end
 
@@ -86,7 +86,7 @@
 
     self.unregisteredUser = [ZMIncompleteRegistrationUser new];
     self.unregisteredUser.accentColorValue = [UIColor indexedAccentColor];
-    self.sessionCreationObserverToken = [[SessionManager shared] addSessionManagerObserver:self];
+    self.postLoginToken = [PostLoginAuthenticationNotification addObserver:self];
     
     [self setupBackgroundViewController];
     [self setupNavigationController];
@@ -295,9 +295,10 @@
 
 #pragma mark - Session observer
 
-@implementation RegistrationViewController (SessionManagerObserver)
+@implementation RegistrationViewController (PostLoginAuthenticationObserver)
 
-- (void)sessionManagerCreatedWithUserSession:(ZMUserSession *)userSession {
+- (void)clientRegistrationDidSucceedWithAccountId:(NSUUID * _Nonnull)accountId
+{
     self.initialSyncObserverToken = [ZMUserSession addInitialSyncCompletionObserver:self userSession:[ZMUserSession sharedSession]];
 }
 


### PR DESCRIPTION
## Problem
Login can take several paths atm which makes it a bit complicated. The login would miss to register for initial sync in the `path 3` case and `path 5`.

Previously this was not an issue because then the login observation was:
```
    if (nil != [ZMUserSession sharedSession]) {
        self.initialSyncObserverToken = [ZMUserSession addInitialSyncCompletionObserver:self userSession:[ZMUserSession sharedSession]];
    } else {
        self.sessionCreationObserverToken = [[SessionManager shared] addSessionManagerObserver:self];
    }
```
But this had a problem in `path 4` where the we would start observing initial sync for the user session which was in the process of tearing down.

### path 1
1. launch app
2. login
3. register client
4. done

### path 2
1. launch app
2. login
3. fail to register client (because you have to many clients)
4 delete client
5. register client
6. done

### path 3
1. launch app
2. login
3. fail to register client (because you have too many clients)
4 kill the app
5. launch app 
6. app will try to open the user session you tried to active but
7. fail to register client (because you are missing credentials)
8 app will transition to login screen (but user session will still be around)
9. delete client
10. register client
11. done

### path 4
1. app is running with two accounts
2. logout from account 1
3. app will transition to account 2 (but account 2 is discovered to be logged out)
4 app will transition to login screen (but user session will still be around until the the transition is done)
5. register client
6. done

### path 5
1. launch app
2. login (client is already there)
3. done

## Solution

We now observe user session creation AND client registration and begin the initial sync on any of those two events.