### PR TITLE
[ZIOS-9417] Implement 3D Touch actions for image preview

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -404,6 +404,7 @@
 "content.message.go_to_conversation" = "Reveal";
 "content.message.forward.to" = "Search…";
 "content.message.open" = "Open";
+"content.message.copy" = "Copy";
 
 "content.reactions_list.likers" = "Liked by";
 

--- a/Wire-iOS/Sources/UserInterface/Collections/ConversationImagesViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/ConversationImagesViewController.swift
@@ -67,6 +67,12 @@ final class ConversationImagesViewController: UIViewController {
             self.createNavigationTitle()
         }
     }
+
+    public var isPreviewing: Bool = false {
+        didSet {
+            updateBarsForPreview()
+        }
+    }
     
     public var swipeToDismiss: Bool = false {
         didSet {
@@ -160,6 +166,8 @@ final class ConversationImagesViewController: UIViewController {
                 navigationBar.centerX == view.centerX
             }
         }
+
+        updateBarsForPreview()
     }
     
     private func createPageController() {
@@ -274,6 +282,12 @@ final class ConversationImagesViewController: UIViewController {
         likeButton.setIcon(currentMessage.liked ? .liked : .like, with: .tiny, for: .normal)
         likeButton.accessibilityLabel = currentMessage.liked ? "unlike" : "like"
     }
+
+    fileprivate func updateBarsForPreview() {
+        navBarContainer?.isHidden = isPreviewing
+        buttonsBar?.isHidden = isPreviewing
+        separator.isHidden = isPreviewing
+    }
     
     fileprivate func imageController(for message: ZMConversationMessage) -> FullscreenImageViewController {
         let imageViewController = FullscreenImageViewController(message: message)
@@ -325,7 +339,9 @@ final class ConversationImagesViewController: UIViewController {
     }
     
     @objc public func saveCurrent(_ sender: UIButton!) {
-        self.currentController?.performSaveImageAnimation(from: sender)
+        if sender != nil {
+            self.currentController?.performSaveImageAnimation(from: sender)
+        }
         self.messageActionDelegate?.wants(toPerform: .save, for: self.currentMessage)
     }
 
@@ -477,4 +493,32 @@ extension MenuVisibilityController {
     }
 }
 
+extension ConversationImagesViewController {
+
+    override var previewActionItems: [UIPreviewActionItem] {
+        let copyAction = UIPreviewAction(title: NSLocalizedString("content.message.copy", comment: ""), style: .default) { _ in
+            self.copyCurrent(nil)
+        }
+
+        let likeActionKey = currentMessage.liked ? "unlike" : "like"
+        let likeAction = UIPreviewAction(title: NSLocalizedString("content.message.\(likeActionKey)", comment: ""), style: .default) { _ in
+            self.likeCurrent()
+        }
+
+        let saveAction = UIPreviewAction(title: NSLocalizedString("content.message.save", comment: ""), style: .default) { _ in
+            self.saveCurrent(nil)
+        }
+
+        let shareAction = UIPreviewAction(title: NSLocalizedString("content.message.forward", comment: ""), style: .default) { _ in
+            self.shareCurrent(nil)
+        }
+
+        let deleteAction = UIPreviewAction(title: NSLocalizedString("content.message.delete", comment: ""), style: .destructive) { _ in
+            self.deleteCurrent(nil)
+        }
+
+        return [copyAction, likeAction, saveAction, shareAction, deleteAction]
+    }
+
+}
 

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.m
@@ -176,6 +176,12 @@
     }
 }
 
+- (void)viewWillLayoutSubviews
+{
+    [super viewWillLayoutSubviews];
+    [self updateZoom];
+}
+
 - (BOOL)prefersStatusBarHidden
 {
     return NO;
@@ -221,6 +227,10 @@
     [self.view addSubview:self.scrollView];
 
     [self.scrollView addConstraintsFittingToView:self.view];
+
+    if (@available(iOS 11, *)) {
+        self.scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
+    }
 
     self.automaticallyAdjustsScrollViewInsets = NO;
     self.scrollView.delegate = self;

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+PeekPop.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+PeekPop.swift
@@ -41,7 +41,7 @@ extension ConversationContentViewController: UIViewControllerPreviewingDelegate 
             lastPreviewURL = url
             controller = SFSafariViewController(url: url)
         } else if message.isImage {
-            controller = self.messagePresenter.viewController(forImageMessage: message, actionResponder: self)
+            controller = self.messagePresenter.viewController(forImageMessagePreview: message, actionResponder: self)
         }
 
         if nil != controller, let cell = tableView.cellForRow(at: cellIndexPath) as? ConversationCell, cell.previewView.bounds != .zero {
@@ -53,6 +53,11 @@ extension ConversationContentViewController: UIViewControllerPreviewingDelegate 
 
     @available(iOS 9.0, *)
     public func previewingContext(_ previewingContext: UIViewControllerPreviewing, commit viewControllerToCommit: UIViewController) {
+        // Restore the navigation and button bars
+        if let imagesViewController = viewControllerToCommit as? ConversationImagesViewController {
+            imagesViewController.isPreviewing = false
+        }
+
         // In case the user has set a 3rd party application to open the URL we do not 
         // want to commit the view controller but instead open the url.
         if let url = lastPreviewURL {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/MessagePresenter+ConversationImages.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/MessagePresenter+ConversationImages.swift
@@ -20,18 +20,24 @@ import Foundation
 import Classy
 
 extension MessagePresenter {
-    func imagesViewController(for message: ZMConversationMessage, actionResponder: MessageActionResponder) -> UIViewController {
+    func imagesViewController(for message: ZMConversationMessage, actionResponder: MessageActionResponder, isPreviewing: Bool) -> UIViewController {
         
         guard let conversation = message.conversation else {
             fatal("Message \(message) has no conversation.")
         }
-        
+
+        guard let imageSize = message.imageMessageData?.originalSize else {
+            fatal("Image in message \(message) has no size.")
+        }
+
         let imagesCategoryMatch = CategoryMatch(including: .image, excluding: .none)
         
         let collection = AssetCollectionWrapper(conversation: conversation, matchingCategories: [imagesCategoryMatch])
         
         let imagesController = ConversationImagesViewController(collection: collection, initialMessage: message, inverse: true)
-        
+        imagesController.isPreviewing = isPreviewing
+        imagesController.preferredContentSize = imageSize
+
         if (UIDevice.current.userInterfaceIdiom == .phone) {
             imagesController.modalPresentationStyle = .fullScreen;
             imagesController.snapshotBackgroundView = UIScreen.main.snapshotView(afterScreenUpdates: true)

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/MessagePresenter.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/MessagePresenter.h
@@ -44,6 +44,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable UIViewController *)viewControllerForImageMessage:(id<ZMConversationMessage>)message
                                              actionResponder:(nullable id<MessageActionResponder>)delegate;
+
+- (nullable UIViewController *)viewControllerForImageMessagePreview:(id<ZMConversationMessage>)message
+                                                    actionResponder:(nullable id<MessageActionResponder>)delegate;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/MessagePresenter.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/MessagePresenter.m
@@ -172,7 +172,22 @@
         return nil;
     }
     
-    return [self imagesViewControllerFor:message actionResponder:delegate];
+    return [self imagesViewControllerFor:message actionResponder:delegate isPreviewing: NO];
+}
+
+- (nullable UIViewController *)viewControllerForImageMessagePreview:(id<ZMConversationMessage>)message
+                                                    actionResponder:(nullable id<MessageActionResponder>)delegate
+
+{
+    if (! [Message isImageMessage:message]) {
+        return nil;
+    }
+
+    if (message.imageMessageData == nil) {
+        return nil;
+    }
+
+    return [self imagesViewControllerFor:message actionResponder:delegate isPreviewing: YES];
 }
 
 - (void)openImageMessage:(id<ZMConversationMessage>)message actionResponder:(nullable id<MessageActionResponder>)delegate


### PR DESCRIPTION
## What's new in this PR?

### Issues

In the current implementation, previewing an image message with 3D Touch displays an image controller with the navigation bar and an action buttons row. These buttons could not be tapped and the user could not quickly interact with the image (like/share/... from the preview).

### Solutions

This PR introduces system preview action items on the image controller. This allows the user to swipe up when previewing and quickly interact with the image from there.

### Attachments

#### Before

![peek_before](https://user-images.githubusercontent.com/16192914/37399926-7fd2974a-2783-11e8-9e71-4bab8b7c9ecb.PNG)

#### After

![peek_after_image](https://user-images.githubusercontent.com/16192914/37399971-9b1e1740-2783-11e8-898a-168c34f67d30.PNG)

![peek_after_actions](https://user-images.githubusercontent.com/16192914/37399978-a1d0644e-2783-11e8-9f00-9fa07673265b.PNG)
