### PR TITLE
Show learn more button when email is already in use

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -832,15 +832,14 @@
 "team.invite.header.subtitle" = "Invite your colleagues to join.";
 "team.invite.textfield.placeholder" = "colleague@yourcompany.com";
 "team.invite.textfield.accesibility" = "Enter e-mail address for colleague to invite.";
-"team.invite.contacts_button.title" = "Add from Addressbook";
+"team.invite.learn_more.title" = "Learn more";
 "team.invite.top_bar.skip" = "Skip";
 "team.invite.top_bar.done" = "Done";
 
 // Team Invite Errors
 "team.invite.error.generic" = "Something went wrong, please try again.";
-"team.invite.error.already_registered" = "This email is already registered on Wire.";
-"team.invite.error.already_invited" = "This email has already been invited.";
-"team.invite.error.too_many_invitations" = "You have reached the maximum amount of invitations.";
+"team.invite.error.already_registered" = "This email address is already in use.";
+"team.invite.error.too_many_invitations" = "The maximum number of invitations has been sent.";
 
 // Registration
 

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Team Invites/TeamMemberInviteViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Team Invites/TeamMemberInviteViewController.swift
@@ -101,10 +101,6 @@ final class TeamMemberInviteViewController: UIViewController, TeamInviteTopbarDe
     
     private func setupFooterView() {
         footerTextFieldView.onConfirm = sendInvite
-        footerTextFieldView.shouldConfirm = { [weak self] email in
-            guard let `self` = self else { return true }
-            return !self.dataSource.data.emails.contains(email)
-        }
         footerTextFieldView.onAddFromAddressbook = {
             // TODO: Present address book picker
         }
@@ -138,6 +134,7 @@ final class TeamMemberInviteViewController: UIViewController, TeamInviteTopbarDe
             footerTextFieldView.clearInput()
         case let .failure(_, error: error):
             footerTextFieldView.errorMessage = error.errorDescription.uppercased()
+            footerTextFieldView.errorButton.isHidden = error != .alreadyRegistered
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/TextFieldValidator.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/TextFieldValidator.swift
@@ -19,14 +19,11 @@
 import Foundation
 
 class TextFieldValidator {
-    
-    var customValidator: ((String) -> ValidationError?)?
 
     enum ValidationError: Error, Equatable {
         case tooShort(kind: AccessoryTextField.Kind)
         case tooLong(kind: AccessoryTextField.Kind)
         case invalidEmail
-        case custom(String)
         case none
 
 
@@ -38,8 +35,6 @@ class TextFieldValidator {
             case (.invalidEmail, .invalidEmail),
                  (.none, .none):
                 return true
-            case (.custom(let lhs), .custom(let rhs)):
-                return lhs == rhs
             default:
                 return false
             }
@@ -49,10 +44,6 @@ class TextFieldValidator {
     func validate(text: String?, kind: AccessoryTextField.Kind) -> TextFieldValidator.ValidationError {
         guard let text = text else {
             return .none
-        }
-        
-        if let customError = customValidator?(text) {
-            return customError
         }
 
         switch kind {
@@ -112,8 +103,6 @@ extension TextFieldValidator.ValidationError: LocalizedError {
             }
         case .invalidEmail:
             return "email.guidance.invalid".localized
-        case .custom(let description):
-            return description
         case .none:
             return ""
         }


### PR DESCRIPTION
## What's new in this PR?

This PR includes multiple minor team invitation UI fixes such as:

* Attempt to fix the accessibility identifiers.
* Show a "learn more" button in case the email is already registered.
* Remove the client-side check wether or not the email is already in use and rely solely on the server response.