### PR TITLE
Fix: system message for guest user

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ParticipantsCell/ParticipantsCells.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ParticipantsCell/ParticipantsCells.swift
@@ -176,6 +176,10 @@ public class ParticipantsCell: ConversationCell {
 
     override public func configure(for message: ZMConversationMessage!, layoutProperties: ConversationCellLayoutProperties!) {
         super.configure(for: message, layoutProperties: layoutProperties)
+        reloadInformation(for: message)
+    }
+
+    private func reloadInformation(for message: ZMConversationMessage) {
         let model = ParticipantsCellViewModel(font: labelFont, boldFont: labelBoldFont, largeFont: labelLargeFont, textColor: labelTextColor, message: message)
         leftIconView.image = model.image()
         attributedText = model.attributedTitle()
@@ -188,4 +192,14 @@ public class ParticipantsCell: ConversationCell {
         collectionViewController.users = model.sortedUsers()
     }
 
+    open override func update(forMessage changeInfo: MessageChangeInfo!) -> Bool {
+        let needsLayout = super.update(forMessage: changeInfo)
+
+        if changeInfo.usersChanged {
+            reloadInformation(for: changeInfo.message)
+            return true
+        }
+
+        return needsLayout
+    }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

When an external guest joins a conversation that you are watching the system message does not show the name. 

### Causes

We insert the system message immediately after we get a push event that a member joined conversation. However at this point we only know the `remoteIdentifier` and user has no other information (name, profile picture etc.). We fetch all the details of this user, but the system message is not actually updated when we receive all this.

### Solutions

Reload all the information of the cell when a user changes. This should solve other similar issues that were happening in various types of `ParticipantCell`.
