### PR TITLE
ZIOS-9811: Fix crash when opening settings for users without email

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
@@ -200,7 +200,7 @@ extension SettingsCellDescriptorFactory {
     }
 
     func backUpElement() -> SettingsCellDescriptorType {
-        if ZMUser.selfUser().emailAddress.isEmpty {
+        if ZMUser.selfUser().emailAddress?.isEmpty != false {
             let presentationAction: () -> UIViewController = {
                 let alert = UIAlertController(
                     title: "self.settings.history_backup.set_email.title".localized,


### PR DESCRIPTION
## What's new in this PR?

### Issues

After registering with a phone number, opening the profile view controller caused a crash.

### Causes

The `emailAddress` field of the user was force unwrapped to check if it's empty, but there was no value.

### Solutions

This is fixed by checking if the field if either `nil` or empty, without implicit or forced unwrapping.