### PR TITLE
Fix: Notification form other account user account is visible when the device is locked by lock screen

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Overlay/NotificationWindowRootViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Overlay/NotificationWindowRootViewController.m
@@ -74,12 +74,12 @@
         [self.appLockViewController wr_removeFromParentViewController];
     }
 
-    self.appLockViewController.view.translatesAutoresizingMaskIntoConstraints = NO;
-    [self addViewController:self.appLockViewController toView:self.view];
-
     self.chatHeadsViewController = [[ChatHeadsViewController alloc] init];
     self.chatHeadsViewController.view.translatesAutoresizingMaskIntoConstraints = NO;
     [self addViewController:self.chatHeadsViewController toView:self.view];
+
+    self.appLockViewController.view.translatesAutoresizingMaskIntoConstraints = NO;
+    [self addViewController:self.appLockViewController toView:self.view];
 
     [self setupConstraints];
     [self updateAppearanceForOrientation:[UIApplication sharedApplication].statusBarOrientation];


### PR DESCRIPTION
## What's new in this PR?

### Issues

Notification form other account user account is visible when the device is locked by lock screen.

### Causes

chatHeadsViewController.view is added after appLockViewController.view is added to NotificationWindowRootViewController's subviews.

### Solutions

Reverse the added order.

