### PR TITLE
Fix retain cycle in tapHandler of title view

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListTopBar.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListTopBar.swift
@@ -29,7 +29,9 @@ final class ConversationListTopBar: TopBar {
         
         if ZMUser.selfUser().isTeamMember {
             let availabilityView = AvailabilityTitleView(user: ZMUser.selfUser(), style: .header)
-            availabilityView.tapHandler = { button in
+            availabilityView.tapHandler = { [weak availabilityView] button in
+                guard let availabilityView = availabilityView else { return }
+                
                 let alert = availabilityView.actionSheet
                 alert.popoverPresentationController?.sourceView = button
                 alert.popoverPresentationController?.sourceRect = button.frame


### PR DESCRIPTION
### Issues

Team account would sometimes crash bringing the app into foreground.

### Causes

A retain cycle in the AvailabilityTitleView's tapHandler was leaking `AvailabilityTitleView` when switching between accounts. If the account was purged from memory the app would crash upon entering the foreground.

### Solutions

Fix the retain cycle.