### PR TITLE
Only try to fetch link when opening guest options for .code access modes

### DIFF
--- a/Wire-iOS Tests/ConversationOptionsViewControllerTests.swift
+++ b/Wire-iOS Tests/ConversationOptionsViewControllerTests.swift
@@ -29,6 +29,7 @@ class MockOptionsViewModelConfiguration: ConversationOptionsViewModelConfigurati
     var linkResult: Result<String?>? = nil
     var deleteResult: VoidResult = .success
     var createResult: Result<String>? = nil
+    var isCodeEnabled = true
     
     init(allowGuests: Bool, title: String = "", setAllowGuests: SetHandler? = nil) {
         self.allowGuests = allowGuests

--- a/Wire-iOS/Sources/UserInterface/Conversation Options/Conversation+OptionsConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/Conversation+OptionsConfiguration.swift
@@ -42,6 +42,10 @@ extension ZMConversation {
             return conversation.allowGuests
         }
         
+        var isCodeEnabled: Bool {
+            return conversation.accessMode?.contains(.code) ?? false
+        }
+        
         func setAllowGuests(_ allowGuests: Bool, completion: @escaping (VoidResult) -> Void) {
             conversation.setAllowGuests(allowGuests, in: userSession) {
                 switch $0 {

--- a/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationOptionsViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationOptionsViewModel.swift
@@ -21,6 +21,7 @@ import UIKit
 protocol ConversationOptionsViewModelConfiguration: class {
     var title: String { get }
     var allowGuests: Bool { get }
+    var isCodeEnabled: Bool { get }
     var allowGuestsChangedHandler: ((Bool) -> Void)? { get set }
     func setAllowGuests(_ allowGuests: Bool, completion: @escaping (VoidResult) -> Void)
     func createConversationLink(completion: @escaping (Result<String>) -> Void)
@@ -76,14 +77,15 @@ class ConversationOptionsViewModel {
         state.title = configuration.title
         updateRows()
         configuration.allowGuestsChangedHandler = { [weak self] allowGuests in
-            if allowGuests {
-                self?.fetchLink()
+            guard let `self` = self else { return }
+            if allowGuests && self.configuration.isCodeEnabled {
+                self.fetchLink()
             } else {
-                self?.updateRows()
+                self.updateRows()
             }
         }
         
-        if configuration.allowGuests {
+        if configuration.allowGuests && configuration.isCodeEnabled {
             fetchLink()
         }
     }


### PR DESCRIPTION
## What's new in this PR?

* Only try to fetch link when opening guest options for `.code` access modes. There was an issue for legacy conversations which have not yet been promoted to `[.invite, .code]` access modes, as we tried to fetch the conversation link when opening the guest options menu the users was shown an error.