### PR TITLE
[bug fix]Mike fixed spinner not dismiss after register with a phone number

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPhoneFlowViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPhoneFlowViewController.m
@@ -256,7 +256,7 @@
 {
     if (self.navigationController.view.window) {
         
-        self.showLoadingView = NO;
+        self.navigationController.showLoadingView = NO;
         
         if (error.code != ZMUserSessionCodeRequestIsAlreadyPending) {
             


### PR DESCRIPTION


The bug occurs when server responses "The SMS or voice call budget for the given phone number has been exhausted. Please try again later. Repeated exhaustion of the SMS or voice call budget is considered abuse of the API and may result in permanent blacklisting of the phone number."