### PR TITLE
Added haptic feedback for common user actions

### DIFF
--- a/Wire-iOS/Sources/Managers/SoundEventListener.swift
+++ b/Wire-iOS/Sources/Managers/SoundEventListener.swift
@@ -70,6 +70,16 @@ extension SoundEventListener : ZMNewUnreadMessagesObserver, ZMNewUnreadKnocksObs
             let isSentBySelfUser = message.sender?.isSelfUser ?? false
             let isSilencedConversation = message.conversation?.isSilenced ?? false
             
+            if #available(iOS 10, *),
+                message.isNormal,
+                isRecentMessage,
+                isSentBySelfUser,
+                let localMessage = message as? ZMMessage,
+                localMessage.deliveryState == .pending
+            {
+                UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+            }
+            
             guard (message.isNormal || message.isSystem) &&
                   isRecentMessage &&
                   !isSentBySelfUser &&

--- a/Wire-iOS/Sources/Managers/SoundEventListener.swift
+++ b/Wire-iOS/Sources/Managers/SoundEventListener.swift
@@ -18,6 +18,20 @@
 
 import Foundation
 
+extension ZMConversationMessage {
+    var isSentBySelfUser: Bool {
+        return self.sender?.isSelfUser ?? false
+    }
+    
+    var isRecentMessage: Bool {
+        return (self.serverTimestamp?.timeIntervalSinceNow ?? -Double.infinity) >= -1.0
+    }
+    
+    var isFirstMessage: Bool {
+        return (self.conversation?.messages.count ?? 0) == 1
+    }
+}
+
 class SoundEventListener : NSObject {
     
     weak var userSession: ZMUserSession?
@@ -52,6 +66,20 @@ class SoundEventListener : NSObject {
         AVSMediaManager.sharedInstance()?.playSound(name)
     }
     
+    func provideHapticFeedback(for message: ZMConversationMessage) {
+        guard #available(iOS 10, *) else {
+            return
+        }
+
+        if message.isNormal,
+            message.isRecentMessage,
+            message.isSentBySelfUser,
+            let localMessage = message as? ZMMessage,
+            localMessage.deliveryState == .pending
+        {
+            UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+        }
+    }
 }
 
 extension SoundEventListener : ZMNewUnreadMessagesObserver, ZMNewUnreadKnocksObserver {
@@ -65,25 +93,14 @@ extension SoundEventListener : ZMNewUnreadMessagesObserver, ZMNewUnreadKnocksObs
             // * If this is the first message in the conversation, don't play the sound
             // * Message is new (recently sent)
             
-            let isRecentMessage = (message.serverTimestamp?.timeIntervalSinceNow ?? -Double.infinity) >= -1.0
-            let isFirstMessage = (message.conversation?.messages.count ?? 0) == 1
-            let isSentBySelfUser = message.sender?.isSelfUser ?? false
             let isSilencedConversation = message.conversation?.isSilenced ?? false
             
-            if #available(iOS 10, *),
-                message.isNormal,
-                isRecentMessage,
-                isSentBySelfUser,
-                let localMessage = message as? ZMMessage,
-                localMessage.deliveryState == .pending
-            {
-                UIImpactFeedbackGenerator(style: .medium).impactOccurred()
-            }
+            provideHapticFeedback(for: message)
             
             guard (message.isNormal || message.isSystem) &&
-                  isRecentMessage &&
-                  !isSentBySelfUser &&
-                  !isFirstMessage &&
+                  message.isRecentMessage &&
+                  !message.isSentBySelfUser &&
+                  !message.isFirstMessage &&
                   !isSilencedConversation else {
                 continue
             }

--- a/Wire-iOS/Sources/UserInterface/Availability/AvailabilityTitleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Availability/AvailabilityTitleView.swift
@@ -88,6 +88,13 @@ import WireDataModel
         self.accessibilityLabel = "\(user.name)_is_\(user.availability.localizedName)".localized
     }
     
+    func provideHapticFeedback() {
+        guard #available(iOS 10, *) else {
+            return
+        }
+        
+        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+    }
 }
 
 extension AvailabilityTitleView: ZMUserObserver {
@@ -95,10 +102,7 @@ extension AvailabilityTitleView: ZMUserObserver {
     public func userDidChange(_ changeInfo: UserChangeInfo) {
         guard changeInfo.availabilityChanged else { return }
         
-        if #available(iOS 10, *) {
-            UIImpactFeedbackGenerator(style: .medium).impactOccurred()
-        }
-        
+        provideHapticFeedback()
         configure()
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Availability/AvailabilityTitleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Availability/AvailabilityTitleView.swift
@@ -95,6 +95,10 @@ extension AvailabilityTitleView: ZMUserObserver {
     public func userDidChange(_ changeInfo: UserChangeInfo) {
         guard changeInfo.availabilityChanged else { return }
         
+        if #available(iOS 10, *) {
+            UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+        }
+        
         configure()
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Components/Views/SwipeMenuCollectionCell.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/SwipeMenuCollectionCell.m
@@ -30,25 +30,27 @@ NSString * const SwipeMenuCollectionCellIDToCloseKey = @"IDToClose";
 
 @interface SwipeMenuCollectionCell () <UIGestureRecognizerDelegate>
 
-@property (nonatomic, strong) UIView *swipeView;
-@property (nonatomic, strong) UIView *menuView;
-@property (nonatomic, strong) UIView *separatorLine;
+@property (nonatomic) UIView *swipeView;
+@property (nonatomic) UIView *menuView;
+@property (nonatomic) UIView *separatorLine;
 
-@property (nonatomic, assign) BOOL hasCreatedSwipeMenuConstraints;
+@property (nonatomic) BOOL hasCreatedSwipeMenuConstraints;
 
-@property (nonatomic, assign) CGFloat initialDrawerWidth;
+@property (nonatomic) CGFloat initialDrawerWidth;
 
-@property (nonatomic, assign) CGFloat initialDrawerOffset;
-@property (nonatomic, assign) CGPoint initialDragPoint;
-@property (nonatomic, assign) BOOL revealDrawerOverscrolled;
-@property (nonatomic, assign) BOOL revealAnimationPerforming;
-@property (nonatomic, assign) CGFloat scrollingFraction;
-@property (nonatomic, assign) CGFloat userInteractionHorizontalOffset;
+@property (nonatomic) CGFloat initialDrawerOffset;
+@property (nonatomic) CGPoint initialDragPoint;
+@property (nonatomic) BOOL revealDrawerOverscrolled;
+@property (nonatomic) BOOL revealAnimationPerforming;
+@property (nonatomic) CGFloat scrollingFraction;
+@property (nonatomic) CGFloat userInteractionHorizontalOffset;
 
-@property (nonatomic, strong) UIPanGestureRecognizer *revealDrawerGestureRecognizer;
-@property (nonatomic, strong) NSLayoutConstraint *swipeViewHorizontalConstraint;
-@property (nonatomic, strong) NSLayoutConstraint *menuViewToSwipeViewLeftConstraint;
-@property (nonatomic, strong) NSLayoutConstraint *maxMenuViewToSwipeViewLeftConstraint;
+@property (nonatomic) UIPanGestureRecognizer *revealDrawerGestureRecognizer;
+@property (nonatomic) NSLayoutConstraint *swipeViewHorizontalConstraint;
+@property (nonatomic) NSLayoutConstraint *menuViewToSwipeViewLeftConstraint;
+@property (nonatomic) NSLayoutConstraint *maxMenuViewToSwipeViewLeftConstraint;
+
+@property (nonatomic) UIImpactFeedbackGenerator *openedFeedbackGenerator;
 
 @end
 
@@ -117,6 +119,10 @@ NSString * const SwipeMenuCollectionCellIDToCloseKey = @"IDToClose";
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(closeDrawer:) name:SwipeMenuCollectionCellCloseDrawerNotification object:nil];
 
     [self setNeedsUpdateConstraints];
+    
+    if (nil != [UIImpactFeedbackGenerator class]) {
+        self.openedFeedbackGenerator = [[UIImpactFeedbackGenerator alloc] initWithStyle:UIImpactFeedbackStyleLight];
+    }
 }
 
 - (void)setSeparatorLineViewDisabled:(BOOL)separatorLineViewDisabled
@@ -191,6 +197,8 @@ NSString * const SwipeMenuCollectionCellIDToCloseKey = @"IDToClose";
                 self.initialDrawerWidth = self.menuView.bounds.size.width;
             }
 
+            [self.openedFeedbackGenerator prepare];
+            
             break;
         case UIGestureRecognizerStateEnded:
         case UIGestureRecognizerStateFailed:
@@ -209,6 +217,7 @@ NSString * const SwipeMenuCollectionCellIDToCloseKey = @"IDToClose";
             }
             else {
                 if (self.visualDrawerOffset > self.drawerWidth / 2.0f) {
+                    [self.openedFeedbackGenerator impactOccurred];
                     [self setDrawerOpen:YES animated:YES];
                 }
                 else {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -147,6 +147,8 @@
 @property (nonatomic) BOOL inRotation;
 
 @property (nonatomic) id typingObserverToken;
+
+@property (nonatomic) UINotificationFeedbackGenerator* feedbackGenerator;
 @end
 
 
@@ -165,6 +167,10 @@
         
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardDidHide:) name:UIKeyboardDidHideNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didEnterBackground:) name:UIApplicationDidEnterBackgroundNotification object:nil];
+        
+        if (nil != [UINotificationFeedbackGenerator class]) {
+            self.feedbackGenerator = [[UINotificationFeedbackGenerator alloc] init];
+        }
     }
     return self;
 }
@@ -1134,6 +1140,8 @@
             [Analytics.shared tagMediaActionCompleted:ConversationMediaActionPing inConversation:self.conversation];
             
             [AVSMediaManager.sharedInstance playSound:MediaManagerSoundOutgoingKnockSound];
+            
+            [self.feedbackGenerator notificationOccurred:UINotificationFeedbackTypeSuccess];
         }
     }];
     

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController.m
@@ -59,6 +59,8 @@ static NSString * const CellReuseIdConversation = @"CellId";
 @property (nonatomic) BOOL animateNextSelection;
 @property (nonatomic, copy) dispatch_block_t selectConversationCompletion;
 @property (nonatomic) ConversationListCell *layoutCell;
+
+@property (nonatomic) UISelectionFeedbackGenerator *selectionFeedbackGenerator;
 @end
 
 @interface ConversationListContentController (ConversationListCellDelegate) <ConversationListCellDelegate>
@@ -91,6 +93,10 @@ static NSString * const CellReuseIdConversation = @"CellId";
         StopWatchEvent *loadContactListEvent = [stopWatch stopEvent:@"LoadContactList"];
         if (loadContactListEvent) {
             DDLogDebug(@"Contact List load after %lums", (unsigned long)loadContactListEvent.elapsedTime);
+        }
+        
+        if (nil != [UISelectionFeedbackGenerator class]) {
+            self.selectionFeedbackGenerator = [[UISelectionFeedbackGenerator alloc] init];
         }
     }
     return self;
@@ -461,8 +467,16 @@ static NSString * const CellReuseIdConversation = @"CellId";
 
 @implementation ConversationListContentController (UICollectionViewDelegate)
 
+- (BOOL)collectionView:(UICollectionView *)collectionView shouldHighlightItemAtIndexPath:(NSIndexPath *)indexPath
+{
+    [self.selectionFeedbackGenerator prepare];
+    return YES;
+}
+
 - (void)collectionView:(UICollectionView *)collectionView didSelectItemAtIndexPath:(NSIndexPath *)indexPath
 {
+    [self.selectionFeedbackGenerator selectionChanged];
+    
     id item = [self.listViewModel itemForIndexPath:indexPath];
     
     self.focusOnNextSelection = YES;

--- a/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelParticipantsController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelParticipantsController.swift
@@ -43,6 +43,18 @@ class VoiceChannelParticipantsController : NSObject {
         collectionView.performBatchUpdates(nil)
     }
     
+    fileprivate func playHapticFeedback(for changeInfo: VoiceChannelParticipantNotification) {
+        guard #available(iOS 10, *) else {
+            return
+        }
+        
+        if changeInfo.insertedIndexes.count > 0 {
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+        }
+        else if changeInfo.deletedIndexes.count > 0 {
+            UINotificationFeedbackGenerator().notificationOccurred(.warning)
+        }
+    }
 }
 
 extension VoiceChannelParticipantsController : UICollectionViewDataSource {
@@ -72,6 +84,8 @@ extension VoiceChannelParticipantsController : VoiceChannelParticipantObserver {
         collectionView.performBatchUpdates({ 
             self.collectionView.insertItems(at: (changeInfo.insertedIndexes as NSIndexSet).indexPaths())
             self.collectionView.deleteItems(at: (changeInfo.deletedIndexes as NSIndexSet).indexPaths())
+            
+            self.playHapticFeedback(for: changeInfo)
             
             for moved in changeInfo.zm_movedIndexPairs {
                 let from = IndexPath(row: Int(moved.from), section: 0)

--- a/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelViewController.swift
@@ -323,6 +323,20 @@ extension VoiceChannelViewController : WireCallCenterCallStateObserver, Received
         }
     }
     
+    func provideHapticFeedback(for callState: CallState, previousCallState: CallState) {
+        guard #available(iOS 10, *) else {
+            return
+        }
+        switch callState {
+        case .established, .establishedDataChannel:
+            if previousCallState != callState {
+                UINotificationFeedbackGenerator().notificationOccurred(.success)
+            }
+        default:
+            break
+        }
+    }
+    
     func updateView(for callState : CallState) {
         defer {
             previousCallState = callState
@@ -331,6 +345,7 @@ extension VoiceChannelViewController : WireCallCenterCallStateObserver, Received
         voiceChannelView.transition(to: viewState(for: callState, previousCallState: previousCallState))
         voiceChannelView.speakerActive = AVSMediaManager.sharedInstance()?.isSpeakerEnabled ?? false
         
+        provideHapticFeedback(for: callState, previousCallState: previousCallState)
         updateCallDurationTimer(for: callState)
         updateIdleTimer(for: callState)
     }


### PR DESCRIPTION
## What's new in this PR?

The haptic feedback is available on the iOS devices that are utilizing the new Taptic Engine chip from Apple.

More info: https://developer.apple.com/ios/human-interface-guidelines/user-interaction/feedback/

Added actions:


- Open conversation from list ui: Feedback "Select"
- Setting a status (as soon as the icon appears next to the name): Feedback "Impact: Medium"
- opening conversation option by swiping right on a list item (as soon as the 3 dots are in position): Feedback "Impact: Light"
- Sending a ping (synchronized with the sound of ping): Feedback "Notification: Success"
- Sending any kind of message (as soon as the me message is placed into the conversation): Feedback "Impact: Medium"
