### PR TITLE
Validate using string byte size instead of character count

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Create/SimpleTextFieldValidator.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Create/SimpleTextFieldValidator.swift
@@ -37,7 +37,8 @@ final class SimpleTextFieldValidator: NSObject {
         if stringToValidate.isEmpty {
             return .empty
         }
-        if stringToValidate.count > 64 {
+        // Check byte size (emoji + zalgo)
+        if stringToValidate.utf8.count > 64 {
             return .tooLong
         }
         return nil


### PR DESCRIPTION
## What's new in this PR?

* Validate using string byte size instead of character count.