### PR TITLE
Fix: When app language set to Chinese simplified or Italian, "Why verify  conversations?" is not clickable 

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -17,6 +17,7 @@
 //
 
 
+// General strings
 "general.ok" = "OK";
 "general.next" = "Next";
 "general.cancel" = "Cancel";
@@ -25,6 +26,9 @@
 "general.open_settings" = "Open Wire Settings";
 "general.edit" = "Edit";
 "general.done" = "Done";
+"general.confirm" = "OK";
+// Language like Chinese does not use space to sperate words or sentences.
+"general.space_between_words" = " ";
 
 "general.guest-room-name" = "Guest room";
 
@@ -577,7 +581,7 @@
 // Device list
 "profile.devices.title" = "Devices";
 "profile.devices.fingerprint_message_unencrypted" = "%@ is using an old version of Wire. No devices are shown here.";
-"profile.devices.fingerprint_message" = "Wire gives every device a unique fingerprint. Compare them with %@ and verify your conversation. Why verify conversations?";
+"profile.devices.fingerprint_message.title" = "Wire gives every device a unique fingerprint. Compare them with %@ and verify your conversation.";
 "profile.devices.fingerprint_message.link" = "Why verify conversations?";
 
 // Device detail
@@ -590,9 +594,6 @@
 "device.class.tablet" = "Tablet";
 "device.class.phone" = "Phone";
 "profile.devices.detail.reset_session.title" = "Reset Session";
-
-// General strings
-"general.confirm" = "OK";
 
 // Bot
 "participants.services.remove_integration.button" = "remove integration";

--- a/Wire-iOS/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/zh-Hans.lproj/Localizable.strings
@@ -17,6 +17,7 @@
 //
 
 
+// General strings
 "general.ok" = "好";
 "general.next" = "继续";
 "general.cancel" = "取消";
@@ -24,6 +25,9 @@
 "general.open_settings" = "开启Wire设定";
 "general.edit" = "修改";
 "general.done" = "完成";
+"general.confirm" = "好";
+// Language like Chinese does not use space to sperate words or sentences.
+"general.space_between_words" = "";
 
 "general.guest-room-name" = "访客聊天室";
 
@@ -566,7 +570,7 @@
 // Device list
 "profile.devices.title" = "设备";
 "profile.devices.fingerprint_message_unencrypted" = "%@使用旧版本的Wire，无法显示设备。";
-"profile.devices.fingerprint_message" = "Wire 给每一台设备一组唯一的指纹，并比较它与%@来验证您的对话。为什么要验证？";
+"profile.devices.fingerprint_message.title" = "Wire 给每一台设备一组唯一的指纹，并比较它与%@来验证您的对话。";
 "profile.devices.fingerprint_message.link" = "为什么要验证对话？";
 
 // Device detail
@@ -579,9 +583,6 @@
 "device.class.tablet" = "平板电脑";
 "device.class.phone" = "电话";
 "profile.devices.detail.reset_session.title" = "重置Session";
-
-// General strings
-"general.confirm" = "好";
 
 // Bot
 "participants.services.remove_integration.button" = "移除服务";

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Views/ParticipantsDeviceHeaderView.m
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Views/ParticipantsDeviceHeaderView.m
@@ -114,12 +114,19 @@
     }
 }
 
+- (NSMutableParagraphStyle *)paragraphStyleForFingerprint
+{
+    NSMutableParagraphStyle *paragraphStyle = NSParagraphStyle.defaultParagraphStyle.mutableCopy;
+    paragraphStyle.lineSpacing = 2;
+
+    return paragraphStyle;
+}
+
 - (NSAttributedString *)attributedFingerprintForUserName:(NSString *)userName message:(NSString *)message
 {
     NSString *fingerprintExplanation = [NSString stringWithFormat:message, userName];
 
-    NSMutableParagraphStyle *paragraphStyle = NSParagraphStyle.defaultParagraphStyle.mutableCopy;
-    paragraphStyle.lineSpacing = 2;
+    NSMutableParagraphStyle *paragraphStyle = [self paragraphStyleForFingerprint];
 
     NSDictionary *textAttributes = @{
                                      NSForegroundColorAttributeName: self.textColor,
@@ -135,8 +142,7 @@
 
 - (NSDictionary *)linkAttributes
 {
-    NSMutableParagraphStyle *paragraphStyle = NSParagraphStyle.defaultParagraphStyle.mutableCopy;
-    paragraphStyle.lineSpacing = 2;
+    NSMutableParagraphStyle *paragraphStyle = [self paragraphStyleForFingerprint];
 
     NSDictionary *linkAttributes = @{
                                      NSFontAttributeName: self.font,

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Views/ParticipantsDeviceHeaderView.m
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Views/ParticipantsDeviceHeaderView.m
@@ -22,6 +22,7 @@
 #import "WebLinkTextView.h"
 #import "NSURL+WireURLs.h"
 #import "WireExtensionComponents.h"
+#import "NSAttributedString+Wire.h"
 
 @import Classy;
 
@@ -96,16 +97,27 @@
 
 - (NSAttributedString *)attributedExplanationTextForUserName:(NSString *)userName showUnencryptedLabel:(BOOL)unencrypted
 {
-    NSString *message = NSLocalizedString(unencrypted ? @"profile.devices.fingerprint_message_unencrypted" : @"profile.devices.fingerprint_message", nil);
-    return [self attributedFingerprintExplanationForUserName:userName message:message];
+    if (unencrypted) {
+        NSString *message = NSLocalizedString(@"profile.devices.fingerprint_message_unencrypted", nil);
+        return [self attributedFingerprintForUserName:userName message:message];
+    }
+    else {
+        NSString *message = [NSString stringWithFormat:@"%@%@", NSLocalizedString(@"profile.devices.fingerprint_message.title", nil), NSLocalizedString(@"general.space_between_words", nil)];
+
+        NSMutableAttributedString * mutableAttributedString = [[NSMutableAttributedString alloc] initWithAttributedString: [self attributedFingerprintForUserName:userName message:message]];
+
+        NSString *fingerprintLearnMoreLink = NSLocalizedString(@"profile.devices.fingerprint_message.link", nil);
+
+        [mutableAttributedString appendString:fingerprintLearnMoreLink attributes:[self linkAttributes]];
+
+        return mutableAttributedString;
+    }
 }
 
-- (NSAttributedString *)attributedFingerprintExplanationForUserName:(NSString *)userName message:(NSString *)message
+- (NSAttributedString *)attributedFingerprintForUserName:(NSString *)userName message:(NSString *)message
 {
     NSString *fingerprintExplanation = [NSString stringWithFormat:message, userName];
-    NSString *fingerprintLearnMoreLink = NSLocalizedString(@"profile.devices.fingerprint_message.link", nil);
-    NSRange learnMoreLinkRange = [fingerprintExplanation rangeOfString:fingerprintLearnMoreLink];
-    
+
     NSMutableParagraphStyle *paragraphStyle = NSParagraphStyle.defaultParagraphStyle.mutableCopy;
     paragraphStyle.lineSpacing = 2;
 
@@ -115,6 +127,17 @@
                                      NSParagraphStyleAttributeName: paragraphStyle
                                      };
 
+    NSMutableAttributedString *attributedText = [[NSMutableAttributedString alloc] initWithString:fingerprintExplanation
+                                                                                       attributes:textAttributes];
+
+    return [[NSAttributedString alloc] initWithAttributedString:attributedText];
+}
+
+- (NSDictionary *)linkAttributes
+{
+    NSMutableParagraphStyle *paragraphStyle = NSParagraphStyle.defaultParagraphStyle.mutableCopy;
+    paragraphStyle.lineSpacing = 2;
+
     NSDictionary *linkAttributes = @{
                                      NSFontAttributeName: self.font,
                                      NSForegroundColorAttributeName: self.linkAttributeColor,
@@ -122,11 +145,7 @@
                                      NSParagraphStyleAttributeName: paragraphStyle
                                      };
 
-    NSMutableAttributedString *attributedText = [[NSMutableAttributedString alloc] initWithString:fingerprintExplanation
-                                                                                       attributes:textAttributes];
-
-    [attributedText addAttributes:linkAttributes range:learnMoreLinkRange];
-    return [[NSAttributedString alloc] initWithAttributedString:attributedText];
+    return linkAttributes;
 }
 
 @end


### PR DESCRIPTION
## What's new in this PR?

### Issues

In device fingerprint screen, no link for the text "Why verify conversations?" for Chinese simplified, Italian and some other languages.

### Causes

In some of the translations, "profile.devices.fingerprint_message.link" is not a substring of "profile.devices.fingerprint_message". Part of "profile.devices.fingerprint_message" is not mark as a link in these languages.

### Solutions

Rewrite the logic to combine two strings, instead of finding "profile.devices.fingerprint_message.link" in "profile.devices.fingerprint_message".

## Notes

"general.space_between_words" is added for localize space for languages which do not have spaces.