### PR TITLE
Fix presenting profile from search

### DIFF
--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/ProfilePresenter.m
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/ProfilePresenter.m
@@ -109,8 +109,7 @@
     profileViewController.delegate = self;
     profileViewController.viewControllerDismissable = self;
 
-    RotationAwareNavigationController *navigationController = [[RotationAwareNavigationController alloc] initWithRootViewController:profileViewController];
-    navigationController.navigationBarHidden = YES;
+    UINavigationController *navigationController = profileViewController.wrapInNavigationController;
     navigationController.transitioningDelegate = self.transitionDelegate;
     navigationController.modalPresentationStyle = UIModalPresentationPopover;
     


### PR DESCRIPTION
### Issues

User profile opened from search was missing the navigation bar.

### Causes

Since we know use a real navigation bar in the user profile we should not hide the navigation bar anymore.

### Solutions

Use our default navigation bar.

