### PR TITLE
Refresh top people when opening the search UI

### DIFF
--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/TopPeopleLine/TopPeopleSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/TopPeopleLine/TopPeopleSectionController.swift
@@ -37,6 +37,7 @@ class TopPeopleSectionController : SearchSectionController {
         self.innerCollectionViewController.delegate = self
         self.innerCollectionViewController.topPeople = topConversationsDirectory.topConversations
         self.innerCollectionView.reloadData()
+        self.topConversationsDirectory.refreshTopConversations()
     }
     
     func createInnerCollectionView() {


### PR DESCRIPTION
### Issues

Top people section was not displayed in the search UI

### Causes

Method call calculate the top people was missing

### Solutions

Add missing method call.