### PR TITLE
Handle notification action also when UI is not loaded

### DIFF
--- a/Wire-iOS/Sources/AppDelegate.m
+++ b/Wire-iOS/Sources/AppDelegate.m
@@ -325,9 +325,7 @@ static AppDelegate *sharedAppDelegate = nil;
 {
     DDLogWarn(@"Received APNS token: %@", newDeviceToken);
     
-    [self.rootViewController performWhenAuthenticated:^{
-        [[SessionManager shared] didRegisteredForRemoteNotificationsWith:newDeviceToken];
-    }];
+    [[SessionManager shared] didRegisteredForRemoteNotificationsWith:newDeviceToken];
 }
 
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error
@@ -354,9 +352,8 @@ static AppDelegate *sharedAppDelegate = nil;
         [[Analytics shared] tagAppLaunchWithType:ApplicationLaunchPush];
         self.trackedResumeEvent = YES;
     }
-    [self.rootViewController performWhenAuthenticated:^{
-        [[SessionManager shared] didReceiveRemoteNotification:userInfo fetchCompletionHandler:completionHandler];
-    }];
+    
+    [[SessionManager shared] didReceiveRemoteNotification:userInfo fetchCompletionHandler:completionHandler];
     
     self.launchType = (application.applicationState == UIApplicationStateInactive || application.applicationState == UIApplicationStateBackground) ? ApplicationLaunchPush: ApplicationLaunchDirect;
 }
@@ -365,9 +362,7 @@ static AppDelegate *sharedAppDelegate = nil;
 {
     DDLogInfo(@"application:didReceiveLocalNotification: %@", notification);
     
-    [self.rootViewController performWhenAuthenticated:^{
-        [[SessionManager shared] didReceiveLocalNotification:notification application:application];
-    }];
+    [[SessionManager shared] didReceiveLocalNotification:notification application:application];
     
     self.launchType = (application.applicationState == UIApplicationStateInactive || application.applicationState == UIApplicationStateBackground) ? ApplicationLaunchPush: ApplicationLaunchDirect;
 }
@@ -379,13 +374,11 @@ forLocalNotification:(UILocalNotification *)notification
 {
     DDLogInfo(@"application:handleActionWithIdentifier:forLocalNotification: identifier: %@, notification: %@", identifier, notification);
     
-    [self.rootViewController performWhenAuthenticated:^{
-        [[SessionManager shared] handleActionWithIdentifier:identifier
-                                       forLocalNotification:notification
-                                           withResponseInfo:[NSDictionary dictionary]
-                                          completionHandler:completionHandler
-                                                application:application];
-    }];
+    [[SessionManager shared] handleActionWithIdentifier:identifier
+                                   forLocalNotification:notification
+                                       withResponseInfo:[NSDictionary dictionary]
+                                      completionHandler:completionHandler
+                                            application:application];
 }
 
 - (void)application:(UIApplication *)application
@@ -396,13 +389,11 @@ forLocalNotification:(UILocalNotification *)notification
 {
     DDLogInfo(@"application:handleActionWithIdentifier:forLocalNotification: identifier: %@, notification: %@ responseInfo: %@", identifier, notification, responseInfo);
     
-    [self.rootViewController performWhenAuthenticated:^{
-        [[SessionManager shared] handleActionWithIdentifier:identifier
-                                       forLocalNotification:notification
-                                           withResponseInfo:responseInfo
-                                          completionHandler:completionHandler
-                                                application:application];
-    }];
+    [[SessionManager shared] handleActionWithIdentifier:identifier
+                                   forLocalNotification:notification
+                                       withResponseInfo:responseInfo
+                                      completionHandler:completionHandler
+                                            application:application];
 }
 
 - (void)application:(UIApplication *)application performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler;


### PR DESCRIPTION
## Problem
Notification actions were getting ignored unless the app had previously loaded the UI. If the
app gets launched from a push the `AppState` will be` .headless` and any calls to
`performWhenAuthenticated:` will get queued until the UI is loaded.

## Solution
Don't wrap push notification action in `performWhenAuthenticated:` which should now be
unnecessary since they now get forwarded to the SessionManager.