### PR TITLE
Let AVS handle the audio category when previewing audio messages

### DIFF
--- a/Wire-iOS/Sources/Components/AudioPlayer/AudioTrackPlayer.m
+++ b/Wire-iOS/Sources/Components/AudioPlayer/AudioTrackPlayer.m
@@ -286,11 +286,6 @@ static NSString* EmptyStringIfNil(NSString *string) {
     return [NSSet setWithObjects:@"avPlayer.error", nil];
 }
 
-- (NSError *)error
-{
-    return self.avPlayer.error;
-}
-
 - (void)setAudioTrack:(NSObject<AudioTrack> *)audioTrack
 {
     if (_audioTrack == audioTrack) {

--- a/Wire-iOS/Sources/Components/AudioPlayer/MediaPlayerController.swift
+++ b/Wire-iOS/Sources/Components/AudioPlayer/MediaPlayerController.swift
@@ -49,7 +49,7 @@ class MediaPlayerController: NSObject {
 extension MediaPlayerController: MediaPlayer {
 
     var title: String? {
-        return message.fileMessageData?.filename ?? ""
+        return message.fileMessageData?.filename
     }
 
     var sourceMessage: ZMConversationMessage? {

--- a/Wire-iOS/Sources/Components/AudioPlayer/MediaPlayerController.swift
+++ b/Wire-iOS/Sources/Components/AudioPlayer/MediaPlayerController.swift
@@ -48,11 +48,11 @@ class MediaPlayerController: NSObject {
 
 extension MediaPlayerController: MediaPlayer {
 
-    var title: String {
+    var title: String? {
         return message.fileMessageData?.filename ?? ""
     }
 
-    var sourceMessage: ZMConversationMessage! {
+    var sourceMessage: ZMConversationMessage? {
         return message
     }
 
@@ -62,10 +62,6 @@ extension MediaPlayerController: MediaPlayer {
         } else {
             return MediaPlayerState.paused
         }
-    }
-
-    var error: Error! {
-        return nil
     }
 
     func play() {

--- a/Wire-iOS/Sources/UserInterface/Components/MediaPreview/MediaPlayer.h
+++ b/Wire-iOS/Sources/UserInterface/Components/MediaPreview/MediaPlayer.h
@@ -38,17 +38,16 @@ typedef NS_ENUM(NSInteger, MediaPlayerState)
 
 @protocol MediaPlayerDelegate <NSObject>
 
-- (void)mediaPlayer:(id<MediaPlayer>)mediaPlayer didChangeToState:(MediaPlayerState)state;
+- (void)mediaPlayer:(_Nonnull id<MediaPlayer>)mediaPlayer didChangeToState:(MediaPlayerState)state;
 
 @end
 
 
 @protocol MediaPlayer <NSObject>
 
-@property (nonatomic, readonly) NSString *title;
-@property (nonatomic, readonly) id<ZMConversationMessage>sourceMessage;
+@property (nonatomic, readonly, nullable) NSString *title;
+@property (nonatomic, readonly, nullable) id<ZMConversationMessage>sourceMessage;
 @property (nonatomic, readonly) MediaPlayerState state;
-@property (nonatomic, readonly) NSError *error;
 
 - (void)play;
 - (void)pause;

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
@@ -182,7 +182,7 @@ final class AudioMessageView: UIView, TransferView {
     
     public func willDeleteMessage() {
         proximityMonitorManager?.stopListening()
-        guard let player = audioTrackPlayer, player.sourceMessage != nil && player.sourceMessage.isEqual(self.fileMessage) else { return }
+        guard let player = audioTrackPlayer, let source = player.sourceMessage, source.isEqual(self.fileMessage) else { return }
         player.stop()
     }
     
@@ -301,7 +301,7 @@ final class AudioMessageView: UIView, TransferView {
     }
     
     public func stopPlaying() {
-        guard let player = self.audioTrackPlayer, player.sourceMessage != nil && player.sourceMessage.isEqual(self.fileMessage) else { return }
+        guard let player = self.audioTrackPlayer, let source = player.sourceMessage, source.isEqual(self.fileMessage) else { return }
         player.pause()
     }
     
@@ -312,7 +312,7 @@ final class AudioMessageView: UIView, TransferView {
         
         self.proximityMonitorManager?.stateChanged = proximityStateDidChange
         
-        let audioTrackPlayingSame = audioTrackPlayer.sourceMessage != nil && audioTrackPlayer.sourceMessage.isEqual(self.fileMessage)
+        let audioTrackPlayingSame = audioTrackPlayer.sourceMessage?.isEqual(self.fileMessage) ?? false
         
         if let track = fileMessage.audioTrack(), !audioTrackPlayingSame {
             audioTrackPlayer.load(track, sourceMessage: fileMessage) { [weak self] success, error in
@@ -348,7 +348,7 @@ final class AudioMessageView: UIView, TransferView {
                 return false
         }
         
-        let audioTrackPlayingSame = audioTrackPlayer.sourceMessage != nil && audioTrackPlayer.sourceMessage.isEqual(self.fileMessage)
+        let audioTrackPlayingSame = audioTrackPlayer.sourceMessage?.isEqual(self.fileMessage) ?? false
         return audioTrackPlayingSame && audioTrackPlayer.audioTrack.isEqual(audioTrack)
     }
     


### PR DESCRIPTION
### Issues

After playing an audio message preview AVS would be confused about in which state the audio session is.

### Causes

When playing an audio message preview we would manually change audio session  category to `.playAndRecord`. 

### Solutions

Generally AVS has the ownership of the audio session and we should therefore request any changes to to it by using the API they expose for telling them when we are about to play sounds on our own.

### Notes

- Removed `error` property from the `MediaPlayer` since it was never referenced.
- MediaPlayers without a `sourceMessage` won't get a media bar in the conversation.