### PR TITLE
StartUI: Clear search input when selecting services

### DIFF
--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchHeaderViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchHeaderViewController.swift
@@ -126,6 +126,12 @@ public class SearchHeaderViewController : UIViewController {
         updateClearIndicator(for: tokenField)
     }
     
+    public func clearInput() {
+        tokenField.removeAllTokens()
+        tokenField.clearFilterText()
+        userSelection.replace([])
+    }
+    
     public func resetQuery() {
         tokenField.filterUnwantedAttachments()
         delegate?.searchHeaderViewController(self, updatedSearchQuery: tokenField.filterText)

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.m
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.m
@@ -110,6 +110,11 @@ static NSUInteger const StartUIInitiallyShowsKeyboardConversationThreshold = 10;
     @weakify(self);
     self.groupSelector.onGroupSelected = ^(SearchGroup group) {
         @strongify(self);
+        if (SearchGroupServices == group) {
+            // Remove selected users when switching to services tab to avoid the user confusion: users in the field are
+            // not going to be added to the new conversation with the bot.
+            [self.searchHeaderViewController clearInput];
+        }
         self.searchResultsViewController.searchGroup = group;
         [self performSearch];
     };


### PR DESCRIPTION
Start UI now has 2 groups: users and services. It is necessary to remove the pre-selected users when switching to services while the pre-selected users are not used on the services tab: they are not added to the conversation that we create with the service.