### PR TITLE
Fix/zios 9042 audio not switching back to speaker after switching to earpiece(phase2)

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
@@ -407,7 +407,7 @@ final class AudioMessageView: UIView, TransferView {
     // MARK: - Proximity Listener
     
     private func updateProximityObserverState() {
-        guard let audioTrackPlayer = self.audioTrackPlayer else { return }
+        guard let audioTrackPlayer = self.audioTrackPlayer, isOwnTrackPlayingInAudioPlayer() else { return }
         
         if audioTrackPlayer.isPlaying && isOwnTrackPlayingInAudioPlayer() {
             proximityMonitorManager?.startListening()

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
@@ -409,7 +409,7 @@ final class AudioMessageView: UIView, TransferView {
     private func updateProximityObserverState() {
         guard let audioTrackPlayer = self.audioTrackPlayer, isOwnTrackPlayingInAudioPlayer() else { return }
         
-        if audioTrackPlayer.isPlaying && isOwnTrackPlayingInAudioPlayer() {
+        if audioTrackPlayer.isPlaying {
             proximityMonitorManager?.startListening()
         } else {
             proximityMonitorManager?.stopListening()


### PR DESCRIPTION
  fixed the case when more then 1 audio message view in the same conversation.    