### PR TITLE
Clear the error code when typing in a new code

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/ViewDescriptions/VerificationCodeFieldDescription.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/ViewDescriptions/VerificationCodeFieldDescription.swift
@@ -83,7 +83,7 @@ extension VerificationCodeFieldDescription: CharacterInputFieldDelegate {
     }
 
     func didChangeText(_ inputField: CharacterInputField, to: String) {
-
+        self.valueValidated?(.none)
     }
 
     func didFillInput(inputField: CharacterInputField) {


### PR DESCRIPTION
## What's new in this PR?

As the title suggests. The callback is set once in `TeamCreationFlowController` and clears the error message if `.none` is passed in.