### PR TITLE
Allow sound while playing videos with the silence switch on

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		1658D2061D3E742A00249609 /* ringing_from_them_long.caf in Resources */ = {isa = PBXBuildFile; fileRef = 87A4DAA31D34FF0400105D44 /* ringing_from_them_long.caf */; };
 		165FDC4B1DD5D447009D75A2 /* NSItemProvider+Helper.m in Sources */ = {isa = PBXBuildFile; fileRef = 165FDC4A1DD5D447009D75A2 /* NSItemProvider+Helper.m */; };
 		1660F2381FBC6E2E00A0EE54 /* silence.m4a in Resources */ = {isa = PBXBuildFile; fileRef = 1660F2371FBC6E2D00A0EE54 /* silence.m4a */; };
+		1660F23A1FBF32D400A0EE54 /* MediaPlayerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1660F2391FBF32D400A0EE54 /* MediaPlayerController.swift */; };
 		166390D41DC34CAB00D7BF1C /* ImageToolbarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166390D31DC34CAB00D7BF1C /* ImageToolbarView.swift */; };
 		166390D61DC8AC0C00D7BF1C /* String+Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166390D51DC8AC0C00D7BF1C /* String+Image.swift */; };
 		1670AFE81B2095B1002BF0AE /* VoiceChannelCollectionViewLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = 1670AFE71B2095B1002BF0AE /* VoiceChannelCollectionViewLayout.m */; };
@@ -1103,6 +1104,7 @@
 		165FDC491DD5D447009D75A2 /* NSItemProvider+Helper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSItemProvider+Helper.h"; sourceTree = "<group>"; };
 		165FDC4A1DD5D447009D75A2 /* NSItemProvider+Helper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSItemProvider+Helper.m"; sourceTree = "<group>"; };
 		1660F2371FBC6E2D00A0EE54 /* silence.m4a */ = {isa = PBXFileReference; lastKnownFileType = file; path = silence.m4a; sourceTree = "<group>"; };
+		1660F2391FBF32D400A0EE54 /* MediaPlayerController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPlayerController.swift; sourceTree = "<group>"; };
 		166390D31DC34CAB00D7BF1C /* ImageToolbarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageToolbarView.swift; sourceTree = "<group>"; };
 		166390D51DC8AC0C00D7BF1C /* String+Image.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Image.swift"; sourceTree = "<group>"; };
 		1670AFE61B2095B1002BF0AE /* VoiceChannelCollectionViewLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VoiceChannelCollectionViewLayout.h; sourceTree = "<group>"; };
@@ -3470,6 +3472,7 @@
 				871BC32D1D34F94200DF0793 /* AudioTrackView.m */,
 				871BC32E1D34F94200DF0793 /* AudioTrackViewController.h */,
 				871BC32F1D34F94200DF0793 /* AudioTrackViewController.m */,
+				1660F2391FBF32D400A0EE54 /* MediaPlayerController.swift */,
 			);
 			path = AudioPlayer;
 			sourceTree = "<group>";
@@ -6283,6 +6286,7 @@
 				AF36C59F1E9F67B600FADECC /* DraftListViewController.swift in Sources */,
 				EF1F9A021FBB1FD800969DD1 /* LandingButton.swift in Sources */,
 				8733378A1DF5B43A006AE609 /* SwiftDependencies.swift in Sources */,
+				1660F23A1FBF32D400A0EE54 /* MediaPlayerController.swift in Sources */,
 				87A15FE11E08339500AED79B /* CollectionLinkCell.swift in Sources */,
 				DBBFBCB919D2CBCB00557444 /* TitleBar.m in Sources */,
 				16E311C91A5FEAE200FF2C9E /* TextMessageCell.m in Sources */,

--- a/Wire-iOS/Sources/Components/AudioPlayer/AudioTrackPlayer.m
+++ b/Wire-iOS/Sources/Components/AudioPlayer/AudioTrackPlayer.m
@@ -68,7 +68,6 @@ static NSString* EmptyStringIfNil(NSString *string) {
     self = [super init];
     
     if (self) {
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(itemDidPlayToEndTime:) name:AVPlayerItemDidPlayToEndTimeNotification object:nil];
         [self configureRemoteCommandCenter];
     }
     
@@ -106,6 +105,9 @@ static NSString* EmptyStringIfNil(NSString *string) {
             self.loadAudioTrackCompletionHandler(YES, nil);
         }
     }
+    
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:AVPlayerItemDidPlayToEndTimeNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(itemDidPlayToEndTime:) name:AVPlayerItemDidPlayToEndTimeNotification object:self.avPlayer.currentItem];
     
     if (self.timeObserverToken != nil) {
         [self.avPlayer removeTimeObserver:self.timeObserverToken];

--- a/Wire-iOS/Sources/Components/AudioPlayer/MediaPlayerController.swift
+++ b/Wire-iOS/Sources/Components/AudioPlayer/MediaPlayerController.swift
@@ -1,0 +1,98 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/**
+ Controls and observe the state of a AVPlayer instance for integration with the AVSMediaManager
+ */
+@objc
+class MediaPlayerController : NSObject {
+    
+    let message : ZMConversationMessage
+    var player : AVPlayer?
+    weak var delegate : MediaPlayerDelegate?
+    
+    fileprivate var playerRateObserver : Any?
+    
+    init(player: AVPlayer, message: ZMConversationMessage, delegate: MediaPlayerDelegate) {
+        self.player = player
+        self.message = message
+        self.delegate = delegate
+        
+        super.init()
+        
+        self.playerRateObserver = KeyValueObserver.observe(player, keyPath: "rate", target: self, selector: #selector(playerRateChanged))
+    }
+    
+    deinit {
+        delegate?.mediaPlayer(self, didChangeTo: MediaPlayerState.completed)
+        
+        self.playerRateObserver = nil
+    }
+    
+}
+
+extension MediaPlayerController : MediaPlayer {
+    
+    var title: String {
+        return message.fileMessageData?.filename ?? ""
+    }
+    
+    var sourceMessage: ZMConversationMessage! {
+        return message
+    }
+    
+    var state: MediaPlayerState {
+        if player?.rate > 0 {
+            return MediaPlayerState.playing
+        } else {
+            return MediaPlayerState.paused
+        }
+    }
+    
+    var error: Error! {
+        return nil
+    }
+    
+    func play() {
+        player?.play()
+    }
+    
+    func stop() {
+        player?.pause()
+    }
+    
+    func pause() {
+        player?.pause()
+    }
+    
+}
+
+extension MediaPlayerController {
+    
+    func playerRateChanged() {
+        if player?.rate > 0 {
+            delegate?.mediaPlayer(self, didChangeTo: MediaPlayerState.playing)
+        } else {
+            delegate?.mediaPlayer(self, didChangeTo: MediaPlayerState.paused)
+        }
+    }
+    
+}
+

--- a/Wire-iOS/Sources/Managers/MediaPlaybackManager.h
+++ b/Wire-iOS/Sources/Managers/MediaPlaybackManager.h
@@ -31,7 +31,7 @@ FOUNDATION_EXPORT NSString *const MediaPlaybackManagerPlayerStateChangedNotifica
 @interface MediaPlaybackManager : NSObject <AVSMedia, MediaPlayerDelegate>
 
 @property (nonatomic, readonly) AudioTrackPlayer *audioTrackPlayer;
-@property (nonatomic, readonly) id<MediaPlayer> activeMediaPlayer;
+@property (nonatomic, weak, readonly) id<MediaPlayer> activeMediaPlayer;
 
 - (instancetype)initWithName:(NSString *)name;
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/MessagePresenter.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/MessagePresenter.m
@@ -29,6 +29,9 @@
 
 
 @interface AVPlayerViewControllerWithoutStatusBar : AVPlayerViewController
+
+@property (nonatomic) MediaPlayerController *playerController;
+
 @end
 
 @implementation AVPlayerViewControllerWithoutStatusBar
@@ -102,10 +105,12 @@
     
     if (message.fileMessageData.isVideo) {
         AVPlayer *player = [[AVPlayer alloc] initWithURL:message.fileMessageData.fileURL];
+        MediaPlayerController *playerController = [[MediaPlayerController alloc]  initWithPlayer:player message:message delegate: AppDelegate.sharedAppDelegate.mediaPlaybackManager];
         
-        AVPlayerViewController *playerController = [[AVPlayerViewControllerWithoutStatusBar alloc] init];
-        playerController.player = player;
-        [self.targetViewController presentViewController:playerController animated:YES completion:^() {
+        AVPlayerViewControllerWithoutStatusBar *playerViewController = [[AVPlayerViewControllerWithoutStatusBar alloc] init];
+        playerViewController.player = player;
+        playerViewController.playerController = playerController;
+        [self.targetViewController presentViewController:playerViewController animated:YES completion:^() {
             [[UIApplication sharedApplication] wr_updateStatusBarForCurrentControllerAnimated:YES];
             [player play];
             [Analytics.shared tagPlayedVideoMessage:CMTimeGetSeconds(player.currentItem.duration)];


### PR DESCRIPTION
### Issues

If you play a video message you do not hear the audio if the silence switch is enabled.

### Causes

In order to play audio while the silence switch is enabled the audio category must be `Playback`.

### Solutions

The audio category is controlled by AVS's media manager,  we should not change audio category directly in the client code. Instead the AVS exposes a protocol called `AVSMediaDelegate` which we should implement so that AVS can select the right category for any external media we play in the client. This protocol also allows AVS to pause the playback of external media if we for example receive a incoming call during media playback.