### PR TITLE
ZIOS-9738: Cannot copy images from the clipboard

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -238,6 +238,7 @@
 		7C5836661FD5ABFE001CC843 /* TitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C5836651FD5ABFE001CC843 /* TitleView.swift */; };
 		7C5DF2CC1FD7DEAD00B793B6 /* AvailabilityExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C5DF2CB1FD7DEAD00B793B6 /* AvailabilityExtensions.swift */; };
 		7C6878DB201B3785003A0C7A /* StartUIViewController+SearchResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C6878D7201B3785003A0C7A /* StartUIViewController+SearchResults.swift */; };
+		7C69ECFB20582A6700203F33 /* UIPasteboard+Compatibility.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C69ECFA20582A6700203F33 /* UIPasteboard+Compatibility.m */; };
 		7C6A69051FDFD80E007EBE41 /* AvailabilityLabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C6A69041FDFD80E007EBE41 /* AvailabilityLabelTests.swift */; };
 		7C72F03D200E0D03001231D3 /* PhotoPermissionsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C72F03C200E0D03001231D3 /* PhotoPermissionsController.swift */; };
 		7CA540831F740B7C00457F4B /* UIScreen+Compact.m in Sources */ = {isa = PBXBuildFile; fileRef = 7CA540821F740B7C00457F4B /* UIScreen+Compact.m */; };
@@ -1465,6 +1466,8 @@
 		7C5836651FD5ABFE001CC843 /* TitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleView.swift; sourceTree = "<group>"; };
 		7C5DF2CB1FD7DEAD00B793B6 /* AvailabilityExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailabilityExtensions.swift; sourceTree = "<group>"; };
 		7C6878D7201B3785003A0C7A /* StartUIViewController+SearchResults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "StartUIViewController+SearchResults.swift"; sourceTree = "<group>"; };
+		7C69ECF920582A6700203F33 /* UIPasteboard+Compatibility.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIPasteboard+Compatibility.h"; sourceTree = "<group>"; };
+		7C69ECFA20582A6700203F33 /* UIPasteboard+Compatibility.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIPasteboard+Compatibility.m"; sourceTree = "<group>"; };
 		7C6A69041FDFD80E007EBE41 /* AvailabilityLabelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailabilityLabelTests.swift; sourceTree = "<group>"; };
 		7C72F03C200E0D03001231D3 /* PhotoPermissionsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPermissionsController.swift; sourceTree = "<group>"; };
 		7C72F03E200E1000001231D3 /* MockPhotoPermissionsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPhotoPermissionsController.swift; sourceTree = "<group>"; };
@@ -4572,6 +4575,8 @@
 				EF2C18A11FED541F00E9F2FD /* Timer+allVersionCompatibleScheduledTimer.swift */,
 				7C4789842021F40E00A38442 /* AddBotError+UIHandler.swift */,
 				1682AEC420484B9B003A052A /* Themeable.swift */,
+				7C69ECF920582A6700203F33 /* UIPasteboard+Compatibility.h */,
+				7C69ECFA20582A6700203F33 /* UIPasteboard+Compatibility.m */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -6603,6 +6608,7 @@
 				871BC26F1D34F8F800DF0793 /* ResizingTextView.m in Sources */,
 				D5168F572010F25400F8222A /* Token.m in Sources */,
 				8742C2EA1E5309FC00329FB6 /* NSAttributedString+Highlight.swift in Sources */,
+				7C69ECFB20582A6700203F33 /* UIPasteboard+Compatibility.m in Sources */,
 				876113E41DD1DD6B007F5969 /* SketchToolbar.swift in Sources */,
 				D5173573201764DD00B473CE /* UIAlertAction+Convenience.swift in Sources */,
 				871BC00A1D34F56300DF0793 /* TimeIntervalClusterizer.m in Sources */,

--- a/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
+++ b/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
@@ -114,7 +114,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-ZMBackendEnvironmentType staging"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-UseAnalytics 1"

--- a/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
+++ b/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
@@ -114,7 +114,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-ZMBackendEnvironmentType staging"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-UseAnalytics 1"

--- a/Wire-iOS/Sources/Helpers/UIPasteboard+Compatibility.h
+++ b/Wire-iOS/Sources/Helpers/UIPasteboard+Compatibility.h
@@ -1,0 +1,28 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+#import <UIKit/UIKit.h>
+
+@interface UIPasteboard (Compatibility)
+
+- (BOOL)wr_hasImages;
+- (BOOL)wr_hasStrings;
+- (BOOL)wr_hasURLs;
+
+@end

--- a/Wire-iOS/Sources/Helpers/UIPasteboard+Compatibility.m
+++ b/Wire-iOS/Sources/Helpers/UIPasteboard+Compatibility.m
@@ -1,0 +1,48 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+#import "UIPasteboard+Compatibility.h"
+
+@implementation UIPasteboard (Compatibility)
+
+- (BOOL)wr_hasImages {
+    if(@available(iOS 10, *)) {
+        return self.hasImages;
+    } else {
+        return [self containsPasteboardTypes:UIPasteboardTypeListImage];
+    }
+}
+
+- (BOOL)wr_hasStrings {
+    if(@available(iOS 10, *)) {
+        return self.hasStrings;
+    } else {
+        return [self containsPasteboardTypes:UIPasteboardTypeListString];
+    }
+}
+
+- (BOOL)wr_hasURLs {
+    if(@available(iOS 10, *)) {
+        return self.hasURLs;
+    } else {
+        return [self containsPasteboardTypes:UIPasteboardTypeListURL];
+    }
+}
+
+@end

--- a/Wire-iOS/Sources/UserInterface/Components/MediaAsset.h
+++ b/Wire-iOS/Sources/UserInterface/Components/MediaAsset.h
@@ -71,9 +71,9 @@
 
 - (id<MediaAsset>)mediaAsset;
 - (void)setMediaAsset:(id<MediaAsset>)image;
-- (BOOL)hasImages;
-- (BOOL)hasStrings;
-- (BOOL)hasURLs;
+- (BOOL)wr_hasImages;
+- (BOOL)wr_hasStrings;
+- (BOOL)wr_hasURLs;
 
 @end
 

--- a/Wire-iOS/Sources/UserInterface/Components/MediaAsset.h
+++ b/Wire-iOS/Sources/UserInterface/Components/MediaAsset.h
@@ -18,6 +18,8 @@
 
 
 #import <UIKit/UIKit.h>
+#import "UIPasteboard+Compatibility.h"
+
 @import FLAnimatedImage;
 
 
@@ -71,9 +73,6 @@
 
 - (id<MediaAsset>)mediaAsset;
 - (void)setMediaAsset:(id<MediaAsset>)image;
-- (BOOL)wr_hasImages;
-- (BOOL)wr_hasStrings;
-- (BOOL)wr_hasURLs;
 
 @end
 

--- a/Wire-iOS/Sources/UserInterface/Components/MediaAsset.h
+++ b/Wire-iOS/Sources/UserInterface/Components/MediaAsset.h
@@ -71,6 +71,9 @@
 
 - (id<MediaAsset>)mediaAsset;
 - (void)setMediaAsset:(id<MediaAsset>)image;
+- (BOOL)hasImages;
+- (BOOL)hasStrings;
+- (BOOL)hasURLs;
 
 @end
 

--- a/Wire-iOS/Sources/UserInterface/Components/MediaAsset.m
+++ b/Wire-iOS/Sources/UserInterface/Components/MediaAsset.m
@@ -128,7 +128,7 @@
         NSData *data = [self dataForPasteboardType:(__bridge NSString *)kUTTypeGIF];
         return [[FLAnimatedImage alloc] initWithAnimatedGIFData:data];
     }
-    else if ([self hasImages]) {
+    else if ([self wr_hasImages]) {
         return [self image];
     }
     return nil;
@@ -140,15 +140,15 @@
     [[UIPasteboard generalPasteboard] setData:image.data forPasteboardType:type];
 }
 
-- (BOOL)hasImages {
+- (BOOL)wr_hasImages {
     return [self containsPasteboardTypes:UIPasteboardTypeListImage] || ([self respondsToSelector:@selector(hasImages)] && self.hasImages);
 }
 
-- (BOOL)hasStrings {
+- (BOOL)wr_hasStrings {
     return [self containsPasteboardTypes:UIPasteboardTypeListString] || ([super respondsToSelector:@selector(hasStrings)] && self.hasStrings);
 }
 
-- (BOOL)hasURLs {
+- (BOOL)wr_hasURLs {
     return [self containsPasteboardTypes:UIPasteboardTypeListURL] || ([super respondsToSelector:@selector(hasURLs)] && self.hasURLs);
 }
 

--- a/Wire-iOS/Sources/UserInterface/Components/MediaAsset.m
+++ b/Wire-iOS/Sources/UserInterface/Components/MediaAsset.m
@@ -128,7 +128,7 @@
         NSData *data = [self dataForPasteboardType:(__bridge NSString *)kUTTypeGIF];
         return [[FLAnimatedImage alloc] initWithAnimatedGIFData:data];
     }
-    else if ([self containsPasteboardTypes:UIPasteboardTypeListImage]) {
+    else if ([self hasImages]) {
         return [self image];
     }
     return nil;
@@ -138,6 +138,18 @@
 {
     NSString *type = [image isGIF] ? (__bridge NSString *)kUTTypeGIF : (__bridge NSString *)kUTTypeJPEG;
     [[UIPasteboard generalPasteboard] setData:image.data forPasteboardType:type];
+}
+
+- (BOOL)hasImages {
+    return [self containsPasteboardTypes:UIPasteboardTypeListImage] || ([self respondsToSelector:@selector(hasImages)] && self.hasImages);
+}
+
+- (BOOL)hasStrings {
+    return [self containsPasteboardTypes:UIPasteboardTypeListString] || ([super respondsToSelector:@selector(hasStrings)] && self.hasStrings);
+}
+
+- (BOOL)hasURLs {
+    return [self containsPasteboardTypes:UIPasteboardTypeListURL] || ([super respondsToSelector:@selector(hasURLs)] && self.hasURLs);
 }
 
 @end

--- a/Wire-iOS/Sources/UserInterface/Components/MediaAsset.m
+++ b/Wire-iOS/Sources/UserInterface/Components/MediaAsset.m
@@ -140,16 +140,4 @@
     [[UIPasteboard generalPasteboard] setData:image.data forPasteboardType:type];
 }
 
-- (BOOL)wr_hasImages {
-    return [self containsPasteboardTypes:UIPasteboardTypeListImage] || ([self respondsToSelector:@selector(hasImages)] && self.hasImages);
-}
-
-- (BOOL)wr_hasStrings {
-    return [self containsPasteboardTypes:UIPasteboardTypeListString] || ([super respondsToSelector:@selector(hasStrings)] && self.hasStrings);
-}
-
-- (BOOL)wr_hasURLs {
-    return [self containsPasteboardTypes:UIPasteboardTypeListURL] || ([super respondsToSelector:@selector(hasURLs)] && self.hasURLs);
-}
-
 @end

--- a/WireExtensionComponents/Views/TextView.m
+++ b/WireExtensionComponents/Views/TextView.m
@@ -204,18 +204,19 @@
 {
     UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
     DDLogDebug(@"types available: %@", [pasteboard pasteboardTypes]);
-
-    if ([pasteboard containsPasteboardTypes:UIPasteboardTypeListImage] && [self.delegate respondsToSelector:@selector(textView:hasImageToPaste:)]) {
+    
+    if (([pasteboard containsPasteboardTypes:UIPasteboardTypeListImage]  || ([pasteboard respondsToSelector:@selector(hasImages)] && pasteboard.hasImages))
+        && [self.delegate respondsToSelector:@selector(textView:hasImageToPaste:)]) {
         id<MediaAsset> image = [[UIPasteboard generalPasteboard] mediaAsset];
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
         [self.delegate performSelector:@selector(textView:hasImageToPaste:) withObject:self withObject:image];
 #pragma clang diagnostic pop
     }
-    else if ([pasteboard containsPasteboardTypes:UIPasteboardTypeListString]) {
+    else if ([pasteboard containsPasteboardTypes:UIPasteboardTypeListString] || ([pasteboard respondsToSelector:@selector(hasStrings)] && pasteboard.hasStrings)) {
         [super paste:sender];
     }
-    else if ([pasteboard containsPasteboardTypes:UIPasteboardTypeListURL]) {
+    else if ([pasteboard containsPasteboardTypes:UIPasteboardTypeListURL] || ([pasteboard respondsToSelector:@selector(hasURLs)] && pasteboard.hasURLs)) {
         if (pasteboard.string.length != 0) {
             [super paste:sender];
         }
@@ -229,7 +230,7 @@
 {
     if (action == @selector(paste:)) {
         UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
-        return pasteboard.image || pasteboard.string;
+        return pasteboard.hasImages || pasteboard.hasStrings;
     }
 
     return [super canPerformAction:action withSender:sender];

--- a/WireExtensionComponents/Views/TextView.m
+++ b/WireExtensionComponents/Views/TextView.m
@@ -205,7 +205,7 @@
     UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
     DDLogDebug(@"types available: %@", [pasteboard pasteboardTypes]);
     
-    if (([pasteboard containsPasteboardTypes:UIPasteboardTypeListImage]  || ([pasteboard respondsToSelector:@selector(hasImages)] && pasteboard.hasImages))
+    if ((pasteboard.wr_hasImages)
         && [self.delegate respondsToSelector:@selector(textView:hasImageToPaste:)]) {
         id<MediaAsset> image = [[UIPasteboard generalPasteboard] mediaAsset];
 #pragma clang diagnostic push
@@ -213,10 +213,10 @@
         [self.delegate performSelector:@selector(textView:hasImageToPaste:) withObject:self withObject:image];
 #pragma clang diagnostic pop
     }
-    else if ([pasteboard containsPasteboardTypes:UIPasteboardTypeListString] || ([pasteboard respondsToSelector:@selector(hasStrings)] && pasteboard.hasStrings)) {
+    else if (pasteboard.wr_hasStrings) {
         [super paste:sender];
     }
-    else if ([pasteboard containsPasteboardTypes:UIPasteboardTypeListURL] || ([pasteboard respondsToSelector:@selector(hasURLs)] && pasteboard.hasURLs)) {
+    else if (pasteboard.wr_hasURLs) {
         if (pasteboard.string.length != 0) {
             [super paste:sender];
         }
@@ -230,7 +230,7 @@
 {
     if (action == @selector(paste:)) {
         UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
-        return pasteboard.hasImages || pasteboard.hasStrings;
+        return pasteboard.wr_hasImages || pasteboard.wr_hasStrings;
     }
 
     return [super canPerformAction:action withSender:sender];

--- a/WireExtensionComponents/Views/TextView.m
+++ b/WireExtensionComponents/Views/TextView.m
@@ -25,6 +25,7 @@
 @import PureLayout;
 #import "MediaAsset.h"
 #import "UILabel+TextTransform.h"
+#import "UIPasteboard+Compatibility.h"
 #import <WireExtensionComponents/WireExtensionComponents-Swift.h>
 @import Classy;
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

As reported here: https://github.com/wireapp/wire-ios/issues/1485, there are some cases where the images are not copied correctly from the clipboard.

### Causes

The main cause is that the images copied from Universal Clipboard are not properly recognized as images: while debugging, `[self containsPasteboardTypes:UIPasteboardTypeListImage]` returns `false` while `self.hasImages` returns `true`. While copying images from other sources like the local clipboard. This method is available only from iOS 10.
Furthermore, calling `pasteboard.image` from `canPerformAction:withSender:` is causing the system to display immediately the "Pasting from <Device>" popup in case of pasting from Universal Clipboard (and it's useless since APIs provide the `hasImages` method).

### Solutions

I've implemented three new methods in the `UIPasteboard` category for checking if the clipboard contains images, strings and urls.
