### PR TITLE
Remove deprecated calls to .characters

### DIFF
--- a/Wire-iOS Share Extension/ShareExtensionViewController.swift
+++ b/Wire-iOS Share Extension/ShareExtensionViewController.swift
@@ -158,7 +158,7 @@ class ShareExtensionViewController: SLComposeServiceViewController {
 
     override func isContentValid() -> Bool {
         // Do validation of contentText and/or NSExtensionContext attachments here
-        let textLength = self.contentText.trimmingCharacters(in: .whitespaces).characters.count
+        let textLength = self.contentText.trimmingCharacters(in: .whitespaces).count
         let remaining = SharedConstants.maximumMessageLength - textLength
         let remainingCharactersThreshold = 30
         

--- a/Wire-iOS Share Extension/UnsentSendable.swift
+++ b/Wire-iOS Share Extension/UnsentSendable.swift
@@ -109,7 +109,7 @@ class UnsentTextSendable: UnsentSendableBase, UnsentSendable {
         if let url = url?.absoluteString, !self.text.contains(url)  {
             var separator = ""
             
-            if !self.text.isEmpty && self.text.characters.last != " " {
+            if !self.text.isEmpty && self.text.last != " " {
                 separator = " "
             }
             

--- a/Wire-iOS/Sources/Helpers/NSData+Fingerprint.swift
+++ b/Wire-iOS/Sources/Helpers/NSData+Fingerprint.swift
@@ -30,7 +30,7 @@ extension NSData {
         var even = true
         strings.forEach { (string: String) -> () in
             if even {
-                if fingerprintString.characters.count > 0 {
+                if fingerprintString.count > 0 {
                     fingerprintString = fingerprintString + " "
                 }
                 even = false

--- a/Wire-iOS/Sources/Helpers/String+WireLocales.swift
+++ b/Wire-iOS/Sources/Helpers/String+WireLocales.swift
@@ -20,8 +20,8 @@ import Foundation
 
 extension String {
     func capitalizingFirstLetter() -> String {
-        let first = String(characters.prefix(1)).capitalized
-        let other = String(characters.dropFirst())
+        let first = String(prefix(1)).capitalized
+        let other = String(dropFirst())
         return first + other
     }
 }

--- a/Wire-iOS/Sources/Helpers/UserClient+Fingerprint.swift
+++ b/Wire-iOS/Sources/Helpers/UserClient+Fingerprint.swift
@@ -61,7 +61,7 @@ extension UserClient {
         
         var paddedIdentifier = remoteIdentifier
         
-        while paddedIdentifier.characters.count < UserClientIdentifierMinimumLength {
+        while paddedIdentifier.count < UserClientIdentifierMinimumLength {
             paddedIdentifier = "0" + paddedIdentifier
         }
         

--- a/Wire-iOS/Sources/UserInterface/Collections/TextSearch/TextSearchViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/TextSearch/TextSearchViewController.swift
@@ -93,7 +93,7 @@ final public class TextSearchViewController: NSObject {
     fileprivate func reloadResults() {
         let query = searchQuery ?? ""
         let noResults = results.isEmpty
-        let validQuery = query.characters.count >= 2
+        let validQuery = query.count >= 2
 
         // We hide the results when we either have none or the query is too short
         resultsView.tableView.isHidden = noResults || !validQuery
@@ -136,7 +136,7 @@ extension TextSearchViewController: TextSearchInputViewDelegate {
         searchStartedDate = nil
         hideLoadingSpinner()
 
-        if query.characters.count < 2 {
+        if query.count < 2 {
             // We reset the results to avoid showing the previous 
             // results for a short period for subsequential searches
             results = []
@@ -146,7 +146,7 @@ extension TextSearchViewController: TextSearchInputViewDelegate {
     }
 
     public func searchViewShouldReturn(_ searchView: TextSearchInputView) -> Bool {
-        return searchView.query.characters.count >= 2
+        return searchView.query.count >= 2
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Components/CharacterInputField.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/CharacterInputField.swift
@@ -30,7 +30,7 @@ public protocol CharacterInputFieldDelegate: NSObjectProtocol {
 public class CharacterInputField: UIControl, UITextInputTraits {
     fileprivate var storage = String() {
         didSet {
-            if storage.characters.count > maxLength {
+            if storage.count > maxLength {
                 storage = String(storage.prefix(maxLength))
             }
             
@@ -64,7 +64,7 @@ public class CharacterInputField: UIControl, UITextInputTraits {
         for index in 0...(maxLength - 1) {
             let characterView = characterViews[index]
             
-            if let character = storage.characters.count > index ? storage[storage.index(storage.startIndex, offsetBy: index)] : nil {
+            if let character = storage.count > index ? storage[storage.index(storage.startIndex, offsetBy: index)] : nil {
                 characterView.character = character
             }
             else {

--- a/Wire-iOS/Sources/UserInterface/Components/Views/MarklightTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/MarklightTextView.swift
@@ -114,7 +114,7 @@ extension MarklightTextView {
             let bulletListPrefix = "(^[*+-])([\\t ]*$)"
             let listPrefixPattern = "(\(numberListPrefix))|(\(bulletListPrefix))"
             let regex = try! NSRegularExpression(pattern: listPrefixPattern, options: [.anchorsMatchLines])
-            let wholeRange = NSMakeRange(0, text.characters.count)
+            let wholeRange = NSMakeRange(0, text.count)
             text = regex.stringByReplacingMatches(in: text, options: [], range: wholeRange, withTemplate: "")
             
             return text
@@ -162,7 +162,7 @@ extension MarklightTextView {
         let lineStart = lineStartForTextAtPosition(start)
         replace(textRange(from: lineStart, to: lineStart)!, withText: syntax)
         // preserve relative caret position
-        let newPos = position(from: start, offset: syntax.characters.count)!
+        let newPos = position(from: start, offset: syntax.count)!
         selectedTextRange = textRange(from: newPos, to: newPos)
     }
     
@@ -177,14 +177,14 @@ extension MarklightTextView {
             replace(preRange, withText: syntax)
             
             // offset acounts for first insertion
-            let end = position(from: selection.end, offset: syntax.characters.count)!
+            let end = position(from: selection.end, offset: syntax.count)!
             let postRange = textRange(from: end, to: end)!
             replace(postRange, withText: syntax)
         }
         else {
             // insert syntax & move caret inside
             replace(selection, withText: syntax + syntax)
-            let newPos = position(from: start, offset: syntax.characters.count)!
+            let newPos = position(from: start, offset: syntax.count)!
             selectedTextRange = textRange(from: newPos, to: newPos)
         }
     }

--- a/Wire-iOS/Sources/UserInterface/ConnectRequests/UserConnectionView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConnectRequests/UserConnectionView.swift
@@ -96,7 +96,7 @@ public final class UserConnectionView: UIView, Copyable {
     }
 
     private var handleLabelText: NSAttributedString? {
-        guard let handle = user.handle, handle.characters.count > 0 else { return nil }
+        guard let handle = user.handle, handle.count > 0 else { return nil }
         return ("@" + handle) && [
             NSForegroundColorAttributeName: ColorScheme.default().color(withName: ColorSchemeColorTextDimmed),
             NSFontAttributeName: UIFont(magicIdentifier: "style.text.small.font_spec_bold")

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationIgnoredDeviceCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationIgnoredDeviceCell.swift
@@ -56,7 +56,7 @@ class ConversationIgnoredDeviceCell : IconSystemCell {
                 let deviceRange = (endResult as NSString).range(of: deviceString)
 
                 let attributedString = NSMutableAttributedString(string: endResult)
-                attributedString.addAttributes([NSFontAttributeName: labelFont, NSForegroundColorAttributeName: labelTextColor], range:NSRange(location: 0, length: endResult.characters.count))
+                attributedString.addAttributes([NSFontAttributeName: labelFont, NSForegroundColorAttributeName: labelTextColor], range:NSRange(location: 0, length: endResult.count))
                 attributedString.addAttributes([NSFontAttributeName: labelBoldFont, NSForegroundColorAttributeName: labelTextColor], range: youRange)
                 attributedString.addAttributes([NSFontAttributeName: labelFont, NSLinkAttributeName: type(of: self).deviceListLink], range: deviceRange)
                 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/UnknownMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/UnknownMessageCell.swift
@@ -59,7 +59,7 @@ public final class UnknownMessageCell : ConversationCell {
         let text = "content.system.unknown_message.body".localized
         let link = "content.system.unknown_message.body.link".localized
         let message = text + " " + link
-        let range : NSRange = NSMakeRange(text.characters.count + 1, link.characters.count)
+        let range : NSRange = NSMakeRange(text.count + 1, link.count)
         
         messageLabel.text = message
         messageLabel.addLink(to: NSURL.wr_unknownMessageHelp() as URL, with: range)

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
@@ -311,7 +311,7 @@ private struct InputBarConstants {
     }
     
     func updateFakeCursorVisibility(_ firstResponder: UIResponder? = nil) {
-        fakeCursor.isHidden = textView.isFirstResponder || textView.text.characters.count != 0 || firstResponder != nil
+        fakeCursor.isHidden = textView.isFirstResponder || textView.text.count != 0 || firstResponder != nil
     }
 
     // MARK: - Disable interactions on the lower part to not to interfere with the keyboard

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/TextFieldValidator.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/TextFieldValidator.swift
@@ -130,7 +130,7 @@ extension String {
         guard let dataDetector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) else { return false }
 
         let stringToMatch = self.trimmingCharacters(in: .whitespacesAndNewlines) // We should ignore leading/trailing whitespace
-        let range = NSRange(location: 0, length: stringToMatch.characters.count)
+        let range = NSRange(location: 0, length: stringToMatch.count)
         let firstMatch = dataDetector.firstMatch(in: stringToMatch, options: NSRegularExpression.MatchingOptions.reportCompletion, range: range)
 
         let numberOfMatches = dataDetector.numberOfMatches(in: stringToMatch, options: NSRegularExpression.MatchingOptions.reportCompletion, range: range)

--- a/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ChangeHandleViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ChangeHandleViewController.swift
@@ -159,8 +159,8 @@ struct HandleChangeState {
     func validate(_ handle: String) throws {
         let subset = CharacterSet(charactersIn: handle).isSubset(of: HandleChangeState.allowedCharacters)
         guard subset && handle.isEqualToUnicodeName else { throw ValidationError.invalidCharacter }
-        guard handle.characters.count >= HandleChangeState.allowedLength.lowerBound else { throw ValidationError.tooShort }
-        guard handle.characters.count <= HandleChangeState.allowedLength.upperBound else { throw ValidationError.tooLong }
+        guard handle.count >= HandleChangeState.allowedLength.lowerBound else { throw ValidationError.tooShort }
+        guard handle.count <= HandleChangeState.allowedLength.upperBound else { throw ValidationError.tooLong }
         guard handle != currentHandle else { throw ValidationError.sameAsPrevious }
     }
 
@@ -331,7 +331,7 @@ extension ChangeHandleViewController: UserProfileUpdateObserver {
     func didSetHandle() {
         showLoadingView = false
         state.availability = .taken
-        Analytics.shared().tag(UserNameEvent.Settings.setUsername(withLength: state.newHandle?.characters.count ?? 0))
+        Analytics.shared().tag(UserNameEvent.Settings.setUsername(withLength: state.newHandle?.count ?? 0))
         guard popOnSuccess else { return }
         _ = navigationController?.popViewController(animated: true)
     }

--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/RequestPasswordViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/RequestPasswordViewController.swift
@@ -67,7 +67,7 @@ class RequestPasswordViewController: UIAlertController {
     
     func passwordTextFieldChanged(_ textField: UITextField) {
         if let passwordField = self.textFields?[0] {
-            self.okAction?.isEnabled = (passwordField.text ?? "").characters.count > 6;
+            self.okAction?.isEnabled = (passwordField.text ?? "").count > 6;
         }
     }
 }

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Views/UserNameDetailView.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Views/UserNameDetailView.swift
@@ -108,7 +108,7 @@ fileprivate let textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTe
     }
 
     static func attributedSubtitle(for user: ZMBareUser?) -> NSAttributedString? {
-        guard let handle = user?.handle, handle.characters.count > 0 else { return nil }
+        guard let handle = user?.handle, handle.count > 0 else { return nil }
         return ("@" + handle) && smallBoldFont && dimmedColor
     }
 

--- a/WireExtensionComponents/Utilities/AutomationHelper.swift
+++ b/WireExtensionComponents/Utilities/AutomationHelper.swift
@@ -153,7 +153,7 @@ extension ArgumentsType {
         for argument in self.arguments {
             let searchString = "--" + commandLineArgument + "="
             if argument.hasPrefix(searchString) {
-                return argument.substring(from: searchString.characters.index(searchString.startIndex, offsetBy: searchString.characters.count))
+                return argument.substring(from: searchString.index(searchString.startIndex, offsetBy: searchString.count))
             }
         }
         return nil


### PR DESCRIPTION
## What's new in this PR?
Restore build on current IOS/XCode

### Issues

The application wasn't building anymore in recent versions of XCode

### Causes

`.characters` seems to be deprecated

### Solutions

Simple removal of all `.characters.`

## Dependencies

None

Needs releases with:

- [ ] GitHub link to the pull request
