### PR TITLE
ZIOS-9434: Audio Message Fixes

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -201,7 +201,7 @@
 "conversation.input_bar.audio_message.tooltip.pull_send" = "Swipe up to send";
 "conversation.input_bar.audio_message.tooltip.tap_send" = "Tap to send";
 "conversation.input_bar.audio_message.too_long.title" = "Recording Stopped";
-"conversation.input_bar.audio_message.too_long.message" = "Audio messages are limited to %@. Send this message?";
+"conversation.input_bar.audio_message.too_long.message" = "Audio messages are limited to %@.";
 "conversation.input_bar.audio_message.send" = "Send";
 
 "conversation.input_bar.audio_message.keyboard.record_tip" = "Tap to record\nYou can  %@  it after that";

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioEffectsPickerViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioEffectsPickerViewController.swift
@@ -182,12 +182,6 @@ import Cartography
         }
     }
     
-    public override func removeFromParentViewController() {
-        self.audioPlayerController?.stop()
-        self.audioPlayerController = nil
-        super.removeFromParentViewController()
-    }
-    
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.selectCurrentFilter()
@@ -196,6 +190,12 @@ import Cartography
                 self.setState(.tip, animated: true)
             }
         }
+    }
+    
+    public override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        self.audioPlayerController?.stop()
+        self.audioPlayerController = nil
     }
     
     public override func viewDidLayoutSubviews() {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioEffectsPickerViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioEffectsPickerViewController.swift
@@ -182,6 +182,12 @@ import Cartography
         }
     }
     
+    public override func removeFromParentViewController() {
+        self.audioPlayerController?.stop()
+        self.audioPlayerController = nil
+        super.removeFromParentViewController()
+    }
+    
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.selectCurrentFilter()

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioEffectsPickerViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioEffectsPickerViewController.swift
@@ -182,6 +182,12 @@ import Cartography
         }
     }
     
+    public override func removeFromParentViewController() {
+        self.audioPlayerController?.stop()
+        self.audioPlayerController = nil
+        super.removeFromParentViewController()
+    }
+    
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.selectCurrentFilter()
@@ -190,12 +196,6 @@ import Cartography
                 self.setState(.tip, animated: true)
             }
         }
-    }
-    
-    public override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        self.audioPlayerController?.stop()
-        self.audioPlayerController = nil
     }
     
     public override func viewDidLayoutSubviews() {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
@@ -276,17 +276,16 @@ import CocoaLumberjackSwift
                 
                 let duration = Int(ceil(self.recorder.maxRecordingDuration ?? 0))
                 let (seconds, minutes) = (duration % 60, duration / 60)
-                
                 let durationLimit = String(format: "%d:%02d", minutes, seconds)
                 
-                let alertController = UIAlertController(title: "conversation.input_bar.audio_message.too_long.title".localized, message: "conversation.input_bar.audio_message.too_long.message".localized(args: durationLimit), preferredStyle: .alert)
-                let actionCancel = UIAlertAction(title: "general.cancel".localized, style: .cancel, handler: nil)
-                alertController.addAction(actionCancel)
+                let alertController = UIAlertController(
+                    title: "conversation.input_bar.audio_message.too_long.title".localized,
+                    message: "conversation.input_bar.audio_message.too_long.message".localized(args: durationLimit),
+                    preferredStyle: .alert
+                )
                 
-                let actionSend = UIAlertAction(title: "conversation.input_bar.audio_message.send".localized, style: .default, handler: { action in
-                    self.sendAudioAsIs(.afterPreview)
-                })
-                alertController.addAction(actionSend)
+                let actionOk = UIAlertAction(title: "general.ok".localized, style: .default, handler: nil)
+                alertController.addAction(actionOk)
                 
                 self.present(alertController, animated: true, completion: .none)
             }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
@@ -98,7 +98,7 @@ import CocoaLumberjackSwift
             self.audioPreviewView.color = color
         }
         
-        [self.audioPreviewView, self.timeLabel, self.tipLabel, self.recordButton, self.stopRecordButton, self.confirmButton, self.redoButton, self.cancelButton, self.tipLabel, self.bottomToolbar, self.topContainer, self.topSeparator].forEach { $0.translatesAutoresizingMaskIntoConstraints = false }
+        [self.audioPreviewView, self.timeLabel, self.tipLabel, self.recordButton, self.stopRecordButton, self.confirmButton, self.redoButton, self.cancelButton, self.bottomToolbar, self.topContainer, self.topSeparator].forEach { $0.translatesAutoresizingMaskIntoConstraints = false }
         
         self.audioPreviewView.gradientWidth = 20
         self.audioPreviewView.gradientColor = colorScheme.color(withName: ColorSchemeColorTextForeground)
@@ -108,7 +108,7 @@ import CocoaLumberjackSwift
         self.createTipLabel()
         
         self.timeLabel.font = UIFont(magicIdentifier: "style.text.small.font_spec_light")
-        self.timeLabel.textColor = colorScheme.color(withName: ColorSchemeColorTextForeground)
+        self.timeLabel.textColor = colorScheme.color(withName: ColorSchemeColorTextForeground, variant: .dark)
         
         [self.audioPreviewView, self.timeLabel, self.tipLabel].forEach(self.topContainer.addSubview)
         

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordViewController.swift
@@ -232,9 +232,7 @@ private let margin = (CGFloat(WAZUIMagic.float(forIdentifier: "content.left_marg
     
     func configureAudioRecorder() {
         recorder.recordTimerCallback = { [weak self] time in
-            guard let `self` = self else {
-                return
-            }
+            guard let `self` = self else { return }
             self.updateTimeLabel(time)
         }
         
@@ -243,41 +241,34 @@ private let margin = (CGFloat(WAZUIMagic.float(forIdentifier: "content.left_marg
         }
         
         recorder.recordEndedCallback = { [weak self] reachedMaxRecordingDuration in
-            guard let `self` = self else {
-                return
-            }
+            guard let `self` = self else { return }
             self.recordingState = .finishedRecording
             if reachedMaxRecordingDuration {
                 
                 let duration = Int(ceil(self.recorder.maxRecordingDuration ?? 0))
                 let (seconds, minutes) = (duration % 60, duration / 60)
-                
                 let durationLimit = String(format: "%d:%02d", minutes, seconds)
                 
-                let alertController = UIAlertController(title: "conversation.input_bar.audio_message.too_long.title".localized, message: "conversation.input_bar.audio_message.too_long.message".localized(args: durationLimit), preferredStyle: .alert)
-                let actionCancel = UIAlertAction(title: "general.cancel".localized, style: .cancel, handler: nil)
-                alertController.addAction(actionCancel)
+                let alertController = UIAlertController(
+                    title: "conversation.input_bar.audio_message.too_long.title".localized,
+                    message: "conversation.input_bar.audio_message.too_long.message".localized(args: durationLimit),
+                    preferredStyle: .alert
+                )
                 
-                let actionSend = UIAlertAction(title: "conversation.input_bar.audio_message.send".localized, style: .default, handler: { action in
-                    self.sendAudio(.afterPreview)
-                })
-                alertController.addAction(actionSend)
+                let actionCancel = UIAlertAction(title: "general.ok".localized, style: .default, handler: nil)
+                alertController.addAction(actionCancel)
                 
                 self.present(alertController, animated: true, completion: .none)
             }
         }
         
         recorder.playingStateCallback = { [weak self] state in
-            guard let `self` = self else {
-                return
-            }
+            guard let `self` = self else { return }
             self.buttonOverlay.playingState = state
         }
         
         recorder.recordLevelCallBack = { [weak self] level in
-            guard let `self` = self else {
-                return
-            }
+            guard let `self` = self else { return }
             self.audioPreviewView.updateWithLevel(CGFloat(level))
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecorder.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecorder.swift
@@ -176,10 +176,10 @@ public final class AudioRecorder: NSObject, AudioRecorderType {
     
     @discardableResult public func stopRecording() -> Bool {
         audioRecorder?.stop()
-        return postRecordingCleanUp()
+        return postRecordingProcessing()
     }
     
-    fileprivate func postRecordingCleanUp() -> Bool {
+    fileprivate func postRecordingProcessing() -> Bool {
         recordLevelCallBack?(0)
         removeDisplayLink()
         guard let filePath = audioRecorder?.url.path , fm.fileExists(atPath: filePath) else { return false }
@@ -303,7 +303,7 @@ extension AudioRecorder: AVAudioRecorderDelegate {
         
         // in the case that the recording finished due to the maxRecordingDuration
         // reached, we should still clean up afterwards
-        if recordedToMaxDuration { _ = postRecordingCleanUp() }
+        if recordedToMaxDuration { _ = postRecordingProcessing() }
         
         self.recordEndedCallback?(recordedToMaxDuration)
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecorder.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecorder.swift
@@ -289,12 +289,12 @@ public final class AudioRecorder: NSObject, AudioRecorderType {
 
 extension AudioRecorder: AVAudioRecorderDelegate {
     public func audioRecorderDidFinishRecording(_ recorder: AVAudioRecorder, successfully flag: Bool) {
-        let recordedToMaxDuration: Bool
+        
+        var recordedToMaxDuration = false
+        
         if let maxRecordingDuration = self.maxRecordingDuration {
-            recordedToMaxDuration = currentDuration >= maxRecordingDuration
-        }
-        else {
-            recordedToMaxDuration = false
+            let duration = AVURLAsset(url: recorder.url).duration.seconds
+            recordedToMaxDuration = duration >= maxRecordingDuration
         }
         
         self.recordEndedCallback?(recordedToMaxDuration)

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecorder.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecorder.swift
@@ -176,6 +176,10 @@ public final class AudioRecorder: NSObject, AudioRecorderType {
     
     @discardableResult public func stopRecording() -> Bool {
         audioRecorder?.stop()
+        return postRecordingCleanUp()
+    }
+    
+    fileprivate func postRecordingCleanUp() -> Bool {
         recordLevelCallBack?(0)
         removeDisplayLink()
         guard let filePath = audioRecorder?.url.path , fm.fileExists(atPath: filePath) else { return false }
@@ -296,6 +300,10 @@ extension AudioRecorder: AVAudioRecorderDelegate {
             let duration = AVURLAsset(url: recorder.url).duration.seconds
             recordedToMaxDuration = duration >= maxRecordingDuration
         }
+        
+        // in the case that the recording finished due to the maxRecordingDuration
+        // reached, we should still clean up afterwards
+        if recordedToMaxDuration { _ = postRecordingCleanUp() }
         
         self.recordEndedCallback?(recordedToMaxDuration)
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

This PR addresses a few bugs relating to the audio messages UX:

1. In the audio message keyboard, the recording timer label is not visible.
2. Whilst previewing a recording, tapping the *redo* icon returns to the recording view, however, the previous recording will play until it finishes.
3. If the max recording limit is reached (25min), the user is presented with an alert view with two actions *cancel* and *send*. Meanwhile, the audio recording is lost. Cancelling dismisses the alert, but the user can not preview nor send the recording. Tapping *send* does nothing.

### Causes

1. The font color of the timer label is exactly the same as the background colour of it's superview.
2. Although the `AVAudioPlayer` within the `AudioEffectsPickerViewController` is stopped in `viewWillDisappear(:)`, this is not called when the player is currently playing.
3. When recording is stopped manually (before 25mins), some post-recording code is executed to ensure the file exists and if so, `fileURL` is set, which will be used when picking an effect. When the recording is stopped automatically (at 25mins), this functionality is not executed, so `fileURL` is nil.

### Solutions

1. Change the font color
2. Stop the audio player when `AudioEffectsPickerViewController` is removed from the view heirarchy.
3. Ensure the post-recording code is executed. Also, change the max duration alert to contain only a single action *ok*, which will simply dismiss the alert. This allows the user to preview, apply affects and send or redo as desired (See screenshots, but note the time limit has been reduced to 5 sec for debugging purposes).

### Attachments

![simulator screen shot - iphone 8 - 2018-01-10 at 10 09 01](https://user-images.githubusercontent.com/28632506/34933691-17cee87a-f9d8-11e7-8f11-1ef98711bb02.png)

