### PR TITLE
ZIOS-9751 fix/crash when calling cellForRow

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
@@ -222,10 +222,13 @@ extension ConversationContentViewController {
     
     func scroll(toIndex indexToShow: Int, completion: ((ConversationCell)->())? = .none) {
         let cellIndexPath = IndexPath(row: indexToShow, section: 0)
-        self.tableView.scrollToRow(at: cellIndexPath, at: .middle, animated: false)
-        
-        delay(0.1) {
-            completion?(self.tableView.cellForRow(at: cellIndexPath) as! ConversationCell)
-        }
+
+        UIView.animate(withDuration: 0.0, animations: {
+            self.tableView.scrollToRow(at: cellIndexPath, at: .middle, animated: false)
+        }, completion: { (didComplete) in
+            if let cell = self.tableView.cellForRow(at: cellIndexPath) {
+                completion?(cell as! ConversationCell)
+            }
+        })
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
@@ -223,12 +223,9 @@ extension ConversationContentViewController {
     func scroll(toIndex indexToShow: Int, completion: ((ConversationCell)->())? = .none) {
         let cellIndexPath = IndexPath(row: indexToShow, section: 0)
 
-        UIView.animate(withDuration: 0.0, animations: {
-            self.tableView.scrollToRow(at: cellIndexPath, at: .middle, animated: false)
-        }, completion: { (didComplete) in
-            if let cell = self.tableView.cellForRow(at: cellIndexPath) {
-                completion?(cell as! ConversationCell)
-            }
-        })
+        self.tableView.scrollToRow(at: cellIndexPath, at: .middle, animated: false)
+        if let cell = self.tableView.cellForRow(at: cellIndexPath) as? ConversationCell {
+            completion?(cell)
+        }
     }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

App crashes sometimes with calling cellForRow after scrollToRow is called.

### Causes

UITableView.cellForRow returns nil if cell is not visible or index path is out of range. Delay for 0.1 sec does not promise that the cell is visible after scrolling without animation.

### Solutions

Unwrap cell before calling completion closure.
Call scrollToRow inside a UIView.animate's closure with duration = 0.0
Call completion closure in UIView.animate's completion closure, instead of hard code delay.

