### PR TITLE
ZIOS-9758: Changed title of the first step in ConversationCreationController

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -243,6 +243,7 @@
 "conversation.input_bar.message_too_long.title" = "Message too long";
 "conversation.input_bar.message_too_long.message" = "You can send messages up to %d characters long.";
 
+"conversation.create.group_name.title" = "Group name";
 "conversation.create.group_name.placeholder" = "Group name";
 "conversation.create.guidance.empty" = "At least 1 character";
 "conversation.create.guidance.toolong" = "Too many characters";

--- a/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
@@ -113,7 +113,7 @@ final class ConversationCreationController: UIViewController {
         Analytics.shared().tagLinearGroupOpened(with: self.source)
 
         view.backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorContentBackground, variant: colorSchemeVariant)
-        title = "profile.create_conversation_button_title".localized.uppercased()
+        title = "conversation.create.group_name.title".localized.uppercased()
         
         setupNavigationBar()
         createViews()


### PR DESCRIPTION
## What's new in this PR?

Changed title of the first step in ConversationCreationController to "Group name". I duplicated the string because the title of the view and the placeholder of the textfield may not coincide in the future, since they're placed in two different controls.