### PR TITLE
Fix: possible to advance to next screen by tapping resend code

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationFlowController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationFlowController.swift
@@ -211,7 +211,15 @@ extension TeamCreationFlowController: RegistrationStatusDelegate {
 
     public func emailActivationCodeSent() {
         currentController?.showLoadingView = false
-        pushNext()
+
+        switch currentState {
+        case .setEmail:
+            pushNext()
+        case .verifyEmail:
+            currentController?.clearError()
+        default:
+            break
+        }
     }
 
     public func emailActivationCodeSendingFailed(with error: Error) {


### PR DESCRIPTION
## What's new in this PR?

### Issues

When in activation code screen entering wrong code and tapping "resend code" button would advance to next screen.

### Causes

The delegate is called when the activation code is sent out. We have used it to advance to the activation code screen. Also this is called when we re-send the code which then also advances to the next screen. 

### Solutions

In delegate we check which state we are in. Also clearing wrong code error after resending
