### PR TITLE
Fixed issue with crashing when deleting from empty char field

### DIFF
--- a/Wire-iOS Tests/CharacterInputFieldTests.swift
+++ b/Wire-iOS Tests/CharacterInputFieldTests.swift
@@ -96,6 +96,18 @@ final class CharacterInputFieldTests: XCTestCase {
         XCTAssertEqual(delegate.didFillInput, 0)
     }
     
+    func testThatItDoesNotDeleteWhenNoSymbols() {
+        // given
+        sut.text = ""
+        // when
+        sut.deleteBackward()
+        // then
+        XCTAssertEqual(delegate.didChangeText, [])
+        XCTAssertEqual(sut.text, "")
+        XCTAssertFalse(sut.isFilled)
+        XCTAssertEqual(delegate.didFillInput, 0)
+    }
+    
     func testThatItAllowsToPasteAndCallsDelegate() {
         // given
         sut.text = "1234"

--- a/Wire-iOS/Sources/UserInterface/Components/CharacterInputField.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/CharacterInputField.swift
@@ -280,6 +280,9 @@ extension CharacterInputField: UIKeyInput {
     }
     
     public func deleteBackward() {
+        guard !self.storage.isEmpty else {
+            return
+        }
         notifyingDelegate {
             self.storage.removeLast()
         }


### PR DESCRIPTION
## What's new in this PR?

Issue happened when user tried to delete the text from the input field when it was empty.
