### PR TITLE
Fix/profile header view tests

### DIFF
--- a/Wire-iOS Tests/ProfileHeaderViewTests.swift
+++ b/Wire-iOS Tests/ProfileHeaderViewTests.swift
@@ -35,7 +35,6 @@ class ProfileHeaderViewTests: ZMSnapshotTestCase {
         let sut = ProfileHeaderView(with: model)
         sut.headerStyle = style
         sut.updateDismissButton()
-        sut.disableHeaderStyleUpdate = true
 
         return sut
     }

--- a/Wire-iOS Tests/ProfileHeaderViewTests.swift
+++ b/Wire-iOS Tests/ProfileHeaderViewTests.swift
@@ -27,7 +27,10 @@ class ProfileHeaderViewTests: ZMSnapshotTestCase {
         snapshotBackgroundColor = .white
     }
 
-    func createSutWithHeadStyle(style: ProfileHeaderStyle, user: ZMBareUser? = nil, addressBookName: String? = nil, fallbackName: String = "Jose Luis") -> ProfileHeaderView {
+    func createSutWithHeadStyle(style: ProfileHeaderStyle,
+                                user: ZMBareUser? = nil,
+                                addressBookName: String? = nil,
+                                fallbackName: String = "Jose Luis") -> ProfileHeaderView {
         let model = ProfileHeaderViewModel(user: user, fallbackName: fallbackName, addressBookName: addressBookName, navigationControllerViewControllerCount: 0)
         let sut = ProfileHeaderView(with: model)
         sut.headerStyle = style
@@ -72,27 +75,27 @@ class ProfileHeaderViewTests: ZMSnapshotTestCase {
 
     func testThatItRendersUserName() {
         let user = MockUser.mockUsers().first
-        let sut = createSutWithHeadStyle(style: .noButton, user: user, addressBookName: nil, fallbackName: "")
+        let sut = createSutWithHeadStyle(style: .noButton, user: user, fallbackName: "")
         verifyInAllPhoneWidths(view: sut)
     }
 
     func testThatItRendersUserName_Verified() {
         let user = MockUser.mockUsers().first
-        let sut = createSutWithHeadStyle(style: .noButton, user: user, addressBookName: nil, fallbackName: "")
+        let sut = createSutWithHeadStyle(style: .noButton, user: user, fallbackName: "")
         sut.showVerifiedShield = true
         verifyInAllPhoneWidths(view: sut)
     }
 
     func testThatItRendersUserNoUsernameButEmail() {
         let user = MockUser.mockUsers().last
-        let sut = createSutWithHeadStyle(style: .noButton, user: user, addressBookName: nil, fallbackName: "")
+        let sut = createSutWithHeadStyle(style: .noButton, user: user, fallbackName: "")
         verifyInAllPhoneWidths(view: sut)
     }
 
     func testThatItRendersUserWithEmptyUserName() {
         let user = MockUser.mockUsers().first
         (user as Any as! MockUser).handle = ""
-        let sut = createSutWithHeadStyle(style: .noButton, user: user, addressBookName: nil, fallbackName: "")
+        let sut = createSutWithHeadStyle(style: .noButton, user: user, fallbackName: "")
         verifyInAllPhoneWidths(view: sut)
     }
 

--- a/Wire-iOS Tests/ProfileHeaderViewTests.swift
+++ b/Wire-iOS Tests/ProfileHeaderViewTests.swift
@@ -16,11 +16,9 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import XCTest
 import Cartography
 @testable import Wire
-
 
 class ProfileHeaderViewTests: ZMSnapshotTestCase {
 
@@ -29,74 +27,74 @@ class ProfileHeaderViewTests: ZMSnapshotTestCase {
         snapshotBackgroundColor = .white
     }
 
-    func testThatItRendersFallbackUserName() {
-        let model = ProfileHeaderViewModel(user: nil, fallbackName: "Jose Luis", addressBookName: nil, style: .noButton)
+    func createSutWithHeadStyle(style: ProfileHeaderStyle, user: ZMBareUser? = nil, addressBookName: String? = nil, fallbackName: String = "Jose Luis") -> ProfileHeaderView {
+        let model = ProfileHeaderViewModel(user: user, fallbackName: fallbackName, addressBookName: addressBookName, navigationControllerViewControllerCount: 0)
         let sut = ProfileHeaderView(with: model)
+        sut.headerStyle = style
+        sut.updateDismissButton()
+        sut.disableHeaderStyleUpdate = true
+
+        return sut
+    }
+
+    func testThatItRendersFallbackUserName() {
+        let sut = createSutWithHeadStyle(style: .noButton)
         verifyInAllPhoneWidths(view: sut)
     }
 
     func testThatItRendersFallbackUserName_CancelButton() {
-        let model = ProfileHeaderViewModel(user: nil, fallbackName: "Jose Luis", addressBookName: nil, style: .cancelButton)
-        let sut = ProfileHeaderView(with: model)
+        let sut = createSutWithHeadStyle(style: .cancelButton)
         verifyInAllPhoneWidths(view: sut)
     }
 
     func testThatItRendersFallbackUserName_CancelButton_Verified() {
-        let model = ProfileHeaderViewModel(user: nil, fallbackName: "Jose Luis", addressBookName: nil, style: .cancelButton)
-        let sut = ProfileHeaderView(with: model)
+        let sut = createSutWithHeadStyle(style: .cancelButton)
         sut.showVerifiedShield = true
         verifyInAllPhoneWidths(view: sut)
     }
 
     func testThatItRendersFallbackUserName_BackButton() {
-        let model = ProfileHeaderViewModel(user: nil, fallbackName: "Jose Luis", addressBookName: nil, style: .backButton)
-        let sut = ProfileHeaderView(with: model)
+        let sut = createSutWithHeadStyle(style: .backButton)
         verifyInAllPhoneWidths(view: sut)
     }
 
     func testThatItRendersAddressBookName() {
         let user = MockUser.mockUsers().first
-        let model = ProfileHeaderViewModel(user: user, fallbackName: "Jose Luis", addressBookName: "JameyBoy", style: .backButton)
-        let sut = ProfileHeaderView(with: model)
+        let sut = createSutWithHeadStyle(style: .backButton, user: user, addressBookName: "JameyBoy")
         verifyInAllPhoneWidths(view: sut)
     }
 
     func testThatItRendersAddressBookName_EqualName() {
         let user = MockUser.mockUsers().first
-        let model = ProfileHeaderViewModel(user: user, fallbackName: "", addressBookName: user?.name, style: .backButton)
-        let sut = ProfileHeaderView(with: model)
+        let sut = createSutWithHeadStyle(style: .backButton, user: user, addressBookName: user?.name, fallbackName: "")
         verifyInAllPhoneWidths(view: sut)
     }
 
     func testThatItRendersUserName() {
         let user = MockUser.mockUsers().first
-        let model = ProfileHeaderViewModel(user: user, fallbackName: "", addressBookName: nil, style: .noButton)
-        let sut = ProfileHeaderView(with: model)
+        let sut = createSutWithHeadStyle(style: .noButton, user: user, addressBookName: nil, fallbackName: "")
         verifyInAllPhoneWidths(view: sut)
     }
 
     func testThatItRendersUserName_Verified() {
         let user = MockUser.mockUsers().first
-        let model = ProfileHeaderViewModel(user: user, fallbackName: "", addressBookName: nil, style: .noButton)
-        let sut = ProfileHeaderView(with: model)
+        let sut = createSutWithHeadStyle(style: .noButton, user: user, addressBookName: nil, fallbackName: "")
         sut.showVerifiedShield = true
         verifyInAllPhoneWidths(view: sut)
     }
 
     func testThatItRendersUserNoUsernameButEmail() {
         let user = MockUser.mockUsers().last
-        let model = ProfileHeaderViewModel(user: user, fallbackName: "", addressBookName: nil, style: .noButton)
-        let sut = ProfileHeaderView(with: model)
+        let sut = createSutWithHeadStyle(style: .noButton, user: user, addressBookName: nil, fallbackName: "")
         verifyInAllPhoneWidths(view: sut)
     }
-
 
     func testThatItRendersUserWithEmptyUserName() {
         let user = MockUser.mockUsers().first
         (user as Any as! MockUser).handle = ""
-        let model = ProfileHeaderViewModel(user: user, fallbackName: "", addressBookName: nil, style: .noButton)
-        let sut = ProfileHeaderView(with: model)
+        let sut = createSutWithHeadStyle(style: .noButton, user: user, addressBookName: nil, fallbackName: "")
         verifyInAllPhoneWidths(view: sut)
     }
 
 }
+

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Views/ProfileHeaderView.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Views/ProfileHeaderView.swift
@@ -77,14 +77,14 @@ final class ProfileHeaderView: UIView {
 
         let detailViewMargin = horizontalMargin + 32
 
-        constrain(self, detailView) { (view: LayoutProxy, detailView: LayoutProxy) -> Void in
+        constrain(self, detailView) { (view: LayoutProxy, detailView: LayoutProxy) -> () in
             detailView.top == view.top + topMargin
             detailView.leading == view.leading + detailViewMargin
             detailView.trailing == view.trailing - detailViewMargin
             detailView.bottom == view.bottom - 12
         }
 
-        constrain(self, dismissButton, verifiedImageView, detailView.titleLabel) { (view: LayoutProxy, dismiss: LayoutProxy, verified: LayoutProxy, title: LayoutProxy) -> Void in
+        constrain(self, dismissButton, verifiedImageView, detailView.titleLabel) { (view: LayoutProxy, dismiss: LayoutProxy, verified: LayoutProxy, title: LayoutProxy) -> () in
             dismiss.top == view.top + 26
             dismiss.width == dismiss.height
             dismiss.width == 32

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Views/ProfileHeaderView.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Views/ProfileHeaderView.swift
@@ -16,10 +16,8 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import UIKit
 import Cartography
-
 
 enum ProfileHeaderStyle: Int {
     case cancelButton, backButton, noButton
@@ -34,7 +32,9 @@ final class ProfileHeaderView: UIView {
     }
 
     private(set) var dismissButton = IconButton.iconButtonCircular()
-    private(set) var headerStyle: ProfileHeaderStyle
+    internal(set) var headerStyle: ProfileHeaderStyle
+    /// flag for disable headerStyle update in traitCollectionDidChange. It should be used for test only.
+    internal(set) var disableHeaderStyleUpdate: Bool = false
     private let navigationControllerViewControllerCount: Int?
     private let profileViewControllerContext: ProfileViewControllerContext?
 
@@ -56,7 +56,7 @@ final class ProfileHeaderView: UIView {
         createConstraints()
         updateDismissButton()
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -76,15 +76,15 @@ final class ProfileHeaderView: UIView {
         let horizontalMargin = WAZUIMagic.cgFloat(forIdentifier: "profile_temp.content_left_margin")
 
         let detailViewMargin = horizontalMargin + 32
-        
-        constrain(self, detailView) { (view: LayoutProxy, detailView: LayoutProxy) -> () in
+
+        constrain(self, detailView) { (view: LayoutProxy, detailView: LayoutProxy) -> Void in
             detailView.top == view.top + topMargin
             detailView.leading == view.leading + detailViewMargin
             detailView.trailing == view.trailing - detailViewMargin
             detailView.bottom == view.bottom - 12
         }
 
-        constrain(self, dismissButton, verifiedImageView, detailView.titleLabel) { (view: LayoutProxy, dismiss: LayoutProxy, verified: LayoutProxy, title: LayoutProxy) -> () in
+        constrain(self, dismissButton, verifiedImageView, detailView.titleLabel) { (view: LayoutProxy, dismiss: LayoutProxy, verified: LayoutProxy, title: LayoutProxy) -> Void in
             dismiss.top == view.top + 26
             dismiss.width == dismiss.height
             dismiss.width == 32
@@ -119,9 +119,8 @@ final class ProfileHeaderView: UIView {
         )
     }
 
-
     // MARK: - DismissButton style and constraints
-    
+
     func updateDismissButton() {
         switch headerStyle {
         case .backButton:
@@ -147,7 +146,7 @@ final class ProfileHeaderView: UIView {
         }
     }
 
-    func updateHeaderStyle() {
+    private func updateHeaderStyle() {
         var headerStyle: ProfileHeaderStyle = .cancelButton
 
         if self.traitCollection.userInterfaceIdiom == .pad && UIApplication.shared.keyWindow?.traitCollection.horizontalSizeClass == .regular {
@@ -167,7 +166,10 @@ final class ProfileHeaderView: UIView {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
+        if disableHeaderStyleUpdate { return }
+
         updateHeaderStyle()
         updateDismissButton()
     }
 }
+

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Views/ProfileHeaderView.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Views/ProfileHeaderView.swift
@@ -34,7 +34,6 @@ final class ProfileHeaderView: UIView {
     private(set) var dismissButton = IconButton.iconButtonCircular()
     internal(set) var headerStyle: ProfileHeaderStyle
     /// flag for disable headerStyle update in traitCollectionDidChange. It should be used for test only.
-    internal(set) var disableHeaderStyleUpdate: Bool = false
     private let navigationControllerViewControllerCount: Int?
     private let profileViewControllerContext: ProfileViewControllerContext?
 
@@ -165,8 +164,10 @@ final class ProfileHeaderView: UIView {
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-
-        if disableHeaderStyleUpdate { return }
+        guard self.traitCollection.userInterfaceIdiom == .pad,
+            UIApplication.shared.keyWindow?.traitCollection.horizontalSizeClass != .unspecified else {
+            return
+        }
 
         updateHeaderStyle()
         updateDismissButton()


### PR DESCRIPTION
## What's new in this PR?

### Issues

ProfileHeaderViewTests failed to compile after ProfileHeaderView's init medthod updated.

### Solutions

Rewrite ProfileHeaderViewTests and create a flag in ProfileHeaderView to prevent traitCollectionDidChange (called by verifyInAllPhoneWidths) changes headerStyle during the snapshot tests.

