### PR TITLE
Fix: Timer is not reset immediately after re-recording the audio message

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
@@ -330,6 +330,7 @@ private let zmLog = ZMSLog(tag: "UI")
         case .ready:
             self.closeEffectsPicker(animated: false)
             self.recordTapGestureRecognizer.isEnabled = true
+            updateTimeLabel(0)
         case .recording:
             self.closeEffectsPicker(animated: false)
             self.recordTapGestureRecognizer.isEnabled = false


### PR DESCRIPTION
## What's new in this PR?

### Issues

Audio record time is not reset immediately after re-recording the audio message.

### Causes

The time label should be reset to 0 after the state change to .ready 

### Solutions

reset time label when the state change to ready.

