### PR TITLE
Fix: App crashes when fast changing audio filter to first(none) effect

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioEffectsPickerViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioEffectsPickerViewController.swift
@@ -113,7 +113,7 @@ import Cartography
 
     func tearDown() {
         self.audioPlayerController?.stop()
-        self.audioPlayerController?.tearDownMediaPlayer()
+        self.audioPlayerController?.tearDown()
         self.audioPlayerController = .none
     }
     
@@ -276,7 +276,7 @@ import Cartography
     fileprivate func playMedia(_ atPath: String) {
         Analytics.shared().tagPreviewedAudioMessageRecording(.keyboard)
 
-        self.audioPlayerController?.tearDownMediaPlayer()
+        self.audioPlayerController?.tearDown()
 
         self.audioPlayerController = try? AudioPlayerController(contentOf: URL(fileURLWithPath: atPath))
         self.audioPlayerController?.delegate = self
@@ -356,10 +356,11 @@ private class AudioPlayerController : NSObject, MediaPlayer, AVAudioPlayerDelega
     }
     
     deinit {
-        tearDownMediaPlayer()
+        tearDown()
     }
 
-    func tearDownMediaPlayer() {
+    func tearDown() {
+        player.delegate = nil
         mediaManager?.mediaPlayer(self, didChangeTo: .completed)
     }
 
@@ -395,7 +396,7 @@ private class AudioPlayerController : NSObject, MediaPlayer, AVAudioPlayerDelega
     
     func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
         if player == self.player {
-            tearDownMediaPlayer()
+            tearDown()
             delegate?.audioPlayerControllerDidFinishPlaying()
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioEffectsPickerViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioEffectsPickerViewController.swift
@@ -358,7 +358,7 @@ private class AudioPlayerController : NSObject, MediaPlayer, AVAudioPlayerDelega
     deinit {
         tearDown()
 
-        delegate = nil
+        player.delegate = nil
     }
 
     func tearDown() {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioEffectsPickerViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioEffectsPickerViewController.swift
@@ -357,10 +357,11 @@ private class AudioPlayerController : NSObject, MediaPlayer, AVAudioPlayerDelega
     
     deinit {
         tearDown()
+
+        delegate = nil
     }
 
     func tearDown() {
-        player.delegate = nil
         mediaManager?.mediaPlayer(self, didChangeTo: .completed)
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioEffectsPickerViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioEffectsPickerViewController.swift
@@ -77,8 +77,7 @@ import Cartography
             
             if self.selectedAudioEffect != .none {
                 self.audioPlayerController?.stop()
-                
-                
+
                 let effectPath = (NSTemporaryDirectory() as NSString).appendingPathComponent("effect.wav")
                 effectPath.deleteFileAtPath()
                 self.selectedAudioEffect.apply(self.recordingPath, outPath: effectPath) {
@@ -357,12 +356,11 @@ private class AudioPlayerController : NSObject, MediaPlayer, AVAudioPlayerDelega
     
     deinit {
         tearDown()
-
-        player.delegate = nil
     }
 
     func tearDown() {
         mediaManager?.mediaPlayer(self, didChangeTo: .completed)
+        player.delegate = nil
     }
 
     var state: MediaPlayerState {
@@ -384,6 +382,7 @@ private class AudioPlayerController : NSObject, MediaPlayer, AVAudioPlayerDelega
     func play() {
         mediaManager?.mediaPlayer(self, didChangeTo: .playing)
         player.currentTime = 0
+        player.delegate = self
         player.play()
     }
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

App crashes when fast tapping audio effect keyboard. 

### Causes

It crashes at the line  -[AVAudioRecorder finishedRecording], possible reason is AVAudioPlayer.delegate is unowned(unsafe), not a weak type. It always assume delegate is non nil.

### Solutions

Manually set AVAudioPlayer.delegate to nil when tearDown.

