### PR TITLE
add a guard for message nil check

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell+Like.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell+Like.swift
@@ -18,7 +18,6 @@
 
 import UIKit
 
-
 public extension ConversationCell {
 
     public func createLikeButton() {
@@ -34,28 +33,29 @@ public extension ConversationCell {
         self.likeButton.hitAreaPadding = CGSize(width: 20, height: 20)
         self.contentView.addSubview(self.likeButton)
     }
-    
+
     @objc public func configureLikeButtonForMessage(_ message: ZMConversationMessage?) {
         let liked = message?.liked ?? false
-        
+
         self.likeButton?.setSelected(liked, animated: false)
     }
-    
+
     @objc public func didDoubleTapMessage(_ sender: AnyObject!) {
         self.likeMessage(sender)
     }
-    
+
     @objc public func likeMessage(_ sender: AnyObject!) {
+        guard let _ = message else { return }
         guard message.canBeLiked else { return }
-        
-        let reactionType : ReactionType = message.liked ? .unlike : .like
+
+        let reactionType: ReactionType = message.liked ? .unlike : .like
         trackReaction(sender, reaction: reactionType)
 
         self.likeButton.setSelected(!self.message.liked, animated: true)
         delegate.conversationCell!(self, didSelect: .like)
     }
-    
-    func trackReaction(_ sender: AnyObject, reaction: ReactionType){
+
+    func trackReaction(_ sender: AnyObject, reaction: ReactionType) {
         var interactionMethod = InteractionMethod.undefined
         if sender is LikeButton {
             interactionMethod = .button
@@ -69,3 +69,4 @@ public extension ConversationCell {
         Analytics.shared().tagReactedOnMessage(message, reactionType:reaction, method: interactionMethod)
     }
 }
+


### PR DESCRIPTION
## What's new in this PR?

### Issues

App crashes when ConversationCell is calling likeMessage()

### Causes

ConversationCell gets class member var message (type: id< ZMConversationMessage >), which may be nil at that time point.

### Solutions

Add a nil check guard in likeMessage()

## Notes

This PR is a simliar to https://github.com/wireapp/wire-ios/pull/1539 .

## Discussion
In ConversationCell, nullable keyword should be added  to 
````
@property (nonatomic, readonly) id<ZMConversationMessage>message;
````
to make sure Swift code must unwrap it before access. All other properties in ConversationCell should define Nullability also.