### PR TITLE
Revert removing custom validation logic

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -845,6 +845,7 @@
 // Team Invite Errors
 "team.invite.error.generic" = "Something went wrong, please try again";
 "team.invite.error.already_registered" = "This email address is already in use";
+"team.invite.error.already_invited" = "This email has already been invited";
 "team.invite.error.too_many_invitations" = "The maximum number of invitations has been sent";
 "team.invite.error.no_internet" = "No internet connection";
 

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Team Invites/TeamInviteTextFieldFooterView.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Team Invites/TeamInviteTextFieldFooterView.swift
@@ -37,6 +37,14 @@ final class TeamInviteTextFieldFooterView: UIView {
     let errorButton = Button()
     private let textField: AccessoryTextField
     private let errorLabel = UILabel()
+
+    var shouldConfirm: ((String) -> Bool)? {
+        didSet {
+            textField.textFieldValidator.customValidator = { [weak self] email in
+                (self?.shouldConfirm?(email) ?? true) ? nil : .custom("team.invite.error.already_invited".localized.uppercased())
+            }
+        }
+    }
     
     var onConfirm: ((String) -> Void)? {
         didSet {
@@ -86,9 +94,9 @@ final class TeamInviteTextFieldFooterView: UIView {
         errorButton.setTitleColor(.darkGray, for: .highlighted)
         errorButton.accessibilityIdentifier = "LearnMoreButton"
         errorButton.addTarget(self, action: #selector(showLearnMorePage), for: .touchUpInside)
+        textField.accessibilityLabel = "EmailInputField"
         [textField, errorLabel, errorButton].forEach(addSubview)
         backgroundColor = .clear
-        
     }
     
     private func createConstraints() {

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Team Invites/TeamInviteTopBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Team Invites/TeamInviteTopBar.swift
@@ -67,7 +67,7 @@ final class TeamInviteTopBar: UIView {
     
     private func createConstraints() {
         constrain(self, actionButton) { view, actionButton in
-            actionButton.trailing == view.trailing - 24
+            actionButton.trailing == view.trailing - 16
             actionButton.bottom == view.bottom - 12
             view.height == 44
         }

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Team Invites/TeamMemberInviteViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Team Invites/TeamMemberInviteViewController.swift
@@ -106,6 +106,10 @@ final class TeamMemberInviteViewController: UIViewController, TeamInviteTopbarDe
     
     private func setupFooterView() {
         footerTextFieldView.onConfirm = sendInvite
+        footerTextFieldView.shouldConfirm = { [weak self] email in
+            guard let `self` = self else { return true }
+            return !self.dataSource.data.emails.contains(email)
+        }
         tableView.tableFooterView = footerTextFieldView.sized(fittingWidth: tableView.bounds.width)
     }
     

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/TextFieldValidator.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/TextFieldValidator.swift
@@ -19,11 +19,14 @@
 import Foundation
 
 class TextFieldValidator {
+    
+    var customValidator: ((String) -> ValidationError?)?
 
     enum ValidationError: Error, Equatable {
         case tooShort(kind: AccessoryTextField.Kind)
         case tooLong(kind: AccessoryTextField.Kind)
         case invalidEmail
+        case custom(String)
         case none
 
 
@@ -35,6 +38,8 @@ class TextFieldValidator {
             case (.invalidEmail, .invalidEmail),
                  (.none, .none):
                 return true
+            case (.custom(let lhs), .custom(let rhs)):
+                return lhs == rhs
             default:
                 return false
             }
@@ -44,6 +49,10 @@ class TextFieldValidator {
     func validate(text: String?, kind: AccessoryTextField.Kind) -> TextFieldValidator.ValidationError {
         guard let text = text else {
             return .none
+        }
+        
+        if let customError = customValidator?(text) {
+            return customError
         }
 
         switch kind {
@@ -103,6 +112,8 @@ extension TextFieldValidator.ValidationError: LocalizedError {
             }
         case .invalidEmail:
             return "email.guidance.invalid".localized
+        case .custom(let description):
+            return description
         case .none:
             return ""
         }


### PR DESCRIPTION
## What's new in this PR?

* It was still possible to invite already invited email addresses, this PR reverts removing the custom validator logic to fix that.