### PR TITLE
ZIOS-9469: audio filter applied when no filter should be applied

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioEffectsPickerViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioEffectsPickerViewController.swift
@@ -89,6 +89,7 @@ import Cartography
                 }
             }
             else {
+                self.delegate?.audioEffectsPickerDidPickEffect(self, effect: .none, resultFilePath: self.recordingPath)
                 self.playMedia(self.recordingPath)
             }
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

After recording an audio message and selecting a filter, removing the filter before sending still applies the last selected filter. As a result, the delegate (`AudioRecordKeyboardViewController`) `currentEffect` property still contains the last selected effect.

### Causes

When selecting `none` as a filter (original recording), the `AudioEffectsPickerDelegate` was not being notified of the selection.

### Solutions

Notify the delegate.