### PR TITLE
Do not allow adding bots to team only conversations

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Services/ServiceDetailViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Services/ServiceDetailViewController.swift
@@ -21,7 +21,7 @@ import Cartography
 
 extension ZMConversation {
     var botCanBeAdded: Bool {
-        return self.conversationType != .oneOnOne
+        return self.conversationType != .oneOnOne && canAddGuest
     }
 }
 


### PR DESCRIPTION
- If it is not possible to add the guest to the conversation, we should not show the bots selection.
