### PR TITLE
fix app crash when delete a nil message

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageDeletion.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageDeletion.swift
@@ -75,8 +75,8 @@ extension CollectionCell: SelectableView {
      - parameter source: The source view used for a potential popover presentation of the dialog.
      - parameter completion: A completion closure which will be invoked with `true` if a deletion occured and `false` otherwise.
      */
-    @objc public func presentDeletionAlertController(forMessage message: ZMConversationMessage, source: SelectableView?, completion: ((Bool) -> Void)?) {
-        guard !message.hasBeenDeleted else { return }
+    @objc public func presentDeletionAlertController(forMessage message: ZMConversationMessage?, source: SelectableView?, completion: ((Bool) -> Void)?) {
+        guard let message = message, !message.hasBeenDeleted else { return }
         let alert = UIAlertController.forMessageDeletion(with: message.deletionConfiguration) { [weak self] (action, alert) in
             
             // Tracking needs to be called before performing the action, since the content of the message is cleared


### PR DESCRIPTION
## What's new in this PR?

### Issues

App crashes when deleting a message.

### Causes

message parameter should be optional and unwrapped before access.

### Solutions

change the type to ZMConversationMessage? and unwrap before use.

