### PR TITLE
Fix guest indicator color in search results and add participants screen

### DIFF
--- a/Wire-iOS Tests/GroupDetailsParticipantCellTests.swift
+++ b/Wire-iOS Tests/GroupDetailsParticipantCellTests.swift
@@ -74,7 +74,7 @@ class GroupDetailsParticipantCellTests: ZMSnapshotTestCase {
         _ = mockUser?.feature(withUserClients: 1)
         
         verify(view: cell({ (cell) in
-            cell.variant = .dark
+            cell.colorSchemeVariant = .dark
             cell.configure(with: user)
         }))
     }
@@ -83,7 +83,7 @@ class GroupDetailsParticipantCellTests: ZMSnapshotTestCase {
         let user = MockUser.mockUsers()[0]
         
         verify(view: cell({ (cell) in
-            cell.variant = .dark
+            cell.colorSchemeVariant = .dark
             cell.configure(with: user)
         }))
     }
@@ -102,7 +102,7 @@ class GroupDetailsParticipantCellTests: ZMSnapshotTestCase {
         let user = MockUser.mockUsers()[0]
         
         verify(view: cell({ (cell) in
-            cell.variant = .dark
+            cell.colorSchemeVariant = .dark
             cell.configure(with: user)
         }))
     }
@@ -127,7 +127,7 @@ class GroupDetailsParticipantCellTests: ZMSnapshotTestCase {
         _ = mockUser?.feature(withUserClients: 1)
         
         verify(view: cell({ (cell) in
-            cell.variant = .dark
+            cell.colorSchemeVariant = .dark
             cell.configure(with: user)
         }))
     }
@@ -144,7 +144,7 @@ class GroupDetailsParticipantCellTests: ZMSnapshotTestCase {
         let user = MockUser.mockUsers()[10]
         
         verify(view: cell({ (cell) in
-            cell.variant = .dark
+            cell.colorSchemeVariant = .dark
             cell.configure(with: user)
         }))
     }

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		1682AEBF20483F73003A052A /* ParticipantsSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1682AEBE20483F73003A052A /* ParticipantsSectionController.swift */; };
 		1682AEC120483FA5003A052A /* GroupDetailsSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1682AEC020483FA5003A052A /* GroupDetailsSectionController.swift */; };
 		1682AEC3204840E7003A052A /* SectionCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1682AEC2204840E7003A052A /* SectionCollectionViewController.swift */; };
+		1682AEC520484B9B003A052A /* Themeable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1682AEC420484B9B003A052A /* Themeable.swift */; };
 		168A16AC1D9597C2005CFA6C /* ShareExtensionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 168A16AB1D9597C2005CFA6C /* ShareExtensionViewController.swift */; };
 		168A16AF1D9597C2005CFA6C /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 168A16AD1D9597C2005CFA6C /* MainInterface.storyboard */; };
 		168A16B31D9597C2005CFA6C /* Wire Share Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 168A16A91D9597C2005CFA6C /* Wire Share Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -1251,6 +1252,7 @@
 		1682AEBE20483F73003A052A /* ParticipantsSectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantsSectionController.swift; sourceTree = "<group>"; };
 		1682AEC020483FA5003A052A /* GroupDetailsSectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupDetailsSectionController.swift; sourceTree = "<group>"; };
 		1682AEC2204840E7003A052A /* SectionCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionCollectionViewController.swift; sourceTree = "<group>"; };
+		1682AEC420484B9B003A052A /* Themeable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Themeable.swift; sourceTree = "<group>"; };
 		168A16A31D95964B005CFA6C /* NSString+URL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSString+URL.swift"; sourceTree = "<group>"; };
 		168A16A91D9597C2005CFA6C /* Wire Share Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "Wire Share Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		168A16AB1D9597C2005CFA6C /* ShareExtensionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareExtensionViewController.swift; sourceTree = "<group>"; };
@@ -4539,6 +4541,7 @@
 				7CA540821F740B7C00457F4B /* UIScreen+Compact.m */,
 				EF2C18A11FED541F00E9F2FD /* Timer+allVersionCompatibleScheduledTimer.swift */,
 				7C4789842021F40E00A38442 /* AddBotError+UIHandler.swift */,
+				1682AEC420484B9B003A052A /* Themeable.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -6485,6 +6488,7 @@
 				F1199D351FC8490A0070FAC3 /* TeamCreationFlowController.swift in Sources */,
 				EF2127161FB9DFE300625A9B /* PhoneVerificationStepViewController.m in Sources */,
 				16E311C31A5FEA2B00FF2C9E /* ConversationCell.m in Sources */,
+				1682AEC520484B9B003A052A /* Themeable.swift in Sources */,
 				F12CDAE31E4386A100CEFCEB /* ChangeHandleViewController.swift in Sources */,
 				8F8914121A9F287E0056AB0C /* ConversationListContentController.m in Sources */,
 				87B8C3401DF9788B0015EC89 /* LinkOpener.swift in Sources */,

--- a/Wire-iOS/Sources/Helpers/Themeable.swift
+++ b/Wire-iOS/Sources/Helpers/Themeable.swift
@@ -1,0 +1,55 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/**
+ Marks a class which supports different color schemes.
+ 
+ A themeable class should be redraw it self  when `colorSchemeVariant` is changed.
+ 
+ **Note:**
+ It is recommened that `colorSchemeVariant` is marked as a dynamic property
+ in order for it work with `UIAppearance`.
+ */
+protocol Themeable {
+    
+    /// Color scheme variant which should be applied to the view
+    var colorSchemeVariant : ColorSchemeVariant { get set }
+    
+    /// Applies a color scheme to a view
+    func applyColorScheme(_ colorSchemeVariant: ColorSchemeVariant)
+    
+}
+
+extension UIView {
+    
+    /// Applies a color scheme to all subviews recursively.
+    func applyColorSchemeOnSubviews(_ colorSchemeVariant: ColorSchemeVariant) {
+        for subview in subviews {
+            if let themable = subview as? Themeable {
+                themable.applyColorScheme(colorSchemeVariant)
+            }
+            
+            subview.applyColorSchemeOnSubviews(colorSchemeVariant)
+        }
+    }
+    
+}
+
+

--- a/Wire-iOS/Sources/UserInterface/Components/Views/GuestIndicator.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/GuestIndicator.swift
@@ -19,11 +19,21 @@
 
 import Foundation
 
-public class GuestIndicator: UIImageView {
-    init(variant: ColorSchemeVariant = ColorScheme.default().variant) {
-        super.init(image: UIImage(for: .guest,
-                                  iconSize: .tiny,
-                                  color: UIColor.wr_color(fromColorScheme: ColorSchemeColorIconNormal, variant: variant)))
+public class GuestIndicator: UIImageView, Themeable {
+    
+    dynamic var colorSchemeVariant: ColorSchemeVariant = ColorScheme.default().variant {
+        didSet {
+            guard oldValue != colorSchemeVariant else { return }
+            applyColorScheme(colorSchemeVariant)
+        }
+    }
+    
+    func applyColorScheme(_ colorSchemeVariant: ColorSchemeVariant) {
+        image = UIImage(for: .guest, iconSize: .tiny, color: UIColor.wr_color(fromColorScheme: ColorSchemeColorIconNormal, variant: colorSchemeVariant))
+    }
+    
+    init() {
+        super.init(image: UIImage(for: .guest, iconSize: .tiny, color: UIColor.wr_color(fromColorScheme: ColorSchemeColorIconNormal, variant: colorSchemeVariant)))
         contentMode = .scaleToFill
         setContentCompressionResistancePriority(UILayoutPriorityRequired, for: .vertical)
         setContentCompressionResistancePriority(UILayoutPriorityRequired, for: .horizontal)
@@ -37,17 +47,30 @@ public class GuestIndicator: UIImageView {
     }
 }
 
-public class GuestLabelIndicator: UIStackView {
+public class GuestLabelIndicator: UIStackView, Themeable {
+    
+    dynamic var colorSchemeVariant: ColorSchemeVariant = ColorScheme.default().variant {
+        didSet {
+            guard oldValue != colorSchemeVariant else { return }
+            applyColorSchemeOnSubviews(colorSchemeVariant)
+            label.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: colorSchemeVariant)
+        }
+    }
+    
+    func applyColorScheme(_ colorSchemeVariant: ColorSchemeVariant) {
+        label.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: colorSchemeVariant)
+    }
+    
     private let guestIcon: GuestIndicator
     private let label = UILabel()
     
-    init(variant: ColorSchemeVariant = ColorScheme.default().variant) {
-        guestIcon = GuestIndicator(variant: variant)
+    init() {
+        guestIcon = GuestIndicator()
         
         label.numberOfLines = 0
         label.textAlignment = .left
         label.font = FontSpec(.medium, .light).font
-        label.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: variant)
+        label.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: colorSchemeVariant)
         label.setContentCompressionResistancePriority(UILayoutPriorityRequired, for: .vertical)
         label.setContentCompressionResistancePriority(UILayoutPriorityRequired, for: .horizontal)
         label.text = "profile.details.guest".localized

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsParticipantCell.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsParticipantCell.swift
@@ -19,7 +19,14 @@
 import UIKit
 import WireExtensionComponents
 
-class GroupDetailsParticipantCell: UICollectionViewCell {
+class GroupDetailsParticipantCell: UICollectionViewCell, Themeable {
+    
+    dynamic var colorSchemeVariant: ColorSchemeVariant = ColorScheme.default().variant {
+        didSet {
+            guard oldValue != colorSchemeVariant else { return }
+            applyColorScheme(colorSchemeVariant)
+        }
+    }
     
     enum AccessoryIcon {
         case none, disclosure, connect
@@ -40,14 +47,7 @@ class GroupDetailsParticipantCell: UICollectionViewCell {
         didSet {
             backgroundColor = isHighlighted
                 ? .init(white: 0, alpha: 0.08)
-                : .wr_color(fromColorScheme: ColorSchemeColorBarBackground, variant: variant)
-        }
-    }
-    
-    var variant : ColorSchemeVariant = ColorScheme.default().variant {
-        didSet {
-            guard oldValue != variant else { return }
-            configureColors()
+                : .wr_color(fromColorScheme: ColorSchemeColorBarBackground, variant: colorSchemeVariant)
         }
     }
     
@@ -77,7 +77,6 @@ class GroupDetailsParticipantCell: UICollectionViewCell {
     }
     
     fileprivate func setup() {
-        guestIconView.image = UIImage(for: .guest, iconSize: .tiny, color: UIColor.wr_color(fromColorScheme: ColorSchemeColorSeparator, variant: variant))
         guestIconView.translatesAutoresizingMaskIntoConstraints = false
         guestIconView.contentMode = .center
         guestIconView.accessibilityIdentifier = "img.guest"
@@ -143,21 +142,21 @@ class GroupDetailsParticipantCell: UICollectionViewCell {
         separator.bottomAnchor.constraint(equalTo: contentView.bottomAnchor).isActive = true
         separator.heightAnchor.constraint(equalToConstant: .hairline).isActive = true
         
-        configureColors()
+        applyColorScheme(colorSchemeVariant)
     }
     
-    private func configureColors() {
-        backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorBarBackground, variant: variant)
-        separator.backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorCellSeparator, variant: variant)
-        guestIconView.image = UIImage(for: .guest, iconSize: .tiny, color: UIColor.wr_color(fromColorScheme: ColorSchemeColorSectionText, variant: variant))
-        accessoryActionButton.setIconColor(UIColor.wr_color(fromColorScheme: ColorSchemeColorSectionText, variant: variant), for: .normal)
-        titleLabel.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: variant)
-        subtitleLabel.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorSectionText, variant: variant)
+    func applyColorScheme(_ colorSchemeVariant: ColorSchemeVariant) {
+        backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorBarBackground, variant: colorSchemeVariant)
+        separator.backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorCellSeparator, variant: colorSchemeVariant)
+        guestIconView.image = UIImage(for: .guest, iconSize: .tiny, color: UIColor.wr_color(fromColorScheme: ColorSchemeColorSectionText, variant: colorSchemeVariant))
+        accessoryActionButton.setIconColor(UIColor.wr_color(fromColorScheme: ColorSchemeColorSectionText, variant: colorSchemeVariant), for: .normal)
+        titleLabel.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: colorSchemeVariant)
+        subtitleLabel.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorSectionText, variant: colorSchemeVariant)
     }
     
     public func configure(with user: ZMBareUser) {
         avatar.user = user
-        titleLabel.attributedText = user.nameIncludingAvailability(color: UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: variant))
+        titleLabel.attributedText = user.nameIncludingAvailability(color: UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: colorSchemeVariant))
         guestIconView.isHidden = !ZMUser.selfUser().isTeamMember || user.isTeamMember || user.isServiceUser
         
         if let user = user as? ZMUser {

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
@@ -50,6 +50,7 @@
 #import "Wire-Swift.h"
 
 #import "NSLayoutConstraint+Helpers.h"
+#import "StartUIViewController.h"
 
 @interface ZClientViewController (InitialState) <SplitViewControllerDelegate>
 
@@ -125,6 +126,8 @@
         
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(contentSizeCategoryDidChange:) name:UIContentSizeCategoryDidChangeNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationWillEnterForeground:) name:UIApplicationWillEnterForegroundNotification object:nil];
+                
+        [[GuestIndicator appearanceWhenContainedInInstancesOfClasses:@[StartUIView.class]] setColorSchemeVariant:ColorSchemeVariantDark];
     }
     return self;
 }

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/Cells/SearchResultCell.m
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/Cells/SearchResultCell.m
@@ -52,7 +52,7 @@ static NSMutableDictionary *correlationFormatters;
 
 @property (nonatomic, strong) UILabel *subtitleLabel;
 
-@property (nonatomic, strong) GuestIndicator *guestIndicator;
+@property (nonatomic, strong) UIImageView *guestIndicator;
 @property (nonatomic, strong) UIView *separatorLineView;
 
 @end
@@ -460,7 +460,11 @@ static NSMutableDictionary *correlationFormatters;
 
     if (nil != self.team && !self.user.isTeamMember) {
         if (nil == self.guestIndicator) {
-            self.guestIndicator = [[GuestIndicator alloc] initWithVariant:ColorSchemeVariantDark];
+            UIColor *guestIconColor = [UIColor wr_colorFromColorScheme:ColorSchemeColorSectionText variant:self.colorSchemeVariant];
+            self.guestIndicator = [[UIImageView alloc] initWithImage:[UIImage imageForIcon:ZetaIconTypeGuest iconSize:ZetaIconSizeTiny color:guestIconColor]];
+            self.guestIndicator.contentMode = UIViewContentModeCenter;
+            [self.guestIndicator setContentHuggingPriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
+            [self.guestIndicator setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
             [self.swipeView addSubview:self.guestIndicator];
             [self.guestIndicator autoAlignAxisToSuperviewAxis:ALAxisHorizontal];
             self.guestIndicatorTrailingConstraint = [self.guestIndicator autoPinEdgeToSuperviewEdge:ALEdgeTrailing withInset:rightMargin];

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+SearchResults.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+SearchResults.swift
@@ -18,6 +18,8 @@
 
 import Foundation
 
+class StartUIView : UIView { }
+
 extension StartUIViewController: SearchResultsViewControllerDelegate {
     public func searchResultsViewController(_ searchResultsViewController: SearchResultsViewController, didTapOnUser user: ZMSearchableUser, indexPath: IndexPath, section: SearchResultsViewControllerSection) {
         

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.m
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.m
@@ -82,6 +82,11 @@ static NSUInteger const StartUIInitiallyShowsKeyboardConversationThreshold = 10;
     return self;
 }
 
+-(void)loadView
+{
+    self.view = [[StartUIView alloc] initWithFrame:CGRectZero];
+}
+
 - (void)viewDidLoad
 {
     [super viewDidLoad];

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileDetailsViewController.m
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileDetailsViewController.m
@@ -162,7 +162,7 @@ typedef NS_ENUM(NSUInteger, ProfileUserAction) {
 
 - (void)createGuestIndicator
 {
-    self.teamsGuestIndicator = [[GuestLabelIndicator alloc] initWithVariant:[[ColorScheme defaultColorScheme] variant]];
+    self.teamsGuestIndicator = [[GuestLabelIndicator alloc] init];
 }
 
 #pragma mark - Footer


### PR DESCRIPTION
## What's new in this PR?

### Issues

The guest indicator has the wrong colour in search results.

### Causes

The guest indicator view was shared with the profile view screen which requires a different colour.

### Solutions

Use a plain a `UIImageVIew` in the `SearchResultCell` so it can have it's own colour.

## Notes

I'm adding a `Themeable` protocol which can be quite useful when combined with `UIAppearance` since we would then not need to pass along a `ColorSchemeVariant` through the whole view hierarchy.