### PR TITLE
Remove non team members when user disables the guest access

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
@@ -27,7 +27,8 @@ final public class ConversationCreationValues {
     var participants: Set<ZMUser>
     init (name: String, participants: Set<ZMUser> = [], allowGuests: Bool) {
         self.name = name
-        self.participants = participants
+        let selfUser = ZMUser.selfUser()!
+        self.participants = allowGuests ? participants : Set(Array(participants).filter { $0.team == selfUser.team })
         self.allowGuests = allowGuests
     }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

When user opens the linear conversation creation flow and selects some users on the second screen, it is still possible to go back to the first screen and choose not to allow guests in the conversation.

### Causes

We are not re-filtering the list of participants in case user selects to disable the guest access.

### Solutions

Filter the list once again.
