### PR TITLE
ZIOS-9722, ZIOS-9744: Improved registration flow on iPad

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/SignIn/EmailSignInViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/SignIn/EmailSignInViewController.m
@@ -158,6 +158,7 @@
     if (self.loginCredentials.password != nil) {
         // User was previously signed in so we prefill the credentials
         self.passwordField.text = self.loginCredentials.password;
+        [self checkPasswordFieldAccessoryView];
     }
     
     if ([[OnePasswordExtension sharedExtension] isAppExtensionAvailable]) {


### PR DESCRIPTION
## What's new in this PR?

### Issues

UX for registration flow on iPad was affected by two problems, in the case of registration with already registered user credentials:

- server registration was performed after accepting ToS, so in the case of an already registered user,  ToS screen was unnecessarily shown
- after switching to the login screen, the arrow icon was hidden, forcing in this way the user to re-insert the password.

### Solutions

- I've moved the registration phase before accepting the terms of use (you need to accept them anyway in order to receive the activation email)
- I'm checking the accessory view of the password field in the login view in case of a `LoginCredentials` object with the `password` field filled.

## Notes

This should solve both ZIOS-9722 and ZIOS-9744, since the alert about credentials is shown correctly.