### PR TITLE
ZIOS-9797: Fix audio player crash when making an outgoing call

### DIFF
--- a/Wire-iOS/Sources/Components/AudioPlayer/MediaPlayerController.swift
+++ b/Wire-iOS/Sources/Components/AudioPlayer/MediaPlayerController.swift
@@ -39,8 +39,8 @@ class MediaPlayerController: NSObject {
         self.playerRateObserver = KeyValueObserver.observe(player, keyPath: "rate", target: self, selector: #selector(playerRateChanged))
     }
 
-    deinit {
-        delegate?.mediaPlayer(self, didChangeTo: MediaPlayerState.completed)
+    func tearDown() {
+        self.delegate?.mediaPlayer(self, didChangeTo: .completed)
     }
 
 }

--- a/Wire-iOS/Sources/Managers/MediaPlaybackManager.m
+++ b/Wire-iOS/Sources/Managers/MediaPlaybackManager.m
@@ -177,8 +177,6 @@ NSString *const MediaPlaybackManagerPlayerStateChangedNotification = @"MediaPlay
 
 - (void)stopObservingMediaPlayerChanges:(id<MediaPlayer>)mediaPlayer
 {
-    // We need to remove the observer manually, because deallocating it does not remove it
-    [((NSObject *)mediaPlayer) removeObserver:self.titleObserver forKeyPath:@"title"];
     self.titleObserver = nil;
 }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/MessagePresenter.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/MessagePresenter.m
@@ -43,7 +43,7 @@
 
 - (void)viewWillDisappear:(BOOL)animated {
     [super viewWillDisappear:animated];
-    self.wr_playerController = nil;
+    [self.wr_playerController tearDown];
 }
 
 @end

--- a/WireExtensionComponents/Utilities/KeyValueObserver.m
+++ b/WireExtensionComponents/Utilities/KeyValueObserver.m
@@ -22,7 +22,7 @@
 
 
 @interface KeyValueObserver ()
-@property (nonatomic, retain) id observedObject;
+@property (nonatomic, weak) id observedObject;
 @property (nonatomic, copy) NSString* keyPath;
 @end
 
@@ -75,7 +75,6 @@
 - (void)dealloc;
 {
     [self.observedObject removeObserver:self forKeyPath:self.keyPath];
-    self.observedObject = nil;
 }
 
 @end

--- a/WireExtensionComponents/Utilities/KeyValueObserver.m
+++ b/WireExtensionComponents/Utilities/KeyValueObserver.m
@@ -22,7 +22,7 @@
 
 
 @interface KeyValueObserver ()
-@property (nonatomic, weak) id observedObject;
+@property (nonatomic, retain) id observedObject;
 @property (nonatomic, copy) NSString* keyPath;
 @end
 
@@ -75,6 +75,7 @@
 - (void)dealloc;
 {
     [self.observedObject removeObserver:self forKeyPath:self.keyPath];
+    self.observedObject = nil;
 }
 
 @end


### PR DESCRIPTION
## What's new in this PR?

### Issues

When making an audio call as an audio message is playing, the app crashes.

### Causes

This happens because the observer for `title` is removed twice.

The workaround that caused this issue was added because the observer was removed from inside the `deinit` of the object. As this causes the object to be removed from the `KeyValueObserver` before we can remove it, we needed to explicitly call `removeObserver`.

### Solutions

We fix this by tearing down the observer outside of `deinit`.