### PR TITLE
Fix crash with conversation input; disable bar in 1-1

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -282,7 +282,9 @@
     
 - (BOOL)guestsBarShouldBePresented
 {
-    BOOL isVisible = YES;
+    if (self.conversation.conversationType == ZMConversationTypeOneOnOne) {
+        return NO;
+    }
     
     if (self.conversation.team == ZMUser.selfUser.team) {
         BOOL containsGuests = NO;
@@ -294,13 +296,11 @@
             }
         }
         
-        isVisible = containsGuests;
+        return containsGuests;
     }
     else {
-        isVisible = NO;
+        return NO;
     }
-    
-    return isVisible;
 }
     
 - (void)updateGuestsBarVisibility

--- a/Wire-iOS/Sources/UserInterface/Conversation/GuestsBarController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/GuestsBarController.swift
@@ -46,6 +46,10 @@ class GuestsBarController: UIViewController {
         
         _isCollapsed = collapsed
 
+        guard self.isViewLoaded else {
+            return
+        }
+        
         let change = {
             if (!collapsed) {
                 self.heightConstraint.constant = collapsed ? GuestsBarController.collapsedHeight : GuestsBarController.expandedHeight

--- a/Wire-iOS/Sources/UserInterface/Conversation/GuestsBarController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/GuestsBarController.swift
@@ -40,16 +40,17 @@ class GuestsBarController: UIViewController {
     }
     
     public func setCollapsed(_ collapsed: Bool, animated: Bool) {
+        
+        guard self.isViewLoaded else {
+            return
+        }
+        
         if collapsed == _isCollapsed {
             return
         }
         
         _isCollapsed = collapsed
 
-        guard self.isViewLoaded else {
-            return
-        }
-        
         let change = {
             if (!collapsed) {
                 self.heightConstraint.constant = collapsed ? GuestsBarController.collapsedHeight : GuestsBarController.expandedHeight


### PR DESCRIPTION
## What's new in this PR?

### Issues

Wire crashes in most of the conversations when user selects the input field.

### Causes

The constraint in `GuestBarController` is not created until the view is loaded. However the controller is trying to access it.

### Solutions

Guard the access checking if the view was already loaded.
