### PR TITLE
Remove full screen loading indicator from invite screen

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -904,6 +904,8 @@
 		D5168F282008ED0700F8222A /* KeyboardBlockObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5168F272008ED0700F8222A /* KeyboardBlockObserver.swift */; };
 		D5168F2A2008F3EF00F8222A /* UIEdgeInsets+Adjusting.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5168F292008F3EF00F8222A /* UIEdgeInsets+Adjusting.swift */; };
 		D5168F2C200CBBF300F8222A /* Analytics+TeamInvites.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5168F2B200CBBF300F8222A /* Analytics+TeamInvites.swift */; };
+		D5168F43200F6F2300F8222A /* CABasicAnimation+Rotation.h in Headers */ = {isa = PBXBuildFile; fileRef = D5168F41200F6F2300F8222A /* CABasicAnimation+Rotation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D5168F44200F6F2300F8222A /* CABasicAnimation+Rotation.m in Sources */ = {isa = PBXBuildFile; fileRef = D5168F42200F6F2300F8222A /* CABasicAnimation+Rotation.m */; };
 		D5490A1D20050AAA0057EAA8 /* TeamMemberInviteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5490A1C20050AAA0057EAA8 /* TeamMemberInviteViewController.swift */; };
 		D5DBAAA720064D5600E9F65B /* ArrayDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DBAAA620064D5600E9F65B /* ArrayDataSource.swift */; };
 		D5DBAAAA20064D8800E9F65B /* InviteResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DBAAA920064D8800E9F65B /* InviteResult.swift */; };
@@ -2416,6 +2418,8 @@
 		D5168F272008ED0700F8222A /* KeyboardBlockObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardBlockObserver.swift; sourceTree = "<group>"; };
 		D5168F292008F3EF00F8222A /* UIEdgeInsets+Adjusting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIEdgeInsets+Adjusting.swift"; sourceTree = "<group>"; };
 		D5168F2B200CBBF300F8222A /* Analytics+TeamInvites.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Analytics+TeamInvites.swift"; sourceTree = "<group>"; };
+		D5168F41200F6F2300F8222A /* CABasicAnimation+Rotation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CABasicAnimation+Rotation.h"; sourceTree = "<group>"; };
+		D5168F42200F6F2300F8222A /* CABasicAnimation+Rotation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "CABasicAnimation+Rotation.m"; sourceTree = "<group>"; };
 		D5490A1C20050AAA0057EAA8 /* TeamMemberInviteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamMemberInviteViewController.swift; sourceTree = "<group>"; };
 		D5DBAAA620064D5600E9F65B /* ArrayDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayDataSource.swift; sourceTree = "<group>"; };
 		D5DBAAA920064D8800E9F65B /* InviteResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteResult.swift; sourceTree = "<group>"; };
@@ -2970,6 +2974,8 @@
 				161541BB1E28FFAE00AC2FFB /* CircularProgressView.swift */,
 				1E8C25361BBC279B00FC373F /* ProgressSpinner.h */,
 				1E8C25371BBC279B00FC373F /* ProgressSpinner.m */,
+				D5168F41200F6F2300F8222A /* CABasicAnimation+Rotation.h */,
+				D5168F42200F6F2300F8222A /* CABasicAnimation+Rotation.m */,
 				1E8C25381BBC279B00FC373F /* UIViewController+LoadingView.h */,
 				1E8C25391BBC279B00FC373F /* UIViewController+LoadingView.m */,
 			);
@@ -5325,6 +5331,7 @@
 				8795A5CE1D34D09E0024101B /* VoiceIndicatorLayer.h in Headers */,
 				1E5E0D061B6B8EDB003B0CAC /* UIImage+ImageUtilities.h in Headers */,
 				87B7DABC1E6976C1005F5140 /* ImageCache.h in Headers */,
+				D5168F43200F6F2300F8222A /* CABasicAnimation+Rotation.h in Headers */,
 				1E5E0CFD1B6B8EDB003B0CAC /* ZetaIconTypes.h in Headers */,
 				87E7C9651BF5E4E2001C5485 /* WireStyleKit.h in Headers */,
 				1E5E0CB21B6B83C6003B0CAC /* IconButton.h in Headers */,
@@ -6038,6 +6045,7 @@
 				878607201D33E3FF00971A19 /* LineNumberLogFormatter.m in Sources */,
 				1E5E0D051B6B8EDB003B0CAC /* UIControl+Wire.m in Sources */,
 				1EE9DCC61B5F9A6D00E347DF /* TokenField.m in Sources */,
+				D5168F44200F6F2300F8222A /* CABasicAnimation+Rotation.m in Sources */,
 				876CC8991E966C5C00F6BABC /* IteratorProtocol+Histogram.swift in Sources */,
 				CE06C9401DF5C3D900497685 /* AVAsset+VideoConvert.m in Sources */,
 				EF1F99F71FBB06C000969DD1 /* UILabel+TextTransform.m in Sources */,

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/AccessoryTextField.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/AccessoryTextField.swift
@@ -46,6 +46,12 @@ class AccessoryTextField: UITextField {
     static let placeholderFont = FontSpec(.small, .regular).font!
     static private let ConfirmButtonWidth: CGFloat = 32
 
+    var isLoading = false {
+        didSet {
+            updateLoadingState()
+        }
+    }
+    
     var kind: Kind {
         didSet {
             setupTextFieldProperties()
@@ -61,15 +67,8 @@ class AccessoryTextField: UITextField {
     let confirmButton: IconButton = {
         let iconButton = IconButton.iconButtonCircularLight()
         iconButton.circular = true
-        iconButton.setIconColor(UIColor.Team.textColor, for: .normal)
-        iconButton.setIconColor(UIColor.Team.textfieldColor, for: .disabled)
-        iconButton.adjustsImageWhenDisabled = false
-        iconButton.setBackgroundImageColor(UIColor.Team.activeButtonColor, for: .normal)
-        iconButton.setBackgroundImageColor(UIColor.Team.inactiveButtonColor, for: .disabled)
-
         iconButton.accessibilityIdentifier = "AccessoryTextFieldConfirmButton"
         iconButton.isEnabled = false
-
         return iconButton
     }()
 
@@ -149,12 +148,42 @@ class AccessoryTextField: UITextField {
         }
     }
     
-    private func updateButtonIcon() {
-        if let overrideIcon = overrideButtonIcon {
-            confirmButton.setIcon(overrideIcon, with: .tiny, for: .normal)
+    private func updateLoadingState() {
+        updateButtonIcon()
+        let animationKey = "rotation_animation"
+        if isLoading {
+            let animation = CABasicAnimation.rotateAnimation(withRotationSpeed: 1.4, beginTime: 0, delegate: nil)
+            confirmButton.layer.add(animation, forKey: animationKey)
         } else {
-            confirmButton.setIcon(UIApplication.isLeftToRightLayout ? .chevronRight : .chevronLeft, with: .tiny, for: .normal)
+            confirmButton.layer.removeAnimation(forKey: animationKey)
         }
+    }
+    
+    private var buttonIcon: ZetaIconType {
+        return isLoading
+        ? .spinner
+        : overrideButtonIcon ?? (UIApplication.isLeftToRightLayout ? .chevronRight : .chevronLeft)
+    }
+    
+    private var iconSize: ZetaIconSize {
+        return isLoading ? .medium : .tiny
+    }
+    
+    private func updateButtonIcon() {
+        confirmButton.setIcon(buttonIcon, with: iconSize, for: .normal)
+        
+        if isLoading {
+            confirmButton.setIconColor(UIColor.Team.inactiveButtonColor, for: .normal)
+            confirmButton.setBackgroundImageColor(.clear, for: .normal)
+            confirmButton.setBackgroundImageColor(.clear, for: .disabled)
+        } else {
+            confirmButton.setIconColor(UIColor.Team.textfieldColor, for: .normal)
+            confirmButton.setIconColor(UIColor.Team.textfieldColor, for: .disabled)
+            confirmButton.setBackgroundImageColor(UIColor.Team.activeButtonColor, for: .normal)
+            confirmButton.setBackgroundImageColor(UIColor.Team.inactiveButtonColor, for: .disabled)
+        }
+
+        confirmButton.adjustsImageWhenDisabled = false
     }
 
     private func setup() {

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Team Invites/TeamInviteTextFieldFooterView.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Team Invites/TeamInviteTextFieldFooterView.swift
@@ -28,6 +28,12 @@ final class TeamInviteTextFieldFooterView: UIView {
         uppercasePlaceholder: false
     )
     
+    var isLoading = false {
+        didSet {
+            updateLoadingState()
+        }
+    }
+    
     let errorButton = Button()
     private let textField: AccessoryTextField
     private let errorLabel = UILabel()
@@ -109,5 +115,10 @@ final class TeamInviteTextFieldFooterView: UIView {
     @objc private func showLearnMorePage() {
         let url = URL(string: "https://support.wire.com/hc/en-us/articles/115004082129-My-email-address-is-already-in-use-and-I-cannot-create-an-account-What-can-I-do-")!
         UIApplication.shared.openURL(url)
+    }
+    
+    private func updateLoadingState() {
+        textField.isLoading = isLoading
+        textFieldDescriptor.acceptsInput = !isLoading
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Team Invites/TeamMemberInviteViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Team Invites/TeamMemberInviteViewController.swift
@@ -116,7 +116,7 @@ final class TeamMemberInviteViewController: UIViewController, TeamInviteTopbarDe
         
         guard let userSession = ZMUserSession.shared() else { return }
         Analytics.shared().tag(TeamInviteEvent.sentInvite(.teamCreation))
-        showLoadingView = true
+        footerTextFieldView.isLoading = true
         
         ZMUser.selfUser().team?.invite(email: email, in: userSession) { [weak self] result in
             self?.handle(inviteResult: result, from:  .manualInput)
@@ -129,7 +129,7 @@ final class TeamMemberInviteViewController: UIViewController, TeamInviteTopbarDe
         case.addressBook: handleAddressBookResult(result)
         }
         
-        showLoadingView = false
+        footerTextFieldView.isLoading = false
         topBar.mode = dataSource.data.count == 0 ? .skip : .done
     }
     

--- a/WireExtensionComponents/Views/Loading/CABasicAnimation+Rotation.h
+++ b/WireExtensionComponents/Views/Loading/CABasicAnimation+Rotation.h
@@ -1,0 +1,14 @@
+//
+//  CABasicAnimation+CABasicAnimation_Rotation.h
+//  WireExtensionComponents
+//
+//  Created by Zeta on 17.01.18.
+//  Copyright © 2018 Zeta Project Germany GmbH. All rights reserved.
+//
+
+#import <QuartzCore/QuartzCore.h>
+
+@interface CABasicAnimation (Rotation)
+    
++ (CABasicAnimation * _Nonnull)rotateAnimationWithRotationSpeed:(CGFloat)rotationSpeed beginTime:(CGFloat)beginTime delegate:(id<CAAnimationDelegate> _Nullable)delegate;
+@end

--- a/WireExtensionComponents/Views/Loading/CABasicAnimation+Rotation.h
+++ b/WireExtensionComponents/Views/Loading/CABasicAnimation+Rotation.h
@@ -1,9 +1,19 @@
 //
-//  CABasicAnimation+CABasicAnimation_Rotation.h
-//  WireExtensionComponents
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
 //
-//  Created by Zeta on 17.01.18.
-//  Copyright © 2018 Zeta Project Germany GmbH. All rights reserved.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
 #import <QuartzCore/QuartzCore.h>

--- a/WireExtensionComponents/Views/Loading/CABasicAnimation+Rotation.m
+++ b/WireExtensionComponents/Views/Loading/CABasicAnimation+Rotation.m
@@ -1,9 +1,19 @@
 //
-//  CABasicAnimation+CABasicAnimation_Rotation.m
-//  WireExtensionComponents
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
 //
-//  Created by Zeta on 17.01.18.
-//  Copyright © 2018 Zeta Project Germany GmbH. All rights reserved.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
 #import "CABasicAnimation+Rotation.h"

--- a/WireExtensionComponents/Views/Loading/CABasicAnimation+Rotation.m
+++ b/WireExtensionComponents/Views/Loading/CABasicAnimation+Rotation.m
@@ -1,0 +1,32 @@
+//
+//  CABasicAnimation+CABasicAnimation_Rotation.m
+//  WireExtensionComponents
+//
+//  Created by Zeta on 17.01.18.
+//  Copyright © 2018 Zeta Project Germany GmbH. All rights reserved.
+//
+
+#import "CABasicAnimation+Rotation.h"
+
+@implementation CABasicAnimation (Rotation)
+
++ (CABasicAnimation * _Nonnull)rotateAnimationWithRotationSpeed:(CGFloat)rotationSpeed beginTime:(CGFloat)beginTime delegate:(id<CAAnimationDelegate> _Nullable)delegate
+    {
+        CABasicAnimation* rotate =  [CABasicAnimation animationWithKeyPath: @"transform.rotation.z"];
+        rotate.fillMode = kCAFillModeForwards;
+        rotate.delegate = delegate;
+        
+        // Do a series of 5 quarter turns for a total of a 1.25 turns
+        // (2PI is a full turn, so pi/2 is a quarter turn)
+        [rotate setToValue: [NSNumber numberWithFloat: M_PI / 2]];
+        rotate.repeatCount = HUGE_VALF;
+        
+        rotate.duration = rotationSpeed / 4;
+        rotate.beginTime = beginTime;
+        rotate.cumulative = YES;
+        rotate.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear];
+        
+        return rotate;
+    }
+    
+@end

--- a/WireExtensionComponents/Views/Loading/ProgressSpinner.m
+++ b/WireExtensionComponents/Views/Loading/ProgressSpinner.m
@@ -20,7 +20,8 @@
 #import "ProgressSpinner.h"
 #import "UIImage+ZetaIconsNeue.h"
 #import "NSLayoutConstraint+Helpers.h"
-
+#import "NSLayoutConstraint+Helpers.h"
+#import "CABasicAnimation+Rotation.h"
 @import QuartzCore;
 
 
@@ -142,7 +143,7 @@
     self.hidden = NO;
     [self stopAnimationInternal];
     if (self.window != nil) {
-        [self.spinner.layer addAnimation:[self rotateAnimationWithRotationSpeed:1.4 beginTime:0] forKey:@"rotateAnimation"];
+        [self.spinner.layer addAnimation:[CABasicAnimation rotateAnimationWithRotationSpeed:1.4 beginTime:0 delegate:self] forKey:@"rotateAnimation"];
     }
 }
 
@@ -164,25 +165,6 @@
 - (void)stopAnimation:(id)sender
 {
     self.animating = NO;
-}
-
-- (CABasicAnimation *)rotateAnimationWithRotationSpeed:(CGFloat)rotationSpeed beginTime:(CGFloat)beginTime
-{
-    CABasicAnimation* rotate =  [CABasicAnimation animationWithKeyPath: @"transform.rotation.z"];
-    rotate.fillMode = kCAFillModeForwards;
-    rotate.delegate = self;
-    
-    // Do a series of 5 quarter turns for a total of a 1.25 turns
-    // (2PI is a full turn, so pi/2 is a quarter turn)
-    [rotate setToValue: [NSNumber numberWithFloat: M_PI / 2]];
-    rotate.repeatCount = HUGE_VALF;
-    
-    rotate.duration = rotationSpeed / 4;
-    rotate.beginTime = beginTime;
-    rotate.cumulative = YES;
-    rotate.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear];
-    
-    return rotate;
 }
 
 - (void)animationDidStop:(CAAnimation *)anim finished:(BOOL)flag

--- a/WireExtensionComponents/WireExtensionComponents.h
+++ b/WireExtensionComponents/WireExtensionComponents.h
@@ -76,4 +76,5 @@ FOUNDATION_EXPORT const unsigned char WireExtensionComponentsVersionString[];
 #import <WireExtensionComponents/AccentColorProvider.h>
 #import <WireExtensionComponents/UIColor+WR_ColorScheme.h>
 #import <WireExtensionComponents/UILabel+TextTransform.h>
+#import <WireExtensionComponents/CABasicAnimation+Rotation.h>
 


### PR DESCRIPTION
## What's new in this PR?

* Remove the full screen loading indicator when inviting a team member.
* Adjust `AccessoryTextField` so it can show a loading spinner instead of the confirm button.