### PR TITLE
Show debug alert when registering a shake motion gesture

### DIFF
--- a/Wire-iOS/Sources/WireApplication.swift
+++ b/Wire-iOS/Sources/WireApplication.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
 import UIKit
 
 @objc public class WireApplication: UIApplication {
@@ -29,5 +28,13 @@ import UIKit
     override public func registerForRemoteNotifications() {
         if AutomationHelper.sharedHelper.skipFirstLoginAlerts { return }
         super.registerForRemoteNotifications()
+    }
+    
+    override public func motionEnded(_ motion: UIEventSubtype, with event: UIEvent?) {
+        guard motion == .motionShake else { return }
+        DebugAlert.show(
+            message: "You have performed a shake motion, please confirm sending debug logs.",
+            sendLogs: true
+        )
     }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

There was no functionality to send debug logs before being logged in.

### Solution

This PR adds showing the debug alert to send debug logs after shaking the device (only in case the developer menu is enabled).