### PR TITLE
[fix]ZIOS-8958 Audio message is not playable after killing and reopening the app

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/AudioMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/AudioMessageCell.swift
@@ -37,7 +37,6 @@ public final class AudioMessageCell: ConversationCell {
         self.containerView.clipsToBounds = true
         
         self.audioMessageView.delegate = self
-        self.audioMessageView.audioTrackPlayer = AppDelegate.shared().mediaPlaybackManager?.audioTrackPlayer
         self.obfuscationView.isHidden = true
         
         self.containerView.addSubview(self.audioMessageView)

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
@@ -24,10 +24,19 @@ import Classy
 final class AudioMessageView: UIView, TransferView {
     public var fileMessage: ZMConversationMessage?
     weak public var delegate: TransferViewDelegate?
+    private var _audioTrackPlayer:AudioTrackPlayer?
     public var audioTrackPlayer : AudioTrackPlayer? {
-        didSet {
-            audioPlayerProgressObserver = KeyValueObserver.observe(audioTrackPlayer, keyPath: "progress", target: self, selector: #selector(audioProgressChanged(_:)), options: [.initial, .new])
-            audioPlayerStateObserver = KeyValueObserver.observe(audioTrackPlayer, keyPath: "state", target: self, selector: #selector(audioPlayerStateChanged(_:)), options: [.initial, .new])
+        get {
+            if _audioTrackPlayer == nil {
+                _audioTrackPlayer = AppDelegate.shared().mediaPlaybackManager?.audioTrackPlayer
+                
+                setupAudioPlayerObservers()
+            }
+            return _audioTrackPlayer
+        }
+        set(newValue) {
+            _audioTrackPlayer = newValue
+            setupAudioPlayerObservers()
         }
     }
     
@@ -337,6 +346,11 @@ final class AudioMessageView: UIView, TransferView {
         return audioTrackPlayingSame && audioTrackPlayer.audioTrack.isEqual(audioTrack)
     }
     
+    func setupAudioPlayerObservers() {
+        audioPlayerProgressObserver = KeyValueObserver.observe(_audioTrackPlayer, keyPath: "progress", target: self, selector: #selector(audioProgressChanged(_:)), options: [.initial, .new])
+        audioPlayerStateObserver = KeyValueObserver.observe(_audioTrackPlayer, keyPath: "state", target: self, selector: #selector(audioPlayerStateChanged(_:)), options: [.initial, .new])
+    }
+
     // MARK: - Actions
     
     dynamic private func onActionButtonPressed(_ sender: UIButton) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
@@ -24,8 +24,8 @@ import Classy
 final class AudioMessageView: UIView, TransferView {
     public var fileMessage: ZMConversationMessage?
     weak public var delegate: TransferViewDelegate?
-    private var _audioTrackPlayer:AudioTrackPlayer?
-    public var audioTrackPlayer : AudioTrackPlayer? {
+    private var _audioTrackPlayer: AudioTrackPlayer?
+    public var audioTrackPlayer: AudioTrackPlayer? {
         get {
             if _audioTrackPlayer == nil {
                 _audioTrackPlayer = AppDelegate.shared().mediaPlaybackManager?.audioTrackPlayer


### PR DESCRIPTION
Fix the no audio issue caused by AppDelegate.shared().mediaPlaybackManager?.audioTrackPlayer is nil when AUdioMessageView is created.

Move the audioTrackPlayer's assignment (from app delegate's shared property) from AudioMessageView to AudioMessageCell.

do nil check every time when AudioMessageCell want to asscees audioTrackPlayer and assign again if it is nil.