### PR TITLE
fix constraint design for iPad and iOS 10

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationStepController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationStepController.swift
@@ -50,7 +50,6 @@ final class TeamCreationStepController: UIViewController {
     private var secondaryViews: [UIView] = []
     fileprivate var secondaryErrorView: UIView?
 
-    //    private var keyboardOffset: NSLayoutConstraint!
     private var mainViewWidthRegular: NSLayoutConstraint!
     private var mainViewWidthCompact: NSLayoutConstraint!
     private var topSpacerHeight: NSLayoutConstraint!
@@ -126,8 +125,10 @@ final class TeamCreationStepController: UIViewController {
     }
 
     dynamic func keyboardWillShow(_ notification: Notification) {
-        if UIDevice.current.userInterfaceIdiom == .pad {
-        } else {
+        switch UIDevice.current.userInterfaceIdiom {
+        case .pad:
+            break
+        default:
             spacerEqualHeight.isActive = false
             topSpacerHeight.isActive = true
             bottomSpacerHeight.isActive = true
@@ -137,8 +138,10 @@ final class TeamCreationStepController: UIViewController {
     }
 
     dynamic func keyboardWillHide(_ notification: Notification) {
-        if UIDevice.current.userInterfaceIdiom == .pad {
-        } else {
+        switch UIDevice.current.userInterfaceIdiom {
+        case .pad:
+            break
+        default:
             topSpacerHeight.isActive = false
             bottomSpacerHeight.isActive = false
             spacerEqualHeight.isActive = true

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationStepController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationStepController.swift
@@ -242,7 +242,7 @@ final class TeamCreationStepController: UIViewController {
         if let backButton = backButton {
 
             var backButtonTopMargin: CGFloat
-            if #available(iOS 10.0, *) {
+            if #available(iOS 11.0, *) {
                 backButtonTopMargin = 12
             } else {
                 backButtonTopMargin = 32

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationStepController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationStepController.swift
@@ -218,11 +218,8 @@ final class TeamCreationStepController: UIViewController {
         secondaryViewsStackView.spacing = 24
         secondaryViewsStackView.translatesAutoresizingMaskIntoConstraints = false
 
-        [backButton, headlineLabel, subtextLabel, mainViewContainer, errorViewContainer, secondaryViewsStackView, topSpacer, bottomSpacer].flatMap {$0}.forEach { self.view.addSubview($0) }
-
-        [topSpacer, bottomSpacer].forEach() { view in
-            self.view.sendSubview(toBack: view)
-        }
+        [topSpacer, bottomSpacer, backButton, headlineLabel, subtextLabel, mainViewContainer, errorViewContainer, secondaryViewsStackView, topSpacer, bottomSpacer].flatMap {$0}.forEach { self.view.addSubview($0) }
+        
     }
 
     fileprivate func updateMainViewWidthConstraint() {

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationStepController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationStepController.swift
@@ -92,8 +92,7 @@ final class TeamCreationStepController: UIViewController {
         UIApplication.shared.wr_updateStatusBarForCurrentControllerAnimated(animated)
         mainView.becomeFirstResponder()
 
-        let keyboardHeight = KeyboardFrameObserver.shared().keyboardFrame().height
-        updateKeyboardOffset(keyboardHeight: keyboardHeight)
+        updateKeyboardOffset(keyboardFrame: KeyboardFrameObserver.shared().keyboardFrame())
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -116,13 +115,11 @@ final class TeamCreationStepController: UIViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillChangeFrame(_:)), name: NSNotification.Name.UIKeyboardWillChangeFrame, object: nil)
     }
 
-    func updateKeyboardOffset(keyboardHeight: CGFloat) {
-        if UIDevice.current.userInterfaceIdiom == .pad {
-            spacerEqualHeight.constant = keyboardHeight
-        }
-        else {
-            bottomSpacerHeight.constant = 24 + keyboardHeight
-        }
+    func updateKeyboardOffset(keyboardFrame: CGRect) {
+        let keyboardHeight = keyboardFrame.height
+
+        spacerEqualHeight.constant = self.view.frame.size.height - keyboardFrame.origin.y
+        bottomSpacerHeight.constant = 24 + keyboardHeight
 
         UIView.performWithoutAnimation {
             self.view.layoutIfNeeded()
@@ -133,9 +130,9 @@ final class TeamCreationStepController: UIViewController {
         if UIDevice.current.userInterfaceIdiom == .pad {
         }
         else {
-        spacerEqualHeight.isActive = false
-        topSpacerHeight.isActive = true
-        bottomSpacerHeight.isActive = true
+            spacerEqualHeight.isActive = false
+            topSpacerHeight.isActive = true
+            bottomSpacerHeight.isActive = true
         }
 
         animateViewsToAccomodateKeyboard(with: notification)
@@ -150,7 +147,6 @@ final class TeamCreationStepController: UIViewController {
             spacerEqualHeight.isActive = true
         }
 
-
         animateViewsToAccomodateKeyboard(with: notification)
     }
 
@@ -160,8 +156,8 @@ final class TeamCreationStepController: UIViewController {
 
     func animateViewsToAccomodateKeyboard(with notification: Notification) {
         if let userInfo = notification.userInfo, let keyboardFrame = userInfo[UIKeyboardFrameEndUserInfoKey] as? NSValue {
-            let keyboardHeight = keyboardFrame.cgRectValue.height
-            updateKeyboardOffset(keyboardHeight: keyboardHeight)
+
+            updateKeyboardOffset(keyboardFrame: keyboardFrame.cgRectValue)
         }
     }
 

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationStepController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationStepController.swift
@@ -51,7 +51,7 @@ final class TeamCreationStepController: UIViewController {
     private var secondaryViews: [UIView] = []
     fileprivate var secondaryErrorView: UIView?
 
-//    private var keyboardOffset: NSLayoutConstraint!
+    //    private var keyboardOffset: NSLayoutConstraint!
     private var mainViewWidthRegular: NSLayoutConstraint!
     private var mainViewWidthCompact: NSLayoutConstraint!
     private var topSpacerHeight: NSLayoutConstraint!
@@ -117,27 +117,39 @@ final class TeamCreationStepController: UIViewController {
     }
 
     func updateKeyboardOffset(keyboardHeight: CGFloat) {
-//        self.keyboardOffset.constant = -keyboardHeight
-        bottomSpacerHeight.constant = 24 + keyboardHeight
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            spacerEqualHeight.constant = keyboardHeight
+        }
+        else {
+            bottomSpacerHeight.constant = 24 + keyboardHeight
+        }
+
         UIView.performWithoutAnimation {
             self.view.layoutIfNeeded()
         }
     }
 
     dynamic func keyboardWillShow(_ notification: Notification) {
-//        self.keyboardOffset.isActive = true
-        ///TODO iPad case
+        if UIDevice.current.userInterfaceIdiom == .pad {
+        }
+        else {
         spacerEqualHeight.isActive = false
         topSpacerHeight.isActive = true
         bottomSpacerHeight.isActive = true
+        }
+
         animateViewsToAccomodateKeyboard(with: notification)
     }
 
     dynamic func keyboardWillHide(_ notification: Notification) {
-//        self.keyboardOffset.isActive = false
-        topSpacerHeight.isActive = false
-        bottomSpacerHeight.isActive = false
-        spacerEqualHeight.isActive = true
+        if UIDevice.current.userInterfaceIdiom == .pad {
+        }
+        else {
+            topSpacerHeight.isActive = false
+            bottomSpacerHeight.isActive = false
+            spacerEqualHeight.isActive = true
+        }
+
 
         animateViewsToAccomodateKeyboard(with: notification)
     }
@@ -255,8 +267,9 @@ final class TeamCreationStepController: UIViewController {
         let keyboardHeight = KeyboardFrameObserver.shared().keyboardFrame().height
 
         constrain(view, topSpacer, bottomSpacer) { view, topSpacer, bottomSpacer in
-            spacerEqualHeight = bottomSpacer.height == topSpacer.height
-            topSpacerHeight = topSpacer.height >= 20
+            spacerEqualHeight = bottomSpacer.height == topSpacer.height + keyboardHeight
+            
+            topSpacerHeight = topSpacer.height >= 24
             bottomSpacerHeight = bottomSpacer.height == 24 + keyboardHeight
 
             topSpacer.centerX == view.centerX
@@ -265,7 +278,14 @@ final class TeamCreationStepController: UIViewController {
             bottomSpacer.width == view.width
         }
 
-        spacerEqualHeight.isActive = false
+
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            topSpacerHeight.isActive = false
+            bottomSpacerHeight.isActive = false
+        }
+        else {
+            spacerEqualHeight.isActive = false
+        }
 
         constrain(view, secondaryViewsStackView, errorViewContainer, mainViewContainer, bottomSpacer) { view, secondaryViewsStackView, errorViewContainer, mainViewContainer, bottomSpacer in
 

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationStepController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationStepController.swift
@@ -21,7 +21,6 @@ import Cartography
 
 final class TeamCreationStepController: UIViewController {
 
-
     /// headline font size is fixed and not affected by dynamic type setting,
     static let headlineFont         = UIFont.systemFont(ofSize: 40, weight: UIFontWeightLight)
     /// For 320 pt width screen
@@ -108,7 +107,7 @@ final class TeamCreationStepController: UIViewController {
     }
 
     // MARK: - Keyboard shown/hide
-    
+
     private func observeKeyboard() {
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow(_:)), name: NSNotification.Name.UIKeyboardWillShow, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide(_:)), name: NSNotification.Name.UIKeyboardWillHide, object: nil)
@@ -122,14 +121,13 @@ final class TeamCreationStepController: UIViewController {
         bottomSpacerHeight.constant = 24 + keyboardHeight
 
         UIView.performWithoutAnimation {
-            self.view.layoutIfNeeded()
+            self.view.setNeedsLayout()
         }
     }
 
     dynamic func keyboardWillShow(_ notification: Notification) {
         if UIDevice.current.userInterfaceIdiom == .pad {
-        }
-        else {
+        } else {
             spacerEqualHeight.isActive = false
             topSpacerHeight.isActive = true
             bottomSpacerHeight.isActive = true
@@ -140,8 +138,7 @@ final class TeamCreationStepController: UIViewController {
 
     dynamic func keyboardWillHide(_ notification: Notification) {
         if UIDevice.current.userInterfaceIdiom == .pad {
-        }
-        else {
+        } else {
             topSpacerHeight.isActive = false
             bottomSpacerHeight.isActive = false
             spacerEqualHeight.isActive = true
@@ -192,7 +189,7 @@ final class TeamCreationStepController: UIViewController {
         topSpacer = UIView()
         bottomSpacer = UIView()
 
-        [topSpacer, bottomSpacer].forEach(){ view in
+        [topSpacer, bottomSpacer].forEach() { view in
             view.translatesAutoresizingMaskIntoConstraints = false
         }
 
@@ -220,7 +217,7 @@ final class TeamCreationStepController: UIViewController {
 
         [backButton, headlineLabel, subtextLabel, mainViewContainer, errorViewContainer, secondaryViewsStackView, topSpacer, bottomSpacer].flatMap {$0}.forEach { self.view.addSubview($0) }
 
-        [topSpacer, bottomSpacer].forEach(){ view in
+        [topSpacer, bottomSpacer].forEach() { view in
             self.view.sendSubview(toBack: view)
         }
     }
@@ -264,7 +261,7 @@ final class TeamCreationStepController: UIViewController {
 
         constrain(view, topSpacer, bottomSpacer) { view, topSpacer, bottomSpacer in
             spacerEqualHeight = bottomSpacer.height == topSpacer.height + keyboardHeight
-            
+
             topSpacerHeight = topSpacer.height >= 24
             bottomSpacerHeight = bottomSpacer.height == 24 + keyboardHeight
 
@@ -274,12 +271,10 @@ final class TeamCreationStepController: UIViewController {
             bottomSpacer.width == view.width
         }
 
-
         if UIDevice.current.userInterfaceIdiom == .pad {
             topSpacerHeight.isActive = false
             bottomSpacerHeight.isActive = false
-        }
-        else {
+        } else {
             spacerEqualHeight.isActive = false
         }
 

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationStepController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationStepController.swift
@@ -45,7 +45,7 @@ final class TeamCreationStepController: UIViewController {
 
     private var backButton: UIView?
 
-    /// mainView is a textField or CharacterInputField in team createion screens
+    /// mainView is a textField or CharacterInputField in team creation screens
     private var mainView: UIView!
     private var secondaryViews: [UIView] = []
     fileprivate var secondaryErrorView: UIView?


### PR DESCRIPTION
## What's new in this PR?

### Issues

Safe area is introduced on iOS 11 and  back buttons's vertical position is not correct on iOS <= 10 devices.

The constraints design does not match the design guideline.  

### Solutions

Set a different value of back buttons's top margin for ios 11/<=11.

Call setNeedsLayout instead of layoutIfNeeded to fix the backbutton move down visual flaw when iOS10 enter name screen shows.

Rewrite constraints for top and bottom spacing. Two spacer view are created and their heights are calculated with these rules:

|            | iPhone | iPad |
| ------- | ------- | ------- |
| keyboard is shown | topSpacer.height >= 20, bottomSpacer.height ==  24 + keyboardHeight | topSpacer.height == bottomSpacer.height + keyboardHeight |
| keyboard is hidden | topSpacer.height == bottomSpacer.height | topSpacer.height == bottomSpacer.height |

