### PR TITLE
Fix - List UI turns black during transition to conversation view

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.m
@@ -174,11 +174,6 @@ NSString *SplitLayoutObservableDidChangeToLayoutSizeNotification = @"SplitLayout
 
 @implementation SplitViewController
 
-- (void)dealloc
-{
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
 - (void)viewDidLoad 
 {
     [super viewDidLoad];

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.m
@@ -197,8 +197,6 @@ NSString *SplitLayoutObservableDidChangeToLayoutSizeNotification = @"SplitLayout
     self.horizontalPanner = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(onHorizontalPan:)];
     self.horizontalPanner.delegate = self;
     [self.view addGestureRecognizer:self.horizontalPanner];
-
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(updateLayoutSizeAndLeftViewVisibility) name:UIApplicationDidChangeStatusBarFrameNotification object:nil];
 }
 
 - (void)viewWillLayoutSubviews
@@ -234,6 +232,12 @@ NSString *SplitLayoutObservableDidChangeToLayoutSizeNotification = @"SplitLayout
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
     
     [self updateForSize:size];
+
+    [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
+    } completion:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
+        [self updateLayoutSizeAndLeftViewVisibility];
+    }];
+
 }
 
 - (void)willTransitionToTraitCollection:(UITraitCollection *)newCollection withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.m
@@ -174,6 +174,11 @@ NSString *SplitLayoutObservableDidChangeToLayoutSizeNotification = @"SplitLayout
 
 @implementation SplitViewController
 
+- (void)dealloc
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
 - (void)viewDidLoad 
 {
     [super viewDidLoad];
@@ -197,6 +202,8 @@ NSString *SplitLayoutObservableDidChangeToLayoutSizeNotification = @"SplitLayout
     self.horizontalPanner = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(onHorizontalPan:)];
     self.horizontalPanner.delegate = self;
     [self.view addGestureRecognizer:self.horizontalPanner];
+
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(updateLayoutSizeAndLeftViewVisibility) name:UIApplicationDidChangeStatusBarFrameNotification object:nil];
 }
 
 - (void)viewWillLayoutSubviews
@@ -256,7 +263,6 @@ NSString *SplitLayoutObservableDidChangeToLayoutSizeNotification = @"SplitLayout
     
     [self updateConstraintsForSize:size];
     [self updateActiveConstraints];
-    [self updateLeftViewVisibility];
 
     self.futureTraitCollection = nil;
 
@@ -291,6 +297,12 @@ NSString *SplitLayoutObservableDidChangeToLayoutSizeNotification = @"SplitLayout
         self.leftViewWidthConstraint.constant = MIN(CGRound(size.width * 0.43), 336);
         self.rightViewWidthConstraint.constant = size.width - self.leftViewWidthConstraint.constant;
     }
+}
+
+- (void)updateLayoutSizeAndLeftViewVisibility
+{
+    [self updateLayoutSizeForTraitCollection:self.traitCollection size:self.view.bounds.size];
+    [self updateLeftViewVisibility];
 }
 
 - (void)updateLeftViewVisibility


### PR DESCRIPTION
## What's new in this PR?

### Issues

list ui turns black during the transition to conversation view

### Causes

The leftView was set to hidden immediately in the line:
self.leftView.hidden = self.openPercentage == 0;

### Solutions

Do not call updateLeftViewVisibility every time in updateForSize, which is called by viewWillLayoutSubviews.

for iPad, call updateLeftViewVisibility after orientation changes, to hide the left view when rotates to portrait mode, and shows the left view when rotates to landscape mode.
