### PR TITLE
ZIOS-9348: PDF files shared from Google Drive causing the Share Extension to get stuck in Sending

### DIFF
--- a/Wire-iOS Share Extension/ShareExtensionAnalytics.swift
+++ b/Wire-iOS Share Extension/ShareExtensionAnalytics.swift
@@ -134,7 +134,7 @@ extension NSItemProvider {
     }
 
     var hasURL: Bool {
-        return hasItemConformingToTypeIdentifier(kUTTypeURL as String)
+        return hasItemConformingToTypeIdentifier(kUTTypeURL as String) && registeredTypeIdentifiers.count == 1
     }
 
     var hasVideo: Bool {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Extension sends the link of the file stored inside the app sandbox, but not the file. Also, the share extension is stuck on the "Sending" screen. 
Links look similar to this one: file:///var/mobile/Containers/Data/Application/F116986B-E4BE-43E6-9E5E-94C7835C7F2C/Documents/drivekit/users/115009962656775385314/files/1jdEpnsFN8SCuCr2ItUXElhy9BwX3Vu0glR7DmOag0eM/License%20Application.pdf

### Causes

When sharing a system item, like texts, images or videos, the resulting `NSItemProvider`contains only the UTI relative to the shared content, e.g. `public.image`. But, when sharing a file from an external app like Google Drive or Apple Files, `NSItemProvider`contains two UTI types. One is relative to the file itself, like `com.adobe.pdf` for PDF files. The other one is `public.url`, probably because the Item Provider contains a local reference to the file. Because of this, the shared item is recognized as a URL on `SendController.swift:68`, breaking the extension into the unexpected behavior.

### Solutions

I've added a control to `hasURL` which checks if the shared content has only one type associated. Together with checking if it's a `public.url` item, it should avoid this behavior.
