### PR TITLE
iOS10: Pin the top to the bottom of the navigation bar

### DIFF
--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchHeaderViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchHeaderViewController.swift
@@ -107,9 +107,11 @@ public class SearchHeaderViewController : UIViewController {
             tokenField.trailing == container.trailing - 8
             tokenField.centerY == container.centerY
         }
-                
+        
+        // pin to the bottom of the navigation bar
+        tokenFieldContainer.topAnchor.constraint(equalTo: self.topLayoutGuide.bottomAnchor).isActive = true
+
         constrain(view, tokenFieldContainer) { view, tokenFieldContainer in
-            tokenFieldContainer.top == view.topMargin
             tokenFieldContainer.bottom == view.bottom
             tokenFieldContainer.leading == view.leading
             tokenFieldContainer.trailing == view.trailing


### PR DESCRIPTION
## What's new in this PR?

### Issues

On iOS 10, when the constraint is created with Cartography, the top of the search bar is not pinned to the bottom of the navigation bar of the parent view controller.

### Causes

Seemingly the Cartography is missing this bit of functionality for iOS10.

### Solutions

Use iOS integrated layout anchors functionality in order to create the necessary constraint to layout margin.
