### PR TITLE
Fix not opening one-to-one in teams

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+StartUI.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+StartUI.m
@@ -43,9 +43,15 @@ typedef void (^ConversationCreatedBlock)(ZMConversation *);
             
             ZMUser *user = users.anyObject;
             if ([user respondsToSelector:@selector(oneToOneConversation)]) {
-                ZMConversation *oneToOneConversation = user.oneToOneConversation;
-                
-                onConversationCreated(oneToOneConversation);
+
+                ZMConversation __block *oneToOneConversation = nil;
+                [[ZMUserSession sharedSession] enqueueChanges:^{
+                    oneToOneConversation = user.oneToOneConversation;
+                } completionHandler:^{
+                    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.3 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                        onConversationCreated(oneToOneConversation);
+                    });
+                }];
             }
         }
         else if (users.count > 1) {


### PR DESCRIPTION
### Issues

Opening team one-to-one conversation didn't work the first time.

### Causes

We we were missing save 

### Solutions

Open the conversation after we've save the context.