### PR TITLE
Clean up usage of NSManagedObjectContext in tests

### DIFF
--- a/Wire-iOS Tests/AnalyticsMixpanelProviderTests.swift
+++ b/Wire-iOS Tests/AnalyticsMixpanelProviderTests.swift
@@ -23,8 +23,13 @@ class AnalyticsMixpanelProviderTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
+    }
+    
+    override func tearDown() {
         UserDefaults.shared().set(nil, forKey: MixpanelDistinctIdKey)
         UserDefaults.shared().synchronize()
+        
+        super.tearDown()
     }
     
     func testThatItGeneratesAndStoresUniqueMixpanelId() {

--- a/Wire-iOS Tests/CallSystemMessageTests.swift
+++ b/Wire-iOS Tests/CallSystemMessageTests.swift
@@ -24,6 +24,10 @@ import XCTest
 class CallSystemMessageTests: CoreDataSnapshotTestCase {
 
     // MARK: - Missed Call
+    
+    override func setUp() {
+        super.setUp()
+    }
 
     func testThatItRendersMissedCallFromSelfUser() {
         let missedCell = cell(for: .missedCall, fromSelf: true)
@@ -60,7 +64,7 @@ class CallSystemMessageTests: CoreDataSnapshotTestCase {
     // MARK: - Helper
 
     private func cell(for type: ZMSystemMessageType, fromSelf: Bool, expanded: Bool = false) -> IconSystemCell {
-        let message = systemMessage(missed: type == .missedCall, in: .insertNewObject(in: moc), from: fromSelf ? selfUser : otherUser)
+        let message = systemMessage(missed: type == .missedCall, in: .insertNewObject(in: uiMOC), from: fromSelf ? selfUser : otherUser)
         let cell = createCell(missed: type == .missedCall)
         cell.layer.speed = 0
         if expanded {

--- a/Wire-iOS Tests/ConversationAvatarViewTests.swift
+++ b/Wire-iOS Tests/ConversationAvatarViewTests.swift
@@ -48,9 +48,9 @@ class ConversationAvatarViewTests: CoreDataSnapshotTestCase {
 
     func testThatItRendersNoUserImages() {
         // GIVEN
-        let thirdUser = ZMUser.insertNewObject(in: moc)
+        let thirdUser = ZMUser.insertNewObject(in: uiMOC)
         thirdUser.name = "Anna"
-        let conversation = ZMConversation.insertGroupConversation(into: moc, withParticipants: [otherUser, thirdUser])
+        let conversation = ZMConversation.insertGroupConversation(into: uiMOC, withParticipants: [otherUser, thirdUser])
         conversation?.removeParticipant(selfUser)
         conversation?.removeParticipant(otherUser)
         conversation?.removeParticipant(thirdUser)
@@ -66,7 +66,7 @@ class ConversationAvatarViewTests: CoreDataSnapshotTestCase {
         // GIVEN
         otherUser.accentColorValue = .strongLimeGreen
         otherUserConversation.conversationType = .oneOnOne
-        moc.saveOrRollback()
+        uiMOC.saveOrRollback()
         
         // WHEN
         sut.conversation = otherUserConversation
@@ -75,9 +75,9 @@ class ConversationAvatarViewTests: CoreDataSnapshotTestCase {
         _ = sut.prepareForSnapshots()
         
         // AND WHEN
-        let thirdUser = ZMUser.insertNewObject(in: moc)
+        let thirdUser = ZMUser.insertNewObject(in: uiMOC)
         thirdUser.name = "Anna"
-        let conversation = ZMConversation.insertGroupConversation(into: moc, withParticipants: [otherUser, thirdUser])
+        let conversation = ZMConversation.insertGroupConversation(into: uiMOC, withParticipants: [otherUser, thirdUser])
         conversation?.removeParticipant(selfUser)
         conversation?.removeParticipant(otherUser)
         conversation?.removeParticipant(thirdUser)
@@ -92,7 +92,7 @@ class ConversationAvatarViewTests: CoreDataSnapshotTestCase {
         // GIVEN
         otherUser.accentColorValue = .strongLimeGreen
         otherUserConversation.conversationType = .oneOnOne
-        moc.saveOrRollback()
+        uiMOC.saveOrRollback()
         
         // WHEN
         sut.conversation = otherUserConversation
@@ -103,9 +103,9 @@ class ConversationAvatarViewTests: CoreDataSnapshotTestCase {
 
     func testThatItRendersTwoUserImages() {
         // GIVEN
-        let thirdUser = ZMUser.insertNewObject(in: moc)
+        let thirdUser = ZMUser.insertNewObject(in: uiMOC)
         thirdUser.name = "Anna"
-        let conversation = ZMConversation.insertGroupConversation(into: moc, withParticipants: [otherUser, thirdUser])
+        let conversation = ZMConversation.insertGroupConversation(into: uiMOC, withParticipants: [otherUser, thirdUser])
         
         (conversation?.activeParticipants.array as! [ZMUser]).assignSomeAccentColors()
         
@@ -118,7 +118,7 @@ class ConversationAvatarViewTests: CoreDataSnapshotTestCase {
 
     func testThatItRendersManyUsers() {
         // GIVEN
-        let conversation = ZMConversation.insertGroupConversation(into: moc, withParticipants: usernames.map(createUser))
+        let conversation = ZMConversation.insertGroupConversation(into: uiMOC, withParticipants: usernames.map(createUser))
         
         (conversation?.activeParticipants.array as! [ZMUser]).assignSomeAccentColors()
         

--- a/Wire-iOS Tests/ConversationImagesViewControllerTests.swift
+++ b/Wire-iOS Tests/ConversationImagesViewControllerTests.swift
@@ -24,15 +24,21 @@ class ConversationImagesViewControllerTests: CoreDataSnapshotTestCase {
     
     var sut: ConversationImagesViewController! = nil
     
+    override var needsCaches: Bool {
+        return true
+    }
+    
     override func setUp() {
         super.setUp()
         snapshotBackgroundColor = UIColor.white
     
         let image = self.image(inTestBundleNamed: "unsplash_matterhorn.jpg")
         let initialMessage = otherUserConversation.appendMessage(withImageData: image.data())!
-        
         let imagesCategoryMatch = CategoryMatch(including: .image, excluding: .none)
-        let assetWrapper = AssetCollectionWrapper(conversation: otherUserConversation, matchingCategories: [imagesCategoryMatch])
+        let collection = MockCollection(messages: [ imagesCategoryMatch : [initialMessage] ])
+        let delegate = AssetCollectionMulticastDelegate()
+        
+        let assetWrapper = AssetCollectionWrapper(conversation: otherUserConversation, assetCollection: collection, assetCollectionDelegate: delegate, matchingCategories: [imagesCategoryMatch])
         sut = ConversationImagesViewController(collection: assetWrapper, initialMessage: initialMessage, inverse: true)
     }
     

--- a/Wire-iOS Tests/ConversationRenamedCellTests.swift
+++ b/Wire-iOS Tests/ConversationRenamedCellTests.swift
@@ -53,7 +53,7 @@ class ConversationRenamedCellTests: CoreDataSnapshotTestCase {
     }
 
     private func renamedMessage(fromSelf: Bool, name: String) -> ZMSystemMessage {
-        let message = ZMSystemMessage.insertNewObject(in: moc)
+        let message = ZMSystemMessage.insertNewObject(in: uiMOC)
         message.systemMessageType = .conversationNameChanged
         message.sender = fromSelf ? selfUser : otherUser
         message.text = name

--- a/Wire-iOS Tests/ConversationStatusLineTests.swift
+++ b/Wire-iOS Tests/ConversationStatusLineTests.swift
@@ -21,6 +21,11 @@ import XCTest
 @testable import Wire
 
 class ConversationStatusLineTests: CoreDataSnapshotTestCase {
+    
+    override var needsCaches: Bool {
+        return true
+    }
+        
     func testStatusForNotActiveConversationWithHandle() {
         // GIVEN
         let sut = self.otherUserConversation!
@@ -63,7 +68,7 @@ class ConversationStatusLineTests: CoreDataSnapshotTestCase {
     func testStatusMissedCall() {
         // GIVEN
         let sut = self.otherUserConversation!
-        let otherMessage = ZMSystemMessage.insertNewObject(in: moc)
+        let otherMessage = ZMSystemMessage.insertNewObject(in: uiMOC)
         otherMessage.sender = self.otherUser
         otherMessage.systemMessageType = .missedCall
         sut.sortedAppendMessage(otherMessage)
@@ -110,7 +115,7 @@ class ConversationStatusLineTests: CoreDataSnapshotTestCase {
         for index in 1...5 {
             (sut.appendMessage(withText: "test \(index)") as! ZMMessage).sender = self.otherUser
         }
-        let otherMessage = ZMSystemMessage.insertNewObject(in: moc)
+        let otherMessage = ZMSystemMessage.insertNewObject(in: uiMOC)
         otherMessage.sender = self.otherUser
         otherMessage.systemMessageType = .conversationNameChanged
         sut.sortedAppendMessage(otherMessage)
@@ -155,7 +160,7 @@ class ConversationStatusLineTests: CoreDataSnapshotTestCase {
     func testStatusForSystemMessageIWasAdded() {
         // GIVEN
         let sut = createGroupConversation()
-        let otherMessage = ZMSystemMessage.insertNewObject(in: moc)
+        let otherMessage = ZMSystemMessage.insertNewObject(in: uiMOC)
         otherMessage.systemMessageType = .participantsAdded
         otherMessage.sender = self.otherUser
         otherMessage.users = Set([self.selfUser])
@@ -172,7 +177,7 @@ class ConversationStatusLineTests: CoreDataSnapshotTestCase {
     func testNoStatusForSystemMessageIAddedSomeone() {
         // GIVEN
         let sut = createGroupConversation()
-        let otherMessage = ZMSystemMessage.insertNewObject(in: moc)
+        let otherMessage = ZMSystemMessage.insertNewObject(in: uiMOC)
         otherMessage.systemMessageType = .participantsAdded
         otherMessage.sender = self.selfUser
         otherMessage.users = Set([self.otherUser])
@@ -190,7 +195,7 @@ class ConversationStatusLineTests: CoreDataSnapshotTestCase {
         // GIVEN
         let sut = createGroupConversation()
         sut.internalAddParticipants([createUser(name: "Vanessa")], isAuthoritative: true)
-        let otherMessage = ZMSystemMessage.insertNewObject(in: moc)
+        let otherMessage = ZMSystemMessage.insertNewObject(in: uiMOC)
         otherMessage.systemMessageType = .participantsRemoved
         otherMessage.sender = self.selfUser
         otherMessage.users = Set([self.otherUser])
@@ -206,10 +211,10 @@ class ConversationStatusLineTests: CoreDataSnapshotTestCase {
 
     func testEveryoneLeftStatusAfterLastPersonLeft() {
         // Given
-        let sut = ZMConversation.insertNewObject(in: moc)
+        let sut = ZMConversation.insertNewObject(in: uiMOC)
         sut.conversationType = .group
 
-        let otherMessage = ZMSystemMessage.insertNewObject(in: moc)
+        let otherMessage = ZMSystemMessage.insertNewObject(in: uiMOC)
         otherMessage.systemMessageType = .participantsRemoved
         otherMessage.sender = selfUser
         otherMessage.users = [otherUser]
@@ -227,7 +232,7 @@ class ConversationStatusLineTests: CoreDataSnapshotTestCase {
     func testStatusForSystemMessageSomeoneWasAdded() {
         // GIVEN
         let sut = createGroupConversation()
-        let otherMessage = ZMSystemMessage.insertNewObject(in: moc)
+        let otherMessage = ZMSystemMessage.insertNewObject(in: uiMOC)
         otherMessage.systemMessageType = .participantsAdded
         otherMessage.sender = self.otherUser
         otherMessage.users = Set([self.otherUser])
@@ -244,7 +249,7 @@ class ConversationStatusLineTests: CoreDataSnapshotTestCase {
     func testStatusForSystemMessageIWasRemoved() {
         // GIVEN
         let sut = createGroupConversation()
-        let otherMessage = ZMSystemMessage.insertNewObject(in: moc)
+        let otherMessage = ZMSystemMessage.insertNewObject(in: uiMOC)
         otherMessage.systemMessageType = .participantsRemoved
         otherMessage.sender = self.otherUser
         otherMessage.users = Set([self.selfUser])
@@ -263,7 +268,7 @@ class ConversationStatusLineTests: CoreDataSnapshotTestCase {
         // GIVEN
         let sut = createGroupConversation()
         sut.internalAddParticipants([createUser(name: "Lilly")], isAuthoritative: true)
-        let otherMessage = ZMSystemMessage.insertNewObject(in: moc)
+        let otherMessage = ZMSystemMessage.insertNewObject(in: uiMOC)
         otherMessage.systemMessageType = .participantsRemoved
         otherMessage.sender = self.otherUser
         otherMessage.users = Set([self.otherUser])
@@ -280,7 +285,7 @@ class ConversationStatusLineTests: CoreDataSnapshotTestCase {
     func testStatusForConversationStarted() {
         // GIVEN
         let sut = self.createGroupConversation()
-        let otherMessage = ZMSystemMessage.insertNewObject(in: moc)
+        let otherMessage = ZMSystemMessage.insertNewObject(in: uiMOC)
         otherMessage.systemMessageType = .newConversation
         otherMessage.sender = self.otherUser
         otherMessage.users = Set([self.otherUser, self.selfUser])
@@ -296,7 +301,7 @@ class ConversationStatusLineTests: CoreDataSnapshotTestCase {
     func testNoStatusForSelfConversationStarted() {
         // GIVEN
         let sut = self.createGroupConversation()
-        let otherMessage = ZMSystemMessage.insertNewObject(in: moc)
+        let otherMessage = ZMSystemMessage.insertNewObject(in: uiMOC)
         otherMessage.systemMessageType = .newConversation
         otherMessage.sender = self.selfUser
         otherMessage.users = Set([self.otherUser, self.selfUser])

--- a/Wire-iOS Tests/ConversationStatusTests.swift
+++ b/Wire-iOS Tests/ConversationStatusTests.swift
@@ -21,6 +21,10 @@ import XCTest
 @testable import Wire
 
 class ConversationStatusTests: CoreDataSnapshotTestCase {
+    
+    override var needsCaches: Bool {
+        return true
+    }
 
     func testThatItReturnsStatusForEmptyConversation() {
         // GIVEN

--- a/Wire-iOS Tests/CoreDataSnapshotTestCase.swift
+++ b/Wire-iOS Tests/CoreDataSnapshotTestCase.swift
@@ -21,8 +21,6 @@
 /// of mock objects.
 open class CoreDataSnapshotTestCase: ZMSnapshotTestCase {
 
-    var testSession: ZMTestSession!
-    var moc: NSManagedObjectContext!
     var selfUser: ZMUser!
     var otherUser: ZMUser!
     var otherUserConversation: ZMConversation!
@@ -31,56 +29,49 @@ open class CoreDataSnapshotTestCase: ZMSnapshotTestCase {
     override open func setUp() {
         super.setUp()
         snapshotBackgroundColor = .white
-        let group = ZMSDispatchGroup(dispatchGroup: DispatchGroup(), label: name)
-        testSession = ZMTestSession(dispatchGroup: group, accountIdentifier: UUID())
-        testSession.prepare(forTestNamed: name)
-        moc = testSession.uiMOC
         setupTestObjects()
     }
 
     override open func tearDown() {
-        moc = nil
         selfUser = nil
         otherUser = nil
         otherUserConversation = nil
-        testSession?.tearDown()
-        testSession = nil
         super.tearDown()
     }
 
     // MARK: – Setup
 
     private func setupTestObjects() {
-        selfUser = ZMUser.insertNewObject(in: moc)
+        selfUser = ZMUser.insertNewObject(in: uiMOC)
         selfUser.remoteIdentifier = UUID()
         selfUser.name = "selfUser"
-        ZMUser.boxSelfUser(selfUser, inContextUserInfo: moc)
+        ZMUser.boxSelfUser(selfUser, inContextUserInfo: uiMOC)
 
-        otherUser = ZMUser.insertNewObject(in: moc)
+        otherUser = ZMUser.insertNewObject(in: uiMOC)
         otherUser.remoteIdentifier = UUID()
         otherUser.name = "Bruno"
         otherUser.setHandle("bruno")
         otherUser.accentColorValue = .brightOrange
 
-        otherUserConversation = ZMConversation.insertNewObject(in: moc)
+        otherUserConversation = ZMConversation.insertNewObject(in: uiMOC)
         otherUserConversation.conversationType = .oneOnOne
-        let connection = ZMConnection.insertNewObject(in: moc)
+        let connection = ZMConnection.insertNewObject(in: uiMOC)
         connection.to = otherUser
         connection.status = .accepted
         connection.conversation = otherUserConversation
 
-        moc.saveOrRollback()
+        uiMOC.saveOrRollback()
     }
 
     func createGroupConversation() -> ZMConversation {
-        let conversation = ZMConversation.insertNewObject(in: moc)
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.conversationType = .group
         conversation.internalAddParticipants([selfUser, otherUser], isAuthoritative: true)
         return conversation
     }
     
     func createUser(name: String) -> ZMUser {
-        let user = ZMUser.insertNewObject(in: moc)
+        let user = ZMUser.insertNewObject(in: uiMOC)
         user.name = name
         user.remoteIdentifier = UUID()
         return user

--- a/Wire-iOS Tests/ParticipantCellTests.swift
+++ b/Wire-iOS Tests/ParticipantCellTests.swift
@@ -82,7 +82,7 @@ class ParticipantsCellTests: CoreDataSnapshotTestCase {
     // MARK: - Helper
 
     private func cell(for type: ZMSystemMessageType, fromSelf: Bool, manyUsers: Bool = false, left: Bool = false) -> IconSystemCell {
-        let message = ZMSystemMessage.insertNewObject(in: moc)
+        let message = ZMSystemMessage.insertNewObject(in: uiMOC)
         message.sender = fromSelf ? selfUser : otherUser
         message.systemMessageType = type
 

--- a/Wire-iOS Tests/ZMSnapshotTestCase.h
+++ b/Wire-iOS Tests/ZMSnapshotTestCase.h
@@ -58,6 +58,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic) NSManagedObjectContext *uiMOC;
 
+/// If YES the uiMOC will have image and file caches. Defaults to NO.
+@property (nonatomic, readonly) BOOL needsCaches;
+
 /// The color of the container view in which the view to
 /// be snapshot will be placed, defaults to UIColor.lightGrayColor
 @property (nonatomic, nullable) UIColor *snapshotBackgroundColor;

--- a/Wire-iOS Tests/ZMSnapshotTestCase.m
+++ b/Wire-iOS Tests/ZMSnapshotTestCase.m
@@ -65,6 +65,11 @@ static NSSet<NSNumber *> *phoneWidths(void) {
 
 @implementation ZMSnapshotTestCase
 
+- (BOOL)needsCaches
+{
+    return NO;
+}
+
 - (void)setUp
 {
     [super setUp];
@@ -108,10 +113,18 @@ static NSSet<NSNumber *> *phoneWidths(void) {
                                                                }];
 
     [self waitForExpectations:@[contextExpectation] timeout:0.1];
+    
+    if (self.needsCaches) {
+        [self setUpCaches];
+    }
 }
 
 - (void)tearDown
 {
+    if (self.needsCaches) {
+        [self wipeCaches];
+    }
+    
     // Needs to be called before setting self.documentsDirectory to nil.
     [self removeContentsOfDocumentsDirectory];
 
@@ -123,6 +136,22 @@ static NSSet<NSNumber *> *phoneWidths(void) {
     [UIView setAnimationsEnabled:YES];
 
     [super tearDown];
+}
+
+- (void)setUpCaches
+{
+    self.uiMOC.zm_imageAssetCache = [[ImageAssetCache alloc] initWithMBLimit:5 location:nil];
+    self.uiMOC.zm_userImageCache = [[UserImageLocalCache alloc] initWithLocation:nil];
+    self.uiMOC.zm_fileAssetCache = [[FileAssetCache alloc] initWithLocation:nil];
+}
+
+- (void)wipeCaches
+{
+    [self.uiMOC.zm_fileAssetCache wipeCaches];
+    [self.uiMOC.zm_userImageCache wipeCache];
+    [self.uiMOC.zm_imageAssetCache wipeCache];
+    
+    [PersonName.stringsToPersonNames removeAllObjects];
 }
 
 - (void)removeContentsOfDocumentsDirectory

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		161541BC1E28FFAE00AC2FFB /* CircularProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 161541BB1E28FFAE00AC2FFB /* CircularProgressView.swift */; };
 		16271BC61D9EB12E00689486 /* TypingIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16271BC51D9EB12E00689486 /* TypingIndicatorView.swift */; };
 		16271BC81DA5213400689486 /* TypingIndicatorViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16271BC71DA5213400689486 /* TypingIndicatorViewTests.swift */; };
+		162836142016574D0027082D /* ProcessInfo+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 162836132016574D0027082D /* ProcessInfo+Tests.swift */; };
 		162917C91F8BB991000F3E92 /* NetworkStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 162917C81F8BB991000F3E92 /* NetworkStatusView.swift */; };
 		162917CC1F8CC176000F3E92 /* NetworkStatusViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 162917CA1F8CC0B0000F3E92 /* NetworkStatusViewTests.swift */; };
 		162917CE1F8CD327000F3E92 /* NetworkStatusViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 162917CD1F8CD327000F3E92 /* NetworkStatusViewController.swift */; };
@@ -1143,6 +1144,7 @@
 		1621AFDA1C0DEE1500FAE41A /* TabBarController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
 		16271BC51D9EB12E00689486 /* TypingIndicatorView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypingIndicatorView.swift; sourceTree = "<group>"; };
 		16271BC71DA5213400689486 /* TypingIndicatorViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypingIndicatorViewTests.swift; sourceTree = "<group>"; };
+		162836132016574D0027082D /* ProcessInfo+Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProcessInfo+Tests.swift"; sourceTree = "<group>"; };
 		162917C81F8BB991000F3E92 /* NetworkStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkStatusView.swift; sourceTree = "<group>"; };
 		162917CA1F8CC0B0000F3E92 /* NetworkStatusViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkStatusViewTests.swift; sourceTree = "<group>"; };
 		162917CD1F8CD327000F3E92 /* NetworkStatusViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkStatusViewController.swift; sourceTree = "<group>"; };
@@ -4392,6 +4394,7 @@
 				8711A59F1E0C320100043ACF /* FloatingPoint.swift */,
 				BF8ECC321E5AED6C0015177D /* UIMenuItem+MessageActions.swift */,
 				8742C2E91E5309FC00329FB6 /* NSAttributedString+Highlight.swift */,
+				162836132016574D0027082D /* ProcessInfo+Tests.swift */,
 				7CA540811F740B7C00457F4B /* UIScreen+Compact.h */,
 				7CA540821F740B7C00457F4B /* UIScreen+Compact.m */,
 				EF2C18A11FED541F00E9F2FD /* Timer+allVersionCompatibleScheduledTimer.swift */,
@@ -6217,6 +6220,7 @@
 				EF2127101FB9DFE300625A9B /* SignInViewController.m in Sources */,
 				871BC2391D34F8F800DF0793 /* KeyboardAvoidingViewController.m in Sources */,
 				8F89140D1A9F287E0056AB0C /* ConnectRequestsCell.m in Sources */,
+				162836142016574D0027082D /* ProcessInfo+Tests.swift in Sources */,
 				8736F1C21E4DCEB8001CBA62 /* AppLockViewController.swift in Sources */,
 				871BC28A1D34F8F800DF0793 /* UIImagePickerController+GetImage.m in Sources */,
 				7CA540831F740B7C00457F4B /* UIScreen+Compact.m in Sources */,

--- a/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
+++ b/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
@@ -107,7 +107,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "OPTIN_STDERR YES"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-DisableHockeyUpdates 1"

--- a/Wire-iOS/Sources/AppStateController.swift
+++ b/Wire-iOS/Sources/AppStateController.swift
@@ -42,7 +42,7 @@ class AppStateController : NSObject {
     fileprivate var hasCompletedRegistration = false
     fileprivate var loadingAccount : Account?
     fileprivate var authenticationError : Error?
-    fileprivate let isRunningTests = ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+    fileprivate let isRunningTests = ProcessInfo.processInfo.isRunningTests
     
     override init() {
         super.init()

--- a/Wire-iOS/Sources/ClassyCache.swift
+++ b/Wire-iOS/Sources/ClassyCache.swift
@@ -110,8 +110,10 @@ extension Dictionary
     // MARK: - CASCacheProtocol
     
     func cacheStyleNodes(_ styleNodes: [AnyObject]!, fromPath path: String!, variables: [AnyHashable: Any]!) {
-        guard let bcasPath = self.bcasPath(path, variables: variables),
-            let styleNodes = styleNodes else {
+
+        guard !ProcessInfo.processInfo.isRunningTests,
+              let bcasPath = self.bcasPath(path, variables: variables),
+              let styleNodes = styleNodes else {
             return
         }
         

--- a/Wire-iOS/Sources/Helpers/ProcessInfo+Tests.swift
+++ b/Wire-iOS/Sources/Helpers/ProcessInfo+Tests.swift
@@ -1,0 +1,27 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension ProcessInfo {
+    
+    var isRunningTests : Bool {
+        return environment["XCTestConfigurationFilePath"] != nil
+    }
+    
+}


### PR DESCRIPTION
### Issues

The UI tests have started to crash on CI.

### Causes

The tests would hit an assertion in `ZMTestSession` because a NSManagedObjectContext tried to save in context whose store has been removed and later it would hit another assertion in the same class because the managed object context wouldn't be created due to a blocked main thread.

While debugging this I noticed that both CoreDataSnapshotTestCase and its parent class ZMSnapshotTestCase were creating managed object contexts.

The blocking of the main thread happens because we queue up blocks which saves the classy configuration to disk with a delay.

### Solutions

- Re-factor the tests to only use the managed object context created in `ZMSnapshotTestCase.
- Skip saving the classy configuration to disk since it's unnecessary in the tests.

## Notes

Also fixed a flaky test in `AnalyticsMixpanelProviderTests` which would fail in every second run.
