### PR TITLE
Fix for crash with ! the user's display name

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ZMConversation+Status.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ZMConversation+Status.swift
@@ -418,6 +418,17 @@ final internal class FailedSendMatcher: ConversationStatusMatcher {
     var combinesWith: [ConversationStatusMatcher] = []
 }
 
+extension ZMUser {
+    func nameAsSender(in conversation: ZMConversation) -> String {
+        if self.isSelfUser {
+            return "conversation.status.you".localized
+        }
+        else {
+            return self.displayName(in: conversation) ?? self.displayName
+        }
+    }
+}
+
 // "[You|User] [added|removed|left] [_|users|you]"
 final internal class GroupActivityMatcher: TypedConversationStatusMatcher {
     let matchedTypes: [StatusMessageType] = [.addParticipants, .removeParticipants]
@@ -437,10 +448,10 @@ final internal class GroupActivityMatcher: TypedConversationStatusMatcher {
             }
             else {
                 let usersList = systemMessage.users.map { $0.displayName(in: conversation) }.joined(separator: ", ")
-                let sender = sender.isSelfUser ? "conversation.status.you".localized : sender.displayName(in: conversation)!
-                let result = String(format: "conversation.status.added_users".localized, sender, usersList) && type(of: self).regularStyle
                 
-                return self.addEmphasis(to: result, for: sender)
+                let result = String(format: "conversation.status.added_users".localized, sender.nameAsSender(in: conversation), usersList) && type(of: self).regularStyle
+                
+                return self.addEmphasis(to: result, for: sender.nameAsSender(in: conversation))
             }
         }
         return .none
@@ -476,9 +487,8 @@ final internal class GroupActivityMatcher: TypedConversationStatusMatcher {
                 }
                 else if type(of: self).indicate3rdPartiesRemoval {
                     let usersList = systemMessage.users.map { $0.displayName(in: conversation) }.joined(separator: ", ")
-                    let sender = sender.isSelfUser ? "conversation.status.you".localized : sender.displayName(in: conversation)!
-                    let result = "conversation.status.removed_users".localized(args: sender, usersList) && type(of: self).regularStyle
-                    return self.addEmphasis(to: result, for: sender)
+                    let result = "conversation.status.removed_users".localized(args: sender.nameAsSender(in: conversation), usersList) && type(of: self).regularStyle
+                    return self.addEmphasis(to: result, for: sender.nameAsSender(in: conversation))
                 }
                 else {
                     return .none


### PR DESCRIPTION
## What's new in this PR?

### Issues

According to Hockey, the users seems to be facing the crash loop with the crash in `ZMConversation+Status.swift:440`.

### Causes

The line of code seems harmless except the force unwrap of the user's display name. I failed to trace the particular case when user's display name in the conversation can be nil.

### Solutions

I fixed the force unwrap by using the fallback value for the name. Also I extracted the duplicated code into the separate method.
