### PR TITLE
Do not crash when logging out

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
@@ -137,6 +137,7 @@ static const CGFloat BurstContainerExpandedHeight = 40;
     if (newWindow != nil) {
         [self scheduledTimerForUpdateBurstTimestamp];
     } else {
+        [self tearDownCountdownLink];
         [self.burstTimestampTimer invalidate];
         self.burstTimestampTimer = nil;
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

The problem happens when user received the timed message and this message is visible with the running timer in the current open conversation. If then user selects then to log out the app would crash.

### Causes

The crash is happening because the countdown timer continues to run. When it updates and the data model is already torn down, there is no way to query the message state, so it causes the crash.

### Solutions

Generally the cell must get `didEndDisplayingInTableView` callback when it's removed from the screen, but it is most likely not happening since the whole table view gets deallocated.
The fix makes the display timer stop when the cell gets removed from the window.