### PR TITLE
Fix/zios 9334 collection button crash

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
@@ -174,6 +174,8 @@ final public class CollectionsViewController: UIViewController {
 
     // MARK:- device orientation
 
+
+    /// Notice: for iPad with iOS9 in landscape mode, horizontalSizeClass is .unspecified (.regular in iOS11).
     override public var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         switch (self.traitCollection.horizontalSizeClass) {
         case .compact:
@@ -192,16 +194,6 @@ final public class CollectionsViewController: UIViewController {
         }
     }
 
-    override public var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
-        /// Notice: for iPad with iOS9 in landscape mode, horizontalSizeClass is .unspecified (.regular in iOS11).
-        switch (self.traitCollection.horizontalSizeClass) {
-        case .compact:
-            return .portrait
-        default:
-            return super.preferredInterfaceOrientationForPresentation
-        }
-    }
-    
     private func flushLayout() {
         for cell in self.contentView.collectionView.visibleCells {
             guard let cell = cell as? CollectionCell else {

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
@@ -170,22 +170,35 @@ final public class CollectionsViewController: UIViewController {
         super.viewWillDisappear(animated)
         self.textSearchController.teardown()
     }
-    
+
+
+    // MARK:- device orientation
+
     override public var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-        if self.traitCollection.horizontalSizeClass == .regular {
-            return .all
-        }
-        else {
+        switch (self.traitCollection.horizontalSizeClass) {
+        case .compact:
             return .portrait
+        default:
+            return .all
         }
     }
     
     override public var shouldAutorotate: Bool {
-        if self.traitCollection.horizontalSizeClass == .regular {
+        switch (self.traitCollection.horizontalSizeClass) {
+        case .compact:
+            return false
+        default:
             return true
         }
-        else {
-            return false
+    }
+
+    override public var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
+        /// Notice: for iPad with iOS9 in landscape mode, horizontalSizeClass is .unspecified (.regular in iOS11).
+        switch (self.traitCollection.horizontalSizeClass) {
+        case .compact:
+            return .portrait
+        default:
+            return super.preferredInterfaceOrientationForPresentation
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/Components/KeyboardAvoidingViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/KeyboardAvoidingViewController.m
@@ -70,6 +70,22 @@
     return [self.viewController supportedInterfaceOrientations];
 }
 
+- (UIInterfaceOrientation)preferredInterfaceOrientationForPresentation
+{
+    if (self.viewController != nil)
+    {
+        return [self.viewController preferredInterfaceOrientationForPresentation];
+    }
+
+    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone)
+    {
+        return UIInterfaceOrientationPortrait;
+    }
+    else {
+        return super.preferredInterfaceOrientationForPresentation;
+    }
+}
+
 - (UINavigationItem *)navigationItem
 {
     return [self.viewController navigationItem];

--- a/Wire-iOS/Sources/UserInterface/Components/KeyboardAvoidingViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/KeyboardAvoidingViewController.m
@@ -70,22 +70,6 @@
     return [self.viewController supportedInterfaceOrientations];
 }
 
-- (UIInterfaceOrientation)preferredInterfaceOrientationForPresentation
-{
-    if (self.viewController != nil)
-    {
-        return [self.viewController preferredInterfaceOrientationForPresentation];
-    }
-
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone)
-    {
-        return UIInterfaceOrientationPortrait;
-    }
-    else {
-        return super.preferredInterfaceOrientationForPresentation;
-    }
-}
-
 - (UINavigationItem *)navigationItem
 {
     return [self.viewController navigationItem];

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import UIKit
 import WireSyncEngine
 import Cartography
@@ -25,12 +24,11 @@ public extension ZMConversationList {
     func hasUnreadMessages(excluding: ZMConversation) -> Bool {
         return self.conversations().filter { $0 != excluding }.map { $0.estimatedUnreadCount }.reduce(0, +) > 0
     }
-    
+
     func conversations() -> [ZMConversation] {
         return self.flatMap { $0 as? ZMConversation }
     }
 }
-
 
 // MARK: - Update left navigator bar item when size class changes
 extension ConversationViewController {
@@ -45,7 +43,7 @@ public extension ConversationViewController {
     func addCallStateObserver() -> Any? {
         return conversation.voiceChannel?.addCallStateObserver(self)
     }
-    
+
     func barButtonItem(withType type: ZetaIconType, target: AnyObject?, action: Selector, accessibilityIdentifier: String?, width: CGFloat = 30, imageEdgeInsets: UIEdgeInsets = .zero) -> IconButton {
         let button = IconButton.iconButtonDefault()
         button.setIcon(type, with: .tiny, for: .normal)
@@ -55,7 +53,7 @@ public extension ConversationViewController {
         button.imageEdgeInsets = imageEdgeInsets
         return button
     }
-    
+
     func accentBarButtonItem(withType type: ZetaIconType, target: AnyObject?, action: Selector, accessibilityIdentifier: String?, width: CGFloat = 30, imageEdgeInsets: UIEdgeInsets = .zero) -> IconButton {
         let button = IconButton()
         button.setIconColor(UIColor.accent(), for: .normal)
@@ -66,24 +64,24 @@ public extension ConversationViewController {
         button.imageEdgeInsets = imageEdgeInsets
         return button
     }
-    
+
     var audioCallButton: IconButton {
         let button = barButtonItem(withType: .callAudio,
                                    target: self,
                                    action: #selector(ConversationViewController.voiceCallItemTapped(_:)),
                                    accessibilityIdentifier: "audioCallBarButton",
                                    width: 38,
-                                   imageEdgeInsets: UIEdgeInsetsMake(0, 0, 0, -16))
+                                   imageEdgeInsets: UIEdgeInsets(top: 0, left: 0, bottom: 0, right: -16))
         return button
     }
-    
+
     var videoCallButton: IconButton {
         let button = barButtonItem(withType: .callVideo,
                                    target: self,
                                    action: #selector(ConversationViewController.videoCallItemTapped(_:)),
                                    accessibilityIdentifier: "videoCallBarButton",
                                    width: 30,
-                                   imageEdgeInsets: UIEdgeInsetsMake(0, 0, 0, -8))
+                                   imageEdgeInsets: UIEdgeInsets(top: 0, left: 0, bottom: 0, right: -8))
         return button
     }
 
@@ -100,18 +98,18 @@ public extension ConversationViewController {
         button.layer.cornerRadius = button.bounds.height / 2
         return button
     }
-    
+
     var backButton: IconButton {
         let hasUnreadInOtherConversations = self.hasUnreadMessagesInOtherConversations
         let arrowIcon: ZetaIconType = hasUnreadInOtherConversations ? .backArrowWithDot : .backArrow
-        
+
         let leftButtonIcon: ZetaIconType = (self.parent?.wr_splitViewController?.layoutSize == .compact) ? arrowIcon : .hamburger
 
         let action = #selector(ConversationViewController.onBackButtonPressed(_:))
         let accessibilityId = "ConversationBackButton"
         let width: CGFloat = 38
-        let imageEdgeInsets = UIEdgeInsetsMake(0, -16, 0, 0)
-        
+        let imageEdgeInsets = UIEdgeInsets(top: 0, left: -16, bottom: 0, right: 0)
+
         if hasUnreadInOtherConversations {
             return accentBarButtonItem(withType: leftButtonIcon,
                                  target: self,
@@ -119,8 +117,7 @@ public extension ConversationViewController {
                                  accessibilityIdentifier: accessibilityId,
                                  width: width,
                                  imageEdgeInsets: imageEdgeInsets)
-        }
-        else {
+        } else {
             return barButtonItem(withType: leftButtonIcon,
                                  target: self,
                                  action: action,
@@ -129,13 +126,13 @@ public extension ConversationViewController {
                                  imageEdgeInsets: imageEdgeInsets)
         }
     }
-    
+
     var collectionsBarButtonItem: IconButton {
         let showingSearchResults = (self.collectionController?.isShowingSearchResults ?? false)
         let action = #selector(ConversationViewController.onCollectionButtonPressed(_:))
         let accessibilityIdentifier = "collection"
-        let imageEdgeInsets = UIEdgeInsetsMake(0, -8, 0, 0)
-        
+        let imageEdgeInsets = UIEdgeInsets(top: 0, left: -8, bottom: 0, right: 0)
+
         if showingSearchResults {
             return accentBarButtonItem(withType:.searchOngoing,
                                        target: self,
@@ -143,8 +140,7 @@ public extension ConversationViewController {
                                        accessibilityIdentifier: accessibilityIdentifier,
                                        width: 30,
                                        imageEdgeInsets: imageEdgeInsets)
-        }
-        else {
+        } else {
             return barButtonItem(withType:.search,
                                        target: self,
                                        action: action,
@@ -153,7 +149,7 @@ public extension ConversationViewController {
                                        imageEdgeInsets: imageEdgeInsets)
         }
     }
-    
+
     var hasUnreadMessagesInOtherConversations: Bool {
         guard let userSession = ZMUserSession.shared() else {
             return false
@@ -175,7 +171,6 @@ public extension ConversationViewController {
         return [UIBarButtonItem(customView: audioCallButton)]
     }
 
-    
     public func leftNavigationItems(forConversation conversation: ZMConversation) -> [UIBarButtonItem] {
         var items: [UIBarButtonItem] = []
 
@@ -184,32 +179,29 @@ public extension ConversationViewController {
             backButton.hitAreaPadding = CGSize(width: 28, height: 20)
             items.append(UIBarButtonItem(customView: backButton))
         }
-        
+
         if self.shouldShowCollectionsButton() {
             let collectionsButton = collectionsBarButtonItem
             collectionsButton.hitAreaPadding = CGSize(width: 0, height: 20)
             items.append(UIBarButtonItem(customView: collectionsButton))
         }
-        
+
         return items
     }
 
     public func updateRightNavigationItemsButtons() {
         if UIApplication.isLeftToRightLayout {
             navigationItem.rightBarButtonItems = rightNavigationItems(forConversation: conversation)
-        }
-        else {
+        } else {
             navigationItem.rightBarButtonItems = leftNavigationItems(forConversation: conversation)
         }
     }
-
 
     /// Update left navigation bar items
     func updateLeftNavigationBarItems() {
         if UIApplication.isLeftToRightLayout {
             self.navigationItem.leftBarButtonItems = leftNavigationItems(forConversation: conversation)
-        }
-        else {
+        } else {
             self.navigationItem.leftBarButtonItems = rightNavigationItems(forConversation: conversation)
         }
     }
@@ -227,38 +219,37 @@ public extension ConversationViewController {
         default: return false
         }
     }
-    
+
     private func confirmCallInGroup(completion: @escaping (_ accepted: Bool) -> ()) {
         let participantsCount = self.conversation.activeParticipants.count - 1
         let message = "conversation.call.many_participants_confirmation.message".localized(args: participantsCount)
-        
+
         let confirmation = UIAlertController(title: "conversation.call.many_participants_confirmation.title".localized,
                                              message: message,
                                              preferredStyle: .alert)
-        
+
         let actionCancel = UIAlertAction(title: "general.cancel".localized, style: .cancel) { _ in
             completion(false)
         }
         confirmation.addAction(actionCancel)
-        
+
         let actionSend = UIAlertAction(title: "conversation.call.many_participants_confirmation.call".localized, style: .default) { _ in
             completion(true)
         }
         confirmation.addAction(actionSend)
-        
+
         self.present(confirmation, animated: true, completion: .none)
     }
-    
+
     func voiceCallItemTapped(_ sender: UIBarButtonItem) {
         let startCall = {
             ConversationInputBarViewController.endEditingMessage()
             self.conversation.startAudioCall()
         }
-        
+
         if self.conversation.activeParticipants.count <= 4 {
             startCall()
-        }
-        else {
+        } else {
             self.confirmCallInGroup { accepted in
                 if accepted {
                     startCall()
@@ -266,7 +257,7 @@ public extension ConversationViewController {
             }
         }
     }
-    
+
     func videoCallItemTapped(_ sender: UIBarButtonItem) {
         ConversationInputBarViewController.endEditingMessage()
         conversation.startVideoCall()
@@ -278,25 +269,24 @@ public extension ConversationViewController {
         // This will result in joining an ongoing call.
         conversation.joinCall()
     }
-    
+
     func onCollectionButtonPressed(_ sender: AnyObject!) {
         if self.collectionController == .none {
             let collections = CollectionsViewController(conversation: conversation)
             collections.delegate = self
-            
+
             collections.onDismiss = { [weak self] _ in
-                
+
                 guard let `self` = self, let collectionController = self.collectionController else {
                     return
                 }
-                
+
                 collectionController.dismiss(animated: true, completion: {
                     UIApplication.shared.wr_updateStatusBarForCurrentControllerAnimated(true)
                 })
             }
             self.collectionController = collections
-        }
-        else {
+        } else {
             self.collectionController?.refetchCollection()
         }
 
@@ -309,7 +299,7 @@ public extension ConversationViewController {
             UIApplication.shared.wr_updateStatusBarForCurrentControllerAnimated(true)
         })
     }
-    
+
     internal func dismissCollectionIfNecessary() {
         if let collectionController = self.collectionController {
             collectionController.dismiss(animated: false)
@@ -329,8 +319,7 @@ extension ConversationViewController: CollectionsViewControllerDelegate {
                     self.contentViewController.showForwardFor(message: message, fromCell: cell)
                 }
             }
-            
-            
+
         case .showInConversation:
             viewController.dismiss(animated: true) { [weak self] in
                 guard let `self` = self else {
@@ -347,12 +336,12 @@ extension ConversationViewController: CollectionsViewControllerDelegate {
     }
 }
 
-extension ConversationViewController : WireCallCenterCallStateObserver {
-    
+extension ConversationViewController: WireCallCenterCallStateObserver {
+
     public func callCenterDidChange(callState: CallState, conversation: ZMConversation, caller: ZMUser, timestamp: Date?) {
         updateRightNavigationItemsButtons()
     }
-    
+
 }
 
 extension ZMConversation {
@@ -360,7 +349,7 @@ extension ZMConversation {
     /// Whether there is an incoming or inactive incoming call that can be joined.
     var canJoinCall: Bool {
         guard let state = voiceChannel?.state else { return false }
-        
+
         if case .incoming = state {
             return true
         } else {

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -336,6 +336,8 @@
     [self updateLeftNavigationBarItems];
 }
 
+#pragma mark - Device orientation
+
 - (BOOL)shouldAutorotate
 {
     return YES;
@@ -343,7 +345,13 @@
 
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations
 {
-    return UIInterfaceOrientationMaskPortrait;
+    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone)
+    {
+        return UIInterfaceOrientationMaskPortrait;
+    }
+    else {
+        return UIInterfaceOrientationMaskAll;
+    }
 }
 
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator


### PR DESCRIPTION
## What's new in this PR?

### Issues

iPad with iOS9 crashes when presenting collection screen.

### Causes

In iOS9, when CollectionsViewController is loading, self.traitCollection.horizontalSizeClass is .unspecified instead of .regular, which causes supportedInterfaceOrientations and shouldAutorotate return invalid value(.portrait). 


### Solutions

Add missing orientation handling code.

