### PR TITLE
Allow email code input field to get the responder automatically

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/ViewDescriptions/VerificationCodeFieldDescription.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/ViewDescriptions/VerificationCodeFieldDescription.swift
@@ -24,7 +24,7 @@ final class VerificationCodeFieldDescription: NSObject, ValueSubmission {
     var constraints: [NSLayoutConstraint] = []
 }
 
-fileprivate final class RepsonderContainer: UIView {
+fileprivate final class ResponderContainer: UIView {
     private let responder: UIView
     
     init(responder: UIView) {
@@ -59,7 +59,7 @@ extension VerificationCodeFieldDescription: ViewDescriptor {
         inputField.accessibilityIdentifier = "VerificationCode"
         inputField.accessibilityLabel = "team.email_code.input_field.accessbility_label".localized
 
-        let containerView = RepsonderContainer(responder: inputField)
+        let containerView = ResponderContainer(responder: inputField)
         containerView.translatesAutoresizingMaskIntoConstraints = false
         
         inputField.heightAnchor.constraint(equalTo: containerView.heightAnchor).isActive = true

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/ViewDescriptions/VerificationCodeFieldDescription.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/ViewDescriptions/VerificationCodeFieldDescription.swift
@@ -24,23 +24,48 @@ final class VerificationCodeFieldDescription: NSObject, ValueSubmission {
     var constraints: [NSLayoutConstraint] = []
 }
 
+fileprivate final class RepsonderContainer: UIView {
+    private let responder: UIView
+    
+    init(responder: UIView) {
+        self.responder = responder
+        super.init(frame: .zero)
+        self.addSubview(self.responder)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override var canBecomeFirstResponder: Bool {
+        return self.responder.canBecomeFirstResponder
+    }
+    
+    override func becomeFirstResponder() -> Bool {
+        return self.responder.becomeFirstResponder()
+    }
+    
+    override func resignFirstResponder() -> Bool {
+        return self.responder.resignFirstResponder()
+    }
+}
+
 extension VerificationCodeFieldDescription: ViewDescriptor {
     func create() -> UIView {
-        let containerView = UIView()
-
-        containerView.translatesAutoresizingMaskIntoConstraints = false
         let inputField = CharacterInputField(maxLength: 6, characterSet: .decimalDigits)
         inputField.keyboardType = .decimalPad
         inputField.translatesAutoresizingMaskIntoConstraints = false
         inputField.delegate = self
         inputField.accessibilityIdentifier = "VerificationCode"
         inputField.accessibilityLabel = "team.email_code.input_field.accessbility_label".localized
-        containerView.addSubview(inputField)
 
+        let containerView = RepsonderContainer(responder: inputField)
+        containerView.translatesAutoresizingMaskIntoConstraints = false
+        
         inputField.heightAnchor.constraint(equalTo: containerView.heightAnchor).isActive = true
         inputField.centerXAnchor.constraint(equalTo: containerView.centerXAnchor).isActive = true
         inputField.centerYAnchor.constraint(equalTo: containerView.centerYAnchor).isActive = true
-
+        
         return containerView
     }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

In the team creation flow only code view haven't received the responder state automatically (keyboard is not up when opening the email code screen).

### Causes

In every screen we call `mainView.becomeFirstResponder()`, in all other cases it's an input field, whereas on the email code screen the input is hidden inside the `UIView` wrapper.

### Solutions

Implement the wrapper that is forwarding the responder calls to the subview.

## Notes

In the past I was under an impression that `becomeFirstResponder` is a recursive call.