### PR TITLE
Disable callkit if we are missing microphone permissions

### DIFF
--- a/Wire-iOS/Sources/Helpers/syncengine/SessionManager+Shared.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/SessionManager+Shared.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import WireSyncEngine
+import AVFoundation
 
 extension SessionManager {
     @objc static var shared : SessionManager? {
@@ -33,8 +34,9 @@ extension SessionManager {
         
         // TODO: CallKit only with 1 account
         let hasMultipleAccounts = self.accountManager.accounts.count > 1
+        let hasAudioPermissions = AVCaptureDevice.authorizationStatus(forMediaType: AVMediaTypeAudio) == AVAuthorizationStatus.authorized
     
-        if isCallKitEnabled && isCallKitSupported && !hasMultipleAccounts {
+        if isCallKitEnabled && isCallKitSupported && !hasMultipleAccounts && hasAudioPermissions {
             self.callNotificationStyle = .callKit
         }
         else {

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
@@ -222,7 +222,7 @@ public extension ConversationViewController {
     func voiceCallItemTapped(_ sender: UIBarButtonItem) {
         let startCall = {
             ConversationInputBarViewController.endEditingMessage()
-            self.conversation.startAudioCall(completionHandler: nil)
+            self.conversation.startAudioCall()
         }
         
         if self.conversation.activeParticipants.count <= 4 {
@@ -239,7 +239,7 @@ public extension ConversationViewController {
     
     func videoCallItemTapped(_ sender: UIBarButtonItem) {
         ConversationInputBarViewController.endEditingMessage()
-        conversation.startVideoCall(completionHandler: nil)
+        conversation.startVideoCall()
     }
 
     private dynamic func joinCallButtonTapped(_sender: UIBarButtonItem) {

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+StartUI.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+StartUI.m
@@ -128,10 +128,10 @@
                     [conversation onCreatedRemotely:^{
                         @strongify(self);
                         if (videoCall) {
-                            [conversation startVideoCallWithCompletionHandler:nil];
+                            [conversation startVideoCall];
                         }
                         else {
-                            [conversation startAudioCallWithCompletionHandler:nil];
+                            [conversation startAudioCall];
                         }
                         self.startCallToken = nil;
                     }];
@@ -155,7 +155,7 @@
                     self.startCallToken =
                     [conversation onCreatedRemotely:^{
                         @strongify(self);
-                        [conversation startAudioCallWithCompletionHandler:nil];
+                        [conversation startAudioCall];
                         self.startCallToken = nil;
                     }];
                     


### PR DESCRIPTION
### Problem
If you receive a Callkit call with microphone access disabled you can accept the call but the call
will never connect.

### Solution
Disable CallKit if microphone access is disabled.

### Additional changes
- Remove unused completion handlers in joinCall methods
- End call if we are missing permissions