### PR TITLE
Fix call quality survey analytics and automation

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -211,6 +211,7 @@
 		54FF9E281E813BA500323D2E /* DebugAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54FF9E271E813BA500323D2E /* DebugAlert.swift */; };
 		55A42A701FC872600056752F /* CallQualityScoreProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A42A6F1FC872600056752F /* CallQualityScoreProvider.swift */; };
 		55DD5C341FA236F60082170C /* CallQualityController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DD5C331FA236F60082170C /* CallQualityController.swift */; };
+		5E0FB21B2057F50C00FD9867 /* CallQualitySurveyReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0FB21A2057F50C00FD9867 /* CallQualitySurveyReview.swift */; };
 		5E4B1385204FE58D00ED5DF1 /* TimeInterval+Days.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4B1384204FE58D00ED5DF1 /* TimeInterval+Days.swift */; };
 		5E4B1387204FE7DA00ED5DF1 /* SystemAnimationCurves.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4B1386204FE7DA00ED5DF1 /* SystemAnimationCurves.swift */; };
 		5E4B1389204FEFCD00ED5DF1 /* UIColor+CallQuality.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4B1388204FEFCD00ED5DF1 /* UIColor+CallQuality.swift */; };
@@ -1432,6 +1433,7 @@
 		55A42A6F1FC872600056752F /* CallQualityScoreProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallQualityScoreProvider.swift; sourceTree = "<group>"; };
 		55DD5C331FA236F60082170C /* CallQualityController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallQualityController.swift; sourceTree = "<group>"; };
 		597184FEC66FBCEC21973EDC /* Pods-WireExtensionComponents.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WireExtensionComponents.release.xcconfig"; path = "Pods/Target Support Files/Pods-WireExtensionComponents/Pods-WireExtensionComponents.release.xcconfig"; sourceTree = "<group>"; };
+		5E0FB21A2057F50C00FD9867 /* CallQualitySurveyReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallQualitySurveyReview.swift; sourceTree = "<group>"; };
 		5E4B1384204FE58D00ED5DF1 /* TimeInterval+Days.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TimeInterval+Days.swift"; sourceTree = "<group>"; };
 		5E4B1386204FE7DA00ED5DF1 /* SystemAnimationCurves.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemAnimationCurves.swift; sourceTree = "<group>"; };
 		5E4B1388204FEFCD00ED5DF1 /* UIColor+CallQuality.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+CallQuality.swift"; sourceTree = "<group>"; };
@@ -3351,6 +3353,7 @@
 				87E3C5071FA76B7C008D1FC3 /* AnalyticsProviderFactory.swift */,
 				CE2402801E0A992200665A91 /* AnalyticsConsoleProvider.swift */,
 				8715F22C1F86758E006F3935 /* AnalyticsMixpanelProvider.swift */,
+				5E0FB21A2057F50C00FD9867 /* CallQualitySurveyReview.swift */,
 				55A42A6F1FC872600056752F /* CallQualityScoreProvider.swift */,
 				AFD4E7291E449925002A4732 /* Analytics+StorableTrackingEvent.swift */,
 				871BBFBD1D34F56300DF0793 /* Clusterizers */,
@@ -6503,6 +6506,7 @@
 				16345574200D01180009B5DB /* ConversationListOnboardHint.swift in Sources */,
 				875F89121D6DCD2C00D8748E /* MessageToolboxView.swift in Sources */,
 				8787D1841EA74F5B00254D02 /* ZMUser+Additions.swift in Sources */,
+				5E0FB21B2057F50C00FD9867 /* CallQualitySurveyReview.swift in Sources */,
 				162936BD1F470B4800D4F386 /* AppStateController.swift in Sources */,
 				BF02CDC31D79A98000C87D38 /* SavableImage.swift in Sources */,
 				877ABB471E8118E300CBCF2B /* BackgroundViewController.swift in Sources */,

--- a/Wire-iOS/Sources/Analytics/CallQualityScoreProvider.swift
+++ b/Wire-iOS/Sources/Analytics/CallQualityScoreProvider.swift
@@ -24,11 +24,13 @@ final class CallQualityScoreProvider: NSObject, AnalyticsType {
     
     private var lastCallingEvent: [String: NSObject] = [:]
 
-    func recordCallQualityReview(score: Int, callDuration: Int) {
+    func recordCallQualityReview(_ review: CallQualitySurveyReview) {
 
         var attributes = lastCallingEvent
-        attributes["score"] = score as NSNumber
-        attributes["duration"] = callDuration as NSNumber
+        attributes["action"] = review.label
+        attributes["score"] = review.score
+        attributes["duration"] = review.callDuration
+        attributes["reason"] = review.reason
 
         nextProvider?.tagEvent(type(of: self).callingEventName, attributes: attributes)
     }

--- a/Wire-iOS/Sources/Analytics/CallQualitySurveyReview.swift
+++ b/Wire-iOS/Sources/Analytics/CallQualitySurveyReview.swift
@@ -1,0 +1,64 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+enum CallQualitySurveyReview {
+
+    case notDisplayed(reason: IgnoreReason, duration: Int)
+    case answered(score: Int, duration: Int)
+    case dismissed(duration: Int)
+
+    enum IgnoreReason: String {
+        case callTooShort = "call-too-short"
+        case callFailed = "call-failed"
+        case muted = "muted"
+    }
+
+    var label: NSString {
+        switch self {
+        case .notDisplayed: return "not-displayed"
+        case .answered: return "answered"
+        case .dismissed: return "dismissed"
+        }
+    }
+
+    var score: NSNumber? {
+        switch self {
+        case .answered(let score, _): return score as NSNumber
+        default: return nil
+        }
+
+    }
+
+    var callDuration: NSNumber {
+        switch self {
+        case .notDisplayed(_, let duration): return duration as NSNumber
+        case .answered(_, let duration): return duration as NSNumber
+        case .dismissed(let duration): return duration as NSNumber
+        }
+    }
+
+    var reason: NSString? {
+        switch self {
+        case .notDisplayed(let reason, _): return reason.rawValue as NSString
+        default: return nil
+        }
+    }
+
+}

--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -133,13 +133,9 @@ class AppRootViewController: UIViewController {
         let analytics = Analytics.shared()
         let sessionManagerAnalytics: AnalyticsType
         
-        if DeveloperMenuState.developerMenuEnabled(){
-            CallQualityScoreProvider.shared.nextProvider = analytics
-            sessionManagerAnalytics = CallQualityScoreProvider.shared
-        }
-        else {
-            sessionManagerAnalytics = analytics
-        }
+        CallQualityScoreProvider.shared.nextProvider = analytics
+        sessionManagerAnalytics = CallQualityScoreProvider.shared
+
         SessionManager.create(
             appVersion: appVersion!,
             mediaManager: mediaManager!,


### PR DESCRIPTION
## What's new in this PR?

### Issues

This fixes several issues regarding analytics and automation for the call quality survey:

- Do not display during automation tests (ZIOS-9729)
- Fix a faulty check that prevented the survey to be displayed on external clients
- Send an analytics event for all cases, even when the user did not see/answer the survey