### PR TITLE
Status update are not visible in UI if received in background

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Availability/AvailabilityTitleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Availability/AvailabilityTitleView.swift
@@ -25,7 +25,7 @@ import WireDataModel
 
 @objc public class AvailabilityTitleView: TitleView {
     
-    private var user: ZMUser?
+    fileprivate var user: ZMUser?
     fileprivate var style: AvailabilityTitleViewStyle
     private var observerToken: Any?
     
@@ -57,6 +57,8 @@ import WireDataModel
         if let sharedSession = ZMUserSession.shared() {
             self.observerToken = UserChangeInfo.add(observer: self, for: user, userSession: sharedSession)
         }
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(applicationDidEnterForeground), name: Notification.Name.UIApplicationWillEnterForeground, object: nil)
         
         configure(user: user)
     }
@@ -96,6 +98,17 @@ import WireDataModel
         
         UIImpactFeedbackGenerator(style: .medium).impactOccurred()
     }
+}
+
+extension AvailabilityTitleView {
+    
+    @objc
+    fileprivate func applicationDidEnterForeground() {
+        guard let user = self.user else { return }
+        
+        configure(user: user)
+    }
+    
 }
 
 extension AvailabilityTitleView: ZMUserObserver {


### PR DESCRIPTION
### Issues

If you receive a status update while you app is in background this wont be reflected in conversation list title until you restart the application.

### Causes

The observation system in SE gets shutdown every time the app goes into the background and all snaphots are cleared. This means that any changes which occur in the background will never trigger a change notification.

### Solutions

For now I will refresh the status when the apps enters the foreground but we should probably also think about better way to handle this in the observation system.