### PR TITLE
Fix crash in Wire.AudioMessageCell prepareForReuse()

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/AudioMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/AudioMessageCell.swift
@@ -142,6 +142,8 @@ public final class AudioMessageCell: ConversationCell {
     }
     
     override open func menuConfigurationProperties() -> MenuConfigurationProperties! {
+        guard let _ = message else {return nil}
+
         let properties = MenuConfigurationProperties()
         properties.targetRect = selectionRect
         properties.targetView = selectionView


### PR DESCRIPTION
## What's new in this PR?

### Issues

App crashes when AudioMessageCell is calling prepareForReuse()

### Causes

AudioMessageCell gets class member var message (type: id< ZMConversationMessage >), which may be nil at that time point.

### Solutions

Add a nil check guard in menuConfigurationProperties() (which is called in ConversationCell.prepareForReuse())