### PR TITLE
Move InviteTeamMemberCell into a separate section without a header

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		1677FD341BBC19A400491481 /* ColorScheme.m in Sources */ = {isa = PBXBuildFile; fileRef = 1677FD321BBC19A400491481 /* ColorScheme.m */; };
 		167AEA101B16031900890435 /* VoiceChannelParticipantCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 167AEA0F1B16031900890435 /* VoiceChannelParticipantCell.m */; };
 		167B3B491BB36F6C003F5104 /* ConversationMessageWindowTableViewAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 167B3B481BB36F6C003F5104 /* ConversationMessageWindowTableViewAdapter.m */; };
+		16829EDF2010D60800F579A0 /* InviteTeamMemberSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16829EDE2010D60800F579A0 /* InviteTeamMemberSection.swift */; };
 		168A16AC1D9597C2005CFA6C /* ShareExtensionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 168A16AB1D9597C2005CFA6C /* ShareExtensionViewController.swift */; };
 		168A16AF1D9597C2005CFA6C /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 168A16AD1D9597C2005CFA6C /* MainInterface.storyboard */; };
 		168A16B31D9597C2005CFA6C /* Wire Share Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 168A16A91D9597C2005CFA6C /* Wire Share Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -1185,6 +1186,7 @@
 		167AEA0F1B16031900890435 /* VoiceChannelParticipantCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VoiceChannelParticipantCell.m; sourceTree = "<group>"; };
 		167B3B471BB36F6C003F5104 /* ConversationMessageWindowTableViewAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ConversationMessageWindowTableViewAdapter.h; sourceTree = "<group>"; };
 		167B3B481BB36F6C003F5104 /* ConversationMessageWindowTableViewAdapter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ConversationMessageWindowTableViewAdapter.m; sourceTree = "<group>"; };
+		16829EDE2010D60800F579A0 /* InviteTeamMemberSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteTeamMemberSection.swift; sourceTree = "<group>"; };
 		168A16A31D95964B005CFA6C /* NSString+URL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSString+URL.swift"; sourceTree = "<group>"; };
 		168A16A91D9597C2005CFA6C /* Wire Share Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "Wire Share Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		168A16AB1D9597C2005CFA6C /* ShareExtensionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareExtensionViewController.swift; sourceTree = "<group>"; };
@@ -2761,6 +2763,14 @@
 			path = InviteContacts;
 			sourceTree = "<group>";
 		};
+		16829EE02010D62300F579A0 /* InviteTeamMember */ = {
+			isa = PBXGroup;
+			children = (
+				16829EDE2010D60800F579A0 /* InviteTeamMemberSection.swift */,
+			);
+			path = InviteTeamMember;
+			sourceTree = "<group>";
+		};
 		168A16AA1D9597C2005CFA6C /* Wire-iOS Share Extension */ = {
 			isa = PBXGroup;
 			children = (
@@ -4035,6 +4045,7 @@
 				87DCF4C01D34EA4500BB420F /* CollectionViewSectionController.h */,
 				87DCF4C11D34EA4500BB420F /* GroupConversations */,
 				87DCF4C41D34EA4500BB420F /* Suggestions */,
+				16829EE02010D62300F579A0 /* InviteTeamMember */,
 				87DCF4C81D34EA4500BB420F /* TopPeopleLine */,
 				87DCF4CF1D34EA4500BB420F /* UsersInContacts */,
 			);
@@ -6614,6 +6625,7 @@
 				EF2127121FB9DFE300625A9B /* PhoneSignInViewController.m in Sources */,
 				8FC854A0199245770008B66B /* ParticipantsHeaderView.m in Sources */,
 				871BC01B1D34F56300DF0793 /* AnalyticsTracker+FileTransfer.m in Sources */,
+				16829EDF2010D60800F579A0 /* InviteTeamMemberSection.swift in Sources */,
 				160DECD71AB329CC000FB575 /* CameraAccessDeniedView.m in Sources */,
 				8FC85452199245770008B66B /* ConversationContentViewController.m in Sources */,
 				871BC0071D34F56300DF0793 /* Application+runDuration.m in Sources */,

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/InviteTeamMember/InviteTeamMemberSection.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/InviteTeamMember/InviteTeamMemberSection.swift
@@ -1,0 +1,79 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+class InviteTeamMemberSection : NSObject, CollectionViewSectionController {
+    
+    weak var delegate: CollectionViewSectionDelegate?
+    var team : Team?
+    var collectionView: UICollectionView? = nil {
+        didSet {
+            collectionView?.register(InviteTeamMemberCell.self, forCellWithReuseIdentifier: InviteTeamMemberCell.zm_reuseIdentifier)
+        }
+    }
+    
+    init(team : Team?) {
+        
+        super.init()
+        
+        self.team = team
+    }
+    
+    var isHidden: Bool {
+        return team?.members.count > 1
+    }
+    
+    func hasSearchResults() -> Bool {
+        return false
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return 1
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        return collectionView.dequeueReusableCell(withReuseIdentifier: InviteTeamMemberCell.zm_reuseIdentifier, for: indexPath)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return CGSize(width: collectionView.bounds.size.width, height: WAZUIMagic.cgFloat(forIdentifier: "people_picker.search_results_mode.tile_height"))
+    }
+
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
+        return CGSize.zero
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+        let top = WAZUIMagic.cgFloat(forIdentifier: "people_picker.search_results_mode.top_padding")
+        let left = WAZUIMagic.cgFloat(forIdentifier: "people_picker.search_results_mode.left_padding")
+        let right = WAZUIMagic.cgFloat(forIdentifier: "people_picker.search_results_mode.right_padding")
+        
+        return UIEdgeInsets(top: top, left: left, bottom: 0, right: right)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        URL.manageTeam(source: .onboarding).open()
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
+        
+    }
+    
+}
+

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/UsersInContacts/UsersInContactsSection.m
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/UsersInContacts/UsersInContactsSection.m
@@ -48,12 +48,7 @@ NSString *const PeoplePickerUsersInContactsReuseIdentifier = @"PeoplePickerUsers
 
 - (BOOL)isHidden
 {
-    return (self.contacts.count == 0 && !self.displaysInviteTeamMemberRow);
-}
-
-- (BOOL)displaysInviteTeamMemberRow
-{
-    return self.team != nil && self.team.members.count == 1;
+    return self.contacts.count == 0;
 }
 
 + (NSSet *)keyPathsForValuesAffectingIsHidden
@@ -65,7 +60,6 @@ NSString *const PeoplePickerUsersInContactsReuseIdentifier = @"PeoplePickerUsers
 {
     _collectionView = collectionView;
     [self.collectionView registerClass:[SearchResultCell class] forCellWithReuseIdentifier:PeoplePickerUsersInContactsReuseIdentifier];
-    [self.collectionView registerClass:[InviteTeamMemberCell class] forCellWithReuseIdentifier:InviteTeamMemberCell.zm_reuseIdentifier];
     [self.collectionView registerClass:[SearchSectionHeaderView class] forSupplementaryViewOfKind:UICollectionElementKindSectionHeader withReuseIdentifier:PeoplePickerHeaderReuseIdentifier];
 }
 
@@ -80,11 +74,7 @@ NSString *const PeoplePickerUsersInContactsReuseIdentifier = @"PeoplePickerUsers
 
 - (NSInteger)collectionView:(UICollectionView *)view numberOfItemsInSection:(NSInteger)section
 {
-    if (self.displaysInviteTeamMemberRow) {
-        return 1;
-    } else  {
-        return self.contacts.count;
-    }
+    return self.contacts.count;
 }
 
 - (UICollectionReusableView *)collectionView:(UICollectionView *)collectionView viewForSupplementaryElementOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath
@@ -104,12 +94,6 @@ NSString *const PeoplePickerUsersInContactsReuseIdentifier = @"PeoplePickerUsers
 
 - (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath
 {
-    if (self.displaysInviteTeamMemberRow && indexPath.row == 0) {
-        UICollectionViewCell *cell = [collectionView dequeueReusableCellWithReuseIdentifier:InviteTeamMemberCell.zm_reuseIdentifier
-                                                                                      forIndexPath:indexPath];
-        return cell;
-    }
-    
     UICollectionViewCell *genericCell = [collectionView dequeueReusableCellWithReuseIdentifier:PeoplePickerUsersInContactsReuseIdentifier
                                                                                   forIndexPath:indexPath];
     
@@ -140,11 +124,6 @@ NSString *const PeoplePickerUsersInContactsReuseIdentifier = @"PeoplePickerUsers
 
 - (void)collectionView:(UICollectionView *)collectionView didSelectItemAtIndexPath:(NSIndexPath *)indexPath
 {
-    if (indexPath.row == 0 && self.displaysInviteTeamMemberRow) {
-        [[NSURL manageTeamWithSource:TeamSourceOnboarding] open];
-        return;
-    }
-    
     ZMUser *modelObject = self.contacts[indexPath.item];
     
     [self.userSelection add:modelObject];
@@ -156,10 +135,6 @@ NSString *const PeoplePickerUsersInContactsReuseIdentifier = @"PeoplePickerUsers
 
 - (void)collectionView:(UICollectionView *)collectionView didDeselectItemAtIndexPath:(NSIndexPath *)indexPath
 {
-    if (indexPath.row == 0 && self.displaysInviteTeamMemberRow) {
-        return;
-    }
-    
     ZMUser *modelObject = self.contacts[indexPath.item];
     
     [self.userSelection remove:modelObject];

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
@@ -100,6 +100,7 @@ public class SearchResultsViewController : UIViewController {
     let directorySection : UsersInDirectorySection
     let conversationsSection : GroupConversationsSection
     let topPeopleSection : TopPeopleLineSection
+    let inviteTeamMemberSection : InviteTeamMemberSection
     
     var team: Team?
     var pendingSearchTask : SearchTask? = nil
@@ -145,6 +146,7 @@ public class SearchResultsViewController : UIViewController {
         topPeopleSection = TopPeopleLineSection()
         topPeopleSection.userSelection = userSelection
         topPeopleSection.topConversationDirectory = ZMUserSession.shared()?.topConversationsDirectory
+        inviteTeamMemberSection = InviteTeamMemberSection(team: team)
         
         super.init(nibName: nil, bundle: nil)
         
@@ -245,7 +247,7 @@ public class SearchResultsViewController : UIViewController {
             case (.list, false):
                 sections = [topPeopleSection, contactsSection]
             case (.list, true):
-                sections = [teamMemberAndContactsSection]
+                sections = [inviteTeamMemberSection, teamMemberAndContactsSection]
             }
         }
         


### PR DESCRIPTION
### Issues

The invite team member cell was hiding the guests if a team owner was only connected to guests.

### Causes

The logic for showing hiding the invite team member cell was only considering team members

### Solutions

Create a new section for the invite team member cell which is only visible when the team owner doesn't have any team members.

## Notes

The invite team member cell is now also only showing upp in the "list mode" in the search UI.