### PR TITLE
ZIOS-9838: Start UI title turns black

### DIFF
--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.m
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.m
@@ -146,6 +146,9 @@ static NSUInteger const StartUIInitiallyShowsKeyboardConversationThreshold = 10;
     self.quickActionsBar = [[StartUIInviteActionBar alloc] init];
     [self.quickActionsBar.inviteButton addTarget:self action:@selector(inviteMoreButtonTapped:) forControlEvents:UIControlEventTouchUpInside];
 
+    self.navigationController.navigationBar.barTintColor = [UIColor clearColor];
+    [self.navigationController.navigationBar setTranslucent:YES];
+    
     self.view.backgroundColor = [UIColor clearColor];
     
     [self createConstraints];


### PR DESCRIPTION
## What's new in this PR?

### Issues

1. Open the Start UI
2. Tap on "Create group"
3. Go back
4. The title inside the navigation bar is black

### Solutions

Setting the tint color and the translucency of the navigation bar inside the `viewDidLoad()` seems to solve the problem

## Notes

The title color seems to be updated only after completing the transition animation between the two view controllers.