### PR TITLE
Fix navigation bar layout during the transistion on iOS 10.x

### DIFF
--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.m
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.m
@@ -194,8 +194,19 @@ typedef NS_ENUM(NSUInteger, ProfileViewControllerTabBarIndex) {
     self.usernameDetailsView = usernameDetailsView;
     
     ProfileTitleView *titleView = [[ProfileTitleView alloc] init];
-    titleView.translatesAutoresizingMaskIntoConstraints = NO;
     [titleView configureWithViewModel:viewModel];
+    
+    if (@available(iOS 11, *)) {
+        titleView.translatesAutoresizingMaskIntoConstraints = NO;
+        self.navigationItem.titleView = titleView;
+    } else {
+        titleView.translatesAutoresizingMaskIntoConstraints = NO;
+        [titleView setNeedsLayout];
+        [titleView layoutIfNeeded];
+        titleView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+        titleView.translatesAutoresizingMaskIntoConstraints = YES;
+    }
+    
     self.navigationItem.titleView = titleView;
     self.profileTitleView = titleView;
 }

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Views/ProfileTitleView.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Views/ProfileTitleView.swift
@@ -31,8 +31,9 @@ class ProfileTitleView : UIView {
         }
     }
     
-    init() {
-        super.init(frame: .zero)
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
         setupViews()
         createConstraints()
     }


### PR DESCRIPTION
### Issues

NavigationBar title is not animating correctly when transitioning to the profile details screen.

### Causes

On iOS 10 and earlier the navigation bar title view doesn't handle auto layout views.

### Solutions

Size view manually on iOS 10 and earlier