### PR TITLE
Unwrap conversation.voiceChannel?.participants before access its elem…

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelParticipantsController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelParticipantsController.swift
@@ -62,8 +62,9 @@ extension VoiceChannelParticipantsController : UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "VoiceChannelParticipantCell", for: indexPath)
         
-        if let user = conversation.voiceChannel?.participants.object(at: indexPath.row) as? ZMUser,
-           let participantState = conversation.voiceChannel?.state(forParticipant: user) {
+        if let participants = conversation.voiceChannel?.participants,
+            let user = participants.object(at: indexPath.row) as? ZMUser,
+            let participantState = conversation.voiceChannel?.state(forParticipant: user) {
             (cell as? VoiceChannelParticipantCell)?.configure(for: user, participantState: participantState)
         }
         


### PR DESCRIPTION
…ents

## What's new in this PR?

### Issues

App crash when access an empty set.

### Causes

It may be a side effect of a not released VoiceChannelViewController, since onversation.voiceChannel?.participants should always have more than 1 member.

### Solutions


Unwrap conversation.voiceChannel?.participants before access its elements



