### PR TITLE
Show archive icon in skeleton view

### DIFF
--- a/Wire-iOS/Sources/UserInterface/SkeletonViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/SkeletonViewController.swift
@@ -174,7 +174,7 @@ class ListSkeletonView  : UIView {
         titleLabel.font = FontSpec(.medium, .semibold).font
         titleLabel.text = "list.title".localized.uppercased()
         
-        buttonRowView = UIStackView(arrangedSubviews: disabledButtons(with: [.person, .compose]))
+        buttonRowView = UIStackView(arrangedSubviews: disabledButtons(with: [.person, .archive]))
         buttonRowView.distribution = .equalCentering
 
         [accountView, titleLabel, listContentView, buttonRowView].forEach(addSubview)


### PR DESCRIPTION
We have been showing wrong icon during the account switch in the bottom right of the skeleton view