### PR TITLE
Support for added landing screen in authentication flow

### DIFF
--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -461,18 +461,17 @@ extension AppRootViewController : LandingViewControllerDelegate {
     }
 
     func landingViewControllerDidChooseLogin() {
-        let registrationViewController = RegistrationViewController()
+        let registrationViewController = RegistrationViewController(authenticationFlow: .onlyLogin)
         registrationViewController.delegate = appStateController
 
 
         transition(to: registrationViewController, animated: true) {
             self.requestToOpenViewDelegate = registrationViewController as? ZMRequestsToOpenViewsDelegate
-            registrationViewController.showLogin = true
         }
     }
 
     func landingViewControllerDidChooseCreateAccount() {
-        let registrationViewController = RegistrationViewController()
+        let registrationViewController = RegistrationViewController(authenticationFlow: .onlyRegistration)
         registrationViewController.delegate = appStateController
 
         transition(to: registrationViewController, animated: true) {

--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -196,7 +196,7 @@ class AppRootViewController : UIViewController {
                 let landingViewController = LandingViewController()
                 landingViewController.delegate = self
                 let navigationController = NavigationController(rootViewController: landingViewController)
-                navigationController.backButtonEnabled = true
+                navigationController.backButtonEnabled = false
                 navigationController.logoEnabled = false
                 navigationController.isNavigationBarHidden = true
                 viewController = navigationController

--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -186,12 +186,9 @@ class AppRootViewController : UIViewController {
         case .unauthenticated(error: let error):
             UIColor.setAccentOverride(ZMUser.pickRandomAccentColor())
             mainWindow.tintColor = UIColor.accent()
-            if let error = error {
-                let registrationViewController = RegistrationViewController()
-                registrationViewController.delegate = appStateController
-                registrationViewController.signInError = error
-                viewController = registrationViewController
-            } else {
+            let authenticatedAccounts = SessionManager.shared?.accountManager.accounts.filter { $0.isAuthenticated } ?? []
+
+            if error == nil && authenticatedAccounts.isEmpty {
                 // When we show the landing controller we want it to be nested in navigation controller
                 let landingViewController = LandingViewController()
                 landingViewController.delegate = self
@@ -200,6 +197,11 @@ class AppRootViewController : UIViewController {
                 navigationController.logoEnabled = false
                 navigationController.isNavigationBarHidden = true
                 viewController = navigationController
+            } else {
+                let registrationViewController = RegistrationViewController()
+                registrationViewController.delegate = appStateController
+                registrationViewController.signInError = error
+                viewController = registrationViewController
             }
         case .authenticated(completedRegistration: let completedRegistration):
             // TODO: CallKit only with 1 account

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/NavigationController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/NavigationController.m
@@ -74,6 +74,11 @@
     [self updateViewConstraints];
 }
 
+- (BOOL)prefersStatusBarHidden
+{
+    return self.topViewController.prefersStatusBarHidden;
+}
+
 - (void)setupBackButton
 {
     self.backButton = [[IconButton alloc] initForAutoLayout];

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/RegistrationRootViewController.h
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/RegistrationRootViewController.h
@@ -21,6 +21,12 @@
 
 #import "FormFlowViewController.h"
 
+typedef NS_ENUM(NSUInteger, AuthenticationFlowType) {
+    AuthenticationFlowRegular,
+    AuthenticationFlowOnlyLogin,
+    AuthenticationFlowOnlyRegistration
+};
+
 @class AnalyticsTracker, ZMIncompleteRegistrationUser, LoginCredentials;
 
 @interface RegistrationRootViewController : FormFlowViewController
@@ -29,7 +35,7 @@
 @property (nonatomic) BOOL showLogin;
 @property (nonatomic) LoginCredentials *loginCredentials;
 
-- (instancetype)initWithUnregisteredUser:(ZMIncompleteRegistrationUser *)unregisteredUser;
+- (instancetype)initWithUnregisteredUser:(ZMIncompleteRegistrationUser *)unregisteredUser authenticationFlow:(AuthenticationFlowType)flow;
 - (void)presentLoginTab;
 - (void)presentRegistrationTab;
 

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/RegistrationRootViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/RegistrationRootViewController.m
@@ -34,6 +34,7 @@
 
 @property (nonatomic) TabBarController *registrationTabBarController;
 @property (nonatomic) ZMIncompleteRegistrationUser *unregisteredUser;
+@property (nonatomic) AuthenticationFlowType flowType;
 @property (nonatomic, weak) SignInViewController *signInViewController;
 @property (nonatomic) IconButton *cancelButton;
 @property (nonatomic, readonly) Account *firstAuthenticatedAccount;
@@ -42,14 +43,15 @@
 
 @implementation RegistrationRootViewController
 
-- (instancetype)initWithUnregisteredUser:(ZMIncompleteRegistrationUser *)unregisteredUser
+- (instancetype)initWithUnregisteredUser:(ZMIncompleteRegistrationUser *)unregisteredUser authenticationFlow:(AuthenticationFlowType)flow
 {
     self = [super initWithNibName:nil bundle:nil];
-    
+
     if (self) {
         self.unregisteredUser = unregisteredUser;
+        self.flowType = flow;
     }
-    
+
     return self;
 }
 
@@ -66,7 +68,6 @@
     
     UIViewController *flowViewController = nil;
     if ([RegistrationViewController registrationFlow] == RegistrationFlowEmail) {
-        
         RegistrationEmailFlowViewController *emailFlowViewController = [[RegistrationEmailFlowViewController alloc] initWithUnregisteredUser:self.unregisteredUser];
         emailFlowViewController.formStepDelegate = self;
         flowViewController = emailFlowViewController;
@@ -77,8 +78,20 @@
         phoneFlowViewController.registrationDelegate = self;
         flowViewController = phoneFlowViewController;
     }
-    
-    self.registrationTabBarController = [[TabBarController alloc] initWithViewControllers:@[flowViewController, signInViewController]];
+
+    NSArray *controllers;
+    switch (self.flowType) {
+        case AuthenticationFlowRegular:
+            controllers = @[flowViewController, signInViewController];
+            break;
+        case AuthenticationFlowOnlyLogin:
+            controllers = @[signInViewController];
+            break;
+        case AuthenticationFlowOnlyRegistration:
+            controllers = @[flowViewController];
+            break;
+    }
+    self.registrationTabBarController = [[TabBarController alloc] initWithViewControllers:controllers];
     self.signInViewController = signInViewController;
     
     if (self.showLogin) {

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/RegistrationRootViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/RegistrationRootViewController.m
@@ -37,6 +37,7 @@
 @property (nonatomic) AuthenticationFlowType flowType;
 @property (nonatomic, weak) SignInViewController *signInViewController;
 @property (nonatomic) IconButton *cancelButton;
+@property (nonatomic) IconButton *backButton;
 @property (nonatomic, readonly) Account *firstAuthenticatedAccount;
 
 @end
@@ -85,9 +86,11 @@
             controllers = @[flowViewController, signInViewController];
             break;
         case AuthenticationFlowOnlyLogin:
+            [self setupBackButton];
             controllers = @[signInViewController];
             break;
         case AuthenticationFlowOnlyRegistration:
+            [self setupBackButton];
             controllers = @[flowViewController];
             break;
     }
@@ -114,6 +117,20 @@
     [self.registrationTabBarController didMoveToParentViewController:self];
     
     [self createConstraints];
+}
+
+- (void)setupBackButton
+{
+    self.backButton = [[IconButton alloc] initForAutoLayout];
+    self.backButton.cas_styleClass = @"navigation";
+
+    ZetaIconType iconType = [UIApplication isLeftToRightLayout] ? ZetaIconTypeChevronLeft : ZetaIconTypeChevronRight;
+
+    [self.backButton setIcon:iconType withSize:ZetaIconSizeSmall forState:UIControlStateNormal];
+    self.backButton.accessibilityIdentifier = @"BackToLaunchScreenButton";
+    [self.view addSubview:self.backButton];
+
+    [self.backButton addTarget:self action:@selector(backButtonTapped) forControlEvents:UIControlEventTouchUpInside];
 }
 
 
@@ -149,6 +166,17 @@
     [self.registrationTabBarController.view autoSetDimension:ALDimensionHeight toSize:IS_IPAD_FULLSCREEN ? 262 : 244];
     [self.cancelButton autoPinEdgeToSuperviewEdge:ALEdgeTop withInset:UIScreen.safeArea.top + 32];
     [self.cancelButton autoPinEdgeToSuperviewEdge:ALEdgeRight withInset:16];
+
+    if (self.backButton) {
+        CGFloat topMargin = 32 + UIScreen.safeArea.top;
+        CGFloat leftMargin = 28 + UIScreen.safeArea.left;
+        CGFloat buttonSize = 32;
+
+        [self.backButton autoSetDimension:ALDimensionHeight toSize:buttonSize];
+        [self.backButton autoSetDimension:ALDimensionWidth toSize:buttonSize relation:NSLayoutRelationGreaterThanOrEqual];
+        [self.backButton autoPinEdgeToSuperviewEdge:ALEdgeTop withInset:topMargin];
+        [self.backButton autoPinEdgeToSuperviewEdge:ALEdgeLeading withInset:leftMargin];
+    }
 }
 
 - (void)presentLoginTab
@@ -159,6 +187,11 @@
 - (void)presentRegistrationTab
 {
     [self.registrationTabBarController selectIndex:0 animated:YES];
+}
+
+- (void)backButtonTapped
+{
+    [self.navigationController.navigationController popViewControllerAnimated:YES];
 }
 
 - (void)cancelAddAccount

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/RegistrationViewController.h
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/RegistrationViewController.h
@@ -20,12 +20,13 @@
 #import <UIKit/UIKit.h>
 
 #import "FormStepDelegate.h"
-
+#import "RegistrationRootViewController.h"
 #import "WireSyncEngine+iOS.h"
 
 @class AnalyticsTracker;
 @class ZMEmailCredentials;
 
+NS_ASSUME_NONNULL_BEGIN
 
 typedef NS_ENUM(NSUInteger, RegistrationFlow) {
     RegistrationFlowEmail,
@@ -44,10 +45,13 @@ typedef NS_ENUM(NSUInteger, RegistrationFlow) {
 
 @interface RegistrationViewController : UIViewController
 
-@property (nonatomic, weak) id<RegistrationViewControllerDelegate> delegate;
-@property (nonatomic) NSError *signInError;
-@property (nonatomic) BOOL showLogin;
+- (instancetype)initWithAuthenticationFlow:(AuthenticationFlowType)flow;
+
+@property (nonatomic, weak) __nullable id<RegistrationViewControllerDelegate> delegate;
+@property (nonatomic)  NSError * __nullable signInError;
 
 + (RegistrationFlow)registrationFlow;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/RegistrationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/RegistrationViewController.m
@@ -69,6 +69,7 @@
 @property (nonatomic) id initialSyncObserverToken;
 @property (nonatomic) id postLoginToken;
 @property (nonatomic) id sessionCreationObserverToken;
+@property (nonatomic) AuthenticationFlowType flowType;
 
 @end
 
@@ -76,8 +77,20 @@
 
 @implementation RegistrationViewController
 
-- (void)setShowLogin: (BOOL)newValue{
-    self.registrationRootViewController.showLogin = newValue;
+- (instancetype)init
+{
+    return [self initWithAuthenticationFlow:AuthenticationFlowRegular];
+}
+
+- (instancetype)initWithAuthenticationFlow:(AuthenticationFlowType)flow
+{
+    self = [super initWithNibName:nil bundle:nil];
+
+    if (self) {
+        self.flowType = flow;
+    }
+
+    return self;
 }
 
 - (void)viewDidLoad
@@ -122,7 +135,7 @@
                                  userSessionErrorCode == ZMUserSessionNeedsPasswordToRegisterClient ||
                                  userSessionErrorCode == ZMUserSessionCanNotRegisterMoreClients;
     
-    RegistrationRootViewController *registrationRootViewController = [[RegistrationRootViewController alloc] initWithUnregisteredUser:self.unregisteredUser];
+    RegistrationRootViewController *registrationRootViewController = [[RegistrationRootViewController alloc] initWithUnregisteredUser:self.unregisteredUser authenticationFlow:self.flowType];
     registrationRootViewController.formStepDelegate = self;
     registrationRootViewController.hasSignInError = self.signInError != nil && !addingAdditionalAccount;
     registrationRootViewController.showLogin = needsToReauthenticate || addingAdditionalAccount;

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/RegistrationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/RegistrationViewController.m
@@ -156,7 +156,7 @@
     self.rootNavigationController.view.opaque = NO;
     self.rootNavigationController.delegate = self;
     self.rootNavigationController.navigationBarHidden = YES;
-    self.rootNavigationController.logoEnabled = ! IS_IPHONE_4;
+    self.rootNavigationController.logoEnabled = !IS_IPHONE_4 && (self.signInError != nil);
     
     self.keyboardAvoidingViewController = [[KeyboardAvoidingViewController alloc] initWithViewController:self.rootNavigationController];
     self.keyboardAvoidingViewController.view.translatesAutoresizingMaskIntoConstraints = NO;

--- a/WireExtensionComponents/Views/TabBar/TabBarController.swift
+++ b/WireExtensionComponents/Views/TabBar/TabBarController.swift
@@ -66,7 +66,7 @@ open class TabBarController: UIViewController {
     fileprivate var tabBar : TabBar?
     fileprivate var contentView : UIView!
     
-    required public init( viewControllers: [UIViewController]) {
+    required public init(viewControllers: [UIViewController]) {
         self.viewControllers = viewControllers
         self.selectedIndex = 0
         super.init(nibName: nil, bundle: nil)
@@ -88,14 +88,12 @@ open class TabBarController: UIViewController {
         self.contentView = UIView(frame: self.view.bounds)
         self.contentView!.translatesAutoresizingMaskIntoConstraints = false
         self.view.addSubview(self.contentView)
-        
-        if self.viewControllers.count > 1 {
-            let items = self.viewControllers.map({ viewController in viewController.tabBarItem! })
-            self.tabBar = TabBar(items: items, style: self.style, selectedIndex: selectedIndex)
-            self.tabBar?.delegate = self
-            self.tabBar?.isUserInteractionEnabled = self.enabled
-            self.view.addSubview(self.tabBar!)
-        }
+
+        let items = self.viewControllers.map({ viewController in viewController.tabBarItem! })
+        self.tabBar = TabBar(items: items, style: self.style, selectedIndex: selectedIndex)
+        self.tabBar?.delegate = self
+        self.tabBar?.isUserInteractionEnabled = self.enabled && items.count > 1
+        self.view.addSubview(self.tabBar!)
     }
     
     fileprivate func createConstraints() {


### PR DESCRIPTION
## What's new in this PR?

### Issues

After adding a new landing screen (from #1423) the logic of the registration flow changed slightly. It needs to be able to open login OR registration screens separately from dedicated buttons. However there are other cases where we need to open the screen in an old way (e.g. when adding account).

### Solutions

Added a new type (`AuthenticationFlowType`) that controls what sort of registration flow needs to be displayed. We also wanted to not change existing code as much as possible so we had to work around some issues. Namely the problem that registration flow creates its own navigation controller, but landing screen also needs to create its own navigation controller. So in certain situations we have navigation-inside-navigation stack, but this should get cleaned up when we overhaul the registration flow in the future.
