### PR TITLE
Layout fixes for unified user cell

### DIFF
--- a/Wire-iOS Tests/GroupDetailsParticipantCellTests.swift
+++ b/Wire-iOS Tests/GroupDetailsParticipantCellTests.swift
@@ -41,6 +41,7 @@ class GroupDetailsParticipantCellTests: ZMSnapshotTestCase {
     
     func cell(_ configuration : (GroupDetailsParticipantCell) -> Void) -> GroupDetailsParticipantCell {
         let cell = GroupDetailsParticipantCell(frame: CGRect(x: 0, y: 0, width: 320, height: 56))
+        cell.accessoryIconView.isHidden = false
         configuration(cell)
         cell.layoutIfNeeded()
         return cell

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsParticipantCell.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsParticipantCell.swift
@@ -93,23 +93,27 @@ class GroupDetailsParticipantCell: UICollectionViewCell, Themeable {
     override func prepareForReuse() {
         super.prepareForReuse()
         
-        verifiedIconView.isHidden = true
-        connectButton.isHidden = true
-        accessoryIconView.isHidden = false
-        checkmarkIconView.image = nil
-        checkmarkIconView.layer.borderColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorIconNormal, variant: colorSchemeVariant).cgColor
-        checkmarkIconView.isHidden = true
+        UIView.performWithoutAnimation {
+            verifiedIconView.isHidden = true
+            connectButton.isHidden = true
+            accessoryIconView.isHidden = false
+            checkmarkIconView.image = nil
+            checkmarkIconView.layer.borderColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorIconNormal, variant: colorSchemeVariant).cgColor
+            checkmarkIconView.isHidden = true
+        }
     }
     
     fileprivate func setup() {
         guestIconView.translatesAutoresizingMaskIntoConstraints = false
         guestIconView.contentMode = .center
         guestIconView.accessibilityIdentifier = "img.guest"
+        guestIconView.isHidden = true
         
         verifiedIconView.image = WireStyleKit.imageOfShieldverified()
         verifiedIconView.translatesAutoresizingMaskIntoConstraints = false
         verifiedIconView.contentMode = .center
         verifiedIconView.accessibilityIdentifier = "img.shield"
+        verifiedIconView.isHidden = true
         
         connectButton.setIcon(.plusCircled, with: .tiny, for: .normal)
         connectButton.imageView?.contentMode = .center
@@ -122,6 +126,7 @@ class GroupDetailsParticipantCell: UICollectionViewCell, Themeable {
 
         accessoryIconView.translatesAutoresizingMaskIntoConstraints = false
         accessoryIconView.contentMode = .center
+        accessoryIconView.isHidden = true
         
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         titleLabel.font = FontSpec.init(.normal, .light).font!

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/ParticipantsSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/ParticipantsSectionController.swift
@@ -63,6 +63,7 @@ class ParticipantsSectionController: GroupDetailsSectionController {
         
         cell.configure(with: user, conversation: conversation)
         cell.separator.isHidden = (participants.count - 1) == indexPath.row
+        cell.accessoryIconView.isHidden = false
         cell.accessibilityIdentifier = "participants.section.participants.cell"
         return cell
     }

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/SectionCollectionViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/SectionCollectionViewController.swift
@@ -79,6 +79,10 @@ extension SectionCollectionViewController: UICollectionViewDataSource {
         return visibleSections.count
     }
     
+    func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+        visibleSections[indexPath.section].collectionView?(collectionView, willDisplay: cell, forItemAt: indexPath)
+    }
+    
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return visibleSections[section].collectionView(collectionView, numberOfItemsInSection: 0)
     }

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/ServicesSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/ServicesSectionController.swift
@@ -54,6 +54,7 @@ class ServicesSectionController: GroupDetailsSectionController {
         
         cell.configure(with: user, conversation: conversation)
         cell.separator.isHidden = (serviceUsers.count - 1) == indexPath.row
+        cell.accessoryIconView.isHidden = false
         cell.accessibilityIdentifier = "participants.section.services.cell"
         return cell
     }

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/Contacts/ContactsSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/Contacts/ContactsSectionController.swift
@@ -68,7 +68,7 @@ class ContactsSectionController : SearchSectionController {
         cell.configure(with: user)
         cell.separator.isHidden = (contacts.count - 1) == indexPath.row
         cell.checkmarkIconView.isHidden = !allowsSelection
-        cell.accessoryIconView.isHidden = allowsSelection
+        cell.accessoryIconView.isHidden = true
         
         let selected = selection?.users.contains(user) ?? false
         cell.isSelected = selected

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/SearchSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/SearchSectionController.swift
@@ -65,6 +65,16 @@ class SearchSectionController: NSObject, CollectionViewSectionController {
         return CGSize(width: collectionView.bounds.size.width, height: 56)
     }
     
+    func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+        
+        // Workaround for when a cell is created inside an animation block. In this case it happens
+        // when the keyboard is animating away which will change the height of the collection view
+        // and therefore reveal more cells.
+        UIView.performWithoutAnimation {
+            cell.layoutIfNeeded()
+        }
+    }
+    
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         fatal("Must be overridden")
     }

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/Suggestions/DirectorySectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/Suggestions/DirectorySectionController.swift
@@ -53,7 +53,6 @@ class DirectorySectionController: SearchSectionController {
         
         cell.configure(with: user)
         cell.separator.isHidden = (suggestions.count - 1) == indexPath.row
-        cell.backgroundColor = .clear
         cell.guestIconView.isHidden = true
         cell.accessoryIconView.isHidden = true
         cell.connectButton.isHidden = false

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchGroupSelector.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchGroupSelector.swift
@@ -105,6 +105,9 @@ final class SearchGroupSelector: UIView {
         }
         
         guard SearchGroupSelector.shouldShowBotResults else {
+            constrain(self) { selfView in
+                selfView.height == 0
+            }
             return
         }
         


### PR DESCRIPTION
### Issues

The new unified user cell had some layout issues:

- When opening the search UI and scrolling down the list the first cell which becomes visible would appear with a broken animation.
- The cell which appear with an broken animation would also show wrong icons all stacked on top each other.

### Causes

The cell with a broken layout is created inside the an animation block when we resize the view as a response to hiding the keyboard. This causes a newly created cell also to animate from its initial zero frame.

The falsely shown icons is also a side effect of creating the cell inside an animation and it has something do with how stack views handle hidden views.

### Solutions

A workaround for for animating cell is invoke another layout before it's displayed. The stack view bug can be workaround by initially hiding all the icons views.