### PR TITLE
zios-9040 fix crash when image screen rotates

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Overlay/NotificationWindowRootViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Overlay/NotificationWindowRootViewController.m
@@ -1,20 +1,20 @@
-// 
+//
 // Wire
 // Copyright (C) 2016 Wire Swiss GmbH
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
+//
 
 #import "UIView+Borders.h"
 
@@ -65,23 +65,23 @@
         [self.appLockViewController wr_removeFromParentViewController];
     }
 }
-    
+
 - (void)loadView
 {
     self.view = [PassthroughTouchesView new];
-    
+
     self.appLockViewController = [AppLockViewController shared];
     if (nil != self.appLockViewController.parentViewController) {
         [self.appLockViewController wr_removeFromParentViewController];
     }
-    
+
     self.appLockViewController.view.translatesAutoresizingMaskIntoConstraints = NO;
     [self addViewController:self.appLockViewController toView:self.view];
-    
+
     self.chatHeadsViewController = [[ChatHeadsViewController alloc] init];
     self.chatHeadsViewController.view.translatesAutoresizingMaskIntoConstraints = NO;
     [self addViewController:self.chatHeadsViewController toView:self.view];
-    
+
     [self setupConstraints];
     [self updateAppearanceForOrientation:[UIApplication sharedApplication].statusBarOrientation];
 }
@@ -112,16 +112,16 @@
     self.networkStatusViewController = [[NetworkStatusViewController alloc] init];
     self.networkStatusViewController.view.translatesAutoresizingMaskIntoConstraints = NO;
     [self addViewController:self.networkStatusViewController toView:self.view];
-    
+
     [self.networkStatusViewController.view autoPinEdgeToSuperviewEdge:ALEdgeTop];
     [self.networkStatusViewController.view autoPinEdgeToSuperviewEdge:ALEdgeLeft];
     self.networkActivityRightMargin = [self.networkStatusViewController.view autoPinEdgeToSuperviewEdge:ALEdgeRight];
     [self.networkStatusViewController.view autoPinEdgeToSuperviewEdge:ALEdgeBottom];
-    
+
     _voiceChannelController = [[ActiveVoiceChannelViewController alloc] init];
     self.voiceChannelController.view.translatesAutoresizingMaskIntoConstraints = NO;
     [self addViewController:self.voiceChannelController toView:self.view];
-    
+
     [self.voiceChannelController.view autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsZero];
 }
 
@@ -134,11 +134,30 @@
 
 #pragma mark - Rotation handling (should match up with root)
 
+/**
+ guard against a stack overflow (when calling shouldAutorotate or supportedInterfaceOrientations)
+
+ @return nil if UIApplication.sharedApplication.wr_topmostViewController is same as self or same class as self or it is a "UIInputWindowController"
+ */
+-(UIViewController *)topViewController
+{
+    UIViewController * topViewController = UIApplication.sharedApplication.wr_topmostViewController;
+    NSString *className = NSStringFromClass([topViewController class]);
+
+    if (self != topViewController &&
+        ![topViewController isKindOfClass: self.class] &&
+        [className compare:@"UIInputWindowController"] != NSOrderedSame) {
+        return topViewController;
+    }
+
+    return nil;
+}
+
 - (BOOL)shouldAutorotate
 {
-    // guard against a stack overflow
-    if (self != UIApplication.sharedApplication.wr_topmostViewController) {
-        return UIApplication.sharedApplication.wr_topmostViewController.shouldAutorotate;
+    UIViewController * topViewController = [self topViewController];
+    if (topViewController != nil) {
+        return topViewController.shouldAutorotate;
     } else {
         return YES;
     }
@@ -146,9 +165,9 @@
 
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations
 {
-    // guard against a stack overflow
-    if (self != UIApplication.sharedApplication.wr_topmostViewController) {
-        return UIApplication.sharedApplication.wr_topmostViewController.supportedInterfaceOrientations;
+    UIViewController * topViewController = [self topViewController];
+    if (topViewController != nil) {
+        return topViewController.supportedInterfaceOrientations;
     } else {
         return [UIViewController wr_supportedInterfaceOrientations];
     }
@@ -157,13 +176,13 @@
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
 {
     [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {
-        
+
         UIInterfaceOrientation orientation = [[UIApplication sharedApplication] statusBarOrientation];
         [self updateAppearanceForOrientation:orientation];
 
     } completion:^(id<UIViewControllerTransitionCoordinatorContext> context) {
     }];
-    
+
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
 }
 
@@ -180,3 +199,4 @@
 }
 
 @end
+


### PR DESCRIPTION
## What's new in this PR?

### Issues

In NotificationWindowRootViewController, supportedInterfaceOrientations() is recursive called and it crashes when stack overflowed.

### Causes

1. A iOS internal class UIInputWindowController is the top view controller. When getting topViewController.supportedInterfaceOrientations, it calls NotificationWindowRootViewController.supportedInterfaceOrientations recursively. 

### Solutions

Check the topViewController's name. If it is "UIInputWindowController", return [UIViewController wr_supportedInterfaceOrientations].