### PR TITLE
fix: ZIOS-9783  First double tap doesn't zoom picture in when it's opened full screen

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.m
@@ -174,12 +174,6 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
     }
 }
 
-- (void)viewWillLayoutSubviews
-{
-    [super viewWillLayoutSubviews];
-    [self updateZoom];
-}
-
 - (BOOL)prefersStatusBarHidden
 {
     return NO;


### PR DESCRIPTION
## What's new in this PR?

### Issues

The image does not zoom in for the first double tap. 

### Causes

For uncertain reason, viewWillLayoutSubview is called for the first call trigger of double tap gesture. The zoom level is reseted

### Solutions

Do not call updateZoom when viewWillLayoutSubview

## Notes

It also fixes "rotate screen and zoom resets issue".