### PR TITLE
Make sure the debug pattern doesn't show during tests

### DIFF
--- a/Wire-iOS Tests/VoiceChannelOverlayTests.swift
+++ b/Wire-iOS Tests/VoiceChannelOverlayTests.swift
@@ -120,6 +120,7 @@ class VoiceChannelOverlayTests: ZMSnapshotTestCase {
         overlay.transition(to: state)
         CASStyler.default().styleItem(overlay)
         overlay.backgroundColor = .darkGray
+        overlay.videoView?.backgroundColor = .clear
         return overlay
     }
     


### PR DESCRIPTION
This should fix tests failing locally but passing on CI.