### PR TITLE
Collections View Controller UI fixes

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
@@ -302,7 +302,8 @@ final public class CollectionsViewController: UIViewController {
         if let navBar = self.navigationController?.navigationBar {
             let imageToStretch = UIImage.shadowImage(withInset: 16.0 * UIScreen.main.scale, color: ColorScheme.default().color(withName: ColorSchemeColorSeparator))
             let scaleImageToStretch = UIImage(cgImage: imageToStretch.cgImage!, scale: UIScreen.main.scale, orientation: .up)
-            navBar.shadowImage = scaleImageToStretch.stretchableImage(withLeftCapWidth: 20, topCapHeight: 0)
+            let stretchedImage = scaleImageToStretch.resizableImage(withCapInsets: UIEdgeInsetsMake(0, 18, 0, 18))
+            navBar.shadowImage = stretchedImage
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/DefaultNavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/DefaultNavigationBar.swift
@@ -42,7 +42,7 @@ class DefaultNavigationBar : UINavigationBar {
         setTitleVerticalPositionAdjustment(-2.0, for: .default)
         
         let separatorPixel = UIImage.singlePixelImage(with: ColorScheme.default().color(withName: ColorSchemeColorSeparator))
-        let retinaSeparatorPixel = UIImage(cgImage: separatorPixel.cgImage!, scale: 2, orientation: separatorPixel.imageOrientation)
+        let retinaSeparatorPixel = UIImage(cgImage: separatorPixel.cgImage!, scale: UIScreen.main.scale, orientation: separatorPixel.imageOrientation)
         shadowImage = retinaSeparatorPixel
         
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationTitleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationTitleView.swift
@@ -44,7 +44,7 @@ class ConversationTitleView: TitleView {
         }
         super.configure(icon: attachment,
                         title: conversation.displayName.uppercased(),
-                        interactive: conversation.relatedConnectionState != .sent)
+                        interactive: self.interactive && conversation.relatedConnectionState != .sent)
     }
 
     override func updateAccessibilityLabel() {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Two issues inside Collections View Controller:

1. The hairline under the navigation bar was not visible on 3x displays (iPhone Plus, iPhone X, etc.)
2. `ConversationTitleView` inside the navigation bar had a clickable right arrow. 

### Causes

1. The left cap inset was too broad on 3x displays.
2. The `interactive` flag was not considered.

### Solutions

1. I've set an inset of 18px, which fits on both 2x and 3x displays. Furthermore, I'm using `resizableImage(withCapInsets:)` instead of `stretchableImage(withLeftCapWidth:topCapHeight:)`, because the last one is deprecated.
2. I'm considering the `interactive` flag when deciding to display or not the right arrow.

## Notes

Partially related to _ZIOS-9106 - iOS 11 and iPhone X visual fixes_. Thanks to the Design team for reporting the issues.
  