### PR TITLE
ZIOS-9491: Fix audio record button reachability on small screens

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarButtonsView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarButtonsView.swift
@@ -76,6 +76,7 @@ public final class InputBarButtonsView: UIView {
         
         buttonInnerContainer.clipsToBounds = true
         expandRowButton.accessibilityIdentifier = "showOtherRowButton"
+        expandRowButton.hitAreaPadding = .zero
         expandRowButton.setIcon(.ellipsis, with: .tiny, for: UIControlState())
         expandRowButton.addTarget(self, action: #selector(ellipsisButtonPressed), for: .touchUpInside)
         buttonOuterContainer.addSubview(buttonInnerContainer)


### PR DESCRIPTION
## What's new in this PR?

### Issues

When using a small screen device (ex: iPhone 4s), the audio recording long press gesture was not recognized.

### Causes

The long press gesture was not detected by the button the because on small screens it is located next to the expand row button, which has a longer padding. The expand button would intercept touches from the record button, even when the finger is visually above the record button.

### Solutions

This was fixed by reducing the padding around the expand button. Both buttons now have an equal hit size.