### PR TITLE
Fixed accessoryContainer expanding over collection view

### DIFF
--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsView.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsView.swift
@@ -28,6 +28,7 @@ class SearchResultsView : UIView {
     let collectionViewLayout : UICollectionViewFlowLayout
     let accessoryContainer = UIView()
     var lastLayoutBounds : CGRect = CGRect.zero
+    var accessoryContainerHeightConstraint: NSLayoutConstraint?
     var accessoryViewBottomOffsetConstraint : NSLayoutConstraint?
     var isContainedInPopover : Bool = false
     
@@ -72,6 +73,7 @@ class SearchResultsView : UIView {
             accessoryContainer.top == collectionView.bottom
             accessoryContainer.left == container.left
             accessoryContainer.right == container.right
+            accessoryContainerHeightConstraint = accessoryContainer.height == 0
             accessoryViewBottomOffsetConstraint = accessoryContainer.bottom == container.bottom - UIScreen.safeArea.bottom
             
             emptyResultContainer.top == container.top + 64
@@ -99,10 +101,13 @@ class SearchResultsView : UIView {
             
             if let accessoryView = accessoryView {
                 accessoryContainer.addSubview(accessoryView)
-                
+                accessoryContainerHeightConstraint?.isActive = false
                 constrain(accessoryContainer, accessoryView) { container, accessoryView in
                     accessoryView.edges == container.edges
                 }
+            }
+            else {
+                accessoryContainerHeightConstraint?.isActive = true
             }
         }
     }


### PR DESCRIPTION
# Problem

On some devices, when searching on the Start UI for the user, for the first letter it displays the result, but if you continue typing then there is no result shown.

# Investigation

The `SearchResultView` is responsible for showing the search results. It contains the collection view and the accessory view. Accessory view is the toolbar on the bottom of the SearchResultView UI. It can either be:

- `INVITE MORE PEOPLE` button.
- Conversation actions button bar.
- Nothing.

The view is built in the following way:
```
+---------------------+
|---------------------|
||                   ||
||  Collection View  ||
||                   ||
|---------------------|
|---------------------|
||Accessory Container||
|---------------------|
+---------------------+
```

The accessory view is inserted into container and constrained when present. Otherwise it has no vertical constraint.

This creates the problem where both Collection View and Accessory Container got no constraint for height, so it's up to iOS how to position them.

# Solution

Insert 0-height constraint for Accessory Container when it contains no accessory view.