### PR TITLE
Remove ‘on’ from Edited/Deleted timestamps

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -290,8 +290,8 @@
 "content.system.failedtosend_message_timestamp_resend" = "Resend";
 "content.system.failedtosend_message_timestamp_delete" = "Delete";
 "content.system.like_tooltip" = "Tap to like";
-"content.system.deleted_message_prefix_timestamp" = "Deleted on %@";
-"content.system.edited_message_prefix_timestamp" = "Edited on %@";
+"content.system.deleted_message_prefix_timestamp" = "Deleted: %@";
+"content.system.edited_message_prefix_timestamp" = "Edited: %@";
 "content.system.connecting_to" = "Connecting to %@.\nStart a conversation";
 "content.system.connected_to" = "Connected to %@\nStart a conversation";
 "content.system.other_wanted_to_talk" = "%@ called";


### PR DESCRIPTION
Since timestamps are dynamic, they may appear as either date or time values.

‘On’ works for date values, but not for time values, where ‘at’ would be correct.

Rather than creating 2 separate strings to handle these grammar differences, this commit removes the preposition entirely, so the same text can be used for both cases.
