### PR TITLE
observe keyboard changes when view appears

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationStepController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationStepController.swift
@@ -74,12 +74,11 @@ final class TeamCreationStepController: UIViewController {
 
         createViews()
         createConstraints()
-        observeKeyboard()
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-
+        observeKeyboard()
         UIApplication.shared.wr_updateStatusBarForCurrentControllerAnimated(animated)
         mainView.becomeFirstResponder()
 

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationStepController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationStepController.swift
@@ -74,11 +74,7 @@ final class TeamCreationStepController: UIViewController {
 
         createViews()
         createConstraints()
-
-        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow(_:)), name: NSNotification.Name.UIKeyboardWillShow, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide(_:)), name: NSNotification.Name.UIKeyboardWillHide, object: nil)
-
-        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillChangeFrame(_:)), name: NSNotification.Name.UIKeyboardWillChangeFrame, object: nil)
+        observeKeyboard()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -103,6 +99,12 @@ final class TeamCreationStepController: UIViewController {
     }
 
     // MARK: - Keyboard shown/hide
+    
+    private func observeKeyboard() {
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow(_:)), name: NSNotification.Name.UIKeyboardWillShow, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide(_:)), name: NSNotification.Name.UIKeyboardWillHide, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillChangeFrame(_:)), name: NSNotification.Name.UIKeyboardWillChangeFrame, object: nil)
+    }
 
     func updateKeyboardOffset(keyboardHeight: CGFloat) {
         self.keyboardOffset.constant = -(keyboardHeight + 10)


### PR DESCRIPTION
## What's new in this PR?

### Issues
The layout constraints on the team name page we're not updating to the keyboard offset when returning from the "what is teams for wire" webview is dismissed.

### Causes
This view controller registers to observe keyboard changes in `viewDidLoad` and removes itself as an observer in `viewWillDisappear`. Thus, when the view re-appears, the keyboard offset is initially zero, and it doesn't update when the keyboard eventually appears.

### Solutions
Move observer code to `viewWillAppear`.
