### PR TITLE
Hide calling buttons in self conversation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
@@ -163,7 +163,7 @@ public extension ConversationViewController {
     }
 
     public func rightNavigationItems(forConversation conversation: ZMConversation) -> [UIBarButtonItem] {
-        guard !conversation.isReadOnly else { return [] }
+        guard !conversation.isReadOnly, conversation.otherActiveParticipants.count != 0 else { return [] }
 
         if conversation.canJoinCall {
             return [UIBarButtonItem(customView: joinCallButton)]
@@ -268,7 +268,7 @@ public extension ConversationViewController {
         conversation.startVideoCall()
     }
 
-    private dynamic func joinCallButtonTapped(_sender: UIBarButtonItem) {
+    private dynamic func joinCallButtonTapped(_sender: AnyObject!) {
         guard conversation.canJoinCall else { return }
 
         // This will result in joining an ongoing call.


### PR DESCRIPTION
## What's new in this PR?

### Issues

If you are the only one participant in the conversation, then the call cannot be established.

### Solutions

Hide calling button in self conversation.
