### PR TITLE
Play incall sound also when Callkit is active

### DIFF
--- a/Wire-iOS/Sources/Managers/SoundEventListener.swift
+++ b/Wire-iOS/Sources/Managers/SoundEventListener.swift
@@ -141,7 +141,7 @@ extension SoundEventListener : WireCallCenterCallStateObserver {
         case .established:
             playSoundIfAllowed(MediaManagerSoundUserJoinsVoiceChannelSound)
         case .incoming(video: _, shouldRing: true, degraded: _):
-            guard userSession.callNotificationStyle != .callKit && !conversation.isSilenced else { return }
+            guard !conversation.isSilenced else { return }
             
             let otherNonIdleCalls = callCenter.nonIdleCalls.filter({ (key: UUID, callState: CallState) -> Bool in
                 return key != conversationId
@@ -149,7 +149,7 @@ extension SoundEventListener : WireCallCenterCallStateObserver {
             
             if otherNonIdleCalls.count > 0 {
                 playSoundIfAllowed(MediaManagerSoundRingingFromThemInCallSound)
-            } else {
+            } else if userSession.callNotificationStyle != .callKit {
                 playSoundIfAllowed(MediaManagerSoundRingingFromThemSound)
             }
         case .incoming(video: _, shouldRing: false, degraded: _):

--- a/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelOverlay.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelOverlay.swift
@@ -22,6 +22,8 @@ import UIKit
 import CocoaLumberjackSwift
 import Classy
 
+fileprivate let zmLog = ZMSLog(tag: "calling")
+
 fileprivate let CameraPreviewContainerSize: CGFloat = 72.0;
 fileprivate let OverlayButtonWidth: CGFloat = 56.0;
 fileprivate let GroupCallAvatarSize: CGFloat = 120.0;
@@ -44,7 +46,7 @@ fileprivate let VoiceChannelOverlayVideoFeedPositionKey = "VideoFeedPosition"
     func switchCameraButtonTapped()
 }
 
-@objc enum VoiceChannelOverlayState: Int {
+@objc enum VoiceChannelOverlayState: Int, CustomStringConvertible {
     case invalid
     case incomingCall
     case incomingCallInactive
@@ -53,6 +55,28 @@ fileprivate let VoiceChannelOverlayVideoFeedPositionKey = "VideoFeedPosition"
     case outgoingCall
     case outgoingCallDegraded
     case connected
+    
+    var description: String {
+        switch self {
+        case .invalid:
+            return "invalid"
+        case .incomingCall:
+            return "incomingCall"
+        case .incomingCallInactive:
+            return "incomingCallInactive"
+        case .incomingCallDegraded:
+            return "incomingCallDegraded"
+        case .joiningCall:
+            return "joiningCall"
+        case .outgoingCall:
+            return "outgoingCall"
+        case .outgoingCallDegraded:
+            return "outgoingCallDegraded"
+        case .connected:
+            return "connected"
+        }
+    }
+    
 }
 
 fileprivate extension IconLabelButton {
@@ -651,6 +675,9 @@ extension VoiceChannelOverlay {
     @objc(transitionToState:)
     public func transition(to state: VoiceChannelOverlayState) {
         guard state != self.state else { return }
+        
+        zmLog.debug("transitioning to view state: \(state)")
+        
         self.state = state
         updateVisibleViewsForCurrentState()
     }

--- a/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelViewController.swift
@@ -337,6 +337,8 @@ extension VoiceChannelViewController : WireCallCenterCallStateObserver, Received
     
     func viewState(for callState : CallState, previousCallState : CallState) -> VoiceChannelOverlayState {
         
+        zmLog.debug("Updating view state from: \(previousCallState) to: \(callState)")
+        
         switch callState {
         case .incoming(video: _, shouldRing: _, degraded: let degraded):
             if degraded {

--- a/avs-versions
+++ b/avs-versions
@@ -17,4 +17,4 @@
 # along with this program. If not, see http://www.gnu.org/licenses/.
 #
 
-export APPSTORE_AVS_VERSION=3.8.7
+export APPSTORE_AVS_VERSION=3.8.9


### PR DESCRIPTION
### Issues

The incoming-call sound which is played while you are already in a call wasn't played if you had CallKit activated.

### Solutions

Allow sound to be played also when CallKit is activated.


### Additional changes

* Bump AVS to latest version
* Improved debug logging for the call overlay