### PR TITLE
ZIOS-9753: Login issues - Landing screen displayed after unsuccessful login

### DIFF
--- a/Wire-iOS/Sources/AppState.swift
+++ b/Wire-iOS/Sources/AppState.swift
@@ -48,4 +48,18 @@ enum AppState : Equatable {
         }   
     }
     
+    public func isSameKindOf(_ error: AppState) -> Bool {
+        
+        switch (self, error) {
+        case (.headless, .headless),
+             (.authenticated, .authenticated),
+             (.unauthenticated, .unauthenticated),
+             (.blacklisted, .blacklisted),
+             (.migrating, .migrating),
+             (.loading, .loading):
+            return true
+        default:
+            return false
+        }
+    }
 }

--- a/Wire-iOS/Sources/AppStateController.swift
+++ b/Wire-iOS/Sources/AppStateController.swift
@@ -95,7 +95,7 @@ class AppStateController : NSObject {
             authenticationError = nil
         }
         
-        if newAppState != appState {
+        if !newAppState.isSameKindOf(appState) {
             zmLog.debug("transitioning to app state: \(newAppState)")
             appState = newAppState
             delegate?.appStateController(transitionedTo: appState) {


### PR DESCRIPTION
## What's new in this PR?

### Issues

This bug is happening on real devices only, since it has to do with push notifications registration. After logging into Wire with an account with too many devices registered, the system dialog for enabling Push Notifications is shown on screen. By tapping on "Allow" when you're on the view that informs you to remove a device ("Remove one of your other devices..."), the Landing view controller is shown.

### Causes

That's because after tapping on "Allow", the `didRegisteredForRemoteNotificationsWith` method of `SessionManager`  is called. This is causing the emission of a request for app state update, comparing the new value `.unauthenticated(error: nil)` with a previous one with a populated `error`.

### Solutions

I'm checking for equal app states, instead of comparing the two errors. @vytis please double check, I don't remember if that was the point for which we've overrided the `==` operator.