### PR TITLE
ZIOS-9369 fix a crash in ConversationListViewController

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+StartUI.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+StartUI.m
@@ -54,14 +54,18 @@
                 
                 if (users.count == 1) {
                     ZMUser *user = users.anyObject;
-                    [[ZMUserSession sharedSession] enqueueChanges:^{
-                        conversation = user.oneToOneConversation;
-                    } completionHandler:^{
-                        [Analytics.shared tagOpenedExistingConversationWithType:conversation.conversationType];
-                        [[ZClientViewController sharedZClientViewController] selectConversation:conversation
-                                                                                    focusOnView:YES
-                                                                                       animated:YES];
-                    }];
+
+                    /// user can be a ZMSearchUser, do not have oneToOneConversation method
+                    if ([user respondsToSelector:@selector(oneToOneConversation)]) {
+                        [[ZMUserSession sharedSession] enqueueChanges:^{
+                            conversation = user.oneToOneConversation;
+                        } completionHandler:^{
+                            [Analytics.shared tagOpenedExistingConversationWithType:conversation.conversationType];
+                            [[ZClientViewController sharedZClientViewController] selectConversation:conversation
+                                                                                        focusOnView:YES
+                                                                                           animated:YES];
+                        }];
+                    }
                 }
                 else {
                     


### PR DESCRIPTION
## What's new in this PR?

### Issues

Crashes when tap a user in ConversationListViewController search user screen.

### Causes

In the method:
- (void)startUI:(StartUIViewController *)startUI didSelectUsers:(NSSet *)users forAction:(StartUIAction)action

users contains user that is a ZMSearchUser, which does not have oneToOneConversation method.

### Solutions

check the user object responds to the method oneToOneConversation.

