### PR TITLE
Fix crash for Message.dayFormatterWithDate()'s nil parameter

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
@@ -427,7 +427,11 @@ static const CGFloat BurstContainerExpandedHeight = 40;
 - (void)updateBurstTimestamp
 {
     if (self.layoutProperties.showDayBurstTimestamp) {
-        self.burstTimestampView.label.text = [[Message dayFormatterWithDate: self.message.serverTimestamp] stringFromDate:self.message.serverTimestamp].uppercaseString;
+        NSDate * serverTimestamp = self.message.serverTimestamp;
+        if (serverTimestamp != nil) {
+            self.burstTimestampView.label.text = [[Message dayFormatterWithDate: serverTimestamp] stringFromDate: serverTimestamp].uppercaseString;
+        }
+
         self.burstTimestampView.label.font = self.burstBoldFont;
     } else {
         self.burstTimestampView.label.text = [Message formattedReceivedDateForMessage:self.message].uppercaseString;


### PR DESCRIPTION
## What's new in this PR?

### Issues

App crashes when passing a nil NSDate object to a Swift method.

### Causes

Message dayFormatterWithDate was rewritten in Swift and does not accept nil Date object.

### Solutions

Add nil check before pass serverTimestamp to dayFormatterWithDate()

### Notice

message property is nullable but nullable keyword is not yet added in header.