### PR TITLE
ZIOS-9775: Update the color of the input field when theme changes

### DIFF
--- a/Wire-iOS Tests/MarkdownTextViewTests.swift
+++ b/Wire-iOS Tests/MarkdownTextViewTests.swift
@@ -207,6 +207,24 @@ final class MarkdownTextViewTests: XCTestCase {
         // THEN: it renders correct attributes
         checkAttributes(for: Markdown(md), inRange: NSMakeRange(0, text.length))
     }
+
+    func testThatItUpdatesTextColor() {
+        // GIVEN: we're currently using the default color
+        sut.updateTextColor(base: nil)
+        insertText("Hieeee")
+
+        // WHEN: we update the colors
+        sut.updateTextColor(base: .red)
+
+        // THEN: the color of the text changes in the attributes
+        var attributedRange: NSRange = NSMakeRange(0, 0)
+        let attributedColor = sut.attributedText.attribute(NSForegroundColorAttributeName, at: 0, effectiveRange: &attributedRange) as? UIColor
+        XCTAssertEqual(attributedColor, .red)
+        XCTAssertEqual(attributedRange, NSMakeRange(0, 6))
+
+        XCTAssertEqual(style.baseFontColor, .red)
+        XCTAssertEqual(sut.textColor, .red)
+    }
     
     // MARK: Atomic ☺️
     

--- a/Wire-iOS/Resources/Classy/stylesheet.cas
+++ b/Wire-iOS/Resources/Classy/stylesheet.cas
@@ -743,11 +743,11 @@ InputBar: {
     writingSeparatorColor: $color-separator;
     ephemeralColor: $color-accent-current;
     placeholderColor: $color-text-placeholder;
+    textColor: $color-text-foreground;
 
     textView: @{
         font: $font-normal-light;
         placeholderFont: $font-small-semibold;
-        textColor: $color-text-foreground;
         backgroundColor: clear;
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Components/Views/MarkdownTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/MarkdownTextView.swift
@@ -115,8 +115,15 @@ class MarkdownTextView: NextResponderTextView {
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     // MARK: - Public Interface
+
+    /// Updates the color of the text.
+    func updateTextColor(base: UIColor?) {
+        let baseColor = base ?? ColorScheme.default().color(withName: ColorSchemeColorTextForeground)
+        self.textColor = baseColor
+        self.style.baseFontColor = baseColor
+    }
     
     /// Clears active markdown & updates typing attributes.
     func resetMarkdown() { activeMarkdown = .none }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
@@ -101,6 +101,7 @@ private struct InputBarConstants {
     public var writingSeparatorColor: UIColor?
     public var ephemeralColor: UIColor?
     public var placeholderColor: UIColor?
+    public var textColor: UIColor?
 
     fileprivate var rowTopInsetConstraint: NSLayoutConstraint? = nil
     
@@ -383,12 +384,14 @@ private struct InputBarConstants {
     }
     
     fileprivate func updateColors() {
+
         backgroundColor = backgroundColor(forInputBarState: inputBarState)
         buttonRowSeparator.backgroundColor = writingSeparatorColor
         textView.placeholderTextColor = self.inputBarState.isEphemeral && self.availabilityPlaceholder == nil ? ephemeralColor : placeholderColor
         fakeCursor.backgroundColor = .accent()
         textView.tintColor = .accent()
-        
+        textView.updateTextColor(base: textColor)
+
         var buttons = self.buttonsView.buttons
         
         buttons.append(self.buttonsView.expandRowButton)


### PR DESCRIPTION
## What's new in this PR?

### Issues

When the user would change the color theme of the app, the color of the text in the message text field would not change, and the text stayed invisible.

### Causes

This regression was caused by the introduction of the markdown view. This view uses its own style object to create the attributed text, and Classy didn't update that object when the theme changed.

### Solutions

This PR introduces a method that correctly updates the color of the text field when needed.