### PR TITLE
ZIOS-9674: Fixed UserNameDetailView that doesn't reflect theme changes

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -31,5 +31,6 @@ github "wireapp/wire-ios-sync-engine" "146.0.0"
 github "wireapp/wire-ios-system" "19.1.0"
 github "wireapp/wire-ios-testing" "13.0.1"
 github "wireapp/wire-ios-transport" "33.0.0"
-github "wireapp/wire-ios-utilities" "20.1.0"
+github "wireapp/wire-ios-utilities" "20.2.0"
 github "wireapp/wire-ios-ziphy" "7.0.1"
+

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Views/UserNameDetailView.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Views/UserNameDetailView.swift
@@ -24,37 +24,6 @@ import Cartography
 fileprivate let smallLightFont = UIFont(magicIdentifier: "style.text.small.font_spec_light")!
 fileprivate let smallBoldFont = UIFont(magicIdentifier: "style.text.small.font_spec_bold")!
 fileprivate let normalBoldFont = UIFont(magicIdentifier: "style.text.normal.font_spec_bold")!
-fileprivate var dimmedColors: [ColorSchemeVariant: UIColor] = [:]
-fileprivate var dimmedColor: UIColor {
-    get {
-        guard let color = dimmedColors[ColorScheme.default().variant] else {
-            let dimmed = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextDimmed)
-            dimmedColors[ColorScheme.default().variant] = dimmed
-            return dimmed
-        }
-        return color
-    }
-    set {
-        if let color = dimmedColors[ColorScheme.default().variant], color == newValue { return }
-        dimmedColors[ColorScheme.default().variant] = newValue
-    }
-}
-
-fileprivate var textColors: [ColorSchemeVariant: UIColor] = [:]
-fileprivate var textColor: UIColor {
-    get {
-        guard let color = textColors[ColorScheme.default().variant] else {
-            let text = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground)
-            textColors[ColorScheme.default().variant] = text
-            return text
-        }
-        return color
-    }
-    set {
-        if let color = textColors[ColorScheme.default().variant], color == newValue { return }
-        textColors[ColorScheme.default().variant] = newValue
-    }
-}
 
 @objc public class AddressBookCorrelationFormatter: NSObject {
 
@@ -121,7 +90,7 @@ fileprivate var textColor: UIColor {
     }
 
     static var formatter: AddressBookCorrelationFormatter = {
-        AddressBookCorrelationFormatter(lightFont: smallLightFont, boldFont: smallBoldFont, color: dimmedColor)
+        AddressBookCorrelationFormatter(lightFont: smallLightFont, boldFont: smallBoldFont, color: UIColor.wr_color(fromColorScheme: ColorSchemeColorTextDimmed))
     }()
 
     init(user: ZMBareUser?, fallbackName fallback: String, addressBookName: String?) {
@@ -131,12 +100,12 @@ fileprivate var textColor: UIColor {
     }
 
     static func attributedTitle(for user: ZMBareUser?, fallback: String) -> NSAttributedString {
-        return (user?.name ?? fallback) && normalBoldFont && textColor
+        return (user?.name ?? fallback) && normalBoldFont && UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground)
     }
 
     static func attributedSubtitle(for user: ZMBareUser?) -> NSAttributedString? {
         guard let handle = user?.handle, handle.count > 0 else { return nil }
-        return ("@" + handle) && smallBoldFont && dimmedColor
+        return ("@" + handle) && smallBoldFont && UIColor.wr_color(fromColorScheme: ColorSchemeColorTextDimmed)
     }
 
     static func attributedCorrelationText(for user: ZMBareUser?, addressBookName: String?) -> NSAttributedString? {

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Views/UserNameDetailView.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Views/UserNameDetailView.swift
@@ -24,10 +24,37 @@ import Cartography
 fileprivate let smallLightFont = UIFont(magicIdentifier: "style.text.small.font_spec_light")!
 fileprivate let smallBoldFont = UIFont(magicIdentifier: "style.text.small.font_spec_bold")!
 fileprivate let normalBoldFont = UIFont(magicIdentifier: "style.text.normal.font_spec_bold")!
+fileprivate var dimmedColors: [ColorSchemeVariant: UIColor] = [:]
+fileprivate var dimmedColor: UIColor {
+    get {
+        guard let color = dimmedColors[ColorScheme.default().variant] else {
+            let dimmed = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextDimmed)
+            dimmedColors[ColorScheme.default().variant] = dimmed
+            return dimmed
+        }
+        return color
+    }
+    set {
+        if let color = dimmedColors[ColorScheme.default().variant], color == newValue { return }
+        dimmedColors[ColorScheme.default().variant] = newValue
+    }
+}
 
-fileprivate let dimmedColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextDimmed)
-fileprivate let textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground)
-
+fileprivate var textColors: [ColorSchemeVariant: UIColor] = [:]
+fileprivate var textColor: UIColor {
+    get {
+        guard let color = textColors[ColorScheme.default().variant] else {
+            let text = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground)
+            textColors[ColorScheme.default().variant] = text
+            return text
+        }
+        return color
+    }
+    set {
+        if let color = textColors[ColorScheme.default().variant], color == newValue { return }
+        textColors[ColorScheme.default().variant] = newValue
+    }
+}
 
 @objc public class AddressBookCorrelationFormatter: NSObject {
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

Title color of `UserNameDetailView` doesn't reflect changes, so while switching from dark to light, the title stays white, and while switching light to dark the title stays gray.

### Solutions

The color was set statically, so now I'm picking the color from a dictionary that keeps the correct color for each variant.