### PR TITLE
add shortcut to cancel message editing

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -215,6 +215,7 @@
 
 "conversation.input_bar.shortcut.send" = "Send Message";
 "conversation.input_bar.shortcut.edit_last_message" = "Edit Last Message";
+"conversation.input_bar.shortcut.cancel_editing_message" = "Cancel";
 
 "conversation.input_bar.message_too_long.title" = "Message too long";
 "conversation.input_bar.message_too_long.message" = "You can send messages up to %d characters long.";

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -556,16 +556,25 @@
 
 - (NSArray<UIKeyCommand *> *)keyCommands
 {
-    return @[
-             [UIKeyCommand keyCommandWithInput:@"\r"
-                                 modifierFlags:UIKeyModifierCommand
-                                        action:@selector(commandReturnPressed)
-                          discoverabilityTitle:NSLocalizedString(@"conversation.input_bar.shortcut.send", nil)],
-             [UIKeyCommand keyCommandWithInput:UIKeyInputUpArrow
-                                 modifierFlags:0
-                                        action:@selector(upArrowPressed)
-                         discoverabilityTitle:NSLocalizedString(@"conversation.input_bar.shortcut.edit_last_message", nil)]
-            ];
+    NSMutableArray *commands = [[NSMutableArray alloc] init];
+    [commands addObject:[UIKeyCommand keyCommandWithInput:@"\r"
+                                            modifierFlags:UIKeyModifierCommand
+                                                   action:@selector(commandReturnPressed)
+                                     discoverabilityTitle:NSLocalizedString(@"conversation.input_bar.shortcut.send", nil)]];
+    
+    if (self.inputBar.isEditing) {
+        [commands addObject:[UIKeyCommand keyCommandWithInput:UIKeyInputEscape
+                                                modifierFlags:0
+                                                       action:@selector(escapePressed)
+                                         discoverabilityTitle:NSLocalizedString(@"conversation.input_bar.shortcut.cancel_editing_message", nil)]];
+    } else {
+        [commands addObject:[UIKeyCommand keyCommandWithInput:UIKeyInputUpArrow
+                                                modifierFlags:0
+                                                       action:@selector(upArrowPressed)
+                                         discoverabilityTitle:NSLocalizedString(@"conversation.input_bar.shortcut.edit_last_message", nil)]];
+    }
+    
+    return commands;
 }
 
 - (BOOL)canBecomeFirstResponder
@@ -586,6 +595,11 @@
     if ([self.delegate respondsToSelector:@selector(conversationInputBarViewControllerEditLastMessage)]) {
         [self.delegate conversationInputBarViewControllerEditLastMessage];
     }
+}
+
+-(void)escapePressed
+{
+    [self endEditingMessageIfNeeded];
 }
 
 #pragma mark - Input views handling


### PR DESCRIPTION
## What's new in this PR?

I've added a minor extension to the  "edit last message" keyboard shortcut (thanks @vorobievalex ) so that it is aligned with the functionality found on desktop, namely that once we are editing a message, the `esc` will cancel editing. Furthermore, I've restricted which shortcuts are available depending on the input bar state, so that the `edit last message` shortcut is only available when the user is not already editing a message, and the `cancel` shortcut is only available when the user is currently editing a message.

### Attachments

![simulator screen shot - ipad pro 9 7-inch - 2017-12-11 at 15 55 52](https://user-images.githubusercontent.com/28632506/33837696-7e323556-de8d-11e7-89e5-91d1e90e9959.png)

![simulator screen shot - ipad pro 9 7-inch - 2017-12-11 at 15 56 10](https://user-images.githubusercontent.com/28632506/33837710-892c78ea-de8d-11e7-9e15-8eee9fc78fc3.png)
