### PR TITLE
ZIOS-4187: Show alert when permission is required to save image

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -431,9 +431,9 @@
 "inbox.connection_request.ignore_button_title" = "Ignore";
 
 // Save image errors
-"library.alert.permission_warning.title" = "Could not save image";
-"library.alert.permission_warning.restrictions.explaination" = "Wire cannot write in your library because restrictions are enabled.";
-"library.alert.permission_warning.not_allowed.explaination" = "Wire needs access to your Photo Library to save images. Go to Settings to allow Wire to access it.";
+"library.alert.permission_warning.title" = "Wire needs access to your Photos";
+"library.alert.permission_warning.restrictions.explaination" = "Wire cannot access your library because restrictions are enabled.";
+"library.alert.permission_warning.not_allowed.explaination" = "Go to Settings and allow Wire to access your photos.";
 
 // Voice
 "voice.status.one_to_one.incoming" = "%@\nCalling";

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -430,6 +430,11 @@
 "inbox.connection_request.connect_button_title" = "Connect";
 "inbox.connection_request.ignore_button_title" = "Ignore";
 
+// Save image errors
+"library.alert.permission_warning.title" = "Could not save image";
+"library.alert.permission_warning.restrictions.explaination" = "Wire cannot write in your library because restrictions are enabled.";
+"library.alert.permission_warning.not_allowed.explaination" = "Wire needs access to your Photo Library to save images. Go to Settings to allow Wire to access it.";
+
 // Voice
 "voice.status.one_to_one.incoming" = "%@\nCalling";
 "voice.status.group_call.incoming" = "%@\nRinging";

--- a/Wire-iOS/Sources/Helpers/UIApplication+Permissions.h
+++ b/Wire-iOS/Sources/Helpers/UIApplication+Permissions.h
@@ -26,5 +26,6 @@ extern NSString * const UserGrantedAudioPermissionsNotification;
 + (void)wr_requestOrWarnAboutMicrophoneAccess:(void(^)(BOOL granted))grantedHandler;
 + (void)wr_requestOrWarnAboutVideoAccess:(void(^)(BOOL granted))grantedHandler;
 + (void)wr_requestVideoAccess:(void(^)(BOOL granted))grantedHandler;
++ (void)wr_requestOrWarnAboutPhotoLibraryAccess:(void(^)(BOOL granted))grantedHandler;
 
 @end

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionImageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionImageCell.swift
@@ -161,7 +161,7 @@ final public class CollectionImageCell: CollectionCell {
         }
         
         saveableImage = SavableImage(data: imageData, orientation: orientation)
-        saveableImage?.saveToLibrary(withCompletion: { [weak self] in
+        saveableImage?.saveToLibrary(withCompletion: { [weak self] _ in
             self?.saveableImage = nil
         })
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -534,8 +534,8 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
         [savableImage saveToLibraryWithCompletion:nil];
     }
     else {
-        [cell.savableImage saveToLibraryWithCompletion:^{
-            if (nil != self.view.window) {
+        [cell.savableImage saveToLibraryWithCompletion:^(BOOL success) {
+            if (nil != self.view.window && success == YES) {
                 UIView *snapshot = [cell.fullImageView snapshotViewAfterScreenUpdates:YES];
                 snapshot.translatesAutoresizingMaskIntoConstraints = YES;
                 CGRect sourceRect = [self.view convertRect:cell.fullImageView.frame fromView:cell.fullImageView.superview];

--- a/Wire-iOS/Sources/UserInterface/Helpers/UIAlertController+Wire.m
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UIAlertController+Wire.m
@@ -32,7 +32,7 @@
                                  preferredStyle:UIAlertControllerStyleAlert];
     
     UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:cancelTitle
-                                                           style:UIAlertActionStyleDefault
+                                                           style:UIAlertActionStyleCancel
                                                          handler:nil];
     
     [alertController addAction:cancelAction];


### PR DESCRIPTION
## What's new in this PR?

### Issues

Permission/failure errors were not checked when saving images to the photo library from a conversation. The save animation would always run, even when the image was not actually saved to the library.

### Solutions

Before saving the image, we request permission if needed, and show an alert if saving the image fails. If permission was denied, we offer a button in the alert for the user to open the settings and change the authorization.