### PR TITLE
Don't show open conversation option for wireless users

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ParticipantsInvitePeopleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ParticipantsInvitePeopleView.swift
@@ -49,7 +49,7 @@ class ParticipantsInvitePeopleView: UIView {
         titleLabel.numberOfLines = 0
         titleLabel.text = "content.system.conversation.invite.title".localized
         titleLabel.textColor = .wr_color(fromColorScheme: ColorSchemeColorTextForeground)
-        titleLabel.font = FontSpec(.medium, .light).font
+        titleLabel.font = FontSpec(.medium, .none).font
         inviteButton.setTitle("content.system.conversation.invite.button".localized, for: .normal)
         inviteButton.setTitleColor(.wr_color(fromColorScheme: ColorSchemeColorTextForeground), for: .normal)
         inviteButton.adjustsTitleWhenHighlighted = true

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileDetailsViewController.m
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileDetailsViewController.m
@@ -332,7 +332,11 @@ typedef NS_ENUM(NSUInteger, ProfileUserAction) {
     }
     else if (user.canBeConnected) {
         return ProfileUserActionSendConnectionRequest;
-    } else {
+    }
+    else if (user.isWirelessUser) {
+        return ProfileUserActionNone;
+    }
+    else {
         return ProfileUserActionOpenConversation;
     }
 }

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.m
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.m
@@ -163,7 +163,7 @@ typedef NS_ENUM(NSUInteger, ProfileViewControllerTabBarIndex) {
         [viewControllers addObject:profileDetailsViewController];
     }
     
-    if (self.fullUser.isConnected || self.fullUser.isTeamMember) {
+    if (self.fullUser.isConnected || self.fullUser.isTeamMember || self.fullUser.isWirelessUser) {
         ProfileDevicesViewController *profileDevicesViewController = [[ProfileDevicesViewController alloc] initWithUser:self.fullUser];
         profileDevicesViewController.title = NSLocalizedString(@"profile.devices.title", nil);
         profileDevicesViewController.delegate = self;


### PR DESCRIPTION
## What's new in this PR?

* Don't show open conversation option for wireless users.
* Show device tab for wireless users.
* Fix participants cell invite section title font.