### PR TITLE
Fix crash on playing video

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/MessagePresenter.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/MessagePresenter.m
@@ -30,7 +30,7 @@
 
 @interface AVPlayerViewControllerWithoutStatusBar : AVPlayerViewController
 
-@property (nonatomic) MediaPlayerController *playerController;
+@property (nonatomic) MediaPlayerController *wr_playerController;
 
 @end
 
@@ -109,7 +109,7 @@
         
         AVPlayerViewControllerWithoutStatusBar *playerViewController = [[AVPlayerViewControllerWithoutStatusBar alloc] init];
         playerViewController.player = player;
-        playerViewController.playerController = playerController;
+        playerViewController.wr_playerController = playerController;
         [self.targetViewController presentViewController:playerViewController animated:YES completion:^() {
             [[UIApplication sharedApplication] wr_updateStatusBarForCurrentControllerAnimated:YES];
             [player play];


### PR DESCRIPTION
### Issues

App crashes when pressing to play button on a video message.

### Causes

We subclass `AVPlayerViewController` to be able to track when the video playback ends. In this subclass we add property called `playerController` tracks the internal `AVPlayer`. This property however clashes with a private property which leads to a crash.

### Solutions

Prefix our property with `wr_ playerController `.