### PR TITLE
Fixed insets margin on Profile Devices Screen

### DIFF
--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileDetailsViewController.m
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileDetailsViewController.m
@@ -139,7 +139,8 @@ typedef NS_ENUM(NSUInteger, ProfileUserAction) {
     [self.stackView autoPinEdgeToSuperviewEdge:ALEdgeTrailing];
     [self.stackView autoPinEdge:ALEdgeBottom toEdge:ALEdgeTop ofView:self.footerView withOffset:0 relation:NSLayoutRelationLessThanOrEqual];
     
-    [self.footerView autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsZero excludingEdge:ALEdgeTop];
+    UIEdgeInsets bottomInset = UIEdgeInsetsMake(0, 0, UIScreen.safeArea.bottom, 0);
+    [self.footerView autoPinEdgesToSuperviewEdgesWithInsets:bottomInset excludingEdge:ALEdgeTop];
 }
 
 #pragma mark - User Image

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.m
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.m
@@ -174,9 +174,8 @@ typedef NS_ENUM(NSUInteger, ProfileViewControllerTabBarIndex) {
     }
     
     [self.headerView autoPinEdgesToSuperviewEdgesWithInsets:edges excludingEdge:ALEdgeBottom];
-    [self.tabsController.view autoPinEdgesToSuperviewEdgesWithInsets:UIScreen.safeArea excludingEdge:ALEdgeTop];
+    [self.tabsController.view autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsZero excludingEdge:ALEdgeTop];
     [self.tabsController.view autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.headerView];
-    
 }
 
 #pragma mark - Header


### PR DESCRIPTION
## What's new in this PR?

The devices Tableview was cut off by the Safe Area. I've changed the constraints for the TabBarController, allowing it to reach the bottom margin under the safe area, and I've moved the footer view of the profile in order to achieve the same appearance as before.