### PR TITLE
Few fixes to the flow

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/ScreenDescriptions/SetEmailStepDescription.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/ScreenDescriptions/SetEmailStepDescription.swift
@@ -21,29 +21,19 @@ import Foundation
 final class SetEmailStepDescription: TeamCreationStepDescription {
 
     let controller: UIViewController
+    let backButton: BackButtonDescription?
+    let mainView: ViewDescriptor & ValueSubmission
+    let headline: String
+    let subtext: String?
+    let secondaryViews: [ViewDescriptor]
 
     init(controller: UIViewController) {
         self.controller = controller
-    }
-
-    var backButtonDescription: BackButtonDescription? {
-        return BackButtonDescription()
-    }
-
-    var mainViewDescription: ViewDescriptor & ValueSubmission {
-        return TextFieldDescription(placeholder: "Email address", actionDescription: "Set e-mail", kind: .email)
-    }
-
-    var headline: String {
-        return "Set email"
-    }
-
-    var subtext: String? {
-        return nil
-    }
-
-    var secondaryViews: [ViewDescriptor] {
-        return []
+        backButton = BackButtonDescription()
+        mainView = TextFieldDescription(placeholder: "Email address", actionDescription: "Set e-mail", kind: .email)
+        headline = "Set email"
+        subtext = nil
+        secondaryViews = []
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/ScreenDescriptions/SetFullNameStepDescription.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/ScreenDescriptions/SetFullNameStepDescription.swift
@@ -19,24 +19,19 @@
 import Foundation
 
 final class SetFullNameStepDescription: TeamCreationStepDescription {
-    var backButtonDescription: BackButtonDescription? {
-        return BackButtonDescription()
-    }
 
-    var mainViewDescription: ViewDescriptor & ValueSubmission {
-        return TextFieldDescription(placeholder: "Name", actionDescription: "Set full name", kind: .name)
-    }
+    let backButton: BackButtonDescription?
+    let mainView: ViewDescriptor & ValueSubmission
+    let headline: String
+    let subtext: String?
+    let secondaryViews: [ViewDescriptor]
 
-    var headline: String {
-        return "Set name"
-    }
-
-    var subtext: String? {
-        return "This should be your real name"
-    }
-
-    var secondaryViews: [ViewDescriptor] {
-        return []
+    init() {
+        backButton = BackButtonDescription()
+        mainView = TextFieldDescription(placeholder: "Name", actionDescription: "Set full name", kind: .name)
+        headline = "Set name"
+        subtext = "This should be your real name"
+        secondaryViews = []
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/ScreenDescriptions/SetPasswordStepDescription.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/ScreenDescriptions/SetPasswordStepDescription.swift
@@ -19,23 +19,18 @@
 import Foundation
 
 final class SetPasswordStepDescription: TeamCreationStepDescription {
-    var backButtonDescription: BackButtonDescription? {
-        return BackButtonDescription()
-    }
 
-    var mainViewDescription: ViewDescriptor & ValueSubmission {
-        return TextFieldDescription(placeholder: "Password", actionDescription: "Set password", kind: .password)
-    }
+    let backButton: BackButtonDescription?
+    let mainView: ViewDescriptor & ValueSubmission
+    let headline: String
+    let subtext: String?
+    let secondaryViews: [ViewDescriptor]
 
-    var headline: String {
-        return "Set password"
-    }
-
-    var subtext: String? {
-        return "Please choose a decent password"
-    }
-
-    var secondaryViews: [ViewDescriptor] {
-        return []
+    init() {
+        backButton = BackButtonDescription()
+        mainView = TextFieldDescription(placeholder: "Password", actionDescription: "Set password", kind: .password)
+        headline = "Set password"
+        subtext = "Please choose a decent password"
+        secondaryViews = []
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/ScreenDescriptions/SetTeamNameStepDescription.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/ScreenDescriptions/SetTeamNameStepDescription.swift
@@ -22,34 +22,24 @@ import SafariServices
 final class SetTeamNameStepDescription: TeamCreationStepDescription {
 
     let controller: UIViewController
+    let backButton: BackButtonDescription?
+    let mainView: ViewDescriptor & ValueSubmission
+    let headline: String
+    let subtext: String?
+    let secondaryViews: [ViewDescriptor]
 
     init(controller: UIViewController) {
         self.controller = controller
-    }
-
-    var backButtonDescription: BackButtonDescription? {
-        return BackButtonDescription()
-    }
-
-    var mainViewDescription: ViewDescriptor & ValueSubmission {
-        return TextFieldDescription(placeholder: "Team name", actionDescription: "Set team name", kind: .name)
-    }
-
-    var headline: String {
-        return "Set team name"
-    }
-
-    var subtext: String? {
-        return "You can always change it later"
-    }
-
-    var secondaryViews: [ViewDescriptor] {
+        backButton = BackButtonDescription()
+        mainView = TextFieldDescription(placeholder: "Team name", actionDescription: "Set team name", kind: .name)
+        headline = "Set team name"
+        subtext = "You can always change it later"
         let whatIsWire = ButtonDescription(title: "What is Wire for teams?", accessibilityIdentifier: "wire_for_teams_button")
-        whatIsWire.buttonTapped = { [weak self] in
+        whatIsWire.buttonTapped = { [weak controller] in
             let webview = SFSafariViewController(url: URL(string: "https://wire.com/en/create-team/")!)
-            self?.controller.present(webview, animated: true, completion: nil)
+            controller?.present(webview, animated: true, completion: nil)
         }
-        return [whatIsWire]
+        secondaryViews = [whatIsWire]
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/ScreenDescriptions/TeamCreationStepDescription.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/ScreenDescriptions/TeamCreationStepDescription.swift
@@ -19,9 +19,16 @@
 import Foundation
 
 protocol TeamCreationStepDescription {
-    var backButtonDescription: BackButtonDescription? { get }
-    var mainViewDescription: ViewDescriptor & ValueSubmission { get }
+    var backButton: BackButtonDescription? { get }
+    var mainView: ViewDescriptor & ValueSubmission { get }
     var headline: String { get }
     var subtext: String? { get }
     var secondaryViews: [ViewDescriptor] { get }
+    func shouldSkipFromNavigation() -> Bool
+}
+
+extension TeamCreationStepDescription {
+    func shouldSkipFromNavigation() -> Bool {
+        return false
+    }
 }

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/ScreenDescriptions/VerifyEmailStepDescription.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/ScreenDescriptions/VerifyEmailStepDescription.swift
@@ -26,38 +26,32 @@ protocol VerifyEmailStepDescriptionDelegate: class {
 final class VerifyEmailStepDescription: TeamCreationStepDescription {
     let email: String
     weak var delegate: VerifyEmailStepDescriptionDelegate?
+    let backButton: BackButtonDescription?
+    let mainView: ViewDescriptor & ValueSubmission
+    let headline: String
+    let subtext: String?
+    let secondaryViews: [ViewDescriptor]
 
     init(email: String, delegate: VerifyEmailStepDescriptionDelegate) {
         self.email = email
         self.delegate = delegate
-    }
+        backButton = nil
+        mainView = VerificationCodeFieldDescription()
+        headline = "You've got mail"
+        subtext = "Enter the verification code we sent to \(email)"
 
-    var backButtonDescription: BackButtonDescription? {
-        return nil
-    }
-
-    var mainViewDescription: ViewDescriptor & ValueSubmission {
-        return VerificationCodeFieldDescription()
-    }
-
-    var headline: String {
-        return "You've got mail"
-    }
-
-    var subtext: String? {
-        return "Enter the verification code we sent to \(email)"
-    }
-
-    var secondaryViews: [ViewDescriptor] {
         let resendCode = ButtonDescription(title: "Resend code", accessibilityIdentifier: "resend_button")
-        resendCode.buttonTapped = { [weak self] in
-            guard let `self` = self else { return }
-            self.delegate?.resendActivationCode(to: self.email)
+        resendCode.buttonTapped = { [weak delegate] in
+            delegate?.resendActivationCode(to: email)
         }
         let changeEmail = ButtonDescription(title: "Change Email", accessibilityIdentifier: "change_email_button")
-        changeEmail.buttonTapped = { [weak self] in
-            self?.delegate?.changeEmail()
+        changeEmail.buttonTapped = { [weak delegate] in
+            delegate?.changeEmail()
         }
-        return [resendCode, changeEmail]
+        secondaryViews = [resendCode, changeEmail]
+    }
+
+    func shouldSkipFromNavigation() -> Bool {
+        return true
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationFlowController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationFlowController.swift
@@ -36,7 +36,8 @@ final class TeamCreationFlowController: NSObject {
     let navigationController: UINavigationController
     let registrationStatus: RegistrationStatus
     var nextState: TeamCreationState?
-    var currentController: TeamCreationStepController?
+    var currentController: TeamCreationStepController? 
+    var currentStepDescription: TeamCreationStepDescription?
     weak var registrationDelegate: RegistrationViewControllerDelegate?
     var syncToken: Any?
     var sessionManagerToken: Any?
@@ -135,6 +136,7 @@ extension TeamCreationFlowController {
         if let description = stepDescription {
             let controller = createViewController(for: description)
             currentController = controller
+            currentStepDescription = description
             navigationController.pushViewController(controller, animated: true)
         }
     }
@@ -157,6 +159,7 @@ extension TeamCreationFlowController {
             currentState = .setTeamName
             self.nextState = nil
             self.currentController = nil
+            self.currentStepDescription = nil
             self.navigationController.popToRootViewController(animated: true)
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationFlowController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationFlowController.swift
@@ -36,8 +36,7 @@ final class TeamCreationFlowController: NSObject {
     let navigationController: UINavigationController
     let registrationStatus: RegistrationStatus
     var nextState: TeamCreationState?
-    var currentController: TeamCreationStepController? 
-    var currentStepDescription: TeamCreationStepDescription?
+    var currentController: TeamCreationStepController?
     weak var registrationDelegate: RegistrationViewControllerDelegate?
     var syncToken: Any?
     var sessionManagerToken: Any?
@@ -132,7 +131,6 @@ extension TeamCreationFlowController {
         if let description = stepDescription {
             let controller = createViewController(for: description)
             currentController = controller
-            currentStepDescription = description
             navigationController.pushViewController(controller, animated: true)
         }
     }
@@ -155,7 +153,6 @@ extension TeamCreationFlowController {
             currentState = .setTeamName
             self.nextState = nil
             self.currentController = nil
-            self.currentStepDescription = nil
             self.navigationController.popToRootViewController(animated: true)
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationFlowController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationFlowController.swift
@@ -59,7 +59,7 @@ final class TeamCreationFlowController: NSObject {
 // MARK: - Creating step controller
 extension TeamCreationFlowController {
     func createViewController(for description: TeamCreationStepDescription) -> TeamCreationStepController {
-        let mainView = description.mainViewDescription
+        let mainView = description.mainView
         mainView.valueSubmitted = { [weak self] (value: String) in
             self?.advanceState(with: value)
         }
@@ -73,16 +73,12 @@ extension TeamCreationFlowController {
             }
         }
 
-        let backButton = description.backButtonDescription
+        let backButton = description.backButton
         backButton?.buttonTapped = { [weak self] in
             self?.rewindState()
         }
 
-        let controller = TeamCreationStepController(headline: description.headline,
-                                                    subtext: description.subtext,
-                                                    mainView: mainView,
-                                                    backButton: backButton,
-                                                    secondaryViews: description.secondaryViews)
+        let controller = TeamCreationStepController(description: description)
         return controller
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationFlowController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationFlowController.swift
@@ -130,8 +130,15 @@ extension TeamCreationFlowController {
 
         if let description = stepDescription {
             let controller = createViewController(for: description)
-            currentController = controller
-            navigationController.pushViewController(controller, animated: true)
+            if let current = currentController, current.stepDescription.shouldSkipFromNavigation() {
+                currentController = controller
+                let withoutLast = navigationController.viewControllers.dropLast()
+                let controllers = withoutLast + [controller]
+                navigationController.setViewControllers(Array(controllers), animated: true)
+            } else {
+                currentController = controller
+                navigationController.pushViewController(controller, animated: true)
+            }
         }
     }
 

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationStepController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationStepController.swift
@@ -93,7 +93,9 @@ final class TeamCreationStepController: UIViewController {
 
     func updateKeyboardOffset(keyboardHeight: CGFloat){
         self.keyboardOffset.constant = -(keyboardHeight + 10)
-        self.view.layoutIfNeeded()
+        UIView.performWithoutAnimation {
+            self.view.layoutIfNeeded()
+        }
     }
 
     dynamic func keyboardWillShow(_ notification: Notification) {

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationStepController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationStepController.swift
@@ -26,11 +26,7 @@ final class TeamCreationStepController: UIViewController {
     static let errorFont = FontSpec(.small, .semibold).font!
     static let textButtonFont = FontSpec(.small, .semibold).font!
 
-    let headline: String
-    let subtext: String?
-    let backButtonDescriptor: ViewDescriptor?
-    let mainViewDescriptor: ViewDescriptor
-    let secondaryViewDescriptors: [ViewDescriptor]
+    let stepDescription: TeamCreationStepDescription
 
     private var stackView: UIStackView!
     private var headlineLabel: UILabel!
@@ -50,12 +46,8 @@ final class TeamCreationStepController: UIViewController {
     private var keyboardOffset: NSLayoutConstraint!
     private var mainViewAlignVerticalCenter: NSLayoutConstraint!
 
-    init(headline: String, subtext: String? = nil, mainView: ViewDescriptor, backButton: ViewDescriptor? = nil, secondaryViews: [ViewDescriptor] = []) {
-        self.headline = headline
-        self.subtext = subtext
-        self.mainViewDescriptor = mainView
-        self.backButtonDescriptor = backButton
-        self.secondaryViewDescriptors = secondaryViews
+    init(description: TeamCreationStepDescription) {
+        self.stepDescription = description
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -130,18 +122,18 @@ final class TeamCreationStepController: UIViewController {
     }
 
     private func createViews() {
-        backButton = backButtonDescriptor?.create()
+        backButton = stepDescription.backButton?.create()
 
         headlineLabel = UILabel()
         headlineLabel.textAlignment = .center
         headlineLabel.font = TeamCreationStepController.headlineFont
         headlineLabel.textColor = UIColor.Team.textColor
-        headlineLabel.text = headline
+        headlineLabel.text = stepDescription.headline
         headlineLabel.translatesAutoresizingMaskIntoConstraints = false
 
         subtextLabel = UILabel()
         subtextLabel.textAlignment = .center
-        subtextLabel.text = subtext
+        subtextLabel.text = stepDescription.subtext
         subtextLabel.font = TeamCreationStepController.subtextFont
         subtextLabel.textColor = UIColor.Team.subtitleColor
         subtextLabel.numberOfLines = 0
@@ -151,7 +143,7 @@ final class TeamCreationStepController: UIViewController {
         mainViewContainer = UIView()
         mainViewContainer.translatesAutoresizingMaskIntoConstraints = false
 
-        mainView = mainViewDescriptor.create()
+        mainView = stepDescription.mainView.create()
         mainViewContainer.addSubview(mainView)
 
         errorViewContainer = UIView()
@@ -164,7 +156,7 @@ final class TeamCreationStepController: UIViewController {
         errorLabel.translatesAutoresizingMaskIntoConstraints = false
         errorViewContainer.addSubview(errorLabel)
 
-        secondaryViews = secondaryViewDescriptors.map { $0.create() }
+        secondaryViews = stepDescription.secondaryViews.map { $0.create() }
 
         secondaryViewsStackView = UIStackView(arrangedSubviews: secondaryViews)
         secondaryViewsStackView.distribution = .equalCentering


### PR DESCRIPTION
## What's new in this PR?

### Issues

Solves several of the issues noticed:
* Tapping "what is wire" and "change email" buttons would do nothing
* After validating email and tapping back we should go back to email screen

### Causes

There were some weird issues happening because we would not keep a reference to `TeamCreationStepDescription`.

### Solutions

Rewamped the `TeamCreationStepController` so that it takes only one parameter and keeps a reference to the step description. This meant that all view descriptions inside a step need to be stored properties, not computed ones.

Another quick fix was to remove email verification controller when pushing a new one on top, so that when coming back we would skip it.