### PR TITLE
fix unit test that fails at midnight

### DIFF
--- a/Wire-iOS Tests/DateFormatterTests.swift
+++ b/Wire-iOS Tests/DateFormatterTests.swift
@@ -137,7 +137,10 @@ final class DateFormatterTests: XCTestCase {
 
         // THEN
         XCTAssertFalse(dateString.contains("just now"), "dateString is \(dateString)")
-        XCTAssert(dateString.hasPrefix(String(hour)), "hour is \(hour), dateString is \(dateString)")
+        ///If two hours before is yesterday, dateString looks like "Yesterday at 11:17 PM"
+        XCTAssert(dateString.hasPrefix(String(hour)) ||
+            (dateString.replacingOccurrences(of: "Yesterday at ", with: "").hasPrefix(String(hour))
+            ), "hour is \(hour), dateString is \(dateString)")
         XCTAssert(dateString.hasSuffix(meridiem), "meridiem is \(meridiem), dateString is \(dateString)")
     }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

A date related test fails if runs at midnight.

### Causes

A prefix is added if the date is another day.

### Solutions

Add logic to for accept the date string with "Yesterday at " prefix.