### PR TITLE
Fixes for mixpanel integration

### DIFF
--- a/Wire-iOS Tests/Mocks/MockUser.h
+++ b/Wire-iOS Tests/Mocks/MockUser.h
@@ -51,7 +51,6 @@
 @property (nonatomic) ZMAddressBookContact *contact;
 @property (nonatomic) AddressBookEntry *addressBookEntry;
 @property (nonatomic) NSUUID *remoteIdentifier;
-@property (nonatomic) NSSet *teams;
 
 - (NSArray<MockUserClient *> *)featureWithUserClients:(NSUInteger)numClients;
 - (NSString *)displayNameInConversation:(MockConversation *)conversation;

--- a/Wire-iOS Tests/Mocks/MockUser.m
+++ b/Wire-iOS Tests/Mocks/MockUser.m
@@ -199,17 +199,13 @@ static id<ZMBareUser> mockSelfUser = nil;
     // no-op
 }
 
-- (NSSet *)teams
-{
-    return [NSSet set];
-}
-
- - (Team *)activeTeam
+- (Team *)team
 {
     return nil;
 }
-    
-- (BOOL)isPendingApproval {
+
+- (BOOL)isPendingApproval
+{
     return false;
 }
 

--- a/Wire-iOS/Sources/Analytics/Analytics.m
+++ b/Wire-iOS/Sources/Analytics/Analytics.m
@@ -107,6 +107,7 @@ static Analytics *sharedAnalytics = nil;
     }
     else {
         self.provider = [[AnalyticsProviderFactory shared] analyticsProvider];
+        self.team = [[ZMUser selfUser] team];
         [self tagEventObject:optEvent source:AnalyticsEventSourceUI];
     }
 }
@@ -115,7 +116,7 @@ static Analytics *sharedAnalytics = nil;
 {
     _team = team;
     if (nil == team) {
-        [self.provider setSuperProperty:@"team.size" value:nil];
+        [self.provider setSuperProperty:@"team.size" value:@"0"];
         [self.provider setSuperProperty:@"team.in_team" value:@"false"];
     }
     else {

--- a/Wire-iOS/Sources/Analytics/AnalyticsMixpanelProvider.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsMixpanelProvider.swift
@@ -42,8 +42,8 @@ extension Dictionary where Key == String, Value == Any {
         var finalAttributes: Properties = self.mapKeysAndValues(keysMapping: identity) { key, value in
             return type(of: self).bridgeOrDescription(for: value)!
         }
-        finalAttributes["$city"] = NSNull.init()
-        finalAttributes["$region"] = NSNull.init()
+        finalAttributes["$city"] = ""
+        finalAttributes["$region"] = ""
         return finalAttributes
     }
 }
@@ -84,8 +84,8 @@ final class AnalyticsMixpanelProvider: NSObject, AnalyticsProvider {
         mixpanelInstance?.minimumSessionDuration = 2_000
         mixpanelInstance?.loggingEnabled = false
         self.setSuperProperty("app", value: "ios")
-        self.setSuperProperty(MixpanelSuperProperties.city.rawValue, value: nil)
-        self.setSuperProperty(MixpanelSuperProperties.region.rawValue, value: nil)
+        self.setSuperProperty(MixpanelSuperProperties.city.rawValue, value: "")
+        self.setSuperProperty(MixpanelSuperProperties.region.rawValue, value: "")
     }
     
     public var isOptedOut : Bool = false {

--- a/Wire-iOS/Sources/Analytics/AnalyticsMixpanelProvider.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsMixpanelProvider.swift
@@ -21,6 +21,11 @@ import Foundation
 import Mixpanel
 import CocoaLumberjackSwift
 
+fileprivate enum MixpanelSuperProperties: String {
+    case city = "$city"
+    case region = "$region"
+    case ignore = "$ignore"
+}
 
 extension Dictionary where Key == String, Value == Any {
     fileprivate static func bridgeOrDescription(for object: Any) -> MixpanelType? {
@@ -42,8 +47,8 @@ extension Dictionary where Key == String, Value == Any {
         var finalAttributes: Properties = self.mapKeysAndValues(keysMapping: identity) { key, value in
             return type(of: self).bridgeOrDescription(for: value)!
         }
-        finalAttributes["$city"] = ""
-        finalAttributes["$region"] = ""
+        finalAttributes[MixpanelSuperProperties.city.rawValue] = ""
+        finalAttributes[MixpanelSuperProperties.region.rawValue] = ""
         return finalAttributes
     }
 }
@@ -51,11 +56,6 @@ extension Dictionary where Key == String, Value == Any {
 final class AnalyticsMixpanelProvider: NSObject, AnalyticsProvider {
     private var mixpanelInstance: MixpanelInstance? = .none
     
-    enum MixpanelSuperProperties: String {
-        case city = "$city"
-        case region = "$region"
-        case ignore = "$ignore"
-    }
     
     private static let enabledEvents = Set<String>([
         conversationMediaCompleteActionEventName,


### PR DESCRIPTION
- Reset the team property when re-creating the mixpanel object.
- Reset the team size to 0 when no team is set.
- Correctly erase the city and region property.