### PR TITLE
Fix: remove space in the string of ConversationNewDeviceCell for languages do not have space

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationNewDeviceCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationNewDeviceCell.swift
@@ -78,7 +78,7 @@ class ConversationNewDeviceCell: IconSystemCell {
         let startedUsingString = NSLocalizedString("content.system.started_using", comment: "") && attributes.startedUsingAttributes
         let userClientString = NSLocalizedString("content.system.new_device", comment: "") && attributes.linkAttributes
         
-        attributedText = senderName + " " + startedUsingString + " " + userClientString
+        attributedText = senderName + "general.space_between_words".localized + startedUsingString + "general.space_between_words".localized + userClientString
         self.leftIconView.isHidden = isSelfClient
     }
     
@@ -87,7 +87,7 @@ class ConversationNewDeviceCell: IconSystemCell {
         let startedUsingString = NSLocalizedString("content.system.started_using", comment: "") && attributes.startedUsingAttributes
         let userClientString = NSLocalizedString("content.system.this_device", comment: "") && attributes.linkAttributes
         
-        attributedText = senderName + " " + startedUsingString + " " + userClientString
+        attributedText = senderName + "general.space_between_words".localized + startedUsingString + "general.space_between_words".localized + userClientString
         self.leftIconView.isHidden = true
     }
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

In ConversationNewDeviceCell, the string "You started using this device" has space in Chinese.

### Causes

The string concatenation did not consider the writing systems which don't use spaces.

### Solutions

Use localized space instead of simple space string.

