### PR TITLE
Fix typo in German translation.

### DIFF
--- a/Wire-iOS/Resources/de.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/de.lproj/Localizable.strings
@@ -401,7 +401,7 @@
 
 "content.file.too_big" = "Du kannst Dateien bis zu %@ senden";
 // Someone pinged
-"content.ping.text" = "%1$@ hast gepingt";
+"content.ping.text" = "%1$@ hat gepingt";
 
 // Current user pinged
 "content.ping.text.you" = "Du";


### PR DESCRIPTION
This PR fixes a simple typo, and is best understood by looking at the commit itself.

thanks!  (-: