### PR TITLE
Profile: Fix missing close button

### DIFF
--- a/Wire-iOS/Sources/UserInterface/UserProfile/Views/ProfileHeaderView.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Views/ProfileHeaderView.swift
@@ -53,6 +53,7 @@ final class ProfileHeaderView: UIView {
         setupViews()
         configure(with: viewModel)
         createConstraints()
+        updateHeaderStyle()
         updateDismissButton()
     }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

The close button is missing from user profile when entering it on iPhone.

### Causes

[Some refactoring](https://github.com/wireapp/wire-ios/pull/1684) was done on the header of participants view in order to adopt it better for the traits change. During the refactoring we broke the tests, so [another fixes](https://github.com/wireapp/wire-ios/pull/1691) have to be done to address this. During those fixes, we missed to check the functionality on the iPhone: the call to `updateHeaderStyle` is necessary in order to make sure the initial close button style is configured.

### Solutions

Missing call is added, so the view is initially correctly configured.