### PR TITLE
 Fix crash in Wire.VideoMessageCell prepareForReuse() 

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/VideoMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/VideoMessageCell.swift
@@ -134,6 +134,8 @@ public final class VideoMessageCell: ConversationCell {
     }
     
     override open func menuConfigurationProperties() -> MenuConfigurationProperties! {
+        guard let _ = message else {return nil}
+
         let properties = MenuConfigurationProperties()
         properties.targetRect = selectionRect
         properties.targetView = selectionView


### PR DESCRIPTION
Issues

App crashes when VideoMessageCell is calling prepareForReuse()
Causes

VideoMessageCell gets class member var message (type: id< ZMConversationMessage >), which may be nil at that time point.
Solutions

Add a nil check guard in menuConfigurationProperties() (which is called in ConversationCell.prepareForReuse())


## Notes

This PR is a clone of https://github.com/wireapp/wire-ios/pull/1539 .