### PR TITLE
Prevented sending search text together with giphy gif

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -995,7 +995,6 @@
 "force.update.ok_button" = "Go to App Store";
 
 // Third Party
-"giphy.conversation.message" = "%@ · via giphy.com";
 "giphy.conversation.random_message" = "via giphy.com";
 "giphy.error.no_more_results" = "no more gifs";
 "giphy.error.no_result" = "no gif found";

--- a/Wire-iOS/Resources/ar.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/ar.lproj/Localizable.strings
@@ -995,7 +995,6 @@
 "force.update.ok_button" = "اذهب لـApp Store";
 
 // Third Party
-"giphy.conversation.message" = "%@ · عبر giphy.com";
 "giphy.conversation.random_message" = "عبر giphy.com";
 "giphy.error.no_more_results" = "لا مزيد من gifs";
 "giphy.error.no_result" = "لم يتم العثور على أي gif";

--- a/Wire-iOS/Resources/da.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/da.lproj/Localizable.strings
@@ -995,7 +995,6 @@
 "force.update.ok_button" = "Gå til App Store";
 
 // Third Party
-"giphy.conversation.message" = "%@ · via giphy.com";
 "giphy.conversation.random_message" = "via giphy.com";
 "giphy.error.no_more_results" = "ikke flere gifs";
 "giphy.error.no_result" = "ingen gif fundet";

--- a/Wire-iOS/Resources/de.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/de.lproj/Localizable.strings
@@ -995,7 +995,6 @@
 "force.update.ok_button" = "Zum App Store";
 
 // Third Party
-"giphy.conversation.message" = "%@ · via giphy.com";
 "giphy.conversation.random_message" = "via giphy.com";
 "giphy.error.no_more_results" = "keine weiteren gifs";
 "giphy.error.no_result" = "kein gif gefunden";

--- a/Wire-iOS/Resources/es.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/es.lproj/Localizable.strings
@@ -995,7 +995,6 @@
 "force.update.ok_button" = "Ir a la App Store";
 
 // Third Party
-"giphy.conversation.message" = "%@ · vía giphy.com";
 "giphy.conversation.random_message" = "vía giphy.com";
 "giphy.error.no_more_results" = "no hay más GIFs";
 "giphy.error.no_result" = "no se encontró ningún GIF";

--- a/Wire-iOS/Resources/et.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/et.lproj/Localizable.strings
@@ -995,7 +995,6 @@
 "force.update.ok_button" = "Mine App Store’i";
 
 // Third Party
-"giphy.conversation.message" = "%@ · via giphy.com";
 "giphy.conversation.random_message" = "via giphy.com";
 "giphy.error.no_more_results" = "rohkem gif’e pole";
 "giphy.error.no_result" = "gif’i ei leitud";

--- a/Wire-iOS/Resources/fi.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/fi.lproj/Localizable.strings
@@ -995,7 +995,6 @@
 "force.update.ok_button" = "Siirry App Storeen";
 
 // Third Party
-"giphy.conversation.message" = "%@ · giphy.com:in kautta";
 "giphy.conversation.random_message" = "giphy.com:in kautta";
 "giphy.error.no_more_results" = "ei enempää giffejä";
 "giphy.error.no_result" = "giffiä ei löytynyt";

--- a/Wire-iOS/Resources/fr.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/fr.lproj/Localizable.strings
@@ -995,7 +995,6 @@
 "force.update.ok_button" = "Aller sur l'App Store";
 
 // Third Party
-"giphy.conversation.message" = "%@ · via giphy.com";
 "giphy.conversation.random_message" = "via giphy.com";
 "giphy.error.no_more_results" = "plus aucun gif";
 "giphy.error.no_result" = "aucun gif trouvé";

--- a/Wire-iOS/Resources/it.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/it.lproj/Localizable.strings
@@ -995,7 +995,6 @@
 "force.update.ok_button" = "Vai all'App Store";
 
 // Third Party
-"giphy.conversation.message" = "%@ · via giphy.com";
 "giphy.conversation.random_message" = "via giphy.com";
 "giphy.error.no_more_results" = "nessun altra gif";
 "giphy.error.no_result" = "nessuna gif trovata";

--- a/Wire-iOS/Resources/ja.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/ja.lproj/Localizable.strings
@@ -995,7 +995,6 @@
 "force.update.ok_button" = "App Storeに行く";
 
 // Third Party
-"giphy.conversation.message" = "%@ giphy.comから";
 "giphy.conversation.random_message" = "giphy.comから";
 "giphy.error.no_more_results" = "これ以上gifがありません。";
 "giphy.error.no_result" = "gifが見つかりませんでした。";

--- a/Wire-iOS/Resources/lt.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/lt.lproj/Localizable.strings
@@ -995,7 +995,6 @@
 "force.update.ok_button" = "Eiti į „App Store“";
 
 // Third Party
-"giphy.conversation.message" = "%@ · iš giphy.com";
 "giphy.conversation.random_message" = "iš giphy.com";
 "giphy.error.no_more_results" = "daugiau jokių gif";
 "giphy.error.no_result" = "gif nerasta";

--- a/Wire-iOS/Resources/nl.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/nl.lproj/Localizable.strings
@@ -995,7 +995,6 @@
 "force.update.ok_button" = "Ga naar de App Store";
 
 // Third Party
-"giphy.conversation.message" = "%@ · via giphy.com";
 "giphy.conversation.random_message" = "via giphy.com";
 "giphy.error.no_more_results" = "geen gifs meer";
 "giphy.error.no_result" = "geen gif gevonden";

--- a/Wire-iOS/Resources/pl.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/pl.lproj/Localizable.strings
@@ -995,7 +995,6 @@
 "force.update.ok_button" = "Przejdź do sklepu App Store";
 
 // Third Party
-"giphy.conversation.message" = "%@ · dzięki giphy.com";
 "giphy.conversation.random_message" = "dzięki giphy.com";
 "giphy.error.no_more_results" = "nie ma więcej GIFów";
 "giphy.error.no_result" = "nie znaleziono GIFa";

--- a/Wire-iOS/Resources/pt-BR.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/pt-BR.lproj/Localizable.strings
@@ -995,7 +995,6 @@
 "force.update.ok_button" = "Vá para a App Store";
 
 // Third Party
-"giphy.conversation.message" = "%@ · via giphy.com";
 "giphy.conversation.random_message" = "via giphy.com";
 "giphy.error.no_more_results" = "não há mais gifs";
 "giphy.error.no_result" = "nenhum gif encontrado";

--- a/Wire-iOS/Resources/ru.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/ru.lproj/Localizable.strings
@@ -995,7 +995,6 @@
 "force.update.ok_button" = "Перейти в App Store";
 
 // Third Party
-"giphy.conversation.message" = "%@ · через giphy.com";
 "giphy.conversation.random_message" = "через giphy.com";
 "giphy.error.no_more_results" = "Больше нет gif'ок";
 "giphy.error.no_result" = "gif не найдена";

--- a/Wire-iOS/Resources/sl.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/sl.lproj/Localizable.strings
@@ -995,7 +995,6 @@
 "force.update.ok_button" = "Pojdi na App Store";
 
 // Third Party
-"giphy.conversation.message" = "%@ · preko giphy.com";
 "giphy.conversation.random_message" = "preko giphy.com";
 "giphy.error.no_more_results" = "ni več gifov";
 "giphy.error.no_result" = "noben gif najden";

--- a/Wire-iOS/Resources/tr.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/tr.lproj/Localizable.strings
@@ -995,7 +995,6 @@
 "force.update.ok_button" = "App Store'a git";
 
 // Third Party
-"giphy.conversation.message" = "%@ · giphy.com aracılığıyla";
 "giphy.conversation.random_message" = "giphy.com aracılığıyla";
 "giphy.error.no_more_results" = "daha fazla gif yok";
 "giphy.error.no_result" = "gif bulunamadı";

--- a/Wire-iOS/Resources/uk.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/uk.lproj/Localizable.strings
@@ -995,7 +995,6 @@
 "force.update.ok_button" = "Перейти в App Store";
 
 // Third Party
-"giphy.conversation.message" = "%@ · через giphy.com";
 "giphy.conversation.random_message" = "через giphy.com";
 "giphy.error.no_more_results" = "більше немає анімацій";
 "giphy.error.no_result" = "анімацій не знайдено";

--- a/Wire-iOS/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/zh-Hans.lproj/Localizable.strings
@@ -995,7 +995,6 @@
 "force.update.ok_button" = "到App Store";
 
 // Third Party
-"giphy.conversation.message" = "%@ · 来源 giphy.com";
 "giphy.conversation.random_message" = "来源 giphy.com";
 "giphy.error.no_more_results" = "没有更多的gif图片";
 "giphy.error.no_result" = "找不到gif图片";

--- a/Wire-iOS/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/zh-Hant.lproj/Localizable.strings
@@ -995,7 +995,6 @@
 "force.update.ok_button" = "到App Store";
 
 // Third Party
-"giphy.conversation.message" = "%@ · 來源 giphy.com";
 "giphy.conversation.random_message" = "來源 giphy.com";
 "giphy.error.no_more_results" = "沒有更多的gif圖像";
 "giphy.error.no_result" = "找不到gif圖像";

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -1167,18 +1167,9 @@
     [[Analytics shared] tagMediaSentPictureSourceOtherInConversation:self.conversation source:ConversationMediaPictureSourceGiphy];
     [self clearInputBar];
     [self dismissViewControllerAnimated:YES completion:nil];
-    
-    
-    
-    NSString *messageText = nil;
-    
-    if ([searchTerm isEqualToString:@""]) {
-        messageText = [NSString stringWithFormat:NSLocalizedString(@"giphy.conversation.random_message", nil), searchTerm];
-    } else {
-        messageText = [NSString stringWithFormat:NSLocalizedString(@"giphy.conversation.message", nil), searchTerm];
-    }
-    
-    [self.sendController sendTextMessage:messageText withImageData:imageData];
+
+    [self.sendController sendTextMessage:NSLocalizedString(@"giphy.conversation.random_message", nil)
+                           withImageData:imageData];
 }
 
 @end


### PR DESCRIPTION
## What's new in this PR?
Search string used to find a gif at giphy.com will not be sent to the conversation.

### Issues
I agree with the author of https://github.com/wireapp/wire-ios/issues/535.
As a user, I do not expect a search text to be sent to a conversation. This can lead to some awkward situations if I use an inappropriate text to search.
