### PR TITLE
Fixed crash on iPad backup

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/BackupViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/BackupViewController.swift
@@ -195,6 +195,10 @@ extension BackupViewController: UITableViewDataSource, UITableViewDelegate {
                     activityController.completionWithItemsHandler = { _, _, _, _ in
                         SessionManager.clearPreviousBackups()
                     }
+                    activityController.popoverPresentationController.apply {
+                        $0.sourceView = tableView
+                        $0.sourceRect = tableView.rectForRow(at: indexPath)
+                    }
                     self.present(activityController, animated: true)
                 #endif
                 BackupEvent.exportSucceeded.track()


### PR DESCRIPTION
On the iPad the activity controller must be presented from the popover.