### PR TITLE
remove observer before audioPlayerController is freed

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioEffectsPickerViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioEffectsPickerViewController.swift
@@ -98,7 +98,7 @@ import Cartography
     fileprivate static let effectColumns = 4
     
     deinit {
-        cleanUp()
+        tearDown()
     }
     
     public required init?(coder aDecoder: NSCoder) {
@@ -111,9 +111,9 @@ import Cartography
         super.init(nibName: .none, bundle: .none)
     }
 
-    func cleanUp() {
+    func tearDown() {
         self.audioPlayerController?.stop()
-        self.audioPlayerController?.cleanUpMediaPlayer()
+        self.audioPlayerController?.tearDownMediaPlayer()
         self.audioPlayerController = .none
     }
     
@@ -188,7 +188,7 @@ import Cartography
     }
     
     public override func removeFromParentViewController() {
-        cleanUp()
+        tearDown()
         super.removeFromParentViewController()
     }
     
@@ -204,7 +204,7 @@ import Cartography
     
     public override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        cleanUp()
+        tearDown()
     }
     
     public override func viewDidLayoutSubviews() {
@@ -276,7 +276,7 @@ import Cartography
     fileprivate func playMedia(_ atPath: String) {
         Analytics.shared().tagPreviewedAudioMessageRecording(.keyboard)
 
-        self.audioPlayerController?.cleanUpMediaPlayer()
+        self.audioPlayerController?.tearDownMediaPlayer()
 
         self.audioPlayerController = try? AudioPlayerController(contentOf: URL(fileURLWithPath: atPath))
         self.audioPlayerController?.delegate = self
@@ -356,10 +356,10 @@ private class AudioPlayerController : NSObject, MediaPlayer, AVAudioPlayerDelega
     }
     
     deinit {
-        cleanUpMediaPlayer()
+        tearDownMediaPlayer()
     }
 
-    func cleanUpMediaPlayer() {
+    func tearDownMediaPlayer() {
         mediaManager?.mediaPlayer(self, didChangeTo: .completed)
     }
 
@@ -395,7 +395,7 @@ private class AudioPlayerController : NSObject, MediaPlayer, AVAudioPlayerDelega
     
     func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
         if player == self.player {
-            cleanUpMediaPlayer()
+            tearDownMediaPlayer()
             delegate?.audioPlayerControllerDidFinishPlaying()
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioEffectsPickerViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioEffectsPickerViewController.swift
@@ -98,8 +98,7 @@ import Cartography
     fileprivate static let effectColumns = 4
     
     deinit {
-        self.audioPlayerController?.stop()
-        self.audioPlayerController = .none
+        cleanUp()
     }
     
     public required init?(coder aDecoder: NSCoder) {
@@ -110,6 +109,12 @@ import Cartography
         self.duration = duration
         self.recordingPath = recordingPath
         super.init(nibName: .none, bundle: .none)
+    }
+
+    func cleanUp() {
+        self.audioPlayerController?.stop()
+        self.audioPlayerController?.cleanUpMediaPlayer()
+        self.audioPlayerController = .none
     }
     
     fileprivate let collectionViewLayout: UICollectionViewFlowLayout = UICollectionViewFlowLayout()
@@ -183,8 +188,7 @@ import Cartography
     }
     
     public override func removeFromParentViewController() {
-        self.audioPlayerController?.stop()
-        self.audioPlayerController = nil
+        cleanUp()
         super.removeFromParentViewController()
     }
     
@@ -200,8 +204,7 @@ import Cartography
     
     public override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        self.audioPlayerController?.stop()
-        self.audioPlayerController = nil
+        cleanUp()
     }
     
     public override func viewDidLayoutSubviews() {
@@ -272,6 +275,9 @@ import Cartography
     
     fileprivate func playMedia(_ atPath: String) {
         Analytics.shared().tagPreviewedAudioMessageRecording(.keyboard)
+
+        self.audioPlayerController?.cleanUpMediaPlayer()
+
         self.audioPlayerController = try? AudioPlayerController(contentOf: URL(fileURLWithPath: atPath))
         self.audioPlayerController?.delegate = self
         self.audioPlayerController?.play()
@@ -350,6 +356,10 @@ private class AudioPlayerController : NSObject, MediaPlayer, AVAudioPlayerDelega
     }
     
     deinit {
+        cleanUpMediaPlayer()
+    }
+
+    func cleanUpMediaPlayer() {
         mediaManager?.mediaPlayer(self, didChangeTo: .completed)
     }
 
@@ -385,7 +395,7 @@ private class AudioPlayerController : NSObject, MediaPlayer, AVAudioPlayerDelega
     
     func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
         if player == self.player {
-            mediaManager?.mediaPlayer(self, didChangeTo: .completed)
+            cleanUpMediaPlayer()
             delegate?.audioPlayerControllerDidFinishPlaying()
         }
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

On iOS 9/10, app crashes when the user changes audio effect, dismiss audio record keyboard or rerecord the audio.

### Causes

AudioPlayerController was deallocated while key value observers were still registered with it.

### Solutions

Before AudioPlayerController is freed, remove the observer.

