### PR TITLE
Only show guest options if user is not guest in team

### DIFF
--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
@@ -148,7 +148,7 @@ class GroupDetailsViewController: UIViewController, ZMConversationObserver, Grou
         sections.append(renameGroupSectionController)
         self.renameGroupSectionController = renameGroupSectionController
         
-        if nil != ZMUser.selfUser().team {
+        if !ZMUser.selfUser().isGuest(in: conversation) {
             let guestOptionsSectionController = GuestOptionsSectionController(conversation: conversation, delegate: self, syncCompleted: didCompleteInitialSync)
             sections.append(guestOptionsSectionController)
         }


### PR DESCRIPTION
## What's new in this PR?

* Check if user is guest in conversation instead of whether she has a team.