### PR TITLE
Fixed bug with availability icon color on Add People screen

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Availability/AvailabilityStringBuilder.swift
+++ b/Wire-iOS/Sources/UserInterface/Availability/AvailabilityStringBuilder.swift
@@ -28,8 +28,10 @@
         switch style {
             case .list: do {
                 title = user.name
-                color = ColorScheme.default().color(withName: ColorSchemeColorTextForeground, variant: .dark)
                 fontSize = .normal
+                if color == nil {
+                    color = ColorScheme.default().color(withName: ColorSchemeColorTextForeground, variant: .dark)
+                }
             }
             case .participants: do {
                 title = user.displayName.uppercased()

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/Cells/SearchResultCell.m
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/Cells/SearchResultCell.m
@@ -248,7 +248,8 @@
     ZMUser *fullUser = BareUserToUser(self.user);
     
     if (fullUser != nil && ZMUser.selfUser.isTeamMember) {
-        self.nameLabel.attributedText = [AvailabilityStringBuilder stringFor:fullUser with:AvailabilityLabelStyleList color:nil];
+        UIColor *textColor = [[ColorScheme defaultColorScheme] colorWithName:ColorSchemeColorTextForeground variant:self.colorSchemeVariant];
+        self.nameLabel.attributedText = [AvailabilityStringBuilder stringFor:fullUser with:AvailabilityLabelStyleList color:textColor];
     } else {
         self.nameLabel.text = self.user.name;
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

The color of the Availability icon was white on the Add People screen, with the light theme activated.

### Causes

This was caused by the default behavior of the label, which was taking the dark variant (= white text color).

### Solutions

I'm passing the right icon color when asking the function `[AvailabilityStringBuilder stringFor:fullUser with:AvailabilityLabelStyleList color:textColor]`.