### PR TITLE
Added image picking options in order to set the high quality format.

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Helpers/UIImagePickerController+GetImage.m
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UIImagePickerController+GetImage.m
@@ -49,7 +49,7 @@
         [PHImageManager.defaultManager requestImageForAsset:resultAsset
                                                  targetSize:PHImageManagerMaximumSize
                                                 contentMode:PHImageContentModeDefault
-                                                    options:[UIImagePickerController getImagePickingOptions]
+                                                    options:[UIImagePickerController pickingOptions]
                                               resultHandler:^(UIImage * _Nullable result, NSDictionary * _Nullable info) {
                                                   dispatch_async(dispatch_get_main_queue(), ^{
                                                       callback(result);
@@ -76,7 +76,7 @@
 
     if (nil != resultAsset) {
         [PHImageManager.defaultManager requestImageDataForAsset:resultAsset
-                                                        options:[UIImagePickerController getImagePickingOptions]
+                                                        options:[UIImagePickerController pickingOptions]
                                                   resultHandler:^(NSData * _Nullable imageData, NSString * _Nullable dataUTI, UIImageOrientation orientation, NSDictionary * _Nullable info) {
                                                       dispatch_async(dispatch_get_main_queue(), ^{
                                                           if (imageData != nil) {
@@ -104,7 +104,7 @@
     }
 }
 
-+(PHImageRequestOptions*)getImagePickingOptions
++(PHImageRequestOptions*)pickingOptions
 {
     PHImageRequestOptions *options = [[PHImageRequestOptions alloc] init];
     options.deliveryMode = PHImageRequestOptionsDeliveryModeHighQualityFormat;

--- a/Wire-iOS/Sources/UserInterface/Helpers/UIImagePickerController+GetImage.m
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UIImagePickerController+GetImage.m
@@ -49,7 +49,7 @@
         [PHImageManager.defaultManager requestImageForAsset:resultAsset
                                                  targetSize:PHImageManagerMaximumSize
                                                 contentMode:PHImageContentModeDefault
-                                                    options:nil
+                                                    options:[UIImagePickerController getImagePickingOptions]
                                               resultHandler:^(UIImage * _Nullable result, NSDictionary * _Nullable info) {
                                                   dispatch_async(dispatch_get_main_queue(), ^{
                                                       callback(result);
@@ -76,7 +76,7 @@
 
     if (nil != resultAsset) {
         [PHImageManager.defaultManager requestImageDataForAsset:resultAsset
-                                                        options:nil
+                                                        options:[UIImagePickerController getImagePickingOptions]
                                                   resultHandler:^(NSData * _Nullable imageData, NSString * _Nullable dataUTI, UIImageOrientation orientation, NSDictionary * _Nullable info) {
                                                       dispatch_async(dispatch_get_main_queue(), ^{
                                                           if (imageData != nil) {
@@ -102,6 +102,13 @@
     else if (info[UIImagePickerControllerOriginalImage]) {
         resultBlock(UIImageJPEGRepresentation(info[UIImagePickerControllerOriginalImage], 0.9));
     }
+}
+
++(PHImageRequestOptions*)getImagePickingOptions
+{
+    PHImageRequestOptions *options = [[PHImageRequestOptions alloc] init];
+    options.deliveryMode = PHImageRequestOptionsDeliveryModeHighQualityFormat;
+    return options;
 }
 
 @end


### PR DESCRIPTION
Images were appearing small when picking an edited image from the Photo Library because of an option of Photos framework (`PHImageRequestOptionsDeliveryMode`, now set to `.highQualityFormat`). Reference: https://stackoverflow.com/questions/28042697/phimagemanager-requestimageforasset-returns-low-res-image-in-ios-swift 