### PR TITLE
“Version Technical Details” button should also work at iPad

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
@@ -202,7 +202,14 @@ import Foundation
 
         let versionTitle =  "self.settings.advanced.version_technical_details.title".localized
         let versionCell = SettingsButtonCellDescriptor(title: versionTitle, isDestructive: false) { _ in
-            UIApplication.shared.keyWindow?.rootViewController?.present(VersionInfoViewController(), animated: true, completion: .none)
+            let versionInfoViewController = VersionInfoViewController()
+            var superViewController = UIApplication.shared.keyWindow?.rootViewController
+            if let presentedViewController = superViewController?.presentedViewController {
+                superViewController = presentedViewController
+                versionInfoViewController.modalPresentationStyle = UIModalPresentationStyle.overCurrentContext
+                versionInfoViewController.navigationController?.modalPresentationStyle = UIModalPresentationStyle.overCurrentContext
+            }
+            superViewController?.present(versionInfoViewController, animated: true, completion: .none)
         }
 
         let versionSection = SettingsSectionDescriptor(cellDescriptors: [versionCell])


### PR DESCRIPTION
## What's new in this PR?

Fix for https://github.com/wireapp/wire-ios/issues/1593 - 'Version Technical Details' are not displayed at iPad

### Issues

The “Version Technical Details” button (Found in Settings / Advanced) on the iPad version it not tappable / doesn’t function at all

### Causes

Code was trying to present VersionInfoViewController from UIApplication.shared.keyWindow?.rootViewController, which is behind the presented Settings form sheet.

### Solutions

Present VersionInfoViewController from presentedViewController when available (on iPad).
modalPresentationStyle for the both VersionInfoViewController  and navigationController set to overCurrentContext to draw in the same form sheet.

## Dependencies

None

Needs releases with:

None