### PR TITLE
prevent changing frame's origin after config is called.

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Availability/TitleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Availability/TitleView.swift
@@ -77,7 +77,7 @@ import Classy
         titleButton.isEnabled = interactive
         titleButton.setContentCompressionResistancePriority(1000, for: .vertical)
         updateAccessibilityLabel()
-        frame = titleButton.bounds
+        frame = CGRect(origin: frame.origin, size: titleButton.bounds.size)
         createConstraints()
         setNeedsLayout()
         layoutIfNeeded()


### PR DESCRIPTION
## What's new in this PR?

### Issues

AvailabilityTitleView misplaced after status changes

### Causes

AvailabilityTitleView's frame is reset to zero after update.

### Solutions

reserve the frame's origin after update the content

## Notes

@nicorsm It is better not to call configure() for UI refresh since it will call createConstraints() every time. 
