### PR TITLE
Fixed missing back button action

### DIFF
--- a/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
@@ -67,6 +67,7 @@ public class AddParticipantsViewController: UIViewController {
     fileprivate let confirmButton : IconButton
     fileprivate let emptyResultLabel = UILabel()
     fileprivate var bottomConstraint: NSLayoutConstraint?
+    fileprivate let backButtonDescriptor = BackButtonDescription()
     
     public weak var delegate : AddParticipantsViewControllerDelegate?
     public weak var conversationCreationDelegate : AddParticipantsConversationCreationDelegate?
@@ -187,10 +188,9 @@ public class AddParticipantsViewController: UIViewController {
         updateSelectionValues()
         
         if case .create = context {
-            let buttonDescriptor = BackButtonDescription()
-            buttonDescriptor.buttonTapped = { [weak self] in self?.backButtonTapped() }
-            buttonDescriptor.accessibilityIdentifier = "button.addpeople.back"
-            navigationItem.leftBarButtonItem = .init(customView: buttonDescriptor.create())
+            backButtonDescriptor.buttonTapped = { [weak self] in self?.backButtonTapped() }
+            backButtonDescriptor.accessibilityIdentifier = "button.addpeople.back"
+            navigationItem.leftBarButtonItem = .init(customView: backButtonDescriptor.create())
         }
     }
 


### PR DESCRIPTION
## Issue

The back button from participants selection screen to the name screen was not reacting on touches.

## Investigation

The instance of `BackButtonDescription` was created locally and was deallocated at the point when the button was clicked. Therefore the callback on it was not called. We need to consider not using the `BackButtonDescription` to host the callbacks, since it's not obvious that the instance of descriptor should persist in order to receive callbacks. Also it's not obvious that it is not possible to call the viewDescriptor.create several times. This questions the concept of view descriptor.