### PR TITLE
ZIOS-9529: Moved Start UI button to center when there are no conversations

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationListBottomBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationListBottomBar.swift
@@ -140,8 +140,13 @@ import Cartography
         constrain(view, cameraButton, startUIButton, archivedButton, composeButton) { view, cameraButton, startUIButton, archivedButton, composeButton in
             startUIButton.centerY == view.centerY
             archivedButton.centerY == view.centerY
-            startUIButton.leading == view.leading + xInset
             archivedButton.trailing == view.trailing - xInset
+            
+            if showArchived {
+                startUIButton.leading == view.leading + xInset
+            } else {
+                startUIButton.centerX == view.centerX
+            }
         }
     }
 
@@ -172,9 +177,12 @@ import Cartography
 
         if showComposeButtons {
             [cameraButton, composeButton, archivedButton, startUIButton, separator].forEach { $0.removeFromSuperview() }
-            addSubviews()
-            createConstraints()
+        } else {
+            [archivedButton, startUIButton, separator].forEach { $0.removeFromSuperview() }
         }
+        
+        addSubviews()
+        createConstraints()
     }
 
     // MARK: - Target Action


### PR DESCRIPTION
## What's new in this PR?

### Issues

In the current public build, after logging into Wire with a new account, the arrow below the "Start a conversation" hint is not pointing anywhere since the Start UI button is positioned on the left-hand side. 

### Solutions

I'm displaying the Start UI button on the center. When the user archives something, the Start UI button moves to the left and the Archive button appears on the right.

### Attachments

Ta-dah!

![simulator screen shot - iphone 8 - 2018-02-01 at 14 34 11](https://user-images.githubusercontent.com/2906234/35682246-4c489ab6-0760-11e8-9eb7-0d43715df4d4.png)

