### PR TITLE
iPad's Landing screen button layout

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/LandingButton.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/LandingButton.swift
@@ -61,6 +61,9 @@ class LandingButton: ButtonWithLargerHitArea {
             subtitleLabel.centerX == selfView.centerX
 
             subtitleLabel.top == iconButton.bottom + 16
+
+            selfView.width >= subtitleLabel.width
+            selfView.width >= iconButton.width
         }
 
     }
@@ -120,3 +123,4 @@ class LandingButton: ButtonWithLargerHitArea {
     }
 
 }
+


### PR DESCRIPTION
## What's new in this PR?

### Issues

We want to arrange landing button in horizontal on iPad (fullscreen mode).
The header and footer should be closer to the buttons.

### Solutions

Create a stack view and put the buttons inside it. Changes stack view's axis when size class changes to fullscreen mode. Switch constraints set when size class changes.

