### PR TITLE
ZIOS-9677: Changed zero variant of participants.people.count to "Only you"

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.stringsdict
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.stringsdict
@@ -35,7 +35,7 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>lu</string>
 			<key>zero</key>
-			<string>Everyone left</string>
+			<string>Only you</string>
 			<key>one</key>
 			<string>One person</string>
 			<key>few</key>


### PR DESCRIPTION
## What's new in this PR?

Changed "Everyone left" for `participants.people.count` value in Localizable.stringsdict (Base) to "Only you".

## Notes

This string is used in two places:
- `ParticipantsViewController` to display the number of people in the current conversation
- `MessageToolboxView` to display the number of likes of a post

So it shouldn't interfere with the second case since we're not displaying the message when we have zero likes.