### PR TITLE
Added more logs to investigate analytics mixpanel issue

### DIFF
--- a/Wire-iOS/Sources/Analytics/Analytics.m
+++ b/Wire-iOS/Sources/Analytics/Analytics.m
@@ -78,6 +78,7 @@ static Analytics *sharedAnalytics = nil;
 {
     self = [super init];
     if (self) {
+        DDLogInfo(@"Analytics initWithOptedOut: %lu", (unsigned long)optedOut);
         self.provider = optedOut ? nil : [[AnalyticsProviderFactory shared] analyticsProvider];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(userSessionDidBecomeAvailable:) name:ZMUserSessionDidBecomeAvailableNotification object:nil];
     }

--- a/Wire-iOS/Sources/Analytics/AnalyticsProviderFactory.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsProviderFactory.swift
@@ -17,6 +17,7 @@
 //
 
 import Foundation
+import CocoaLumberjackSwift
 
 fileprivate let ZMEnableConsoleLog = "ZMEnableAnalyticsLog"
 
@@ -28,12 +29,15 @@ fileprivate let ZMEnableConsoleLog = "ZMEnableAnalyticsLog"
   
     @objc public func analyticsProvider() -> AnalyticsProvider? {
         if self.useConsoleAnalytics || UserDefaults.standard.bool(forKey: ZMEnableConsoleLog) {
+            DDLogInfo("Creating analyticsProvider: AnalyticsConsoleProvider")
             return AnalyticsConsoleProvider()
         }
         else if UseAnalytics.boolValue || AutomationHelper.sharedHelper.useAnalytics {
+            DDLogInfo("Creating analyticsProvider: AnalyticsMixpanelProvider")
             return AnalyticsMixpanelProvider()
         }
         else {
+            DDLogInfo("Creating analyticsProvider: no provider")
             return nil
         }
     }


### PR DESCRIPTION
In theory we should be able to see the Mixpanel client ID in the console in order to verify actions on the client create events in Mixpanel. Right now this is not happening, we need some more logs to investigate it.