### PR TITLE
ZIOS-9089: Do not allow sending the text messages longer than 8KB

### DIFF
--- a/Wire-iOS Share Extension/ShareExtensionViewController.swift
+++ b/Wire-iOS Share Extension/ShareExtensionViewController.swift
@@ -49,6 +49,8 @@ class ShareExtensionViewController: SLComposeServiceViewController {
     private var observer: SendableBatchObserver? = nil
     private weak var progressViewController: SendingProgressViewController? = nil
     
+    private let maxTextLength = 8_000
+    
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         setupObserver()
@@ -72,6 +74,7 @@ class ShareExtensionViewController: SLComposeServiceViewController {
         let activity = ExtensionActivity(attachments: allAttachments)
         sharingSession?.analyticsEventPersistence.add(activity.openedEvent())
         extensionActivity = activity
+        self.charactersRemaining = maxTextLength as NSNumber
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -126,7 +129,9 @@ class ShareExtensionViewController: SLComposeServiceViewController {
 
     override func isContentValid() -> Bool {
         // Do validation of contentText and/or NSExtensionContext attachments here
-        return sharingSession != nil && self.postContent?.target != nil
+        let textLength = self.contentText.trimmingCharacters(in: .whitespaces).characters.count
+        self.charactersRemaining = maxTextLength - textLength as NSNumber
+        return sharingSession != nil && self.postContent?.target != nil && self.charactersRemaining.intValue >= 0
     }
 
     /// invoked when the user wants to post

--- a/Wire-iOS Share Extension/ShareExtensionViewController.swift
+++ b/Wire-iOS Share Extension/ShareExtensionViewController.swift
@@ -49,8 +49,6 @@ class ShareExtensionViewController: SLComposeServiceViewController {
     private var observer: SendableBatchObserver? = nil
     private weak var progressViewController: SendingProgressViewController? = nil
     
-    private let maxTextLength = 8_000
-    
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         setupObserver()
@@ -129,13 +127,17 @@ class ShareExtensionViewController: SLComposeServiceViewController {
     override func isContentValid() -> Bool {
         // Do validation of contentText and/or NSExtensionContext attachments here
         let textLength = self.contentText.trimmingCharacters(in: .whitespaces).characters.count
-        let remaining = maxTextLength - textLength
-        if remaining <= 30 {
+        let remaining = SharedConstants.maximumMessageLength - textLength
+        let remainingCharactersThreshold = 30
+        
+        if remaining <= remainingCharactersThreshold {
             self.charactersRemaining = remaining as NSNumber
         } else {
             self.charactersRemaining = nil
         }
-        return sharingSession != nil && self.postContent?.target != nil && self.charactersRemaining.intValue >= 0
+        
+        let conditions = sharingSession != nil && self.postContent?.target != nil
+        return self.charactersRemaining == nil ? conditions : conditions && self.charactersRemaining.intValue >= 0
     }
 
     /// invoked when the user wants to post

--- a/Wire-iOS Share Extension/ShareExtensionViewController.swift
+++ b/Wire-iOS Share Extension/ShareExtensionViewController.swift
@@ -74,7 +74,6 @@ class ShareExtensionViewController: SLComposeServiceViewController {
         let activity = ExtensionActivity(attachments: allAttachments)
         sharingSession?.analyticsEventPersistence.add(activity.openedEvent())
         extensionActivity = activity
-        self.charactersRemaining = maxTextLength as NSNumber
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -130,7 +129,12 @@ class ShareExtensionViewController: SLComposeServiceViewController {
     override func isContentValid() -> Bool {
         // Do validation of contentText and/or NSExtensionContext attachments here
         let textLength = self.contentText.trimmingCharacters(in: .whitespaces).characters.count
-        self.charactersRemaining = maxTextLength - textLength as NSNumber
+        let remaining = maxTextLength - textLength
+        if remaining <= 30 {
+            self.charactersRemaining = remaining as NSNumber
+        } else {
+            self.charactersRemaining = nil
+        }
         return sharingSession != nil && self.postContent?.target != nil && self.charactersRemaining.intValue >= 0
     }
 

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -199,6 +199,7 @@
 		7C4918A11F8BB1A20038AF4B /* UIScreen+SafeArea.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C4918A01F8BB1A20038AF4B /* UIScreen+SafeArea.swift */; };
 		7CA540831F740B7C00457F4B /* UIScreen+Compact.m in Sources */ = {isa = PBXBuildFile; fileRef = 7CA540821F740B7C00457F4B /* UIScreen+Compact.m */; };
 		7CC085461F7AA30F0010F96B /* DotView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CC085451F7AA30F0010F96B /* DotView.swift */; };
+		7CCBE24D1FC72FE500CBD55D /* SharedConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CCBE24C1FC72FE500CBD55D /* SharedConstants.swift */; };
 		7CE71D8D1FC453E300C43E19 /* SettingsPropertyName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C98DCFF1FC32F41005C0042 /* SettingsPropertyName.swift */; };
 		7CE71D8E1FC454AA00C43E19 /* AppLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8778AAEC1F6BC6AD0022F53F /* AppLock.swift */; };
 		7CEB45281F8FAAC400D772D5 /* UINavigationBarContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CEB45271F8FAAC400D772D5 /* UINavigationBarContainer.swift */; };
@@ -1276,6 +1277,7 @@
 		7CA540811F740B7C00457F4B /* UIScreen+Compact.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIScreen+Compact.h"; sourceTree = "<group>"; };
 		7CA540821F740B7C00457F4B /* UIScreen+Compact.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIScreen+Compact.m"; sourceTree = "<group>"; };
 		7CC085451F7AA30F0010F96B /* DotView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DotView.swift; sourceTree = "<group>"; };
+		7CCBE24C1FC72FE500CBD55D /* SharedConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedConstants.swift; sourceTree = "<group>"; };
 		7CEB45271F8FAAC400D772D5 /* UINavigationBarContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UINavigationBarContainer.swift; sourceTree = "<group>"; };
 		848DE12A1A83D20000E154B1 /* emoticons.min.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = emoticons.min.json; path = ../Sources/emoticons.min.json; sourceTree = "<group>"; };
 		8571A3524311D898C8012582 /* libPods-WireExtensionComponents.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-WireExtensionComponents.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2814,6 +2816,7 @@
 				87831A991E69B6D000DDF3C3 /* UIColor+WR_ColorScheme.m */,
 				876376891E8413D900B2CCF0 /* RawRepresentable+AllValues.swift */,
 				876CC8981E966C5C00F6BABC /* IteratorProtocol+Histogram.swift */,
+				7CCBE24C1FC72FE500CBD55D /* SharedConstants.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -5761,6 +5764,7 @@
 				BF6EC9061EB1FC3D009D9A69 /* URL+Backup.swift in Sources */,
 				8795A5A91D34CF7A0024101B /* NSLayoutConstraint+Helpers.m in Sources */,
 				872C2B7F1DD9C22B0086A574 /* ShareViewController+Views.swift in Sources */,
+				7CCBE24D1FC72FE500CBD55D /* SharedConstants.swift in Sources */,
 				1EE9DCC81B5F9A6D00E347DF /* TokenTextAttachment.m in Sources */,
 				BFB332681E3A2D95003B0CD2 /* ExtensionSettings.swift in Sources */,
 				870533FF1DD6162400A7F822 /* OverflowSeparatorView.swift in Sources */,

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -216,7 +216,7 @@
 "conversation.input_bar.shortcut.send" = "Send Message";
 
 "conversation.input_bar.message_too_long.title" = "Message too long";
-"conversation.input_bar.message_too_long.message" = "You can send messages up to 8000 characters long.";
+"conversation.input_bar.message_too_long.message" = "You can send messages up to %d characters long.";
 
 // Image confirmation dialogue
 "image_confirmer.confirm" = "OK";

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -215,6 +215,9 @@
 
 "conversation.input_bar.shortcut.send" = "Send Message";
 
+"conversation.input_bar.message_too_long.title" = "Message too long";
+"conversation.input_bar.message_too_long.message" = "You can send messages up to 8000 characters long.";
+
 // Image confirmation dialogue
 "image_confirmer.confirm" = "OK";
 "image_confirmer.cancel" = "Cancel";

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -1046,11 +1046,12 @@
 
 -(BOOL)checkMessageLength{
     
-    BOOL allowed = self.inputBar.textView.text.length <= 8000;
+    BOOL allowed = self.inputBar.textView.text.length <= (NSUInteger)SharedConstants.maximumMessageLength;
     
     if(!allowed) {
+        NSString *message = [NSString stringWithFormat:NSLocalizedString(@"conversation.input_bar.message_too_long.message", nil), SharedConstants.maximumMessageLength];
         UIAlertController *alert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"conversation.input_bar.message_too_long.title", nil)
-                                                                       message:NSLocalizedString(@"conversation.input_bar.message_too_long.message", nil)
+                                                                       message:message
                                                                 preferredStyle:UIAlertControllerStyleAlert];
         [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"general.ok", nil) style:UIAlertActionStyleCancel handler:nil]];
         [self presentViewController:alert animated:YES completion:nil];

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -1037,8 +1037,8 @@
 
 - (void)sendButtonPressed:(id)sender
 {
+    [self.inputBar.textView autocorrectLastWord];
     if([self checkMessageLength]){
-        [self.inputBar.textView autocorrectLastWord];
         [self sendOrEditText:self.inputBar.textView.preparedText];
         [self.inputBar.textView resetTypingAttributes];
     }
@@ -1052,7 +1052,7 @@
         UIAlertController *alert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"conversation.input_bar.message_too_long.title", nil)
                                                                        message:NSLocalizedString(@"conversation.input_bar.message_too_long.message", nil)
                                                                 preferredStyle:UIAlertControllerStyleAlert];
-        [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleCancel handler:nil]];
+        [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"general.ok", nil) style:UIAlertActionStyleCancel handler:nil]];
         [self presentViewController:alert animated:YES completion:nil];
     }
     

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -1037,6 +1037,15 @@
 
 - (void)sendButtonPressed:(id)sender
 {
+    if(self.inputBar.textView.text.length > 8000) {
+        UIAlertController *alert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"conversation.input_bar.message_too_long.title", nil)
+                                                                       message:NSLocalizedString(@"conversation.input_bar.message_too_long.message", nil)
+                                                                preferredStyle:UIAlertControllerStyleAlert];
+        [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleCancel handler:nil]];
+        [self presentViewController:alert animated:YES completion:nil];
+        return;
+    }
+    
     [self.inputBar.textView autocorrectLastWord];
     [self sendOrEditText:self.inputBar.textView.preparedText];
     [self.inputBar.textView resetTypingAttributes];

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -1037,21 +1037,26 @@
 
 - (void)sendButtonPressed:(id)sender
 {
-    [self checkMessageLength];
-    [self.inputBar.textView autocorrectLastWord];
-    [self sendOrEditText:self.inputBar.textView.preparedText];
-    [self.inputBar.textView resetTypingAttributes];
+    if([self checkMessageLength]){
+        [self.inputBar.textView autocorrectLastWord];
+        [self sendOrEditText:self.inputBar.textView.preparedText];
+        [self.inputBar.textView resetTypingAttributes];
+    }
 }
 
--(void)checkMessageLength{
-    if(self.inputBar.textView.text.length > 8000) {
+-(BOOL)checkMessageLength{
+    
+    BOOL allowed = self.inputBar.textView.text.length <= 8000;
+    
+    if(!allowed) {
         UIAlertController *alert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"conversation.input_bar.message_too_long.title", nil)
                                                                        message:NSLocalizedString(@"conversation.input_bar.message_too_long.message", nil)
                                                                 preferredStyle:UIAlertControllerStyleAlert];
         [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleCancel handler:nil]];
         [self presentViewController:alert animated:YES completion:nil];
-        return;
     }
+    
+    return allowed;
 }
 
 @end

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -1037,6 +1037,13 @@
 
 - (void)sendButtonPressed:(id)sender
 {
+    [self checkMessageLength];
+    [self.inputBar.textView autocorrectLastWord];
+    [self sendOrEditText:self.inputBar.textView.preparedText];
+    [self.inputBar.textView resetTypingAttributes];
+}
+
+-(void)checkMessageLength{
     if(self.inputBar.textView.text.length > 8000) {
         UIAlertController *alert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"conversation.input_bar.message_too_long.title", nil)
                                                                        message:NSLocalizedString(@"conversation.input_bar.message_too_long.message", nil)
@@ -1045,10 +1052,6 @@
         [self presentViewController:alert animated:YES completion:nil];
         return;
     }
-    
-    [self.inputBar.textView autocorrectLastWord];
-    [self sendOrEditText:self.inputBar.textView.preparedText];
-    [self.inputBar.textView resetTypingAttributes];
 }
 
 @end

--- a/WireExtensionComponents/Utilities/SharedConstants.swift
+++ b/WireExtensionComponents/Utilities/SharedConstants.swift
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import UIKit
+
+public class SharedConstants: NSObject {
+    public static let maximumMessageLength = 8000
+}


### PR DESCRIPTION
## What's new in this PR?

### Issues

Actually, you're able to send messages longer than 8KB.

### Solutions

- Added a control that shows the same alert that is shown on the web version. The alert is visible when tapping on the Send button, if the content of the input bar is greater than 8.000 characters.
- Added support to the `charactersRemaining` property of `SLComposeServiceViewController`. In this way, the remaining characters count is shown on the share extension.

## Attachments

![simulator screen shot - iphone 7 - 2017-11-23 at 12 00 11](https://user-images.githubusercontent.com/2906234/33169789-30373194-d046-11e7-9c9a-3ce60fd5f5ef.png)
![simulator screen shot - iphone 7 - 2017-11-23 at 12 01 05](https://user-images.githubusercontent.com/2906234/33169790-30510c90-d046-11e7-8467-d898ff925543.png)
