### PR TITLE
Reload the participant list when the connection state changes

### DIFF
--- a/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/ParticipantsSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/ParticipantsSectionController.swift
@@ -21,20 +21,28 @@ import Foundation
 
 class ParticipantsSectionController: GroupDetailsSectionController {
     
+    fileprivate weak var collectionView: UICollectionView?
     private weak var delegate: GroupDetailsSectionControllerDelegate?
     private let participants: [ZMBareUser]
     private let conversation: ZMConversation
+    private var token: AnyObject?
     
     init(participants: [ZMBareUser], conversation: ZMConversation, delegate: GroupDetailsSectionControllerDelegate) {
         self.participants = participants
         self.conversation = conversation
         self.delegate = delegate
+        
+        super.init()
+        
+        token = UserChangeInfo.add(observer: self, for: nil, userSession: ZMUserSession.shared()!)
     }
     
     override func prepareForUse(in collectionView : UICollectionView?) {
         super.prepareForUse(in: collectionView)
         
         collectionView?.register(GroupDetailsParticipantCell.self, forCellWithReuseIdentifier: GroupDetailsParticipantCell.zm_reuseIdentifier)
+        
+        self.collectionView = collectionView
     }
     
     override var sectionTitle: String {
@@ -62,6 +70,16 @@ class ParticipantsSectionController: GroupDetailsSectionController {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard let user = participants[indexPath.row] as? ZMUser else { return }
         delegate?.presentDetails(for: user)
+    }
+    
+}
+
+extension ParticipantsSectionController: ZMUserObserver {
+    
+    func userDidChange(_ changeInfo: UserChangeInfo) {
+        guard changeInfo.connectionStateChanged || changeInfo.nameChanged else { return }
+        
+        collectionView?.reloadData()
     }
     
 }


### PR DESCRIPTION
### Issues

After connecting to a user on the user details screen the participants list wouldn't reflect the updated connection state.

### Causes

We weren't observing connection state changes in the participants list.

### Solutions

Observe connection state changes and reload the list of participants in case it changes.