### PR TITLE
Set userSession on UserImageView so that it will observe the user

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Views/UserCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/UserCell.swift
@@ -136,6 +136,7 @@ class UserCell: UICollectionViewCell, Themeable {
         subtitleLabel.font = FontSpec.init(.small, .regular).font!
         subtitleLabel.accessibilityIdentifier = "user_cell.username"
         
+        avatar.userSession = ZMUserSession.shared()
         avatar.initials.font = UIFont.systemFont(ofSize: 11, weight: UIFontWeightLight)
         avatar.size = .tiny
         avatar.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
### Issues

Profile picture weren't shown for search users.

### Causes

The `UserImageView` didn't start observing the search user because it didn't have the `userSession` property set

### Solutions

Set the `userSession` property.