### PR TITLE
ZIOS-9501: set ShareDestinationCell selection style to none

### DIFF
--- a/Wire-iOS/Sources/Components/ShareViewController/ShareDestinationCell.swift
+++ b/Wire-iOS/Sources/Components/ShareViewController/ShareDestinationCell.swift
@@ -64,6 +64,7 @@ final class ShareDestinationCell<D: ShareDestination>: UITableViewCell {
         self.titleLabel.backgroundColor = .clear
         self.titleLabel.textColor = .white
         
+        self.selectionStyle = .none
         self.contentView.backgroundColor = .clear
         self.backgroundView = UIView()
         self.selectedBackgroundView = UIView()


### PR DESCRIPTION
## What's new in this PR?

There was a little glitch when tapping on a service in `ShareViewController` - the background of the avatar view was switching between light and transparent. That's caused by the default value of the  `selectionStyle` property in `ShareDestinationCell`, now set to `.none`.