### PR TITLE
Linear conv. creation flow: fixed sections order; color of skip button

### DIFF
--- a/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
@@ -101,7 +101,7 @@ public class AddParticipantsViewController: UIViewController {
     public init(context: Context, variant: ColorSchemeVariant = ColorScheme.default().variant) {
         self.variant = variant
         
-        viewModel = AddParticipantsViewModel(with: context)
+        viewModel = AddParticipantsViewModel(with: context, variant: variant)
         
         collectionViewLayout = UICollectionViewFlowLayout()
         collectionViewLayout.scrollDirection = .vertical
@@ -251,7 +251,7 @@ public class AddParticipantsViewController: UIViewController {
         // Update view model after selection changed
         if case .create(let values) = viewModel.context {
             let updated = ConversationCreationValues(name: values.name, participants: userSelection.users)
-            viewModel = AddParticipantsViewModel(with: .create(updated))
+            viewModel = AddParticipantsViewModel(with: .create(updated), variant: variant)
         }
 
         // Update confirm button visibility

--- a/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewModel.swift
@@ -20,9 +20,11 @@ import UIKit
 
 struct AddParticipantsViewModel {
     let context: AddParticipantsViewController.Context
+    let variant: ColorSchemeVariant
     
-    init(with context: AddParticipantsViewController.Context) {
+    init(with context: AddParticipantsViewController.Context, variant: ColorSchemeVariant) {
         self.context = context
+        self.variant = variant
     }
     
     var botCanBeAdded: Bool {
@@ -81,11 +83,11 @@ struct AddParticipantsViewModel {
             return item
         case .create(let values):
             let button = ButtonWithLargerHitArea()
-            let key = values.participants.isEmpty ?  "peoplepicker.group.skip" : "peoplepicker.group.done"
+            let key = values.participants.isEmpty ? "peoplepicker.group.skip" : "peoplepicker.group.done"
             button.frame = CGRect(x: 0, y: 0, width: 40, height: 20)
             button.setTitle(key.localized.uppercased(), for: .normal)
-            button.setTitleColor(.wr_color(fromColorScheme: ColorSchemeColorTextForeground), for: .normal)
-            button.setTitleColor(.wr_color(fromColorScheme: ColorSchemeColorTextBackground), for: [.highlighted, .disabled])
+            button.setTitleColor(.accent(), for: .normal)
+            button.setTitleColor(.wr_color(fromColorScheme: ColorSchemeColorTextBackground, variant: variant), for: [.highlighted, .disabled])
             button.addTarget(target, action: action, for: .touchUpInside)
             button.titleLabel?.font = FontSpec(.medium, .medium).font!
             button.accessibilityIdentifier = values.participants.isEmpty ? "button.addpeople.skip" : "button.addpeople.create"

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
@@ -307,9 +307,9 @@ public class SearchResultsViewController : UIViewController {
             case (.selection, true):
                 sections = [teamMemberAndContactsSection]
             case (.list, false):
-                sections = [topPeopleSection, createGroupSection, contactsSection]
+                sections = [createGroupSection, topPeopleSection, contactsSection]
             case (.list, true):
-                sections = [inviteTeamMemberSection, createGroupSection, teamMemberAndContactsSection]
+                sections = [createGroupSection, inviteTeamMemberSection, teamMemberAndContactsSection]
             }
         }
         


### PR DESCRIPTION
Skip button in the linear group conversation creation flow used to have the wrong color. Also the order of sections in the start UI should be starting with create group button.
