### PR TITLE
Fix/zios 9280 i pad   automation   keyboard gallery and voice recorder are replaced with keyboard upon orientation change

### DIFF
--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -61,6 +61,8 @@ class AppRootViewController: UIViewController {
     }
 
     override public func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        
         mainWindow.frame.size = size
 
         coordinator.animate(alongsideTransition: nil, completion: { _ in

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -796,10 +796,9 @@
 
 - (void)keyboardDidHide:(NSNotification *)notification
 {
-//    return;
-//    if (!self.inRotation) {///FIXME: iPad rotates
-//        self.mode = ConversationInputBarViewControllerModeTextInput;
-//    }
+    if (!self.inRotation) {
+        self.mode = ConversationInputBarViewControllerModeTextInput;
+    }
 }
 
 - (void)sendOrEditText:(NSString *)text

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -796,9 +796,10 @@
 
 - (void)keyboardDidHide:(NSNotification *)notification
 {
-    if (!self.inRotation) {
-        self.mode = ConversationInputBarViewControllerModeTextInput;
-    }
+//    return;
+//    if (!self.inRotation) {///FIXME: iPad rotates
+//        self.mode = ConversationInputBarViewControllerModeTextInput;
+//    }
 }
 
 - (void)sendOrEditText:(NSString *)text


### PR DESCRIPTION
## What's new in this PR?

### Issues

On iPad, if camera keyboard or other custom keyboards is toggled, it changes to text keyboard after rotation.

### Causes

In ConversationInputBarViewController, inRotation is not set to true when rotation. The reason is viewWillTransition is not called in the same class.

### Solutions

Add super.viewWillTransition(to: size, with: coordinator) in the AppRootViewController, which is the root of ConversationInputBarViewController.

## Notes
"In your current view controller, if you override viewWillTransitionToSize:withTransitionCoordinator:, make sure you call super. Otherwise, this message won't get propagated to children view controllers."
ref: 
https://stackoverflow.com/questions/32884147/viewwilltransitiontosize-not-called-in-ios-9-when-the-view-controller-is-pres