### PR TITLE
Correctly adjust the bottom inset in KeyboardAvoiding on iPhone X

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/KeyboardAvoidingViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/KeyboardAvoidingViewController.m
@@ -112,7 +112,11 @@
 {
     [super viewWillAppear:animated];
     
-    self.bottomEdgeConstraint.constant = -[[KeyboardFrameObserver sharedObserver] keyboardFrame].size.height + UIScreen.safeArea.bottom;
+    CGFloat bottomOffset = -[[KeyboardFrameObserver sharedObserver] keyboardFrame].size.height;
+    if (fabs(bottomOffset) > 0) {
+        bottomOffset = bottomOffset + UIScreen.safeArea.bottom;
+    }
+    self.bottomEdgeConstraint.constant = bottomOffset;
 }
 
 - (void)createInitialConstraints


### PR DESCRIPTION
The inset was not correctly calculated for the case when the keyboard was not shown.