### PR TITLE
ZIOS-9782: Replace the empty conversation placeholder

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/PlaceholderConversationViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/PlaceholderConversationViewController.swift
@@ -18,7 +18,27 @@
 
 
 import Foundation
+import Cartography
 
 @objc class PlaceholderConversationViewController : UIViewController {
+    
+    var shieldImageView: UIImageView!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        let image = WireStyleKit.imageOfShield(with: UIColor(rgb: 0xbac8d1, alpha: 0.24))
+        shieldImageView = UIImageView(image: image)
+        self.view.addSubview(shieldImageView)
+        
+        constrain(self.view, shieldImageView) {
+            selfView, shieldImageView in
+                shieldImageView.centerX == selfView.centerX
+            shieldImageView.centerY == selfView.centerY
+        }
+        
+    }
+    
+    
     
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/PlaceholderConversationViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/PlaceholderConversationViewController.swift
@@ -27,6 +27,8 @@ import Cartography
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        self.view.backgroundColor = ColorScheme.default().color(withName: ColorSchemeColorBackground)
+        
         let image = WireStyleKit.imageOfShield(with: UIColor(rgb: 0xbac8d1, alpha: 0.24))
         shieldImageView = UIImageView(image: image)
         self.view.addSubview(shieldImageView)
@@ -34,7 +36,7 @@ import Cartography
         constrain(self.view, shieldImageView) {
             selfView, shieldImageView in
                 shieldImageView.centerX == selfView.centerX
-            shieldImageView.centerY == selfView.centerY
+                shieldImageView.centerY == selfView.centerY
         }
         
     }

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
@@ -617,7 +617,6 @@
             // If there's no previously selected screen
             if (self.isConversationViewVisible) {
                 [self selectListItemWhenNoPreviousItemSelected];
-                [self loadPlaceholderConversationControllerAnimated:YES];
             }
             
             break;
@@ -664,6 +663,8 @@
     if (list.count > 0) {
         // select the first conversation and don't focus on it
         [self selectConversation:list[0]];
+    } else {
+        [self loadPlaceholderConversationControllerAnimated:YES];
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
@@ -617,6 +617,7 @@
             // If there's no previously selected screen
             if (self.isConversationViewVisible) {
                 [self selectListItemWhenNoPreviousItemSelected];
+                [self loadPlaceholderConversationControllerAnimated:YES];
             }
             
             break;


### PR DESCRIPTION
## What's new in this PR?

Implemented `PlaceholderConversationViewController`, which was actually empty. It contains the grey placeholder of the new shield, displayed when there are no conversations to show.