### PR TITLE
Add textfield validation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/AccessoryTextField.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/AccessoryTextField.swift
@@ -166,16 +166,15 @@ class AccessoryTextField: UITextField {
     }
 
     func textFieldDidChange(textField: UITextField) {
-        /// enable button after first key tapped
-        confirmButton.isEnabled = true
+        /// enable button if we have some text entered
+        let text = textField.text ?? ""
+        confirmButton.isEnabled = !text.isEmpty
     }
 
     // MARK: - text validation
 
     func confirmButtonTapped(button: UIButton) {
         let error = textFieldValidator.validate(text: text, kind: kind)
-
-        confirmButton.isEnabled = (error == .none)
 
         textFieldValidationDelegate?.validationUpdated(sender: self, error: error)
     }

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationFlowController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationFlowController.swift
@@ -20,6 +20,7 @@ import Foundation
 import WireSyncEngine
 
 typealias ValueSubmitted = (String) -> ()
+typealias ValueValidated = (TextFieldValidator.ValidationError) -> ()
 
 protocol ViewDescriptor: class {
     func create() -> UIView
@@ -27,6 +28,7 @@ protocol ViewDescriptor: class {
 
 protocol ValueSubmission: class {
     var valueSubmitted: ValueSubmitted? { get set }
+    var valueValidated: ValueValidated? { get set }
 }
 
 final class TeamCreationFlowController: NSObject {
@@ -59,6 +61,15 @@ extension TeamCreationFlowController {
         let mainView = description.mainViewDescription
         mainView.valueSubmitted = { [weak self] (value: String) in
             self?.advanceState(with: value)
+        }
+
+        mainView.valueValidated = { [weak self] (error: TextFieldValidator.ValidationError) in
+            switch error {
+            case .none:
+                self?.currentController?.clearError()
+            default:
+                self?.currentController?.displayError(error)
+            }
         }
 
         let backButton = description.backButtonDescription

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationFlowController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationFlowController.swift
@@ -36,7 +36,7 @@ final class TeamCreationFlowController: NSObject {
     let navigationController: UINavigationController
     let registrationStatus: RegistrationStatus
     var nextState: TeamCreationState?
-    var currentController: TeamCreationStepController!
+    var currentController: TeamCreationStepController?
     weak var registrationDelegate: RegistrationViewControllerDelegate?
     var syncToken: Any?
     var sessionManagerToken: Any?
@@ -133,8 +133,9 @@ extension TeamCreationFlowController {
         }
 
         if let description = stepDescription {
-            currentController = createViewController(for: description)
-            navigationController.pushViewController(currentController, animated: true)
+            let controller = createViewController(for: description)
+            currentController = controller
+            navigationController.pushViewController(controller, animated: true)
         }
     }
 
@@ -151,9 +152,11 @@ extension TeamCreationFlowController {
             currentState = nextState
             self.nextState = nil
             self.navigationController.popViewController(animated: true)
+            self.currentController = navigationController.viewControllers.last as? TeamCreationStepController
         } else {
             currentState = .setTeamName
             self.nextState = nil
+            self.currentController = nil
             self.navigationController.popToRootViewController(animated: true)
         }
     }
@@ -187,7 +190,7 @@ extension TeamCreationFlowController: RegistrationStatusDelegate {
     }
 
     public func teamRegistrationFailed(with error: Error) {
-        currentController.displayError(error)
+        currentController?.displayError(error)
     }
 
     public func emailActivationCodeSent() {
@@ -195,7 +198,7 @@ extension TeamCreationFlowController: RegistrationStatusDelegate {
     }
 
     public func emailActivationCodeSendingFailed(with error: Error) {
-        currentController.displayError(error)
+        currentController?.displayError(error)
     }
 
     public func emailActivationCodeValidated() {
@@ -203,7 +206,7 @@ extension TeamCreationFlowController: RegistrationStatusDelegate {
     }
 
     public func emailActivationCodeValidationFailed(with error: Error) {
-        currentController.displayError(error)
+        currentController?.displayError(error)
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationStepController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationStepController.swift
@@ -38,7 +38,7 @@ final class TeamCreationStepController: UIViewController {
     fileprivate var errorLabel: UILabel!
 
     private var secondaryViewsStackView: UIStackView!
-    private var errorViewContainer: UIView!
+    fileprivate var errorViewContainer: UIView!
     private var mainViewContainer: UIView!
 
     private var backButton: UIView?
@@ -205,10 +205,12 @@ extension TeamCreationStepController {
 
     func clearError() {
         errorLabel.text = nil
+        self.errorViewContainer.setNeedsLayout()
     }
 
     func displayError(_ error: Error) {
         errorLabel.text = error.localizedDescription
+        self.errorViewContainer.setNeedsLayout()
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationStepController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationStepController.swift
@@ -203,9 +203,12 @@ final class TeamCreationStepController: UIViewController {
 // MARK: - Error handling
 extension TeamCreationStepController {
 
+    func clearError() {
+        errorLabel.text = nil
+    }
+
     func displayError(_ error: Error) {
-        let nsError = error as NSError
-        errorLabel.text = nsError.localizedDescription
+        errorLabel.text = error.localizedDescription
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/ViewDescriptions/TextFieldDescription.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/ViewDescriptions/TextFieldDescription.swift
@@ -23,6 +23,8 @@ final class TextFieldDescription: NSObject, ValueSubmission {
     let actionDescription: String
     let kind: AccessoryTextField.Kind
     var valueSubmitted: ValueSubmitted?
+    var valueValidated: ValueValidated?
+    var validationError: TextFieldValidator.ValidationError
 
     fileprivate var currentValue: String = ""
 
@@ -30,6 +32,7 @@ final class TextFieldDescription: NSObject, ValueSubmission {
         self.placeholder = placeholder
         self.actionDescription = actionDescription
         self.kind = kind
+        validationError = .tooShort(kind: kind)
         super.init()
     }
 }
@@ -51,29 +54,39 @@ extension TextFieldDescription: ViewDescriptor {
 extension TextFieldDescription: UITextFieldDelegate {
 
     func confirmButtonTapped(_ sender: AnyObject) {
-        self.valueSubmitted?(currentValue)
+        submitValue(with: currentValue)
     }
 
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         let oldValue = textField.text as NSString?
         let result = oldValue?.replacingCharacters(in: range, with: string)
         currentValue = (result as String?) ?? ""
+        if !currentValue.isEmpty {
+            self.valueValidated?(.none)
+        }
         return true
-    }
-
-    func textFieldDidEndEditing(_ textField: UITextField) {
     }
 
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         guard let text = textField.text else { return true }
-        self.valueSubmitted?(text)
+        submitValue(with: text)
         return true
+    }
+
+    func submitValue(with text: String) {
+        switch validationError {
+        case .none:
+            self.valueValidated?(.none)
+            self.valueSubmitted?(text)
+        default:
+            self.valueValidated?(validationError)
+        }
     }
 }
 
 extension TextFieldDescription: TextFieldValidationDelegate {
     func validationUpdated(sender: UITextField, error: TextFieldValidator.ValidationError) {
-        ///
+        self.validationError = error
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/ViewDescriptions/TextFieldDescription.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/ViewDescriptions/TextFieldDescription.swift
@@ -61,9 +61,7 @@ extension TextFieldDescription: UITextFieldDelegate {
         let oldValue = textField.text as NSString?
         let result = oldValue?.replacingCharacters(in: range, with: string)
         currentValue = (result as String?) ?? ""
-        if !currentValue.isEmpty {
-            self.valueValidated?(.none)
-        }
+        self.valueValidated?(.none)
         return true
     }
 

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/ViewDescriptions/VerificationCodeFieldDescription.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/ViewDescriptions/VerificationCodeFieldDescription.swift
@@ -21,6 +21,7 @@ import Cartography
 
 final class VerificationCodeFieldDescription: NSObject, ValueSubmission {
     var valueSubmitted: ValueSubmitted?
+    var valueValidated: ValueValidated?
     var constraints: [NSLayoutConstraint] = []
 }
 

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/TextFieldValidator.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/TextFieldValidator.swift
@@ -26,36 +26,6 @@ class TextFieldValidator {
         case invalidEmail
         case none
 
-        var localizedDescription: String {
-            switch self {
-            case .tooShort(kind: let kind):
-                switch kind {
-                case .name:
-                    return "name.guidance.tooshort".localized
-                case .email:
-                    return "email.guidance.tooshort".localized
-                case .password:
-                    return "password.guidance.tooshort".localized
-                case .unknown:
-                    return "unknown.guidance.tooshort".localized
-                }
-            case .tooLong(kind: let kind):
-                switch kind {
-                case .name:
-                    return "name.guidance.toolong".localized
-                case .email:
-                    return "email.guidance.toolong".localized
-                case .password:
-                    return "password.guidance.toolong".localized
-                case .unknown:
-                    return "unknown.guidance.toolong".localized
-                }
-            case .invalidEmail:
-                return "email.guidance.invalid".localized
-            case .none:
-                return ""
-            }
-        }
 
         static func ==(lhs: ValidationError, rhs: ValidationError) -> Bool {
             switch (lhs, rhs) {
@@ -102,6 +72,40 @@ class TextFieldValidator {
         return .none
 
     }
+}
+
+extension TextFieldValidator.ValidationError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .tooShort(kind: let kind):
+            switch kind {
+            case .name:
+                return "name.guidance.tooshort".localized
+            case .email:
+                return "email.guidance.tooshort".localized
+            case .password:
+                return "password.guidance.tooshort".localized
+            case .unknown:
+                return "unknown.guidance.tooshort".localized
+            }
+        case .tooLong(kind: let kind):
+            switch kind {
+            case .name:
+                return "name.guidance.toolong".localized
+            case .email:
+                return "email.guidance.toolong".localized
+            case .password:
+                return "password.guidance.toolong".localized
+            case .unknown:
+                return "unknown.guidance.toolong".localized
+            }
+        case .invalidEmail:
+            return "email.guidance.invalid".localized
+        case .none:
+            return ""
+        }
+    }
+
 }
 
 // MARK: - Email validator


### PR DESCRIPTION
## What's new in this PR?

### Issues

We should do local validation of values in the textfield depending on the type of value to be entered.

### Solutions

After discussing with design, we decided to enable the arrow button after first character has been entered. When user presses the button we first do local validation and show an error if there are any problems.

### Note

There is a nice protocol `LocalizedError` that an `Error` can conform to and then `error.localizedDescription` works as expected, no need to cast to concrete type.
