### PR TITLE
Disable call survey in public builds

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Overlay/ActiveVoiceChannelViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/ActiveVoiceChannelViewController.swift
@@ -180,6 +180,9 @@ extension ActiveVoiceChannelViewController : WireCallCenterCallStateObserver {
 
         let changeDate = Date()
 
+        // Only show the survey in internal builds (review required)
+        guard DeveloperMenuState.developerMenuEnabled() else { return }
+
         guard !Analytics.shared().isOptedOut,
             !TrackingManager.shared.disableCrashAndAnalyticsSharing else {
                 return


### PR DESCRIPTION
## What's new in this PR?

Only show the survey in internal builds until the review has completed.