### PR TITLE
ZIOS-8802: Fix music pausing when removing someone from a group

### DIFF
--- a/Wire-iOS/Resources/Sounds/audio-notifications/MediaManagerConfig.plist
+++ b/Wire-iOS/Resources/Sounds/audio-notifications/MediaManagerConfig.plist
@@ -298,7 +298,7 @@
 			<key>loopAllowed</key>
 			<integer>0</integer>
 			<key>mixingAllowed</key>
-			<integer>0</integer>
+			<integer>1</integer>
 			<key>incallAllowed</key>
 			<integer>0</integer>
 			<key>intensity</key>


### PR DESCRIPTION
## What's new in this PR?

### Issues

When removing someone from a group and music was playing, the music was paused for a few seconds.

### Causes

The alert sound played before confirming the removal of the participant required the music to be paused. 

### Solutions

This was fixed by allowing the alert sound to be mixed with other currently playing sounds.