### PR TITLE
ZIOS-9806: Fix spacing

### DIFF
--- a/Wire-iOS/Sources/UserInterface/UserProfile/Views/ProfileFooterView.m
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Views/ProfileFooterView.m
@@ -48,10 +48,9 @@
     self.leftButton = [IconButton iconButtonCircular];
     self.leftButton.translatesAutoresizingMaskIntoConstraints = NO;
     self.leftButton.accessibilityIdentifier = @"left_button";
-    self.leftButton.titleEdgeInsets = UIEdgeInsetsMake(0, 15, 0, -16);
-    self.leftButton.contentEdgeInsets = UIEdgeInsetsMake(0, 0, 0, 16);
     [self.leftButton setTitleColor:[UIColor wr_colorFromColorScheme:ColorSchemeColorTextForeground] forState:UIControlStateNormal];
     [self.leftButton setTitleColor:[UIColor wr_colorFromColorScheme:ColorSchemeColorTextDimmed] forState:UIControlStateHighlighted];
+    [self.leftButton setTitleImageSpacing:16];
     self.leftButton.titleLabel.font = UIFont.smallLightFont;
     [self addSubview:self.leftButton];
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

In the profile details view controller, there was no spacing between the icon and the title on the bottom left footer button.

### Solutions

The title edge insets were used to set the margin but were not taken into account by the button. Changed to use the dedicated `-[IconButton  setTitleImageSpacing:]` with a 16pt spacing.