### PR TITLE
Fix TokenField placeholder not appearing, disable dynamic type for TokenField  

### DIFF
--- a/Wire-iOS/Sources/Components/TokenField/TokenField+DefaultAppearance.swift
+++ b/Wire-iOS/Sources/Components/TokenField/TokenField+DefaultAppearance.swift
@@ -20,7 +20,10 @@ import UIKit
 
 extension TokenField {
     func setupFonts() {
-        font = FontSpec(.normal, .regular).font
-        tokenTitleFont = FontSpec(.small, .regular).font
+        // Dynamic Type is disabled for now until the separator dots
+        // vertical alignment has been fixed for larger fonts.
+        let schema = FontScheme(contentSizeCategory: .medium)
+        font = schema.font(for: .init(.normal, .regular))
+        tokenTitleFont = schema.font(for: .init(.small, .regular))
     }
 }

--- a/Wire-iOS/Sources/Components/TokenField/TokenField.m
+++ b/Wire-iOS/Sources/Components/TokenField/TokenField.m
@@ -400,6 +400,7 @@ CGFloat const accessoryButtonSize = 32.0f;
 - (void)removeAllTokens
 {
     [self removeTokens:[self.currentTokens copy]];
+    [self.textView showOrHidePlaceholder];
 }
 
 - (void)removeTokens:(NSArray *)tokensToRemove

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchHeaderViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchHeaderViewController.swift
@@ -63,8 +63,6 @@ public class SearchHeaderViewController : UIViewController {
         super.init(nibName: nil, bundle: nil)
         
         userSelection.add(observer: self)
-        tokenField.font = FontSpec(.normal, .regular).font
-        tokenField.tokenTitleFont = FontSpec(.small, .regular).font
     }
     
     public override func viewDidLoad() {

--- a/WireExtensionComponents/Views/TextView.h
+++ b/WireExtensionComponents/Views/TextView.h
@@ -37,6 +37,8 @@ IB_DESIGNABLE
 @property (nonatomic) UIEdgeInsets placeholderTextContainerInset;
 @property (nonatomic) NSTextAlignment placeholderTextAlignment;
 
+- (void)showOrHidePlaceholder;
+    
 @end
 
 @protocol MediaAsset;


### PR DESCRIPTION
## What's new in this PR?

**Recreation of https://github.com/wireapp/wire-ios/pull/1624/ against `release/3.6`**

* Disable dynamic type for the `TokenField` for now until the vertical alignment of the separator dot has been fixed.
* Fix the placeholder not appearing when tapping the clear-all button of the text field.