### PR TITLE
All titles in settings navigation controllers are now uppercase

### DIFF
--- a/Wire-iOS/Sources/Developer/DeveloperOptionsController.swift
+++ b/Wire-iOS/Sources/Developer/DeveloperOptionsController.swift
@@ -40,7 +40,7 @@ class DeveloperOptionsController : UIViewController {
 extension DeveloperOptionsController {
     
     override func loadView() {
-        self.title = "options"
+        self.title = "OPTIONS"
         self.view = UIView()
         self.edgesForExtendedLayout = UIRectEdge()
         self.view.backgroundColor = .clear

--- a/Wire-iOS/Sources/UserInterface/Settings/SettingsTableViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/SettingsTableViewController.swift
@@ -151,7 +151,7 @@ class SettingsTableViewController: SettingsBaseTableViewController {
     required init(group: SettingsInternalGroupCellDescriptorType) {
         self.group = group
         super.init(style: group.style == .plain ? .plain : .grouped)
-        self.title = group.title
+        self.title = group.title.uppercased()
 
         self.group.items.flatMap { return $0.cellDescriptors }.forEach {
             if let groupDescriptor = $0 as? SettingsGroupCellDescriptorType {

--- a/Wire-iOS/Sources/UserInterface/Settings/SettingsTableViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/SettingsTableViewController.swift
@@ -151,7 +151,7 @@ class SettingsTableViewController: SettingsBaseTableViewController {
     required init(group: SettingsInternalGroupCellDescriptorType) {
         self.group = group
         super.init(style: group.style == .plain ? .plain : .grouped)
-        self.title = group.title.uppercased()
+        self.title = group.title.localizedUppercase
 
         self.group.items.flatMap { return $0.cellDescriptors }.forEach {
             if let groupDescriptor = $0 as? SettingsGroupCellDescriptorType {

--- a/Wire-iOS/Sources/UserInterface/Settings/SettingsTechnicalReportViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/SettingsTechnicalReportViewController.swift
@@ -57,7 +57,7 @@ class SettingsTechnicalReportViewController: UITableViewController, MFMailCompos
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        title = NSLocalizedString("self.settings.technical_report_section.title", comment: "").uppercased()
+        title = NSLocalizedString("self.settings.technical_report_section.title", comment: "").localizedUppercase
         tableView.backgroundColor = UIColor.clear
         tableView.isScrollEnabled = false
         tableView.separatorColor = UIColor(white: 1, alpha: 0.1)

--- a/Wire-iOS/Sources/UserInterface/Settings/SettingsTechnicalReportViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/SettingsTechnicalReportViewController.swift
@@ -57,7 +57,7 @@ class SettingsTechnicalReportViewController: UITableViewController, MFMailCompos
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        title = NSLocalizedString("self.settings.technical_report_section.title", comment: "")
+        title = NSLocalizedString("self.settings.technical_report_section.title", comment: "").uppercased()
         tableView.backgroundColor = UIColor.clear
         tableView.isScrollEnabled = false
         tableView.separatorColor = UIColor(white: 1, alpha: 0.1)


### PR DESCRIPTION
## What's new in this PR?

All navigation titles in Settings view controllers are now uppercase. The only leftover is the default Edit/Done button in Devices list provided by `UITableView`.