### PR TITLE
Added accessibility information to team creation flow

### DIFF
--- a/Wire-iOS Tests/CharacterInputFieldTests.swift
+++ b/Wire-iOS Tests/CharacterInputFieldTests.swift
@@ -70,6 +70,7 @@ final class CharacterInputFieldTests: XCTestCase {
         // then
         XCTAssertEqual(delegate.didChangeText, [])
         XCTAssertEqual(sut.text, "1234")
+        XCTAssertEqual(sut.accessibilityValue, "1234")
         XCTAssertFalse(sut.isFilled)
         XCTAssertEqual(delegate.didFillInput, 0)
     }
@@ -80,6 +81,7 @@ final class CharacterInputFieldTests: XCTestCase {
         // then
         XCTAssertEqual(delegate.didChangeText, ["1"])
         XCTAssertEqual(sut.text, "1")
+        XCTAssertEqual(sut.accessibilityValue, "1")
         XCTAssertFalse(sut.isFilled)
         XCTAssertEqual(delegate.didFillInput, 0)
     }
@@ -92,6 +94,7 @@ final class CharacterInputFieldTests: XCTestCase {
         // then
         XCTAssertEqual(delegate.didChangeText, ["123"])
         XCTAssertEqual(sut.text, "123")
+        XCTAssertEqual(sut.accessibilityValue, "123")
         XCTAssertFalse(sut.isFilled)
         XCTAssertEqual(delegate.didFillInput, 0)
     }
@@ -104,6 +107,7 @@ final class CharacterInputFieldTests: XCTestCase {
         // then
         XCTAssertEqual(delegate.didChangeText, [])
         XCTAssertEqual(sut.text, "")
+        XCTAssertEqual(sut.accessibilityValue, "")
         XCTAssertFalse(sut.isFilled)
         XCTAssertEqual(delegate.didFillInput, 0)
     }
@@ -117,6 +121,7 @@ final class CharacterInputFieldTests: XCTestCase {
         // then
         XCTAssertEqual(delegate.didChangeText, ["567"])
         XCTAssertEqual(sut.text, "567")
+        XCTAssertEqual(sut.accessibilityValue, "567")
         XCTAssertFalse(sut.isFilled)
         XCTAssertEqual(delegate.didFillInput, 0)
     }
@@ -128,6 +133,7 @@ final class CharacterInputFieldTests: XCTestCase {
         // then
         XCTAssertEqual(delegate.didChangeText, [])
         XCTAssertEqual(sut.text, "1234")
+        XCTAssertEqual(sut.accessibilityValue, "1234")
         XCTAssertFalse(sut.isFilled)
         XCTAssertEqual(delegate.didFillInput, 0)
     }
@@ -138,6 +144,7 @@ final class CharacterInputFieldTests: XCTestCase {
         // then
         XCTAssertEqual(delegate.didChangeText, ["12345678"])
         XCTAssertEqual(sut.text, "12345678")
+        XCTAssertEqual(sut.accessibilityValue, "12345678")
         XCTAssertTrue(sut.isFilled)
         XCTAssertEqual(delegate.didFillInput, 1)
     }

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -805,6 +805,8 @@
 "team.name.textfield.placeholder" = "team name";
 "team.name.whatiswireforteams" = "What is Wire for teams?";
 
+"team.email_code.input_field.accessbility_label" = "Please enter the six-digit code from the email.";
+
 // Registration
 
 "registration.title" = "Registration";

--- a/Wire-iOS/Sources/UserInterface/Components/CharacterInputField.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/CharacterInputField.swift
@@ -34,6 +34,7 @@ public class CharacterInputField: UIControl, UITextInputTraits {
             }
             
             self.updateCharacterViews(isFirstResponder: self.isFirstResponder)
+            self.accessibilityValue = storage
         }
     }
     
@@ -89,6 +90,12 @@ public class CharacterInputField: UIControl, UITextInputTraits {
         }
     }
     
+    fileprivate func showMenu() {
+        let menuController = UIMenuController.shared
+        menuController.setTargetRect(bounds, in: self)
+        menuController.setMenuVisible(true, animated: true)
+    }
+    
     class CharacterView: UIView {
         private let label = UILabel()
         private let cursorView = UIView()
@@ -119,6 +126,7 @@ public class CharacterInputField: UIControl, UITextInputTraits {
         
         init() {
             super.init(frame: .zero)
+            
             self.layer.cornerRadius = 4
             self.backgroundColor = .white
             
@@ -170,6 +178,10 @@ public class CharacterInputField: UIControl, UITextInputTraits {
         characterViews = (0..<maxLength).map { _ in CharacterView() }
 
         super.init(frame: .zero)
+        
+        self.isAccessibilityElement = true
+        self.shouldGroupAccessibilityChildren = true
+        
         stackView.spacing = 8
         stackView.axis = .horizontal
         
@@ -216,12 +228,20 @@ public class CharacterInputField: UIControl, UITextInputTraits {
         self.becomeFirstResponder()
     }
     
+    public override func accessibilityElementIsFocused() -> Bool {
+        return self.becomeFirstResponder()
+    }
+    
+    public override func accessibilityActivate() -> Bool {
+        self.showMenu()
+        
+        return true
+    }
+    
     // MARK: - Paste support
     
     @objc fileprivate func onLongPress(_ sender: Any?) {
-        let menuController = UIMenuController.shared
-        menuController.setTargetRect(bounds, in: self)
-        menuController.setMenuVisible(true, animated: true)
+        self.showMenu()
     }
     
     public override func paste(_ sender: Any?) {
@@ -292,3 +312,4 @@ extension CharacterInputField: UIKeyInput {
         return !storage.isEmpty
     }
 }
+

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationState.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationState.swift
@@ -40,15 +40,15 @@ extension TeamCreationState {
     var mainViewDescription: ViewDescriptor & ValueSubmission {
         switch self {
         case .setTeamName:
-            return TextFieldDescription(placeholder: "Team name", kind: .name)
+            return TextFieldDescription(placeholder: "Team name", actionDescription: "Set team name", kind: .name)
         case .setEmail:
-            return TextFieldDescription(placeholder: "Email address", kind: .email)
+            return TextFieldDescription(placeholder: "Email address", actionDescription: "Set e-mail", kind: .email)
         case .verifyEmail:
             return VerificationCodeFieldDescription()
         case .setFullName:
-            return TextFieldDescription(placeholder: "Name", kind: .name)
+            return TextFieldDescription(placeholder: "Name", actionDescription: "Set full name", kind: .name)
         case .setPassword:
-            return TextFieldDescription(placeholder: "Password", kind: .password)
+            return TextFieldDescription(placeholder: "Password", actionDescription: "Set password", kind: .password)
         }
     }
 

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/ViewDescriptions/TextFieldDescription.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/ViewDescriptions/TextFieldDescription.swift
@@ -20,13 +20,15 @@ import Foundation
 
 final class TextFieldDescription: NSObject, ValueSubmission {
     let placeholder: String
+    let actionDescription: String
     let kind: AccessoryTextField.Kind
     var valueSubmitted: ValueSubmitted?
 
     fileprivate var currentValue: String = ""
 
-    init(placeholder: String, kind: AccessoryTextField.Kind) {
+    init(placeholder: String, actionDescription: String, kind: AccessoryTextField.Kind) {
         self.placeholder = placeholder
+        self.actionDescription = actionDescription
         self.kind = kind
         super.init()
     }
@@ -41,6 +43,7 @@ extension TextFieldDescription: ViewDescriptor {
         textField.delegate = self
         textField.textFieldValidationDelegate = self
         textField.confirmButton.addTarget(self, action: #selector(TextFieldDescription.confirmButtonTapped(_:)), for: .touchUpInside)
+        textField.confirmButton.accessibilityLabel = self.actionDescription
         return textField
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/ViewDescriptions/VerificationCodeFieldDescription.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/ViewDescriptions/VerificationCodeFieldDescription.swift
@@ -33,6 +33,8 @@ extension VerificationCodeFieldDescription: ViewDescriptor {
         inputField.keyboardType = .decimalPad
         inputField.translatesAutoresizingMaskIntoConstraints = false
         inputField.delegate = self
+        inputField.accessibilityIdentifier = "VerificationCode"
+        inputField.accessibilityLabel = "team.email_code.input_field.accessbility_label".localized
         containerView.addSubview(inputField)
 
         inputField.heightAnchor.constraint(equalTo: containerView.heightAnchor).isActive = true


### PR DESCRIPTION
## What's new in this PR?

The accessibility values for the following parts of the team creation where added:

1. `CharacterInputField` now returns the correct accessibility value (it's textual content). Covered with tests.
2. The instance of `CharacterInputField` is returning the correct accessibility label and identifier for automation.
3. The confirmation button in the input fields is now having the localized description.
