### PR TITLE
ZIOS-9058, ZIOS-9193: copy calling and registration events to Mixpanel

### DIFF
--- a/Wire-iOS/Sources/Analytics/AnalyticsMixpanelProvider.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsMixpanelProvider.swift
@@ -72,7 +72,19 @@ final class AnalyticsMixpanelProvider: NSObject, AnalyticsProvider {
         "team.accepted_terms",
         "team.created",
         "team.finished_invite_step",
-        "settings.opened_manage_team"
+        "settings.opened_manage_team",
+        "registration.succeeded",
+        "calling.joined_call",
+        "calling.joined_video_call",
+        "calling.established_call",
+        "calling.established_video_call",
+        "calling.ended_call",
+        "calling.ended_video_call",
+        "calling.initiated_call",
+        "calling.initiated_video_call",
+        "calling.received_call",
+        "calling.received_video_call",
+        "calling.avs_metrics_ended_call",
         ])
     
     private static let enabledSuperProperties = Set<String>([

--- a/Wire-iOS/Sources/Analytics/Events/Analytics+CallEvents.m
+++ b/Wire-iOS/Sources/Analytics/Events/Analytics+CallEvents.m
@@ -69,7 +69,7 @@
     [attributes addEntriesFromDictionary:[self attributesForInitiatedCall:initiatedCall]];
     [attributes addEntriesFromDictionary:[self attributesForCallSetupDuration:setupDuration]];
     
-    [self tagEvent:video ? @"calling.established_successful_video_call" : @"calling.established_successful_call" attributes:attributes];
+    [self tagEvent:video ? @"calling.established_video_call" : @"calling.established_call" attributes:attributes];
 }
 
 - (void)tagEndedCallInConversation:(ZMConversation *)conversation video:(BOOL)video initiatedCall:(BOOL)initiatedCall duration:(NSTimeInterval)duration callEndReason:(NSString *)callEndReason


### PR DESCRIPTION
## What's new in this PR?

### Issues

Some events regarding calling and registration are not declared inside `AnalyticsMixpanelProvider.enabledEvents`, so actually they're not tracked.

### Solutions

- Added events to `AnalyticsMixpanelProvider.enabledEvents`
- Changed `calling.established_successful_(video)_call` to `calling.established_(video)_call` (need confirmation from @shumengye) 