### PR TITLE
Fixed start UI camera picker using iOS integrated one (iPhone X)

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/CameraPicker.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/CameraPicker.swift
@@ -30,6 +30,8 @@ enum CameraPickerResult {
 final public class CameraPicker: NSObject {
     weak var target: UIViewController? = .none
     var didPickResult: ((CameraPickerResult)->())? = .none
+    var didPickImage: ((UIImage)->())? = .none
+    var didPickVideo: ((URL)->())? = .none
     
     init(target: UIViewController) {
         self.target = target
@@ -134,6 +136,7 @@ extension CameraPicker: UIImagePickerControllerDelegate, UINavigationControllerD
             
                 self.target?.dismiss(animated: true) {
                     self.didPickResult?(.video(url))
+                    self.didPickVideo?(url)
                     self.finishPicking()
                 }
             }
@@ -145,6 +148,7 @@ extension CameraPicker: UIImagePickerControllerDelegate, UINavigationControllerD
             
             target?.dismiss(animated: true) {
                 self.didPickResult?(.image(image))
+                self.didPickImage?(image)
                 self.finishPicking()
             }
         default:

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+StartUI.h
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+StartUI.h
@@ -21,5 +21,4 @@
 #import "CameraViewController.h"
 
 @interface ConversationListViewController ()
-@property (nonatomic) NSSet *startUISelectedUsers;
 @end

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+StartUI.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+StartUI.m
@@ -26,11 +26,49 @@
 
 #import "Wire-Swift.h"
 
-@interface ConversationListViewController (StartUI) <CameraViewControllerDelegate>
+@import MobileCoreServices;
+
+@interface ConversationListViewController (StartUI)
 
 @end
 
+typedef void (^ConversationCreatedBlock)(ZMConversation *);
+
 @implementation ConversationListViewController (StartUI)
+
+- (void)withConversationForUsers:(NSSet<ZMUser *>*)users callback:(ConversationCreatedBlock)onConversationCreated {
+    
+    [self dismissPeoplePickerWithCompletionBlock:^{
+        if (users.count == 1) {
+            
+            ZMUser *user = users.anyObject;
+            if ([user respondsToSelector:@selector(oneToOneConversation)]) {
+                ZMConversation *oneToOneConversation = user.oneToOneConversation;
+                
+                onConversationCreated(oneToOneConversation);
+            }
+        }
+        else if (users.count > 1) {
+            
+            ZMConversation __block *conversation = nil;
+            [[ZMUserSession sharedSession] enqueueChanges:^{
+                Team *team = ZMUser.selfUser.team;
+
+                conversation = [ZMConversation insertGroupConversationIntoUserSession:[ZMUserSession sharedSession]
+                                                                     withParticipants:users.allObjects
+                                                                               inTeam:team];
+            } completionHandler:^{
+                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.3 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                    onConversationCreated(conversation);
+                });
+                
+                AnalyticsGroupConversationEvent *event = [AnalyticsGroupConversationEvent eventForCreatedGroupWithContext:CreatedGroupContextStartUI
+                                                                                                         participantCount:conversation.activeParticipants.count]; // Include self
+                [[Analytics shared] tagEventObject:event];
+            }];
+        }
+    }];
+}
 
 #pragma mark - People picker delegate
 
@@ -41,42 +79,76 @@
         
         return;
     }
-    BOOL call = NO;
-    BOOL videoCall = NO;
     
-    Team *team = ZMUser.selfUser.team;
+    BOOL videoCall = NO;
     
     switch (action) {
         case StartUIActionCreateOrOpenConversation:
         {
+            [self withConversationForUsers:users callback:^(ZMConversation *conversation) {
+                [[ZClientViewController sharedZClientViewController] selectConversation:conversation
+                                                                            focusOnView:YES
+                                                                               animated:YES];
+            }];
+        }
+            break;
+        case StartUIActionVideoCall:
+        {
+            videoCall = YES;
+            // fallthrough
+        }
+        case StartUIActionCall:
+        {
             [self dismissPeoplePickerWithCompletionBlock:^{
-                __block ZMConversation *conversation = nil;
-                
                 if (users.count == 1) {
+                    __block ZMConversation *conversation = nil;
                     ZMUser *user = users.anyObject;
-
-                    /// user can be a ZMSearchUser, do not have oneToOneConversation method
+                    
                     if ([user respondsToSelector:@selector(oneToOneConversation)]) {
                         [[ZMUserSession sharedSession] enqueueChanges:^{
                             conversation = user.oneToOneConversation;
                         } completionHandler:^{
-                            [Analytics.shared tagOpenedExistingConversationWithType:conversation.conversationType];
                             [[ZClientViewController sharedZClientViewController] selectConversation:conversation
                                                                                         focusOnView:YES
                                                                                            animated:YES];
+                            @weakify(self);
+                            self.startCallToken =
+                            [conversation onCreatedRemotely:^{
+                                @strongify(self);
+                                if (videoCall) {
+                                    [conversation startVideoCall];
+                                }
+                                else {
+                                    [conversation startAudioCall];
+                                }
+                                self.startCallToken = nil;
+                            }];
                         }];
                     }
                 }
-                else {
+                else if (users.count > 1) {
+                    
+                    ZMConversation __block *conversation = nil;
                     
                     [[ZMUserSession sharedSession] enqueueChanges:^{
+                        Team *team = ZMUser.selfUser.team;
+                        
                         conversation = [ZMConversation insertGroupConversationIntoUserSession:[ZMUserSession sharedSession]
                                                                              withParticipants:users.allObjects
                                                                                        inTeam:team];
                     } completionHandler:^{
+                        
                         [[ZClientViewController sharedZClientViewController] selectConversation:conversation
                                                                                     focusOnView:YES
                                                                                        animated:YES];
+                        
+                        @weakify(self);
+                        self.startCallToken =
+                        [conversation onCreatedRemotely:^{
+                            @strongify(self);
+                            [conversation startAudioCall];
+                            self.startCallToken = nil;
+                        }];
                         
                         AnalyticsGroupConversationEvent *event = [AnalyticsGroupConversationEvent eventForCreatedGroupWithContext:CreatedGroupContextStartUI
                                                                                                                  participantCount:conversation.activeParticipants.count]; // Include self
@@ -86,89 +158,42 @@
             }];
         }
             break;
-        case StartUIActionVideoCall:
-            call = YES;
-            videoCall = YES;
-            break;
-        case StartUIActionCall:
-            call = YES;
-            videoCall = NO;
-            break;
-            break;
         case StartUIActionPostPicture:
         {
-            self.startUISelectedUsers = users;
-            CameraViewController *cameraViewController = [[CameraViewController alloc] init];
-            cameraViewController.savePhotosToCameraRoll = YES;
-            cameraViewController.delegate = self;
+            CameraPicker *picker = [[CameraPicker alloc] initWithTarget:self];
+            picker.didPickImage = ^(UIImage *image) {
+                NSData *imageData = UIImageJPEGRepresentation(image, 0.9);
+                [self withConversationForUsers:users callback:^(ZMConversation *conversation) {
+                    [[ZMUserSession sharedSession] enqueueChanges:^{
+                        [conversation appendMessageWithImageData:imageData];
+                    } completionHandler:^{
+                        [[Analytics shared] tagMediaAction:ConversationMediaActionPhoto inConversation:conversation];
+                        [[Analytics shared] tagMediaActionCompleted:ConversationMediaActionPhoto inConversation:conversation];
+                        [[ZClientViewController sharedZClientViewController] selectConversation:conversation
+                                                                                    focusOnView:YES
+                                                                                       animated:YES];
+                    }];
+                }];
+            };
+            picker.didPickVideo = ^(NSURL *videoURL) {
+                [self withConversationForUsers:users callback:^(ZMConversation *conversation) {
+                    [FileMetaDataGenerator metadataForFileAtURL:videoURL
+                                                            UTI:(NSString *)kUTTypeMovie
+                                                           name:@"Recording"
+                                                     completion:^(ZMFileMetadata * metadata) {
+                                                         [conversation appendMessageWithFileMetadata:metadata];
+                                                         [[ZClientViewController sharedZClientViewController] selectConversation:conversation
+                                                                                                                     focusOnView:YES
+                                                                                                                        animated:YES];
+                                                     }];
+                }];
+            };
             
-            if (users.count == 1) {
-                ZMUser *user = users.anyObject;
-                
-                cameraViewController.previewTitle = [user.displayName uppercasedWithCurrentLocale];
-            }
-            
-            [self presentViewController:cameraViewController animated:YES completion:nil];
+            [picker pick];
         }
             break;
         default:
             break;
-    }
-    
-    if (call) {
-        [self dismissPeoplePickerWithCompletionBlock:^{
-            if (users.count == 1) {
-                __block ZMConversation *conversation = nil;
-                ZMUser *user = users.anyObject;
-
-                [[ZMUserSession sharedSession] enqueueChanges:^{
-                    conversation = user.oneToOneConversation;
-                } completionHandler:^{
-                    [[ZClientViewController sharedZClientViewController] selectConversation:conversation
-                                                                                focusOnView:YES
-                                                                                   animated:YES];
-                    @weakify(self);
-                    self.startCallToken =
-                    [conversation onCreatedRemotely:^{
-                        @strongify(self);
-                        if (videoCall) {
-                            [conversation startVideoCall];
-                        }
-                        else {
-                            [conversation startAudioCall];
-                        }
-                        self.startCallToken = nil;
-                    }];
-                }];
-            }
-            else if (users.count > 1) {
-                
-                ZMConversation __block *conversation = nil;
-                
-                [[ZMUserSession sharedSession] enqueueChanges:^{
-                    conversation = [ZMConversation insertGroupConversationIntoUserSession:[ZMUserSession sharedSession]
-                                                                         withParticipants:users.allObjects
-                                                                                   inTeam:team];
-                } completionHandler:^{
-                    
-                    [[ZClientViewController sharedZClientViewController] selectConversation:conversation
-                                                                                focusOnView:YES
-                                                                                   animated:YES];
-                    
-                    @weakify(self);
-                    self.startCallToken =
-                    [conversation onCreatedRemotely:^{
-                        @strongify(self);
-                        [conversation startAudioCall];
-                        self.startCallToken = nil;
-                    }];
-                    
-                    AnalyticsGroupConversationEvent *event = [AnalyticsGroupConversationEvent eventForCreatedGroupWithContext:CreatedGroupContextStartUI
-                                                                                                             participantCount:conversation.activeParticipants.count]; // Include self
-                    [[Analytics shared] tagEventObject:event];
-                }];
-            }
-        }];
     }
     
     [[Analytics shared] tagEventObject:[AnalyticsSearchResultEvent eventForSearchResultUsed:YES participantCount:[users count]]];
@@ -190,76 +215,6 @@
                                                                     focusOnView:YES
                                                                        animated:YES];
     }];
-}
-
-#pragma mark - CameraViewControllerDelegate
-
-- (void)cameraViewControllerDidCancel:(CameraViewController *)cameraViewController
-{
-    [self dismissViewControllerAnimated:YES completion:nil];
-    
-}
-
-- (void)cameraViewController:(CameraViewController *)cameraViewController didPickImageData:(NSData *)imageData imageMetadata:(ImageMetadata *)metadata
-{
-    Team *team = ZMUser.selfUser.team;
-
-    [self dismissViewControllerAnimated:YES completion:^() {
-        [self dismissPeoplePickerWithCompletionBlock:^{
-            
-            if (self.startUISelectedUsers.count == 1) {
-                
-                ZMUser *user = self.startUISelectedUsers.anyObject;
-                ZMConversation *oneToOneConversation = user.oneToOneConversation;
-                
-                [[ZMUserSession sharedSession] enqueueChanges:^{
-                    [oneToOneConversation appendMessageWithImageData:imageData];
-                } completionHandler:^{
-                    [[Analytics shared] tagMediaAction:ConversationMediaActionPhoto inConversation:oneToOneConversation];
-                    [[Analytics shared] tagMediaActionCompleted:ConversationMediaActionPhoto inConversation:oneToOneConversation];
-                    
-                    [[Analytics shared] tagMediaSentPictureInConversation:oneToOneConversation
-                                                                 metadata:metadata];
-                    [[ZClientViewController sharedZClientViewController] selectConversation:oneToOneConversation
-                                                                                focusOnView:YES
-                                                                                   animated:YES];
-                }];
-                self.startUISelectedUsers = nil;
-            }
-            else if (self.startUISelectedUsers.count > 1) {
-                
-                ZMConversation __block *conversation = nil;
-                @weakify(self);
-                [[ZMUserSession sharedSession] enqueueChanges:^{
-                    conversation = [ZMConversation insertGroupConversationIntoUserSession:[ZMUserSession sharedSession]
-                                                                         withParticipants:self.startUISelectedUsers.allObjects
-                                                                                   inTeam:team];
-                } completionHandler:^{
-                    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.3 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-                        [[ZMUserSession sharedSession] enqueueChanges:^{
-                            [conversation appendMessageWithImageData:imageData];
-                        } completionHandler:^{
-                            [[Analytics shared] tagMediaAction:ConversationMediaActionPhoto inConversation:conversation];
-                            [[Analytics shared] tagMediaActionCompleted:ConversationMediaActionPhoto inConversation:conversation];
-                            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.3 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-                                [[ZClientViewController sharedZClientViewController] selectConversation:conversation
-                                                                                            focusOnView:YES
-                                                                                               animated:YES];
-                            });
-                        }];
-                    });
-                    
-                    @strongify(self);
-                    AnalyticsGroupConversationEvent *event = [AnalyticsGroupConversationEvent eventForCreatedGroupWithContext:CreatedGroupContextStartUI
-                                                                                                             participantCount:conversation.activeParticipants.count]; // Include self
-                    [[Analytics shared] tagEventObject:event];
-                    
-                    self.startUISelectedUsers = nil;
-                }];
-            }
-        }];
-    }];
-    
 }
 
 @end

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+StartUI.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+StartUI.m
@@ -58,9 +58,7 @@ typedef void (^ConversationCreatedBlock)(ZMConversation *);
                                                                      withParticipants:users.allObjects
                                                                                inTeam:team];
             } completionHandler:^{
-                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.3 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-                    onConversationCreated(conversation);
-                });
+                onConversationCreated(conversation);
                 
                 AnalyticsGroupConversationEvent *event = [AnalyticsGroupConversationEvent eventForCreatedGroupWithContext:CreatedGroupContextStartUI
                                                                                                          participantCount:conversation.activeParticipants.count]; // Include self

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController.m
@@ -122,7 +122,6 @@
 
 
 @implementation ConversationListViewController
-@synthesize startUISelectedUsers;
 
 - (void)dealloc
 {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Users noticed that on iPhone X the custom picture picker camera UI is pretty broken. In other places of the app the custom UI seems to work fine.

### Solutions

I decided to replace the custom UI with iOS integrated one, since then we don't have the overhead of supporting it.

