### PR TITLE
Fix layout of the participants when only one bot is added

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Participants/ParticipantsCollectionHeaderView.swift
+++ b/Wire-iOS/Sources/UserInterface/Participants/ParticipantsCollectionHeaderView.swift
@@ -24,7 +24,7 @@ import Cartography
 final public class ParticipantsCollectionHeaderView: UICollectionReusableView, Reusable {
     public var title: String = "" {
         didSet {
-            titleLabel.text = title.localized.uppercased()
+            titleLabel.text = title.uppercased()
             titleLabel.sizeToFit()
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Participants/ParticipantsViewController+CollectionView.swift
+++ b/Wire-iOS/Sources/UserInterface/Participants/ParticipantsViewController+CollectionView.swift
@@ -20,12 +20,15 @@ import Foundation
 
 extension ParticipantsViewController: UICollectionViewDataSource {
 
+    func participants(of type: UserType) -> [ZMUser] {
+        return groupedParticipants[type] as? [ZMUser] ?? []
+    }
+    
     public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        guard let userType = UserType(rawValue:section),
-            let array = groupedParticipants[userType] as? [ZMUser]
+        guard let userType = UserType(rawValue:section)
             else { return 0 }
 
-        return array.count
+        return participants(of: userType).count
     }
 
     public func collectionView(_ collectionView: UICollectionView,
@@ -108,7 +111,7 @@ extension ParticipantsViewController: UICollectionViewDelegateFlowLayout {
                                insetForSectionAt section: Int) -> UIEdgeInsets {
         let section = UserType(rawValue: section)!
         
-        let hasFirstSection = ((groupedParticipants[UserType.user] as? Array<ZMUser>)?.count ?? 0) > 0
+        let hasFirstSection = !self.participants(of: .user).isEmpty
 
         switch (section, hasFirstSection) {
         case (_, true):
@@ -148,13 +151,13 @@ extension ParticipantsViewController {
     // MARK: - Cell configuration
 
     func user(at indexPath: IndexPath) -> ZMUser? {
-        guard let userType = UserType(rawValue:indexPath.section),
-            let array = groupedParticipants[userType] as? [ZMUser],
-            indexPath.row < array.count else { return nil }
+        guard let userType = UserType(rawValue:indexPath.section) else { return nil }
+        
+        let users = participants(of: userType)
+        
+        guard indexPath.row < users.count else { return nil }
 
-        let user = array[indexPath.row]
-
-        return user
+        return users[indexPath.row]
     }
 
     func configureCell(_ cell: ParticipantsListCell, at indexPath: IndexPath) {
@@ -164,10 +167,7 @@ extension ParticipantsViewController {
     // MARK: - Service user identification
 
     func hasServiceUserInParticipants() -> Bool {
-        guard let array = groupedParticipants[UserType.serviceUser] as? [ZMUser]
-            else { return false }
-
-        return array.count >= 1
+        return !participants(of: .serviceUser).isEmpty
     }
 
     // MARK: - refresh collection view data source

--- a/Wire-iOS/Sources/UserInterface/Participants/ParticipantsViewController+CollectionView.swift
+++ b/Wire-iOS/Sources/UserInterface/Participants/ParticipantsViewController+CollectionView.swift
@@ -28,8 +28,13 @@ extension ParticipantsViewController: UICollectionViewDataSource {
         return array.count
     }
 
-    public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ParticipantCellReuseIdentifier, for: indexPath) as? ParticipantsListCell else { fatal("unable to dequeue cell with ParticipantCellReuseIdentifier") }
+    public func collectionView(_ collectionView: UICollectionView,
+                               cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ParticipantCellReuseIdentifier, for: indexPath) as? ParticipantsListCell
+            else {
+                fatal("unable to dequeue cell with ParticipantCellReuseIdentifier")
+                
+        }
 
         configureCell(cell, at: indexPath)
         return cell
@@ -41,7 +46,10 @@ extension ParticipantsViewController: UICollectionViewDataSource {
 
     // MARK: - section header
 
-    public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
+    public func collectionView(_ collectionView: UICollectionView,
+                               layout collectionViewLayout: UICollectionViewLayout,
+                               referenceSizeForHeaderInSection section: Int) -> CGSize {
+        
         guard let userType = UserType(rawValue: section), userType == .serviceUser else {
             return .zero
         }
@@ -94,6 +102,34 @@ extension ParticipantsViewController: UICollectionViewDelegate {
     }
 }
 
+extension ParticipantsViewController: UICollectionViewDelegateFlowLayout {
+    public func collectionView(_ collectionView: UICollectionView,
+                               layout collectionViewLayout: UICollectionViewLayout,
+                               insetForSectionAt section: Int) -> UIEdgeInsets {
+        let section = UserType(rawValue: section)!
+        
+        let hasFirstSection = ((groupedParticipants[UserType.user] as? Array<ZMUser>)?.count ?? 0) > 0
+
+        switch (section, hasFirstSection) {
+        case (_, true):
+            return UIEdgeInsets(top: self.insetMargin,
+                                left: self.insetMargin,
+                                bottom: self.insetMargin,
+                                right: self.insetMargin)
+        case (.user, false):
+            return UIEdgeInsets(top: 0,
+                                left: self.insetMargin,
+                                bottom: 0,
+                                right: self.insetMargin)
+        case (.serviceUser, false):
+            return UIEdgeInsets(top: 0,
+                                left: self.insetMargin,
+                                bottom: self.insetMargin,
+                                right: self.insetMargin)
+        }
+    }
+}
+
 extension ParticipantsViewController {
 
     // MARK: - collectionview layout configuration
@@ -107,8 +143,6 @@ extension ParticipantsViewController {
             self.collectionViewLayout.itemSize = CGSize(width: 96, height: 106)
             self.collectionViewLayout.minimumLineSpacing = 26
         }
-
-        self.collectionViewLayout.sectionInset = UIEdgeInsets(top: self.insetMargin, left: self.insetMargin, bottom: self.insetMargin, right: self.insetMargin)
     }
 
     // MARK: - Cell configuration

--- a/Wire-iOS/Sources/UserInterface/Participants/ParticipantsViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Participants/ParticipantsViewController.m
@@ -100,8 +100,7 @@ static NSString *const ParticipantHeaderReuseIdentifier = @"ParticipantListHeade
         self.conversation = conversation;
         self.userImageObserverTokens = [NSMutableSet setWithCapacity:5];
         self.navigationControllerDelegate = [[ProfileNavigationControllerDelegate alloc] init];
-        
-        [self loadMagic];
+        self.insetMargin = 24;
     }
     
     return self;
@@ -285,13 +284,6 @@ static NSString *const ParticipantHeaderReuseIdentifier = @"ParticipantListHeade
 - (void)onTapToResign:(id)sender
 {
     [self.headerView.titleView resignFirstResponder];
-}
-
-#pragma mark - Magic
-
-- (void)loadMagic
-{
-    self.insetMargin = 24;
 }
 
 #pragma mark - ZMConversationObserver


### PR DESCRIPTION
## What's new in this PR?

### Issues

When there are no regular users in the group conversation, the collection view used to show the second section slightly scrolled down from the top of the collection view.

### Causes

The collection view that is showing the conversation participants is designed to show 2 sections: users and bots. When the first section is empty, the collection view still thinks it's in the view, even without the cells. The collection view layout is configured in the way that both sections are having the inset, so the second section is off from the top on the height of the first section insets.

### Solutions

There is a way to supply the inset per section dynamically via the collection view flow layout delegate.
