### PR TITLE
ZIOS-9679: Removed endEditingMessage while displaying UIMenu in conversations

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -799,7 +799,6 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
     if ([self.delegate respondsToSelector:@selector(conversationContentViewController:shouldBecomeFirstResponderWhenShowMenuFromCell:)]) {
         shouldBecomeFirstResponder = [self.delegate conversationContentViewController:self shouldBecomeFirstResponderWhenShowMenuFromCell:cell];
     }
-    [ConversationInputBarViewController endEditingMessage];
     return shouldBecomeFirstResponder;
 }
 


### PR DESCRIPTION
## What's new in this PR?

Long pressing on a message while editing another message inside a conversation was causing the input field to discard changes. This because `conversationCell:shouldBecomeFirstResponderWhenShowMenuWithCellType:` was calling `[ConversationInputBarViewController endEditingMessage]`.