### PR TITLE
Team Creation: Setting default profile picture to account

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/Steps/ProfilePictureStepViewController.h
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/Steps/ProfilePictureStepViewController.h
@@ -20,10 +20,9 @@
 #import "RegistrationStepViewController.h"
 #import "AnalyticsTracker+Registration.h"
 
+extern NSString * const UnsplashRandomImageHiQualityURL;
 
 @class ZMIncompleteRegistrationUser;
-
-
 
 @interface ProfilePictureStepViewController : RegistrationStepViewController
 

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationFlowController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationFlowController.swift
@@ -189,6 +189,13 @@ extension TeamCreationFlowController: VerifyEmailStepDescriptionDelegate {
 extension TeamCreationFlowController: SessionManagerCreatedSessionObserver {
     func sessionManagerCreated(userSession : ZMUserSession) {
         self.sessionManagerToken = ZMUserSession.addInitialSyncCompletionObserver(self, userSession: userSession)
+        URLSession.shared.dataTask(with: URL(string: UnsplashRandomImageHiQualityURL)!) { (data, _, error) in
+            if let data = data, error == nil {
+                DispatchQueue.main.async {
+                    SessionManager.shared?.unauthenticatedSession?.setProfileImage(imageData: data)
+                }
+            }
+        }.resume()
     }
 }
 

--- a/Wire-iOS/WireBridgingHeader.h
+++ b/Wire-iOS/WireBridgingHeader.h
@@ -108,6 +108,7 @@
 #import "LaunchImageViewController.h"
 #import "VoiceUserImageView.h"
 #import "VoiceChannelParticipantCell.h"
+#import "ProfilePictureStepViewController.h"
 
 // Helper objects
 #import "PushTransition.h"


### PR DESCRIPTION
## What's new in this PR?

### Issues

We were not setting any profile picture after account with team got created which caused many weird issues.

### Solutions

Downloading a random picture from unsplash.com (the same what we do during normal registration) and set it as profile picture.
