### PR TITLE
Status bar not touchable

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Overlay/NetworkStatus/NetworkStatusView.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/NetworkStatus/NetworkStatusView.swift
@@ -186,4 +186,8 @@ class NetworkStatusView : UIView {
         }
     }
     
+    // Detects when the view can be touchable
+    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        return state == .offlineExpanded
+    }
 }


### PR DESCRIPTION
This PR fixes the issue that is currently avoiding status bar to be touched, e.g. when the "Back to previous app" action is available. Touch is enabled on the Network Status View only if it's currently expanded - when the "No internet" message is shown.