### PR TITLE
Better labels for the log sending dialogues

### DIFF
--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
@@ -545,14 +545,14 @@
 - (void)requestLoopNotification:(NSNotification *)notification;
 {
     NSString *path = notification.userInfo[@"path"];
-    [DebugAlert showWithMessage:[NSString stringWithFormat:@"A request loop is going on at %@", path] sendLogs:YES];
+    [DebugAlert showSendLogsMessageWithMessage:[NSString stringWithFormat:@"A request loop is going on at %@", path]];
 }
 
 #pragma mark - SE inconsistency notification
 
 - (void)potentialErrorNotification:(NSNotification *)notification;
 {
-    [DebugAlert showWithMessage:[NSString stringWithFormat:@"We detected a potential error, please send logs"] sendLogs:YES];
+    [DebugAlert showSendLogsMessageWithMessage:[NSString stringWithFormat:@"We detected a potential error, please send logs"]];
 }
 
 #pragma mark -  Share extension analytics

--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
@@ -340,7 +340,7 @@ import CocoaLumberjackSwift
                             self.deleteUserClient(userClient, credentials: newCredentials)
                         } else {
                             if DeveloperMenuState.developerMenuEnabled() {
-                                DebugAlert.show(message: "No email set!")
+                                DebugAlert.showGeneric(message: "No email set!")
                             }
                         }
                     case .right(let error):

--- a/Wire-iOS/Sources/WireApplication.swift
+++ b/Wire-iOS/Sources/WireApplication.swift
@@ -32,9 +32,8 @@ import UIKit
     
     override public func motionEnded(_ motion: UIEventSubtype, with event: UIEvent?) {
         guard motion == .motionShake else { return }
-        DebugAlert.show(
-            message: "You have performed a shake motion, please confirm sending debug logs.",
-            sendLogs: true
+        DebugAlert.showSendLogsMessage(
+            message: "You have performed a shake motion, please confirm sending debug logs."
         )
     }
 }


### PR DESCRIPTION
## What's new in this PR?
Tweaked copy of the dialogues to send logs (internal builds only).

### Issues
The log sending dialogues had labels that were confusing with certain messages (e.g. "Please confirm sending" -> "Send logs" or "OK").

## Changes
I fixed the alert to have "Send debug logs" as title, and "Send" and "Cancel" as buttons.