### PR TITLE
ZIOS-9337 iPad - conversation list is not visible after rotation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.m
@@ -234,7 +234,6 @@ NSString *SplitLayoutObservableDidChangeToLayoutSizeNotification = @"SplitLayout
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
     
     [self updateForSize:size];
-    [self updateLeftViewVisibility];
 }
 
 - (void)willTransitionToTraitCollection:(UITraitCollection *)newCollection withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
@@ -259,7 +258,8 @@ NSString *SplitLayoutObservableDidChangeToLayoutSizeNotification = @"SplitLayout
     
     [self updateConstraintsForSize:size];
     [self updateActiveConstraints];
-    
+    [self updateLeftViewVisibility];
+
     self.futureTraitCollection = nil;
 }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
@@ -37,6 +37,12 @@ extension ConversationViewController {
         super.willTransition(to: newCollection, with: coordinator)
         self.updateLeftNavigationBarItems()
     }
+
+    override open func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        self.updateLeftNavigationBarItems()
+    }
 }
 
 public extension ConversationViewController {

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
@@ -38,9 +38,8 @@ extension ConversationViewController {
         self.updateLeftNavigationBarItems()
     }
 
-    override open func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-
+    override open func viewWillLayoutSubviews() {
+        super.viewWillLayoutSubviews()
         self.updateLeftNavigationBarItems()
     }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

- menu button in conversation view is not hidden after rotates to landscape mode
- conversation list is not visible after rotates to landscape mode

### Causes

In SplitViewController, updateLeftViewVisibility() is not called after updateForSize() is called.
in ConversationViewController, updateLeftNavigationBarItems() should be called when viewWillLayoutSubviews
### Solutions

Add the missing UI update code.