### PR TITLE
Only show guest option for team users

### DIFF
--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
@@ -148,7 +148,7 @@ class GroupDetailsViewController: UIViewController, ZMConversationObserver, Grou
         sections.append(renameGroupSectionController)
         self.renameGroupSectionController = renameGroupSectionController
         
-        if !ZMUser.selfUser().isGuest(in: conversation) {
+        if !ZMUser.selfUser().isGuest(in: conversation) && ZMUser.selfUser().isTeamMember {
             let guestOptionsSectionController = GuestOptionsSectionController(conversation: conversation, delegate: self, syncCompleted: didCompleteInitialSync)
             sections.append(guestOptionsSectionController)
         }


### PR DESCRIPTION
### Issues

Guest option was shown to non-team users

### Causes

We were only checking that the user is not guest in the conversation.

### Solutions

We also need to check that the user is in team.
