### PR TITLE
Wrap trustClient in enqueueChanges

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/SettingsClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/SettingsClientViewController.swift
@@ -131,15 +131,19 @@ class SettingsClientViewController: UIViewController, UITableViewDelegate, UITab
     
     func onVerifiedChanged(_ sender: UISwitch!) {
         let selfClient = ZMUserSession.shared()!.selfUserClient()
-        if(sender.isOn) {
-            selfClient?.trustClient(self.userClient)
-        } else {
-            selfClient?.ignoreClient(self.userClient)
-        }
-        sender.isOn = self.userClient.verified
         
-        let verificationType : DeviceVerificationType = sender.isOn ? .verified : .unverified
-        Analytics.shared().tagChange(verificationType, deviceOwner: .self)
+        ZMUserSession.shared()?.enqueueChanges({
+            if (sender.isOn) {
+                selfClient?.trustClient(self.userClient)
+            } else {
+                selfClient?.ignoreClient(self.userClient)
+            }
+        }, completionHandler: {
+            sender.isOn = self.userClient.verified
+            
+            let verificationType : DeviceVerificationType = sender.isOn ? .verified : .unverified
+            Analytics.shared().tagChange(verificationType, deviceOwner: .self)
+        })
     }
     
     func onDonePressed(_ sender: AnyObject!) {


### PR DESCRIPTION
### Issues

Verifying one of your own devices is not saved if you kill the app right after.

### Causes

All all methods which alter data model must be wrapped in `enqueueChanges` in order for the change to be persisted.

### Solutions

Wrap `trustClient()` method in a `enqueueChanges` block.