### PR TITLE
Disable renaming conversation and hide icon for past members

### DIFF
--- a/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/RenameGroupSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/RenameGroupSectionController.swift
@@ -34,6 +34,7 @@ class RenameGroupSectionController: NSObject, _CollectionViewSectionController {
     }
     
     func focus() {
+        guard conversation.isSelfAnActiveMember else { return }
         renameCell?.titleTextField.becomeFirstResponder()
     }
     
@@ -49,6 +50,8 @@ class RenameGroupSectionController: NSObject, _CollectionViewSectionController {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: GroupDetailsRenameCell.zm_reuseIdentifier, for: indexPath) as! GroupDetailsRenameCell
         cell.configure(for: conversation)
         cell.titleTextField.textFieldDelegate = self
+        renameCell?.titleTextField.isUserInteractionEnabled = conversation.isSelfAnActiveMember
+        renameCell?.accessoryIconView.isHidden = !conversation.isSelfAnActiveMember
         renameCell = cell
         return cell
     }


### PR DESCRIPTION
## What's new in this PR?

* Disable renaming conversation and hide icon for past members.