### PR TITLE
Audio recorder timer with Bluetooth headset

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
@@ -298,7 +298,7 @@ import CocoaLumberjackSwift
     }
     
     func updateTimeLabel(_ durationInSeconds: TimeInterval) {
-        let duration = Int(ceil(durationInSeconds))
+        let duration = Int(floor(durationInSeconds))
         let (seconds, minutes) = (duration % 60, duration / 60)
         timeLabel.text = String(format: "%d:%02d", minutes, seconds)
         timeLabel.accessibilityValue = timeLabel.text

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordViewController.swift
@@ -315,7 +315,7 @@ private let margin = (CGFloat(WAZUIMagic.float(forIdentifier: "content.left_marg
     }
     
     func updateTimeLabel(_ durationInSeconds: TimeInterval) {
-        let duration = Int(ceil(durationInSeconds))
+        let duration = Int(floor(durationInSeconds))
         let (seconds, minutes) = (duration % 60, duration / 60)
         timeLabel.text = String(format: "%d:%02d", minutes, seconds)
         timeLabel.accessibilityValue = timeLabel.text

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecorder.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecorder.swift
@@ -161,21 +161,20 @@ public final class AudioRecorder: NSObject, AudioRecorderType {
         recordTimerCallback?(0)
         fileURL = nil
         setupDisplayLink()
+        
+        var successfullyStarted = false
+        
         if let maxDuration = self.maxRecordingDuration {
-            if !audioRecorder.record(forDuration: maxDuration) {
-                DDLogError("Failed to start audio recording")
-            }
-            else {
-                self.recordStartedCallback?()
-            }
+            successfullyStarted = audioRecorder.record(forDuration: maxDuration)
+            if !successfullyStarted { DDLogError("Failed to start audio recording") }
+            else { self.recordStartedCallback?() }
         }
         else {
-            if !audioRecorder.record() { // 25 minutes max recording
-                DDLogError("Failed to start audio recording")
-            }
+            successfullyStarted = audioRecorder.record()
+            if !successfullyStarted { DDLogError("Failed to start audio recording") }
         }
         
-        recordingStartTime = audioRecorder.deviceCurrentTime
+        recordingStartTime = successfullyStarted ? audioRecorder.deviceCurrentTime : nil
     }
     
     @discardableResult public func stopRecording() -> Bool {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecorder.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecorder.swift
@@ -121,6 +121,8 @@ public final class AudioRecorder: NSObject, AudioRecorderType {
     public var recordEndedCallback: ((Bool) -> Void)? // recordedToMaxDuration: Bool
     public var fileURL: URL?
     
+    fileprivate var recordingStartTime: TimeInterval?
+    
     override init() {
         fatalError("init() is not implemented for AudioRecorder")
     }
@@ -172,6 +174,8 @@ public final class AudioRecorder: NSObject, AudioRecorderType {
                 DDLogError("Failed to start audio recording")
             }
         }
+        
+        recordingStartTime = audioRecorder.deviceCurrentTime
     }
     
     @discardableResult public func stopRecording() -> Bool {
@@ -281,10 +285,15 @@ public final class AudioRecorder: NSObject, AudioRecorderType {
     }
     
     public func durationForCurrentState() -> TimeInterval? {
-        if case .recording = state {
-            return audioRecorder?.currentTime
-        } else {
-            return audioPlayer?.currentTime ?? audioRecorder?.currentTime
+        switch state {
+        case .recording:
+            guard let recorder = audioRecorder, let startTime = recordingStartTime else {
+                return nil
+            }
+            return recorder.deviceCurrentTime - startTime
+            
+        case .playback:
+            return audioPlayer?.currentTime
         }
     }
     
@@ -295,6 +304,7 @@ extension AudioRecorder: AVAudioRecorderDelegate {
     public func audioRecorderDidFinishRecording(_ recorder: AVAudioRecorder, successfully flag: Bool) {
         
         var recordedToMaxDuration = false
+        recordingStartTime = nil
         
         if let maxRecordingDuration = self.maxRecordingDuration {
             let duration = AVURLAsset(url: recorder.url).duration.seconds


### PR DESCRIPTION
## What's new in this PR?

### Issues

When recording an audio message with a Bluetooth headset, the timer label does not start at zero.

### Causes

The timer label reflects the value of `AVAudioRecorder`s `currentTime` property, which according to the documentation is

> The time, in seconds, since the beginning of the recording.

When the internal iPhone microphone is used, this works correctly. But when a Bluetooth microphone is connected, it appears to be displaying the device time, since the label increases monotonously. I have not been able to identify what the problem is, but a [similar issue](https://stackoverflow.com/questions/45162064/avaudiorecorder-sets-current-time-to-negative-values-when-plugged-headphone-at-i) on stack overflow indicates that it could be a bug with `AVAudioRecorder`.

### Solutions

The first attempt at a solution is to use the `deviceCurrentTime` property to calculate the current duration, by capturing the initial device time when recording begins, and to subtract this value from the actual device time each time the label is updated. This works fine for recordings with the iPhone microphone. 

In the case of the Bluetooth microphone, the timer begins at zero as desired, but the timer tends to exceed the actual recording duration by a few seconds. The reason being is that when recording is started (tapping the icon) with a Bluetooth microphone, we capture the device time, but a few seconds elapse before the actual recording initiates. The user is aware of this because there is a delay between tapping record and hearing a tone in the Bluetooth headset indicating the microphone is active.

There doesn't seem to be a way to be notified when the actual recording is started, which makes it hard to ensure we capture the initial device time at the right moment. To be clear, the main issue is that the user thinks they have recorded for 5 seconds, but when previewing/sending they see only 3 seconds was recorded.

## Notes

To make matters worse, this is quite hard to debug since it is not clear when the Bluetooth microphone is used or not. On devices running iOS 11.1 or higher, the Bluetooth microphone is used. However, when running the a debug build directly from XCode, the iPhone microphone is used. So I've been testing using Playground builds which takes a fair bit of time.

**Any ideas or suggestions are welcome!**