### PR TITLE
Ignore dark mode for linear conv creation flow

### DIFF
--- a/Wire-iOS/Resources/Classy/stylesheet.cas
+++ b/Wire-iOS/Resources/Classy/stylesheet.cas
@@ -1252,13 +1252,6 @@ AddParticipantsViewController SearchHeaderViewController {
     }
 }
 
-
-AddParticipantsViewController {
-    view: @{
-        backgroundColor: $color-bar-background;
-    }
-}
-
 /* Invite Contacts */
 
 ContactsViewController, InviteContactsViewController {

--- a/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
@@ -57,6 +57,7 @@ public class AddParticipantsViewController: UIViewController {
         case create(ConversationCreationValues)
     }
     
+    fileprivate let variant: ColorSchemeVariant
     fileprivate let searchResultsViewController : SearchResultsViewController
     fileprivate let searchGroupSelector : SearchGroupSelector
     fileprivate let searchHeaderViewController : SearchHeaderViewController
@@ -97,7 +98,9 @@ public class AddParticipantsViewController: UIViewController {
         }
     }
     
-    public init(context: Context) {
+    public init(context: Context, variant: ColorSchemeVariant? = nil) {
+        self.variant = variant ?? ColorScheme.default().variant
+        
         viewModel = AddParticipantsViewModel(with: context)
         
         collectionViewLayout = UICollectionViewFlowLayout()
@@ -128,17 +131,17 @@ public class AddParticipantsViewController: UIViewController {
         bottomContainer.backgroundColor = UIColor.clear
         bottomContainer.addSubview(confirmButton)
 
-        searchHeaderViewController = SearchHeaderViewController(userSelection: userSelection, variant: ColorScheme.default().variant)
+        searchHeaderViewController = SearchHeaderViewController(userSelection: userSelection, variant: self.variant)
         
-        searchGroupSelector = SearchGroupSelector(variant: ColorScheme.default().variant)
+        searchGroupSelector = SearchGroupSelector(variant: self.variant)
 
-        searchResultsViewController = SearchResultsViewController(userSelection: userSelection, variant: ColorScheme.default().variant, isAddingParticipants: true)
+        searchResultsViewController = SearchResultsViewController(userSelection: userSelection, variant: self.variant, isAddingParticipants: true)
 
         super.init(nibName: nil, bundle: nil)
         updateValues()
 
         emptyResultLabel.text = everyoneHasBeenAddedText
-        emptyResultLabel.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground)
+        emptyResultLabel.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: self.variant)
         emptyResultLabel.font = FontSpec(.normal, .none).font!
         
         confirmButton.addTarget(self, action: #selector(searchHeaderViewControllerDidConfirmAction(_:)), for: .touchUpInside)
@@ -182,7 +185,9 @@ public class AddParticipantsViewController: UIViewController {
         view.addSubview(searchResultsViewController.view)
         searchResultsViewController.didMove(toParentViewController: self)
         searchResultsViewController.searchResultsView?.emptyResultView = emptyResultLabel
-        searchResultsViewController.searchResultsView?.backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorContentBackground)
+        searchResultsViewController.searchResultsView?.backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorContentBackground, variant: self.variant)
+        
+        view.backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorContentBackground, variant: self.variant)
         
         createConstraints()
         updateSelectionValues()
@@ -379,7 +384,7 @@ extension AddParticipantsViewController: SearchResultsViewControllerDelegate {
             serviceUser: user,
             destinationConversation: conversation,
             actionType: .addService,
-            variant: .init(colorScheme: ColorScheme.default().variant, opaque: true)
+            variant: .init(colorScheme: self.variant, opaque: true)
         )
 
         detail.completion = { [weak self] result in

--- a/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
@@ -98,8 +98,8 @@ public class AddParticipantsViewController: UIViewController {
         }
     }
     
-    public init(context: Context, variant: ColorSchemeVariant? = nil) {
-        self.variant = variant ?? ColorScheme.default().variant
+    public init(context: Context, variant: ColorSchemeVariant = ColorScheme.default().variant) {
+        self.variant = variant
         
         viewModel = AddParticipantsViewModel(with: context)
         

--- a/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
@@ -201,7 +201,7 @@ final class ConversationCreationController: UIViewController {
             textField.resignFirstResponder()
             let newValues = ConversationCreationValues(name: name, participants: values?.participants ?? [])
             values = newValues
-            let participantsController = AddParticipantsViewController(context: .create(newValues))
+            let participantsController = AddParticipantsViewController(context: .create(newValues), variant: .light)
             participantsController.conversationCreationDelegate = self
             navigationController?.pushViewController(participantsController, animated: true)
         }

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchHeaderViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchHeaderViewController.swift
@@ -58,8 +58,10 @@ public class SearchHeaderViewController : UIViewController {
     }
     
     public override func viewDidLoad() {
+        super.viewDidLoad()
+
         view.backgroundColor = UIColor(white: 1.0, alpha: 0.08)
-        
+
         searchIcon.image = UIImage(for: .search, iconSize: .tiny, color: UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: colorSchemeVariant))
         
         clearButton.accessibilityLabel = "clear"


### PR DESCRIPTION
## What's new in this PR?

### Issues

The linear conversation creation flow can be opened from both start UI and the conversation details. The `AddParticipantsViewController` is designed to respect the user's dark theme mode, since it's shown from the conversation details. 

Therefore, if user has the dark mode selected then when opening the linear conv creation flow from start UI, the conv name screen is white and add participants screen in dark.

### Solutions

For the moment the linear conv creation flow would always be white, does not matter from where it is presented. This is achieved by passing in the color scheme variant.