### PR TITLE
Fix crash for action sheet shown for connections, update for iPad popovers

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ArchivedListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ArchivedListViewController.swift
@@ -153,6 +153,6 @@ extension ArchivedListViewController: ArchivedListViewModelDelegate {
 extension ArchivedListViewController: ConversationListCellDelegate {
     func conversationListCellOverscrolled(_ cell: ConversationListCell!) {
         actionController = ConversationActionController(conversation: cell.conversation, target: self)
-        actionController?.presentMenu()
+        actionController?.presentMenu(from: cell)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -889,19 +889,17 @@
                     if (user.clients.count == 1) {
                         ProfileClientViewController *userClientController = [[ProfileClientViewController alloc] initWithClient:user.clients.anyObject fromConversation:YES];
                         userClientController.showBackButton = NO;
-                        NavigationController *navigationController = [[NavigationController alloc] init];
+                        UINavigationController *navigationController = userClientController.wrapInNavigationController;
                         navigationController.modalPresentationStyle = UIModalPresentationFormSheet;
-                        navigationController.backButton.cas_styleClass = @"circular";
-                        navigationController.rightButtonEnabled = YES;
-                        [navigationController updateRightButtonWithIconType:ZetaIconTypeX iconSize:ZetaIconSizeTiny target:self action:@selector(degradedConversationDismissed:) animated:NO];
-                        navigationController.view.backgroundColor = [UIColor whiteColor];
-                        [navigationController setViewControllers:@[userClientController]];
+                        userClientController.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithIcon:ZetaIconTypeX style:UIBarButtonItemStylePlain target:self action:@selector(dismissProfileClientViewController:)];
                         [self presentViewController:navigationController animated:YES completion:nil];
                     } else {
                         ProfileViewController *profileViewController = [[ProfileViewController alloc] initWithUser:user context:ProfileViewControllerContextDeviceList];
                         profileViewController.delegate = self;
                         profileViewController.viewControllerDismissable = self;
-                        [self presentViewController:profileViewController animated:YES completion:nil];
+                        UINavigationController *navigationController = profileViewController.wrapInNavigationController;
+                        navigationController.modalPresentationStyle = UIModalPresentationFormSheet;
+                        [self presentViewController:navigationController animated:YES completion:nil];
                     }
                 } else if (self.conversation.conversationType == ZMConversationTypeGroup) {
                     UIViewController *participantsController = [self participantsController];
@@ -915,7 +913,7 @@
     [self presentViewController:controller animated:YES completion:nil];
 }
 
-- (void)degradedConversationDismissed:(id)sender
+- (void)dismissProfileClientViewController:(UIBarButtonItem *)sender
 {
     [self dismissViewControllerAnimated:YES completion:nil];
 }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController.m
@@ -486,10 +486,10 @@
     [self.listContentController scrollToCurrentSelectionAnimated:animated];
 }
 
-- (void)showActionMenuForConversation:(ZMConversation *)conversation
+- (void)showActionMenuForConversation:(ZMConversation *)conversation fromView:(UIView *)view
 {
     self.actionsController = [[ConversationActionController alloc] initWithConversation:conversation target:self];
-    [self.actionsController presentMenu];
+    [self.actionsController presentMenuFromSourceView:view];
 }
 
 #pragma mark - Push permissions
@@ -685,9 +685,9 @@
     }
 }
 
-- (void)conversationListContentController:(ConversationListContentController *)controller wantsActionMenuForConversation:(ZMConversation *)conversation
+- (void)conversationListContentController:(ConversationListContentController *)controller wantsActionMenuForConversation:(ZMConversation *)conversation fromSourceView:(UIView *)sourceView
 {
-    [self showActionMenuForConversation:conversation];
+    [self showActionMenuForConversation:conversation fromView:sourceView];
 }
 
 @end

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController.h
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController.h
@@ -35,7 +35,7 @@
 
 - (void)conversationListDidScroll:(ConversationListContentController *)controller;
 
-- (void)conversationListContentController:(ConversationListContentController *)controller wantsActionMenuForConversation:(ZMConversation *)conversation;
+- (void)conversationListContentController:(ConversationListContentController *)controller wantsActionMenuForConversation:(ZMConversation *)conversation fromSourceView:(UIView *)sourceView;
 
 @end
 

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController.m
@@ -528,8 +528,8 @@ static NSString * const CellReuseIdConversation = @"CellId";
         return;
     }
     
-    if ([self.contentDelegate respondsToSelector:@selector(conversationListContentController:wantsActionMenuForConversation:)]) {
-        [self.contentDelegate conversationListContentController:self wantsActionMenuForConversation:conversation];
+    if ([self.contentDelegate respondsToSelector:@selector(conversationListContentController:wantsActionMenuForConversation:fromSourceView:)]) {
+        [self.contentDelegate conversationListContentController:self wantsActionMenuForConversation:conversation fromSourceView:cell];
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/AlertResultConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/AlertResultConfiguration.swift
@@ -33,7 +33,7 @@ extension AlertResultConfiguration {
 extension ConversationActionController {
     
     func request<T: AlertResultConfiguration>(_ result: T.Type, handler: @escaping (T) -> Void) {
-        target.present(result.controller(handler), animated: true)
+        present(result.controller(handler))
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationAction.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationAction.swift
@@ -33,7 +33,7 @@ extension ZMConversation {
     
     var actions: [Action] {
         switch conversationType {
-        case .connection: return availableOneToOneActions()
+        case .connection: return availablePendingActions()
         case .oneOnOne: return availableOneToOneActions()
         default: return availableGroupActions()
         }

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+Block.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+Block.swift
@@ -57,7 +57,7 @@ extension ConversationActionController {
         guard let user = conversation.connectedUser else { return }
         let controller = UIAlertController(title: BlockResult.title(for: user), message: nil, preferredStyle: .actionSheet)
         BlockResult.all(isBlocked: user.isBlocked).map { $0.action(handler) }.forEach(controller.addAction)
-        target.present(controller, animated: true)
+        present(controller)
     }
     
     func handleBlockResult(_ result: BlockResult, for conversation: ZMConversation) {
@@ -68,4 +68,3 @@ extension ConversationActionController {
     }
     
 }
-

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+CancelRequest.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+CancelRequest.swift
@@ -69,15 +69,14 @@ extension ConversationActionController {
     
     func requestCancelConnectionRequestResult(for user: ZMUser, handler: @escaping (CancelConnectionRequestResult) -> Void) {
         let controller = CancelConnectionRequestResult.controller(for: user, handler: handler)
-        target.present(controller, animated: true)
+        present(controller)
     }
     
     func handleConnectionRequestResult(_ result: CancelConnectionRequestResult, for conversation: ZMConversation) {
         guard case .cancelRequest = result else { return }
-        dismissAndEnqueue {
+        enqueue {
             conversation.connectedUser?.cancelConnectionRequest()
         }
     }
     
 }
-

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/UIAlertController+ConversationDegraded.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/UIAlertController+ConversationDegraded.swift
@@ -30,10 +30,11 @@ extension UIAlertController {
         let title = "meta.degraded.degradation_reason_message.\(keySuffix)".localized(args: names)
         let message = "meta.degraded.dialog_message".localized
         
+        let iPad = ZClientViewController.shared()?.traitCollection.userInterfaceIdiom == .pad
         let controller = UIAlertController(
             title: title + "\n" + message,
             message: nil,
-            preferredStyle: .actionSheet
+            preferredStyle: iPad ? .alert : .actionSheet
         )
         let acceptAction = UIAlertAction(
             title: "meta.degraded.show_device_button".localized.localizedCapitalized,

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
@@ -153,7 +153,7 @@ class GroupDetailsViewController: UIViewController, ZMConversationObserver, Grou
             present(navigationController, animated: true)
         case .more:
             actionController = ConversationActionController(conversation: conversation, target: self)
-            actionController?.presentMenu()
+            actionController?.presentMenu(from: view)
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileDetailsViewController.m
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileDetailsViewController.m
@@ -421,7 +421,7 @@ typedef NS_ENUM(NSUInteger, ProfileUserAction) {
 - (void)presentMenuSheetController
 {
     self.actionsController = [[ConversationActionController alloc] initWithConversation:self.conversation target:self];
-    [self.actionsController presentMenu];
+    [self.actionsController presentMenuFromSourceView:self.footerView];
 }
 
 - (void)presentAddParticipantsViewController
@@ -472,6 +472,9 @@ typedef NS_ENUM(NSUInteger, ProfileUserAction) {
             [self cancelConnectionRequest];
         }
     }];
+    
+    controller.popoverPresentationController.sourceView = self.view;
+    controller.popoverPresentationController.sourceRect = [self.view convertRect:self.footerView.frame fromView:self.footerView.superview];
     [self presentViewController:controller animated:YES completion:nil];
 }
 
@@ -482,6 +485,7 @@ typedef NS_ENUM(NSUInteger, ProfileUserAction) {
             [self cancelConnectionRequest];
         }
     }];
+
     [self presentViewController:controller animated:YES completion:nil];
 }
 


### PR DESCRIPTION
## What's new in this PR?

* Present conversation degraded overlay as regular alert on iPad.
* Fix crash for action sheet shown for connections (the wrong method was called)
* Update `ConversationActionController` to work with iPad popovers.
* Fix action execution after selection on iPad (leave / archive etc.).
* Fix "show devices" view controller presentation after a conversation degraded (it was impossible to dismiss the presented devices list controller in some cases).