### PR TITLE
Remove separator line from collections view

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
@@ -298,13 +298,6 @@ final public class CollectionsViewController: UIViewController {
             backButton.addTarget(self, action: #selector(CollectionsViewController.backButtonPressed(_:)), for: .touchUpInside)
             self.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: backButton)
         }
-        
-        if let navBar = self.navigationController?.navigationBar {
-            let imageToStretch = UIImage.shadowImage(withInset: 16.0 * UIScreen.main.scale, color: ColorScheme.default().color(withName: ColorSchemeColorSeparator))
-            let scaleImageToStretch = UIImage(cgImage: imageToStretch.cgImage!, scale: UIScreen.main.scale, orientation: .up)
-            let stretchedImage = scaleImageToStretch.resizableImage(withCapInsets: UIEdgeInsetsMake(0, 18, 0, 18))
-            navBar.shadowImage = stretchedImage
-        }
     }
     
     public func perform(_ action: MessageAction, for message: ZMConversationMessage, from view: UIView) {

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/DefaultNavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/DefaultNavigationBar.swift
@@ -41,10 +41,9 @@ class DefaultNavigationBar : UINavigationBar {
                                NSForegroundColorAttributeName: ColorScheme.default().color(withName: ColorSchemeColorTextForeground)]
         setTitleVerticalPositionAdjustment(-2.0, for: .default)
         
-        let separatorPixel = UIImage.singlePixelImage(with: ColorScheme.default().color(withName: ColorSchemeColorSeparator))
+        let separatorPixel = UIImage.singlePixelImage(with: UIColor.clear)
         let retinaSeparatorPixel = UIImage(cgImage: separatorPixel.cgImage!, scale: UIScreen.main.scale, orientation: separatorPixel.imageOrientation)
         shadowImage = retinaSeparatorPixel
-        
     }
     
 }

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/DefaultNavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/DefaultNavigationBar.swift
@@ -37,13 +37,10 @@ class DefaultNavigationBar : UINavigationBar {
         tintColor = ColorScheme.default().color(withName: ColorSchemeColorTextForeground)
         barTintColor = ColorScheme.default().color(withName: ColorSchemeColorBarBackground)
         setBackgroundImage(UIImage.singlePixelImage(with: ColorScheme.default().color(withName: ColorSchemeColorBarBackground)), for: .default)
+        shadowImage = UIImage.singlePixelImage(with: UIColor.clear)
         titleTextAttributes = [NSFontAttributeName: UIFont(magicIdentifier: "style.text.title.font_spec"),
                                NSForegroundColorAttributeName: ColorScheme.default().color(withName: ColorSchemeColorTextForeground)]
         setTitleVerticalPositionAdjustment(-2.0, for: .default)
-        
-        let separatorPixel = UIImage.singlePixelImage(with: UIColor.clear)
-        let retinaSeparatorPixel = UIImage(cgImage: separatorPixel.cgImage!, scale: UIScreen.main.scale, orientation: separatorPixel.imageOrientation)
-        shadowImage = retinaSeparatorPixel
     }
     
 }


### PR DESCRIPTION
## What's new in this PR?
Remove the separator line above the search field in the collections view controller.

## Notes
The design has changed so that the navigation bar and the content view has different colours making the separator line unnecessary.