### PR TITLE
Team creation: fix for profile picture not being set sometimes

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationFlowController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationFlowController.swift
@@ -188,10 +188,11 @@ extension TeamCreationFlowController: VerifyEmailStepDescriptionDelegate {
 extension TeamCreationFlowController: SessionManagerCreatedSessionObserver {
     func sessionManagerCreated(userSession : ZMUserSession) {
         syncToken = ZMUserSession.addInitialSyncCompletionObserver(self, userSession: userSession)
+        let unauthenticatedSession = SessionManager.shared?.unauthenticatedSession
         URLSession.shared.dataTask(with: URL(string: UnsplashRandomImageHiQualityURL)!) { (data, _, error) in
             if let data = data, error == nil {
                 DispatchQueue.main.async {
-                    SessionManager.shared?.unauthenticatedSession?.setProfileImage(imageData: data)
+                    unauthenticatedSession?.setProfileImage(imageData: data)
                 }
             }
         }.resume()


### PR DESCRIPTION
## What's new in this PR?

### Issues

After creating a team sometimes the profile picture of the user is not set.

### Causes

After logging in we are nil'ing the unauthenticated session. This introduces a race condition, because profile picture setting is handled by it. In the case where we manage to login quicker than download an image from Unsplash the unauthenticated session is gone and profile picture is not set.

### Solutions

We retain the unauthenticated session in the request completion block. 

## Notes

After looking into memory debugger it seems we are leaking the unauthenticated session because there is a retain cycle in sync engine. We will have to address it at a later point to avoid introducing any new issues.
