### PR TITLE
Fix notifying that audio recording has stopped before recorder is shutdown

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecorder.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecorder.swift
@@ -187,7 +187,6 @@ public final class AudioRecorder: NSObject, AudioRecorderType {
         removeDisplayLink()
         guard let filePath = audioRecorder?.url.path , fm.fileExists(atPath: filePath) else { return false }
         fileURL = audioRecorder?.url
-        AVSMediaManager.sharedInstance().stopRecording()
         return true
     }
     
@@ -295,8 +294,9 @@ extension AudioRecorder: AVAudioRecorderDelegate {
         if recordedToMaxDuration { _ = postRecordingProcessing() }
         
         self.recordEndedCallback?(recordedToMaxDuration)
+        AVSMediaManager.sharedInstance().stopRecording()
     }
-    
+        
     public func audioRecorderEncodeErrorDidOccur(_ recorder: AVAudioRecorder, error: Error?) {
         DDLogError("Cannot finish recording: \(String(describing: error))")
     }


### PR DESCRIPTION
### Issues

AVS was noticing that they were sometimes failing to change audio category after an audio recording.

### Causes

Were were notifying AVS too early that we've stopped recording which caused any update to the audio category to fail

### Solutions

Notify AVS when the `AVAudioRecorder` delegate tells us that it has stopped.