### PR TITLE
Fix: callkit call and not show Quality UI incase of second call

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Overlay/ActiveVoiceChannelViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/ActiveVoiceChannelViewController.swift
@@ -184,13 +184,21 @@ extension ActiveVoiceChannelViewController : WireCallCenterCallStateObserver {
             return
         }
         
+        
+        if case .answered = callState,
+            let presentedController = self.presentedViewController,
+            presentedController is BaseCallQualityViewController {
+            
+            presentedController.dismiss(animated: true, completion: nil)
+        }
+        
         if case .answered = callState {
             answeredCalls.insert(conversation.remoteIdentifier!)
         }
         
         if case .terminating = callState, answeredCalls.contains(conversation.remoteIdentifier!) {
-            answeredCalls.remove(conversation.remoteIdentifier!)
             let baseQualityController = BaseCallQualityViewController()
+            answeredCalls.remove(conversation.remoteIdentifier!)
             present(baseQualityController, animated: true)
         }
     }


### PR DESCRIPTION
## What's new in this PR?
This fixes the issue of showing the Quality UI after you accepted a callkit call on lock screen and receive a second call. Quality UI should not be shown in that case, because it blocks the call UI of the second call.

### Solutions
I am checking if when the callstate is answered and the quality ui controller is already presented, to dismiss it right away.

