### PR TITLE
Notify sync engine about opening and closing the conversation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -361,6 +361,8 @@
     }
 
     self.contentViewController.searchQueries = self.collectionController.currentTextSearchQuery;
+
+    [[ZMUserSession sharedSession] didOpenWithConversation:self.conversation];
     
     self.isAppearing = NO;
 }
@@ -369,6 +371,7 @@
 {
     [super viewWillDisappear:animated];
     [self updateLeftNavigationBarItems];
+    [[ZMUserSession sharedSession] didCloseWithConversation:self.conversation];
 }
 
 - (void)viewDidDisappear:(BOOL)animated


### PR DESCRIPTION
- The new API should be triggering the check if the users are already expired from the backend.