### PR TITLE
bugfix: prevent creating multiple audio message if user click the green tick button multiple times in a second

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
@@ -412,7 +412,9 @@ import CocoaLumberjackSwift
             DDLogError("No file to send")
             return
         }
-        
+
+        button?.isEnabled = false
+
         let effectName: String
         
         if self.currentEffect == .none {


### PR DESCRIPTION
disable confirm button after it is pressed