### PR TITLE
ZIOS-9649: Fix for TailEditingTextField width on iOS 10

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/TailEditingTextField.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/TailEditingTextField.swift
@@ -47,9 +47,11 @@ class TailEditingTextField: UITextField {
     }
     
     func replaceNormalSpacesWithNonBreakingSpaces() {
-        guard let isContainsNormalSpace = (self.text?.contains(type(of: self).normalSpace)), isContainsNormalSpace else { return }
-        
-        self.text = self.text?.replacingOccurrences(of: type(of: self).normalSpace, with: type(of: self).nonBreakingSpace)
+        if let isContainsNormalSpace = (self.text?.contains(type(of: self).normalSpace)), isContainsNormalSpace {
+            self.text = self.text?.replacingOccurrences(of: type(of: self).normalSpace, with: type(of: self).nonBreakingSpace)
+        } else {
+            self.text = self.text
+        }
     }
     
     func replaceNonBreakingSpacesWithNormalSpaces() {


### PR DESCRIPTION
## What's new in this PR?

### Issues

The width of the input field inside `TailEditingTextField` (used in `SettingsCell`) was not updated after typing something inside it, only on iOS 10. So, for example, if you write a short display name inside the Account settings, you go back and return on that screen, the width of the text field doesn't get updated until you press the spacebar.

### Solutions

I'm setting the `text` property of the text field every time. This is causing the text field to update its frame.