### PR TITLE
Zios 9275 search icon does not switch to menu icon when switch form fullscreen mode to slide over mode

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,11 +5,11 @@ PODS:
   - GoogleAPIClient/YouTube (1.0.4):
     - GoogleAPIClient/Core
     - GTMSessionFetcher (~> 1.1)
-  - GTMSessionFetcher (1.1.8):
-    - GTMSessionFetcher/Full (= 1.1.8)
-  - GTMSessionFetcher/Core (1.1.8)
-  - GTMSessionFetcher/Full (1.1.8):
-    - GTMSessionFetcher/Core (= 1.1.8)
+  - GTMSessionFetcher (1.1.12):
+    - GTMSessionFetcher/Full (= 1.1.12)
+  - GTMSessionFetcher/Core (1.1.12)
+  - GTMSessionFetcher/Full (1.1.12):
+    - GTMSessionFetcher/Core (= 1.1.12)
   - Localytics (4.3.0)
   - RBBAnimation (0.4.0)
   - SCSiriWaveformView (1.0.3)
@@ -46,7 +46,7 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   ARCollectionViewMasonryLayout: 97cb468434b546b79a98c7c0908447ff803eb85e
   GoogleAPIClient: bde49b31072d3c296d051f58c37b27a66ca45936
-  GTMSessionFetcher: 6f8d8b28b7e345549ac471071608170b31cb4977
+  GTMSessionFetcher: ebaa1f79a5366922c1735f1566901f50beba23b7
   Localytics: 45fc45f5600bdb151e839d14db1360c971f0b9de
   RBBAnimation: 74263069442b91350aa4264089c1c05c0395503e
   SCSiriWaveformView: b8b2756af42addcd31900c3945f24edafefb5395

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,11 +5,11 @@ PODS:
   - GoogleAPIClient/YouTube (1.0.4):
     - GoogleAPIClient/Core
     - GTMSessionFetcher (~> 1.1)
-  - GTMSessionFetcher (1.1.12):
-    - GTMSessionFetcher/Full (= 1.1.12)
-  - GTMSessionFetcher/Core (1.1.12)
-  - GTMSessionFetcher/Full (1.1.12):
-    - GTMSessionFetcher/Core (= 1.1.12)
+  - GTMSessionFetcher (1.1.8):
+    - GTMSessionFetcher/Full (= 1.1.8)
+  - GTMSessionFetcher/Core (1.1.8)
+  - GTMSessionFetcher/Full (1.1.8):
+    - GTMSessionFetcher/Core (= 1.1.8)
   - Localytics (4.3.0)
   - RBBAnimation (0.4.0)
   - SCSiriWaveformView (1.0.3)
@@ -46,7 +46,7 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   ARCollectionViewMasonryLayout: 97cb468434b546b79a98c7c0908447ff803eb85e
   GoogleAPIClient: bde49b31072d3c296d051f58c37b27a66ca45936
-  GTMSessionFetcher: ebaa1f79a5366922c1735f1566901f50beba23b7
+  GTMSessionFetcher: 6f8d8b28b7e345549ac471071608170b31cb4977
   Localytics: 45fc45f5600bdb151e839d14db1360c971f0b9de
   RBBAnimation: 74263069442b91350aa4264089c1c05c0395503e
   SCSiriWaveformView: b8b2756af42addcd31900c3945f24edafefb5395

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.m
@@ -240,9 +240,10 @@ NSString *SplitLayoutObservableDidChangeToLayoutSizeNotification = @"SplitLayout
 - (void)willTransitionToTraitCollection:(UITraitCollection *)newCollection withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
 {
     self.futureTraitCollection = newCollection;
+    [self updateLayoutSizeForTraitCollection:newCollection size:self.view.bounds.size];
+
     [super willTransitionToTraitCollection:newCollection withTransitionCoordinator:coordinator];
     
-    [self updateLayoutSizeForTraitCollection:newCollection size:self.view.bounds.size];
     [self updateActiveConstraints];
     
     [self updateLeftViewVisibility];

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
@@ -31,8 +31,17 @@ public extension ZMConversationList {
     }
 }
 
+
+// MARK: - Update left navigator bar item when size class changes
+extension ConversationViewController {
+    override open func willTransition(to newCollection: UITraitCollection,
+                                      with coordinator: UIViewControllerTransitionCoordinator) {
+        super.willTransition(to: newCollection, with: coordinator)
+        self.updateLeftNavigationBarItems()
+    }
+}
+
 public extension ConversationViewController {
-    
     func addCallStateObserver() -> Any? {
         return conversation.voiceChannel?.addCallStateObserver(self)
     }
@@ -151,7 +160,7 @@ public extension ConversationViewController {
         }
         return ZMConversationList.conversations(inUserSession: userSession).hasUnreadMessages(excluding: self.conversation)
     }
-    
+
     public func rightNavigationItems(forConversation conversation: ZMConversation) -> [UIBarButtonItem] {
         guard !conversation.isReadOnly else { return [] }
 
@@ -165,11 +174,11 @@ public extension ConversationViewController {
 
         return [UIBarButtonItem(customView: audioCallButton)]
     }
+
     
     public func leftNavigationItems(forConversation conversation: ZMConversation) -> [UIBarButtonItem] {
         var items: [UIBarButtonItem] = []
 
-        ///FIXME: do this again in trait did change
         if self.parent?.wr_splitViewController?.layoutSize != .regularLandscape {
             let backButton = self.backButton
             backButton.hitAreaPadding = CGSize(width: 28, height: 20)
@@ -183,6 +192,27 @@ public extension ConversationViewController {
         }
         
         return items
+    }
+
+    public func updateRightNavigationItemsButtons() {
+        // FIXME: iOS8 - we can use UIView's semanticContentAttribute on navigation bar
+        if UIApplication.isLeftToRightLayout {
+            navigationItem.rightBarButtonItems = rightNavigationItems(forConversation: conversation)
+        }
+        else {
+            navigationItem.rightBarButtonItems = leftNavigationItems(forConversation: conversation)
+        }
+    }
+
+
+    /// Update left navigation bar items
+    func updateLeftNavigationBarItems() {
+        if UIApplication.isLeftToRightLayout {
+            self.navigationItem.leftBarButtonItems = leftNavigationItems(forConversation: conversation)
+        }
+        else {
+            self.navigationItem.leftBarButtonItems = rightNavigationItems(forConversation: conversation)
+        }
     }
 
     private func shouldShowCollectionsButton() -> Bool {
@@ -325,24 +355,6 @@ extension ConversationViewController : WireCallCenterCallStateObserver {
     }
     
 }
-
-// MARK:- update Left NavigationBar Items
-
-extension ConversationListViewController {
-
-    @objc func updateLeftNavigationBarItems() {
-        // FIXME: iOS8 - we can use UIView's semanticContentAttribute on navigation bar
-        if UIApplication.isLeftToRightLayout {
-            self.navigationItem.leftBarButtonItems = leftNavigationItems(forConversation: self.conversation)
-        }
-        else {
-            self.navigationItem.leftBarButtonItems = rightNavigationItems(forConversation: conversation)
-        }
-        ///TODO: slide mode, call leftNavigationItems
-    }
-
-}
-
 
 extension ZMConversation {
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
@@ -195,7 +195,6 @@ public extension ConversationViewController {
     }
 
     public func updateRightNavigationItemsButtons() {
-        // FIXME: iOS8 - we can use UIView's semanticContentAttribute on navigation bar
         if UIApplication.isLeftToRightLayout {
             navigationItem.rightBarButtonItems = rightNavigationItems(forConversation: conversation)
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
@@ -168,7 +168,8 @@ public extension ConversationViewController {
     
     public func leftNavigationItems(forConversation conversation: ZMConversation) -> [UIBarButtonItem] {
         var items: [UIBarButtonItem] = []
-        
+
+        ///FIXME: do this again in trait did change
         if self.parent?.wr_splitViewController?.layoutSize != .regularLandscape {
             let backButton = self.backButton
             backButton.hitAreaPadding = CGSize(width: 28, height: 20)
@@ -323,6 +324,23 @@ extension ConversationViewController : WireCallCenterCallStateObserver {
         updateRightNavigationItemsButtons()
     }
     
+}
+
+// MARK:- update Left NavigationBar Items
+
+extension ConversationListViewController {
+
+    @objc func updateLeftNavigationBarItems() {
+        // FIXME: iOS8 - we can use UIView's semanticContentAttribute on navigation bar
+        if UIApplication.isLeftToRightLayout {
+            self.navigationItem.leftBarButtonItems = leftNavigationItems(forConversation: self.conversation)
+        }
+        else {
+            self.navigationItem.leftBarButtonItems = rightNavigationItems(forConversation: conversation)
+        }
+        ///TODO: slide mode, call leftNavigationItems
+    }
+
 }
 
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+Private.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+Private.h
@@ -38,7 +38,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)onBackButtonPressed:(UIButton *)backButton;
 - (void)updateRightNavigationItemsButtons;
-- (void)updateLeftNavigationBarItems;
 
 @end
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+Private.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+Private.h
@@ -37,7 +37,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable) CollectionsViewController *collectionController;
 
 - (void)onBackButtonPressed:(UIButton *)backButton;
-- (void)updateRightNavigationItemsButtons;
 
 @end
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -429,16 +429,6 @@
     }
 }
 
-- (void)updateLeftNavigationBarItems
-{
-    // FIXME: iOS8 - we can use UIView's semanticContentAttribute on navigation bar
-    if ([UIApplication isLeftToRightLayout]) {
-        self.navigationItem.leftBarButtonItems = [self leftNavigationItemsForConversation:self.conversation];
-    } else {
-        self.navigationItem.leftBarButtonItems = [self rightNavigationItemsForConversation:self.conversation];
-    }
-}
-
 - (void)updateInputBarVisibility
 {
     self.inputBarZeroHeight.active = self.conversation.isReadOnly;

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -419,16 +419,6 @@
     [self updateRightNavigationItemsButtons];
 }
 
-- (void)updateRightNavigationItemsButtons
-{
-    // FIXME: iOS8 - we can use UIView's semanticContentAttribute on navigation bar
-    if ([UIApplication isLeftToRightLayout]) {
-        self.navigationItem.rightBarButtonItems = [self rightNavigationItemsForConversation:self.conversation];
-    } else {
-        self.navigationItem.rightBarButtonItems = [self leftNavigationItemsForConversation:self.conversation];
-    }
-}
-
 - (void)updateInputBarVisibility
 {
     self.inputBarZeroHeight.active = self.conversation.isReadOnly;


### PR DESCRIPTION
## What's new in this PR?
Fix the issue left navigation bar item not updates when iPad app transits to slide over mode/fullscreen mode

### Issues

iPad: left navigation bar item not updates when iPad app transits to slide over mode/fullscreen mode

### Causes
In SplitViewController.m, this line was called after  [super willTransitionToTraitCollection:newCollection withTransitionCoordinator:coordinator];

[self updateLayoutSizeForTraitCollection:newCollection size:self.view.bounds.size];

which causes ConversationViewController can not get the updated trait collection when going to display.

### Solutions

call [self updateLayoutSizeForTraitCollection:newCollection size:self.view.bounds.size]; before  [super willTransitionToTraitCollection:newCollection withTransitionCoordinator:coordinator];

implement func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) for ConversationViewController, which updates  left navigation bar item when traitCollection changes.

## Dependencies

## Notes

### Attachments

