### PR TITLE
ZIOS-9795: Disable call quality overlay if UseAnalytics is set to 0

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Overlay/ActiveVoiceChannelViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/ActiveVoiceChannelViewController.swift
@@ -198,7 +198,8 @@ extension ActiveVoiceChannelViewController : WireCallCenterCallStateObserver {
 
         if case let .terminating(reason) = callState {
             
-            guard let callStartDate = answeredCalls[conversation.remoteIdentifier!] else {
+            guard let callStartDate = answeredCalls[conversation.remoteIdentifier!],
+                AutomationHelper.sharedHelper.useAnalytics else {
                 return
             }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

Call quality survey overlay was shown when `UseAnalytics` flag was set to zero.

### Solutions

I'm now checking if `UseAnalytics` is active before showing the survey overlay.