### PR TITLE
Remove check which disable callkit option with multiple accounts

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Options.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Options.swift
@@ -110,8 +110,7 @@ extension SettingsCellDescriptorFactory {
         let soundAlertSection = SettingsSectionDescriptor(cellDescriptors: [soundAlert])
         cellDescriptors.append(soundAlertSection)
         
-        // TODO: CallKit only with 1 account
-        if #available(iOS 10.0, *), (SessionManager.shared?.accountManager.accounts.count ?? 0 <= 1) {
+        if #available(iOS 10.0, *) {
             let callKitDescriptor = SettingsPropertyToggleCellDescriptor(settingsProperty: settingsPropertyFactory.property(.disableCallKit), inverse: true)
             let callKitHeader = "self.settings.callkit.title".localized
             let callKitDescription = "self.settings.callkit.description".localized


### PR DESCRIPTION
### Issues

CallKit option was not visible in settings when you have multiple accounts.

### Causes

Multi account restriction was still active in settings.

### Solutions

Remove restriction