### PR TITLE
Enable Callkit immediately after granted audio permissions

### DIFF
--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -91,6 +91,7 @@ class AppRootViewController : UIViewController {
         
         NotificationCenter.default.addObserver(self, selector: #selector(onContentSizeCategoryChange), name: Notification.Name.UIContentSizeCategoryDidChange, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(applicationDidEnterBackground), name: Notification.Name.UIApplicationDidEnterBackground, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(onUserGrantedAudioPermissions), name: Notification.Name.UserGrantedAudioPermissions, object: nil)
         
         transition(to: .headless)
         
@@ -416,4 +417,14 @@ extension AppRootViewController : LocalNotificationResponder {
         let unreadConversations = sessionManager?.accountManager.totalUnreadCount ?? 0
         UIApplication.shared.applicationIconBadgeNumber = unreadConversations
     }
+}
+
+// MARK: - Audio Permissions granted
+
+extension AppRootViewController  {
+    
+    func onUserGrantedAudioPermissions() {
+        sessionManager?.updateCallNotificationStyleFromSettings()
+    }
+    
 }

--- a/Wire-iOS/Sources/Helpers/UIApplication+Permissions.h
+++ b/Wire-iOS/Sources/Helpers/UIApplication+Permissions.h
@@ -19,6 +19,8 @@
 
 #import <UIKit/UIKit.h>
 
+extern NSString * const UserGrantedAudioPermissionsNotification;
+
 @interface UIApplication (Permissions)
 
 + (void)wr_requestOrWarnAboutMicrophoneAccess:(void(^)(BOOL granted))grantedHandler;

--- a/Wire-iOS/Sources/Helpers/UIApplication+Permissions.m
+++ b/Wire-iOS/Sources/Helpers/UIApplication+Permissions.m
@@ -24,15 +24,25 @@
 
 #import <AVFoundation/AVFoundation.h>
 
+NSString * const UserGrantedAudioPermissionsNotification = @"UserGrantedAudioPermissionsNotification";
+
 @implementation UIApplication (Permissions)
 
 + (void)wr_requestOrWarnAboutMicrophoneAccess:(void(^)(BOOL granted))grantedHandler
 {
+    BOOL audioPermissionNotDetermined = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeAudio] == AVAuthorizationStatusNotDetermined;
+    
     [[AVAudioSession sharedInstance] requestRecordPermission:^(BOOL granted) {
+        
         dispatch_async(dispatch_get_main_queue(), ^{
             if (! granted) {
                 [self wr_warnAboutMicrophonePermission];
             }
+            
+            if (audioPermissionNotDetermined && granted) {
+                [[NSNotificationCenter defaultCenter] postNotificationName:UserGrantedAudioPermissionsNotification object:nil];
+            }
+            
             if (grantedHandler != nil) grantedHandler(granted);
         });
     }];

--- a/Wire-iOS/Sources/Helpers/UIApplication+Permissions.m
+++ b/Wire-iOS/Sources/Helpers/UIApplication+Permissions.m
@@ -30,7 +30,7 @@ NSString * const UserGrantedAudioPermissionsNotification = @"UserGrantedAudioPer
 
 + (void)wr_requestOrWarnAboutMicrophoneAccess:(void(^)(BOOL granted))grantedHandler
 {
-    BOOL audioPermissionNotDetermined = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeAudio] == AVAuthorizationStatusNotDetermined;
+    BOOL audioPermissionsWereNotDetermined = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeAudio] == AVAuthorizationStatusNotDetermined;
     
     [[AVAudioSession sharedInstance] requestRecordPermission:^(BOOL granted) {
         
@@ -39,7 +39,7 @@ NSString * const UserGrantedAudioPermissionsNotification = @"UserGrantedAudioPer
                 [self wr_warnAboutMicrophonePermission];
             }
             
-            if (audioPermissionNotDetermined && granted) {
+            if (audioPermissionsWereNotDetermined && granted) {
                 [[NSNotificationCenter defaultCenter] postNotificationName:UserGrantedAudioPermissionsNotification object:nil];
             }
             


### PR DESCRIPTION
## Problem
If the user has not granted us audio permission we will not enable Callkit, because the call wouldn't be established if answered outside of the app. The user would then need to restart app in order to have Callkit activated. This behaviour breaks automation test which can't restart the app in the middle of a test.

## Solution
Attempt to re-activate Callkit immediately after being granted audio permissions.