### PR TITLE
iPad fixed #2 for linear conv creation flow

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+StartUI.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+StartUI.m
@@ -104,6 +104,18 @@ typedef void (^ConversationCreatedBlock)(ZMConversation *);
 
 - (void)startUI:(StartUIViewController *)startUI createConversationWithUsers:(NSSet<ZMUser *> *)users name:(NSString *)name
 {
+    if (self.presentedViewController != nil) {
+        [self dismissViewControllerAnimated:YES completion:^{
+            [self createConversationWithUsers:users name:name];
+        }];
+    }
+    else {
+        [self createConversationWithUsers:users name:name];
+    }
+}
+
+- (void)createConversationWithUsers:(NSSet<ZMUser *> *)users name:(NSString *)name
+{
     __block ZMConversation *conversation = nil;
     [ZMUserSession.sharedSession enqueueChanges:^{
         conversation = [ZMConversation insertGroupConversationIntoUserSession:ZMUserSession.sharedSession

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/ViewDescriptions/BackButtonDescription.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/ViewDescriptions/BackButtonDescription.swift
@@ -30,7 +30,7 @@ extension BackButtonDescription: ViewDescriptor {
         button.setIconColor(UIColor.wr_color(fromColorScheme: ColorSchemeColorIconNormal, variant: .light), for: .normal)
         button.setIconColor(UIColor.wr_color(fromColorScheme: ColorSchemeColorTextDimmed, variant: .light), for: .highlighted)
         let iconType: ZetaIconType = UIApplication.isLeftToRightLayout ? .chevronLeft : .chevronRight
-        button.setIcon(iconType, with: .small, for: .normal)
+        button.setIcon(iconType, with: .tiny, for: .normal)
         button.accessibilityIdentifier = accessibilityIdentifier
         button.addTarget(self, action: #selector(BackButtonDescription.backButtonTapped(_:)), for: .touchUpInside)
         button.sizeToFit()

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileDetailsViewController.m
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileDetailsViewController.m
@@ -415,19 +415,32 @@ typedef NS_ENUM(NSUInteger, ProfileUserAction) {
     }
     
     ConversationCreationController *conversationCreationController = [[ConversationCreationController alloc] initWithPreSelectedParticipants:selectedUsers];
-    KeyboardAvoidingViewController *avoiding = [[KeyboardAvoidingViewController alloc] initWithViewController:conversationCreationController];
-    UINavigationController *presentedViewController = [avoiding wrapInNavigationController:AddParticipantsNavigationController.class];
     
-    presentedViewController.modalPresentationStyle = UIModalPresentationOverCurrentContext;
-    presentedViewController.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
-    
-    [self presentViewController:presentedViewController
-                       animated:YES
-                     completion:^{
-        [Analytics.shared tagOpenedPeoplePickerGroupAction];
-        [UIApplication.sharedApplication wr_updateStatusBarForCurrentControllerAnimated:YES];
-    }];
-    
+    if ([[[UIScreen mainScreen] traitCollection] horizontalSizeClass] == UIUserInterfaceSizeClassRegular) {
+        [self dismissViewControllerAnimated:YES completion:^{
+            UINavigationController *presentedViewController = [conversationCreationController wrapInNavigationController:AddParticipantsNavigationController.class];
+            
+            presentedViewController.modalPresentationStyle = UIModalPresentationFormSheet;
+            
+            [[ZClientViewController sharedZClientViewController] presentViewController:presentedViewController
+                                                                              animated:YES
+                                                                            completion:nil];
+        }];
+    }
+    else {
+        KeyboardAvoidingViewController *avoiding = [[KeyboardAvoidingViewController alloc] initWithViewController:conversationCreationController];
+        UINavigationController *presentedViewController = [avoiding wrapInNavigationController:AddParticipantsNavigationController.class];
+        
+        presentedViewController.modalPresentationStyle = UIModalPresentationOverCurrentContext;
+        presentedViewController.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
+        
+        [self presentViewController:presentedViewController
+                           animated:YES
+                         completion:^{
+            [Analytics.shared tagOpenedPeoplePickerGroupAction];
+            [UIApplication.sharedApplication wr_updateStatusBarForCurrentControllerAnimated:YES];
+        }];
+    }
     [self.delegate profileDetailsViewController:self didPresentConversationCreationController:conversationCreationController];
 }
 


### PR DESCRIPTION
- Fixed the back icon size (should be 16).
- Fixed presentation of conv. creation controller from conv. details (should be modal).
- Fixed not opening the conversation in iPad Landscape.