### PR TITLE
Back up to tmp on simulator

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/BackupViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/BackupViewController.swift
@@ -190,11 +190,6 @@ extension BackupViewController: UITableViewDataSource, UITableViewDelegate {
                 #if arch(i386) || arch(x86_64)
                     let tmpURL = URL(fileURLWithPath: "/var/tmp/").appendingPathComponent(url.lastPathComponent)
                     try! FileManager.default.moveItem(at: url, to: tmpURL)
-                    
-                    let alert = UIAlertController(title: "Debug",
-                                                  message: "Backup saved to \(tmpURL)",
-                                                  cancelButtonTitle: "general.ok".localized)
-                    self.present(alert, animated: true)
                 #else
                     let activityController = UIActivityViewController(activityItems: [url], applicationActivities: nil)
                     activityController.completionWithItemsHandler = { _, _, _, _ in

--- a/Wire-iOS/Sources/UserInterface/Settings/BackupViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/BackupViewController.swift
@@ -187,11 +187,21 @@ extension BackupViewController: UITableViewDataSource, UITableViewDelegate {
                 self.present(alert, animated: true)
                 BackupEvent.exportFailed.track()
             case .success(let url):
-                let activityController = UIActivityViewController(activityItems: [url], applicationActivities: nil)
-                activityController.completionWithItemsHandler = { _, _, _, _ in
-                    SessionManager.clearPreviousBackups()
-                }
-                self.present(activityController, animated: true)
+                #if arch(i386) || arch(x86_64)
+                    let tmpURL = URL(fileURLWithPath: "/var/tmp/").appendingPathComponent(url.lastPathComponent)
+                    try! FileManager.default.moveItem(at: url, to: tmpURL)
+                    
+                    let alert = UIAlertController(title: "Debug",
+                                                  message: "Backup saved to \(tmpURL)",
+                                                  cancelButtonTitle: "general.ok".localized)
+                    self.present(alert, animated: true)
+                #else
+                    let activityController = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+                    activityController.completionWithItemsHandler = { _, _, _, _ in
+                        SessionManager.clearPreviousBackups()
+                    }
+                    self.present(activityController, animated: true)
+                #endif
                 BackupEvent.exportSucceeded.track()
             }
         }


### PR DESCRIPTION
Store the back up on simulator to the `tmp` folder to allow automation to fetch it.