### PR TITLE
Search Results Accessory View visual fix

### DIFF
--- a/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
@@ -146,7 +146,7 @@ public class AddParticipantsViewController : UIViewController {
             confirmButton.top == bottomContainer.top
             confirmButton.left == bottomContainer.left + margin
             confirmButton.right == bottomContainer.right - margin
-            confirmButton.bottom == bottomContainer.bottom - margin
+            confirmButton.bottom == bottomContainer.bottom - margin - UIScreen.safeArea.bottom
         }
     }
         

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsView.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsView.swift
@@ -65,13 +65,16 @@ class SearchResultsView : UIView {
     func createConstraints() {
         
         constrain(self, collectionView, accessoryContainer, emptyResultContainer) { container, collectionView, accessoryContainer, emptyResultContainer in
-
-            collectionView.edges == container.edges
-
+            
+            collectionView.top == container.top
+            collectionView.left == container.left
+            collectionView.right == container.right
+            
+            accessoryContainer.top == collectionView.bottom
             accessoryContainer.left == container.left
             accessoryContainer.right == container.right
             accessoryContainerHeightConstraint = accessoryContainer.height == 0
-            accessoryViewBottomOffsetConstraint = accessoryContainer.bottom == container.bottom - UIScreen.safeArea.bottom
+            accessoryViewBottomOffsetConstraint = accessoryContainer.bottom == container.bottom
             
             emptyResultContainer.top == container.top + 64
             emptyResultContainer.centerX == container.centerX


### PR DESCRIPTION
## What's new in this PR?

### Issues

The accessory view was overlapping the search results view without its blurry effect, also avoiding to choose the last people on the list.

### Causes

This issue was caused by setting this constraint: `collectionView.edges == container.edges`. I was also leaving out  the `accessoryContainer.top` constraint.

### Solutions

I've restored the correct behavior of the accessory view handled in `SearchResultsView`.
