### PR TITLE
fix iOS10 top margin with navigation bar issue

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Services/ServiceDetailViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Services/ServiceDetailViewController.swift
@@ -160,7 +160,7 @@ final class ServiceDetailViewController: UIViewController {
         confirmButton.setTitle("peoplepicker.services.add_service.button".localized, for: .normal)
 
         var topMargin: CGFloat = 16
-        if #available(iOS 10.0, *) {
+        if #available(iOS 11.0, *) {
             topMargin = 16
         }
         else {


### PR DESCRIPTION
## What's new in this PR?

### Issues

On iOS9, ServiceDetailViewController.view overlaps with navigation bar.
(Follow up of https://github.com/wireapp/wire-ios/pull/1628)

### Causes

iOS11 new save area feature affects the top margin constraint. 

## Solutions

For iOS11-, include navigation bar's height for margin calculation.