### PR TITLE
Show "unlock with touch ID" system dialog when user tapped cancel button, put the app to background, then open the app again

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
@@ -159,7 +159,9 @@ extension AppLockViewController {
         if !self.localAuthenticationNeeded {
             AppLock.lastUnlockedDate = Date()
         }
-        
+
+        self.localAuthenticationCancelled = false
+
         self.localAuthenticationNeeded = true
         if AppLock.isActive {
             self.dimContents = true


### PR DESCRIPTION
## What's new in this PR?

### Issues

When user taps cancel of "unlock with touch ID" system dialog, then put the app into background, the next time the user switches back to Wire app, the "unlock with touch ID" system dialog does not appear without tapping the "Unlock" button.

### Causes

The flag localAuthenticationCancelled is not reset to its initial value when the app goes to background.  It prevents calling requireLocalAuthenticationIfNeeded when the app becomes active.

### Solutions

set the flag localAuthenticationCancelled to false when the app goes to background.

