### PR TITLE
ZIOS-9273 Lock screen does not block some of the view when user disabled rotation lock 

### DIFF
--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -96,6 +96,7 @@ class AppRootViewController : UIViewController {
         
         NotificationCenter.default.addObserver(self, selector: #selector(onContentSizeCategoryChange), name: Notification.Name.UIContentSizeCategoryDidChange, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(applicationDidEnterBackground), name: Notification.Name.UIApplicationDidEnterBackground, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(applicationDidBecomeActive), name: Notification.Name.UIApplicationDidBecomeActive, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(onUserGrantedAudioPermissions), name: Notification.Name.UserGrantedAudioPermissions, object: nil)
         
         transition(to: .headless)
@@ -417,6 +418,10 @@ extension AppRootViewController : LocalNotificationResponder {
     @objc fileprivate func applicationDidEnterBackground() {
         let unreadConversations = sessionManager?.accountManager.totalUnreadCount ?? 0
         UIApplication.shared.applicationIconBadgeNumber = unreadConversations
+    }
+
+    @objc fileprivate func applicationDidBecomeActive() {
+        overlayWindow.frame.size = UIScreen.main.bounds.size
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Overlay/NotificationWindowRootViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Overlay/NotificationWindowRootViewController.m
@@ -138,7 +138,7 @@
 {
     // guard against a stack overflow
     if (self != UIApplication.sharedApplication.wr_topmostViewController) {
-        return UIApplication.sharedApplication.wr_topmostViewController.supportedInterfaceOrientations;
+        return UIApplication.sharedApplication.wr_topmostViewController.shouldAutorotate;
     } else {
         return YES;
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

The overlayWindow contains AppLockViewController does not resize after app become active.

### Causes
For unknown reason, overlayWindow's frame didn't update even viewWillTransition is called when app became active after device rotated
`
    override public func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
        mainWindow.frame.size = size
        overlayWindow.frame.size = size
    }
`

### Solutions

add an observer in AppRootViewController for UIApplicationDidBecomeActive. Update overlayWindow.frame.size when app become active.

