### PR TITLE
Changed "Choose a status" label to "Set a status"

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -1041,7 +1041,6 @@
 "compose.drafts.compose.dismiss.confirm.action.title" = "Save";
 "compose.drafts.compose.dismiss.delete.action.title" = "Delete";
 
-"availability.message.title" = "Choose a status";
 "availability.message.cancel" = "Cancel";
 "availability.message.set_status" = "Set a status";
 

--- a/Wire-iOS/Sources/UserInterface/Availability/AvailabilityTitleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Availability/AvailabilityTitleView.swift
@@ -103,7 +103,7 @@ extension AvailabilityTitleView {
     
     var actionSheet: UIAlertController {
         get {
-            let alert = UIAlertController(title: "availability.message.title".localized, message: nil, preferredStyle: .actionSheet)
+            let alert = UIAlertController(title: "availability.message.set_status".localized, message: nil, preferredStyle: .actionSheet)
             for type in Availability.allValues {
                 alert.addAction(UIAlertAction(title: type.localizedName, style: .default, handler: { [weak self] (action) in
                     self?.didSelectAvailability(type)


### PR DESCRIPTION
## What's new in this PR?

Changed "Choose a status" label for Availability ActionSheet to "Set a status"