### PR TITLE
Use same method for guests conversations

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation Options/Conversation+OptionsConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/Conversation+OptionsConfiguration.swift
@@ -39,7 +39,7 @@ extension ZMConversation {
         }
         
         var allowGuests: Bool {
-            return conversation.accessMode == .allowGuests
+            return conversation.allowGuests
         }
         
         func setAllowGuests(_ allowGuests: Bool, completion: @escaping (VoidResult) -> Void) {


### PR DESCRIPTION
## What's new in this PR?

### Issues

There are two places where we check that guests are allowed in a conversation - in participants screen and then inside the conversation options screen. They were using different ways of doing the same check and values were not matching sometimes.

### Causes

After https://github.com/wireapp/wire-ios-data-model/pull/444 is merged `allowGuests` will be true if any type of guests are allowed and it is not the same as `conversation.accessMode == .allowGuests`.

### Solutions

Use the same check in both screens for consistency