### PR TITLE
Bump AVS and fix avs download script

### DIFF
--- a/Scripts/download-avs.sh
+++ b/Scripts/download-avs.sh
@@ -78,6 +78,7 @@ pushd $CARTHAGE_BUILD_PATH > /dev/null
 
 # remove previous, will unzip new
 rm -fr $AVS_FRAMEWORK_NAME > /dev/null
+rm -fr "${AVS_FRAMEWORK_NAME}.dSYM" > /dev/null
 
 ##################################
 # DOWNLOAD

--- a/avs-versions
+++ b/avs-versions
@@ -17,4 +17,4 @@
 # along with this program. If not, see http://www.gnu.org/licenses/.
 #
 
-export APPSTORE_AVS_VERSION=3.8.32
+export APPSTORE_AVS_VERSION=3.8.34


### PR DESCRIPTION
## What's new in this PR?

Bump AVS which contain a crash fix

### Issues

AVS dSYM file wasn't working consistently on hockey.

### Causes

The unpacking script for AVS would fail to unpack the dSYM if the directory contained a previous version of the dSYM.

### Solutions

Delete any previous dSYM files before unpacking.