### PR TITLE
feature: ZIOS-7694  [UX] [Improvement] Not possible to sketch/add emoji on a photo taken from a full screen camera in camera keyboard

### DIFF
--- a/Wire-iOS/Sources/Analytics/Events/Analytics+MediaActionEvents.swift
+++ b/Wire-iOS/Sources/Analytics/Events/Analytics+MediaActionEvents.swift
@@ -132,6 +132,16 @@ public extension ConversationMediaSketchSource {
     var method: ConversationMediaPictureTakeMethod = .none
     var sketchSource: ConversationMediaSketchSource = .none
     var camera: ConversationMediaPictureCamera = .none
+
+    @objc static func metadata(with camera: ConversationMediaPictureCamera, method: ConversationMediaPictureTakeMethod) -> ImageMetadata {
+        let metadata = ImageMetadata()
+        metadata.camera = camera
+        metadata.method = method
+        metadata.source = ConversationMediaPictureSource.camera
+        metadata.sketchSource = .none
+
+        return metadata
+    }
 }
 
 extension AudioMessageContext {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
@@ -457,13 +457,9 @@ extension CameraKeyboardViewController: CameraCellDelegate {
         let isFrontCamera = cameraController.currentCamera == .front
         
         let camera: ConversationMediaPictureCamera = isFrontCamera ? ConversationMediaPictureCamera.front : ConversationMediaPictureCamera.back
-        
-        let metadata = ImageMetadata()
-        metadata.camera = camera
-        metadata.method = ConversationMediaPictureTakeMethod.keyboard
-        metadata.source = ConversationMediaPictureSource.camera
-        metadata.sketchSource = .none
-        
+
+        let metadata = ImageMetadata.metadata(with: camera, method: .keyboard)
+
         self.delegate?.cameraKeyboardViewController(self, didSelectImageData: imageData, metadata: metadata)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Files.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Files.m
@@ -378,10 +378,11 @@ const NSTimeInterval ConversationUploadMaxVideoDuration = 4.0f * 60.0f; // 4 min
                 ConversationMediaPictureCamera camera = picker.cameraDevice == UIImagePickerControllerCameraDeviceFront ? ConversationMediaPictureCameraFront : ConversationMediaPictureCameraBack;
                 
                 [Analytics.shared tagMediaSentPictureSourceCameraInConversation:self.conversation method:ConversationMediaPictureTakeMethodFullFromKeyboard camera:camera];
-                
-                [self.sendController sendMessageWithImageData:UIImageJPEGRepresentation(image, 0.9) completion:^{
+
+                [self.parentViewController dismissViewControllerAnimated:YES completion:^(){
                     picker.showLoadingView = NO;
-                    [self.parentViewController dismissViewControllerAnimated:YES completion:nil];
+                    ImageMetadata *metadata = [ImageMetadata metadataWith:camera method:ConversationMediaPictureTakeMethodFullFromKeyboard];
+                    [self showConfirmationForImage:UIImageJPEGRepresentation(image, 0.9) metadata:metadata];
                 }];
             }
             else {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Right now in a full screen camera we are using a native camera. But in this case we couldn't have a preview with sketch and emoji.

### Solutions

When shot a photo with full screen camera, follow camera keyboard's workflow.

