### PR TITLE
ZIOS-8569: Added control about camera permissions in Conversation List

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+CameraPicker.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+CameraPicker.swift
@@ -96,21 +96,24 @@ extension URL: Shareable {
 extension ConversationListViewController {
 
     @objc public func showCameraPicker() {
-        let cameraPicker = CameraPicker(target: self)
-        cameraPicker.didPickResult = { [weak self] result in
-            guard let `self` = self else {
-                return
-            }
-            
-            switch result {
-            case .image(let image):
-                self.showShareControllerFor(image: image)
-            case .video(let videoURL):
-                self.showShareControllerFor(videoAtURL: videoURL)
+        UIApplication.wr_requestOrWarnAboutVideoAccess { (granted) in
+            if granted {
+                let cameraPicker = CameraPicker(target: self)
+                cameraPicker.didPickResult = { [weak self] result in
+                    guard let `self` = self else {
+                        return
+                    }
+                    
+                    switch result {
+                    case .image(let image):
+                        self.showShareControllerFor(image: image)
+                    case .video(let videoURL):
+                        self.showShareControllerFor(videoAtURL: videoURL)
+                    }
+                }
+                cameraPicker.pick()
             }
         }
-        
-        cameraPicker.pick()
     }
     
     public func showShareControllerFor(image: UIImage) {


### PR DESCRIPTION
## What's new in this PR?

### Issues

If you tap on the Camera button inside the Conversation List, you'll need to grant access to the camera. If you refuse access, the camera will open with a black view on the next attempt.

### Solutions

I've added the `UIApplication.wr_requestOrWarnAboutVideoAccess`, so now the user is informed to grant access to the camera from the Settings app, in order to take pictures.