### PR TITLE
iPhone X: fixed UI issues with Accessory view of Search Results View Controller

### DIFF
--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsView.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsView.swift
@@ -65,12 +65,9 @@ class SearchResultsView : UIView {
     func createConstraints() {
         
         constrain(self, collectionView, accessoryContainer, emptyResultContainer) { container, collectionView, accessoryContainer, emptyResultContainer in
-            
-            collectionView.top == container.top
-            collectionView.left == container.left
-            collectionView.right == container.right
-            collectionView.bottom == container.bottom
-            
+
+            collectionView.edges == container.edges
+
             accessoryContainer.left == container.left
             accessoryContainer.right == container.right
             accessoryContainerHeightConstraint = accessoryContainer.height == 0

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsView.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsView.swift
@@ -69,8 +69,8 @@ class SearchResultsView : UIView {
             collectionView.top == container.top
             collectionView.left == container.left
             collectionView.right == container.right
+            collectionView.bottom == container.bottom
             
-            accessoryContainer.top == collectionView.bottom
             accessoryContainer.left == container.left
             accessoryContainer.right == container.right
             accessoryContainerHeightConstraint = accessoryContainer.height == 0

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIQuickActionsBar.m
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIQuickActionsBar.m
@@ -157,24 +157,25 @@ static const CGFloat padding = 12;
 
 - (void)createConstrains
 {
-    [self.inviteButton autoPinEdgeToSuperviewEdge:ALEdgeTop withInset: padding];
+    [self.cameraButton autoPinEdgeToSuperviewEdge:ALEdgeTop withInset: padding];
+    [self.cameraButton autoPinEdgeToSuperviewEdge:ALEdgeTrailing withInset:padding*2];
+    [self autoPinEdge:ALEdgeTrailing toEdge:ALEdgeTrailing ofView:self.cameraButton withOffset:padding*2];
+    
+    [self.callButton autoPinEdgeToSuperviewEdge:ALEdgeTop withInset: padding];
+    [self.callButton autoPinEdge:ALEdgeTrailing toEdge:ALEdgeLeading ofView:self.cameraButton withOffset:-padding*2];
+    
+    [self.videoCallButton autoPinEdgeToSuperviewEdge:ALEdgeTop withInset: padding];
+    [self.videoCallButton autoPinEdge:ALEdgeTrailing toEdge:ALEdgeLeading ofView:self.callButton withOffset:-padding*2];
+    
+    [self.inviteButton autoAlignAxis:ALAxisHorizontal toSameAxisOfView:self.cameraButton];
     [self.inviteButton autoPinEdgeToSuperviewEdge:ALEdgeLeading withInset: padding*2];
     [self.inviteButton autoPinEdgeToSuperviewEdge:ALEdgeTrailing withInset: padding*2];
     [self.inviteButton autoSetDimension:ALDimensionHeight toSize:28];
     self.bottomEdgeConstraint = [self.inviteButton autoPinEdgeToSuperviewEdge:ALEdgeBottom withInset: padding + UIScreen.safeArea.bottom];
     
-    [self.conversationButton autoAlignAxisToSuperviewAxis:ALAxisHorizontal];
+    [self.conversationButton autoAlignAxis:ALAxisHorizontal toSameAxisOfView:self.cameraButton];
     [self.conversationButton autoPinEdgeToSuperviewEdge:ALEdgeLeading withInset: padding*2];
-        
-    [self.cameraButton autoAlignAxisToSuperviewAxis:ALAxisHorizontal];
-    [self.cameraButton autoPinEdgeToSuperviewEdge:ALEdgeTrailing withInset:padding*2];
-    [self autoPinEdge:ALEdgeTrailing toEdge:ALEdgeTrailing ofView:self.cameraButton withOffset:padding*2];
-    
-    [self.callButton autoAlignAxisToSuperviewAxis:ALAxisHorizontal];
-    [self.callButton autoPinEdge:ALEdgeTrailing toEdge:ALEdgeLeading ofView:self.cameraButton withOffset:-padding*2];
-
-    [self.videoCallButton autoAlignAxisToSuperviewAxis:ALAxisHorizontal];
-    [self.videoCallButton autoPinEdge:ALEdgeTrailing toEdge:ALEdgeLeading ofView:self.callButton withOffset:-padding*2];
+    [self.conversationButton autoSetDimension:ALDimensionHeight toSize:28];
     
     [self.lineView autoPinEdgeToSuperviewEdge:ALEdgeTop];
     [self.lineView autoPinEdgeToSuperviewEdge:ALEdgeLeft];


### PR DESCRIPTION
## What's new in this PR?

When adding a people from Start UI, the list was cut off under the safe area. I made some changes in order to let the list go behind the safe area. I've also fixed a visual bug with the size of the Add People bar while opening the keyboard.