### PR TITLE
Fix text erase when up arrow key pressed

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -594,7 +594,7 @@
                                                 modifierFlags:0
                                                        action:@selector(escapePressed)
                                          discoverabilityTitle:NSLocalizedString(@"conversation.input_bar.shortcut.cancel_editing_message", nil)]];
-    } else {
+    } else if(self.inputBar.textView.text.length == 0) {
         [commands addObject:[UIKeyCommand keyCommandWithInput:UIKeyInputUpArrow
                                                 modifierFlags:0
                                                        action:@selector(upArrowPressed)


### PR DESCRIPTION
## What's new in this PR?
Up arrow key starts latest message editing only if the input text is empty.

### Issues

There was an error in https://github.com/wireapp/wire-ios/pull/1511 - up arrow key press erased entered text.

### Causes

non-empty input text use case was missed during the up arrow feature development.

### Solutions

Up arrow key responder is only added to the Input Bar if it is empty. Otherwise up arrow key is handled by the TextView.

## Dependencies

no