### PR TITLE
Don't show add participants button for guests

### DIFF
--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsFooterView.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsFooterView.swift
@@ -30,8 +30,8 @@ final class GroupDetailsFooterView: UIView {
     weak var delegate: GroupDetailsFooterViewDelegate?
     
     private let variant: ColorSchemeVariant
-    private let moreButton = IconButton()
-    private let addButton = IconButton()
+    public let moreButton = IconButton()
+    public let addButton = IconButton()
     
     init(variant: ColorSchemeVariant = ColorScheme.default().variant) {
         self.variant = variant

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
@@ -94,6 +94,7 @@ class GroupDetailsViewController: UIViewController, ZMConversationObserver, Grou
         
         collectionViewController.collectionView = collectionView
         footerView.delegate = self
+        footerView.addButton.isHidden = ZMUser.selfUser().isGuest(in: conversation)
     
         emptyView.translatesAutoresizingMaskIntoConstraints = false
         emptyView.isHidden = true


### PR DESCRIPTION
## What's new in this PR?

### Issues

We are showing "add participants" - button for guests

### Causes

We always show it

### Solutions

Hide it when you (self user) are a guest in a conversation.