### PR TITLE
Do not show guests bar for people not in the team

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -286,7 +286,13 @@
         return NO;
     }
     
-    if (self.conversation.team == ZMUser.selfUser.team) {
+    Team *selfUserTeam = ZMUser.selfUser.team;
+    
+    if (selfUserTeam == nil) {
+        return NO;
+    }
+    
+    if (self.conversation.team == selfUserTeam) {
         BOOL containsGuests = NO;
         
         for (ZMUser *user in self.conversation.activeParticipants) {


### PR DESCRIPTION
The issue appeared that the users outside the team are seeing the bar.