### PR TITLE
Added support for up arrow key

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -214,6 +214,7 @@
 "conversation.connection_view.in_address_book" = "in Contacts";
 
 "conversation.input_bar.shortcut.send" = "Send Message";
+"conversation.input_bar.shortcut.edit_last_message" = "Edit Last Message";
 
 "conversation.input_bar.message_too_long.title" = "Message too long";
 "conversation.input_bar.message_too_long.message" = "You can send messages up to %d characters long.";

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.h
@@ -51,6 +51,7 @@
 
 @interface ConversationContentViewController (EditMessages)
 
+- (void)editLastMessage;
 - (void)didFinishEditingMessage:(id<ZMConversationMessage>)message;
 
 @end

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -831,6 +831,14 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
 
 @implementation ConversationContentViewController (EditMessages)
 
+- (void)editLastMessage
+{
+    ZMMessage *lastEditableMessage = self.conversation.lastEditableMessage;
+    if (lastEditableMessage != nil) {
+        [self wantsToPerformAction:MessageActionEdit forMessage:lastEditableMessage];
+    }
+}
+
 - (void)didFinishEditingMessage:(id<ZMConversationMessage>)message
 {
     self.conversationMessageWindowTableViewAdapter.editingMessage = nil;

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -752,6 +752,11 @@
     [self.contentViewController didFinishEditingMessage:message];
 }
 
+- (void)conversationInputBarViewControllerEditLastMessage
+{
+    [self.contentViewController editLastMessage];
+}
+
 @end
 
 @implementation ConversationViewController (ParticipantsViewController)

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.h
@@ -44,6 +44,7 @@ typedef NS_ENUM(NSUInteger, ConversationInputBarViewControllerMode) {
 - (void)conversationInputBarViewControllerDidNotSendMessageConversationDegraded:(ConversationInputBarViewController *)controller;
 - (void)conversationInputBarViewControllerDidFinishEditingMessage:(id <ZMConversationMessage>)message withText:(NSString *)newText;
 - (void)conversationInputBarViewControllerDidCancelEditingMessage:(id <ZMConversationMessage>)message;
+- (void)conversationInputBarViewControllerEditLastMessage;
 
 @end
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -560,8 +560,12 @@
              [UIKeyCommand keyCommandWithInput:@"\r"
                                  modifierFlags:UIKeyModifierCommand
                                         action:@selector(commandReturnPressed)
-                          discoverabilityTitle:NSLocalizedString(@"conversation.input_bar.shortcut.send", nil)]
-             ];
+                          discoverabilityTitle:NSLocalizedString(@"conversation.input_bar.shortcut.send", nil)],
+             [UIKeyCommand keyCommandWithInput:UIKeyInputUpArrow
+                                 modifierFlags:0
+                                        action:@selector(upArrowPressed)
+                         discoverabilityTitle:NSLocalizedString(@"conversation.input_bar.shortcut.edit_last_message", nil)]
+            ];
 }
 
 - (BOOL)canBecomeFirstResponder
@@ -574,6 +578,13 @@
     NSString *candidateText = self.inputBar.textView.preparedText;
     if (nil != candidateText) {
         [self sendOrEditText:candidateText];
+    }
+}
+
+- (void)upArrowPressed
+{
+    if ([self.delegate respondsToSelector:@selector(conversationInputBarViewControllerEditLastMessage)]) {
+        [self.delegate conversationInputBarViewControllerEditLastMessage];
     }
 }
 


### PR DESCRIPTION
## What's new in this PR?
Up arrow keyboard shortcut starts editing of last message.
(The same shortcut is already available on desktop app)

### Issues
Keyboard shortcuts support requested in #1125

### Solutions
Up Arrow key in InputBar initiates editLastMessage in ConversationContentViewController (via ConversationViewController).
If there is a lastEditableMessage in the conversation, wantsToPerformAction is sent to ConversationContentViewController for the message found.

## Dependencies
Needs releases with:
- [ ] https://github.com/wireapp/wire-ios-data-model/pull/400
