### PR TITLE
Add workaround to fix empty list when opening push

### DIFF
--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
@@ -461,7 +461,18 @@
         [self.splitViewController.rightViewController dismissViewControllerAnimated:NO completion:callback];
     }
     else if (self.conversationListViewController.presentedViewController != nil) {
-        [self.conversationListViewController dismissViewControllerAnimated:NO completion:callback];
+        // This is a workaround around the fact that the transitioningDelegate of the settings
+        // view controller is not called when the transition is not being performed animated.
+        // This sounds like a bug in UIKit (Radar incoming) as I would expect the custom animator
+        // being called with `transitionContext.isAnimated == false`. As this is not the case
+        // we have to restore the proper pre-presentation state here.
+        UIView *conversationView = self.conversationListViewController.view;
+        if (!CATransform3DIsIdentity(conversationView.layer.transform) || 1 != conversationView.alpha) {
+            conversationView.layer.transform = CATransform3DIdentity;
+            conversationView.alpha = 1;
+        }
+        
+        [self.conversationListViewController.presentedViewController dismissViewControllerAnimated:NO completion:callback];
     }
     else if (self.presentedViewController != nil) {
         [self dismissViewControllerAnimated:NO completion:callback];


### PR DESCRIPTION
## What's new in this PR?

When leaving the application with the settings screen being visible last and opening a push notification to get into the app again, we try to dismiss all presented view controllers before showing the selected conversation. The settings screen is presented using a custom view controller transition `SwizzleTransition` which is presented over the current context and applies some transforms and alpha modifications to the conversation list.

For some reason though, the `transitioningDelegate` is not being queried to provide an `UIViewControllerAnimatedTransitioning` object when the view controller is being dismissed without animation. I would have assumed the delegate being queried and the transition contexts property `isAnimated` evaluating to false, so that the pre-presentation state can be restored. I haven't figured out why this is not the case here and will continue investigating.

This PR adds a fix restoring the correct alpha and transform of the `conversationListViewController's` view when dismissing modals non-animated.