### PR TITLE
ZIOS-9688: Images disappear when scrolling between pictures in a conversation	

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.m
@@ -145,7 +145,6 @@
 - (void)viewDidLayoutSubviews
 {
     [super viewDidLayoutSubviews];
-    [self updateZoom];
     [self centerScrollViewContent];
 }
 
@@ -172,6 +171,9 @@
 {
     [super viewWillAppear:animated];
     self.closeButton.hidden = !self.showCloseButton;
+    if(self.parentViewController != nil) {
+        [self updateZoomWithSize:self.parentViewController.view.frame.size];
+    }
 }
 
 - (BOOL)prefersStatusBarHidden

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.m
@@ -145,6 +145,7 @@
 - (void)viewDidLayoutSubviews
 {
     [super viewDidLayoutSubviews];
+    [self updateZoom];
     [self centerScrollViewContent];
 }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

Pictures were disappearing while scrolling inside the conversation photogallery.

### Causes

The main cause is that `UIPageViewController` pre-loads the next page in memory before scrolling, but its view has size zero, in the beginning, causing a wrong calculation of the initial zoom (which is zero). In fact, the imageView has the correct bounds, but frame is zero.

### Solutions

I'm calculating the initial zoom in ~`viewDidLayoutSubviews`~ incorrect! That's causing the zoom to reset on device rotation.

## Notes

Related to https://github.com/wireapp/wire-ios/issues/1766