### PR TITLE
Enable analytics from command line

### DIFF
--- a/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
+++ b/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
@@ -126,6 +126,10 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
+            argument = "-UseAnalytics 1"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "-ConsoleAnalytics"
             isEnabled = "NO">
          </CommandLineArgument>

--- a/Wire-iOS/Sources/Analytics/AnalyticsProviderFactory.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsProviderFactory.swift
@@ -30,7 +30,7 @@ fileprivate let ZMEnableConsoleLog = "ZMEnableAnalyticsLog"
         if self.useConsoleAnalytics || UserDefaults.standard.bool(forKey: ZMEnableConsoleLog) {
             return AnalyticsConsoleProvider()
         }
-        else if UseAnalytics.boolValue {
+        else if UseAnalytics.boolValue || AutomationHelper.sharedHelper.useAnalytics {
             return AnalyticsMixpanelProvider()
         }
         else {

--- a/WireExtensionComponents/Utilities/AutomationHelper.swift
+++ b/WireExtensionComponents/Utilities/AutomationHelper.swift
@@ -28,9 +28,14 @@ import WireSyncEngine
     
     static public let sharedHelper = AutomationHelper()
     
-    ///  Whether Hockeyapp should be used
+    /// Whether Hockeyapp should be used
     public var useHockey: Bool {
         return UserDefaults.standard.bool(forKey: "UseHockey")
+    }
+    
+    /// Whether analytics should be used
+    public var useAnalytics: Bool {
+        return UserDefaults.standard.bool(forKey: "UseAnalytics")
     }
     
     /// Whether to skip the first login alert


### PR DESCRIPTION
## What's new in this PR?

### Issue

The analytics is disabled on the simulator builds. For testing the Mixpanel integration with automation we need to have the way to enable Mixpanel.
