### PR TITLE
Bump AVS to 4.2.

### DIFF
--- a/avs-versions
+++ b/avs-versions
@@ -17,4 +17,4 @@
 # along with this program. If not, see http://www.gnu.org/licenses/.
 #
 
-export APPSTORE_AVS_VERSION=4.1.20
+export APPSTORE_AVS_VERSION=4.2.1


### PR DESCRIPTION
Please update to latest AVS 4.2. branch. No API changes. All initial tests are positive. Release notes are here: https://github.com/wearezeta/avs/blob/release-4.2/ChangeLog.txt
