### PR TITLE
Fix observing of playback rate

### DIFF
--- a/Wire-iOS/Sources/Components/AudioPlayer/MediaPlayerController.swift
+++ b/Wire-iOS/Sources/Components/AudioPlayer/MediaPlayerController.swift
@@ -27,6 +27,7 @@ class MediaPlayerController: NSObject {
     let message: ZMConversationMessage
     var player: AVPlayer?
     weak var delegate: MediaPlayerDelegate?
+    fileprivate var playerRateObserver : Any?
 
     init(player: AVPlayer, message: ZMConversationMessage, delegate: MediaPlayerDelegate) {
         self.player = player
@@ -35,12 +36,10 @@ class MediaPlayerController: NSObject {
 
         super.init()
 
-        NotificationCenter.default.addObserver(self, selector: #selector(playerRateChanged), name:NSNotification.Name(rawValue: "rate"), object: .none)
+        self.playerRateObserver = KeyValueObserver.observe(player, keyPath: "rate", target: self, selector: #selector(playerRateChanged))
     }
 
     deinit {
-        NotificationCenter.default.removeObserver(self)
-
         delegate?.mediaPlayer(self, didChangeTo: MediaPlayerState.completed)
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/MessagePresenter.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/MessagePresenter.m
@@ -41,6 +41,12 @@
     return YES;
 }
 
+- (void)viewWillDisappear:(BOOL)animated {
+    [super viewWillDisappear:animated];
+    
+    self.wr_playerController = nil;
+}
+
 @end
 
 


### PR DESCRIPTION
### Issues

Video playback is silent if the silence switcher is on.

### Causes

We must tell AVS that we are about to play a video so that they can configure the audio session for playback. We do listening to "rate" notifications from the `AVPlayer`. This appears not to be working on iOS 11 anymore

### Solutions

Switch back to KVO observing of the playback rate and remove the kvo observer early to avoid crashes on iOS 10.

### Notes

see: https://github.com/wireapp/wire-ios/pull/1529