### PR TITLE
Fix accessibility label for start UI cells

### DIFF
--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/Cells/SearchResultCell.m
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/Cells/SearchResultCell.m
@@ -316,7 +316,15 @@
 
 - (void)updateAccessibilityLabel
 {
-    self.accessibilityLabel = [NSString stringWithFormat:@"%@ - %@", self.nameLabel.text, self.subtitleLabel.text];
+    if (self.nameLabel.text.length != 0 && self.subtitleLabel.text.length != 0) {
+        self.accessibilityLabel = [NSString stringWithFormat:@"%@ - %@", self.nameLabel.text, self.subtitleLabel.text];
+    }
+    else if (self.nameLabel.text.length != 0) {
+        self.accessibilityLabel = self.nameLabel.text;
+    }
+    else {
+        self.accessibilityLabel = @"";
+    }
 }
 
 #pragma mark - Public API


### PR DESCRIPTION
## What's new in this PR?

### Issues

QA automation is seeing the cells with accessibility labels like "Name - (nil)".

### Causes

The label calculation was relying on the string that can be nil (subtitle).

### Solutions

Develop complex Objc-Style logic to fix the issue :)