### PR TITLE
Show informational alert if password is needed after phone verification

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -913,6 +913,8 @@
 		D5168F562010F25000F8222A /* TokenField.m in Sources */ = {isa = PBXBuildFile; fileRef = 1EE9DCAE1B5F9A6D00E347DF /* TokenField.m */; };
 		D5168F572010F25400F8222A /* Token.m in Sources */ = {isa = PBXBuildFile; fileRef = 1EE9DCAC1B5F9A6D00E347DF /* Token.m */; };
 		D5168F592010F2F700F8222A /* TokenField+DefaultAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5168F582010F2F700F8222A /* TokenField+DefaultAppearance.swift */; };
+		D51735712017640D00B473CE /* UIAlertController+PasswordVerification.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51735702017640D00B473CE /* UIAlertController+PasswordVerification.swift */; };
+		D5173573201764DD00B473CE /* UIAlertAction+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5173572201764DD00B473CE /* UIAlertAction+Convenience.swift */; };
 		D5490A1D20050AAA0057EAA8 /* TeamMemberInviteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5490A1C20050AAA0057EAA8 /* TeamMemberInviteViewController.swift */; };
 		D5DBAAA720064D5600E9F65B /* ArrayDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DBAAA620064D5600E9F65B /* ArrayDataSource.swift */; };
 		D5DBAAAA20064D8800E9F65B /* InviteResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DBAAA920064D8800E9F65B /* InviteResult.swift */; };
@@ -2437,6 +2439,8 @@
 		D5168F42200F6F2300F8222A /* CABasicAnimation+Rotation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "CABasicAnimation+Rotation.m"; sourceTree = "<group>"; };
 		D5168F4C2010B61D00F8222A /* URL+Wire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Wire.swift"; sourceTree = "<group>"; };
 		D5168F582010F2F700F8222A /* TokenField+DefaultAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TokenField+DefaultAppearance.swift"; sourceTree = "<group>"; };
+		D51735702017640D00B473CE /* UIAlertController+PasswordVerification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertController+PasswordVerification.swift"; sourceTree = "<group>"; };
+		D5173572201764DD00B473CE /* UIAlertAction+Convenience.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertAction+Convenience.swift"; sourceTree = "<group>"; };
 		D5490A1C20050AAA0057EAA8 /* TeamMemberInviteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamMemberInviteViewController.swift; sourceTree = "<group>"; };
 		D5DBAAA620064D5600E9F65B /* ArrayDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayDataSource.swift; sourceTree = "<group>"; };
 		D5DBAAA920064D8800E9F65B /* InviteResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteResult.swift; sourceTree = "<group>"; };
@@ -3557,6 +3561,7 @@
 				D5168F272008ED0700F8222A /* KeyboardBlockObserver.swift */,
 				D5F8BFF32007AC84008F8C3D /* UIView+TableViewHeaderFooterSizing.swift */,
 				87AAE41E1E423C2A00E1D13A /* CASStyler+Fonts.swift */,
+				D5173572201764DD00B473CE /* UIAlertAction+Convenience.swift */,
 				CE8E4FB61DF17BBE0009F437 /* TextTransform */,
 				871BC1ED1D34F8F800DF0793 /* CALayer+EasyAnimation.h */,
 				871BC1EE1D34F8F800DF0793 /* CALayer+EasyAnimation.m */,
@@ -5219,6 +5224,7 @@
 			isa = PBXGroup;
 			children = (
 				EF2126D61FB9DFE300625A9B /* SignInViewController.m */,
+				D51735702017640D00B473CE /* UIAlertController+PasswordVerification.swift */,
 				EF2126D71FB9DFE300625A9B /* LoginCredentials.swift */,
 				EF2126D81FB9DFE300625A9B /* EmailSignInViewController.h */,
 				EF2126D91FB9DFE300625A9B /* PhoneSignInViewController.m */,
@@ -6356,6 +6362,7 @@
 				D5168F572010F25400F8222A /* Token.m in Sources */,
 				8742C2EA1E5309FC00329FB6 /* NSAttributedString+Highlight.swift in Sources */,
 				876113E41DD1DD6B007F5969 /* SketchToolbar.swift in Sources */,
+				D5173573201764DD00B473CE /* UIAlertAction+Convenience.swift in Sources */,
 				871BC00A1D34F56300DF0793 /* TimeIntervalClusterizer.m in Sources */,
 				EF2127201FB9DFE300625A9B /* NavigationController.m in Sources */,
 				871BC0031D34F56300DF0793 /* AnalyticsFileTransferObserver.swift in Sources */,
@@ -6632,6 +6639,7 @@
 				87F6D1BB1C1590B7000AB4D2 /* RequestPasswordViewController.swift in Sources */,
 				87DCF4E01D34EA4500BB420F /* TopPeopleCell.m in Sources */,
 				8F5A3E9D19AE2C9E00D0E9DA /* AVSMediaManager+Additions.m in Sources */,
+				D51735712017640D00B473CE /* UIAlertController+PasswordVerification.swift in Sources */,
 				BF3A3DCE1EA75290005477F8 /* RotatingKeyboardAvoidingViewController.swift in Sources */,
 				BFC914921D1814AF001F068B /* LocationMessageCell.swift in Sources */,
 				871BC2731D34F8F800DF0793 /* UpsideDownTableView.m in Sources */,

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -932,6 +932,9 @@
 "registration.signin.email_button.title" = "Email";
 "registration.signin.phone_button.title" = "Phone";
 
+"registration.signin.alert.password_needed.title" = "Password needed";
+"registration.signin.alert.password_needed.message" = "Please enter your Password in order to log in.";
+
 "registration.devices.title" = "Devices";
 "registration.devices.active_list_header" = "Active";
 "registration.devices.current_list_header" = "Current";

--- a/Wire-iOS/Sources/UserInterface/Helpers/UIAlertAction+Convenience.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UIAlertAction+Convenience.swift
@@ -1,0 +1,35 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+extension UIAlertAction {
+    @objc(cancelActionWithCompletion:) static func cancel(_ completion: (() -> Void)? = nil) -> UIAlertAction {
+        return UIAlertAction(
+            title: "general.cancel".localized,
+            style: .cancel,
+            handler: { _ in completion?() }
+        )
+    }
+    
+    @objc(okActionWithCompletion:) static func ok(_ completion:(() -> Void)? = nil) -> UIAlertAction {
+        return UIAlertAction(
+            title: "general.ok".localized,
+            style: .default,
+            handler: { _ in completion?() }
+        )
+    }
+}

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/SignIn/SignInViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/SignIn/SignInViewController.m
@@ -262,6 +262,8 @@
 {
     self.loginCredentials = loginCredentials;
     [self presentEmailSignInViewControllerToEnterPassword];
+    UIAlertController *controller = [UIAlertController passwordVerificationNeededControllerWithCompletion:nil];
+    [self presentViewController:controller animated:YES completion:nil];
 }
 
 @end

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/SignIn/UIAlertController+PasswordVerification.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/SignIn/UIAlertController+PasswordVerification.swift
@@ -1,0 +1,34 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import UIKit
+
+extension UIAlertController {
+    @objc(passwordVerificationNeededControllerWithCompletion:)
+    static func passwordVerificationNeeded(completion: (() -> Void)? = nil) -> UIAlertController {
+        let controller = UIAlertController(
+            title: "registration.signin.alert.password_needed.title".localized,
+            message: "registration.signin.alert.password_needed.message".localized,
+            preferredStyle: .alert
+        )
+        
+        controller.addAction(.ok(completion))
+        return controller
+    }
+}
+


### PR DESCRIPTION
## What's new in this PR?

Users with an associated email address have to enter their password after trying to login via phone number. To make this flow less confusing an alert controller will now be presented in that case.

