### PR TITLE
Update placeholder visibility after removing textview tokens

### DIFF
--- a/Wire-iOS/Sources/Components/TokenField/TokenField.m
+++ b/Wire-iOS/Sources/Components/TokenField/TokenField.m
@@ -435,6 +435,8 @@ CGFloat const accessoryButtonSize = 32.0f;
     [self.currentTokens removeObjectsInArray:tokensToRemove];
     [self invalidateIntrinsicContentSize];
     [self updateTextAttributes];
+    
+    [self.textView showOrHidePlaceholder];
 }
 
 - (Token *)tokenForRepresentedObject:(id)object


### PR DESCRIPTION
## What's new in this PR?

The text view placeholder visibility was not updated after removing tokens from the token field.