### PR TITLE
Fix the issue: Sketch gets stretched upon device orientation.

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Sketchpad/CanvasViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Sketchpad/CanvasViewController.swift
@@ -62,9 +62,21 @@ class CanvasViewController: UIViewController, UINavigationControllerDelegate {
     
     let emojiKeyboardViewController =  EmojiKeyboardViewController()
     let colorPickerController = SketchColorPickerController()
-    
+
+
     override var shouldAutorotate: Bool {
-        return false
+        switch UIDevice.current.userInterfaceIdiom {
+        case .pad:
+            return true
+        default:
+            return false
+        }
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        canvas.setNeedsDisplay()
     }
 
     override func viewDidLoad() {

--- a/Wire-iOS/Sources/UserInterface/Sketchpad/SketchColorPickerController.m
+++ b/Wire-iOS/Sources/UserInterface/Sketchpad/SketchColorPickerController.m
@@ -54,6 +54,12 @@ static NSUInteger const SketchColorPickerDefaultBrushWidth = 6;
     [self setUpColorsCollectionView];
 }
 
+- (void)viewDidLayoutSubviews
+{
+    [super viewDidLayoutSubviews];
+    [self.colorsCollectionViewLayout invalidateLayout];
+}
+
 - (void)setUpColorsCollectionView
 {
     UICollectionViewFlowLayout *flowLayout = [[UICollectionViewFlowLayout alloc] init];


### PR DESCRIPTION
implement viewDidLayoutSubviews for CanvasViewController and SketchColorPickerController, refresh their subviews.

## What's new in this PR?

### Issues
Fix the issue:
Sketch gets stretched upon device orientation. 
https://github.com/wireapp/wire-ios/issues/13

### Causes

When iPad rotates, CanvasViewController and SketchColorPickerController did not layout or redraw their subviews.

### Solutions

implement viewDidLayoutSubviews for CanvasViewController and SketchColorPickerController, refresh their subviews.


