### PR TITLE
Fix transition to landing page on during login

### DIFF
--- a/Wire-iOS/Sources/AppStateController.swift
+++ b/Wire-iOS/Sources/AppStateController.swift
@@ -91,7 +91,11 @@ class AppStateController : NSObject {
     func updateAppState(completion: (() -> Void)? = nil) {
         let newAppState = calculateAppState()
         
-        if newAppState != .unauthenticated(error: nil) {
+        switch newAppState {
+        case .unauthenticated:
+            break;
+        default:
+            // only clear the error when transitioning out of the unauthenticated state
             authenticationError = nil
         }
         


### PR DESCRIPTION
## What's new in this PR?

### Issues

This PR replaces: https://github.com/wireapp/wire-ios/pull/1889

There was an issue where the app would transition to the landing page if the application did become inactive/active while being in the unauthenticated state.

### Causes

The `authenticatedError` would get cleared on all state changes except when transitioning to the `unauthenticated(error: nil)`. 

The intent of: https://github.com/wireapp/wire-ios/blob/a2a4e34347d5a4da53e137f938790377c41dd1a9/Wire-iOS/Sources/AppStateController.swift#L94 was however to only clear the error when transitioning out of the `unauthenticated`. That behaviour changed when the `==` operator for the AppState started taking associated values into account.

### Solutions

Restore intended behaviour by comparing using a switch statement.