### PR TITLE
ZIOS-9771: enable opt-in and out analytics data

### DIFF
--- a/Wire-iOS/Sources/Analytics/AnalyticsMixpanelProvider.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsMixpanelProvider.swift
@@ -75,6 +75,7 @@ final class AnalyticsMixpanelProvider: NSObject, AnalyticsProvider {
         "settings.opted_in_tracking",
         "settings.opted_out_tracking",
         "settings.changed_status",
+        "settings.changed_value",
         "e2ee.failed_message_decyption",
         "start.opened_start_screen",
         "start.opened_person_registration",

--- a/Wire-iOS/Sources/Analytics/Events/Analytics+Settings.swift
+++ b/Wire-iOS/Sources/Analytics/Events/Analytics+Settings.swift
@@ -27,8 +27,7 @@ extension Analytics {
     
     internal func tagSettingsChanged(for propertyName: SettingsPropertyName, to value: SettingsPropertyValue) {
         guard let value = value.value(),
-              propertyName != SettingsPropertyName.lockAppLastDate &&
-                propertyName != SettingsPropertyName.disableCrashAndAnalyticsSharing else {
+              propertyName != SettingsPropertyName.lockAppLastDate else {
             return
         }
         let attributes = [settingsChangeEventPropertyName: propertyName,


### PR DESCRIPTION
## What's new in this PR?

Mixpanel was not tracking the opt-in and opt-out actions because:
- event was ignored in `Analytics+Settings`
- `settings.changed_value` event was not whitelisted