### PR TITLE
Create VoiceChannelParticipantController after frame has been set

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelOverlay.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelOverlay.swift
@@ -619,8 +619,8 @@ extension VoiceChannelOverlay {
 extension VoiceChannelOverlay: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
         
-        let numberOfItems: CGFloat = CGFloat(collectionView.numberOfItems(inSection: 0))
-        let contentWidth: CGFloat = numberOfItems * participantsCollectionViewLayout.itemSize.width + max(numberOfItems - 1, 0) * participantsCollectionViewLayout.minimumLineSpacing
+        let numberOfItems: CGFloat = max(CGFloat(collectionView.numberOfItems(inSection: 0)), 1)
+        let contentWidth: CGFloat = numberOfItems * participantsCollectionViewLayout.itemSize.width + (numberOfItems - 1) * participantsCollectionViewLayout.minimumLineSpacing
         let frameWidth: CGFloat = participantsCollectionView.frame.size.width
         
         let insets: UIEdgeInsets

--- a/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelViewController.swift
@@ -75,8 +75,6 @@ class VoiceChannelViewController: UIViewController {
         doubleTapRecognizer.delegate = self
         view.addGestureRecognizer(doubleTapRecognizer)
         
-        createParticipantsControllerIfNecessary()
-        
         if let callState = conversation.voiceChannel?.state {
             updateView(for: callState)
         }
@@ -90,6 +88,8 @@ class VoiceChannelViewController: UIViewController {
         voiceChannelView.muted = mediaManager.isMicrophoneMuted
         voiceChannelView.speakerActive = mediaManager.isSpeakerEnabled
         voiceChannelView.outgoingVideoActive = conversation.voiceChannel?.isVideoCall ?? false
+        
+        createParticipantsControllerIfNecessary()
     }
     
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {


### PR DESCRIPTION
## Problem
If a `VoiceChannelViewController` is created with an already ongoing group call the the call participants wouldn't be centered. This happens because the collection view insets is calculated with a zero sized frame.

## Solution
Create `VoiceChannelParticipantsController` in `viewWillAppear` so that collection view will have a non zero frame when configuration the initial cell layout

 