### PR TITLE
Correctly handle SoundCloud response errors

### DIFF
--- a/Wire-iOS Tests/Soundcloud/SoundcloudServiceTests.m
+++ b/Wire-iOS Tests/Soundcloud/SoundcloudServiceTests.m
@@ -64,14 +64,28 @@
     // given
     NSArray *responseStructure = @[@"some", @"test", @{@"some": @1}];
     NSData *jsonResponseData = [NSJSONSerialization dataWithJSONObject:responseStructure options:NSJSONWritingPrettyPrinted error:NULL];
-    
+    NSURLResponse *response = nil;
+
     // when
-    id result = [self.service audioObjectFromData:jsonResponseData response:nil];
+    id result = [self.service audioObjectFromData:jsonResponseData response:response];
     
     // then
     // No crash happened and
     XCTAssertNil(result);
 }
 
+- (void)testThatItIgnoresNilResponse
+{
+    // given
+    NSData *responseData = nil;
+    NSURLResponse *response = nil;
+    
+    // when
+    id result = [self.service audioObjectFromData:responseData response:response];
+    
+    // then
+    // No crash happened and
+    XCTAssertNil(result);
+}
 
 @end

--- a/Wire-iOS/Sources/Components/Soundcloud/SoundcloudService+Testing.h
+++ b/Wire-iOS/Sources/Components/Soundcloud/SoundcloudService+Testing.h
@@ -18,6 +18,10 @@
 
 #import "SoundcloudService.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface SoundcloudService ()
-- (id)audioObjectFromData:(NSData *)data response:(NSURLResponse *)response;
+- (nullable id)audioObjectFromData:(NSData *)data response:(NSURLResponse *)response;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Wire-iOS/Sources/Components/Soundcloud/SoundcloudService.m
+++ b/Wire-iOS/Sources/Components/Soundcloud/SoundcloudService.m
@@ -157,6 +157,10 @@
 
 - (id)audioObjectFromData:(NSData *)data response:(NSURLResponse *)response
 {
+    if (data.length == 0) {
+        return nil;
+    }
+    
     NSError *error = nil;
     NSDictionary *JSON = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
     

--- a/Wire-iOS/Sources/Components/Soundcloud/SoundcloudService.m
+++ b/Wire-iOS/Sources/Components/Soundcloud/SoundcloudService.m
@@ -63,9 +63,32 @@
     return ^(NSData *data, NSURLResponse *response, NSError *error) {
         id audioObject = nil;
         
-        if (! error) {
-            audioObject = [self audioObjectFromData:data response:response];
+        void (^reportError)() = ^{
+            DDLogError(@"Error: %@, %@", response, error);
+            
+            if (completionHandler) {
+                completionHandler(audioObject, error);
+            }
+        };
+        
+        if (![response isKindOfClass:[NSHTTPURLResponse class]] || error != nil) {
+            reportError();
+            return;
         }
+        
+        NSHTTPURLResponse *HTTPResponse = (NSHTTPURLResponse *)response;
+        
+        if (HTTPResponse.statusCode >= 300 || HTTPResponse.statusCode < 200) {
+            reportError();
+            return;
+        }
+        
+        if (data == nil) {
+            reportError();
+            return;
+        }
+        
+        audioObject = [self audioObjectFromData:data response:response];
         
         NSArray *tracks = nil;
         if ([audioObject isKindOfClass:[SoundcloudAudioTrack class]]) {


### PR DESCRIPTION
# Issue

The QA reported that on simulator it's possible to crash the client by sending the particular soundcloud link. 

# Investigation

The SoundCloud seem to forbid playing some tracks on third-party services. For those the API fetch request returns 403. This error is forwarded by the backend proxy to Wire clients. However with the completion of the request we receive the empty data. According to the crash the data is nil for the QA client. During the testing the data returned was not nil but a data object of 0 length.

# Fix

Verify if the request was successful before trying to parse the response.