### PR TITLE
fix app crash when forward a nil message

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
@@ -135,7 +135,9 @@ extension ZMConversationList {
 }
 
 extension ConversationContentViewController: UIAdaptivePresentationControllerDelegate {
-    @objc public func showForwardFor(message: ZMConversationMessage, fromCell: ConversationCell?) {
+    @objc public func showForwardFor(message: ZMConversationMessage?, fromCell: ConversationCell?) {
+        guard let message = message else { return }
+
         if let window = self.view.window {
             window.endEditing(true)
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

App crashes when forwarding a message.

### Causes

message parameter should be optional and unwrapped before access.

### Solutions

change the type to ZMConversationMessage? and unwrap before use.

