### PR TITLE
Fix/ephemeral timer

### DIFF
--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
@@ -519,20 +519,15 @@
 - (void)reloadCurrentConversation
 {
     // Need to reload conversation to apply color scheme changes
-    if (self.currentConversation != nil) {
+    if (self.currentConversation) {
         ConversationRootViewController *currentConversationViewController = [self conversationRootControllerForConversation:self.currentConversation];
         [self pushContentViewController:currentConversationViewController focusOnView:NO animated:NO completion:nil];
-    }
-    else {
-        [self attemptToLoadLastViewedConversationWithFocus:NO animated:NO];
     }
 }
 
 - (void)colorSchemeControllerDidApplyChanges:(NSNotification *)notification
 {
-    if (self.currentConversation) {
-        [self reloadCurrentConversation];
-    }
+    [self reloadCurrentConversation];
 }
 
 - (void)contentSizeCategoryDidChange:(NSNotification *)notification

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
@@ -228,6 +228,19 @@
     }
 }
 
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
+{
+    [super traitCollectionDidChange:previousTraitCollection];
+    
+    // if changing from compact width to regular width, make sure current conversation is loaded
+    if (previousTraitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact
+        && self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular) {
+        [self reloadCurrentConversation];
+    }
+    
+    [self.view setNeedsLayout];
+}
+
 #pragma mark - Setup methods
 
 - (void)setupConversationListViewController
@@ -506,8 +519,13 @@
 - (void)reloadCurrentConversation
 {
     // Need to reload conversation to apply color scheme changes
-    ConversationRootViewController *currentConversationViewController = [self conversationRootControllerForConversation:self.currentConversation];
-    [self pushContentViewController:currentConversationViewController focusOnView:NO animated:NO completion:nil];
+    if (self.currentConversation != nil) {
+        ConversationRootViewController *currentConversationViewController = [self conversationRootControllerForConversation:self.currentConversation];
+        [self pushContentViewController:currentConversationViewController focusOnView:NO animated:NO completion:nil];
+    }
+    else {
+        [self attemptToLoadLastViewedConversationWithFocus:NO animated:NO];
+    }
 }
 
 - (void)colorSchemeControllerDidApplyChanges:(NSNotification *)notification

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
@@ -235,7 +235,12 @@
     // if changing from compact width to regular width, make sure current conversation is loaded
     if (previousTraitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact
         && self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular) {
-        [self reloadCurrentConversation];
+        if (self.currentConversation) {
+            [self selectConversation:self.currentConversation];
+        }
+        else {
+            [self attemptToLoadLastViewedConversationWithFocus:NO animated:NO];
+        }
     }
     
     [self.view setNeedsLayout];

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
@@ -469,15 +469,7 @@
 
 - (BOOL)isConversationViewVisible
 {
-    if (IS_IPAD_LANDSCAPE_LAYOUT) {
-        return [self.splitViewController.rightViewController isKindOfClass:[ConversationViewController class]];
-    }
-    else if (self.splitViewController.leftViewControllerRevealed) {
-        return NO;
-    }
-    else {
-        return YES;
-    }
+    return IS_IPAD_LANDSCAPE_LAYOUT || !self.splitViewController.leftViewControllerRevealed;
 }
 
 - (ZMUserSession *)context


### PR DESCRIPTION
## What's new in this PR?

### Issues
When switching accounts, the ephemeral message timer is started even though the message is not visible.

### Causes
Each time we switch accounts, the last viewed conversation is loaded. If this conversation contains any ephemeral messages, their timers will begin. The problem is that although the conversation is loaded, we don't necessarily see it because when the horizontal size class is `compact` the `splitViewController` acts like a navigation controller and only the master view (`ConversationListViewController`) is visible.

### Solutions
When switching accounts, only load the last viewed conversation iff the split view's content controller (`ConversationContentViewController`) would be visible. This is the case when the horizontal size class is `regular`.

## Notes
By not loading a conversation immediately, we encounter problems when the horizontal size class changes from `compact` to `regular`, which happens when expanding the app in multitasking mode on the iPad. We must therefore load a conversation (first we try the selected conversation, then the last viewed, then the first conversation in the list). One **problem** I have noticed however is that when expanding and contracting the app width can produce inconsistencies regarding the selected list item and the open conversation, however I feel this should be addressed in a separate PR.