### PR TITLE
Restore: Do not remove the checkmark after the animation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/Steps/NoHistoryViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/Steps/NoHistoryViewController.swift
@@ -136,9 +136,9 @@ extension NoHistoryViewController {
                 self.showLoadingView = false
             case .success:
                 BackupEvent.importSucceeded.track()
-                self.indicateLoadingSuccess {
+                self.indicateLoadingSuccess(completion: {
                     self.formStepDelegate.didCompleteFormStep(self)
-                }
+                }, removeCheckmark: false)
             }
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/Steps/NoHistoryViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/Steps/NoHistoryViewController.swift
@@ -136,9 +136,9 @@ extension NoHistoryViewController {
                 self.showLoadingView = false
             case .success:
                 BackupEvent.importSucceeded.track()
-                self.indicateLoadingSuccess(completion: {
+                self.indicateLoadingSuccessRemovingCheckmark(false) {
                     self.formStepDelegate.didCompleteFormStep(self)
-                }, removeCheckmark: false)
+                }
             }
         }
     }

--- a/WireExtensionComponents/Views/Loading/UIViewController+LoadingView.h
+++ b/WireExtensionComponents/Views/Loading/UIViewController+LoadingView.h
@@ -29,6 +29,6 @@
 @property (strong, nonatomic) ProgressSpinner *activityIndicator;
 @property (assign, nonatomic) BOOL showLoadingView;
 
-- (void)indicateLoadingSuccessWithCompletion:(dispatch_block_t)completion;
+- (void)indicateLoadingSuccessWithCompletion:(dispatch_block_t)completion removeCheckmark:(BOOL)removeCheckmark;
 
 @end

--- a/WireExtensionComponents/Views/Loading/UIViewController+LoadingView.h
+++ b/WireExtensionComponents/Views/Loading/UIViewController+LoadingView.h
@@ -29,6 +29,6 @@
 @property (strong, nonatomic) ProgressSpinner *activityIndicator;
 @property (assign, nonatomic) BOOL showLoadingView;
 
-- (void)indicateLoadingSuccessWithCompletion:(dispatch_block_t)completion removeCheckmark:(BOOL)removeCheckmark;
+- (void)indicateLoadingSuccessRemovingCheckmark:(BOOL)removingCheckmark completion:(dispatch_block_t)completion;
 
 @end

--- a/WireExtensionComponents/Views/Loading/UIViewController+LoadingView.m
+++ b/WireExtensionComponents/Views/Loading/UIViewController+LoadingView.m
@@ -91,7 +91,7 @@ const NSString *LoadingViewKey = @"loadingView";
     OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
-- (void)indicateLoadingSuccessWithCompletion:(dispatch_block_t)completion
+- (void)indicateLoadingSuccessWithCompletion:(dispatch_block_t)completion removeCheckmark:(BOOL)removeCheckmark
 {
     CheckAnimationView __block *checkView = nil;
     
@@ -114,10 +114,12 @@ const NSString *LoadingViewKey = @"loadingView";
             if (completion != nil) {
                 completion();
             }
-            self.activityIndicator.alpha = 1;
-            self.activityIndicator.transform = CGAffineTransformIdentity;
-            [self setShowLoadingView:NO];
-            [checkView removeFromSuperview];
+            if (removeCheckmark) {
+                self.activityIndicator.alpha = 1;
+                self.activityIndicator.transform = CGAffineTransformIdentity;
+                [self setShowLoadingView:NO];
+                [checkView removeFromSuperview];
+            }
         });
     }];
 }

--- a/WireExtensionComponents/Views/Loading/UIViewController+LoadingView.m
+++ b/WireExtensionComponents/Views/Loading/UIViewController+LoadingView.m
@@ -91,7 +91,7 @@ const NSString *LoadingViewKey = @"loadingView";
     OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
-- (void)indicateLoadingSuccessWithCompletion:(dispatch_block_t)completion removeCheckmark:(BOOL)removeCheckmark
+- (void)indicateLoadingSuccessRemovingCheckmark:(BOOL)removingCheckmark completion:(dispatch_block_t)completion
 {
     CheckAnimationView __block *checkView = nil;
     
@@ -114,7 +114,7 @@ const NSString *LoadingViewKey = @"loadingView";
             if (completion != nil) {
                 completion();
             }
-            if (removeCheckmark) {
+            if (removingCheckmark) {
                 self.activityIndicator.alpha = 1;
                 self.activityIndicator.transform = CGAffineTransformIdentity;
                 [self setShowLoadingView:NO];


### PR DESCRIPTION
When user restores the backup due to the timing issue when the check mark is removed the view controller is not dismissed yet.

The proposed solution is to keep the check mark and just dismiss the whole controller.