### PR TITLE
Do not show the options in non-team conversation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
@@ -148,7 +148,7 @@ class GroupDetailsViewController: UIViewController, ZMConversationObserver, Grou
         sections.append(renameGroupSectionController)
         self.renameGroupSectionController = renameGroupSectionController
         
-        if !ZMUser.selfUser().isGuest(in: conversation) && ZMUser.selfUser().isTeamMember {
+        if conversation.team != nil && !ZMUser.selfUser().isGuest(in: conversation) && ZMUser.selfUser().isTeamMember {
             let guestOptionsSectionController = GuestOptionsSectionController(conversation: conversation, delegate: self, syncCompleted: didCompleteInitialSync)
             sections.append(guestOptionsSectionController)
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Client crashes if:
1. User A is a team user.
2. User A is added by non-team user to the group conversation.
3. User A tries to change the guest only settings.

### Causes

If the conversation is not created in team it's not possible to set the team-only flag.

### Solutions

Hide the options section in this case.
