### PR TITLE
set default stackView.axis value

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/LandingViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/LandingViewController.swift
@@ -86,6 +86,7 @@ final class LandingViewController: UIViewController {
         let stackView = UIStackView()
         stackView.distribution = .fillEqually
         stackView.spacing = 24
+        stackView.axis = .vertical
 
         return stackView
     }()


### PR DESCRIPTION
## What's new in this PR?

### Issues

Landing button stackview's axis is horizontal by default, iPhone should have a stackView with vertical axis.


### Solutions

Set the stackview's axis to vertical with the stackview is created. If the app runs on iPad, the axis will be updated at the end of viewDidLoad().