### PR TITLE
Bump AVS to 4.1.

### DIFF
--- a/avs-versions
+++ b/avs-versions
@@ -17,4 +17,4 @@
 # along with this program. If not, see http://www.gnu.org/licenses/.
 #
 
-export APPSTORE_AVS_VERSION=4.0.16
+export APPSTORE_AVS_VERSION=4.1.1


### PR DESCRIPTION
## What's new in this PR?

Shiny new version of AVS 4.1.

From ChangeLog.txt:

==============================================================================
AVS Release 4.1

Date:	    29. January 2018
GIT:	    https://github.com/wearezeta/avs/tree/release-4.1
Android:    Android NDK r12b
iOS:	    iOS SDK 8.0
OSX:	    OSX SDK 10.9
Linux:	    Ubuntu x86_64 14.04 (LTS)

Summary:        - Improved BT handling (both iOS and Android)
		- Increased ptime for group calling (also with Webapp)
                - bug fixes
