### PR TITLE
Fix/markdown link alert

### DIFF
--- a/Wire-iOS Tests/AccessoryTextField/LinkInteractionTextViewTests.swift
+++ b/Wire-iOS Tests/AccessoryTextField/LinkInteractionTextViewTests.swift
@@ -17,29 +17,65 @@
 //
 
 import XCTest
+@testable import Wire
 
 class LinkInteractionTextViewTests: XCTestCase {
     
+    var sut: LinkInteractionTextView!
+    
     override func setUp() {
         super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+        sut = LinkInteractionTextView(frame: .zero, textContainer: nil)
     }
     
     override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        sut = nil
         super.tearDown()
     }
     
-    func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    func testThatItDoesOpenLinkWithoutHiddenURL_iOS9() {
+        // GIVEN
+        let str = "http://www.wire.com"
+        let url = URL(string: str)!
+        sut.attributedText = NSAttributedString(string: str, attributes: [NSLinkAttributeName: url])
+        // WHEN
+        let shouldOpenURL = sut.delegate!.textView!(sut, shouldInteractWith: url, in: NSMakeRange(0, str.characters.count))
+        // THEN
+        XCTAssertTrue(shouldOpenURL)
     }
     
-    func testPerformanceExample() {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
+    func testThatItDoesNotOpenLinkWithHiddenURL_iOS9() {
+        // GIVEN
+        let str = "tap me!"
+        let url = URL(string: "www.wire.com")!
+        sut.attributedText = NSAttributedString(string: str, attributes: [NSLinkAttributeName: url])
+        // WHEN
+        let shouldOpenURL = sut.delegate!.textView!(sut, shouldInteractWith: url, in: NSMakeRange(0, str.characters.count))
+        // THEN
+        XCTAssertFalse(shouldOpenURL)
     }
     
+    @available(iOS 10.0, *)
+    func testThatItDoesOpenLinkWithoutHiddenURL_iOS10() {
+        // GIVEN
+        let str = "http://www.wire.com"
+        let url = URL(string: str)!
+        sut.attributedText = NSAttributedString(string: str, attributes: [NSLinkAttributeName: url])
+        // WHEN
+        let shouldOpenURL = sut.delegate!.textView!(sut, shouldInteractWith: url, in: NSMakeRange(0, str.characters.count), interaction: .invokeDefaultAction)
+        // THEN
+        XCTAssertTrue(shouldOpenURL)
+    }
+    
+    @available(iOS 10.0, *)
+    func testThatItDoesNotOpenLinkWithHiddenURL_iOS10() {
+        // GIVEN
+        let str = "tap me!"
+        let url = URL(string: "www.wire.com")!
+        sut.attributedText = NSAttributedString(string: str, attributes: [NSLinkAttributeName: url])
+        // WHEN
+        let shouldOpenURL = sut.delegate!.textView!(sut, shouldInteractWith: url, in: NSMakeRange(0, str.characters.count), interaction: .invokeDefaultAction)
+        // THEN
+        XCTAssertFalse(shouldOpenURL)
+    }
 }

--- a/Wire-iOS Tests/AccessoryTextField/LinkInteractionTextViewTests.swift
+++ b/Wire-iOS Tests/AccessoryTextField/LinkInteractionTextViewTests.swift
@@ -1,0 +1,45 @@
+////
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+
+class LinkInteractionTextViewTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testExample() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+    
+    func testPerformanceExample() {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+    
+}

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -988,6 +988,7 @@
 		EE8E9267202496C2000F4752 /* NSAttributedString+Down.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8E9266202496C2000F4752 /* NSAttributedString+Down.swift */; };
 		EE8E926E2024F085000F4752 /* MarkdownTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8E926D2024F085000F4752 /* MarkdownTextView.swift */; };
 		EEA747A81FCEBAD1000B529E /* AnalyticsMixpanelProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEA747A71FCEBAD1000B529E /* AnalyticsMixpanelProviderTests.swift */; };
+		EEAC654C206BD64700365C0C /* LinkInteractionTextViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEAC654B206BD64700365C0C /* LinkInteractionTextViewTests.swift */; };
 		EEB8A2D01F628D1100958881 /* Settings+Account.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB8A2CF1F628D1100958881 /* Settings+Account.swift */; };
 		EEBE8C5C1F681694009D78C9 /* NSData+ImageType.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBE8C5B1F681694009D78C9 /* NSData+ImageType.swift */; };
 		EEBE8C5E1F68171F009D78C9 /* NSData_ImageTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBE8C5D1F68171F009D78C9 /* NSData_ImageTypeTests.swift */; };
@@ -2552,6 +2553,7 @@
 		EE8E9266202496C2000F4752 /* NSAttributedString+Down.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Down.swift"; sourceTree = "<group>"; };
 		EE8E926D2024F085000F4752 /* MarkdownTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownTextView.swift; sourceTree = "<group>"; };
 		EEA747A71FCEBAD1000B529E /* AnalyticsMixpanelProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsMixpanelProviderTests.swift; sourceTree = "<group>"; };
+		EEAC654B206BD64700365C0C /* LinkInteractionTextViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkInteractionTextViewTests.swift; sourceTree = "<group>"; };
 		EEB8A2CF1F628D1100958881 /* Settings+Account.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Settings+Account.swift"; sourceTree = "<group>"; };
 		EEBE8C5B1F681694009D78C9 /* NSData+ImageType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSData+ImageType.swift"; sourceTree = "<group>"; };
 		EEBE8C5D1F68171F009D78C9 /* NSData_ImageTypeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSData_ImageTypeTests.swift; sourceTree = "<group>"; };
@@ -5398,6 +5400,7 @@
 		EF61B33E1FC8461200D8E631 /* AccessoryTextField */ = {
 			isa = PBXGroup;
 			children = (
+				EEAC654B206BD64700365C0C /* LinkInteractionTextViewTests.swift */,
 				EF159F361FD59556006E0A9C /* TextFieldValidatorTests.swift */,
 				EF61B33F1FC84B0100D8E631 /* AccessoryTextFieldValidationTests.swift */,
 				EF25F8851FC57EE90040C3CC /* AccessoryTextFieldTests.swift */,
@@ -7031,6 +7034,7 @@
 				87B0ACAA1FA20D7C001B2B9D /* AnalyticsTests.swift in Sources */,
 				EFB23D0B1FC853CF0055B866 /* AccessoryTextFieldValidationTests.swift in Sources */,
 				1E18C2BC1AFBB7E00043F3CF /* EmoticonSubstitutionConfigurationTests.m in Sources */,
+				EEAC654C206BD64700365C0C /* LinkInteractionTextViewTests.swift in Sources */,
 				5EE115E1204EEC7D002AD6C2 /* CallQualityControllerTests.swift in Sources */,
 				87DE06B41D2663960009411F /* AudioEffectsPickerViewControllerTests.swift in Sources */,
 				EF7F74041FCC033D0059C13F /* EmailAdresssValidatorTests.swift in Sources */,

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -411,6 +411,10 @@
 "content.message.open" = "Open";
 "content.message.copy" = "Copy";
 
+"content.message.open_link_alert.title" = "Visit Link";
+"content.message.open_link_alert.message" = "This will take you to %@";
+"content.message.open_link_alert.open" = "Open";
+
 "content.reactions_list.likers" = "Liked by";
 
 "content.file.too_big" = "You can send files up to %@";

--- a/Wire-iOS/Sources/UserInterface/Components/Views/LinkInteractionTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/LinkInteractionTextView.swift
@@ -42,10 +42,10 @@ import UIKit
         let isInside = super.point(inside: point, with: event)
         guard let position = characterRange(at: point), isInside else { return false }
         let index = offset(from: beginningOfDocument, to: position.start)
-        return urlAttribtue(at: index)
+        return urlAttribute(at: index)
     }
 
-    private func urlAttribtue(at index: Int) -> Bool {
+    private func urlAttribute(at index: Int) -> Bool {
         guard attributedText.length > 0 else { return false }
         let attributes = attributedText.attributes(at: index, effectiveRange: nil)
         return attributes[NSLinkAttributeName] != nil

--- a/Wire-iOS/Sources/UserInterface/Components/Views/LinkInteractionTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/LinkInteractionTextView.swift
@@ -51,6 +51,48 @@ import UIKit
         return attributes[NSLinkAttributeName] != nil
     }
     
+    /// Returns true if the substring in the given range is a link and its
+    /// attached URL is not described by this link.
+    private func link(in range: NSRange, hides url: URL) -> Bool {
+        
+        guard
+            // try to detect a link in the given range
+            let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue),
+            let match = detector.firstMatch(in: text, options: [], range: range),
+            let detectedURL = match.url, match.range == range
+            else { return true }
+        
+        return detectedURL.absoluteString != url.absoluteString
+    }
+    
+    /// Returns an alert controller configured to open the given URL.
+    private func openAlert(for url: URL) -> UIAlertController {
+        let alert = UIAlertController(
+            title: "Open Link",
+            message: "Do you want to open the link: \(url.absoluteString) ?",
+            preferredStyle: .alert
+        )
+        
+        let okAction = UIAlertAction(title: "Open", style: .default) { _ in
+            _ = self.interactionDelegate?.textView(self, open: url)
+        }
+        
+        alert.addAction(.cancel())
+        alert.addAction(okAction)
+        return alert
+    }
+    
+    /// An alert is shown (asking the user if they wish to open the url) if the link
+    /// attachment contains a hidden url, i.e the substring in the given range
+    /// doesn't not describe its attched url.
+    fileprivate func showAlertIfNeeded(for url: URL, in range: NSRange) -> Bool {
+        // if link has hidden url
+        if link(in: range, hides: url) {
+            ZClientViewController.shared()?.present(openAlert(for: url), animated: true, completion: nil)
+            return true
+        }
+        return false
+    }
 }
 
 
@@ -71,6 +113,9 @@ extension LinkInteractionTextView: UITextViewDelegate {
             interactionDelegate?.textViewDidLongPress(self)
             return false
         }
+        
+        // if alert shown, link opening is handled in alert actions
+        if showAlertIfNeeded(for: URL, in: characterRange) { return false }
         
         // data detector links should be handled by the system
         return URL.scheme == "x-apple-data-detectors" || !(interactionDelegate?.textView(self, open: URL) ?? false)
@@ -95,13 +140,16 @@ extension LinkInteractionTextView: UITextViewDelegate {
     public func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
         switch interaction {
         case .invokeDefaultAction:
+            // if alert shown, link opening is handled in alert actions
+            if showAlertIfNeeded(for: URL, in: characterRange) { return false }
             // data detector links should be handle by the system
-            return URL.scheme == "x-apple-data-detectors" || !(interactionDelegate?.textView(self, open: URL) ?? false)
+            return  URL.scheme == "x-apple-data-detectors" || !(interactionDelegate?.textView(self, open: URL) ?? false)
         case .presentActions:
             interactionDelegate?.textViewDidLongPress(self)
             return false
-        default:
-            return true
+        case .preview:
+            // if no alert is shown, still allow preview peeking
+            return !showAlertIfNeeded(for: URL, in: characterRange)
         }
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Components/Views/LinkInteractionTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/LinkInteractionTextView.swift
@@ -68,12 +68,12 @@ import UIKit
     /// Returns an alert controller configured to open the given URL.
     private func openAlert(for url: URL) -> UIAlertController {
         let alert = UIAlertController(
-            title: "Open Link",
-            message: "Do you want to open the link: \(url.absoluteString) ?",
+            title: "content.message.open_link_alert.title".localized,
+            message: "content.message.open_link_alert.message".localized(args: url.absoluteString),
             preferredStyle: .alert
         )
         
-        let okAction = UIAlertAction(title: "Open", style: .default) { _ in
+        let okAction = UIAlertAction(title: "content.message.open_link_alert.open".localized, style: .default) { _ in
             _ = self.interactionDelegate?.textView(self, open: url)
         }
         


### PR DESCRIPTION
## What's new in this PR?

### Issues

Markdown named links (e.g. `[Github](www.github.com]`) can be used to spoof links using Punycodes, i.e it is possible for a link to be sent that appears to take you to URL A, but in fact takes you to URL B.

### Causes

As a security measure, named links will not render if the name contains a URL (e.g. `[www.github.com](www.gitlab.com)`). However, this protection can be subverted if Punycode dots (`․`) are used, which look like normal dots.

### Solutions

Instead of fixing exclusively the case of the Punycode dots (there could potentially be several ways to write a fake link), we instead present an alert to the user when they tap on a named link. This alert informs the user of the URL they have tapped on, and whether they wish to open it.

### Attachments

![simulator screen shot - iphone 8 - 2018-03-29 at 08 45 47](https://user-images.githubusercontent.com/28632506/38074767-2e6a08b2-3330-11e8-9227-82109dcbf5e8.png)

![simulator screen shot - iphone 8 - 2018-03-29 at 08 45 53](https://user-images.githubusercontent.com/28632506/38074770-336b7328-3330-11e8-8400-c624440bb086.png)
