### PR TITLE
Fix: Update cancel button hidden property in ParticipantsHeaderView when traitCollectionDidChange

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Participants/ParticipantsHeaderView.m
+++ b/Wire-iOS/Sources/UserInterface/Participants/ParticipantsHeaderView.m
@@ -136,6 +136,20 @@ static NSTimeInterval const ParticipantsHeaderViewEditHintDismissTimeout = 10.0f
     [self updateEditHintViewLeftOffset];
 }
 
+#pragma mark - UITraitEnvironment
+
+/**
+ When iPad switches size class, hide cancel button if switch to iPad Full screen mode, otherwise show the cancel button.
+
+ @param previousTraitCollection previousTraitCollection
+ */
+- (void)traitCollectionDidChange:(nullable UITraitCollection *)previousTraitCollection
+{
+    [super traitCollectionDidChange:previousTraitCollection];
+
+    [self updateCancelButtonHidden];
+}
+
 #pragma mark - UI creation
 
 - (void)addContainerView
@@ -158,11 +172,13 @@ static NSTimeInterval const ParticipantsHeaderViewEditHintDismissTimeout = 10.0f
     [self.cancelButton setIcon:ZetaIconTypeX withSize:ZetaIconSizeTiny forState:UIControlStateNormal];
 
 	[self.cancelButton addTarget:self action:@selector(buttonTapped:) forControlEvents:UIControlEventTouchUpInside];
-	
-	if (IS_IPAD_FULLSCREEN) {
-		// Don’t show the button in iPad popovers (Full screen mode).
-		self.cancelButton.hidden = YES;
-	}
+
+    [self updateCancelButtonHidden];
+}
+
+- (void)updateCancelButtonHidden
+{
+    self.cancelButton.hidden = (IS_IPAD_FULLSCREEN);
 }
 
 - (void)addTitle


### PR DESCRIPTION
## What's new in this PR?

### Issues

On iPad, when participant view is show in full screen mode, then switch to split mode, the user can not go back to conversation screen.

### Causes

Cancel button hidden property is not updated when ParticipantsHeaderView's trait collection (size class) changed.

### Solutions

Update cancel button hidden property in traitCollectionDidChange method.
