### PR TITLE
ZIOS-9538: Single bot conversations shows up in people search not as that 1:1 conversation but as a bot service

### DIFF
--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/Cells/SearchResultCell.m
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/Cells/SearchResultCell.m
@@ -262,7 +262,7 @@
         canBeConnected = NO;
     }
     else if (fullUser != nil) {
-        canBeConnected = fullUser.canBeConnected && ! fullUser.isBlocked && ! fullUser.isPendingApproval && !fullUser.isTeamMember;
+        canBeConnected = fullUser.canBeConnected && ! fullUser.isBlocked && ! fullUser.isPendingApproval && !fullUser.isTeamMember && !fullUser.isServiceUser;
     }
     else {
         canBeConnected = self.user.canBeConnected;

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+SearchResults.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+SearchResults.swift
@@ -50,7 +50,8 @@ extension StartUIViewController: SearchResultsViewControllerDelegate {
     }
     
     public func searchResultsViewController(_ searchResultsViewController: SearchResultsViewController, didTapOnConversation conversation: ZMConversation) {
-        if conversation.conversationType == .group {
+        if conversation.conversationType == .group
+            || (conversation.conversationType == .oneOnOne && conversation.includesServiceUser) {
             self.delegate.startUI?(self, didSelect: conversation)
         }
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

After creating a conversation with a service, that conversation was shown in the search of Start UI with the same layout and the same behavior of a service (the same of the "Services" tab).

### Causes

This was caused by:
- behavior: `searchResultsViewController(_ searchResultsViewController:, didTapOnConversation:)` was not checking the case with service users.
- UI: while deciding which UI elements to show, the conversation was treated as a service user - and not as a search result

### Solutions

Now I'm checking in both places if the conversation has a service user.