### PR TITLE
Load MediaManager only after FlowManager

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -484,6 +484,7 @@
 		87831A971E69B5E600DDF3C3 /* ThreeDotsLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87831A961E69B5E600DDF3C3 /* ThreeDotsLoadingView.swift */; };
 		87831A9A1E69B6D000DDF3C3 /* UIColor+WR_ColorScheme.h in Headers */ = {isa = PBXBuildFile; fileRef = 87831A981E69B6D000DDF3C3 /* UIColor+WR_ColorScheme.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		87831A9B1E69B6D000DDF3C3 /* UIColor+WR_ColorScheme.m in Sources */ = {isa = PBXBuildFile; fileRef = 87831A991E69B6D000DDF3C3 /* UIColor+WR_ColorScheme.m */; };
+		8784AE3E1FC2DE5300AAEAB8 /* MediaManagerLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8784AE3D1FC2DE5300AAEAB8 /* MediaManagerLoader.swift */; };
 		8784B6291D89448700AB71BD /* ProfileSelfPictureViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8784B6261D89448700AB71BD /* ProfileSelfPictureViewController.m */; };
 		8784B62A1D89448700AB71BD /* UIAlertController+NewSelfClients.m in Sources */ = {isa = PBXBuildFile; fileRef = 8784B6281D89448700AB71BD /* UIAlertController+NewSelfClients.m */; };
 		8784D4551E817D13007A6867 /* ConversationListTopBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8784D4541E817D13007A6867 /* ConversationListTopBar.swift */; };
@@ -1724,6 +1725,7 @@
 		87831A961E69B5E600DDF3C3 /* ThreeDotsLoadingView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThreeDotsLoadingView.swift; sourceTree = "<group>"; };
 		87831A981E69B6D000DDF3C3 /* UIColor+WR_ColorScheme.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIColor+WR_ColorScheme.h"; sourceTree = "<group>"; };
 		87831A991E69B6D000DDF3C3 /* UIColor+WR_ColorScheme.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIColor+WR_ColorScheme.m"; sourceTree = "<group>"; };
+		8784AE3D1FC2DE5300AAEAB8 /* MediaManagerLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaManagerLoader.swift; sourceTree = "<group>"; };
 		8784B6251D89448700AB71BD /* ProfileSelfPictureViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ProfileSelfPictureViewController.h; sourceTree = "<group>"; };
 		8784B6261D89448700AB71BD /* ProfileSelfPictureViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ProfileSelfPictureViewController.m; sourceTree = "<group>"; };
 		8784B6271D89448700AB71BD /* UIAlertController+NewSelfClients.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIAlertController+NewSelfClients.h"; sourceTree = "<group>"; };
@@ -3987,6 +3989,7 @@
 				8F5A3E9B19AE2C9E00D0E9DA /* AVSMediaManager+Additions.h */,
 				8F5A3E9C19AE2C9E00D0E9DA /* AVSMediaManager+Additions.m */,
 				87F280A91D080E8400F813CA /* AVSMediaManager+CustomSounds.swift */,
+				8784AE3D1FC2DE5300AAEAB8 /* MediaManagerLoader.swift */,
 			);
 			path = sound;
 			sourceTree = "<group>";
@@ -5941,6 +5944,7 @@
 				BF3A3DCA1EA642AB005477F8 /* MessageDraftStorage.swift in Sources */,
 				87DCF4F11D34EA4500BB420F /* UIViewController+WR_Invite.m in Sources */,
 				871067401C0DC5570035603B /* SettingsPropertyTextValueCellDescriptor.swift in Sources */,
+				8784AE3E1FC2DE5300AAEAB8 /* MediaManagerLoader.swift in Sources */,
 				876EECB31F5078D200E269F3 /* AccountSelectorController.swift in Sources */,
 				871BC2811D34F8F800DF0793 /* NSString+Fingerprint.m in Sources */,
 				BF989D081E896D210052BF8F /* ConversationCellBurstTimestampView.swift in Sources */,

--- a/Wire-iOS/Sources/Analytics/TrackingManager.swift
+++ b/Wire-iOS/Sources/Analytics/TrackingManager.swift
@@ -29,10 +29,8 @@ import WireExtensionComponents
     private override init() {
         AVSFlowManager.getInstance()?.setEnableMetrics(!ExtensionSettings.shared.disableCrashAndAnalyticsSharing)
         
-        flowManagerObserver = NotificationCenter.default.addObserver(forName: FlowManager.AVSFlowManagerCreatedNotification, object: nil, queue: nil, using: { _ in
-            DispatchQueue.main.async {
-                AVSFlowManager.getInstance()?.setEnableMetrics(!ExtensionSettings.shared.disableCrashAndAnalyticsSharing)
-            }
+        flowManagerObserver = NotificationCenter.default.addObserver(forName: FlowManager.AVSFlowManagerCreatedNotification, object: nil, queue: OperationQueue.main, using: { _ in
+            AVSFlowManager.getInstance()?.setEnableMetrics(!ExtensionSettings.shared.disableCrashAndAnalyticsSharing)
         })
     }
     

--- a/Wire-iOS/Sources/AppDelegate.m
+++ b/Wire-iOS/Sources/AppDelegate.m
@@ -96,9 +96,9 @@ static AppDelegate *sharedAppDelegate = nil;
 
 - (BOOL)application:(UIApplication *)application willFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-    DDLogInfo(@"application:willFinishLaunchingWithOptions %@ (applicationState = %ld)", launchOptions, (long)application.applicationState);
-    
     [self setupLogging];
+
+    DDLogInfo(@"application:willFinishLaunchingWithOptions %@ (applicationState = %ld)", launchOptions, (long)application.applicationState);
     
     // Initial log line to indicate the client version and build
     DDLogInfo(@"Wire-ios version %@ (%@)",

--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -41,6 +41,7 @@ class AppRootViewController : UIViewController {
     fileprivate var authenticatedBlocks : [() -> Void] = []
     fileprivate let transitionQueue : DispatchQueue = DispatchQueue(label: "transitionQueue")
     fileprivate var isClassyInitialized = false
+    fileprivate let mediaManagerLoader = MediaManagerLoader()
     
     fileprivate weak var requestToOpenViewDelegate: ZMRequestsToOpenViewsDelegate? {
         didSet {
@@ -296,15 +297,8 @@ class AppRootViewController : UIViewController {
         }
     }
     
-    func configureMediaManager() {        
-        guard let mediaManager = AVSMediaManager.sharedInstance() else {
-            return
-        }
-        
-        mediaManager.configureSounds()
-        mediaManager.observeSoundConfigurationChanges()
-        mediaManager.isMicrophoneMuted = false
-        mediaManager.isSpeakerEnabled = false
+    func configureMediaManager() {
+        self.mediaManagerLoader.send(message: .appStart)
     }
     
     func setupClassy(with windows: [UIWindow]) {

--- a/Wire-iOS/Sources/Helpers/sound/MediaManagerLoader.swift
+++ b/Wire-iOS/Sources/Helpers/sound/MediaManagerLoader.swift
@@ -95,10 +95,8 @@ extension MediaManagerState {
     
     override init() {
         super.init()
-        flowManagerObserver = NotificationCenter.default.addObserver(forName: FlowManager.AVSFlowManagerCreatedNotification, object: nil, queue: nil, using: { _ in
-            DispatchQueue.main.async { [weak self] in
-                self?.send(message: .flowManagerLoaded)
-            }
+        flowManagerObserver = NotificationCenter.default.addObserver(forName: FlowManager.AVSFlowManagerCreatedNotification, object: nil, queue: OperationQueue.main, using: { [weak self] _ in
+            self?.send(message: .flowManagerLoaded)
         })
         
         if let _ = AVSFlowManager.getInstance() {

--- a/Wire-iOS/Sources/Helpers/sound/MediaManagerLoader.swift
+++ b/Wire-iOS/Sources/Helpers/sound/MediaManagerLoader.swift
@@ -1,0 +1,108 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import CocoaLumberjackSwift
+import avs
+
+
+// The AVS libarary consists of several components, those are:
+// - FlowManager: the component for establishing the network media flows.
+// - MediaManager: the part responsible for audio routing on the device.
+// - wcall: the Calling3 implementation.
+// The entities must be initialized in certain expected order. The main requirement is that the MediaManager is only
+// initialized after the FlowManager.
+
+
+enum LoadingMessage {
+    // Called when the app is starting
+    case appStart
+    // Called whem the FlowManager is created.
+    case flowManagerLoaded
+}
+
+enum MediaManagerState {
+    // MediaManager is not loaded.
+    case initial
+    // MediaManager is loaded.
+    case loaded
+}
+
+
+// This enum is implementing the redundant Elm architecture state change. There is a single state and it's mutated by
+// sending it the messages (there is no way to directly alter the state).
+extension MediaManagerState {
+    public mutating func send(message: LoadingMessage) {
+        switch (self, message) {
+        case (.initial, .flowManagerLoaded):
+            self = .loaded
+            
+        default:
+            // already loaded
+            break
+        }
+    }
+}
+
+@objc final class MediaManagerLoader: NSObject {
+    
+    private var flowManagerObserver: AnyObject?
+    private var state: MediaManagerState = .initial {
+        didSet {
+            switch state {
+            case .loaded:
+                self.loadMediaManager()
+            default: break
+            }
+        }
+    }
+    
+    internal func send(message: LoadingMessage) {
+        self.state.send(message: message)
+    }
+    
+    private func loadMediaManager() {
+        AVSMediaManager.sharedInstance()
+        configureMediaManager()
+    }
+    
+    private func configureMediaManager() {
+        guard let _ = AVSFlowManager.getInstance(),
+                let mediaManager = AVSMediaManager.sharedInstance() else {
+            return
+        }
+        
+        mediaManager.configureSounds()
+        mediaManager.observeSoundConfigurationChanges()
+        mediaManager.isMicrophoneMuted = false
+        mediaManager.isSpeakerEnabled = false
+    }
+    
+    override init() {
+        super.init()
+        flowManagerObserver = NotificationCenter.default.addObserver(forName: FlowManager.AVSFlowManagerCreatedNotification, object: nil, queue: nil, using: { _ in
+            DispatchQueue.main.async { [weak self] in
+                self?.send(message: .flowManagerLoaded)
+            }
+        })
+        
+        if let _ = AVSFlowManager.getInstance() {
+            self.send(message: .flowManagerLoaded)
+        }
+    }
+}

--- a/Wire-iOS/Sources/Helpers/sound/MediaManagerLoader.swift
+++ b/Wire-iOS/Sources/Helpers/sound/MediaManagerLoader.swift
@@ -21,7 +21,7 @@ import CocoaLumberjackSwift
 import avs
 
 
-// The AVS libarary consists of several components, those are:
+// The AVS library consists of several components, those are:
 // - FlowManager: the component for establishing the network media flows.
 // - MediaManager: the part responsible for audio routing on the device.
 // - wcall: the Calling3 implementation.


### PR DESCRIPTION
## What's new in this PR?

### Issues

The app takes a really long time to cold start (10s+).

### Causes

The MediaManger is waiting for some thread to spawn, but seems like it's happening too late.

The AVS libarary consists of several components, those are:
- FlowManager: the component for establishing the network media flows.
- MediaManager: the part responsible for audio routing on the device.
- wcall: the Calling3 implementation.

### Solutions

The entities must be initialized in certain expected order. The main requirement is that the MediaManager is only initialized after the FlowManager.


