### PR TITLE
Stop call timer when stopping call to prevent retain cycle

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Overlay/ActiveVoiceChannelViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/ActiveVoiceChannelViewController.swift
@@ -24,8 +24,13 @@ class ActiveVoiceChannelViewController : UIViewController {
     
     var callStateObserverToken : Any?
     
+    deinit {
+        visibleVoiceChannelViewController?.stopCallDurationTimer()
+    }
+    
     var visibleVoiceChannelViewController : VoiceChannelViewController? {
         didSet {
+            oldValue?.stopCallDurationTimer()
             transition(to: visibleVoiceChannelViewController, from: oldValue)
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelViewController.swift
@@ -35,7 +35,7 @@ class VoiceChannelViewController: UIViewController {
     fileprivate var isSwitchingCamera = false
     fileprivate var currentCaptureDevice: CaptureDevice = .front
     fileprivate var previousCallState : CallState = .none
-    fileprivate var callDurationTimer : Timer?
+    fileprivate weak var callDurationTimer : Timer?
     fileprivate var outgoingVideoWasActiveBeforeEnteringEnteringBackground = false
     
     override func loadView() {
@@ -310,7 +310,7 @@ extension VoiceChannelViewController : WireCallCenterCallStateObserver, Received
         callDurationTimer = Timer.scheduledTimer(timeInterval: 0.1, target: self, selector: #selector(updateCallDuration), userInfo: nil, repeats: true)
     }
     
-    func stopCallDurationTimer() {
+    public func stopCallDurationTimer() {
         callDurationTimer?.invalidate()
         callDurationTimer = nil
     }


### PR DESCRIPTION
## Problem
The `VoiceChannelViewController` wasn't deallocated directly after ending the call. Causing a crash if you tried to re-join the call.

## Solution
Make sure the `VoiceChannelViewController` gets deallocated immediately.

https://wearezeta.atlassian.net/browse/ZIOS-9097