### PR TITLE
Fix/zios 9466 sign in view controller crash

### DIFF
--- a/Wire-iOS Tests/SignInViewControllerTests.swift
+++ b/Wire-iOS Tests/SignInViewControllerTests.swift
@@ -36,16 +36,15 @@ final class SignInViewControllerTests: XCTestCase {
 
     func testThatTheAppWouldNotCrashAfterSignInByPhone(){
         // GIVEN
-        /// remove emailSignInViewControllerContainer
-//        sut.presentedSignInViewController = sut.phoneSignInViewControllerContainer
-//        sut.present(sut.emailSignInViewControllerContainer)
+        ///TODO: test for case !hasAddedEmailAddress, hasAddedPhoneNumber
 
-        ///crash if emailSignInViewControllerContainer is removed
-        sut.phoneSignInViewControllerContainer.removeFromParentViewController()
+        sut.presentedSignInViewController = sut.emailSignInViewControllerContainer
+        sut.present(sut.phoneSignInViewController)
 
         // WHEN
         sut.signInByPhone(nil)
 
         // THEN
+        XCTAssertTrue(true)
     }
 }

--- a/Wire-iOS Tests/SignInViewControllerTests.swift
+++ b/Wire-iOS Tests/SignInViewControllerTests.swift
@@ -1,0 +1,48 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+@testable import Wire
+
+final class SignInViewControllerTests: XCTestCase {
+    
+    var sut: SignInViewController!
+    
+    override func setUp() {
+        super.setUp()
+        sut = SignInViewController()
+        sut.viewDidLoad()
+    }
+    
+    override func tearDown() {
+        sut = nil
+        super.tearDown()
+    }
+
+    func testExample(){
+        // GIVEN
+
+        // WHEN
+        sut.emailSignInViewControllerContainer.removeFromParentViewController()
+        sut.phoneSignInViewControllerContainer.removeFromParentViewController()
+
+        sut.signInByPhone(nil)
+
+        // THEN
+    }
+}

--- a/Wire-iOS Tests/SignInViewControllerTests.swift
+++ b/Wire-iOS Tests/SignInViewControllerTests.swift
@@ -34,13 +34,16 @@ final class SignInViewControllerTests: XCTestCase {
         super.tearDown()
     }
 
-    func testExample(){
+    func testThatTheAppWouldNotCrashAfterSignInByPhone(){
         // GIVEN
+        /// remove emailSignInViewControllerContainer
+//        sut.presentedSignInViewController = sut.phoneSignInViewControllerContainer
+//        sut.present(sut.emailSignInViewControllerContainer)
 
-        // WHEN
-        sut.emailSignInViewControllerContainer.removeFromParentViewController()
+        ///crash if emailSignInViewControllerContainer is removed
         sut.phoneSignInViewControllerContainer.removeFromParentViewController()
 
+        // WHEN
         sut.signInByPhone(nil)
 
         // THEN

--- a/Wire-iOS Tests/SignInViewControllerTests.swift
+++ b/Wire-iOS Tests/SignInViewControllerTests.swift
@@ -33,7 +33,7 @@ final class SignInViewControllerTests: XCTestCase {
         super.tearDown()
     }
 
-    func testThatTheAppWouldNotCrashAfterSignInByPhone(){
+    func testThatSignInViewControllerCanHandleTheCaseWithLoginCredentialsHasNilEmailButPhoneNumber(){
         // GIVEN
         ///TODO: test for case !hasAddedEmailAddress, hasAddedPhoneNumber
         let credentials = LoginCredentials(emailAddress: nil, phoneNumber: "fake number", password: nil)
@@ -44,6 +44,6 @@ final class SignInViewControllerTests: XCTestCase {
         sut.signInByPhone(nil)
 
         // THEN
-        XCTAssertTrue(true)
+        XCTAssertEqual(sut.presentedSignInViewController, sut.phoneSignInViewControllerContainer)
     }
 }

--- a/Wire-iOS Tests/SignInViewControllerTests.swift
+++ b/Wire-iOS Tests/SignInViewControllerTests.swift
@@ -35,7 +35,6 @@ final class SignInViewControllerTests: XCTestCase {
 
     func testThatSignInViewControllerCanHandleTheCaseWithLoginCredentialsHasNilEmailButPhoneNumber(){
         // GIVEN
-        ///TODO: test for case !hasAddedEmailAddress, hasAddedPhoneNumber
         let credentials = LoginCredentials(emailAddress: nil, phoneNumber: "fake number", password: nil)
         sut.loginCredentials = credentials
         sut.viewDidLoad()

--- a/Wire-iOS Tests/SignInViewControllerTests.swift
+++ b/Wire-iOS Tests/SignInViewControllerTests.swift
@@ -26,7 +26,6 @@ final class SignInViewControllerTests: XCTestCase {
     override func setUp() {
         super.setUp()
         sut = SignInViewController()
-        sut.viewDidLoad()
     }
     
     override func tearDown() {
@@ -37,9 +36,9 @@ final class SignInViewControllerTests: XCTestCase {
     func testThatTheAppWouldNotCrashAfterSignInByPhone(){
         // GIVEN
         ///TODO: test for case !hasAddedEmailAddress, hasAddedPhoneNumber
-
-        sut.presentedSignInViewController = sut.emailSignInViewControllerContainer
-        sut.present(sut.phoneSignInViewController)
+        let credentials = LoginCredentials(emailAddress: nil, phoneNumber: "fake number", password: nil)
+        sut.loginCredentials = credentials
+        sut.viewDidLoad()
 
         // WHEN
         sut.signInByPhone(nil)

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1001,6 +1001,7 @@
 		EF159F381FD59607006E0A9C /* TextFieldValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF159F361FD59556006E0A9C /* TextFieldValidatorTests.swift */; };
 		EF18C7E41F9E4DA00085A832 /* NSString+FileNameForZMUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF18C7E31F9E4DA00085A832 /* NSString+FileNameForZMUser.swift */; };
 		EF1EA4631FB0937000B53063 /* MockUser+filename.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF1EA4611FB0934D00B53063 /* MockUser+filename.swift */; };
+		EF1EF1C320627075004DB245 /* SignInViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF1EF1C220627075004DB245 /* SignInViewControllerTests.swift */; };
 		EF1F99F71FBB06C000969DD1 /* UILabel+TextTransform.m in Sources */ = {isa = PBXBuildFile; fileRef = CE8E4FBA1DF17BBE0009F437 /* UILabel+TextTransform.m */; };
 		EF1F99F81FBB06D400969DD1 /* UILabel+TextTransform.h in Headers */ = {isa = PBXBuildFile; fileRef = CE8E4FB91DF17BBE0009F437 /* UILabel+TextTransform.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EF1F9A021FBB1FD800969DD1 /* LandingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF1F9A011FBB1FD800969DD1 /* LandingButton.swift */; };
@@ -2560,6 +2561,8 @@
 		EF159F361FD59556006E0A9C /* TextFieldValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldValidatorTests.swift; sourceTree = "<group>"; };
 		EF18C7E31F9E4DA00085A832 /* NSString+FileNameForZMUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSString+FileNameForZMUser.swift"; sourceTree = "<group>"; };
 		EF1EA4611FB0934D00B53063 /* MockUser+filename.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MockUser+filename.swift"; sourceTree = "<group>"; };
+		EF1EF1C220627075004DB245 /* SignInViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInViewControllerTests.swift; sourceTree = "<group>"; };
+		EF1EF1C420627305004DB245 /* SignInViewController+internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SignInViewController+internal.h"; sourceTree = "<group>"; };
 		EF1F9A011FBB1FD800969DD1 /* LandingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LandingButton.swift; sourceTree = "<group>"; };
 		EF2126B71FB9DFE300625A9B /* CheckmarkView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CheckmarkView.m; sourceTree = "<group>"; };
 		EF2126B81FB9DFE300625A9B /* RegistrationViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RegistrationViewController.m; sourceTree = "<group>"; };
@@ -5009,6 +5012,7 @@
 				5EE115E0204EEC7D002AD6C2 /* CallQualityControllerTests.swift */,
 				16C02A11204EE5EC00811912 /* GroupConversationCellTests.swift */,
 				FE996D9B2032039100BDE573 /* LandingViewControllerTests.swift */,
+				EF1EF1C220627075004DB245 /* SignInViewControllerTests.swift */,
 			);
 			path = "Wire-iOS Tests";
 			sourceTree = "<group>";
@@ -5314,12 +5318,13 @@
 		EF2126D51FB9DFE300625A9B /* SignIn */ = {
 			isa = PBXGroup;
 			children = (
+				EF2126DA1FB9DFE300625A9B /* SignInViewController.h */,
+				EF1EF1C420627305004DB245 /* SignInViewController+internal.h */,
 				EF2126D61FB9DFE300625A9B /* SignInViewController.m */,
 				D51735702017640D00B473CE /* UIAlertController+PasswordVerification.swift */,
 				EF2126D71FB9DFE300625A9B /* LoginCredentials.swift */,
 				EF2126D81FB9DFE300625A9B /* EmailSignInViewController.h */,
 				EF2126D91FB9DFE300625A9B /* PhoneSignInViewController.m */,
-				EF2126DA1FB9DFE300625A9B /* SignInViewController.h */,
 				EF2126DB1FB9DFE300625A9B /* PhoneSignInViewController.h */,
 				EF2126DC1FB9DFE300625A9B /* EmailSignInViewController.m */,
 			);
@@ -7022,6 +7027,7 @@
 				DBB45F3B1B53F8DE0010053C /* NSString+MentionsTests.m in Sources */,
 				8740205C1BF4CF7E001F2D4C /* AVSStub.m in Sources */,
 				87FC0AEB1FC71C020036E029 /* CharacterInputFieldTests.swift in Sources */,
+				EF1EF1C320627075004DB245 /* SignInViewControllerTests.swift in Sources */,
 				7C23A26D20247500005FEB54 /* ShareViewControllerTests.swift in Sources */,
 				AF1D126B1C7CF02A00959DF5 /* ParticipantDeviceCellTests.m in Sources */,
 				87D553681C86F0450026573C /* MockUserClient.m in Sources */,

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/SignIn/SignInViewController+internal.h
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/SignIn/SignInViewController+internal.h
@@ -1,0 +1,29 @@
+////
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+#import "SignInViewController.h"
+
+@interface SignInViewController ()
+
+@property (nonatomic) UIViewController *emailSignInViewControllerContainer;
+@property (nonatomic) UIViewController *phoneSignInViewControllerContainer;
+
+- (void)signInByPhone:(id)sender;
+- (void)signInByEmail:(id)sender;
+- (void)presentEmailSignInViewControllerToEnterPassword;
+@end

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/SignIn/SignInViewController+internal.h
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/SignIn/SignInViewController+internal.h
@@ -17,7 +17,6 @@
 //
 
 #import "SignInViewController.h"
-//@class PhoneSignInViewController;
 #import "PhoneSignInViewController.h"
 
 @interface SignInViewController ()

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/SignIn/SignInViewController+internal.h
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/SignIn/SignInViewController+internal.h
@@ -22,8 +22,10 @@
 
 @property (nonatomic) UIViewController *emailSignInViewControllerContainer;
 @property (nonatomic) UIViewController *phoneSignInViewControllerContainer;
+@property (nonatomic) UIViewController *presentedSignInViewController;
 
 - (void)signInByPhone:(id)sender;
 - (void)signInByEmail:(id)sender;
 - (void)presentEmailSignInViewControllerToEnterPassword;
+- (void)presentSignInViewController:(UIViewController *)viewController;
 @end

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/SignIn/SignInViewController+internal.h
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/SignIn/SignInViewController+internal.h
@@ -17,12 +17,17 @@
 //
 
 #import "SignInViewController.h"
+//@class PhoneSignInViewController;
+#import "PhoneSignInViewController.h"
 
 @interface SignInViewController ()
 
 @property (nonatomic) UIViewController *emailSignInViewControllerContainer;
 @property (nonatomic) UIViewController *phoneSignInViewControllerContainer;
+
 @property (nonatomic) UIViewController *presentedSignInViewController;
+
+@property (nonatomic) PhoneSignInViewController *phoneSignInViewController;
 
 - (void)signInByPhone:(id)sender;
 - (void)signInByEmail:(id)sender;

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/SignIn/SignInViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/SignIn/SignInViewController.m
@@ -36,7 +36,6 @@
 
 @property (nonatomic) PhoneSignInViewController *phoneSignInViewController;
 @property (nonatomic) EmailSignInViewController *emailSignInViewController;
-@property (nonatomic) UIViewController *presentedSignInViewController;
 @property (nonatomic) UIView *viewControllerContainer;
 @property (nonatomic) UIView *buttonContainer;
 @property (nonatomic) Button *emailSignInButton;

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/SignIn/SignInViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/SignIn/SignInViewController.m
@@ -97,7 +97,7 @@
     if (hasAddedEmailAddress || ! hasAddedPhoneNumber) {
         [self presentSignInViewController:self.emailSignInViewControllerContainer];
     } else {
-        [self presentSignInViewController:self.phoneSignInViewController];
+        [self presentSignInViewController:self.phoneSignInViewControllerContainer];
     }
     
     self.view.opaque = NO;
@@ -188,11 +188,6 @@
     toViewController.view.translatesAutoresizingMaskIntoConstraints = YES;
     toViewController.view.frame = fromViewController.view.frame;
     [toViewController.view layoutIfNeeded];
-
-    ///TODO: check parent VC at this point
-//    if (fromViewController.parentViewController != toViewController.parentViewController) {
-//        return;
-//    }
 
     [self transitionFromViewController:fromViewController
                       toViewController:toViewController

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/SignIn/SignInViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/SignIn/SignInViewController.m
@@ -18,6 +18,7 @@
 
 
 #import "SignInViewController.h"
+#import "SignInViewController+internal.h"
 
 @import PureLayout;
 
@@ -34,7 +35,6 @@
 
 @interface SignInViewController () <PhoneSignInViewControllerDelegate>
 
-@property (nonatomic) PhoneSignInViewController *phoneSignInViewController;
 @property (nonatomic) EmailSignInViewController *emailSignInViewController;
 @property (nonatomic) UIView *viewControllerContainer;
 @property (nonatomic) UIView *buttonContainer;

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/SignIn/SignInViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/SignIn/SignInViewController.m
@@ -37,8 +37,6 @@
 @property (nonatomic) PhoneSignInViewController *phoneSignInViewController;
 @property (nonatomic) EmailSignInViewController *emailSignInViewController;
 @property (nonatomic) UIViewController *presentedSignInViewController;
-@property (nonatomic) UIViewController *emailSignInViewControllerContainer;
-@property (nonatomic) UIViewController *phoneSignInViewControllerContainer;
 @property (nonatomic) UIView *viewControllerContainer;
 @property (nonatomic) UIView *buttonContainer;
 @property (nonatomic) Button *emailSignInButton;
@@ -187,11 +185,16 @@
     
     [fromViewController willMoveToParentViewController:nil];
     [self addChildViewController:toViewController];
-    
+
     toViewController.view.translatesAutoresizingMaskIntoConstraints = YES;
     toViewController.view.frame = fromViewController.view.frame;
     [toViewController.view layoutIfNeeded];
-    
+
+    ///TODO: check parent VC at this point
+//    if (fromViewController.parentViewController != toViewController.parentViewController) {
+//        return;
+//    }
+
     [self transitionFromViewController:fromViewController
                       toViewController:toViewController
                               duration:0.35 options:UIViewAnimationOptionTransitionCrossDissolve

--- a/Wire-iOS/WireBridgingHeader.h
+++ b/Wire-iOS/WireBridgingHeader.h
@@ -82,6 +82,7 @@
 #import "FormFlowViewController.h"
 #import "RegistrationStepViewController.h"
 #import "SignInViewController.h"
+#import "SignInViewController+internal.h"
 #import "NavigationController.h"
 #import "ConversationInputBarViewController.h"
 #import "ConversationInputBarViewController+Files.h"

--- a/Wire-iOS/WireBridgingHeader.h
+++ b/Wire-iOS/WireBridgingHeader.h
@@ -116,6 +116,7 @@
 #import "StartUIViewController.h"
 #import "Button.h"
 #import "ViewControllerDismissable.h"
+#import "PhoneSignInViewController.h"
 
 // Helper objects
 #import "PushTransition.h"


### PR DESCRIPTION
## What's new in this PR?

### Issues

App crashes when calling [SignInViewController swapFromViewController:toViewController:] 

### Causes

In viewDidLoad, invalid phoneSignInViewController is added to view hierarchy. When calling transitionFromViewController with phoneSignInViewControllerContainer and emailSignInViewControllerContainer, it crashes since phoneSignInViewControllerContainer is not in the 
view hierarchy.

## Notes

Test is added for the case LoginCredentials with no email but phone number, to simulate the case would cause the crash.