### PR TITLE
Added highlight effect to Settings button of CameraKeyboardPermissionsCell

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardPermissionsCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardPermissionsCell.swift
@@ -29,7 +29,7 @@ public enum DeniedAuthorizationType {
 
 open class CameraKeyboardPermissionsCell: UICollectionViewCell, Reusable {
 
-    let settingsButton = UIButton()
+    let settingsButton = Button()
     let descriptionLabel = UILabel()
     
     private let containerView = UIView()
@@ -46,7 +46,6 @@ open class CameraKeyboardPermissionsCell: UICollectionViewCell, Reusable {
         descriptionLabel.numberOfLines = 0
         descriptionLabel.textAlignment = .center
         
-        settingsButton.backgroundColor = UIColor.white.withAlphaComponent(0.16)
         settingsButton.setTitleColor(.white, for: .normal)
         settingsButton.titleLabel?.font = UIFont.systemFont(ofSize: textSize, weight: UIFontWeightSemibold)
         settingsButton.setTitle("keyboard_photos_access.denied.keyboard.settings".localized, for: .normal)
@@ -54,7 +53,8 @@ open class CameraKeyboardPermissionsCell: UICollectionViewCell, Reusable {
         settingsButton.layer.cornerRadius = 4.0
         settingsButton.layer.masksToBounds = true
         settingsButton.addTarget(self, action: #selector(CameraKeyboardPermissionsCell.openSettings), for: .touchUpInside)
-        
+        settingsButton.setBackgroundImageColor(UIColor.white.withAlphaComponent(0.16), for: .normal)
+        settingsButton.setBackgroundImageColor(UIColor.white.withAlphaComponent(0.24), for: .highlighted)
         containerView.backgroundColor = .clear
         
         [descriptionLabel, settingsButton].forEach(containerView.addSubview)

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
@@ -167,9 +167,9 @@ open class CameraKeyboardViewController: UIViewController {
     }
     
     fileprivate func createCollectionView() {
-        self.setupPhotoKeyboardAppearance()
         self.collectionViewLayout.scrollDirection = .horizontal
         self.collectionView = UICollectionView(frame: CGRect.zero, collectionViewLayout: collectionViewLayout)
+        self.setupPhotoKeyboardAppearance()
         self.collectionView.register(CameraCell.self, forCellWithReuseIdentifier: CameraCell.reuseIdentifier)
         self.collectionView.register(AssetCell.self, forCellWithReuseIdentifier: AssetCell.reuseIdentifier)
         self.collectionView.register(CameraKeyboardPermissionsCell.self, forCellWithReuseIdentifier: CameraKeyboardPermissionsCell.reuseIdentifier)
@@ -300,8 +300,10 @@ open class CameraKeyboardViewController: UIViewController {
         
         if permissions.areCameraAndPhotoLibraryAuthorized {
             self.view.backgroundColor = .white
+            self.collectionView.delaysContentTouches = true
         } else {
             self.view.backgroundColor = ColorScheme.default().color(withName: ColorSchemeColorGraphite)
+            self.collectionView.delaysContentTouches = false
         }
         
         if permissions.isPhotoLibraryAuthorized {


### PR DESCRIPTION
## What's new in this PR?

I've added highlight effect to the "Settings" button inside `CameraKeyboardPermissionsCell`. I've also handled the `delaysContentTouches` flag of `UICollectionView`, in order to display the effect whenever the cell is shown onscreen.