### PR TITLE
Fix guest icon being shown for users in non-team group

### DIFF
--- a/Wire-iOS Tests/GroupDetailsParticipantCellTests.swift
+++ b/Wire-iOS Tests/GroupDetailsParticipantCellTests.swift
@@ -20,13 +20,22 @@ import XCTest
 @testable import Wire
 
 class GroupDetailsParticipantCellTests: ZMSnapshotTestCase {
+    
+    var mockConversation: MockConversation!
+    
+    var conversation : ZMConversation {
+        return (mockConversation as Any) as! ZMConversation
+    }
         
     override func setUp() {
         super.setUp()
+        
+        mockConversation = MockConversationFactory.mockConversation()
     }
     
     override func tearDown() {
         MockUser.mockSelf().isTeamMember = false
+        mockConversation = nil
         super.tearDown()
     }
     
@@ -44,7 +53,7 @@ class GroupDetailsParticipantCellTests: ZMSnapshotTestCase {
         mockUser?.isServiceUser = true
         
         verify(view: cell({ (cell) in
-            cell.configure(with: user)
+            cell.configure(with: user, conversation: conversation)
         }))
     }
     
@@ -52,7 +61,7 @@ class GroupDetailsParticipantCellTests: ZMSnapshotTestCase {
         let user = MockUser.mockUsers()[0]
         
         verify(view: cell({ (cell) in
-            cell.configure(with: user)
+            cell.configure(with: user, conversation: conversation)
         }))
     }
     
@@ -63,7 +72,7 @@ class GroupDetailsParticipantCellTests: ZMSnapshotTestCase {
         _ = mockUser?.feature(withUserClients: 1)
         
         verify(view: cell({ (cell) in
-            cell.configure(with: user)
+            cell.configure(with: user, conversation: conversation)
         }))
     }
     
@@ -75,7 +84,7 @@ class GroupDetailsParticipantCellTests: ZMSnapshotTestCase {
         
         verify(view: cell({ (cell) in
             cell.variant = .dark
-            cell.configure(with: user)
+            cell.configure(with: user, conversation: conversation)
         }))
     }
     
@@ -84,26 +93,30 @@ class GroupDetailsParticipantCellTests: ZMSnapshotTestCase {
         
         verify(view: cell({ (cell) in
             cell.variant = .dark
-            cell.configure(with: user)
+            cell.configure(with: user, conversation: conversation)
         }))
     }
     
     func testGuestUser() {
         MockUser.mockSelf().isTeamMember = true
         let user = MockUser.mockUsers()[0]
+        let mockUser = MockUser(for: user)
+        mockUser?.isGuestInConversation = true
         
         verify(view: cell({ (cell) in
-            cell.configure(with: user)
+            cell.configure(with: user, conversation: conversation)
         }))
     }
     
     func testGuestUser_DarkMode() {
         MockUser.mockSelf().isTeamMember = true
         let user = MockUser.mockUsers()[0]
+        let mockUser = MockUser(for: user)
+        mockUser?.isGuestInConversation = true
         
         verify(view: cell({ (cell) in
             cell.variant = .dark
-            cell.configure(with: user)
+            cell.configure(with: user, conversation: conversation)
         }))
     }
     
@@ -112,10 +125,11 @@ class GroupDetailsParticipantCellTests: ZMSnapshotTestCase {
         let user = MockUser.mockUsers()[0]
         let mockUser = MockUser(for: user)
         mockUser?.trusted = true
+        mockUser?.isGuestInConversation = true
         _ = mockUser?.feature(withUserClients: 1)
         
         verify(view: cell({ (cell) in
-            cell.configure(with: user)
+            cell.configure(with: user, conversation: conversation)
         }))
     }
     
@@ -124,11 +138,12 @@ class GroupDetailsParticipantCellTests: ZMSnapshotTestCase {
         let user = MockUser.mockUsers()[0]
         let mockUser = MockUser(for: user)
         mockUser?.trusted = true
+        mockUser?.isGuestInConversation = true
         _ = mockUser?.feature(withUserClients: 1)
         
         verify(view: cell({ (cell) in
             cell.variant = .dark
-            cell.configure(with: user)
+            cell.configure(with: user, conversation: conversation)
         }))
     }
     
@@ -136,7 +151,7 @@ class GroupDetailsParticipantCellTests: ZMSnapshotTestCase {
         let user = MockUser.mockUsers()[10]
         
         verify(view: cell({ (cell) in
-            cell.configure(with: user)
+            cell.configure(with: user, conversation: conversation)
         }))
     }
     
@@ -145,7 +160,7 @@ class GroupDetailsParticipantCellTests: ZMSnapshotTestCase {
         
         verify(view: cell({ (cell) in
             cell.variant = .dark
-            cell.configure(with: user)
+            cell.configure(with: user, conversation: conversation)
         }))
     }
     

--- a/Wire-iOS Tests/Mocks/MockUser.h
+++ b/Wire-iOS Tests/Mocks/MockUser.h
@@ -48,6 +48,7 @@
 @property (nonatomic, assign) BOOL isSelfUser;
 @property (nonatomic, assign) BOOL isServiceUser;
 @property (nonatomic, assign) BOOL isTeamMember;
+@property (nonatomic, assign) BOOL isGuestInConversation;
 
 @property (nonatomic) NSSet <id<UserClientType>> * clients;
 - (UIColor *)accentColor;

--- a/Wire-iOS Tests/Mocks/MockUser.m
+++ b/Wire-iOS Tests/Mocks/MockUser.m
@@ -68,7 +68,7 @@ static id<ZMBareUser> mockSelfUser = nil;
 
 - (BOOL)isGuestInConversation:(ZMConversation *)conversation
 {
-    return NO;
+    return self.isGuestInConversation;
 }
 
 + (ZMUser<ZMEditableUser> *)selfUserInUserSession:(ZMUserSession *)session

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsParticipantCell.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsParticipantCell.swift
@@ -155,10 +155,10 @@ class GroupDetailsParticipantCell: UICollectionViewCell {
         subtitleLabel.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorSectionText, variant: variant)
     }
     
-    public func configure(with user: ZMBareUser) {
+    public func configure(with user: ZMBareUser, conversation: ZMConversation) {
         avatar.user = user
         titleLabel.attributedText = user.nameIncludingAvailability(color: UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: variant))
-        guestIconView.isHidden = !ZMUser.selfUser().isTeamMember || user.isTeamMember || user.isServiceUser
+        guestIconView.isHidden = !user.isGuest(in: conversation)
         
         if let user = user as? ZMUser {
             verifiedIconView.isHidden = !user.trusted() || user.clients.isEmpty

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
@@ -140,11 +140,11 @@ class GroupDetailsViewController: UIViewController, ZMConversationObserver, Grou
         }
         let (participants, serviceUsers) = (conversation.sortedOtherParticipants, conversation.sortedServiceUsers)
         if !participants.isEmpty {
-            let participantsSectionController = ParticipantsSectionController(participants: participants, delegate: self)
+            let participantsSectionController = ParticipantsSectionController(participants: participants, conversation: conversation, delegate: self)
             sections.append(participantsSectionController)
         }
         if !serviceUsers.isEmpty {
-            let servicesSection = ServicesSectionController(serviceUsers: serviceUsers, delegate: self)
+            let servicesSection = ServicesSectionController(serviceUsers: serviceUsers, conversation: conversation, delegate: self)
             sections.append(servicesSection)
         }
         

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/ParticipantsSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/ParticipantsSectionController.swift
@@ -23,9 +23,11 @@ class ParticipantsSectionController: GroupDetailsSectionController {
     
     private weak var delegate: GroupDetailsSectionControllerDelegate?
     private let participants: [ZMBareUser]
+    private let conversation: ZMConversation
     
-    init(participants: [ZMBareUser], delegate: GroupDetailsSectionControllerDelegate) {
+    init(participants: [ZMBareUser], conversation: ZMConversation, delegate: GroupDetailsSectionControllerDelegate) {
         self.participants = participants
+        self.conversation = conversation
         self.delegate = delegate
     }
     
@@ -51,7 +53,7 @@ class ParticipantsSectionController: GroupDetailsSectionController {
         let user = participants[indexPath.row]
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: GroupDetailsParticipantCell.zm_reuseIdentifier, for: indexPath) as! GroupDetailsParticipantCell
         
-        cell.configure(with: user)
+        cell.configure(with: user, conversation: conversation)
         cell.separator.isHidden = (participants.count - 1) == indexPath.row
         return cell
     }

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/ServicesSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/ServicesSectionController.swift
@@ -22,9 +22,11 @@ class ServicesSectionController: GroupDetailsSectionController {
     
     private weak var delegate: GroupDetailsSectionControllerDelegate?
     private let serviceUsers: [ZMBareUser]
+    private let conversation: ZMConversation
     
-    init(serviceUsers: [ZMBareUser], delegate: GroupDetailsSectionControllerDelegate) {
+    init(serviceUsers: [ZMBareUser], conversation: ZMConversation, delegate: GroupDetailsSectionControllerDelegate) {
         self.serviceUsers = serviceUsers
+        self.conversation = conversation
         self.delegate = delegate
     }
     
@@ -50,7 +52,7 @@ class ServicesSectionController: GroupDetailsSectionController {
         let user = serviceUsers[indexPath.row]
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: GroupDetailsParticipantCell.zm_reuseIdentifier, for: indexPath) as! GroupDetailsParticipantCell
         
-        cell.configure(with: user)
+        cell.configure(with: user, conversation: conversation)
         cell.separator.isHidden = (serviceUsers.count - 1) == indexPath.row
         return cell
     }


### PR DESCRIPTION
### Issues

When team user is added to non-team group he would see all participants as guests.

### Causes

Guest icon logic was not taking the conversation into account.

### Solutions

Use the `isGuest(_ in: ZMConversation)` function to determine if a group participant is a guest.