### PR TITLE
Fix/zios 9310 trim space in name

### DIFF
--- a/Wire-iOS Tests/AccessoryTextField/AccessoryTextFieldValidationTests.swift
+++ b/Wire-iOS Tests/AccessoryTextField/AccessoryTextFieldValidationTests.swift
@@ -73,7 +73,8 @@ final class AccessoryTextFieldValidateionTests: XCTestCase {
     }
 
     fileprivate func checkError(textFieldType: AccessoryTextField.Kind,
-                                text: String?, expectedError: TextFieldValidator.ValidationError,
+                                text: String?,
+                                expectedError: TextFieldValidator.ValidationError,
                                 file: StaticString = #file,
                                 line: UInt = #line) {
 

--- a/Wire-iOS Tests/AccessoryTextField/TextFieldValidatorTests.swift
+++ b/Wire-iOS Tests/AccessoryTextField/TextFieldValidatorTests.swift
@@ -47,4 +47,43 @@ final class TextFieldValidatorTests: XCTestCase {
         // THEN
         XCTAssertEqual(expectedError, error, "Error should be \(expectedError), was \(error)")
     }
+
+    func testOneCharacterNameWithLeadingAndTrailingSpaceIsNotAccepted(){
+        // GIVEN
+        let text = " a "
+        let type: AccessoryTextField.Kind = .name
+        let expectedError: TextFieldValidator.ValidationError = .tooShort(kind: type)
+
+        // WHEN
+        let error = sut.validate(text: text, kind: type)
+
+        // THEN
+        XCTAssertEqual(expectedError, error, "Error should be \(expectedError), was \(error)")
+    }
+
+    func testNameWithTenSpaceIsNotAccepted(){
+        // GIVEN
+        let text = String(repeating: " ", count: 10)
+        let type: AccessoryTextField.Kind = .name
+        let expectedError: TextFieldValidator.ValidationError = .tooShort(kind: type)
+
+        // WHEN
+        let error = sut.validate(text: text, kind: type)
+
+        // THEN
+        XCTAssertEqual(expectedError, error, "Error should be \(expectedError), was \(error)")
+    }
+
+    func testTwoCharacterNameIsAccepted(){
+        // GIVEN
+        let text = "aa"
+        let type: AccessoryTextField.Kind = .name
+        let expectedError: TextFieldValidator.ValidationError = .none
+
+        // WHEN
+        let error = sut.validate(text: text, kind: type)
+
+        // THEN
+        XCTAssertEqual(expectedError, error, "Error should be \(expectedError), was \(error)")
+    }
 }

--- a/Wire-iOS Tests/TextFieldValidatorTests.swift
+++ b/Wire-iOS Tests/TextFieldValidatorTests.swift
@@ -1,0 +1,50 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import XCTest
+@testable import Wire
+
+final class TextFieldValidatorTests: XCTestCase {
+    
+    var sut: TextFieldValidator!
+    
+    override func setUp() {
+        super.setUp()
+        sut = TextFieldValidator()
+    }
+    
+    override func tearDown() {
+        sut = nil
+        super.tearDown()
+    }
+
+
+    func testOneCharacterNameIsNotAccepted(){
+        // GIVEN
+        let text = "a"
+        let type: AccessoryTextField.Kind = .name
+        let expectedError: TextFieldValidator.ValidationError = .tooShort(kind: type)
+
+        // WHEN
+        let error = sut.validate(text: text, kind: type)
+
+        // THEN
+        XCTAssertEqual(expectedError, error, "Error should be \(expectedError), was \(error)")
+    }
+}

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -4692,7 +4692,6 @@
 			isa = PBXGroup;
 			children = (
 				EEA747A71FCEBAD1000B529E /* AnalyticsMixpanelProviderTests.swift */,
-				EF159F361FD59556006E0A9C /* TextFieldValidatorTests.swift */,
 				EF61B33E1FC8461200D8E631 /* AccessoryTextField */,
 				EE3A5B0C1F7A7BD400733045 /* ChatHeadTests.swift */,
 				EEBE8C5D1F68171F009D78C9 /* NSData_ImageTypeTests.swift */,
@@ -5085,6 +5084,7 @@
 		EF61B33E1FC8461200D8E631 /* AccessoryTextField */ = {
 			isa = PBXGroup;
 			children = (
+				EF159F361FD59556006E0A9C /* TextFieldValidatorTests.swift */,
 				EF61B33F1FC84B0100D8E631 /* AccessoryTextFieldValidationTests.swift */,
 				EF25F8851FC57EE90040C3CC /* AccessoryTextFieldTests.swift */,
 				EF7F74021FCC01140059C13F /* EmailAdresssValidatorTests.swift */,

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -917,6 +917,7 @@
 		EEF28EEA1F1613DA007642E2 /* MarkdownBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF28EE91F1613DA007642E2 /* MarkdownBarView.swift */; };
 		EEF28EED1F16692A007642E2 /* InputBarSecondaryButtonsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF28EEC1F16692A007642E2 /* InputBarSecondaryButtonsView.swift */; };
 		EEF28EEF1F168039007642E2 /* ConversationInputBarViewController+Markdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF28EEE1F168039007642E2 /* ConversationInputBarViewController+Markdown.swift */; };
+		EF159F381FD59607006E0A9C /* TextFieldValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF159F361FD59556006E0A9C /* TextFieldValidatorTests.swift */; };
 		EF18C7E41F9E4DA00085A832 /* NSString+FileNameForZMUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF18C7E31F9E4DA00085A832 /* NSString+FileNameForZMUser.swift */; };
 		EF1EA4631FB0937000B53063 /* MockUser+filename.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF1EA4611FB0934D00B53063 /* MockUser+filename.swift */; };
 		EF1F99F71FBB06C000969DD1 /* UILabel+TextTransform.m in Sources */ = {isa = PBXBuildFile; fileRef = CE8E4FBA1DF17BBE0009F437 /* UILabel+TextTransform.m */; };
@@ -2407,6 +2408,7 @@
 		EEF28EE91F1613DA007642E2 /* MarkdownBarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MarkdownBarView.swift; path = ../../MarkdownBarView.swift; sourceTree = "<group>"; };
 		EEF28EEC1F16692A007642E2 /* InputBarSecondaryButtonsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InputBarSecondaryButtonsView.swift; sourceTree = "<group>"; };
 		EEF28EEE1F168039007642E2 /* ConversationInputBarViewController+Markdown.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ConversationInputBarViewController+Markdown.swift"; sourceTree = "<group>"; };
+		EF159F361FD59556006E0A9C /* TextFieldValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldValidatorTests.swift; sourceTree = "<group>"; };
 		EF18C7E31F9E4DA00085A832 /* NSString+FileNameForZMUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSString+FileNameForZMUser.swift"; sourceTree = "<group>"; };
 		EF1EA4611FB0934D00B53063 /* MockUser+filename.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MockUser+filename.swift"; sourceTree = "<group>"; };
 		EF1F9A011FBB1FD800969DD1 /* LandingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LandingButton.swift; sourceTree = "<group>"; };
@@ -4690,6 +4692,7 @@
 			isa = PBXGroup;
 			children = (
 				EEA747A71FCEBAD1000B529E /* AnalyticsMixpanelProviderTests.swift */,
+				EF159F361FD59556006E0A9C /* TextFieldValidatorTests.swift */,
 				EF61B33E1FC8461200D8E631 /* AccessoryTextField */,
 				EE3A5B0C1F7A7BD400733045 /* ChatHeadTests.swift */,
 				EEBE8C5D1F68171F009D78C9 /* NSData_ImageTypeTests.swift */,
@@ -6563,6 +6566,7 @@
 				876376881E840E9C00B2CCF0 /* ConversationStatusTests.swift in Sources */,
 				87AAE4211E42441B00E1D13A /* FontSchemeTests.swift in Sources */,
 				8759DB851E6B696C000A832D /* ImageMessageViewTests.swift in Sources */,
+				EF159F381FD59607006E0A9C /* TextFieldValidatorTests.swift in Sources */,
 				BF5127161CC9119400F23DEA /* ZMSnapshotTestCase+Swift.swift in Sources */,
 				BF29C9871C6E357100601EE7 /* ZMSnapshotTestCase.m in Sources */,
 				BFE08C1E1D5B6F34002367F6 /* MessageDeletedCellTests.swift in Sources */,

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/AccessoryTextField.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/AccessoryTextField.swift
@@ -165,7 +165,6 @@ class AccessoryTextField: UITextField {
 
     func confirmButtonTapped(button: UIButton) {
         let error = textFieldValidator.validate(text: text, kind: kind)
-
         textFieldValidationDelegate?.validationUpdated(sender: self, error: error)
     }
 

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/TextFieldValidator.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/TextFieldValidator.swift
@@ -60,9 +60,11 @@ class TextFieldValidator {
                 return .tooShort(kind: kind)
             }
         case .name:
-            if text.count > 64 {
+            /// We should ignore leading/trailing whitespace when counting the number of characters in the string
+            let stringToValidate = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            if stringToValidate.count > 64 {
                 return .tooLong(kind: kind)
-            } else if text.count < 2 {
+            } else if stringToValidate.count < 2 {
                 return .tooShort(kind: kind)
             }
         case .unknown:


### PR DESCRIPTION
## What's new in this PR?

### Issues

When a user enters a name with leading and/or trailing spaces, the spaces are counted as valid characters in the name. The names like "  ", '' 1 " should not be accepted as valid names.

### Solutions

Trim the name before validation.
