### PR TITLE
Add missing parentheses in guard expression

### DIFF
--- a/Wire-iOS/Sources/Managers/SoundEventListener.swift
+++ b/Wire-iOS/Sources/Managers/SoundEventListener.swift
@@ -82,7 +82,7 @@ extension SoundEventListener : ZMNewUnreadMessagesObserver, ZMNewUnreadKnocksObs
             let isSentBySelfUser = message.sender?.isSelfUser ?? false
             let isSilencedConversation = message.conversation?.isSilenced ?? false
             
-            guard message.isNormal || message.isSystem &&
+            guard (message.isNormal || message.isSystem) &&
                   isRecentMessage &&
                   !isSentBySelfUser &&
                   !isFirstMessage &&


### PR DESCRIPTION
Without a parentheses all the negative cases got skipped.

https://wearezeta.atlassian.net/browse/ZIOS-9045