### PR TITLE
hide expandRowButton when it is not added to row one

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarButtonsView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarButtonsView.swift
@@ -135,7 +135,9 @@ public final class InputBarButtonsView: UIView {
         
         let (firstRow, secondRow): ([UIButton], [UIButton])
         let customButtonCount = numberOfButtons - 1 // Last one is alway the expand button
-        
+
+        expandRowButton.isHidden = !multilineLayout
+
         if multilineLayout {
             firstRow = buttons.prefix(customButtonCount) + [expandRowButton]
             secondRow = Array<UIButton>(buttons.suffix(buttons.count - customButtonCount))


### PR DESCRIPTION
## What's new in this PR?

### Issues

Conversation view - toolbar's expandRowButton is shown when trait collection changes to regular.

### Causes

expandRowButton is not included in first row but not removed form the view or set hidden

### Solutions

set expandRowButton hidden when multilineLayout == false


