### PR TITLE
Fix: [iPad]Portrait split mode - conversation list view not dismiss after another app added to screen

### DIFF
--- a/Wire-iOS Tests/SplitViewControllerTests.swift
+++ b/Wire-iOS Tests/SplitViewControllerTests.swift
@@ -1,0 +1,72 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+@testable import Wire
+
+final class SplitViewControllerTests: XCTestCase {
+    
+    var sut: SplitViewController!
+    var mockParentViewController: UIViewController!
+
+    // simulate iPad Pro 12.9 inch portrait mode
+    let iPadHeight: CGFloat = 1024
+    let iPadWidth: CGFloat = 1366
+
+    override func setUp() {
+        super.setUp()
+
+        sut = SplitViewController()
+        sut.view.frame = CGRect(origin: .zero, size: CGSize(width: iPadWidth, height: iPadHeight))
+        sut.viewDidLoad()
+
+        mockParentViewController = UIViewController()
+        mockParentViewController.addToSelf(sut)
+
+    }
+    
+    override func tearDown() {
+        sut = nil
+        mockParentViewController = nil
+        super.tearDown()
+    }
+
+    func testThatWhenSwitchFromRegularModeToCompactModeChildViewsUpdatesTheirSize(){
+        // GIVEN
+        let regularTraitCollection = UITraitCollection(horizontalSizeClass: .regular)
+        mockParentViewController.setOverrideTraitCollection(regularTraitCollection, forChildViewController: sut)
+        sut.view.layoutIfNeeded()
+
+        let leftViewWidth = sut.leftView.frame.width
+
+        // check the value match the hard code value in SplitViewController
+        XCTAssertEqual(leftViewWidth, 336)
+        XCTAssertEqual(sut.rightView.frame.width, iPadWidth - leftViewWidth)
+
+        // WHEN
+        let compactWidth = round(iPadWidth / 3)
+        sut.view.frame = CGRect(origin: .zero, size: CGSize(width: compactWidth, height: iPadHeight))
+        let compactTraitCollection = UITraitCollection(horizontalSizeClass: .compact)
+        mockParentViewController.setOverrideTraitCollection(compactTraitCollection, forChildViewController: sut)
+        sut.view.layoutIfNeeded()
+
+        // THEN
+        XCTAssertEqual(sut.leftView.frame.width, compactWidth)
+        XCTAssertEqual(sut.rightView.frame.width, compactWidth)
+    }
+}

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1053,6 +1053,7 @@
 		EF40005720568C4400E03347 /* NetworkStatusBarConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF40005620568C4400E03347 /* NetworkStatusBarConstants.swift */; };
 		EF4018BE205975C100CFBCB0 /* ApplicationProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF4018BD205975C100CFBCB0 /* ApplicationProtocol.swift */; };
 		EF4018C02059761D00CFBCB0 /* MockApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF4018BF2059761D00CFBCB0 /* MockApplication.swift */; };
+		EF60FC412064FD400017D083 /* SplitViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF60FC402064FD400017D083 /* SplitViewControllerTests.swift */; };
 		EF6163A51FE9583400C6F5A9 /* Message+dayFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF6163A41FE9583400C6F5A9 /* Message+dayFormatter.swift */; };
 		EF6163A61FE9682700C6F5A9 /* TextMessageCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF8EE5591D636F4600B0D6D7 /* TextMessageCellTests.swift */; };
 		EF7CCAFD204E96390050325B /* MockUser+PointOfView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF7CCAFC204E96390050325B /* MockUser+PointOfView.swift */; };
@@ -2649,6 +2650,8 @@
 		EF4018BD205975C100CFBCB0 /* ApplicationProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationProtocol.swift; sourceTree = "<group>"; };
 		EF4018BF2059761D00CFBCB0 /* MockApplication.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockApplication.swift; sourceTree = "<group>"; };
 		EF538FE02028AB6600EA4048 /* ProfileViewController+internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ProfileViewController+internal.h"; sourceTree = "<group>"; };
+		EF60FC402064FD400017D083 /* SplitViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitViewControllerTests.swift; sourceTree = "<group>"; };
+		EF60FC4220652F9F0017D083 /* SplitViewController+internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SplitViewController+internal.h"; sourceTree = "<group>"; };
 		EF6163A41FE9583400C6F5A9 /* Message+dayFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Message+dayFormatter.swift"; sourceTree = "<group>"; };
 		EF61B33F1FC84B0100D8E631 /* AccessoryTextFieldValidationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccessoryTextFieldValidationTests.swift; sourceTree = "<group>"; };
 		EF61B3411FC8508400D8E631 /* TextFieldValidator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFieldValidator.swift; sourceTree = "<group>"; };
@@ -3482,6 +3485,7 @@
 				871BC1431D34F8F800DF0793 /* ImagePickerConfirmationController.m */,
 				871BC1441D34F8F800DF0793 /* RotationAwareNavigationController.swift */,
 				871BC1451D34F8F800DF0793 /* SplitViewController.h */,
+				EF60FC4220652F9F0017D083 /* SplitViewController+internal.h */,
 				871BC1461D34F8F800DF0793 /* SplitViewController.m */,
 				87A1F9DA200CEDCA0040E9A9 /* ClearBackgroundNavigationController.swift */,
 				1682AEC2204840E7003A052A /* SectionCollectionViewController.swift */,
@@ -5011,6 +5015,7 @@
 				16C02A11204EE5EC00811912 /* GroupConversationCellTests.swift */,
 				FE996D9B2032039100BDE573 /* LandingViewControllerTests.swift */,
 				EF1EF1C220627075004DB245 /* SignInViewControllerTests.swift */,
+				EF60FC402064FD400017D083 /* SplitViewControllerTests.swift */,
 			);
 			path = "Wire-iOS Tests";
 			sourceTree = "<group>";
@@ -7040,6 +7045,7 @@
 				16271BC81DA5213400689486 /* TypingIndicatorViewTests.swift in Sources */,
 				16EB9B3A1CE1DBB400883FCF /* VideoMessageCellTests.swift in Sources */,
 				BF16FC4F1DAFCE9300FF4325 /* MockConversationFactory.m in Sources */,
+				EF60FC412064FD400017D083 /* SplitViewControllerTests.swift in Sources */,
 				BFAD3A171CD0F14800F0FBED /* ConversationTitleViewTests.m in Sources */,
 				D59EA0C72024756B00B17CE7 /* MessagePreviewViewTests.swift in Sources */,
 				BF735D011E716816003BC61F /* CallSystemMessageTests.swift in Sources */,

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController+internal.h
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController+internal.h
@@ -1,0 +1,24 @@
+////
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+@interface SplitViewController ()
+
+@property (nonatomic) UIView *leftView;
+@property (nonatomic) UIView *rightView;
+
+@end

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.m
@@ -21,6 +21,7 @@
 
 
 #import "SplitViewController.h"
+#import "SplitViewController+internal.h"
 #import "CrossfadeTransition.h"
 #import "SwizzleTransition.h"
 #import "VerticalTransition.h"
@@ -152,9 +153,6 @@ NSString *SplitLayoutObservableDidChangeToLayoutSizeNotification = @"SplitLayout
 
 
 @interface SplitViewController () <UIGestureRecognizerDelegate>
-
-@property (nonatomic) UIView *leftView;
-@property (nonatomic) UIView *rightView;
 
 @property (nonatomic) NSLayoutConstraint *leftViewOffsetConstraint;
 @property (nonatomic) NSLayoutConstraint *rightViewOffsetConstraint;

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.m
@@ -263,7 +263,7 @@ NSString *SplitLayoutObservableDidChangeToLayoutSizeNotification = @"SplitLayout
     self.futureTraitCollection = nil;
 
     // update right view constraits after size changes
-    [self resetOpenPercentage];
+    [self updateRightAndLeftEdgoConstants: self.openPercentage];
 }
 
 - (void)updateLayoutSizeForTraitCollection:(UITraitCollection *)traitCollection size:(CGSize)size
@@ -565,6 +565,11 @@ NSString *SplitLayoutObservableDidChangeToLayoutSizeNotification = @"SplitLayout
 - (void)setOpenPercentage:(CGFloat)percentage
 {
     _openPercentage = percentage;
+    [self updateRightAndLeftEdgoConstants: percentage];
+}
+
+- (void)updateRightAndLeftEdgoConstants:(CGFloat)percentage
+{
     self.rightViewOffsetConstraint.constant = self.leftViewWidthConstraint.constant * percentage;
     self.leftViewOffsetConstraint.constant = 64.0f * (1.0f - percentage);
 }

--- a/Wire-iOS/WireBridgingHeader.h
+++ b/Wire-iOS/WireBridgingHeader.h
@@ -92,6 +92,7 @@
 #import "ConversationListViewModel+Private.h"
 #import "NotificationWindowRootViewController.h"
 #import "SplitViewController.h"
+#import "SplitViewController+internal.h"
 #import "ConfirmAssetViewController.h"
 #import "ProfileSelfPictureViewController.h"
 #import "AddEmailPasswordViewController.h"


### PR DESCRIPTION
## What's new in this PR?

This PR is follow up and bug fix of https://github.com/wireapp/wire-ios/pull/1903

### Issues

After the previous fix, swipe gesture to open list screen does not work.

### Causes

openPercentage is reset when viewWillLayoutSubview is called.

### Solutions

Instead of reset openPercentage after size change, only update leftViewOffsetConstraint.constant and rightViewOffsetConstraint.constant.

### Notes

a test will be written to cover "swipe to open list view" functionalities. 