### PR TITLE
Fixed initial layout of the navigation bar when presented with Swizzle transition

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Transitions/SwizzleTransition.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Transitions/SwizzleTransition.m
@@ -40,8 +40,9 @@
         [transitionContext completeTransition:YES];
         return;
     }
+    [containerView setNeedsLayout];
+    [containerView layoutIfNeeded];
     
-    [toView layoutIfNeeded];
     NSTimeInterval durationPhase1 = 0.0f;
     NSTimeInterval durationPhase2 = 0.0f;
     if (self.direction == SwizzleTransitionDirectionHorizontal) {


### PR DESCRIPTION
## What's new in this PR?

### Issues

The navigation bar is jumping from the very top (under the status bar) to it's normal position right after showing.

### Causes

Navigation controller has a special tailored logic for positioning the navigation bar when the status bar is visible or not.

Any view controller, when presented with custom transition, is being laid out when it's not the part of the view hierarchy yet. Therefore the navigation controller does not know when it's laid out if it should adopt for the status bar or not. Existing call was not laying out the presented view controller view's position.

### Solutions

Re-layout of the view controller when it's already in the view hierarchy is putting the navigation bar in place.