### PR TITLE
Delay checking the availability status until the app is active

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Availability/AvailabilityTitleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Availability/AvailabilityTitleView.swift
@@ -58,7 +58,7 @@ import WireDataModel
             self.observerToken = UserChangeInfo.add(observer: self, for: user, userSession: sharedSession)
         }
         
-        NotificationCenter.default.addObserver(self, selector: #selector(applicationDidEnterForeground), name: Notification.Name.UIApplicationWillEnterForeground, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(applicationDidBecomeActive), name: Notification.Name.UIApplicationDidBecomeActive, object: nil)
         
         configure(user: user)
     }
@@ -103,7 +103,7 @@ import WireDataModel
 extension AvailabilityTitleView {
     
     @objc
-    fileprivate func applicationDidEnterForeground() {
+    fileprivate func applicationDidBecomeActive() {
         guard let user = self.user else { return }
         
         configure(user: user)


### PR DESCRIPTION
### Issues

The app sometimes crashes when it checks the availability status upon entering the foreground.

### Causes

The app crashes with an error: `An NSManagedObject must have a valid NSEntityDescription.` which is still unclear why that would be the case of the self user.

### Solutions

Delay querying the vailability status until the app is active and observe the crash logs to see if that has an impact.