### PR TITLE
Unified the nav bars in Start UI, AddParticipants

### DIFF
--- a/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
@@ -20,6 +20,19 @@ import Foundation
 import Cartography
 import Classy
 
+
+class AddParticipantsNavigationController: UINavigationController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.navigationBar.tintColor = .black
+        self.navigationBar.setBackgroundImage(UIImage(), for:.default)
+        self.navigationBar.shadowImage = UIImage()
+        self.navigationBar.isTranslucent = true
+        self.navigationBar.titleTextAttributes = [NSForegroundColorAttributeName: UIColor.black,
+                                                  NSFontAttributeName: FontSpec(.medium, .medium).font!.allCaps()]
+    }
+}
+
 @objc
 public protocol AddParticipantsViewControllerDelegate : class {
     
@@ -96,7 +109,9 @@ public class AddParticipantsViewController : UIViewController {
         searchResultsViewController = SearchResultsViewController(userSelection: userSelection, variant: ColorScheme.default().variant, isAddingParticipants: true)
 
         super.init(nibName: nil, bundle: nil)
-        
+
+        title = conversation.displayName
+        navigationItem.rightBarButtonItem = UIBarButtonItem(icon: .X, target: self, action: #selector(AddParticipantsViewController.onDismissTapped(_:)))
         emptyResultLabel.text = everyoneHasBeenAddedText
         emptyResultLabel.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground)
         emptyResultLabel.font = FontSpec(.normal, .none).font!
@@ -134,7 +149,6 @@ public class AddParticipantsViewController : UIViewController {
             view.addSubview(searchGroupSelector)
         }
         
-        searchHeaderViewController.title = conversation.displayName
         searchHeaderViewController.delegate = self
         addChildViewController(searchHeaderViewController)
         view.addSubview(searchHeaderViewController.view)
@@ -144,7 +158,7 @@ public class AddParticipantsViewController : UIViewController {
         view.addSubview(searchResultsViewController.view)
         searchResultsViewController.didMove(toParentViewController: self)
         searchResultsViewController.searchResultsView?.emptyResultView = emptyResultLabel
-        searchResultsViewController.searchResultsView?.backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorContentBackground);
+        searchResultsViewController.searchResultsView?.backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorContentBackground)
 
         createConstraints()
         updateConfirmButtonVisibility()
@@ -205,6 +219,10 @@ public class AddParticipantsViewController : UIViewController {
         return "add_participants.all_contacts_added".localized
     }
     
+    @objc public func onDismissTapped(_ sender: Any!) {
+        self.navigationController?.dismiss(animated: true, completion: nil)
+    }
+    
     func keyboardFrameWillChange(notification: Notification) {
         let firstResponder = UIResponder.wr_currentFirst()
         let inputAccessoryHeight = firstResponder?.inputAccessoryView?.bounds.size.height ?? 0
@@ -252,10 +270,6 @@ extension AddParticipantsViewController : UserSelectionObserver {
 }
 
 extension AddParticipantsViewController : SearchHeaderViewControllerDelegate {
-    
-    public func searchHeaderViewControllerDidCancelAction(_ searchHeaderViewController: SearchHeaderViewController) {
-        delegate?.addParticipantsViewControllerDidCancel(self)
-    }
     
     public func searchHeaderViewControllerDidConfirmAction(_ searchHeaderViewController: SearchHeaderViewController) {
         delegate?.addParticipantsViewController(self, didSelectUsers: userSelection.users)
@@ -311,8 +325,8 @@ extension AddParticipantsViewController: SearchResultsViewControllerDelegate {
                 }
             }
         }
-        
-        self.present(detail.wrapInNavigationController(), animated: true, completion: nil)
+
+        self.navigationController?.pushViewController(serviceDetails, animated: true)
     }
     
 }

--- a/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
@@ -318,7 +318,7 @@ extension AddParticipantsViewController: SearchResultsViewControllerDelegate {
                 switch result {
                 case .success( _):
                     self.dismiss(animated: true, completion: {
-                        self.delegate?.addParticipantsViewController(self, didSelectUsers: [user as! ZMUser])
+                        self.delegate?.addParticipantsViewController(self, didSelectUsers: [])
                     })
                 case .failure(let error):
                     error.displayAddBotError(in: detail)

--- a/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
@@ -309,7 +309,8 @@ extension AddParticipantsViewController: SearchResultsViewControllerDelegate {
 
     public func searchResultsViewController(_ searchResultsViewController: SearchResultsViewController, didTapOnSeviceUser user: ServiceUser) {
         
-        let detail = ServiceDetailViewController(serviceUser: user, variant: .light)
+        let detail = ServiceDetailViewController(serviceUser: user,
+                                                 variant: ServiceDetailVariant(colorScheme: ColorScheme.default().variant, opaque: true))
         detail.destinationConversation = self.conversation
         detail.completion = { [weak self] result in
             guard let `self` = self else { return }

--- a/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
@@ -326,7 +326,7 @@ extension AddParticipantsViewController: SearchResultsViewControllerDelegate {
             }
         }
 
-        self.navigationController?.pushViewController(serviceDetails, animated: true)
+        self.navigationController?.pushViewController(detail, animated: true)
     }
     
 }

--- a/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
@@ -24,11 +24,11 @@ import Classy
 class AddParticipantsNavigationController: UINavigationController {
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.navigationBar.tintColor = .black
+        self.navigationBar.tintColor = ColorScheme.default().color(withName: ColorSchemeColorTextForeground)
         self.navigationBar.setBackgroundImage(UIImage(), for:.default)
         self.navigationBar.shadowImage = UIImage()
         self.navigationBar.isTranslucent = true
-        self.navigationBar.titleTextAttributes = [NSForegroundColorAttributeName: UIColor.black,
+        self.navigationBar.titleTextAttributes = [NSForegroundColorAttributeName: ColorScheme.default().color(withName: ColorSchemeColorTextForeground),
                                                   NSFontAttributeName: FontSpec(.medium, .medium).font!.allCaps()]
     }
 }
@@ -104,7 +104,7 @@ public class AddParticipantsViewController : UIViewController {
  
         searchHeaderViewController = SearchHeaderViewController(userSelection: userSelection, variant: ColorScheme.default().variant)
         
-        searchGroupSelector = SearchGroupSelector(variant: .light)
+        searchGroupSelector = SearchGroupSelector(variant: ColorScheme.default().variant)
 
         searchResultsViewController = SearchResultsViewController(userSelection: userSelection, variant: ColorScheme.default().variant, isAddingParticipants: true)
 

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/ClearBackgroundNavigationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/ClearBackgroundNavigationController.swift
@@ -54,11 +54,11 @@ class ClearBackgroundNavigationController: UINavigationController {
         self.navigationBar.setBackgroundImage(UIImage(), for:.default)
         self.navigationBar.shadowImage = UIImage()
         self.navigationBar.isTranslucent = true
-        self.navigationBar.titleTextAttributes = [NSForegroundColorAttributeName: UIColor.white, NSFontAttributeName: UIFont(magicIdentifier: "style.text.normal.font_spec_bold").allCaps()]
+        self.navigationBar.titleTextAttributes = [NSForegroundColorAttributeName: UIColor.white, NSFontAttributeName: FontSpec(.medium, .medium).font!.allCaps()]
         
         let navButtonAppearance = UIBarButtonItem.appearance(whenContainedInInstancesOf: [UINavigationBar.self])
         
-        let attributes = [NSFontAttributeName : UIFont(magicIdentifier: "style.text.normal.font_spec").allCaps()]
+        let attributes = [NSFontAttributeName : FontSpec(.normal, .light).font!.allCaps()]
         navButtonAppearance.setTitleTextAttributes(attributes, for: UIControlState.normal)
         navButtonAppearance.setTitleTextAttributes(attributes, for: UIControlState.highlighted)
         

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -585,15 +585,20 @@
 {
     AddParticipantsViewController *addParticipantsViewController = [[AddParticipantsViewController alloc] initWithConversation:self.conversation];
     addParticipantsViewController.delegate = self;
-    addParticipantsViewController.modalPresentationStyle = UIModalPresentationPopover;
-    addParticipantsViewController.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
+    
+    UINavigationController *presentedViewController = [addParticipantsViewController wrapInNavigationController:[AddParticipantsNavigationController class]];
+    
+    presentedViewController.modalPresentationStyle = UIModalPresentationPopover;
+    presentedViewController.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
 
-    UIPopoverPresentationController *popoverPresentationController = addParticipantsViewController.popoverPresentationController;
+    UIPopoverPresentationController *popoverPresentationController = presentedViewController.popoverPresentationController;
     popoverPresentationController.sourceView = button;
     popoverPresentationController.sourceRect = button.bounds;
     popoverPresentationController.delegate = addParticipantsViewController;
 
-    [self presentViewController:addParticipantsViewController animated:YES completion:nil];
+    [self presentViewController:presentedViewController
+                       animated:YES
+                     completion:nil];
 }
 
 - (void)conversationContentViewController:(ConversationContentViewController *)contentViewController didTriggerResendingMessage:(id <ZMConversationMessage>)message

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+StartUI.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+StartUI.m
@@ -204,13 +204,6 @@ typedef void (^ConversationCreatedBlock)(ZMConversation *);
     [[Analytics shared] tagEventObject:[AnalyticsSearchResultEvent eventForSearchResultUsed:YES participantCount:[users count]]];
 }
 
-- (void)startUIDidCancel:(StartUIViewController *)startUI
-{
-    [[Analytics shared] tagSearchAbortedWithSource:AnalyticsEventSourceUnspecified];
-    
-    [self dismissPeoplePickerWithCompletionBlock:nil];
-}
-
 - (void)startUI:(StartUIViewController *)startUI didSelectConversation:(ZMConversation *)conversation
 {
     [Analytics.shared tagOpenedExistingConversationWithType:conversation.conversationType];

--- a/Wire-iOS/Sources/UserInterface/Participants/ParticipantsHeaderView.m
+++ b/Wire-iOS/Sources/UserInterface/Participants/ParticipantsHeaderView.m
@@ -244,7 +244,7 @@ static NSTimeInterval const ParticipantsHeaderViewEditHintDismissTimeout = 10.0f
     
     // Cancel button
     [self.cancelButton addConstraintForAligningTopToTopOfView:self distance:- 26];
-    [self.cancelButton addConstraintForRightMargin:16 relativeToView:self];
+    [self.cancelButton addConstraintForRightMargin:8 relativeToView:self];
     [self.cancelButton autoMatchDimension:ALDimensionHeight toDimension:ALDimensionWidth ofView:self.cancelButton];
     self.cancelButtonWidthConstraint = [self.cancelButton autoSetDimension:ALDimensionWidth toSize:32];
     

--- a/Wire-iOS/Sources/UserInterface/Participants/ParticipantsViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Participants/ParticipantsViewController.m
@@ -478,11 +478,15 @@ static NSString *const ParticipantHeaderReuseIdentifier = @"ParticipantListHeade
 - (void)presentAddParticipantsViewController
 {    
     AddParticipantsViewController *addParticipantsViewController = [[AddParticipantsViewController alloc] initWithConversation:self.conversation];
-    addParticipantsViewController.modalPresentationStyle = UIModalPresentationOverCurrentContext;
-    addParticipantsViewController.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
     addParticipantsViewController.delegate = self;
     
-    [self presentViewController:addParticipantsViewController animated:YES completion:nil];
+    UINavigationController *presentedViewController = [addParticipantsViewController wrapInNavigationController:[AddParticipantsNavigationController class]];
+    presentedViewController.modalPresentationStyle = UIModalPresentationOverCurrentContext;
+    presentedViewController.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
+    
+    [self presentViewController:presentedViewController
+                       animated:YES
+                     completion:nil];
 }
 
 /// Returns whether the conversation name was valid and could be set as the new name.

--- a/Wire-iOS/Sources/UserInterface/Services/ServiceDetailViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Services/ServiceDetailViewController.swift
@@ -155,6 +155,11 @@ extension ServiceConversation: ShareDestination {
     }
 }
 
+struct ServiceDetailVariant {
+    let colorScheme: ColorSchemeVariant
+    let opaque: Bool
+}
+
 final class ServiceDetailViewController: UIViewController {
     private let detailView: ServiceDetailView
     private let confirmButton = Button(styleClass: "dialogue-button-full")
@@ -168,12 +173,12 @@ final class ServiceDetailViewController: UIViewController {
     public var completion: ((AddBotResult?)->())? = nil
     public var destinationConversation: ZMConversation?
 
-    public let variant: ColorSchemeVariant
+    public let variant: ServiceDetailVariant
     
-    init(serviceUser: ServiceUser, variant: ColorSchemeVariant) {
+    init(serviceUser: ServiceUser, variant: ServiceDetailVariant) {
         self.variant = variant
         self.service = Service(serviceUser: serviceUser)
-        self.detailView = ServiceDetailView(service: service, variant: variant)
+        self.detailView = ServiceDetailView(service: service, variant: variant.colorScheme)
         
         super.init(nibName: nil, bundle: nil)
         
@@ -191,11 +196,12 @@ final class ServiceDetailViewController: UIViewController {
             self?.onAddServicePressed()
         }
         
-        switch self.variant {
-        case .dark:
+        if self.variant.opaque {
+            view.backgroundColor = ColorScheme.default().color(withName: ColorSchemeColorBackground,
+                                                               variant: self.variant.colorScheme)
+        }
+        else {
             view.backgroundColor = .clear
-        case .light:
-            view.backgroundColor = .white
         }
         
         view.addSubview(detailView)

--- a/Wire-iOS/Sources/UserInterface/Services/ServiceDetailViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Services/ServiceDetailViewController.swift
@@ -242,8 +242,6 @@ final class ServiceDetailViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        self.navigationController?.setNavigationBarHidden(false, animated: animated)
-        
         if (self.navigationController?.viewControllers.count ?? 0) > 1 {
             self.navigationItem.leftBarButtonItem = UIBarButtonItem(icon: .backArrow,
                                                                     target: self,

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/Cells/SearchResultCell.m
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/Cells/SearchResultCell.m
@@ -220,6 +220,8 @@
     self.avatarViewSizeConstraint.constant = squareImageWidth;
     self.conversationImageViewSize.constant = squareImageWidth;
     self.badgeUserImageView.badgeColor = [UIColor whiteColor];
+    
+    [self updateSubtitle];
 }
 
 - (void)prepareForReuse

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchHeaderViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchHeaderViewController.swift
@@ -22,19 +22,12 @@ import Cartography
 
 @objc
 public protocol SearchHeaderViewControllerDelegate : class {
-    
     func searchHeaderViewController(_ searchHeaderViewController : SearchHeaderViewController, updatedSearchQuery query: String)
-    func searchHeaderViewControllerDidCancelAction(_ searchHeaderViewController : SearchHeaderViewController)
     func searchHeaderViewControllerDidConfirmAction(_ searchHeaderViewController : SearchHeaderViewController)
-    
-    
 }
 
 public class SearchHeaderViewController : UIViewController {
     
-    let titleContainer = UIView()
-    let titleLabel = UILabel()
-    let closeButton : IconButton
     let tokenFieldContainer = UIView()
     let tokenField = TokenField()
     let searchIcon = UIImageView()
@@ -56,7 +49,6 @@ public class SearchHeaderViewController : UIViewController {
     public init(userSelection: UserSelection, variant: ColorSchemeVariant) {
         self.userSelection = userSelection
         self.colorSchemeVariant = variant
-        self.closeButton = variant == .dark ? IconButton.iconButtonDefaultLight() : IconButton.iconButtonDefaultDark()
         self.clearButton = variant == .dark ? IconButton.iconButtonDefaultLight() : IconButton.iconButtonDefaultDark()
         
         super.init(nibName: nil, bundle: nil)
@@ -75,10 +67,6 @@ public class SearchHeaderViewController : UIViewController {
         clearButton.alpha = 0.4
         clearButton.isHidden = true
         
-        titleLabel.text = title?.uppercased()
-        titleLabel.textAlignment = .center
-        titleLabel.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: colorSchemeVariant)
-        
         tokenField.layer.cornerRadius = 4
         tokenField.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: colorSchemeVariant)
         tokenField.tokenTitleColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: colorSchemeVariant)
@@ -94,29 +82,14 @@ public class SearchHeaderViewController : UIViewController {
         tokenField.textView.textContainerInset = UIEdgeInsets(top: 9, left: 40, bottom: 11, right: 32)
         tokenField.delegate = self
         
-        closeButton.accessibilityLabel = "close"
-        closeButton.setIcon(.X, with: .tiny, for: .normal)
-        closeButton.addTarget(self, action: #selector(onCloseButtonPressed), for: .touchUpInside)
-        
-        [titleLabel, closeButton].forEach(titleContainer.addSubview)
         [tokenField, searchIcon, clearButton].forEach(tokenFieldContainer.addSubview)
-        [titleContainer, tokenFieldContainer].forEach(view.addSubview)
+        [tokenFieldContainer].forEach(view.addSubview)
         
         createConstraints()
     }
     
     fileprivate func createConstraints() {
         
-        constrain(titleContainer, titleLabel, closeButton) { container, titleLabel, closeButton in
-            titleLabel.leading == container.leading + 8
-            titleLabel.trailing == container.trailing - 8
-            titleLabel.centerY == container.centerY
-            
-            closeButton.width == 44
-            closeButton.height == closeButton.width
-            closeButton.centerY == container.centerY
-            closeButton.trailing == container.trailing
-        }
         
         constrain(tokenFieldContainer, tokenField, searchIcon, clearButton) { container, tokenField, searchIcon, clearButton in
             searchIcon.centerY == tokenField.centerY
@@ -135,23 +108,13 @@ public class SearchHeaderViewController : UIViewController {
             tokenField.centerY == container.centerY
         }
                 
-        constrain(view, titleContainer, tokenFieldContainer) { view, titleContainer, tokenFieldContainer in
-            
-            titleContainer.top == view.top + UIScreen.safeArea.top
-            titleContainer.leading == view.leading
-            titleContainer.trailing == view.trailing
-            titleContainer.height == 44
-            
-            tokenFieldContainer.top == titleContainer.bottom
+        constrain(view, tokenFieldContainer) { view, tokenFieldContainer in
+            tokenFieldContainer.top == view.topMargin
             tokenFieldContainer.bottom == view.bottom
             tokenFieldContainer.leading == view.leading
             tokenFieldContainer.trailing == view.trailing
             tokenFieldContainer.height == 56
         }
-    }
-    
-    fileprivate dynamic func onCloseButtonPressed() {
-        delegate?.searchHeaderViewControllerDidCancelAction(self)
     }
     
     fileprivate dynamic func onClearButtonPressed() {

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
@@ -200,6 +200,8 @@ public class SearchResultsViewController : UIViewController {
         sectionAggregator.collectionView = searchResultsView?.collectionView
         
         updateVisibleSections()
+        
+        searchResultsView?.emptyResultContainer.isHidden = !isResultEmpty
     }
     
     @objc
@@ -248,11 +250,17 @@ public class SearchResultsViewController : UIViewController {
         pendingSearchTask = task
     }
     
+    var isResultEmpty: Bool = true {
+        didSet {
+            searchResultsView?.emptyResultContainer.isHidden = !isResultEmpty
+        }
+    }
+    
     func handleSearchResult(result: SearchResult, isCompleted: Bool) {
         self.updateSections(withSearchResult: result)
         
         if isCompleted {
-            searchResultsView?.emptyResultContainer.isHidden = !sectionAggregator.visibleSectionControllers.isEmpty
+            isResultEmpty = sectionAggregator.visibleSectionControllers.isEmpty
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+SearchResults.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+SearchResults.swift
@@ -72,7 +72,7 @@ extension StartUIViewController: SearchResultsViewControllerDelegate {
                     error.displayAddBotError(in: self)
                 }
             } else {
-                self?.navigationController?.dismiss(animated: true, completion: nil)
+                self.navigationController?.dismiss(animated: true, completion: nil)
             }
         }
         

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+SearchResults.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+SearchResults.swift
@@ -59,7 +59,7 @@ extension StartUIViewController: SearchResultsViewControllerDelegate {
     
     public func searchResultsViewController(_ searchResultsViewController: SearchResultsViewController, didTapOnSeviceUser user: ServiceUser) {
         
-        let detail = ServiceDetailViewController(serviceUser: user, variant: .dark)
+        let detail = ServiceDetailViewController(serviceUser: user, variant: ServiceDetailVariant(colorScheme: .dark, opaque: false))
         
         detail.completion = { [weak self] result in
             guard let `self` = self else { return }

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+SearchResults.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+SearchResults.swift
@@ -39,14 +39,15 @@ extension StartUIViewController: SearchResultsViewControllerDelegate {
     
     public func searchResultsViewController(_ searchResultsViewController: SearchResultsViewController, didDoubleTapOnUser user: ZMSearchableUser, indexPath: IndexPath) {
     
-        if let unboxedUser = BareUserToUser(user), unboxedUser.isConnected, !unboxedUser.isBlocked {
-            
-            if self.userSelection.users.count == 1 && !self.userSelection.users.contains(unboxedUser) {
-                return
-            }
-            
-            self.delegate.startUI(self, didSelectUsers: NSSet(object: user) as! Set<AnyHashable>, for: .createOrOpenConversation)
+        guard let unboxedUser = BareUserToUser(user), unboxedUser.isConnected, !unboxedUser.isBlocked else {
+            return
         }
+            
+        guard self.userSelection.users.count != 1 || self.userSelection.users.contains(unboxedUser) else {
+            return
+        }
+            
+        self.delegate.startUI(self, didSelect: Set(arrayLiteral: unboxedUser), for: .createOrOpenConversation)
     }
     
     public func searchResultsViewController(_ searchResultsViewController: SearchResultsViewController, didTapOnConversation conversation: ZMConversation) {
@@ -71,7 +72,7 @@ extension StartUIViewController: SearchResultsViewControllerDelegate {
                     error.displayAddBotError(in: self)
                 }
             } else {
-                self.delegate.startUIDidCancel(self)
+                self?.navigationController?.dismiss(animated: true, completion: nil)
             }
         }
         

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.h
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.h
@@ -43,9 +43,7 @@ typedef NS_ENUM(NSUInteger, StartUIAction) {
 
 
 @protocol StartUIDelegate <NSObject>
-- (void)startUIDidCancel:(StartUIViewController *)startUI;
-/// NSSet of ZMUsers
-- (void)startUI:(StartUIViewController *)startUI didSelectUsers:(NSSet *)users forAction:(StartUIAction)action;
+- (void)startUI:(StartUIViewController *)startUI didSelectUsers:(NSSet<ZMUser *> *)users forAction:(StartUIAction)action;
 @optional
 - (void)startUI:(StartUIViewController *)startUI didSelectConversation:(ZMConversation *)conversation;
 @end

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.m
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.m
@@ -98,7 +98,7 @@ static NSUInteger const StartUIInitiallyShowsKeyboardConversationThreshold = 10;
     self.emptyResultLabel.font = [UIFont fontWithMagicIdentifier:@"style.text.normal.font_spec"];
     
     self.searchHeaderViewController = [[SearchHeaderViewController alloc] initWithUserSelection:self.userSelection variant:ColorSchemeVariantDark];
-    self.searchHeaderViewController.title = team != nil ? team.name : ZMUser.selfUser.displayName;
+    self.title = team != nil ? team.name : ZMUser.selfUser.displayName;
     self.searchHeaderViewController.delegate = self;
     [self addChildViewController:self.searchHeaderViewController];
     [self.view addSubview:self.searchHeaderViewController.view];
@@ -140,7 +140,11 @@ static NSUInteger const StartUIInitiallyShowsKeyboardConversationThreshold = 10;
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
-    [self.navigationController setNavigationBarHidden:YES animated:animated];
+    
+    self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithIcon:ZetaIconTypeX
+                                                                             style:UIBarButtonItemStylePlain
+                                                                            target:self
+                                                                            action:@selector(onDismissPressed)];
 }
 
 - (void)createConstraints
@@ -218,6 +222,12 @@ static NSUInteger const StartUIInitiallyShowsKeyboardConversationThreshold = 10;
     }
     
     [self.view setNeedsLayout];
+}
+
+- (void)onDismissPressed
+{
+    [self.searchHeaderViewController.tokenField resignFirstResponder];
+    [self.navigationController dismissViewControllerAnimated:YES completion:nil];
 }
 
 #pragma mark - Instance methods
@@ -327,12 +337,6 @@ static NSUInteger const StartUIInitiallyShowsKeyboardConversationThreshold = 10;
 }
 
 #pragma mark - SearchHeaderViewControllerDelegate
-
-- (void)searchHeaderViewControllerDidCancelAction:(SearchHeaderViewController *)searchHeaderViewController
-{
-    [self.searchHeaderViewController.tokenField resignFirstResponder];
-    [self.delegate startUIDidCancel:self];
-}
 
 - (void)searchHeaderViewControllerDidConfirmAction:(SearchHeaderViewController *)searchHeaderViewController
 {

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileDetailsViewController.m
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileDetailsViewController.m
@@ -409,10 +409,14 @@ typedef NS_ENUM(NSUInteger, ProfileUserAction) {
 {
     AddParticipantsViewController *addParticipantsViewController = [[AddParticipantsViewController alloc] initWithConversation:self.conversation];
     
-    addParticipantsViewController.modalPresentationStyle = UIModalPresentationOverCurrentContext;
-    addParticipantsViewController.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
+    UINavigationController *presentedViewController = [addParticipantsViewController wrapInNavigationController:[AddParticipantsNavigationController class]];
     
-    [self presentViewController:addParticipantsViewController animated:YES completion:^{
+    presentedViewController.modalPresentationStyle = UIModalPresentationOverCurrentContext;
+    presentedViewController.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
+    
+    [self presentViewController:presentedViewController
+                       animated:YES
+                     completion:^{
         [Analytics.shared tagOpenedPeoplePickerGroupAction];
     }];
     


### PR DESCRIPTION
### Issues

The service detail controller is designed to be shown as the part of the navigation sequence. Therefore during the original implementation of services I had to put in the ugly solution of
1. Wrapping Start UI/Add Participants VC into the navigation controller.
2. Showing / hiding the nav bar depending on the screen being looked on.

It was semantically inconsistent and simply not future-proof.

### Solutions

It was noticed that the start UI view controller is showing it's title in the way that is very similar to the navigation view controller's navigation bar. Therefore the proposed solution is to replace the title line of Start UI / Add people with the navigation bar. The benefits of this solution:

1. Style of the bar is consistent between the screens.
2. No need to hide / show the bar.

## Additional changes

The `ConversationListViewController` has a not that nice state variable that is showing which controller is shown now. We used the delegate call to dismiss the start UI and reset the state. It also seems not consistent with the regular iOS modal / navigation presentation logic. The state variable is up to be removed in the future.
