### PR TITLE
fix: unwrap name of ZMBareUser before creating Attributed string

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Views/UserCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/UserCell.swift
@@ -294,7 +294,7 @@ extension ZMBareUser {
             return AvailabilityStringBuilder.string(for: user, with: .list, color: color)
         } else {
             if let name = name {
-                return NSAttributedString(string: name) ///TODO: unwrap? name is nil when a guest adding a bot
+                return NSAttributedString(string: name)
             } else {
                 return nil
             }

--- a/Wire-iOS/Sources/UserInterface/Components/Views/UserCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/UserCell.swift
@@ -289,11 +289,15 @@ extension UserCell {
 
 extension ZMBareUser {
     
-    func nameIncludingAvailability(color: UIColor) -> NSAttributedString {
+    func nameIncludingAvailability(color: UIColor) -> NSAttributedString? {
         if ZMUser.selfUser().isTeamMember, let user = self as? ZMUser {
             return AvailabilityStringBuilder.string(for: user, with: .list, color: color)
         } else {
-            return NSAttributedString(string: name)
+            if let name = name {
+                return NSAttributedString(string: name) ///TODO: unwrap? name is nil when a guest adding a bot
+            } else {
+                return nil
+            }
         }
     }
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

App crashes when calling ZMBareUser.nameIncludingAvailability (the ZMBareUser is a service user)

### Causes

name property is nil

### Solutions

unwrap before creating attributed string

