### PR TITLE
Workaround for failing to pre-fill password on iOS11

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Registration/EmailSignInViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/EmailSignInViewController.m
@@ -208,6 +208,12 @@
 
 - (void)takeFirstResponder
 {
+    if (@available(iOS 11, *)) {
+        // A workaround for iOS11 not autofilling the password textfield (https://wearezeta.atlassian.net/browse/ZIOS-9080).
+        // We need to put focus on the textfield as it seems to force iOS to "see" this texfield
+        [self.passwordField becomeFirstResponder];
+    }
+
     if (self.emailField.isEnabled) {
         [self.emailField becomeFirstResponder];
     } else {


### PR DESCRIPTION
The reason behind this is still unknown, maybe some bug in UIKit. It seems that if we switch the order of login and registration tabs (thus showing login first, not registration) all seems to be working fine. Another workaround was to simply activate the password field and then put focus to email field immediately.