### PR TITLE
Group details: Use the correct status bar style

### DIFF
--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
@@ -42,6 +42,10 @@ class GroupDetailsViewController: UIViewController, ZMConversationObserver, Grou
         return wr_supportedInterfaceOrientations
     }
 
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return ColorScheme.default().statusBarStyle
+    }
+    
     public init(conversation: ZMConversation) {
         self.conversation = conversation
         collectionViewController = SectionCollectionViewController()


### PR DESCRIPTION
- In the dark mode the status bar was dark.