### PR TITLE
Linear conversation creation for iPad: always call the creation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -818,7 +818,7 @@
 
 - (void)profileViewController:(ProfileViewController *)controller wantsToCreateConversationWithName:(NSString *)name users:(NSSet *)users
 {
-    [self dismissViewControllerAnimated:YES completion:^{
+    dispatch_block_t conversationCreation = ^{
         __block  ZMConversation *newConversation = nil;
         
         @weakify(self);
@@ -828,7 +828,14 @@
             @strongify(self);
             [self.zClientViewController selectConversation:newConversation focusOnView:YES animated:YES];
         }];
-    }];
+    };
+    
+    if (nil != self.presentedViewController) {
+        [self dismissViewControllerAnimated:YES completion:conversationCreation];
+    }
+    else {
+        conversationCreation();
+    }
 }
 
 @end


### PR DESCRIPTION
## What's new in this PR?

### Issues

The linear conversation creation flow started on iPad from the conversation details does not create the conversation.

### Causes

The callback was expecting that the conversation details popover is still visible. Unfortunately after the last update the conv. creation flow is presented in the form sheet, so the conv. details controller is dismissed before that. This creates the situation when we try to dismiss controller, but there is nothing presented, so iOS is not calling the completion block.

### Solutions

Check if there is a controller to dismiss before trying to dismiss it.
