### PR TITLE
Fix/keyboard type for user name

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/AccessoryTextField.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/AccessoryTextField.swift
@@ -136,7 +136,6 @@ class AccessoryTextField: UITextField {
             isSecureTextEntry = true
             accessibilityIdentifier = "PasswordField"
         case .name:
-//            keyboardType = .asciiCapable
             autocapitalizationType = .words
             accessibilityIdentifier = "NameField"
         case .unknown:

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/AccessoryTextField.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/AccessoryTextField.swift
@@ -136,7 +136,7 @@ class AccessoryTextField: UITextField {
             isSecureTextEntry = true
             accessibilityIdentifier = "PasswordField"
         case .name:
-            keyboardType = .asciiCapable
+//            keyboardType = .asciiCapable
             autocapitalizationType = .words
             accessibilityIdentifier = "NameField"
         case .unknown:


### PR DESCRIPTION
## What's new in this PR?

Allow user switch to other language's keyboard when entering name. Tested server accepts team name and user name in Chinese.