### PR TITLE
Fix crash in (extension in Wire):__ObjC.ConversationCell.willDisplayInTableView() -> (), line 41

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell+BurstTimestamp.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell+BurstTimestamp.swift
@@ -38,7 +38,8 @@ public extension ConversationCell {
             delegate.responds(to: #selector(ConversationCellDelegate.conversationCellShouldStartDestructionTimer)) &&
             delegate.conversationCellShouldStartDestructionTimer!(self) {
             updateCountdownView()
-            if message.startSelfDestructionIfNeeded() {
+
+            if let message = message, message.startSelfDestructionIfNeeded() {
                 startCountdownAnimationIfNeeded(message)
             }
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

App crashes when calling ConversationCell.willDisplayInTableView()

### Causes

message is nil when reading.

### Solutions

unwrap message before access 

## Notes

Need further study about why message is nil when willDisplayInTableView(). (viewWillAppear & UITable.willDisplayCell are the callers.)