### PR TITLE
Showing both tabs in login and registration

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/RegistrationRootViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/RegistrationRootViewController.m
@@ -80,21 +80,20 @@
         flowViewController = phoneFlowViewController;
     }
 
-    NSArray *controllers;
     switch (self.flowType) {
         case AuthenticationFlowRegular:
-            controllers = @[flowViewController, signInViewController];
             break;
         case AuthenticationFlowOnlyLogin:
+            self.showLogin = true;
             [self setupBackButton];
-            controllers = @[signInViewController];
             break;
         case AuthenticationFlowOnlyRegistration:
+            self.showLogin = false;
             [self setupBackButton];
-            controllers = @[flowViewController];
             break;
     }
-    self.registrationTabBarController = [[TabBarController alloc] initWithViewControllers:controllers];
+    
+    self.registrationTabBarController = [[TabBarController alloc] initWithViewControllers:@[flowViewController, signInViewController]];
     self.signInViewController = signInViewController;
     
     if (self.showLogin) {


### PR DESCRIPTION
## What's new in this PR?

### Issues

After design review it seems we have changed too much in the current registration flow. We should keep it as it was and coming from landing page show both login and registration tabs.

### Solutions

We simply preselect login or registration, but show both tabs.
