### PR TITLE
ZIOS-9624: Fixed background color of ProfileHeaderServiceDetailViewController

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Services/ProfileHeaderServiceDetailViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Services/ProfileHeaderServiceDetailViewController.swift
@@ -45,7 +45,7 @@ final class ProfileHeaderServiceDetailViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        view.backgroundColor = .white
+        view.backgroundColor = ColorScheme.default().color(withName: ColorSchemeColorBackground)
 
         self.navigationController?.delegate = self.navigationControllerDelegate
 
@@ -100,10 +100,11 @@ final class ProfileHeaderServiceDetailViewController: UIViewController {
     }
 
     func setupServiceDetailViewController(serviceUser: ServiceUser) {
+        let variant = ColorScheme.default().variant
         serviceDetailViewController = ServiceDetailViewController(serviceUser: serviceUser,
                                                                   destinationConversation: self.conversation,
                                                                   actionType: .removeService,
-                                                                  variant: ServiceDetailVariant(colorScheme: .light, opaque: false))
+                                                                  variant: ServiceDetailVariant(colorScheme: variant, opaque: false))
         serviceDetailViewController.viewControllerDismissable = self.viewControllerDismissable
 
         self.addToSelf(serviceDetailViewController)


### PR DESCRIPTION
## What's new in this PR?

Background color of `ProfileHeaderServiceDetailViewController` was fixed to white and, consequently, not respecting the preference for dark or light theme. Now I'm fetching the colors from the current color scheme.