### PR TITLE
Added Mixpanel events for Availability

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -198,6 +198,7 @@
 		6DC7310EF4FE22057C3A6DC8 /* libPods-Wire-iOS-Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CC9C38FFEE2CB1B4A68D125E /* libPods-Wire-iOS-Tests.a */; };
 		7C17ECA51F74F4540056600C /* ConversationCell+Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C17ECA41F74F4540056600C /* ConversationCell+Preview.swift */; };
 		7C17ECA81F7508980056600C /* CellSizesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C17ECA71F7508980056600C /* CellSizesProvider.swift */; };
+		7C232CD91FE029BD00792E9B /* Analytics+Availability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C232CD81FE029BD00792E9B /* Analytics+Availability.swift */; };
 		7C4918A11F8BB1A20038AF4B /* UIScreen+SafeArea.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C4918A01F8BB1A20038AF4B /* UIScreen+SafeArea.swift */; };
 		7C5836641FD5ABE7001CC843 /* AvailabilityTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C5836631FD5ABE7001CC843 /* AvailabilityTitleView.swift */; };
 		7C5836661FD5ABFE001CC843 /* TitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C5836651FD5ABFE001CC843 /* TitleView.swift */; };
@@ -1309,6 +1310,7 @@
 		7C17ECA41F74F4540056600C /* ConversationCell+Preview.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ConversationCell+Preview.swift"; sourceTree = "<group>"; };
 		7C17ECA61F74F7710056600C /* PreviewProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PreviewProvider.h; sourceTree = "<group>"; };
 		7C17ECA71F7508980056600C /* CellSizesProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CellSizesProvider.swift; sourceTree = "<group>"; };
+		7C232CD81FE029BD00792E9B /* Analytics+Availability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Analytics+Availability.swift"; sourceTree = "<group>"; };
 		7C4918A01F8BB1A20038AF4B /* UIScreen+SafeArea.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScreen+SafeArea.swift"; sourceTree = "<group>"; };
 		7C5836631FD5ABE7001CC843 /* AvailabilityTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailabilityTitleView.swift; sourceTree = "<group>"; };
 		7C5836651FD5ABFE001CC843 /* TitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleView.swift; sourceTree = "<group>"; };
@@ -3163,6 +3165,7 @@
 				871BBFDF1D34F56300DF0793 /* AnalyticsSearchResultEvent.h */,
 				871BBFE01D34F56300DF0793 /* AnalyticsSearchResultEvent.m */,
 				87D38F9B1E5D9EE0004C5730 /* Analytics+Settings.swift */,
+				7C232CD81FE029BD00792E9B /* Analytics+Availability.swift */,
 			);
 			path = Events;
 			sourceTree = "<group>";
@@ -6594,6 +6597,7 @@
 				871BC00B1D34F56300DF0793 /* Analytics+CallEvents.m in Sources */,
 				EF21271D1FB9DFE300625A9B /* AddEmailPasswordViewController.m in Sources */,
 				871BC3591D34F94200DF0793 /* AudioTrackView.m in Sources */,
+				7C232CD91FE029BD00792E9B /* Analytics+Availability.swift in Sources */,
 				166390D41DC34CAB00D7BF1C /* ImageToolbarView.swift in Sources */,
 				16E2A0A41F6BF0C6005F4DB1 /* AnalyticsVoiceChannelTracker.swift in Sources */,
 				871BC0011D34F56300DF0793 /* AnalyticsConversationVerifiedObserver.m in Sources */,

--- a/Wire-iOS/Sources/Analytics/AnalyticsMixpanelProvider.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsMixpanelProvider.swift
@@ -63,6 +63,7 @@ final class AnalyticsMixpanelProvider: NSObject, AnalyticsProvider {
         conversationMediaCompleteActionEventName,
         "settings.opted_in_tracking",
         "settings.opted_out_tracking",
+        "settings.changed_status",
         "e2ee.failed_message_decyption",
         "start.opened_start_screen",
         "start.opened_person_registration",

--- a/Wire-iOS/Sources/Analytics/Events/Analytics+Availability.swift
+++ b/Wire-iOS/Sources/Analytics/Events/Analytics+Availability.swift
@@ -1,0 +1,43 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import Foundation
+
+private let availabilityChangedEventName = "settings.changed_status"
+private let availabilityChangedStatusKey = "status"
+private let availabilityChangedMethodKey = "method"
+
+enum AvailabilityStatusChangedSource: String {
+    case settings = "settings"
+    case listHeader = "list_header"
+}
+
+extension Analytics {
+    
+    func tagAvailabilityChanged(to availability: Availability, source: AvailabilityStatusChangedSource) {
+
+        let attributes = [
+            availabilityChangedStatusKey : availability.canonicalName,
+            availabilityChangedMethodKey : source.rawValue
+        ]
+        
+        tagEvent(availabilityChangedEventName, attributes: attributes)
+    }
+    
+}

--- a/Wire-iOS/Sources/UserInterface/Availability/AvailabilityTitleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Availability/AvailabilityTitleView.swift
@@ -81,8 +81,17 @@ import WireDataModel
     }
     
     func didSelectAvailability(_ availability: Availability) {
-        ZMUserSession.shared()?.performChanges {
+        ZMUserSession.shared()?.performChanges { [weak self] in
             ZMUser.selfUser().availability = availability
+            self?.trackChanges(with: availability)
+        }
+    }
+    
+    func trackChanges(with availability: Availability) {
+        switch style {
+            case .header:       do { Analytics.shared().tagAvailabilityChanged(to: availability, source: .listHeader)   }
+            case .selfProfile:  do { Analytics.shared().tagAvailabilityChanged(to: availability, source: .settings)     }
+            default: break
         }
     }
     


### PR DESCRIPTION
## What's new in this PR?

Added Mixpanel events tracking for Availability. They're inside `Analytics+Availability.swift`.
