### PR TITLE
Only use default transitions for non-clear opaque backgrounds

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/ClearBackgroundNavigationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/ClearBackgroundNavigationController.swift
@@ -85,11 +85,19 @@ class ClearBackgroundNavigationController: UINavigationController {
         }
     }
     
-    func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
-        let clearBackround = viewController.view.backgroundColor == .clear
-        let opaqueBackground = fabs(viewController.view.backgroundColor?.alpha ?? 1.0 - 1.0) < CGFloat.ulpOfOne
-        useDefaultPopGesture = !clearBackround && opaqueBackground
+    func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
+        if let avoiding = viewController as? KeyboardAvoidingViewController {
+            updateGesture(for: avoiding.viewController)
+        } else {
+            updateGesture(for: viewController)
+        }
     }
+    
+    private func updateGesture(for viewController: UIViewController) {
+        let translucentBackground = viewController.view.backgroundColor?.alpha < 1.0
+        useDefaultPopGesture = !translucentBackground
+    }
+    
 }
 
 

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/ClearBackgroundNavigationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/ClearBackgroundNavigationController.swift
@@ -86,7 +86,9 @@ class ClearBackgroundNavigationController: UINavigationController {
     }
     
     func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
-        useDefaultPopGesture = fabs(viewController.view.backgroundColor?.alpha ?? 1.0 - 1.0) < CGFloat.ulpOfOne
+        let clearBackround = viewController.view.backgroundColor == .clear
+        let opaqueBackground = fabs(viewController.view.backgroundColor?.alpha ?? 1.0 - 1.0) < CGFloat.ulpOfOne
+        useDefaultPopGesture = !clearBackround && opaqueBackground
     }
 }
 


### PR DESCRIPTION
## What's new in this PR?

* Only use default transitions when the background is neither clear nor translucent.