### PR TITLE
make sure data detected urls are handled by os

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Views/LinkInteractionTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/LinkInteractionTextView.swift
@@ -29,6 +29,9 @@ import UIKit
     
     public weak var interactionDelegate: TextViewInteractionDelegate?
     
+    // URLs with these schemes should be handled by the os.
+    fileprivate let dataDetectedURLSchemes = [ "x-apple-data-detectors", "tel", "mailto"]
+    
     override init(frame: CGRect, textContainer: NSTextContainer?) {
         super.init(frame: frame, textContainer: textContainer)
         delegate = self
@@ -101,7 +104,7 @@ extension LinkInteractionTextView: UITextViewDelegate {
         if showAlertIfNeeded(for: URL, in: characterRange) { return false }
         
         // data detector links should be handled by the system
-        return URL.scheme == "x-apple-data-detectors" || !(interactionDelegate?.textView(self, open: URL) ?? false)
+        return dataDetectedURLSchemes.contains(URL.scheme ?? "") || !(interactionDelegate?.textView(self, open: URL) ?? false)
     }
     
     public func textView(_ textView: UITextView, shouldInteractWith textAttachment: NSTextAttachment, in characterRange: NSRange) -> Bool {
@@ -126,7 +129,7 @@ extension LinkInteractionTextView: UITextViewDelegate {
             // if alert shown, link opening is handled in alert actions
             if showAlertIfNeeded(for: URL, in: characterRange) { return false }
             // data detector links should be handle by the system
-            return  URL.scheme == "x-apple-data-detectors" || !(interactionDelegate?.textView(self, open: URL) ?? false)
+            return  dataDetectedURLSchemes.contains(URL.scheme ?? "") || !(interactionDelegate?.textView(self, open: URL) ?? false)
         case .presentActions:
             interactionDelegate?.textViewDidLongPress(self)
             return false


### PR DESCRIPTION
## What's new in this PR?

### Issues

When *Chrome* was set as the default browser, tapping on a detected email or phone number would open chrome, instead of performing native actions (opening *Mail* or asking to call that number).

### Causes

Detected email addresses and phone numbers have the URL schemes `mailto` and `tel` respectively. When opening a link, we check if the URL scheme is `x-apple-data-detectors`, and if so, allow the operating system to handle it, otherwise we open the link ourselves, adhering to the user's default browser setting.

### Solutions

Create a list of URL schemes for links that need to be opened by the operating system, against which we compare the schemes of tapped links.
