### PR TITLE
Properly migrate value from Localytics

### DIFF
--- a/Wire-iOS Tests/AnalyticsTests.swift
+++ b/Wire-iOS Tests/AnalyticsTests.swift
@@ -23,15 +23,11 @@ import HockeySDK
 
 class AnalyticsTests : XCTestCase {
     
-    override func setUp() {
-        super.setUp()
-        Localytics.integrate(LocalyticsAPIKey)
-    }
-    
     func testThatItMigratesTheOptOutFromLocalytics() {
         // GIVEN
         TrackingManager.shared.disableCrashAndAnalyticsSharing = false
         UserDefaults.shared().set(false, forKey: "DidMigrateLocalyticsSettingInitially")
+        Localytics.integrate(LocalyticsAPIKey)
         Localytics.setOptedOut(true)
         // WHEN
         XCTAssertFalse(TrackingManager.shared.disableCrashAndAnalyticsSharing)

--- a/Wire-iOS/Sources/Analytics/TrackingManager.swift
+++ b/Wire-iOS/Sources/Analytics/TrackingManager.swift
@@ -40,6 +40,7 @@ import WireExtensionComponents
     
     @objc public func migrateFromLocalytics() {
         if !UserDefaults.shared().bool(forKey: UserDefaultDidMigrateLocalyticsSettingInitially) {
+            Localytics.integrate(LocalyticsAPIKey)
             let isOptedOut = Localytics.isOptedOut()
             self.disableCrashAndAnalyticsSharing = isOptedOut
             UserDefaults.shared().set(true, forKey: UserDefaultDidMigrateLocalyticsSettingInitially)


### PR DESCRIPTION
- Localytics must be initialized, otherwise the opt-out value is not accessible