### PR TITLE
Fix issue when it's not possible to record an audio message

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecorder.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecorder.swift
@@ -221,19 +221,10 @@ public final class AudioRecorder: NSObject, AudioRecorderType {
             DDLogError("Failed to set session activity to \(active): \(error)")
         }
         
-        if active {
-            do {
-                try AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryPlayAndRecord)
-            } catch let error {
-                DDLogError("Failed change audio category for recording: \(error)")
-            }
-        }
-        else {
-            do {
-                try AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategorySoloAmbient)
-            } catch let error {
-                DDLogError("Failed change audio category for recording: \(error)")
-            }
+        do {
+            try AVAudioSession.sharedInstance().setCategory(active ? AVAudioSessionCategoryPlayAndRecord : AVAudioSessionCategorySoloAmbient)
+        } catch let error {
+            DDLogError("Failed change audio category for recording: \(error)")
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecorder.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecorder.swift
@@ -132,7 +132,6 @@ public final class AudioRecorder: NSObject, AudioRecorderType {
     }
     
     deinit {
-        NotificationCenter.default.removeObserver(self)
         removeDisplayLink()
     }
     
@@ -153,13 +152,9 @@ public final class AudioRecorder: NSObject, AudioRecorderType {
     
     public func startRecording() {
         guard let audioRecorder = self.audioRecorder else { return }
-        
-        do {
-            try AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryPlayAndRecord)
-        } catch let error {
-            DDLogError("Failed change audio category for recording: \(error)")
-        }
-        
+
+        setSessionActive(true)
+
         state = .recording
         recordTimerCallback?(0)
         fileURL = nil
@@ -185,6 +180,7 @@ public final class AudioRecorder: NSObject, AudioRecorderType {
         removeDisplayLink()
         guard let filePath = audioRecorder?.url.path , fm.fileExists(atPath: filePath) else { return false }
         fileURL = audioRecorder?.url
+        setSessionActive(false)
         return true
     }
     
@@ -210,6 +206,35 @@ public final class AudioRecorder: NSObject, AudioRecorderType {
         guard let duration = durationForCurrentState() , currentDuration != duration else { return }
         currentDuration = duration
         recordTimerCallback?(currentDuration)
+    }
+    
+    private func setSessionActive(_ active: Bool) {
+        if active {
+            AVSMediaManager.sharedInstance().stopAudio()
+            AppDelegate.shared().mediaPlaybackManager?.audioTrackPlayer.stop()
+        }
+        
+        do {
+            try AVAudioSession.sharedInstance().setActive(active)
+        }
+        catch let error {
+            DDLogError("Failed to set session activity to \(active): \(error)")
+        }
+        
+        if active {
+            do {
+                try AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryPlayAndRecord)
+            } catch let error {
+                DDLogError("Failed change audio category for recording: \(error)")
+            }
+        }
+        else {
+            do {
+                try AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategorySoloAmbient)
+            } catch let error {
+                DDLogError("Failed change audio category for recording: \(error)")
+            }
+        }
     }
     
     // MARK: Playing


### PR DESCRIPTION
## What's new in this PR?

### Issues

Users reported that sometimes it's not possible to record an audio message: the duration is 0, and it's not possible to send such message.

### Causes

The cause is the update of how we are handling the audio sessions. To reproduce the issue it is enough to place one call, start speaking over wire and end the call. Afterwards it is going to be impossible to record the audio message.

### Solutions

The root issue is that the AVS media manager is deactivating the audio session after the call is ended. Therefore it is necessary to re-activate it when the recording is about to start.

Another fix introduced for the case when another audio message is playing, and user is trying to record the new audio message. In this case we first stop the player, and then start the recording.
