### PR TITLE
Updated link with more information about teams

### DIFF
--- a/Wire-iOS/Sources/Helpers/NSURL+WireURLs.m
+++ b/Wire-iOS/Sources/Helpers/NSURL+WireURLs.m
@@ -95,7 +95,7 @@
 
 + (instancetype)wr_createTeamFeaturesURL
 {
-    return [self URLWithString:@"https://wire.com/create-team?pk_campaign=client&pk_kwd=ios#features"];
+    return [self URLWithString:@"https://wire.com/teams/learnmore/"];
 }
 
 + (instancetype)wr_manageTeamURL


### PR DESCRIPTION
## What's new in this PR?

### Issues

We had a hardcoded link to point to team creation page. It is used from team creation flow and should contain background information about Wire teams.

### Solutions

Changed to a more general link that can be easily redirected on the server side to a relevant page.

