### PR TITLE
Fix: Update dismiss button apperance in ProfileHeaderView when traitCollectionDidChange

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1010,6 +1010,7 @@
 		EF2C189E1FED0D6900E9F2FD /* ConversationCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2C189C1FED0D3000E9F2FD /* ConversationCellTests.swift */; };
 		EF2C18A01FED435600E9F2FD /* ConversationCell+BurstTimestamp.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2C189F1FED435600E9F2FD /* ConversationCell+BurstTimestamp.swift */; };
 		EF2C18A21FED541F00E9F2FD /* Timer+allVersionCompatibleScheduledTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2C18A11FED541F00E9F2FD /* Timer+allVersionCompatibleScheduledTimer.swift */; };
+		EF538FDF2028AB2B00EA4048 /* ProfileViewController+headerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF538FDD2028A9A600EA4048 /* ProfileViewController+headerView.swift */; };
 		EF6163A51FE9583400C6F5A9 /* Message+dayFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF6163A41FE9583400C6F5A9 /* Message+dayFormatter.swift */; };
 		EF6163A61FE9682700C6F5A9 /* TextMessageCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF8EE5591D636F4600B0D6D7 /* TextMessageCellTests.swift */; };
 		EF7D75A6201B6149003A8AF8 /* DeviceNativeBoundsSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF7D75A5201B6149003A8AF8 /* DeviceNativeBoundsSize.swift */; };
@@ -2601,6 +2602,8 @@
 		EF2C189F1FED435600E9F2FD /* ConversationCell+BurstTimestamp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationCell+BurstTimestamp.swift"; sourceTree = "<group>"; };
 		EF2C18A11FED541F00E9F2FD /* Timer+allVersionCompatibleScheduledTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Timer+allVersionCompatibleScheduledTimer.swift"; sourceTree = "<group>"; };
 		EF2CC33C1FF3C567009FFE4C /* ConversationCell+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ConversationCell+Private.h"; sourceTree = "<group>"; };
+		EF538FDD2028A9A600EA4048 /* ProfileViewController+headerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProfileViewController+headerView.swift"; sourceTree = "<group>"; };
+		EF538FE02028AB6600EA4048 /* ProfileViewController+internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ProfileViewController+internal.h"; sourceTree = "<group>"; };
 		EF6163A41FE9583400C6F5A9 /* Message+dayFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Message+dayFormatter.swift"; sourceTree = "<group>"; };
 		EF61B33F1FC84B0100D8E631 /* AccessoryTextFieldValidationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccessoryTextFieldValidationTests.swift; sourceTree = "<group>"; };
 		EF61B3411FC8508400D8E631 /* TextFieldValidator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFieldValidator.swift; sourceTree = "<group>"; };
@@ -4842,7 +4845,9 @@
 			isa = PBXGroup;
 			children = (
 				8FC852BE199245760008B66B /* ProfileViewController.h */,
+				EF538FE02028AB6600EA4048 /* ProfileViewController+internal.h */,
 				8FC852BF199245760008B66B /* ProfileViewController.m */,
+				EF538FDD2028A9A600EA4048 /* ProfileViewController+headerView.swift */,
 				BFAAB23C1DED8BB900CBC096 /* ProfileHeaderViewModel.swift */,
 				1613C76C1C3D2E7400B1FB8A /* ProfileDetailsViewController.h */,
 				1613C76D1C3D2E7400B1FB8A /* ProfileDetailsViewController.m */,
@@ -6451,6 +6456,7 @@
 				8711A5A01E0C320100043ACF /* FloatingPoint.swift in Sources */,
 				87DCF47A1D34E95B00BB420F /* ShareContactsViewController.m in Sources */,
 				871BC00D1D34F56300DF0793 /* Analytics+MediaActionEvents.swift in Sources */,
+				EF538FDF2028AB2B00EA4048 /* ProfileViewController+headerView.swift in Sources */,
 				87D5E4421C3E79C600EB8289 /* NSData+Fingerprint.swift in Sources */,
 				871BC3511D34F94200DF0793 /* AccentColorChangeHandler.m in Sources */,
 				BF0BDF9A1DAD3806003C61DE /* Analytics+EmojiKeyboard.swift in Sources */,

--- a/Wire-iOS/Sources/UserInterface/Services/ProfileHeaderServiceDetailViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Services/ProfileHeaderServiceDetailViewController.swift
@@ -79,12 +79,12 @@ final class ProfileHeaderServiceDetailViewController: UIViewController {
     // MARK: - header view
 
     func headerViewModel(with user: ZMBareUser) -> ProfileHeaderViewModel {
-        var headerStyle: ProfileHeaderStyle = .cancelButton
+//        var headerStyle: ProfileHeaderStyle = .cancelButton
         /// TODO: It is possible that headerStyle changes in run time, e.g. iPad changes its size class. Rewrite ProfileHeaderView to handle size class changing.
-        if UIApplication.shared.keyWindow?.traitCollection.horizontalSizeClass == .regular {
-            headerStyle = .backButton
-        }
-        return ProfileHeaderViewModel(user: user, fallbackName: user.displayName, addressBookName: nil, style: headerStyle)
+//        if UIApplication.shared.keyWindow?.traitCollection.horizontalSizeClass == .regular {
+//            headerStyle = .backButton
+//        }
+        return ProfileHeaderViewModel(user: user, fallbackName: user.displayName, addressBookName: nil)
     }
 
     func setupHeader() {

--- a/Wire-iOS/Sources/UserInterface/Services/ProfileHeaderServiceDetailViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Services/ProfileHeaderServiceDetailViewController.swift
@@ -79,12 +79,7 @@ final class ProfileHeaderServiceDetailViewController: UIViewController {
     // MARK: - header view
 
     func headerViewModel(with user: ZMBareUser) -> ProfileHeaderViewModel {
-//        var headerStyle: ProfileHeaderStyle = .cancelButton
-        /// TODO: It is possible that headerStyle changes in run time, e.g. iPad changes its size class. Rewrite ProfileHeaderView to handle size class changing.
-//        if UIApplication.shared.keyWindow?.traitCollection.horizontalSizeClass == .regular {
-//            headerStyle = .backButton
-//        }
-        return ProfileHeaderViewModel(user: user, fallbackName: user.displayName, addressBookName: nil)
+        return ProfileHeaderViewModel(user: user, fallbackName: user.displayName, addressBookName: nil, navigationControllerViewControllerCount: self.navigationController?.viewControllers.count)
     }
 
     func setupHeader() {

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileHeaderViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileHeaderViewModel.swift
@@ -24,11 +24,14 @@ import UIKit
 
     let userDetailViewModel: UserNameDetailViewModel
     let profileViewControllerContext: ProfileViewControllerContext?
+    let navigationControllerViewControllerCount: Int?
 
     init(user: ZMBareUser?,
          fallbackName fallback: String,
          addressBookName: String?,
+         navigationControllerViewControllerCount: Int?,
          profileViewControllerContext: ProfileViewControllerContext? = nil) {
+        self.navigationControllerViewControllerCount = navigationControllerViewControllerCount
         self.profileViewControllerContext = profileViewControllerContext
         self.userDetailViewModel = UserNameDetailViewModel(
             user: user,

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileHeaderViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileHeaderViewModel.swift
@@ -23,16 +23,25 @@ import UIKit
 @objc final class ProfileHeaderViewModel: NSObject {
 
     let userDetailViewModel: UserNameDetailViewModel
-    let profileViewControllerContext: ProfileViewControllerContext?
+    let context: ProfileViewControllerContext?
     let navigationControllerViewControllerCount: Int?
 
+
+    /// Create a ProfileHeaderViewModel for ProfileHeaderView apperance
+    ///
+    /// - Parameters:
+    ///   - user: a ZMBareUser object for showing user's name
+    ///   - fallback: fallback name
+    ///   - addressBookName: address book name for subtitle
+    ///   - navigationControllerViewControllerCount: the number of parent view controller's navigationController's viewController(s), for choosing dismiss button icon type.
+    ///   - profileViewControllerContext: default is nil, for choosing dismiss button icon type.
     init(user: ZMBareUser?,
          fallbackName fallback: String,
          addressBookName: String?,
          navigationControllerViewControllerCount: Int?,
-         profileViewControllerContext: ProfileViewControllerContext? = nil) {
+         context: ProfileViewControllerContext? = nil) {
         self.navigationControllerViewControllerCount = navigationControllerViewControllerCount
-        self.profileViewControllerContext = profileViewControllerContext
+        self.context = context
         self.userDetailViewModel = UserNameDetailViewModel(
             user: user,
             fallbackName: fallback,

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController+headerView.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController+headerView.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
+// Copyright (C) 2018 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -16,25 +16,11 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
+import Foundation
 
-import UIKit
-
-
-@objc final class ProfileHeaderViewModel: NSObject {
-
-    let userDetailViewModel: UserNameDetailViewModel
-    let profileViewControllerContext: ProfileViewControllerContext?
-
-    init(user: ZMBareUser?,
-         fallbackName fallback: String,
-         addressBookName: String?,
-         profileViewControllerContext: ProfileViewControllerContext? = nil) {
-        self.profileViewControllerContext = profileViewControllerContext
-        self.userDetailViewModel = UserNameDetailViewModel(
-            user: user,
-            fallbackName: fallback,
-            addressBookName: addressBookName
-        )
+extension ProfileViewController {
+    @objc(headerViewModelWithUser:)
+    func headerViewModel(with user: ZMBareUser) -> ProfileHeaderViewModel {
+        return ProfileHeaderViewModel(user: user, fallbackName: user.displayName, addressBookName: BareUserToUser(user).addressBookEntry.cachedName, profileViewControllerContext: context)
     }
-
 }

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController+headerView.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController+headerView.swift
@@ -21,6 +21,10 @@ import Foundation
 extension ProfileViewController {
     @objc(headerViewModelWithUser:)
     func headerViewModel(with user: ZMBareUser) -> ProfileHeaderViewModel {
-        return ProfileHeaderViewModel(user: user, fallbackName: user.displayName, addressBookName: BareUserToUser(user).addressBookEntry.cachedName, profileViewControllerContext: context)
+        return ProfileHeaderViewModel(user: user,
+                                      fallbackName: user.displayName,
+                                      addressBookName: BareUserToUser(user)?.addressBookEntry?.cachedName,
+                                      navigationControllerViewControllerCount: navigationController?.viewControllers.count,
+                                      profileViewControllerContext: context)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController+headerView.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController+headerView.swift
@@ -25,6 +25,6 @@ extension ProfileViewController {
                                       fallbackName: user.displayName,
                                       addressBookName: BareUserToUser(user)?.addressBookEntry?.cachedName,
                                       navigationControllerViewControllerCount: navigationController?.viewControllers.count,
-                                      profileViewControllerContext: context)
+                                      context: context)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController+internal.h
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController+internal.h
@@ -1,0 +1,23 @@
+////
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+@interface ProfileViewController () <ZMUserObserver>
+
+@property (nonatomic, readonly) ProfileViewControllerContext context;
+
+@end

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.m
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.m
@@ -196,25 +196,6 @@ typedef NS_ENUM(NSUInteger, ProfileViewControllerTabBarIndex) {
     self.headerView = headerView;
 }
 
-//- (ProfileHeaderViewModel *)headerViewModelWithUser:(id<ZMBareUser>)user
-//{
-//    ProfileHeaderStyle headerStyle = ProfileHeaderStyleCancelButton;
-//
-//    ///TODO: clean 
-//    if (IS_IPAD_FULLSCREEN) {
-//        if (self.navigationController.viewControllers.count > 1) {
-//            headerStyle = ProfileHeaderStyleBackButton;
-//        } else if (self.context != ProfileViewControllerContextDeviceList) {
-//            headerStyle = ProfileHeaderStyleNoButton; // no button in 1:1 profile popover
-//        }
-//    }
-
-//    return [[ProfileHeaderViewModel alloc] initWithUser:user
-//                                           fallbackName:user.displayName
-//                                        addressBookName:BareUserToUser(user).addressBookEntry.cachedName
-//                           profileViewControllerContext:self.context];
-//}
-
 #pragma mark - User observation
 
 - (void)updateShowVerifiedShield

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.m
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.m
@@ -18,6 +18,7 @@
 
 
 #import "ProfileViewController.h"
+#import "ProfileViewController+internal.h"
 
 #import "WireSyncEngine+iOS.h"
 #import "avs+iOS.h"
@@ -69,7 +70,6 @@ typedef NS_ENUM(NSUInteger, ProfileViewControllerTabBarIndex) {
 
 @interface ProfileViewController () <ZMUserObserver>
 
-@property (nonatomic, readonly) ProfileViewControllerContext context;
 @property (nonatomic, readonly) ZMConversation *conversation;
 
 @property (nonatomic) id observerToken;
@@ -196,22 +196,24 @@ typedef NS_ENUM(NSUInteger, ProfileViewControllerTabBarIndex) {
     self.headerView = headerView;
 }
 
-- (ProfileHeaderViewModel *)headerViewModelWithUser:(id<ZMBareUser>)user
-{
-    ProfileHeaderStyle headerStyle = ProfileHeaderStyleCancelButton;
-    if (IS_IPAD_FULLSCREEN) {
-        if (self.navigationController.viewControllers.count > 1) {
-            headerStyle = ProfileHeaderStyleBackButton;
-        } else if (self.context != ProfileViewControllerContextDeviceList) {
-            headerStyle = ProfileHeaderStyleNoButton; // no button in 1:1 profile popover
-        }
-    }
+//- (ProfileHeaderViewModel *)headerViewModelWithUser:(id<ZMBareUser>)user
+//{
+//    ProfileHeaderStyle headerStyle = ProfileHeaderStyleCancelButton;
+//
+//    ///TODO: clean 
+//    if (IS_IPAD_FULLSCREEN) {
+//        if (self.navigationController.viewControllers.count > 1) {
+//            headerStyle = ProfileHeaderStyleBackButton;
+//        } else if (self.context != ProfileViewControllerContextDeviceList) {
+//            headerStyle = ProfileHeaderStyleNoButton; // no button in 1:1 profile popover
+//        }
+//    }
 
-    return [[ProfileHeaderViewModel alloc] initWithUser:user
-                                           fallbackName:user.displayName
-                                        addressBookName:BareUserToUser(user).addressBookEntry.cachedName
-                                                  style:headerStyle];
-}
+//    return [[ProfileHeaderViewModel alloc] initWithUser:user
+//                                           fallbackName:user.displayName
+//                                        addressBookName:BareUserToUser(user).addressBookEntry.cachedName
+//                           profileViewControllerContext:self.context];
+//}
 
 #pragma mark - User observation
 

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Views/ProfileHeaderView.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Views/ProfileHeaderView.swift
@@ -35,20 +35,20 @@ final class ProfileHeaderView: UIView {
 
     private(set) var dismissButton = IconButton.iconButtonCircular()
     private(set) var headerStyle: ProfileHeaderStyle
-    let navigationControllerViewControllerCount: Int?
-    let profileViewControllerContext: ProfileViewControllerContext?
+    private let navigationControllerViewControllerCount: Int?
+    private let profileViewControllerContext: ProfileViewControllerContext?
 
     private let detailView = UserNameDetailView()
     private let verifiedImageView = UIImageView(image: WireStyleKit.imageOfShieldverified())
 
-    var backButtonLeading: NSLayoutConstraint?
-    var cancelButtonTrailing: NSLayoutConstraint?
+    private var backButtonLeading: NSLayoutConstraint?
+    private var cancelButtonTrailing: NSLayoutConstraint?
 
     @objc(initWithViewModel:)
     init(with viewModel: ProfileHeaderViewModel) {
         headerStyle = .noButton
         navigationControllerViewControllerCount = viewModel.navigationControllerViewControllerCount
-        profileViewControllerContext = viewModel.profileViewControllerContext
+        profileViewControllerContext = viewModel.context
         super.init(frame: .zero)
 
         setupViews()

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Views/ProfileHeaderView.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Views/ProfileHeaderView.swift
@@ -123,25 +123,27 @@ final class ProfileHeaderView: UIView {
     // MARK: - DismissButton style and constraints
     
     func updateDismissButton() {
-        // switch constraints
         switch headerStyle {
         case .backButton:
             cancelButtonTrailing?.isActive = false
             backButtonLeading?.isActive = true
+
+            dismissButton.isHidden = false
+
+            dismissButton.setIcon(.chevronLeft, with: .tiny, for: .normal)
         case .cancelButton:
             backButtonLeading?.isActive = false
             cancelButtonTrailing?.isActive = true
-        case .noButton:
-            backButtonLeading?.isActive = false
-            cancelButtonTrailing?.isActive = false
-        }
 
-        // switch icon
-        dismissButton.isHidden = false
-        switch headerStyle {
-        case .backButton: dismissButton.setIcon(.chevronLeft, with: .tiny, for: .normal)
-        case .cancelButton: dismissButton.setIcon(.X, with: .tiny, for: .normal)
-        case .noButton: dismissButton.isHidden = true
+            dismissButton.isHidden = false
+
+            dismissButton.setIcon(.X, with: .tiny, for: .normal)
+        case .noButton:
+            ///the button is hidden, the position is not important
+            backButtonLeading?.isActive = false
+            cancelButtonTrailing?.isActive = true
+
+            dismissButton.isHidden = true
         }
     }
 
@@ -159,6 +161,8 @@ final class ProfileHeaderView: UIView {
 
         self.headerStyle = headerStyle
     }
+
+    // MARK: - UITraitCollection
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Views/ProfileHeaderView.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Views/ProfileHeaderView.swift
@@ -36,13 +36,18 @@ final class ProfileHeaderView: UIView {
 
     private(set) var dismissButton = IconButton.iconButtonCircular()
     private(set) var headerStyle: ProfileHeaderStyle
+    let profileViewControllerContext: ProfileViewControllerContext?
 
     private let detailView = UserNameDetailView()
     private let verifiedImageView = UIImageView(image: WireStyleKit.imageOfShieldverified())
 
+    var backButtonLeading: NSLayoutConstraint?
+    var cancelButtonTrailing: NSLayoutConstraint?
+
     @objc(initWithViewModel:)
     init(with viewModel: ProfileHeaderViewModel) {
-        headerStyle = viewModel.style
+        headerStyle = .noButton
+        profileViewControllerContext = viewModel.profileViewControllerContext
         super.init(frame: .zero)
 
         setupViews()
@@ -64,6 +69,7 @@ final class ProfileHeaderView: UIView {
         dismissButton.accessibilityIdentifier = "OtherUserProfileCloseButton"
 
         switch headerStyle {
+        ///TODO: change icon when trait changes
         case .backButton: dismissButton.setIcon(.chevronLeft, with: .tiny, for: .normal)
         case .cancelButton: dismissButton.setIcon(.X, with: .tiny, for: .normal)
         default: break
@@ -93,11 +99,20 @@ final class ProfileHeaderView: UIView {
             verified.width == 16
             verified.leading == view.leading + horizontalMargin
 
-            switch headerStyle {
-            case .backButton: dismiss.leading == view.leading + horizontalMargin
-            case .cancelButton: dismiss.trailing == view.trailing - horizontalMargin
-            default: break
-            }
+            backButtonLeading = dismiss.leading == view.leading + horizontalMargin
+            cancelButtonTrailing = dismiss.trailing == view.trailing - horizontalMargin
+        }
+
+        switch headerStyle {
+        case .backButton:
+            cancelButtonTrailing?.isActive = false
+            backButtonLeading?.isActive = true
+        case .cancelButton:
+            backButtonLeading?.isActive = false
+            cancelButtonTrailing?.isActive = true
+        default:
+            backButtonLeading?.isActive = false
+            cancelButtonTrailing?.isActive = false
         }
     }
 
@@ -121,4 +136,7 @@ final class ProfileHeaderView: UIView {
         )
     }
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+    }
 }

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Views/ProfileHeaderView.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Views/ProfileHeaderView.swift
@@ -99,6 +99,29 @@ final class ProfileHeaderView: UIView {
         }
     }
 
+    @objc(configureWithViewModel:)
+    public func configure(with model: ProfileHeaderViewModel) {
+        detailView.configure(with: model.userDetailViewModel)
+    }
+
+    private func updateVerifiedShield() {
+        var shouldHide = true
+        if headerStyle != .backButton {
+            shouldHide = !showVerifiedShield
+        }
+
+        UIView.transition(
+            with: verifiedImageView,
+            duration: 0.2,
+            options: .transitionCrossDissolve,
+            animations: { self.verifiedImageView.isHidden = shouldHide },
+            completion: nil
+        )
+    }
+
+
+    // MARK: - DismissButton style and constraints
+    
     func updateDismissButton() {
         // switch constraints
         switch headerStyle {
@@ -120,26 +143,6 @@ final class ProfileHeaderView: UIView {
         case .cancelButton: dismissButton.setIcon(.X, with: .tiny, for: .normal)
         case .noButton: dismissButton.isHidden = true
         }
-    }
-
-    @objc(configureWithViewModel:)
-    public func configure(with model: ProfileHeaderViewModel) {
-        detailView.configure(with: model.userDetailViewModel)
-    }
-
-    private func updateVerifiedShield() {
-        var shouldHide = true
-        if headerStyle != .backButton {
-            shouldHide = !showVerifiedShield
-        }
-
-        UIView.transition(
-            with: verifiedImageView,
-            duration: 0.2,
-            options: .transitionCrossDissolve,
-            animations: { self.verifiedImageView.isHidden = shouldHide },
-            completion: nil
-        )
     }
 
     func updateHeaderStyle() {

--- a/Wire-iOS/WireBridgingHeader.h
+++ b/Wire-iOS/WireBridgingHeader.h
@@ -76,6 +76,7 @@
 #import "ParticipantsViewController+internal.h"
 #import "ParticipantsHeaderView.h"
 #import "ProfileViewController.h"
+#import "ProfileViewController+internal.h"
 #import "ProfileNavigationControllerDelegate.h"
 #import "StartUIViewController.h"
 #import "StartUIViewController+internal.h"


### PR DESCRIPTION
## What's new in this PR?

### Issues

On iPad, when ProfileHeaderView(subview of ProfileViewController and ProfileHeaderServiceDetailViewController's view) shows in full screen mode, then switches to compact mode, the dismiss icon is not updated to corresponding appearance.

### Causes

Dismiss button 's icon and constraints are set when ProfileHeaderView is created. UI styles are not updated when ProfileHeaderView's trait collection (size class) changed.

### Solutions

Update dismiss button's icon and constrants in traitCollectionDidChange method. Move the button type definition from the parent classes to ProfileHeaderView. ProfileHeaderView choose headerStyle depends on userInterfaceIdiom, horizontalSizeClass, context(ProfileViewControllerContext) and parent's navigationController.viewControllers.count