### PR TITLE
move marginContainer to backmost

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
@@ -152,15 +152,14 @@ static const CGFloat BurstContainerExpandedHeight = 40;
     self.clipsToBounds = NO;
     self.contentView.clipsToBounds = NO;
     
+    self.marginContainer = [[UIView alloc] init];
+    self.marginContainer.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.contentView addSubview:self.marginContainer];
+
     self.messageContentView = [[UIView alloc] init];
     self.messageContentView.translatesAutoresizingMaskIntoConstraints = NO;
     self.messageContentView.accessibilityElementsHidden = NO;
     [self.contentView addSubview:self.messageContentView];
-    
-    
-    self.marginContainer = [[UIView alloc] init];
-    self.marginContainer.translatesAutoresizingMaskIntoConstraints = NO;
-    [self.contentView addSubview:self.marginContainer];
 
     self.authorLabel = [[UILabel alloc] init];
     self.authorLabel.translatesAutoresizingMaskIntoConstraints = NO;


### PR DESCRIPTION
## What's new in this PR?

### Issues

This PR is a follow up of https://github.com/wireapp/wire-ios/pull/1572
Tap on image cell does not open full screen view immediately.

### Causes

A new container view's z-index is higher than messageContentView.

### Solutions

move marginContainer to back most.

