### PR TITLE
bugfix: move audioTrackPlayer before it is used. When it is nil, get duration from fileMessage

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
@@ -223,12 +223,13 @@ final class AudioMessageView: UIView, TransferView {
     }
     
     private func updateTimeLabel() {
-        guard let audioTrackPlayer = self.audioTrackPlayer else { return }
         
         var duration: Int? = .none
         
         if self.isOwnTrackPlayingInAudioPlayer() {
-            duration = Int(audioTrackPlayer.elapsedTime)
+            if let audioTrackPlayer = self.audioTrackPlayer {
+                duration = Int(audioTrackPlayer.elapsedTime)
+            }
         }
         else {
             guard let message = self.fileMessage,


### PR DESCRIPTION
move audioTrackPlayer nil check from the beginning of the func to the place uses audioTrackPlayer.