### PR TITLE
Strip object replacement character (U+FFFC) from token field filter text

### DIFF
--- a/Wire-iOS/Sources/Components/TokenField/TokenField.m
+++ b/Wire-iOS/Sources/Components/TokenField/TokenField.m
@@ -867,7 +867,7 @@ CGFloat const accessoryButtonSize = 32.0f;
                                           }];
     
     NSString *oldFilterText = self.filterText;
-    self.filterText = [self.textView.text substringFromIndex:indexOfFilterText];
+    self.filterText = [[self.textView.text substringFromIndex:indexOfFilterText] stringByReplacingOccurrencesOfString:@"\uFFFC" withString:@""];
     if ([oldFilterText isEqualToString:self.filterText] == NO) {
         if ([self.delegate respondsToSelector:@selector(tokenField:changedFilterTextTo:)]) {
             [self.delegate tokenField:self changedFilterTextTo:self.filterText];

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchHeaderViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchHeaderViewController.swift
@@ -156,11 +156,16 @@ public class SearchHeaderViewController : UIViewController {
         tokenField.clearFilterText()
         tokenField.removeAllTokens()
         resetQuery()
+        updateClearIndicator(for: tokenField)
     }
     
     public func resetQuery() {
         tokenField.filterUnwantedAttachments()
         delegate?.searchHeaderViewController(self, updatedSearchQuery: tokenField.filterText)
+    }
+    
+    fileprivate func updateClearIndicator(for tokenField: TokenField) {
+        clearButton.isHidden = tokenField.filterText.isEmpty && tokenField.tokens.isEmpty
     }
     
 }
@@ -178,15 +183,12 @@ extension SearchHeaderViewController : UserSelectionObserver {
     public func userSelection(_ userSelection: UserSelection, didRemoveUser user: ZMUser) {
         guard let token = tokenField.token(forRepresentedObject: user) else { return }
         tokenField.removeToken(token)
+        updateClearIndicator(for: tokenField)
     }
     
 }
 
 extension SearchHeaderViewController : TokenFieldDelegate {
-    
-    func updateClearIndicator(for tokenField: TokenField) {
-        clearButton.isHidden = tokenField.filterText.isEmpty && tokenField.tokens.isEmpty
-    }
 
     public func tokenField(_ tokenField: TokenField, changedTokensTo tokens: [Token]) {
         userSelection.replace(tokens.map { $0.representedObject as! ZMUser })


### PR DESCRIPTION
## What's new in this PR?

The `TokenField` filterText was containing the object replacement character [`U+FFFC`](http://graphemica.com/%EF%BF%BC), which is probably due to the token text attachments, but shouldn't be part of the filter text.

This lead to `isEmpty` called on the filter string returning wrong values which in turns was leading to the clear button staying visible in certain cases.