### PR TITLE
Fix layout of profile screens for small screens

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		1670AFE81B2095B1002BF0AE /* VoiceChannelCollectionViewLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = 1670AFE71B2095B1002BF0AE /* VoiceChannelCollectionViewLayout.m */; };
 		16719A101D99647D00AA6B63 /* GiphySearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16719A0F1D99647D00AA6B63 /* GiphySearchViewController.swift */; };
 		16719A1D1D9ABB7C00AA6B63 /* GiphyConfirmationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16719A1C1D9ABB7C00AA6B63 /* GiphyConfirmationViewController.swift */; };
+		1671DD5E1FDFED280096FBDB /* UIStackView+CustomSpacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1671DD5D1FDFED280096FBDB /* UIStackView+CustomSpacing.swift */; };
 		1677FD331BBC19A400491481 /* ColorScheme.h in Headers */ = {isa = PBXBuildFile; fileRef = 1677FD311BBC19A400491481 /* ColorScheme.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1677FD341BBC19A400491481 /* ColorScheme.m in Sources */ = {isa = PBXBuildFile; fileRef = 1677FD321BBC19A400491481 /* ColorScheme.m */; };
 		167AEA101B16031900890435 /* VoiceChannelParticipantCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 167AEA0F1B16031900890435 /* VoiceChannelParticipantCell.m */; };
@@ -1144,6 +1145,7 @@
 		1670AFE71B2095B1002BF0AE /* VoiceChannelCollectionViewLayout.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VoiceChannelCollectionViewLayout.m; sourceTree = "<group>"; };
 		16719A0F1D99647D00AA6B63 /* GiphySearchViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GiphySearchViewController.swift; sourceTree = "<group>"; };
 		16719A1C1D9ABB7C00AA6B63 /* GiphyConfirmationViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GiphyConfirmationViewController.swift; sourceTree = "<group>"; };
+		1671DD5D1FDFED280096FBDB /* UIStackView+CustomSpacing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+CustomSpacing.swift"; sourceTree = "<group>"; };
 		1677FD311BBC19A400491481 /* ColorScheme.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ColorScheme.h; sourceTree = "<group>"; };
 		1677FD321BBC19A400491481 /* ColorScheme.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ColorScheme.m; sourceTree = "<group>"; };
 		167AEA0E1B16031900890435 /* VoiceChannelParticipantCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VoiceChannelParticipantCell.h; sourceTree = "<group>"; };
@@ -4246,6 +4248,7 @@
 				EEBE8C5B1F681694009D78C9 /* NSData+ImageType.swift */,
 				7C4918A01F8BB1A20038AF4B /* UIScreen+SafeArea.swift */,
 				F194AD791E3F3BBC00B0049B /* UIApplication+RTL.swift */,
+				1671DD5D1FDFED280096FBDB /* UIStackView+CustomSpacing.swift */,
 				BF8ECC2C1E570A920015177D /* UIActivityViewController+FileSaving.swift */,
 				1693D9661CEDB26200D1F13C /* UIApplication+Permissions.h */,
 				1693D9671CEDB26200D1F13C /* UIApplication+Permissions.m */,
@@ -6355,6 +6358,7 @@
 				870A8C6B1CF719C400874B16 /* RecordingDotView.swift in Sources */,
 				BFBB03081D61AF8D0065AF4F /* InputBarEditView.swift in Sources */,
 				160DECE01AB3347B000FB575 /* CameraExposureSlider.m in Sources */,
+				1671DD5E1FDFED280096FBDB /* UIStackView+CustomSpacing.swift in Sources */,
 				87A773CF1DD0B48400ACAA73 /* ObfuscationView.swift in Sources */,
 				7C17ECA51F74F4540056600C /* ConversationCell+Preview.swift in Sources */,
 				871BC22D1D34F8F800DF0793 /* RotationAwareNavigationController.swift in Sources */,

--- a/Wire-iOS/Sources/Helpers/UIStackView+CustomSpacing.swift
+++ b/Wire-iOS/Sources/Helpers/UIStackView+CustomSpacing.swift
@@ -1,0 +1,83 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import UIKit
+
+extension UIStackView {
+    
+    /**
+     This initializer must be used if you intend to call wr_addCustomSpacing.
+     */
+    convenience init(customSpacedArrangedSubviews subviews : [UIView]) {
+        
+        var subviewsWithSpacers : [UIView] = []
+        
+        subviews.forEach { view in
+            subviewsWithSpacers.append(view)
+            subviewsWithSpacers.append(SpacingView(0))
+        }
+        
+        self.init(arrangedSubviews: subviewsWithSpacers)
+    }
+    
+    /**
+     Add a custom spacing after a view.
+     
+     This is a approximation of the addCustomSpacing method only available since iOS 11. This method
+     has several constraints:
+     
+     - The stackview must be initialized with customSpacedArrangedSubviews
+     - spacing dosesn't update if views are hidden after this method is called
+     - custom spacing can't be smaller than 2x the minimum spacing
+     */
+    func wr_addCustomSpacing(_ customSpacing: CGFloat, after view: UIView) {
+        if let spacerIndex = subviews.index(of: view)?.advanced(by: 1) {
+            if let spacer = subviews[spacerIndex] as? SpacingView {
+                if view.isHidden || customSpacing < (spacing * 2) {
+                    spacer.isHidden = true
+                } else {
+                    spacer.size = customSpacing - spacing
+                }
+            }
+        }
+    }
+    
+}
+
+fileprivate class SpacingView : UIView {
+    
+    var size : CGFloat
+    
+    public init(_ size : CGFloat) {
+        self.size = size
+        
+        super.init(frame: CGRect(origin: CGPoint.zero, size: CGSize(width: size, height: size)))
+        
+        setContentCompressionResistancePriority(999, for: .vertical)
+        setContentCompressionResistancePriority(999, for: .horizontal)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override var intrinsicContentSize: CGSize {
+        return CGSize(width: size, height: size)
+    }
+    
+}

--- a/Wire-iOS/Sources/UserInterface/Availability/TitleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Availability/TitleView.swift
@@ -78,6 +78,7 @@ import Classy
         titleButton.setAttributedTitle(selectedLabel, for: .highlighted)
         titleButton.sizeToFit()
         titleButton.isEnabled = interactive
+        titleButton.setContentCompressionResistancePriority(1000, for: .vertical)
         updateAccessibilityLabel()
         frame = titleButton.bounds
         createConstraints()

--- a/Wire-iOS/Sources/UserInterface/SelfProfile/ProfileView.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/ProfileView.swift
@@ -16,16 +16,16 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
 import Cartography
 
 @objc internal class ProfileView: UIView {
-    public let imageView = UserImageView(size: .big)
+    public let imageView =  UserImageView(size: .big)
     public let nameLabel = UILabel()
     public let handleLabel = UILabel()
     public let teamNameLabel = UILabel()
-    public var availabilityView : AvailabilityTitleView?
+    public var availabilityView = AvailabilityTitleView(user: ZMUser.selfUser(), style: .selfProfile)
+    var stackView : UIStackView!
     var userObserverToken: NSObjectProtocol?
     
     init(user: ZMUser) {
@@ -58,19 +58,22 @@ import Cartography
         if let team = user.team, let teamName = team.name {
             teamNameLabel.text = teamName.uppercased()
             teamNameLabel.accessibilityValue = teamNameLabel.text
-            availabilityView = AvailabilityTitleView(user: ZMUser.selfUser(), style: .selfProfile)
-        }
-        else {
+        } else {
             teamNameLabel.isHidden = true
+            availabilityView.isHidden = true
         }
         
         updateHandleLabel(user: user)
         
-        [imageView, nameLabel, handleLabel, teamNameLabel].forEach(addSubview)
-        
-        if let availabilityView = availabilityView {
-            self.addSubview(availabilityView)
-        }
+        stackView = UIStackView(customSpacedArrangedSubviews: [nameLabel, handleLabel, teamNameLabel, imageView, availabilityView])
+        stackView.alignment = .center
+        stackView.axis = .vertical
+        stackView.spacing = 2
+        stackView.wr_addCustomSpacing(32, after: handleLabel)
+        stackView.wr_addCustomSpacing(32, after: teamNameLabel)
+        stackView.wr_addCustomSpacing(32, after: imageView)
+        stackView.wr_addCustomSpacing(32, after: availabilityView)
+        addSubview(stackView)
         
         self.createConstraints()
     }
@@ -86,43 +89,11 @@ import Cartography
     }
     
     private func createConstraints() {
-        constrain(self, imageView, nameLabel, handleLabel, teamNameLabel) { [weak self] selfView, imageView, nameLabel, handleLabel, teamNameLabel in
-            
-            nameLabel.top >= selfView.top
-            nameLabel.centerX == selfView.centerX
-            nameLabel.leading >= selfView.leading
-            nameLabel.trailing <= selfView.trailing
-            
-            handleLabel.top == nameLabel.bottom + 4
-            handleLabel.centerX == selfView.centerX
-            handleLabel.leading >= selfView.leading
-            handleLabel.trailing <= selfView.trailing
-            
-            teamNameLabel.bottom == handleLabel.bottom + 24
-            teamNameLabel.centerX == selfView.centerX
-            teamNameLabel.leading >= selfView.leading
-            teamNameLabel.trailing <= selfView.trailing
-            
-            imageView.top == teamNameLabel.bottom + 32 ~ LayoutPriority(750.0)
-            imageView.top >= teamNameLabel.bottom + 16
-            imageView.width == imageView.height
-            imageView.width <= 240
-            imageView.centerX == selfView.centerX
-            imageView.leading >= selfView.leading
-            imageView.trailing <= selfView.trailing
-            
-            if self?.availabilityView == nil {
-                imageView.bottom == selfView.bottom - 32 ~ LayoutPriority(750.0)
-                imageView.bottom <= selfView.bottom - 24
-            }
-        }
-        
-        if let availabilityView = availabilityView {
-            constrain(self, imageView, availabilityView) { (selfView, imageView, availabilityView) in
-                availabilityView.top == imageView.bottom + 40
-                availabilityView.centerX == selfView.centerX
-                availabilityView.bottom == selfView.bottom
-            }
+        constrain(self, stackView) { selfView, stackView in
+            stackView.top == selfView.top
+            stackView.bottom <= selfView.bottom
+            stackView.leading == selfView.leading
+            stackView.trailing == selfView.trailing
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileDetailsViewController.m
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileDetailsViewController.m
@@ -82,11 +82,11 @@ typedef NS_ENUM(NSUInteger, ProfileUserAction) {
 @property (nonatomic) ZMConversation *conversation;
 
 @property (nonatomic) UserImageView *userImageView;
-@property (nonatomic) UIView *userImageViewContainer;
 @property (nonatomic) UIView *footerView;
 @property (nonatomic) UILabel *teamsGuestLabel;
 @property (nonatomic) BOOL showGuestLabel;
 @property (nonatomic) AvailabilityTitleView *availabilityView;
+@property (nonatomic) UIStackView *stackView;
 
 @end
 
@@ -116,58 +116,41 @@ typedef NS_ENUM(NSUInteger, ProfileUserAction) {
 {
     [self createUserImageView];
     [self createFooter];
-    [self createAvailabilityView];
-    if (self.showGuestLabel) {
-        [self createTeamsGuestLabel];
-    }
+    [self createTeamsGuestLabel];
+    
+    self.teamsGuestLabel.hidden = !self.showGuestLabel;
+    self.availabilityView.hidden = !ZMUser.selfUser.isTeamMember || self.fullUser.availability == AvailabilityNone;
+
+    self.stackView = [[UIStackView alloc] initWithCustomSpacedArrangedSubviews:@[self.userImageView, self.teamsGuestLabel, self.availabilityView]];
+    self.stackView.axis = UILayoutConstraintAxisVertical;
+    self.stackView.spacing = 0;
+    self.stackView.alignment = UIStackViewAlignmentCenter;
+    [self.view addSubview:self.stackView];
+    
+    [self.stackView wr_addCustomSpacing:(self.teamsGuestLabel.isHidden ? 32 : 4) after:self.userImageView];
+    [self.stackView wr_addCustomSpacing:(self.availabilityView.isHidden ? 40 : 32) after:self.teamsGuestLabel];
+    [self.stackView wr_addCustomSpacing:32 after:self.availabilityView];
 }
 
 - (void)setupConstraints
 {
-    [self.userImageViewContainer autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsZero excludingEdge:ALEdgeBottom];
+    [self.stackView autoPinEdgeToSuperviewEdge:ALEdgeTop withInset:32];
+    [self.stackView autoPinEdgeToSuperviewEdge:ALEdgeLeading];
+    [self.stackView autoPinEdgeToSuperviewEdge:ALEdgeTrailing];
+    [self.stackView autoPinEdge:ALEdgeBottom toEdge:ALEdgeTop ofView:self.footerView withOffset:0 relation:NSLayoutRelationLessThanOrEqual];
     
-    [self.userImageView autoMatchDimension:ALDimensionHeight toDimension:ALDimensionWidth ofView:self.userImageView];
-    [self.userImageView autoPinEdgeToSuperviewEdge:ALEdgeLeft withInset:48 relation:NSLayoutRelationGreaterThanOrEqual];
-    [self.userImageView autoPinEdgeToSuperviewEdge:ALEdgeRight withInset:48 relation:NSLayoutRelationGreaterThanOrEqual];
-    [self.userImageView autoPinEdgeToSuperviewEdge:ALEdgeTop withInset:0 relation:NSLayoutRelationGreaterThanOrEqual];
-    
-
-    if (self.showGuestLabel) {
-        [self.teamsGuestLabel autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.userImageView withOffset:15];
-        [self.teamsGuestLabel autoPinEdge:ALEdgeLeft toEdge:ALEdgeLeft ofView:self.userImageView];
-        [self.teamsGuestLabel autoPinEdge:ALEdgeRight toEdge:ALEdgeRight ofView:self.userImageView];
-        [self.availabilityView autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.teamsGuestLabel withOffset:40.0];
-    } else {
-        [self.availabilityView autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.userImageView withOffset:40.0];
-    }
-    
-    [self.availabilityView autoAlignAxisToSuperviewAxis:ALAxisVertical];
-    [self.userImageView autoAlignAxisToSuperviewAxis:ALAxisVertical];
-    [NSLayoutConstraint autoSetPriority:UILayoutPriorityDefaultLow forConstraints:^{
-        [self.userImageView autoAlignAxisToSuperviewAxis:ALAxisHorizontal];
-    }];
-
-    [self.footerView autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.userImageViewContainer];
     [self.footerView autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsZero excludingEdge:ALEdgeTop];
 }
 
 #pragma mark - User Image
 
-- (void)createAvailabilityView {
-    [self.userImageViewContainer addSubview:self.availabilityView];
-}
-
 - (void)createUserImageView
 {
-    self.userImageViewContainer = [[UIView alloc] initForAutoLayout];
-    [self.view addSubview:self.userImageViewContainer];
-    
     self.userImageView = [[UserImageView alloc] initWithMagicPrefix:@"profile.user_image"];
     self.userImageView.userSession = [ZMUserSession sharedSession];
     self.userImageView.translatesAutoresizingMaskIntoConstraints = NO;
     self.userImageView.size = UserImageViewSizeBig;
     self.userImageView.user = self.bareUser;
-    [self.userImageViewContainer addSubview:self.userImageView];
 }
 
 - (void)createTeamsGuestLabel
@@ -175,7 +158,7 @@ typedef NS_ENUM(NSUInteger, ProfileUserAction) {
     self.teamsGuestLabel = [[UILabel alloc] initForAutoLayout];
     self.teamsGuestLabel.numberOfLines = 0;
     self.teamsGuestLabel.textAlignment = NSTextAlignmentCenter;
-    [self.userImageViewContainer addSubview:self.teamsGuestLabel];
+    [self.teamsGuestLabel setContentCompressionResistancePriority:1000 forAxis:UILayoutConstraintAxisVertical];
     self.teamsGuestLabel.text = NSLocalizedString(@"profile.details.guest", nil);
 }
 

--- a/WireExtensionComponents/Views/AvatarImageView.m
+++ b/WireExtensionComponents/Views/AvatarImageView.m
@@ -65,6 +65,7 @@
     
     [self.containerView autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsZero];
     [self.imageView autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsZero];
+    [self.imageView autoMatchDimension:ALDimensionWidth toDimension:ALDimensionHeight ofView:self.imageView];
     [self.initials autoCenterInSuperview];
     
     [self updateCornerRadius];
@@ -73,7 +74,7 @@
 - (void)updateCornerRadius
 {
     if (self.circular) {
-        self.containerView.layer.cornerRadius = self.bounds.size.width / 2;
+        self.containerView.layer.cornerRadius = MIN(self.bounds.size.width, self.bounds.size.height) / 2;
     }
 }
 


### PR DESCRIPTION
### Issues

On smaller screens the availability status would overflow the screen space.

### Solutions

Re-arrange the screen so that we we'll shrink the user image until all elements fit on the screen.

## Notes

This also fixes showing the availability status in personal accounts on the  user profile screen.
