### PR TITLE
Copying AVS debug symbols together with the framework

### DIFF
--- a/Scripts/download-avs.sh
+++ b/Scripts/download-avs.sh
@@ -127,6 +127,10 @@ if ! mv "${CARTHAGE_BUILD_PATH}/${AVS_FRAMEWORK_NAME}" .; then
 	exit 1
 fi
 
+if ! mv "${CARTHAGE_BUILD_PATH}/${AVS_FRAMEWORK_NAME}.dSYM" .; then
+	echo "ℹ️  Debug symbols not found, crash reports will have to be symbolicated manually! ⚠️"
+fi
+
 rm -rf "Carthage"
 
 echo "✅  Done"


### PR DESCRIPTION
## What's new in this PR?

### Issues

Crashes that were originating in AVS would not have descriptive function names in crashlogs.

### Causes

For each `.framework` that we use in the app we also have a corresponding `.framework.dSYM` that contains all the symbols needed to make crash reports readable.

For few last AVS releases the symbols are present in the archive, but the script was not moving them to the right place

### Solutions

Updated `download-avs.sh` script that is called from `./setup.sh`
