### PR TITLE
Notify UI that sign in is successful

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/RegistrationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/RegistrationViewController.m
@@ -305,6 +305,9 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
         
         [self.rootNavigationController pushViewController:addEmailPasswordViewController animated:YES];
     }
+    else if (! [[ZMUserSession sharedSession] registeredOnThisDevice]) {
+        [self.delegate registrationViewControllerDidSignIn];
+    }
     else if ([self.class registrationFlow] == RegistrationFlowPhone) {
         [self.delegate registrationViewControllerDidCompleteRegistration];
     }


### PR DESCRIPTION
This portion of code used to show the "You logged in on the new device" screen, which was moved in the flow.