### PR TITLE
fix: unwrap user name before access

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Availability/AvailabilityStringBuilder.swift
+++ b/Wire-iOS/Sources/UserInterface/Availability/AvailabilityStringBuilder.swift
@@ -27,7 +27,10 @@
         
         switch style {
             case .list: do {
-                title = user.name
+                if let name = user.name {
+                    title = name
+                }
+
                 fontSize = .normal
                 if color == nil {
                     color = ColorScheme.default().color(withName: ColorSchemeColorTextForeground, variant: .dark)


### PR DESCRIPTION
## What's new in this PR?

### Issues

App crashes when access user name.

### Causes

user name is nil when access.

### Solutions

Unwrap user.name before access.

