### PR TITLE
Fix self profile retain cycle

### DIFF
--- a/Wire-iOS/Sources/UserInterface/SelfProfile/ProfileView.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/ProfileView.swift
@@ -27,7 +27,7 @@ import Cartography
     public var availabilityView = AvailabilityTitleView(user: ZMUser.selfUser(), style: .selfProfile)
     var stackView : UICustomSpacingStackView!
     var userObserverToken: NSObjectProtocol?
-    var source: UIViewController?
+    weak var source: UIViewController?
     
     init(user: ZMUser) {
         super.init(frame: .zero)


### PR DESCRIPTION
### Issues

The app was crashing in the `AvailabilityTitleView` due to  an exception: `An NSManagedObject must have a valid NSEntityDescription`

### Causes

There was a retain cycle in the `ProfileView` which contains a `AvailabilityTitleView`. The steps leading up to a crash:

1. Launch app into  account 1
2. Switch to account 2 (this will leak a `AvailabilityTitleView`)
3. App gets a memory warning which will shutdown the user session for account 1
4. Open app and the `AvailabilityTitleView` will try access no longer existing user object and crash.

### Solutions

Fix retain cycle.