### PR TITLE
Feature/zios 9800 add a delay before network status bar shows sync bar

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/NetworkStatus/NetworkStatusView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/NetworkStatus/NetworkStatusView.swift
@@ -151,11 +151,7 @@ class NetworkStatusView: UIView {
 
     private lazy var topMargin = UIScreen.hasNotch ? CGFloat(0) : CGFloat.NetworkStatusBar.topMargin
 
-    public weak var delegate: NetworkStatusViewDelegate! {
-        didSet {
-            createConstraints()
-        }
-    }
+    public weak var delegate: NetworkStatusViewDelegate!
 
     var offlineViewTopMargin: NSLayoutConstraint?
     var offlineViewBottomMargin: NSLayoutConstraint?

--- a/Wire-iOS/Sources/UserInterface/Components/NetworkStatus/NetworkStatusView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/NetworkStatus/NetworkStatusView.swift
@@ -185,6 +185,8 @@ class NetworkStatusView: UIView {
         [offlineView, connectingView].forEach(addSubview)
 
         state = .online
+
+        createConstraints()
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/Wire-iOS/Sources/UserInterface/Components/NetworkStatus/NetworkStatusView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/NetworkStatus/NetworkStatusView.swift
@@ -139,7 +139,7 @@ class NetworkStatusView: UIView {
 
     private lazy var topMargin = UIScreen.hasNotch ? CGFloat(0) : CGFloat.NetworkStatusBar.topMargin
 
-    public weak var delegate: NetworkStatusViewDelegate!
+    public weak var delegate: NetworkStatusViewDelegate?
 
     var offlineViewTopMargin: NSLayoutConstraint?
     var offlineViewBottomMargin: NSLayoutConstraint?
@@ -269,11 +269,17 @@ class NetworkStatusView: UIView {
                   animated: Bool,
                   connectingViewHidden: Bool,
                   offlineViewHidden: Bool) {
-        offlineViewBottomMargin?.constant = offlineBarState == .expanded ? -delegate.bottomMargin : 0
+        var bottomMargin: CGFloat = 0
+
+        if let margin = delegate?.bottomMargin {
+            bottomMargin = margin
+        }
+
+        offlineViewBottomMargin?.constant = offlineBarState == .expanded ? -bottomMargin : 0
         offlineViewTopMargin?.constant = offlineBarState == .expanded ? topMargin : 0
 
         connectingViewHeight?.constant = connectingViewHidden ? 0 : CGFloat.SyncBar.height
-        connectingViewBottomMargin?.constant = connectingViewHidden ? 0 : -delegate.bottomMargin
+        connectingViewBottomMargin?.constant = connectingViewHidden ? 0 : -bottomMargin
 
         /// offlineViewBottomMargin is active iff connectingViewHidden is visible
         if offlineViewHidden && !connectingViewHidden {

--- a/Wire-iOS/Sources/UserInterface/Components/NetworkStatus/NetworkStatusView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/NetworkStatus/NetworkStatusView.swift
@@ -208,19 +208,17 @@ class NetworkStatusView: UIView {
     }
 
     func createConstraints() {
-        let bottomMargin = delegate.bottomMargin
-
         constrain(self, offlineView, connectingView) { containerView, offlineView, connectingView in
             offlineView.left == containerView.left + CGFloat.NetworkStatusBar.horizontalMargin
             offlineView.right == containerView.right - CGFloat.NetworkStatusBar.horizontalMargin
-            offlineViewTopMargin = offlineView.top == containerView.top + topMargin
-            offlineViewBottomMargin = offlineView.bottom == containerView.bottom - bottomMargin
+            offlineViewTopMargin = offlineView.top == containerView.top
+            offlineViewBottomMargin = offlineView.bottom == containerView.bottom
 
             connectingView.left == offlineView.left
             connectingView.right == offlineView.right
             connectingView.top == offlineView.top
-            connectingViewHeight = connectingView.height == CGFloat.SyncBar.height
-            connectingViewBottomMargin = connectingView.bottom == containerView.bottom - bottomMargin
+            connectingViewHeight = connectingView.height == 0
+            connectingViewBottomMargin = connectingView.bottom == containerView.bottom
         }
     }
 

--- a/Wire-iOS/Sources/UserInterface/Components/NetworkStatus/NetworkStatusView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/NetworkStatus/NetworkStatusView.swift
@@ -132,18 +132,6 @@ extension NetworkStatusViewDelegate where Self: UIViewController {
     }
 }
 
-extension UIApplicationState : CustomStringConvertible {
-    public var description: String {
-        switch self {
-        case .active: return "active"
-
-        case .inactive: return "inactive"
-
-        case .background: return "background"
-        }
-    }
-}
-
 class NetworkStatusView: UIView {
     private let connectingView: BreathLoadingBar
     private let offlineView: OfflineBar

--- a/Wire-iOS/Sources/UserInterface/Components/NetworkStatus/NetworkStatusView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/NetworkStatus/NetworkStatusView.swift
@@ -219,9 +219,6 @@ class NetworkStatusView: UIView {
     }
 
     private func updateViewState(animated: Bool) {
-
-        print("⏳ time(ms) = \(round(Date().timeIntervalSince1970*1000)), animated = \(animated), applicationState = \(application.applicationState) state = \(state)")
-
         var connectingViewHidden = state != .onlineSynchronizing
         connectingView.animating = state == .onlineSynchronizing
         let offlineViewHidden = state != .offlineExpanded

--- a/Wire-iOS/Sources/UserInterface/Components/NetworkStatus/NetworkStatusView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/NetworkStatus/NetworkStatusView.swift
@@ -132,6 +132,18 @@ extension NetworkStatusViewDelegate where Self: UIViewController {
     }
 }
 
+extension UIApplicationState : CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .active: return "active"
+
+        case .inactive: return "inactive"
+
+        case .background: return "background"
+        }
+    }
+}
+
 class NetworkStatusView: UIView {
     private let connectingView: BreathLoadingBar
     private let offlineView: OfflineBar
@@ -213,6 +225,9 @@ class NetworkStatusView: UIView {
     }
 
     private func updateViewState(animated: Bool) {
+
+        print("⏳ time(ms) = \(round(Date().timeIntervalSince1970*1000)), animated = \(animated), applicationState = \(application.applicationState) state = \(state)")
+
         var connectingViewHidden = state != .onlineSynchronizing
         connectingView.animating = state == .onlineSynchronizing
         let offlineViewHidden = state != .offlineExpanded

--- a/Wire-iOS/Sources/UserInterface/Components/NetworkStatus/NetworkStatusViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/NetworkStatus/NetworkStatusViewController.swift
@@ -92,7 +92,6 @@ class NetworkStatusViewController : UIViewController {
         }
 
         if let userSession = ZMUserSession.shared() {
-//            update(state: viewState(from: userSession.networkState))
             enqueue(state: viewState(from: userSession.networkState))
             networkStatusObserverToken = ZMNetworkAvailabilityChangeNotification.addNetworkAvailabilityObserver(self, userSession: userSession)
         }
@@ -107,7 +106,6 @@ class NetworkStatusViewController : UIViewController {
 
         finishedViewWillAppear = true
         if let userSession = ZMUserSession.shared() {
-//            update(state: viewState(from: userSession.networkState))
             enqueue(state: viewState(from: userSession.networkState))
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Components/NetworkStatus/NetworkStatusViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/NetworkStatus/NetworkStatusViewController.swift
@@ -150,8 +150,6 @@ class NetworkStatusViewController : UIViewController {
     }
 
     fileprivate func enqueue(state: NetworkStatusViewState) {
-        print("⏰ time(ms) = \(round(Date().timeIntervalSince1970*1000)), applicationState = \(application.applicationState) state = \(state)")
-
         pendingState = state
         NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(applyPendingState), object: nil)
 
@@ -165,8 +163,6 @@ class NetworkStatusViewController : UIViewController {
     }
 
     func update(state: NetworkStatusViewState) {
-        print("🔔 time(ms) = \(round(Date().timeIntervalSince1970*1000)), applicationState = \(application.applicationState) state = \(state)")
-
         self.state = state
         guard shouldShowOnIPad() else { return }
 

--- a/Wire-iOS/Sources/UserInterface/Components/NetworkStatus/NetworkStatusViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/NetworkStatus/NetworkStatusViewController.swift
@@ -92,7 +92,8 @@ class NetworkStatusViewController : UIViewController {
         }
 
         if let userSession = ZMUserSession.shared() {
-            update(state: viewState(from: userSession.networkState))
+//            update(state: viewState(from: userSession.networkState))
+            enqueue(state: viewState(from: userSession.networkState))
             networkStatusObserverToken = ZMNetworkAvailabilityChangeNotification.addNetworkAvailabilityObserver(self, userSession: userSession)
         }
 
@@ -106,7 +107,8 @@ class NetworkStatusViewController : UIViewController {
 
         finishedViewWillAppear = true
         if let userSession = ZMUserSession.shared() {
-            update(state: viewState(from: userSession.networkState))
+//            update(state: viewState(from: userSession.networkState))
+            enqueue(state: viewState(from: userSession.networkState))
         }
     }
 
@@ -148,6 +150,8 @@ class NetworkStatusViewController : UIViewController {
     }
 
     fileprivate func enqueue(state: NetworkStatusViewState) {
+        print("⏰ time(ms) = \(round(Date().timeIntervalSince1970*1000)), applicationState = \(application.applicationState) state = \(state)")
+
         pendingState = state
         NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(applyPendingState), object: nil)
 
@@ -161,6 +165,8 @@ class NetworkStatusViewController : UIViewController {
     }
 
     func update(state: NetworkStatusViewState) {
+        print("🔔 time(ms) = \(round(Date().timeIntervalSince1970*1000)), applicationState = \(application.applicationState) state = \(state)")
+
         self.state = state
         guard shouldShowOnIPad() else { return }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

Sync bar shows every time when the app starts. We want to have a show it after some delay when the network state changes to loading.

### Causes

In viewDidLoad and viewWillAppear, the network state applies immediately, not delayed. Other state change are delayed before showing on the UI. 

### Solutions

Enqueue the initial network state with a delay. The later network state change will override the init state.

## Notes

This PR is a follow up of https://github.com/wireapp/wire-ios/pull/1894.