### PR TITLE
ZIOS-9292: Allow users to share logs via UIActivityViewController if unable to send mails

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -807,6 +807,7 @@
 "self.settings.technical_report.mail.subject" = "Wire Calling Report";
 "self.settings.technical_report.include_log" = "Include detailed log";
 "self.settings.technical_report.privacy_warning" = "Detailed logs could contain personal data";
+"self.settings.technical_report.no_mail_alert" = "No mail client detected. Tap \"OK\" and send logs manually to: ";
 
 // Password reset
 "self.settings.password_reset_menu.title" = "Reset Password";

--- a/Wire-iOS/Sources/UserInterface/Settings/SettingsTechnicalReportViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/SettingsTechnicalReportViewController.swift
@@ -64,27 +64,26 @@ class SettingsTechnicalReportViewController: UITableViewController, MFMailCompos
     }
     
     func sendReport() {
-        let report = "Calling report"
-        
+        let fileName = "voice.log"
+        let attachmentData = AppDelegate.shared().currentVoiceLogData
+        let mailRecipient = NSLocalizedString("self.settings.technical_report.mail.recipient", comment: "")
+
         guard MFMailComposeViewController.canSendMail() else {
-            let activityViewController = UIActivityViewController(activityItems: [report as Any], applicationActivities: nil)
-            activityViewController.popoverPresentationController?.sourceView = sendReportCell.textLabel
-            guard let bounds = sendReportCell.textLabel?.bounds else { return }
-            activityViewController.popoverPresentationController?.sourceRect = bounds
-            self.present(activityViewController, animated: true, completion: nil)
+            DebugAlert.displayFallbackActivityController(logData: attachmentData(), logFileName: fileName, email: mailRecipient, from: self)
             return
         }
-        
+    
+        let report = "Calling report"
+
         let mailComposeViewController = MFMailComposeViewController()
         mailComposeViewController.mailComposeDelegate = self
-        mailComposeViewController.setToRecipients([NSLocalizedString("self.settings.technical_report.mail.recipient", comment: "")])
+        mailComposeViewController.setToRecipients([mailRecipient])
         mailComposeViewController.setSubject(NSLocalizedString("self.settings.technical_report.mail.subject", comment: ""))
-        let attachmentData = AppDelegate.shared().currentVoiceLogData
         
         if attachmentData().count > 0 && includedVoiceLogCell.accessoryType == .checkmark {
-            mailComposeViewController.addAttachmentData(attachmentData(), mimeType: "text/plain", fileName: "voice.log")
+            mailComposeViewController.addAttachmentData(attachmentData(), mimeType: "text/plain", fileName: fileName)
         }
-        
+    
         mailComposeViewController.setMessageBody(report, isHTML: false)
         self.present(mailComposeViewController, animated: true, completion: nil)
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Users without Mail.app installed cannot send logs.

### Solutions

I've added the possibility to send logs to us by using `UIActivityViewController`. Since this action is detached from sending emails, I've added an alert to remind the user to send the email after completing actions with the activity controller.
