### PR TITLE
ZIOS-9546: Fixed margins for Browser View Controller on iPhone X

### DIFF
--- a/Wire-iOS/Sources/Components/Youtube/MediaPreviewViewController.m
+++ b/Wire-iOS/Sources/Components/Youtube/MediaPreviewViewController.m
@@ -137,7 +137,7 @@
     NSArray *queryItems = components.queryItems == nil ? @[] : components.queryItems;
     components.queryItems = [queryItems arrayByAddingObject:[NSURLQueryItem queryItemWithName:@"autoplay" value:@"1"]];
 
-    BrowserViewController *browserViewController = [[BrowserViewController alloc] initWithURL:components.URL forUseWithStatusBar:YES];
+    BrowserViewController *browserViewController = [[BrowserViewController alloc] initWithURL:components.URL];
     [self.view.window.rootViewController presentViewController:browserViewController animated:YES completion:nil];
 }
 

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/BrowserBarView.h
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/BrowserBarView.h
@@ -18,7 +18,7 @@
 
 
 #import <UIKit/UIKit.h>
-
+#import "Wire-Swift.h"
 
 @class IconButton;
 
@@ -29,7 +29,5 @@
 @property (nonatomic) IconButton *closeButton;
 @property (nonatomic) UILabel *titleLabel;
 @property (nonatomic) CGFloat progress;
-
-- (instancetype)initForUseWithStatusBar:(BOOL)statusBar;
 
 @end

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/BrowserBarView.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/BrowserBarView.m
@@ -27,7 +27,6 @@
 
 @property (nonatomic) CAShapeLayer *progressLayer;
 @property (nonatomic) BOOL initialConstraintsCreated;
-@property (nonatomic) BOOL useWithStatusBar;
 
 @end
 
@@ -35,15 +34,8 @@
 
 - (instancetype)init
 {
-    return [self initForUseWithStatusBar:NO];
-}
-
-- (instancetype)initForUseWithStatusBar:(BOOL)statusBar
-{
     self = [super init];
     if (self) {
-        self.useWithStatusBar = statusBar;
-
         self.shareButton = [IconButton iconButtonCircular];
         self.shareButton.translatesAutoresizingMaskIntoConstraints = NO;
         [self.shareButton setIcon:ZetaIconTypeExport withSize:ZetaIconSizeTiny forState:UIControlStateNormal];
@@ -74,7 +66,7 @@
     if(! self.initialConstraintsCreated) {
         self.initialConstraintsCreated = YES;
 
-        CGFloat offset = self.useWithStatusBar ? 10 : 0;
+        CGFloat offset = UIScreen.safeArea.top / 2.0;
         [self.shareButton autoPinEdgeToSuperviewEdge:ALEdgeLeft withInset:8];
         [self.shareButton autoSetDimensionsToSize:CGSizeMake(32, 32)];
         [self.shareButton autoAlignAxis:ALAxisHorizontal toSameAxisOfView:self withOffset:offset];

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/BrowserViewController.h
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/BrowserViewController.h
@@ -25,7 +25,6 @@
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
 - (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil NS_UNAVAILABLE;
-- (instancetype)initWithURL:(NSURL *)URL forUseWithStatusBar:(BOOL)statusBar NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithURL:(NSURL *)URL;
 
 @end

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/BrowserViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/BrowserViewController.m
@@ -35,7 +35,6 @@
 @property (nonatomic) BrowserBarView *browserBarView;
 @property (nonatomic) NSObject *estimatedProgressObserver;
 @property (nonatomic) NSObject *titleObserver;
-@property (nonatomic) BOOL useWithStatusBar;
 
 @end
 
@@ -43,16 +42,10 @@
 
 - (instancetype)initWithURL:(NSURL *)URL
 {
-    return [self initWithURL:URL forUseWithStatusBar:NO];
-}
-
-- (instancetype)initWithURL:(NSURL *)URL forUseWithStatusBar:(BOOL)statusBar
-{
     self = [super initWithNibName:nil bundle:nil];
     
     if (self) {
         _URL = URL;
-        _useWithStatusBar = statusBar;
     }
     
     return self;
@@ -71,7 +64,7 @@
     [self.webView loadRequest:[NSURLRequest requestWithURL:self.URL]];
     [self.view addSubview:self.webView];
     
-    self.browserBarView = [[BrowserBarView alloc] initForUseWithStatusBar:self.useWithStatusBar];
+    self.browserBarView = [[BrowserBarView alloc] init];
     self.browserBarView.translatesAutoresizingMaskIntoConstraints = NO;
     [self.view addSubview:self.browserBarView];
     
@@ -96,7 +89,7 @@
 - (void)createInitialConstraints
 {
     [self.browserBarView autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsZero excludingEdge:ALEdgeBottom];
-    [self.browserBarView autoSetDimension:ALDimensionHeight toSize:64];
+    [self.browserBarView autoSetDimension:ALDimensionHeight toSize:44 + UIScreen.safeArea.top];
     
     [self.webView autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsZero excludingEdge:ALEdgeTop];
     [self.webView autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.browserBarView];


### PR DESCRIPTION
## What's new in this PR?

- Fixed margins for Browser View Controller on iPhone X
- Removed usage of `useWithStatusBar`, since now we're calculating the space occupied by the status bar in `UIScreen.safeArea` (even on iOS versions before 11.0).

## Note

Also referenced in https://github.com/wireapp/wire-ios/issues/1582