### PR TITLE
Fix keyboard avoiding view controller's initial constraint value

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/KeyboardAvoidingViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/KeyboardAvoidingViewController.m
@@ -24,6 +24,7 @@
 #import "UIView+Zeta.h"
 #import "Constants.h"
 #import "KeyboardFrameObserver+iOS.h"
+#import "Wire-Swift.h"
 
 
 
@@ -38,6 +39,16 @@
 
 
 @implementation KeyboardAvoidingViewController
+
++ (void)load
+{
+    @autoreleasepool {
+        static dispatch_once_t onceToken;
+        dispatch_once(&onceToken, ^{
+            [KeyboardFrameObserver sharedObserver];
+        });
+    }
+}
 
 - (instancetype)initWithViewController:(UIViewController *)viewController
 {
@@ -109,7 +120,9 @@
     [self.viewController.view autoPinEdgeToSuperviewEdge:ALEdgeLeft withInset:0];
     [self.viewController.view autoPinEdgeToSuperviewEdge:ALEdgeRight withInset:0];
     self.topEdgeConstraint = [self.viewController.view autoPinEdgeToSuperviewEdge:ALEdgeTop withInset:self.topInset];
-    self.bottomEdgeConstraint = [self.viewController.view autoPinEdgeToSuperviewEdge:ALEdgeBottom withInset:0];
+    
+    self.bottomEdgeConstraint = [self.viewController.bottomLayoutGuide.bottomAnchor constraintEqualToAnchor:self.bottomLayoutGuide.bottomAnchor constant:0];
+    [self.bottomEdgeConstraint setActive:YES];
 }
 
 - (void)setTopInset:(CGFloat)topInset
@@ -130,8 +143,13 @@
 {
     [UIView animateWithKeyboardNotification:notification inView:self.view animations:^(CGRect keyboardFrameInView) {
         CGFloat bottomOffset = -keyboardFrameInView.size.height;
+        // Take in account the bottom screen inset on iPhone X and others.
+        if (fabs(bottomOffset) > 0) {
+            bottomOffset = bottomOffset + UIScreen.safeArea.bottom;
+        }
         if (self.bottomEdgeConstraint.constant != bottomOffset) {
             self.bottomEdgeConstraint.constant = bottomOffset;
+            
             [self.view layoutIfNeeded];
         }
     } completion:nil];

--- a/Wire-iOS/Sources/UserInterface/Components/KeyboardAvoidingViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/KeyboardAvoidingViewController.m
@@ -112,7 +112,7 @@
 {
     [super viewWillAppear:animated];
     
-    self.bottomEdgeConstraint.constant = -[[KeyboardFrameObserver sharedObserver] keyboardFrame].size.height;
+    self.bottomEdgeConstraint.constant = -[[KeyboardFrameObserver sharedObserver] keyboardFrame].size.height + UIScreen.safeArea.bottom;
 }
 
 - (void)createInitialConstraints


### PR DESCRIPTION
## What's new in this PR?

### Issues

When opening the create conversation flow, the input is not initially visible if the keyboard is up.

### Causes

The initial size of `KeyboardAvoidingViewController` was not correct, since the keyboard size observer was not created initially.

### Solutions

I added the creation of the observer when the class is loaded. In this way it would know the current keyboard state and size at any moment.

## Notes

Additional fix was added to take in account the bottom safe area.