### PR TITLE
ZIOS-7590: Use light gray placeholder color for sketch hint

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Sketchpad/CanvasViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Sketchpad/CanvasViewController.swift
@@ -90,7 +90,7 @@ class CanvasViewController: UIViewController, UINavigationControllerDelegate {
     
         toolbar = SketchToolbar(buttons: [photoButton, drawButton, emojiButton, sendButton])
         separatorLine.backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorSeparator)
-        hintImageView.image = UIImage(for: .brush, fontSize: 172, color: ColorScheme.default().color(withName: ColorSchemeColorPlaceholderBackground))
+        hintImageView.image = UIImage(for: .brush, fontSize: 172, color: .wr_color(fromColorScheme: ColorSchemeColorPlaceholderBackground, variant: .light))
         hintLabel.text = "sketchpad.initial_hint".localized.uppercased(with: Locale.current)
         hintLabel.numberOfLines = 0
         hintLabel.font = FontSpec(.small, .regular).font!


### PR DESCRIPTION
## What's new in this PR?

### Issues

The sketch hint was not using the correct placeholder color.

### New Appearance

![Light](https://user-images.githubusercontent.com/16192914/38300212-8288ed0c-37fc-11e8-9c03-b0047e3d4b19.png)

![Dark](https://user-images.githubusercontent.com/16192914/38300211-826f1274-37fc-11e8-8b57-5aed84b7e464.png)
