### PR TITLE
ZIOS-9875: Fix reversed content cell in 3D Touch peek

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+PeekPop.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+PeekPop.swift
@@ -28,7 +28,9 @@ extension ConversationContentViewController: UIViewControllerPreviewingDelegate 
 
     public func previewingContext(_ previewingContext: UIViewControllerPreviewing, viewControllerForLocation location: CGPoint) -> UIViewController? {
 
-        guard let cellIndexPath = self.tableView.indexPathForRow(at: location),
+        let cellLocation = view.convert(location, to: tableView)
+
+        guard let cellIndexPath = self.tableView.indexPathForRow(at: cellLocation),
               let message = self.messageWindow.messages[cellIndexPath.row] as? ZMConversationMessage else {
             return .none
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -203,13 +203,10 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
 - (void)viewDidAppear:(BOOL)animated
 {
     [super viewDidAppear:animated];
-    
     [self updateVisibleMessagesWindow];
-    
-    if ([self respondsToSelector:@selector(registerForPreviewingWithDelegate:sourceView:)] &&
-        [[UIApplication sharedApplication] keyWindow].traitCollection.forceTouchCapability == UIForceTouchCapabilityAvailable) {
-        
-        [self registerForPreviewingWithDelegate:self sourceView:self.tableView];
+
+    if (self.traitCollection.forceTouchCapability == UIForceTouchCapabilityAvailable) {
+        [self registerForPreviewingWithDelegate:self sourceView:self.view];
     }
 
     [self scrollToLastUnreadMessageIfNeeded];


### PR DESCRIPTION
## What's new in this PR?

### Issues

When lightly pressing on a conversation content cell, the contents appear flipped inside the 3D Touch preview.

### Causes

The previewing was registered with the content table view. This view has an affine transform that flips the contents. When the peek is created, the transforms are removed from the snapshot and thus the contents appeared flipped.

### Solutions

Previewing is now registered with the parent view of the table, which has no transform.