### PR TITLE
Fix crash: when presenting video editor on iPad

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
@@ -287,8 +287,8 @@ open class CameraKeyboardViewController: UIViewController {
                 exportSession.outputFileType = AVFileTypeMPEG4
 
                 exportSession.exportAsynchronously {
-                    self.showLoadingView = false
                     DispatchQueue.main.async(execute: {
+                        self.showLoadingView = false
                         self.delegate?.cameraKeyboardViewController(self, didSelectVideo: exportSession.outputURL!, duration: CMTimeGetSeconds(exportSession.asset.duration))
                     })
                 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
@@ -80,17 +80,12 @@ extension ConversationInputBarViewController: CameraKeyboardViewControllerDelega
             switch UIDevice.current.userInterfaceIdiom {
             case .pad:
                 self.hideCameraKeyboardViewController {
-//                    self.shouldRefocusKeyboardAfterImagePickerDismiss = true
                     videoEditor.modalPresentationStyle = .popover
-                    if let size = self.parent?.view.frame.size {
-                        videoEditor.preferredContentSize = size
-                    }
 
                     self.present(videoEditor, animated: true)
 
                     let popover = videoEditor.popoverPresentationController
                     popover?.sourceView = self.parent?.view
-//                    popover?.canOverlapSourceViewRect = true
 
                     ///arrow point to camera button.
                     popover?.permittedArrowDirections = .down
@@ -98,6 +93,8 @@ extension ConversationInputBarViewController: CameraKeyboardViewControllerDelega
 //                        let buttonCenter = self.photoButton.convert(self.photoButton.frame.origin, to: parentView)
                         let buttonCenter = self.photoButton.convert(self.photoButton.center, to: parentView)
                         popover?.sourceRect = CGRect(origin: buttonCenter, size: .zero)
+
+                        videoEditor.preferredContentSize = parentView.frame.size
                     }
                 }
             default:

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
@@ -45,6 +45,16 @@ class StatusBarVideoEditorController: UIVideoEditorController {
     override var preferredStatusBarStyle : UIStatusBarStyle {
         return UIStatusBarStyle.default
     }
+
+    func adaptivePresentationStyle(for controller: UIPresentationController) -> UIModalPresentationStyle {
+        switch UIDevice.current.userInterfaceIdiom {
+        case .pad:
+            return .none
+        default:
+            return .fullScreen
+        }
+
+    }
 }
 
 extension ConversationInputBarViewController: CameraKeyboardViewControllerDelegate {
@@ -69,15 +79,27 @@ extension ConversationInputBarViewController: CameraKeyboardViewControllerDelega
 
             switch UIDevice.current.userInterfaceIdiom {
             case .pad:
-                videoEditor.modalPresentationStyle = .popover
-                self.present(videoEditor, animated: true)
+                self.hideCameraKeyboardViewController {
+//                    self.shouldRefocusKeyboardAfterImagePickerDismiss = true
+                    videoEditor.modalPresentationStyle = .popover
+                    if let size = self.parent?.view.frame.size {
+                        videoEditor.preferredContentSize = size
+                    }
 
-                let popover = videoEditor.popoverPresentationController
-                popover?.sourceView = self.view
-                popover?.canOverlapSourceViewRect = true
-                let buttonRect = self.photoButton.frame
-                popover?.sourceRect = CGRect(origin: CGPoint(x: buttonRect.midX, y: buttonRect.midY), size: .zero)
+                    self.present(videoEditor, animated: true)
 
+                    let popover = videoEditor.popoverPresentationController
+                    popover?.sourceView = self.parent?.view
+//                    popover?.canOverlapSourceViewRect = true
+
+                    ///arrow point to camera button.
+                    popover?.permittedArrowDirections = .down
+                    if let parentView = self.parent?.view {
+//                        let buttonCenter = self.photoButton.convert(self.photoButton.frame.origin, to: parentView)
+                        let buttonCenter = self.photoButton.convert(self.photoButton.center, to: parentView)
+                        popover?.sourceRect = CGRect(origin: buttonCenter, size: .zero)
+                    }
+                }
             default:
                 self.present(videoEditor, animated: true) {
                     UIApplication.shared.wr_updateStatusBarForCurrentControllerAnimated(false)

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
@@ -74,14 +74,15 @@ extension ConversationInputBarViewController: CameraKeyboardViewControllerDelega
 
                 let popover = videoEditor.popoverPresentationController
                 popover?.sourceView = self.view
+                popover?.canOverlapSourceViewRect = true
+                let buttonRect = self.photoButton.frame
+                popover?.sourceRect = CGRect(origin: CGPoint(x: buttonRect.midX, y: buttonRect.midY), size: .zero)
 
             default:
                 self.present(videoEditor, animated: true) {
                     UIApplication.shared.wr_updateStatusBarForCurrentControllerAnimated(false)
                 }
             }
-
-
         }
         else {
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
@@ -84,7 +84,6 @@ extension ConversationInputBarViewController: CameraKeyboardViewControllerDelega
                     ///arrow point to camera button.
                     popover?.permittedArrowDirections = .down
                     if let parentView = self.parent?.view {
-//                        let buttonCenter = self.photoButton.convert(self.photoButton.frame.origin, to: parentView)
                         let buttonCenter = self.photoButton.convert(self.photoButton.center, to: parentView)
                         popover?.sourceRect = CGRect(origin: buttonCenter, size: .zero)
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
@@ -47,13 +47,7 @@ class StatusBarVideoEditorController: UIVideoEditorController {
     }
 
     func adaptivePresentationStyle(for controller: UIPresentationController) -> UIModalPresentationStyle {
-        switch UIDevice.current.userInterfaceIdiom {
-        case .pad:
-            return .none
-        default:
-            return .fullScreen
-        }
-
+        return traitCollection.horizontalSizeClass == .regular ? .popover : .overFullScreen
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
@@ -66,10 +66,22 @@ extension ConversationInputBarViewController: CameraKeyboardViewControllerDelega
             videoEditor.videoMaximumDuration = ConversationUploadMaxVideoDuration
             videoEditor.videoPath = videoURL.path
             videoEditor.videoQuality = UIImagePickerControllerQualityType.typeMedium
-            
-            self.present(videoEditor, animated: true) {
-                UIApplication.shared.wr_updateStatusBarForCurrentControllerAnimated(false)
+
+            switch UIDevice.current.userInterfaceIdiom {
+            case .pad:
+                videoEditor.modalPresentationStyle = .popover
+                self.present(videoEditor, animated: true)
+
+                let popover = videoEditor.popoverPresentationController
+                popover?.sourceView = self.view
+
+            default:
+                self.present(videoEditor, animated: true) {
+                    UIApplication.shared.wr_updateStatusBarForCurrentControllerAnimated(false)
+                }
             }
+
+
         }
         else {
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

App crashes when showing video editor on iPad.

### Causes

"Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: 'On iPad, Wire.StatusBarVideoEditorController must be presented via UIPopoverController'"

### Solutions

Present videoEditor in popover style on iPad. 

###Note 
This PR fixed a run time warning for dismiss spinner in non-main thread.

