### PR TITLE
Fix: Change 'anruf' to 'Anruf'

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -446,9 +446,9 @@
 "library.alert.permission_warning.not_allowed.explaination" = "Go to Settings and allow Wire to access your photos.";
 
 // Voice
-"voice.status.one_to_one.incoming" = "%@\nCalling";
-"voice.status.group_call.incoming" = "%@\nRinging";
-"voice.status.one_to_one.outgoing" = "%@\nRinging";
+"voice.status.one_to_one.incoming" = "%@\ncalling";
+"voice.status.group_call.incoming" = "%@\nringing";
+"voice.status.one_to_one.outgoing" = "%@\nringing";
 "voice.status.joining" = "%@\nConnecting";
 "voice.status.leaving" = "%@\nCall ended";
 "voice.status.video_not_available" = "Video turned off";

--- a/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelOverlay.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/VoiceChannelOverlay.swift
@@ -292,14 +292,14 @@ extension VoiceChannelOverlay {
         switch state {
         case .incomingCall:
             if callingConversation.conversationType == .oneOnOne {
-                let statusText = "voice.status.one_to_one.incoming".localized.lowercasedWithCurrentLocale
+                let statusText = "voice.status.one_to_one.incoming".localized
                 return labelText(withFormat: statusText, name: conversationName)
             } else {
-                let statusText = "voice.status.group_call.incoming".localized.lowercasedWithCurrentLocale
+                let statusText = "voice.status.group_call.incoming".localized
                 return labelText(withFormat: statusText, name: conversationName)
             }
         case .outgoingCall:
-            let statusText = "voice.status.one_to_one.outgoing".localized.lowercasedWithCurrentLocale
+            let statusText = "voice.status.one_to_one.outgoing".localized
             return labelText(withFormat: statusText, name: conversationName)
         case .incomingCallDegraded, .outgoingCallDegraded:
             return labelText(withFormat: "%@\n", name: conversationName)


### PR DESCRIPTION
## What's new in this PR?

### Issues

"Bill calling" is translated to "Bill anruf" in German. The correct translation should be "Bill Anruf"

### Causes

"Anruf" is lowercase in the code.

### Solutions

Keep the original Uppercased localization. Handle the casing in Crowdin.

