### PR TITLE
Improved flow for managing team

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -559,8 +559,13 @@
 "self.new_device_alert.trust_devices" = "OK";
 
 // Settings - top level
-"self.settings.create_team.title" = "Create Team";
-"self.settings.add_account.title" = "Add Account";
+"self.settings.create_team.title" = "Create a team";
+"self.settings.manage_team.title" = "Manage Team";
+"self.settings.add_team_or_account.title" = "New Team or Account";
+"self.settings.add_account.title" = "Add an account";
+
+"self.settings.add_account.error.title" = "Three accounts active";
+"self.settings.add_account.error.message" = "You can only be logged in with three accounts at once. Log out from one to add another.";
 
 // Settings - Account details
 "self.settings.account_section" = "Account";

--- a/Wire-iOS/Sources/Helpers/NSURL+WireURLs.h
+++ b/Wire-iOS/Sources/Helpers/NSURL+WireURLs.h
@@ -51,6 +51,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (instancetype)wr_createTeamURL;
 
++ (instancetype)wr_manageTeamURL;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Wire-iOS/Sources/Helpers/NSURL+WireURLs.m
+++ b/Wire-iOS/Sources/Helpers/NSURL+WireURLs.m
@@ -93,4 +93,9 @@
     return [self URLWithString:@"https://wire.com/create-team?pk_campaign=client&pk_kwd=ios"];
 }
 
++ (instancetype)wr_manageTeamURL
+{
+    return [self URLWithString:@"https://teams.wire.com/login?pk_campaign=client&pk_kwd=ios"];
+}
+
 @end

--- a/Wire-iOS/Sources/Helpers/syncengine/ZMUser+Additions.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMUser+Additions.swift
@@ -23,4 +23,8 @@ extension ZMUser {
     var pov: PointOfView {
         return self.isSelfUser ? .secondPerson : .thirdPerson
     }
+    
+    var canManageTeam: Bool {
+        return self.membership?.permissions.contains(.owner) ?? false || self.membership?.permissions.contains(.admin) ?? false
+    }
 }

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
@@ -105,7 +105,7 @@ extension SettingsCellDescriptorFactory {
                     return SettingsCellPreview.text("self.add_email_password".localized)
                 }
         },
-            hideAccesoryView: true
+            accessoryViewMode: .alwaysHide
         )
     }
 
@@ -134,7 +134,7 @@ extension SettingsCellDescriptorFactory {
                     return SettingsCellPreview.text("self.add_phone_number".localized)
                 }
         },
-            hideAccesoryView: true
+            accessoryViewMode: .alwaysHide
         )
 
     }
@@ -156,7 +156,7 @@ extension SettingsCellDescriptorFactory {
                 presentationStyle: .navigation,
                 presentationAction: presentation,
                 previewGenerator: preview,
-                hideAccesoryView: true
+                accessoryViewMode: .alwaysHide
             )
         }
 

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
@@ -38,7 +38,7 @@ import Foundation
     func rootGroup() -> SettingsControllerGeneratorType & SettingsInternalGroupCellDescriptorType {
         var rootElements: [SettingsCellDescriptorType] = []
         
-        if ZMUser.selfUser().membership?.permissions.contains(.owner) ?? false || ZMUser.selfUser().membership?.permissions.contains(.admin) ?? false {
+        if ZMUser.selfUser().canManageTeam {
             rootElements.append(self.manageTeamCell())
         }
         

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
@@ -36,13 +36,14 @@ import Foundation
     }
     
     func rootGroup() -> SettingsControllerGeneratorType & SettingsInternalGroupCellDescriptorType {
-        var rootElements = [self.createTeamCell()]
+        var rootElements: [SettingsCellDescriptorType] = []
         
-        if SessionManager.shared?.accountManager.accounts.count < SessionManager.maxNumberAccounts {
-            rootElements.append(self.addAccountCell())
+        if ZMUser.selfUser().membership?.permissions.contains(.owner) ?? false || ZMUser.selfUser().membership?.permissions.contains(.admin) ?? false {
+            rootElements.append(self.manageTeamCell())
         }
         
         rootElements.append(self.settingsGroup())
+        rootElements.append(self.addAccountOrTeamCell())
         
         let topSection = SettingsSectionDescriptor(cellDescriptors: rootElements)
         
@@ -63,30 +64,60 @@ import Foundation
         
     }
     
-    func createTeamCell() -> SettingsCellDescriptorType {
-        return SettingsExternalScreenCellDescriptor(title: "self.settings.create_team.title".localized,
+    func manageTeamCell() -> SettingsCellDescriptorType {
+        return SettingsExternalScreenCellDescriptor(title: "self.settings.manage_team.title".localized,
                                                     isDestructive: false,
                                                     presentationStyle: PresentationStyle.navigation,
                                                     identifier: nil,
                                                     presentationAction: { () -> (UIViewController?) in
-                                                        NSURL.wr_createTeam().wr_URLByAppendingLocaleParameter().open()
+                                                        NSURL.wr_manageTeam().wr_URLByAppendingLocaleParameter().open()
                                                         return nil
                                                     },
                                                     previewGenerator: nil,
-                                                    icon: .createTeam)
+                                                    icon: .team)
     }
     
-    func addAccountCell() -> SettingsCellDescriptorType {
-        return SettingsExternalScreenCellDescriptor(title: "self.settings.add_account.title".localized,
+    static func addAccountController() -> UIViewController {
+        let actionSheet = UIAlertController(title: nil,
+                                            message: nil,
+                                            preferredStyle: .actionSheet)
+        
+        let createATeamAction = UIAlertAction(title: "self.settings.create_team.title".localized, style: .default, handler: { action in
+            NSURL.wr_createTeam().wr_URLByAppendingLocaleParameter().open()
+        })
+        actionSheet.addAction(createATeamAction)
+        let addAnAccountAction = UIAlertAction(title: "self.settings.add_account.title".localized, style: .default, handler: { action in
+            if SessionManager.shared?.accountManager.accounts.count < SessionManager.maxNumberAccounts {
+                SessionManager.shared?.addAccount()
+            }
+            else {
+                let alert = UIAlertController(title: "self.settings.add_account.error.title".localized,
+                                              message: "self.settings.add_account.error.message".localized,
+                                              cancelButtonTitle: "general.ok".localized)
+                
+                guard let controller = UIApplication.shared.wr_topmostController(onlyFullScreen: false) else { return }
+                controller.present(alert, animated: true, completion: nil)
+            }
+        })
+        actionSheet.addAction(addAnAccountAction)
+        let cancelAction = UIAlertAction(title: "general.cancel".localized, style: .cancel, handler: { action in
+            actionSheet.dismiss(animated: true, completion: nil)
+        })
+        actionSheet.addAction(cancelAction)
+        return actionSheet
+    }
+    
+    func addAccountOrTeamCell() -> SettingsCellDescriptorType {
+        return SettingsExternalScreenCellDescriptor(title: "self.settings.add_team_or_account.title".localized,
                                                     isDestructive: false,
-                                                    presentationStyle: PresentationStyle.navigation,
+                                                    presentationStyle: PresentationStyle.modal,
                                                     identifier: nil,
                                                     presentationAction: { () -> (UIViewController?) in
-                                                        SessionManager.shared?.addAccount()
-                                                        return nil
+                                                    return SettingsCellDescriptorFactory.addAccountController()
         },
                                                     previewGenerator: nil,
-                                                    icon: .convMetaAddPerson)
+                                                    icon: .plus,
+                                                    accessoryViewMode: .alwaysShow)
     }
     
     func settingsGroup() -> SettingsControllerGeneratorType & SettingsInternalGroupCellDescriptorType {

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsExternalScreenCellDescriptor.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsExternalScreenCellDescriptor.swift
@@ -32,6 +32,12 @@ class InviteCellDescriptor: SettingsExternalScreenCellDescriptor {
     }
 }
 
+enum AccessoryViewMode: Int {
+    case `default`
+    case alwaysShow
+    case alwaysHide
+}
+
 class SettingsExternalScreenCellDescriptor: SettingsExternalScreenCellDescriptorType, SettingsControllerGeneratorType {
     static let cellType: SettingsTableCell.Type = SettingsGroupCell.self
     var visible: Bool = true
@@ -41,7 +47,7 @@ class SettingsExternalScreenCellDescriptor: SettingsExternalScreenCellDescriptor
     let identifier: String?
     let icon: ZetaIconType
 
-    private let hideAccesoryView: Bool
+    private let accessoryViewMode: AccessoryViewMode
 
     weak var group: SettingsGroupCellDescriptorType?
     weak var viewController: UIViewController?
@@ -62,7 +68,7 @@ class SettingsExternalScreenCellDescriptor: SettingsExternalScreenCellDescriptor
         )
     }
     
-    convenience init(title: String, isDestructive: Bool, presentationStyle: PresentationStyle, presentationAction: @escaping () -> (UIViewController?), previewGenerator: PreviewGeneratorType? = .none, icon: ZetaIconType = .none, hideAccesoryView: Bool = false) {
+    convenience init(title: String, isDestructive: Bool, presentationStyle: PresentationStyle, presentationAction: @escaping () -> (UIViewController?), previewGenerator: PreviewGeneratorType? = .none, icon: ZetaIconType = .none, accessoryViewMode: AccessoryViewMode = .default) {
         self.init(
             title: title,
             isDestructive: isDestructive,
@@ -71,11 +77,11 @@ class SettingsExternalScreenCellDescriptor: SettingsExternalScreenCellDescriptor
             presentationAction: presentationAction,
             previewGenerator: previewGenerator,
             icon: icon,
-            hideAccesoryView: hideAccesoryView
+            accessoryViewMode: accessoryViewMode
         )
     }
     
-    init(title: String, isDestructive: Bool, presentationStyle: PresentationStyle, identifier: String?, presentationAction: @escaping () -> (UIViewController?), previewGenerator: PreviewGeneratorType? = .none, icon: ZetaIconType = .none, hideAccesoryView: Bool = false) {
+    init(title: String, isDestructive: Bool, presentationStyle: PresentationStyle, identifier: String?, presentationAction: @escaping () -> (UIViewController?), previewGenerator: PreviewGeneratorType? = .none, icon: ZetaIconType = .none, accessoryViewMode: AccessoryViewMode = .default) {
         self.title = title
         self.destructive = isDestructive
         self.presentationStyle = presentationStyle
@@ -83,7 +89,7 @@ class SettingsExternalScreenCellDescriptor: SettingsExternalScreenCellDescriptor
         self.identifier = identifier
         self.previewGenerator = previewGenerator
         self.icon = icon
-        self.hideAccesoryView = hideAccesoryView
+        self.accessoryViewMode = accessoryViewMode
     }
     
     func select(_ value: SettingsPropertyValue?) {
@@ -119,11 +125,19 @@ class SettingsExternalScreenCellDescriptor: SettingsExternalScreenCellDescriptor
         }
         cell.icon = self.icon
         if let groupCell = cell as? SettingsGroupCell {
-            if self.presentationStyle == .modal || self.hideAccesoryView {
+            switch accessoryViewMode {
+            case .default:
+                if self.presentationStyle == .modal {
+                    groupCell.accessoryType = .none
+                } else {
+                    groupCell.accessoryType = .disclosureIndicator
+                }
+            case .alwaysHide:
                 groupCell.accessoryType = .none
-            } else {
+            case .alwaysShow:
                 groupCell.accessoryType = .disclosureIndicator
             }
+            
         }
     }
     

--- a/WireExtensionComponents/Icons/ZetaIconTypes.h
+++ b/WireExtensionComponents/Icons/ZetaIconTypes.h
@@ -172,6 +172,7 @@ typedef NS_ENUM(NSInteger, ZetaIconType)
     ZetaIconTypeSearchOngoing                   = 0x261,
     
     ZetaIconTypeCreateTeam                      = 0x269,
+    ZetaIconTypeTeam                            = 0x264,
     
     // Emoji Categories
     ZetaIconTypeFlower                          = 0x250,


### PR DESCRIPTION
- Manage team item is only shown for admins and owners. Button is taking user to the login screen of the admin panel.
- Add item is showing now add team or add account, add team takes to the team creation flow, add user opens the log in screen.