### PR TITLE
Removed unnecessary check for team users in Start UI

### DIFF
--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.m
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.m
@@ -191,11 +191,7 @@ static NSUInteger const StartUIInitiallyShowsKeyboardConversationThreshold = 10;
     }
     else if (self.userSelection.users.count == 1) {
         self.searchResultsViewController.searchResultsView.accessoryView = self.quickActionsBar;
-        if (ZMUser.selfUser.hasTeam) { // When in a team we always open group conversations
-            self.quickActionsBar.mode = StartUIQuickActionBarModeOpenGroupConversation;
-        } else {
-            self.quickActionsBar.mode = StartUIQuickActionBarModeOpenConversation;
-        }
+        self.quickActionsBar.mode = StartUIQuickActionBarModeOpenConversation;
     }
     else {
         self.searchResultsViewController.searchResultsView.accessoryView = self.quickActionsBar;


### PR DESCRIPTION
## What's new in this PR?

### Issues

The video call button was disabled for the team users.

### Causes

Teams have the `fake` 1-1 conversations that are just the group conversations with 2 participants. Back in the day the video calls where not supported in such conversations.

### Solutions

The check is not necessary any more.

