### PR TITLE
Fix/zios 9404 camera keyboard collection view does not refreshed after toggling

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/AssetCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/AssetCell.swift
@@ -85,15 +85,15 @@ open class AssetCell: UICollectionViewCell, Reusable {
             let maxDimensionRetina = max(self.bounds.size.width, self.bounds.size.height) * (self.window ?? UIApplication.shared.keyWindow!).screen.scale
 
             representedAssetIdentifier = asset.localIdentifier
-            self.imageRequestTag = manager.requestImage(for: asset,
-                                                        targetSize: CGSize(width: maxDimensionRetina, height: maxDimensionRetina),
-                                                        contentMode: .aspectFill,
-                                                        options: type(of: self).imageFetchOptions,
-                                                        resultHandler: { [weak self] result, info -> Void in
-                                                            guard let `self` = self,
-                                                                asset.localIdentifier == self.representedAssetIdentifier
-                                                                else { return }
-                                                            self.imageView.image = result
+            imageRequestTag = manager.requestImage(for: asset,
+                                                   targetSize: CGSize(width: maxDimensionRetina, height: maxDimensionRetina),
+                                                   contentMode: .aspectFill,
+                                                   options: type(of: self).imageFetchOptions,
+                                                   resultHandler: { [weak self] result, info -> Void in
+                                                    guard let `self` = self,
+                                                        self.representedAssetIdentifier == asset.localIdentifier
+                                                        else { return }
+                                                    self.imageView.image = result
             })
             
             if asset.mediaType == .video {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/AssetCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/AssetCell.swift
@@ -27,7 +27,8 @@ open class AssetCell: UICollectionViewCell, Reusable {
     let durationView = UILabel()
     
     var imageRequestTag: PHImageRequestID = PHInvalidImageRequestID
-    
+    var representedAssetIdentifier: String!
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         
@@ -83,23 +84,16 @@ open class AssetCell: UICollectionViewCell, Reusable {
             
             let maxDimensionRetina = max(self.bounds.size.width, self.bounds.size.height) * (self.window ?? UIApplication.shared.keyWindow!).screen.scale
 
-            ///TODO: imageRequestTag assigned after the block is done? try call this in bg thread
+            representedAssetIdentifier = asset.localIdentifier
             self.imageRequestTag = manager.requestImage(for: asset,
-                                                                 targetSize: CGSize(width: maxDimensionRetina, height: maxDimensionRetina),
-                                                                 contentMode: .aspectFill,
-                                                                 options: type(of: self).imageFetchOptions,
-                                                                 resultHandler: { [weak self] result, info -> Void in
-                                                                    guard let `self` = self,
-                                                                        let requesId = info?[PHImageResultRequestIDKey] as? PHImageRequestID//,
-//                                                                        Int(self.imageRequestTag) == requesId
-                                                                        else {
-                                                                        return
-                                                                    }
-                                                                    if self.imageRequestTag == requesId
-                                                                        //|| self.imageRequestTag == 0
-                                                                    {
-                                                                    self.imageView.image = result
-                                                                    }
+                                                        targetSize: CGSize(width: maxDimensionRetina, height: maxDimensionRetina),
+                                                        contentMode: .aspectFill,
+                                                        options: type(of: self).imageFetchOptions,
+                                                        resultHandler: { [weak self] result, info -> Void in
+                                                            guard let `self` = self,
+                                                                asset.localIdentifier == self.representedAssetIdentifier
+                                                                else { return }
+                                                            self.imageView.image = result
             })
             
             if asset.mediaType == .video {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/AssetCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/AssetCell.swift
@@ -26,7 +26,7 @@ open class AssetCell: UICollectionViewCell, Reusable {
     let imageView = UIImageView()
     let durationView = UILabel()
     
-    var imageRequestTag: PHImageRequestID = 0
+    var imageRequestTag: PHImageRequestID = PHInvalidImageRequestID
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -70,9 +70,9 @@ open class AssetCell: UICollectionViewCell, Reusable {
 
             let manager = PHImageManager.default()
             
-            if self.imageRequestTag != 0 {
+            if self.imageRequestTag != PHInvalidImageRequestID {
                 manager.cancelImageRequest(self.imageRequestTag)
-                self.imageRequestTag = 0
+                self.imageRequestTag = PHInvalidImageRequestID
             }
             
             guard let asset = self.asset else {
@@ -90,12 +90,14 @@ open class AssetCell: UICollectionViewCell, Reusable {
                                                                  options: type(of: self).imageFetchOptions,
                                                                  resultHandler: { [weak self] result, info -> Void in
                                                                     guard let `self` = self,
-                                                                        let requesId = info?[PHImageResultRequestIDKey] as? Int//,
+                                                                        let requesId = info?[PHImageResultRequestIDKey] as? PHImageRequestID//,
 //                                                                        Int(self.imageRequestTag) == requesId
                                                                         else {
                                                                         return
                                                                     }
-                                                                    if Int(self.imageRequestTag) == requesId || self.imageRequestTag == 0 {
+                                                                    if self.imageRequestTag == requesId
+                                                                        //|| self.imageRequestTag == 0
+                                                                    {
                                                                     self.imageView.image = result
                                                                     }
             })

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/AssetCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/AssetCell.swift
@@ -82,19 +82,21 @@ open class AssetCell: UICollectionViewCell, Reusable {
             }
             
             let maxDimensionRetina = max(self.bounds.size.width, self.bounds.size.height) * (self.window ?? UIApplication.shared.keyWindow!).screen.scale
+
+            ///TODO: imageRequestTag assigned after the block is done? try call this in bg thread
             self.imageRequestTag = manager.requestImage(for: asset,
                                                                  targetSize: CGSize(width: maxDimensionRetina, height: maxDimensionRetina),
                                                                  contentMode: .aspectFill,
                                                                  options: type(of: self).imageFetchOptions,
                                                                  resultHandler: { [weak self] result, info -> Void in
                                                                     guard let `self` = self,
-                                                                        let requesId = info?[PHImageResultRequestIDKey] as? Int
+                                                                        let requesId = info?[PHImageResultRequestIDKey] as? Int//,
+//                                                                        Int(self.imageRequestTag) == requesId
                                                                         else {
                                                                         return
                                                                     }
-                                                                    
-                                                                    if requesId == Int(self.imageRequestTag) {
-                                                                        self.imageView.image = result
+                                                                    if Int(self.imageRequestTag) == requesId || self.imageRequestTag == 0 {
+                                                                    self.imageView.image = result
                                                                     }
             })
             


### PR DESCRIPTION
## What's new in this PR?

### Issues

Some photos are not loaded in camera keyboard after refresh.

### Causes

RequestID was used as key to check the image is requested by the cell. However, requestID may be zeroed after cancelImageRequest is called.

### Solutions

Ref to apple's "Example app using Photos framework" sample, use PHAsset.localIdentifier as the key to check the image received in block is the image the cell requested.

https://developer.apple.com/library/content/samplecode/UsingPhotosFramework/Introduction/Intro.html#//apple_ref/doc/uid/TP40014575