### PR TITLE
Profile: do not show shield for unconnected users

### DIFF
--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.m
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.m
@@ -227,6 +227,9 @@ typedef NS_ENUM(NSUInteger, ProfileViewControllerTabBarIndex) {
 
         self.profileTitleView.showVerifiedShield = showShield;
     }
+    else {
+        self.profileTitleView.showVerifiedShield = NO;
+    }
 }
 
 - (void)userDidChange:(UserChangeInfo *)note


### PR DESCRIPTION
- The case when user is not connected was not handled.
- No tests affected.