### PR TITLE
ZIOS-9429: Update username for current user in the header of Conversation List

### DIFF
--- a/Wire-iOS Tests/AvailabilityTitleViewTests.swift
+++ b/Wire-iOS Tests/AvailabilityTitleViewTests.swift
@@ -93,7 +93,7 @@ class AvailabilityTitleViewTests: ZMSnapshotTestCase {
         updateAvailability(for: user, newValue: availability)
         self.sut = AvailabilityTitleView(user: user, style: style)
         guard let sut = self.sut else { XCTFail(); return }
-        sut.configure()
+        sut.configure(user: user)
         
         switch style {
             case .header, .selfProfile:     sut.backgroundColor = .black

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -2530,8 +2530,8 @@
 		EF61B33F1FC84B0100D8E631 /* AccessoryTextFieldValidationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccessoryTextFieldValidationTests.swift; sourceTree = "<group>"; };
 		EF61B3411FC8508400D8E631 /* TextFieldValidator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFieldValidator.swift; sourceTree = "<group>"; };
 		EF7F74021FCC01140059C13F /* EmailAdresssValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailAdresssValidatorTests.swift; sourceTree = "<group>"; };
-		EFC530A31FF3F26D004D2B31 /* VoiceChannelViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceChannelViewControllerTests.swift; sourceTree = "<group>"; };
 		EF91A0541FF3A04700FE2F53 /* GiphySearchViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiphySearchViewControllerTests.swift; sourceTree = "<group>"; };
+		EFC530A31FF3F26D004D2B31 /* VoiceChannelViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceChannelViewControllerTests.swift; sourceTree = "<group>"; };
 		EFE8062A1FDFF24C006A0EE7 /* NSDate+Format.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSDate+Format.swift"; sourceTree = "<group>"; };
 		EFE8062E1FE005A7006A0EE7 /* DateFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatterTests.swift; sourceTree = "<group>"; };
 		EFFF9E841FBF335700491F9A /* UIColor+TeamCreation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+TeamCreation.swift"; sourceTree = "<group>"; };

--- a/Wire-iOS/Sources/UserInterface/Availability/AvailabilityTitleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Availability/AvailabilityTitleView.swift
@@ -100,8 +100,9 @@ import WireDataModel
 extension AvailabilityTitleView: ZMUserObserver {
     
     public func userDidChange(_ changeInfo: UserChangeInfo) {
-        guard changeInfo.availabilityChanged else { return }
-        
+        guard changeInfo.availabilityChanged || changeInfo.nameChanged,
+            let user = changeInfo.user as? ZMUser else { return }
+        self.user = user
         provideHapticFeedback()
         configure()
     }

--- a/Wire-iOS/Sources/UserInterface/Availability/AvailabilityTitleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Availability/AvailabilityTitleView.swift
@@ -25,12 +25,11 @@ import WireDataModel
 
 @objc public class AvailabilityTitleView: TitleView {
     
-    internal var user: ZMUser
-    internal var style: AvailabilityTitleViewStyle
-    internal var observerToken: Any?
+    private var user: ZMUser?
+    fileprivate var style: AvailabilityTitleViewStyle
+    private var observerToken: Any?
     
     public init(user: ZMUser, style: AvailabilityTitleViewStyle) {
-        self.user = user
         self.style = style
         
         var titleColor: UIColor
@@ -59,32 +58,34 @@ import WireDataModel
             self.observerToken = UserChangeInfo.add(observer: self, for: user, userSession: sharedSession)
         }
         
-        configure()
+        configure(user: user)
     }
     
     public required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
-    func configure() {
-        let availability = self.user.availability
+    func configure(user: ZMUser) {
+        let availability = user.availability
         let fontStyle: FontSize = (style == .header) ? .normal : .small
         let icon = AvailabilityStringBuilder.icon(for: availability, with: self.titleColor!, and: fontStyle)
         let interactive = (style == .selfProfile || style == .header)
         var title = ""
         
         if self.style == .header {
-            title = self.user.name
-        } else if self.user == ZMUser.selfUser() && availability == .none {
+            title = user.name
+        } else if user == ZMUser.selfUser() && availability == .none {
             title = "availability.message.set_status".localized.uppercased()
         } else if availability != .none {
             title = availability.localizedName.uppercased()
         }
         
+        self.user = user
         super.configure(icon: icon, title: title, interactive: interactive, showInteractiveIcon: style == .selfProfile)
     }
     
     override func updateAccessibilityLabel() {
+        guard let user = user else { return }
         self.accessibilityLabel = "\(user.name)_is_\(user.availability.localizedName)".localized
     }
     
@@ -102,9 +103,8 @@ extension AvailabilityTitleView: ZMUserObserver {
     public func userDidChange(_ changeInfo: UserChangeInfo) {
         guard changeInfo.availabilityChanged || changeInfo.nameChanged,
             let user = changeInfo.user as? ZMUser else { return }
-        self.user = user
         provideHapticFeedback()
-        configure()
+        configure(user: user)
     }
 }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

If you try to update your username on the settings, it won't get updated on the header of the Conversation List until you restart the app or switch to another account.

### Causes

Currently, the two versions of the header in Conversation List don't have a mechanism to update the username on changes.

### Solutions

I've updated the `UserChangeInfo` observer into the `AvailabilityTitleView` (Teams) class and I've added it into `ConversationListTopBar` class (Non-teams).
