### PR TITLE
Fix conversation creation flow navigation bar buttons

### DIFF
--- a/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewModel.swift
@@ -82,12 +82,14 @@ struct AddParticipantsViewModel {
         case .create(let values):
             let button = ButtonWithLargerHitArea()
             let key = values.participants.isEmpty ?  "peoplepicker.group.skip" : "peoplepicker.group.done"
+            button.frame = CGRect(x: 0, y: 0, width: 40, height: 20)
             button.setTitle(key.localized.uppercased(), for: .normal)
             button.setTitleColor(.wr_color(fromColorScheme: ColorSchemeColorTextForeground), for: .normal)
             button.setTitleColor(.wr_color(fromColorScheme: ColorSchemeColorTextBackground), for: [.highlighted, .disabled])
             button.addTarget(target, action: action, for: .touchUpInside)
             button.titleLabel?.font = FontSpec(.medium, .medium).font!
             button.accessibilityIdentifier = values.participants.isEmpty ? "button.addpeople.skip" : "button.addpeople.create"
+            button.sizeToFit()
             return UIBarButtonItem(customView: button)
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
@@ -147,12 +147,14 @@ final class ConversationCreationController: UIViewController {
         
         // right button
         nextButton = ButtonWithLargerHitArea(type: .custom)
+        nextButton.frame = CGRect(x: 0, y: 0, width: 40, height: 20)
         nextButton.accessibilityIdentifier = "button.newgroup.next"
         nextButton.setTitle("general.next".localized.uppercased(), for: .normal)
         nextButton.setTitleColor(UIColor.wr_color(fromColorScheme: ColorSchemeColorIconNormal, variant: .light), for: .normal)
         nextButton.setTitleColor(UIColor.wr_color(fromColorScheme: ColorSchemeColorTextDimmed, variant: .light), for: .highlighted)
         nextButton.setTitleColor(UIColor.wr_color(fromColorScheme: ColorSchemeColorIconShadow, variant: .light), for: .disabled)
         nextButton.titleLabel?.font = FontSpec(.medium, .medium).font!
+        nextButton.sizeToFit()
         
         nextButton.addCallback(for: .touchUpInside) { [weak self] _ in
             self?.tryToProceed()

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/ViewDescriptions/BackButtonDescription.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/ViewDescriptions/BackButtonDescription.swift
@@ -26,6 +26,7 @@ final class BackButtonDescription {
 extension BackButtonDescription: ViewDescriptor {
     func create() -> UIView {
         let button = IconButton()
+        button.frame = CGRect(x: 0, y: 0, width: 40, height: 20)
         button.setIconColor(UIColor.wr_color(fromColorScheme: ColorSchemeColorIconNormal, variant: .light), for: .normal)
         button.setIconColor(UIColor.wr_color(fromColorScheme: ColorSchemeColorTextDimmed, variant: .light), for: .highlighted)
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -33,6 +34,7 @@ extension BackButtonDescription: ViewDescriptor {
         button.setIcon(iconType, with: .small, for: .normal)
         button.accessibilityIdentifier = accessibilityIdentifier
         button.addTarget(self, action: #selector(BackButtonDescription.backButtonTapped(_:)), for: .touchUpInside)
+        button.sizeToFit()
         return button
     }
 


### PR DESCRIPTION
### Issues

There are no navigation bar buttons in the conversation creation flow.

### Causes

On iOS 10 and 9, the status bar was not supporting the autolayout yet, therefore the button with 0 frame was not displayed properly.