### PR TITLE
Don't reset margins on trait collection changes when rendering for preview

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -919,6 +919,7 @@
 		D51735712017640D00B473CE /* UIAlertController+PasswordVerification.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51735702017640D00B473CE /* UIAlertController+PasswordVerification.swift */; };
 		D5173573201764DD00B473CE /* UIAlertAction+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5173572201764DD00B473CE /* UIAlertAction+Convenience.swift */; };
 		D5490A1D20050AAA0057EAA8 /* TeamMemberInviteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5490A1C20050AAA0057EAA8 /* TeamMemberInviteViewController.swift */; };
+		D59EA0C520234EE300B17CE7 /* ConversationCellLayoutProperties+Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59EA0C420234EE300B17CE7 /* ConversationCellLayoutProperties+Preview.swift */; };
 		D5D89780201A12D300FAF69C /* Account+ShareExtensionDisplayName.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D8977E201A121900FAF69C /* Account+ShareExtensionDisplayName.swift */; };
 		D5D89782201A25E000FAF69C /* Analytics+Services.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D89781201A25E000FAF69C /* Analytics+Services.swift */; };
 		D5DBAAA720064D5600E9F65B /* ArrayDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DBAAA620064D5600E9F65B /* ArrayDataSource.swift */; };
@@ -2454,6 +2455,7 @@
 		D51735702017640D00B473CE /* UIAlertController+PasswordVerification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertController+PasswordVerification.swift"; sourceTree = "<group>"; };
 		D5173572201764DD00B473CE /* UIAlertAction+Convenience.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertAction+Convenience.swift"; sourceTree = "<group>"; };
 		D5490A1C20050AAA0057EAA8 /* TeamMemberInviteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamMemberInviteViewController.swift; sourceTree = "<group>"; };
+		D59EA0C420234EE300B17CE7 /* ConversationCellLayoutProperties+Preview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationCellLayoutProperties+Preview.swift"; sourceTree = "<group>"; };
 		D5D8977E201A121900FAF69C /* Account+ShareExtensionDisplayName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Account+ShareExtensionDisplayName.swift"; sourceTree = "<group>"; };
 		D5D89781201A25E000FAF69C /* Analytics+Services.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Analytics+Services.swift"; sourceTree = "<group>"; };
 		D5DBAAA620064D5600E9F65B /* ArrayDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayDataSource.swift; sourceTree = "<group>"; };
@@ -4601,6 +4603,7 @@
 				16E311C11A5FEA2B00FF2C9E /* ConversationCell.h */,
 				EF2CC33C1FF3C567009FFE4C /* ConversationCell+Private.h */,
 				16E311C21A5FEA2B00FF2C9E /* ConversationCell.m */,
+				D59EA0C420234EE300B17CE7 /* ConversationCellLayoutProperties+Preview.swift */,
 				EF2C189F1FED435600E9F2FD /* ConversationCell+BurstTimestamp.swift */,
 				BF989D071E896D210052BF8F /* ConversationCellBurstTimestampView.swift */,
 				87CB36BB1D7480F6007AB4E5 /* ConversationCell+Like.swift */,
@@ -6785,6 +6788,7 @@
 				164C29AB1ED33A5F0026562A /* SearchResultsViewController.swift in Sources */,
 				D5168F522010F20700F8222A /* ShareDestinationCell.swift in Sources */,
 				873C5FE91C10426A00D5132A /* ClientUnregisterFlowViewController.swift in Sources */,
+				D59EA0C520234EE300B17CE7 /* ConversationCellLayoutProperties+Preview.swift in Sources */,
 				16D68E9B1CEF99C7003AB9E0 /* WaveformProgressView.swift in Sources */,
 				87BEB0441D3E478500DE9575 /* AssetLibrary.swift in Sources */,
 				EE43324B1F1A785800096D90 /* PopUpIconButtonView.swift in Sources */,

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell+Preview.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell+Preview.swift
@@ -26,14 +26,9 @@ import Classy
 extension ConversationCell {
     
     func prepareLayoutForPreview(message: ZMMessage? = nil) -> CGFloat {
-        let layoutProperties = ConversationCellLayoutProperties()
-        layoutProperties.showSender = false
-        layoutProperties.showUnreadMarker = false
-        layoutProperties.showBurstTimestamp = false
-        layoutProperties.topPadding = 0
-        layoutProperties.alwaysShowDeliveryState = false
-        
-        self.configure(for: message, layoutProperties: layoutProperties)
+        // Prevent trait collection changes adjusting content insets
+        showsPreview = true
+        self.configure(for: message, layoutProperties: .preview)
         
         constrain(self, self.contentView) { cell, contentView in
             contentView.edges == cell.edges

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
@@ -18,6 +18,7 @@
 
 
 #import "ConversationCell.h"
+#import "ConversationCell+Private.h"
 
 @import PureLayout;
 
@@ -429,10 +430,12 @@ static const CGFloat BurstContainerExpandedHeight = 40;
 
  @param previousTraitCollection previousTraitCollection
  */
-- (void)traitCollectionDidChange:(nullable UITraitCollection *)previousTraitCollection {
+- (void)traitCollectionDidChange:(nullable UITraitCollection *)previousTraitCollection
+{
     [super traitCollectionDidChange:previousTraitCollection];
-
-    self.contentLayoutMargins = self.class.layoutDirectionAwareLayoutMargins;
+    if (!self.showsPreview) {
+        self.contentLayoutMargins = self.class.layoutDirectionAwareLayoutMargins;
+    }
 }
 
 #pragma mark - Long press management

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCellLayoutProperties+Preview.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCellLayoutProperties+Preview.swift
@@ -1,6 +1,6 @@
-////
+//
 // Wire
-// Copyright (C) 2017 Wire Swiss GmbH
+// Copyright (C) 2018 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -16,14 +16,16 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-#import "ConversationCell.h"
+import UIKit
 
-@interface ConversationCell ()
-
-@property (nonatomic) BOOL showsPreview;
-
-- (void)updateCountdownView;
-- (void)startCountdownAnimationIfNeeded:(id<ZMConversationMessage>)message;
-
-@end
-
+extension ConversationCellLayoutProperties {
+    static let preview: ConversationCellLayoutProperties = {
+        let properties = ConversationCellLayoutProperties()
+        properties.showSender = false
+        properties.showUnreadMarker = false
+        properties.showBurstTimestamp = false
+        properties.topPadding = 0
+        properties.alwaysShowDeliveryState = false
+        return properties
+    }()
+}

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ImageMessageCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ImageMessageCell.m
@@ -34,6 +34,7 @@
 #import "Analytics.h"
 #import "Wire-Swift.h"
 #import "UIImage+ZetaIconsNeue.h"
+#import "ConversationCell+Private.h"
 
 #import "UIView+Borders.h"
 
@@ -61,7 +62,6 @@
 
 @property (nonatomic) CGSize originalImageSize;
 @property (nonatomic) CGSize imageSize;
-@property (nonatomic) BOOL showsPreview;
 
 @end
 
@@ -588,12 +588,9 @@ static const CGFloat ImageToolbarMinimumSize = 192;
 
 - (CGFloat)prepareLayoutForPreviewWithMessage:(ZMMessage *)message
 {
-    CGFloat unused __attribute__((unused)) = [super prepareLayoutForPreviewWithMessage:message];
-    
+    NOT_USED([super prepareLayoutForPreviewWithMessage:message]);
     self.autoStretchVertically = NO;
-    self.showsPreview = YES;
     self.defaultLayoutMargins = UIEdgeInsetsZero;
-    
     return [PreviewHeightCalculator heightForImage:self.fullImageView.image];
 }
 


### PR DESCRIPTION
## What's new in this PR?

The share preview views had a large leading margin in some cases, which was caused by the `contentLayoutMargins` being reset to a non `.zero` value when the trait collection changes (which is the case when presenting a view controller).

The height is still not rendered correctly in some cases, which will be addressed in a separate PR.