### PR TITLE
Support for error handling with bots in AddParticipantsViewController

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -202,6 +202,7 @@
 		7C374E4D1FDE7B8C00A43B9C /* unsplash_matterhorn_small_size.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 7C374E491FDE7B8C00A43B9C /* unsplash_matterhorn_small_size.jpg */; };
 		7C374E4E1FDE7B8C00A43B9C /* unsplash_matterhorn_small_width.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 7C374E4A1FDE7B8C00A43B9C /* unsplash_matterhorn_small_width.jpg */; };
 		7C37E3441FDE89520077B2E3 /* unsplash_matterhorn.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 7C37E3431FDE89510077B2E3 /* unsplash_matterhorn.jpg */; };
+		7C4789852021F40E00A38442 /* AddBotError+UIHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C4789842021F40E00A38442 /* AddBotError+UIHandler.swift */; };
 		7C4918A11F8BB1A20038AF4B /* UIScreen+SafeArea.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C4918A01F8BB1A20038AF4B /* UIScreen+SafeArea.swift */; };
 		7C49D0E2201A3E8400A99760 /* ShareServiceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C49D0E1201A3E8400A99760 /* ShareServiceViewController.swift */; };
 		7C52F723200CBE61009F85FB /* CameraKeyboardPermissionsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C52F722200CBE61009F85FB /* CameraKeyboardPermissionsCell.swift */; };
@@ -1368,6 +1369,7 @@
 		7C374E491FDE7B8C00A43B9C /* unsplash_matterhorn_small_size.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = unsplash_matterhorn_small_size.jpg; sourceTree = "<group>"; };
 		7C374E4A1FDE7B8C00A43B9C /* unsplash_matterhorn_small_width.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = unsplash_matterhorn_small_width.jpg; sourceTree = "<group>"; };
 		7C37E3431FDE89510077B2E3 /* unsplash_matterhorn.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = unsplash_matterhorn.jpg; sourceTree = "<group>"; };
+		7C4789842021F40E00A38442 /* AddBotError+UIHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AddBotError+UIHandler.swift"; sourceTree = "<group>"; };
 		7C4918A01F8BB1A20038AF4B /* UIScreen+SafeArea.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScreen+SafeArea.swift"; sourceTree = "<group>"; };
 		7C49D0E1201A3E8400A99760 /* ShareServiceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareServiceViewController.swift; sourceTree = "<group>"; };
 		7C52F722200CBE61009F85FB /* CameraKeyboardPermissionsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraKeyboardPermissionsCell.swift; sourceTree = "<group>"; };
@@ -4425,6 +4427,7 @@
 				7CA540811F740B7C00457F4B /* UIScreen+Compact.h */,
 				7CA540821F740B7C00457F4B /* UIScreen+Compact.m */,
 				EF2C18A11FED541F00E9F2FD /* Timer+allVersionCompatibleScheduledTimer.swift */,
+				7C4789842021F40E00A38442 /* AddBotError+UIHandler.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -6440,6 +6443,7 @@
 				8723342A1CD0D8F100CF8B11 /* VideoMessageCell.swift in Sources */,
 				EF21271A1FB9DFE300625A9B /* ProfilePictureStepViewController.m in Sources */,
 				16F9EB2B1BC52EE40021EF39 /* ActionSheetController+Conversation.m in Sources */,
+				7C4789852021F40E00A38442 /* AddBotError+UIHandler.swift in Sources */,
 				16063D0B1BE0D5CE0097F62C /* ProfileNavigationControllerDelegate.m in Sources */,
 				EF2127131FB9DFE300625A9B /* EmailSignInViewController.m in Sources */,
 				871BC2711D34F8F800DF0793 /* SwipeMenuCollectionCell.m in Sources */,

--- a/Wire-iOS/Sources/Helpers/AddBotError+UIHandler.swift
+++ b/Wire-iOS/Sources/Helpers/AddBotError+UIHandler.swift
@@ -1,0 +1,42 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension AddBotError {
+    
+    var localizedTitle: String {
+        return "peoplepicker.services.add_service.error.title".localized
+    }
+    
+    var localizedMessage: String {
+        switch self {
+        case .tooManyParticipants:
+            return "peoplepicker.services.add_service.error.full".localized
+        default:
+            return "peoplepicker.services.add_service.error.default".localized
+        }
+    }
+    
+    func displayAddBotError(in viewController: UIViewController) {
+        let alert = UIAlertController(title: self.localizedTitle,
+                                      message: self.localizedMessage,
+                                      cancelButtonTitle: "general.confirm".localized)
+        viewController.present(alert, animated: true, completion: nil)
+    }
+}

--- a/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
@@ -292,18 +292,28 @@ extension AddParticipantsViewController: SearchResultsViewControllerDelegate {
         // no-op
     }
     
+
     public func searchResultsViewController(_ searchResultsViewController: SearchResultsViewController, didTapOnSeviceUser user: ServiceUser) {
-        let serviceDetails = ServiceDetailViewController(serviceUser: user, variant: .light)
-        serviceDetails.destinationConversation = self.conversation
-        serviceDetails.completion = { [weak self] _ in
-            guard let `self` = self else {
-                return
-            }
-            self.dismiss(animated: true) {
-                self.delegate?.addParticipantsViewControllerDidCancel(self)
+        
+        let detail = ServiceDetailViewController(serviceUser: user, variant: .light)
+        detail.destinationConversation = self.conversation
+        detail.completion = { [weak self] result in
+            guard let `self` = self else { return }
+            
+            if let result = result {
+                switch result {
+                case .success( _):
+                    self.dismiss(animated: true, completion: {
+                        self.delegate?.addParticipantsViewController(self, didSelectUsers: [user as! ZMUser])
+                    })
+                case .failure(let error):
+                    error.displayAddBotError(in: detail)
+                }
             }
         }
-        self.present(serviceDetails.wrapInNavigationController(), animated: true, completion: nil)
+        
+        self.present(detail.wrapInNavigationController(), animated: true, completion: nil)
     }
+    
 }
 

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+SearchResults.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+SearchResults.swift
@@ -61,42 +61,21 @@ extension StartUIViewController: SearchResultsViewControllerDelegate {
         let detail = ServiceDetailViewController(serviceUser: user, variant: .dark)
         
         detail.completion = { [weak self] result in
+            guard let `self` = self else { return }
             if let result = result {
                 switch result {
                     
                 case .success(let conversation):
-                    self?.delegate.startUI?(self, didSelect: conversation)
+                    self.delegate.startUI?(self, didSelect: conversation)
                 case .failure(let error):
-                    self?.handleAddBotError(error)
+                    error.displayAddBotError(in: self)
                 }
             } else {
-                self?.delegate.startUIDidCancel(self)
+                self.delegate.startUIDidCancel(self)
             }
         }
         
         self.navigationController?.pushViewController(detail, animated: true)
     }
     
-    private func handleAddBotError(_ error: AddBotError) {
-        let alert = UIAlertController(title: error.localizedTitle,
-                                      message: error.localizedMessage,
-                                      cancelButtonTitle: "general.confirm".localized)
-        self.present(alert, animated: true, completion: nil)
-    }
-}
-
-extension AddBotError {
-    
-    var localizedTitle: String {
-        return "peoplepicker.services.add_service.error.title".localized
-    }
-    
-    var localizedMessage: String {
-        switch self {
-        case .tooManyParticipants:
-            return "peoplepicker.services.add_service.error.full".localized
-        default:
-            return "peoplepicker.services.add_service.error.default".localized
-        }
-    }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Add Participants View Controller was not handling errors with bots.

### Solutions

I've added (almost) the same error handling of Start UI. Error messages and alerts are now managed in the `AddBotError+UIHandler` extension.

## Notes

In the current build, the Service Detail dismisses all the modal views in case of success or error. In this PR, I'm dismissing the modal views only in case the service is added successfully to the conversation; otherwise, it will display the error alert without closing the modal view. I believe it's a better implementation since in this way you're still able to choose another service or add another contact.
