### PR TITLE
Team creation: add loading spinners

### DIFF
--- a/Wire-iOS Tests/CharacterInputFieldTests.swift
+++ b/Wire-iOS Tests/CharacterInputFieldTests.swift
@@ -82,6 +82,22 @@ final class CharacterInputFieldTests: XCTestCase {
         XCTAssertEqual(delegate.didChangeText, [])
         XCTAssertEqual(sut.text, "")
     }
+
+    func testThatItIgnoresDeleteWhenDelegateSaysItShouldNotAcceptInput() {
+        // given
+        let text = "12"
+        sut.text = text
+        XCTAssertEqual(delegate.didChangeText, [])
+
+        // when
+        delegate.shouldAccept = false
+        sut.deleteBackward()
+
+        // then
+        XCTAssertEqual(delegate.didChangeText, [])
+        XCTAssertEqual(sut.text, text)
+    }
+
     
     func testThatItDoesNotCallDelegateForSettingTextDirectly() {
         // when

--- a/Wire-iOS Tests/CharacterInputFieldTests.swift
+++ b/Wire-iOS Tests/CharacterInputFieldTests.swift
@@ -22,6 +22,12 @@ import Cartography
 @testable import Wire
 
 class TestCharacterInputFieldDelegate: NSObject, CharacterInputFieldDelegate {
+
+    var shouldAccept = true
+    func shouldAcceptChanges(_ inputField: CharacterInputField) -> Bool {
+        return shouldAccept
+    }
+
     var didChangeText: [String] = []
     func didChangeText(_ inputField: CharacterInputField, to: String) {
         didChangeText.append(to)
@@ -62,6 +68,19 @@ final class CharacterInputFieldTests: XCTestCase {
     
     func testThatItSupportsPaste() {
         XCTAssertTrue(sut.canPerformAction(#selector(UIControl.paste(_:)), withSender: nil))
+    }
+
+    func testThatItIgnoresInputWhenDelegateSaysItShouldNotAcceptInput() {
+        // given
+        XCTAssertEqual(delegate.didChangeText, [])
+
+        // when
+        delegate.shouldAccept = false
+        sut.insertText("1")
+
+        // then
+        XCTAssertEqual(delegate.didChangeText, [])
+        XCTAssertEqual(sut.text, "")
     }
     
     func testThatItDoesNotCallDelegateForSettingTextDirectly() {

--- a/Wire-iOS/Sources/UserInterface/Components/CharacterInputField.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/CharacterInputField.swift
@@ -20,6 +20,7 @@ import Foundation
 import Cartography
 
 public protocol CharacterInputFieldDelegate: NSObjectProtocol {
+    func shouldAcceptChanges(_ inputField: CharacterInputField) -> Bool
     func didChangeText(_ inputField: CharacterInputField, to: String)
     func didFillInput(inputField: CharacterInputField)
 }
@@ -284,6 +285,9 @@ public class CharacterInputField: UIControl, UITextInputTraits {
 
 extension CharacterInputField: UIKeyInput {
     public func insertText(_ text: String) {
+        let shouldInsert = delegate?.shouldAcceptChanges(self) ?? true
+        guard shouldInsert else { return }
+        
         if let _ = text.rangeOfCharacter(from: CharacterSet.newlines) {
             self.resignFirstResponder()
             return
@@ -303,6 +307,10 @@ extension CharacterInputField: UIKeyInput {
         guard !self.storage.isEmpty else {
             return
         }
+
+        let shouldDelete = delegate?.shouldAcceptChanges(self) ?? true
+        guard shouldDelete else { return }
+
         notifyingDelegate {
             self.storage.removeLast()
         }

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationFlowController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationFlowController.swift
@@ -98,12 +98,15 @@ extension TeamCreationFlowController {
         case .setEmail:
             pushNext() // Pushing email step
         case let .verifyEmail(teamName: _, email: email):
+            currentController?.showLoadingView = true
             registrationStatus.sendActivationCode(to: email) // Sending activation code to email
         case let .setFullName(teamName: _, email: email, activationCode: activationCode):
+            currentController?.showLoadingView = true
             registrationStatus.checkActivationCode(email: email, code: activationCode)
         case .setPassword:
             pushNext()
         case let .createTeam(teamName: teamName, email: email, activationCode: activationCode, fullName: fullName, password: password):
+            currentController?.showLoadingView = true
             let teamToRegister = TeamToRegister(teamName: teamName, email: email, emailCode:activationCode, fullName: fullName, password: password, accentColor: ZMUser.pickRandomAccentColor())
             registrationStatus.create(team: teamToRegister)
         }
@@ -167,6 +170,7 @@ extension TeamCreationFlowController {
 
 extension TeamCreationFlowController: VerifyEmailStepDescriptionDelegate {
     func resendActivationCode(to email: String) {
+        currentController?.showLoadingView = true
         registrationStatus.sendActivationCode(to: email)
     }
 
@@ -183,6 +187,7 @@ extension TeamCreationFlowController: SessionManagerCreatedSessionObserver {
 
 extension TeamCreationFlowController: ZMInitialSyncCompletionObserver {
     func initialSyncCompleted() {
+        currentController?.showLoadingView = false
         registrationDelegate?.registrationViewControllerDidCompleteRegistration()
     }
 }
@@ -193,22 +198,27 @@ extension TeamCreationFlowController: RegistrationStatusDelegate {
     }
 
     public func teamRegistrationFailed(with error: Error) {
+        currentController?.showLoadingView = false
         currentController?.displayError(error)
     }
 
     public func emailActivationCodeSent() {
+        currentController?.showLoadingView = false
         pushNext()
     }
 
     public func emailActivationCodeSendingFailed(with error: Error) {
+        currentController?.showLoadingView = false
         currentController?.displayError(error)
     }
 
     public func emailActivationCodeValidated() {
+        currentController?.showLoadingView = false
         pushNext()
     }
 
     public func emailActivationCodeValidationFailed(with error: Error) {
+        currentController?.showLoadingView = false
         currentController?.displayError(error)
     }
 

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationFlowController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationFlowController.swift
@@ -27,6 +27,7 @@ protocol ViewDescriptor: class {
 }
 
 protocol ValueSubmission: class {
+    var acceptsInput: Bool { get set }
     var valueSubmitted: ValueSubmitted? { get set }
     var valueValidated: ValueValidated? { get set }
 }

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationStepController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationStepController.swift
@@ -61,6 +61,12 @@ final class TeamCreationStepController: UIViewController {
         return false
     }
 
+    override var showLoadingView: Bool {
+        didSet {
+            stepDescription.mainView.acceptsInput = !showLoadingView
+        }
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/ViewDescriptions/TextFieldDescription.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/ViewDescriptions/TextFieldDescription.swift
@@ -24,6 +24,7 @@ final class TextFieldDescription: NSObject, ValueSubmission {
     let kind: AccessoryTextField.Kind
     var valueSubmitted: ValueSubmitted?
     var valueValidated: ValueValidated?
+    var acceptsInput: Bool = true
     var validationError: TextFieldValidator.ValidationError
 
     fileprivate var currentValue: String = ""
@@ -58,14 +59,17 @@ extension TextFieldDescription: UITextFieldDelegate {
     }
 
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        guard acceptsInput else { return false }
         let oldValue = textField.text as NSString?
         let result = oldValue?.replacingCharacters(in: range, with: string)
         currentValue = (result as String?) ?? ""
         self.valueValidated?(.none)
+        self.validationError = .none
         return true
     }
 
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        guard acceptsInput else { return false }
         guard let text = textField.text else { return true }
         submitValue(with: text)
         return true

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/ViewDescriptions/VerificationCodeFieldDescription.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/ViewDescriptions/VerificationCodeFieldDescription.swift
@@ -22,6 +22,7 @@ import Cartography
 final class VerificationCodeFieldDescription: NSObject, ValueSubmission {
     var valueSubmitted: ValueSubmitted?
     var valueValidated: ValueValidated?
+    var acceptsInput: Bool = true
     var constraints: [NSLayoutConstraint] = []
 }
 
@@ -76,6 +77,11 @@ extension VerificationCodeFieldDescription: ViewDescriptor {
 }
 
 extension VerificationCodeFieldDescription: CharacterInputFieldDelegate {
+
+    func shouldAcceptChanges(_ inputField: CharacterInputField) -> Bool {
+        return acceptsInput
+    }
+
     func didChangeText(_ inputField: CharacterInputField, to: String) {
 
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

There are steps in the team creation flow that involve asynchronous operations (round trip to the server) and we need to have some feedback to the user about it.

### Solutions

We show a spinner on the whole screen while the operation is in progress. The spinner unfortunately does't cover the keyboard. To work around this we make the textfields ignore keyboard input while the spinner is visible. The user is able to tap on the keyboard but nothing happens.
