### PR TITLE
ZIOS-9497: While selecting a unconnected user from search to connect to, App crashes

### DIFF
--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
@@ -354,7 +354,7 @@ extension SearchResultsViewController : CollectionViewSectionDelegate {
         if let user = item as? ZMUser {
             delegate?.searchResultsViewController(self, didTapOnUser: user, indexPath: indexPath, section: sectionFor(controller: controller))
         }
-        else if let service = item as? ServiceUser {
+        else if let service = item as? ServiceUser, service.isServiceUser {
             delegate?.searchResultsViewController(self, didTapOnSeviceUser: service)
         }
         else if let searchUser = item as? ZMSearchUser {


### PR DESCRIPTION
## What's new in this PR?

### Issues

The app was crashing after searching for unconnected users in the Start UI and tapping on one of them.

### Causes

This was caused by 

https://github.com/wireapp/wire-ios/blob/301b0843217a58669b62de53ab5996c76a39102c/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift#L357-L362

If you select an unconnected user, you'll fall on the first case, because now `ZMSearchUser` is compliant with the `ServiceUser` protocol. Search users don't have `providerIdentifier` and `serviceIdentifier`, so that's why the app crashes some steps later.

### Solutions

Now I'm checking if the object is compliant with the `ServiceUser` protocol **and** if the `isServiceUser` property is `true`.
