### PR TITLE
ZIOS-9650: Fix 3D Touch preview margins

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationPreviewViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationPreviewViewController.swift
@@ -51,7 +51,7 @@ import Cartography
 
     func createConstraints() {
         constrain(view, contentViewController.view) { view, conversationView in
-            conversationView.edges == inset(view.edges, 0, 16)
+            conversationView.edges == view.edges
         }
     }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

When previewing a conversation in the list UI, the top of the 3D touch view cuts off the conversation.

### Solutions

This is fixed by removing unwanted constraint insets at the top of the conversation view.