### PR TITLE
Fixed weak reference for SavableImage object in CollectionImageCell

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionImageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionImageCell.swift
@@ -161,8 +161,8 @@ final public class CollectionImageCell: CollectionCell {
         }
         
         saveableImage = SavableImage(data: imageData, orientation: orientation)
-        saveableImage?.saveToLibrary(withCompletion: {
-            self.saveableImage = nil
+        saveableImage?.saveToLibrary(withCompletion: { [weak self] in
+            self?.saveableImage = nil
         })
     }
     

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionImageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionImageCell.swift
@@ -153,15 +153,17 @@ final public class CollectionImageCell: CollectionCell {
         UIPasteboard.general.setMediaAsset(UIImage(data: imageData))
     }
     
-    var savableImage : SavableImage?
+    var saveableImage : SavableImage?
     
     func save(_ sender: AnyObject!) {
         guard let imageData = self.message?.imageMessageData?.imageData, let orientation = self.imageView.image?.imageOrientation else {
             return
         }
         
-        savableImage = SavableImage(data: imageData, orientation: orientation)
-        savableImage?.saveToLibrary()
+        saveableImage = SavableImage(data: imageData, orientation: orientation)
+        saveableImage?.saveToLibrary(withCompletion: {
+            self.saveableImage = nil
+        })
     }
     
     fileprivate func loadImage() {

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionImageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionImageCell.swift
@@ -153,13 +153,15 @@ final public class CollectionImageCell: CollectionCell {
         UIPasteboard.general.setMediaAsset(UIImage(data: imageData))
     }
     
+    var savableImage : SavableImage?
+    
     func save(_ sender: AnyObject!) {
         guard let imageData = self.message?.imageMessageData?.imageData, let orientation = self.imageView.image?.imageOrientation else {
             return
         }
         
-        let savableImage = SavableImage(data: imageData, orientation: orientation)
-        savableImage.saveToLibrary()
+        savableImage = SavableImage(data: imageData, orientation: orientation)
+        savableImage?.saveToLibrary()
     }
     
     fileprivate func loadImage() {


### PR DESCRIPTION
Images weren't saved while tapping on the "Save" button of the UIMenuController (via long press) due to the weak reference of the object - it was deallocated before completing the operations.

Related to ZIOS-9181.