### PR TITLE
Backup: Changed parent UTI type from ZIP to public.data

### DIFF
--- a/Wire-iOS/Wire-Info.plist
+++ b/Wire-iOS/Wire-Info.plist
@@ -136,10 +136,12 @@
 		<dict>
 			<key>UTTypeConformsTo</key>
 			<array>
-				<string>com.pkware.zip-archive</string>
+				<string>public.data</string>
 			</array>
 			<key>UTTypeDescription</key>
 			<string>Wire iOS Backup File</string>
+			<key>UTTypeIconFiles</key>
+			<array/>
 			<key>UTTypeIdentifier</key>
 			<string>com.wire.backup-ios</string>
 			<key>UTTypeSize320IconFile</key>


### PR DESCRIPTION
## What's new in this PR?

### Issues


The UTI types are building a graph-like hierarchy. Initially the backup used to be a ZIP archive, therefore it was inherited from ZIP file UTI. Now as we changed the files to be encrypted the inheritance from ZIP does not make sense any more.

### Reference

[Apple System-Defined UTI Types](https://developer.apple.com/library/content/documentation/Miscellaneous/Reference/UTIRef/Articles/System-DeclaredUniformTypeIdentifiers.html)
