### PR TITLE
Fix: app freezes while showing skeleton screen

### DIFF
--- a/Wire-iOS/Sources/AppStateController.swift
+++ b/Wire-iOS/Sources/AppStateController.swift
@@ -120,6 +120,7 @@ extension AppStateController : SessionManagerDelegate {
     }
     
     func sessionManagerDidFailToLogin(error: Error) {
+        loadingAccount = nil
         authenticationError = error
         isLoggedIn = false
         isLoggedOut = true


### PR DESCRIPTION
This was happening because we were switching to an account without authentication cookie. It immediately fired login failure notification, but app was thinking it is still in loading state. 