### PR TITLE
ZIOS-9347: Added support for switching between accounts in share extension

### DIFF
--- a/Wire-iOS Share Extension/AccountSelectionViewController.swift
+++ b/Wire-iOS Share Extension/AccountSelectionViewController.swift
@@ -40,7 +40,6 @@ class AccountSelectionViewController : UITableViewController {
         
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: cellReuseIdentifier)
         
-        //preferredContentSize = UIScreen.main.bounds.size
         definesPresentationContext = true
     }
     

--- a/Wire-iOS Share Extension/AccountSelectionViewController.swift
+++ b/Wire-iOS Share Extension/AccountSelectionViewController.swift
@@ -1,0 +1,81 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireExtensionComponents
+import WireShareEngine
+
+
+private let cellReuseIdentifier = "AccountCell"
+
+
+class AccountSelectionViewController : UITableViewController {
+    
+    fileprivate var accounts : [Account]
+    fileprivate var current : Account?
+    
+    var selectionHandler : ((_ account: Account) -> Void)?
+    
+    init(accounts: [Account], current: Account?) {
+        self.accounts = accounts
+        
+        super.init(style: .plain)
+        
+        self.current = current
+        
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: cellReuseIdentifier)
+        
+        //preferredContentSize = UIScreen.main.bounds.size
+        definesPresentationContext = true
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+    
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return accounts.count
+    }
+    
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let account = accounts[indexPath.row]
+        let cell = UITableViewCell(style: UITableViewCellStyle.subtitle, reuseIdentifier: cellReuseIdentifier)
+
+        cell.textLabel?.text = account.userName
+        cell.detailTextLabel?.text = account.teamName
+        cell.backgroundColor = .clear
+        cell.accessoryType = (account == current) ? .checkmark : .none
+        
+        return cell
+    }
+    
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        if let selectionHandler = selectionHandler {
+            selectionHandler(accounts[indexPath.row])
+        }
+    }
+}
+

--- a/Wire-iOS Share Extension/Base.lproj/Localizable.strings
+++ b/Wire-iOS Share Extension/Base.lproj/Localizable.strings
@@ -20,6 +20,7 @@
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Share Extension
 
+"share_extension.conversation_selection.account" = "Account:";
 "share_extension.conversation_selection.title" = "Conversation:";
 "share_extension.send_button.title" = "Send";
 "share_extension.conversation_selection.empty.value" = "Choose";

--- a/Wire-iOS Share Extension/ShareExtensionViewController.swift
+++ b/Wire-iOS Share Extension/ShareExtensionViewController.swift
@@ -31,6 +31,18 @@ private let progressDisplayDelay: TimeInterval = 0.5
 
 class ShareExtensionViewController: SLComposeServiceViewController {
     
+    lazy var accountItem : SLComposeSheetConfigurationItem = { [weak self] in
+        let item = SLComposeSheetConfigurationItem()!
+        let accountName = self?.accountManager?.selectedAccount?.userName
+        
+        item.title = "share_extension.conversation_selection.account".localized
+        item.value = accountName ?? "share_extension.conversation_selection.empty.value".localized
+        item.tapHandler = { [weak self] in
+            self?.presentChooseAccount()
+        }
+        return item
+    }()
+    
     lazy var conversationItem : SLComposeSheetConfigurationItem = {
         let item = SLComposeSheetConfigurationItem()!
         
@@ -109,23 +121,31 @@ class ShareExtensionViewController: SLComposeServiceViewController {
         }
     }
 
-    private func recreateSharingSession() {
-        let infoDict = Bundle.main.infoDictionary
+    private var applicationGroupIdentifier: String? {
+        return Bundle.main.infoDictionary?["ApplicationGroupIdentifier"] as? String
+    }
     
-        guard
-            let applicationGroupIdentifier = infoDict?["ApplicationGroupIdentifier"] as? String,
-            let hostBundleIdentifier = infoDict?["HostBundleIdentifier"] as? String
+    private var hostBundleIdentifier: String? {
+        return Bundle.main.infoDictionary?["HostBundleIdentifier"] as? String
+    }
+    
+    private func recreateSharingSession() {
+        guard let applicationGroupIdentifier = applicationGroupIdentifier,
+            let hostBundleIdentifier = hostBundleIdentifier,
+            let accountIdentifier = accountManager?.selectedAccount?.userIdentifier
         else { return }
         
-        let sharedContainerURL = FileManager.sharedContainerDirectory(for: applicationGroupIdentifier)
-        let accountManager = AccountManager(sharedDirectory: sharedContainerURL)
-        guard let accountIdentifier = accountManager.selectedAccount?.userIdentifier else { return }
-
         sharingSession = try? SharingSession(
             applicationGroupIdentifier: applicationGroupIdentifier,
             accountIdentifier: accountIdentifier,
             hostBundleIdentifier: hostBundleIdentifier
         )
+    }
+    
+    private var accountManager: AccountManager? {
+        guard let applicationGroupIdentifier = applicationGroupIdentifier else { return nil }
+        let sharedContainerURL = FileManager.sharedContainerDirectory(for: applicationGroupIdentifier)
+        return AccountManager(sharedDirectory: sharedContainerURL)
     }
 
     override func isContentValid() -> Bool {
@@ -239,7 +259,11 @@ class ShareExtensionViewController: SLComposeServiceViewController {
     }
     
     override func configurationItems() -> [Any]! {
-        return [conversationItem]
+        if accountManager?.accounts.count > 1 {
+            return [accountItem, conversationItem]
+        } else {
+            return [conversationItem]
+        }
     }
     
     private func presentSendingProgress(mode: SendingProgressViewController.ProgressMode) {
@@ -272,6 +296,26 @@ class ShareExtensionViewController: SLComposeServiceViewController {
         extensionActivity?.conversation = conversation
     }
     
+    func updateAccount(_ account: Account?) {
+        guard let accountManager = self.accountManager, let account = account,
+            account != accountManager.selectedAccount else { return }
+        
+        accountManager.select(account)
+        accountItem.value = account.userName
+        conversationItem.value = "share_extension.conversation_selection.empty.value".localized
+        postContent?.target = nil
+        extensionActivity?.conversation = nil
+        recreateSharingSession()
+    }
+    
+    private func presentChooseAccount() {
+        requireLocalAuthenticationIfNeeded(with: { [weak self] (granted) in
+            if granted == nil || (granted != nil && granted!) {
+                self?.showChooseAccount()
+            }
+        })
+    }
+    
     private func presentChooseConversation() {
         requireLocalAuthenticationIfNeeded(with: { [weak self] (granted) in
             if granted == nil || (granted != nil && granted!) {
@@ -294,6 +338,21 @@ class ShareExtensionViewController: SLComposeServiceViewController {
         }
         
         pushConfigurationViewController(conversationSelectionViewController)
+    }
+    
+    func showChooseAccount() {
+        
+        guard let accountManager = accountManager else { return }
+        let accountSelectionViewController = AccountSelectionViewController(accounts: accountManager.accounts,
+                                                                                 current: accountManager.selectedAccount)
+        
+        accountSelectionViewController.selectionHandler = { [weak self] account in
+            self?.updateAccount(account)
+            self?.popConfigurationViewController()
+            self?.validateContent()
+        }
+        
+        pushConfigurationViewController(accountSelectionViewController)
     }
 
     /// @param callback confirmation; if the auth is not needed or is not possible on the current device called with '.none'

--- a/Wire-iOS Share Extension/ShareExtensionViewController.swift
+++ b/Wire-iOS Share Extension/ShareExtensionViewController.swift
@@ -33,7 +33,7 @@ class ShareExtensionViewController: SLComposeServiceViewController {
     
     lazy var accountItem : SLComposeSheetConfigurationItem = { [weak self] in
         let item = SLComposeSheetConfigurationItem()!
-        let accountName = self?.accountManager?.selectedAccount?.userName
+        let accountName = self?.currentAccount?.userName
         
         item.title = "share_extension.conversation_selection.account".localized
         item.value = accountName ?? "share_extension.conversation_selection.empty.value".localized
@@ -57,6 +57,7 @@ class ShareExtensionViewController: SLComposeServiceViewController {
     fileprivate var postContent: PostContent?
     fileprivate var sharingSession: SharingSession? = nil
     fileprivate var extensionActivity: ExtensionActivity? = nil
+    fileprivate var currentAccount: Account? = nil
 
     private var observer: SendableBatchObserver? = nil
     private weak var progressViewController: SendingProgressViewController? = nil
@@ -79,6 +80,7 @@ class ShareExtensionViewController: SLComposeServiceViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        currentAccount = accountManager?.selectedAccount
         ExtensionBackupExcluder.exclude()
         CrashReporter.setupHockeyIfNeeded()
         navigationController?.view.backgroundColor = .white
@@ -132,7 +134,7 @@ class ShareExtensionViewController: SLComposeServiceViewController {
     private func recreateSharingSession() {
         guard let applicationGroupIdentifier = applicationGroupIdentifier,
             let hostBundleIdentifier = hostBundleIdentifier,
-            let accountIdentifier = accountManager?.selectedAccount?.userIdentifier
+            let accountIdentifier = currentAccount?.userIdentifier
         else { return }
         
         sharingSession = try? SharingSession(
@@ -297,10 +299,9 @@ class ShareExtensionViewController: SLComposeServiceViewController {
     }
     
     func updateAccount(_ account: Account?) {
-        guard let accountManager = self.accountManager, let account = account,
-            account != accountManager.selectedAccount else { return }
+        guard let account = account, account != currentAccount else { return }
         
-        accountManager.select(account)
+        currentAccount = account
         accountItem.value = account.userName
         conversationItem.value = "share_extension.conversation_selection.empty.value".localized
         postContent?.target = nil
@@ -344,7 +345,7 @@ class ShareExtensionViewController: SLComposeServiceViewController {
         
         guard let accountManager = accountManager else { return }
         let accountSelectionViewController = AccountSelectionViewController(accounts: accountManager.accounts,
-                                                                                 current: accountManager.selectedAccount)
+                                                                            current: currentAccount)
         
         accountSelectionViewController.selectionHandler = { [weak self] account in
             self?.updateAccount(account)

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -195,6 +195,7 @@
 		54F7C2851D746F3F004D8087 /* AddressBookHelper+Automation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F7C2841D746F3F004D8087 /* AddressBookHelper+Automation.swift */; };
 		54FF9E281E813BA500323D2E /* DebugAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54FF9E271E813BA500323D2E /* DebugAlert.swift */; };
 		6DC7310EF4FE22057C3A6DC8 /* libPods-Wire-iOS-Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CC9C38FFEE2CB1B4A68D125E /* libPods-Wire-iOS-Tests.a */; };
+		7C0BB6E61FE682A200386A19 /* AccountSelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C0BB6E41FE680F200386A19 /* AccountSelectionViewController.swift */; };
 		7C17ECA51F74F4540056600C /* ConversationCell+Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C17ECA41F74F4540056600C /* ConversationCell+Preview.swift */; };
 		7C17ECA81F7508980056600C /* CellSizesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C17ECA71F7508980056600C /* CellSizesProvider.swift */; };
 		7C232CD91FE029BD00792E9B /* Analytics+Availability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C232CD81FE029BD00792E9B /* Analytics+Availability.swift */; };
@@ -1306,6 +1307,7 @@
 		597184FEC66FBCEC21973EDC /* Pods-WireExtensionComponents.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WireExtensionComponents.release.xcconfig"; path = "Pods/Target Support Files/Pods-WireExtensionComponents/Pods-WireExtensionComponents.release.xcconfig"; sourceTree = "<group>"; };
 		64D671EBEE8C57217EB00733 /* Pods-Wire-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Wire-iOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-Wire-iOS/Pods-Wire-iOS.release.xcconfig"; sourceTree = "<group>"; };
 		7190BAB91AC2BC0874284A71 /* Pods-WireExtensionComponents.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WireExtensionComponents.debug.xcconfig"; path = "Pods/Target Support Files/Pods-WireExtensionComponents/Pods-WireExtensionComponents.debug.xcconfig"; sourceTree = "<group>"; };
+		7C0BB6E41FE680F200386A19 /* AccountSelectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSelectionViewController.swift; sourceTree = "<group>"; };
 		7C17ECA41F74F4540056600C /* ConversationCell+Preview.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ConversationCell+Preview.swift"; sourceTree = "<group>"; };
 		7C17ECA61F74F7710056600C /* PreviewProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PreviewProvider.h; sourceTree = "<group>"; };
 		7C17ECA71F7508980056600C /* CellSizesProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CellSizesProvider.swift; sourceTree = "<group>"; };
@@ -2710,6 +2712,7 @@
 				BFBE45761E36205F009FBF60 /* Error+Logging.swift */,
 				BF96A6C31E2F845E0057974A /* UnsentSendable.swift */,
 				543E0C611E2394E7000E2161 /* ConversationSelectionViewController.swift */,
+				7C0BB6E41FE680F200386A19 /* AccountSelectionViewController.swift */,
 				F1D0445E1ED8675200EAC1DA /* TeamSelectionViewController.swift */,
 				543E0C651E23A72F000E2161 /* SendingProgressViewController.swift */,
 				BF96A6C91E2FD3340057974A /* SLComposeServiceViewController+Attachments.swift */,
@@ -5865,6 +5868,7 @@
 				BF96A6CC1E2FD3BA0057974A /* NSItemProvider+Fetching.swift in Sources */,
 				BF9AEE161E4A0BA20005FBA7 /* CrashReporter.swift in Sources */,
 				168A16AC1D9597C2005CFA6C /* ShareExtensionViewController.swift in Sources */,
+				7C0BB6E61FE682A200386A19 /* AccountSelectionViewController.swift in Sources */,
 				543E0C661E23A72F000E2161 /* SendingProgressViewController.swift in Sources */,
 				BF2756DB1E38E16D00082786 /* ShareExtensionAnalytics.swift in Sources */,
 				BF96A6C81E2FC7B60057974A /* SendController.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Issues

Currently, it's not possible to switch between accounts inside the Share Extension. You should open the container app and open the Self Profile view. It's pretty annoying!  😄

### Solutions

I've added the possibility to switch between accounts. The behavior is similar to the one already implemented for choosing conversations: if multiple accounts are logged into the app, the "Account" row appears before the "Conversation" row. Then you can select which account to switch. If the user is in a team, you'll also see the name of the team in the account selection view.

![simulator screen shot - iphone x - 2017-12-17 at 12 20 17](https://user-images.githubusercontent.com/2906234/34079006-c71cbc00-e324-11e7-91b4-91afa70737c1.png)
![simulator screen shot - iphone x - 2017-12-17 at 12 20 22](https://user-images.githubusercontent.com/2906234/34079007-c74334d4-e324-11e7-9d0f-8aa196f3c6da.png)


