### PR TITLE
ZIOS-9889: Audio message is discarded after Wire call

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
@@ -81,7 +81,7 @@ private let zmLog = ZMSLog(tag: "UI")
     
     public override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        recorder.stopRecording()
+        //recorder.stopRecording()
     }
     
     func configureViews() {
@@ -250,6 +250,14 @@ private let zmLog = ZMSLog(tag: "UI")
             cancelButton.centerY == bottomToolbar.centerY
             cancelButton.right == bottomToolbar.right - 8
         }
+    }
+    
+    func stopRecording() {
+        recorder.stopRecording()
+    }
+    
+    var isRecording: Bool {
+        return self.recorder.state == .recording
     }
     
     public override func viewDidLayoutSubviews() {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
@@ -81,7 +81,7 @@ private let zmLog = ZMSLog(tag: "UI")
     
     public override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        //recorder.stopRecording()
+        recorder.stopRecording()
     }
     
     func configureViews() {
@@ -250,10 +250,6 @@ private let zmLog = ZMSLog(tag: "UI")
             cancelButton.centerY == bottomToolbar.centerY
             cancelButton.right == bottomToolbar.right - 8
         }
-    }
-    
-    func stopRecording() {
-        recorder.stopRecording()
     }
     
     var isRecording: Bool {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Audio.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Audio.swift
@@ -35,7 +35,7 @@ extension ConversationInputBarViewController {
         let longPressRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(audioButtonLongPressed(_:)))
         longPressRecognizer.minimumPressDuration = 0.3
         button.addGestureRecognizer(longPressRecognizer)
-        
+
         let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(audioButtonPressed(_:)))
         tapGestureRecognizer.require(toFail: longPressRecognizer)
         button.addGestureRecognizer(tapGestureRecognizer)
@@ -45,7 +45,7 @@ extension ConversationInputBarViewController {
         guard sender.state == .ended else {
             return
         }
-        
+
         if self.mode != .audioRecord {
             UIApplication.wr_requestOrWarnAboutMicrophoneAccess({ accepted in
                 if accepted {
@@ -110,13 +110,13 @@ extension ConversationInputBarViewController {
         guard let audioRecordViewController = self.audioRecordViewController else {
             return
         }
-        
+
         audioRecordViewController.setOverlayState(.hidden, animated: false)
         
         UIView.transition(with: inputBar, duration: 0.1, options: [.transitionCrossDissolve, .allowUserInteraction], animations: {
             audioRecordViewController.view.isHidden = false
-        }, completion: { _ in
-            audioRecordViewController.setOverlayState(.expanded(0), animated: true)
+            }, completion: { _ in
+                audioRecordViewController.setOverlayState(.expanded(0), animated: true)
         })
     }
     
@@ -144,7 +144,7 @@ extension ConversationInputBarViewController {
         
         UIView.transition(with: inputBar, duration: 0.2, options: .transitionCrossDissolve, animations: {
             audioRecordViewController.view.isHidden = true
-        }, completion: nil)
+            }, completion: nil)
     }
     
     public func hideCameraKeyboardViewController(_ completion: @escaping ()->()) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Audio.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Audio.swift
@@ -24,6 +24,13 @@ import Cartography
 
 extension ConversationInputBarViewController {
     
+    
+    func setupCallStateObserver() {
+        if let userSession = ZMUserSession.shared() {
+            callStateObserverToken = WireCallCenterV3.addCallStateObserver(observer: self, userSession:userSession)
+        }
+    }
+    
     func configureAudioButton(_ button: IconButton) {
         let longPressRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(audioButtonLongPressed(_:)))
         longPressRecognizer.minimumPressDuration = 0.3
@@ -172,6 +179,27 @@ extension ConversationInputBarViewController: AudioRecordViewControllerDelegate 
         uploadFile(at: recordingURL as URL)
         
         self.hideAudioRecordViewController()
+    }
+    
+}
+
+
+extension ConversationInputBarViewController : WireCallCenterCallStateObserver {
+    
+    public func callCenterDidChange(callState: CallState, conversation: ZMConversation, caller: ZMUser, timestamp: Date?) {
+        
+        if case .incoming = callState, self.audioRecordKeyboardViewController?.recorder.state == .recording, !self.wasRecordingBeforeCall {
+            self.wasRecordingBeforeCall = true
+            self.audioRecordKeyboardViewController?.stopRecording()
+        }
+        
+        //better handle all the cases here (e.g. when you reply from another device)
+        
+        if case .terminating = callState, self.wasRecordingBeforeCall {
+            self.wasRecordingBeforeCall = false
+            self.mode = .audioRecord
+            self.inputBar.textView.becomeFirstResponder()
+        }
     }
     
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Audio.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Audio.swift
@@ -35,7 +35,7 @@ extension ConversationInputBarViewController {
         let longPressRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(audioButtonLongPressed(_:)))
         longPressRecognizer.minimumPressDuration = 0.3
         button.addGestureRecognizer(longPressRecognizer)
-
+        
         let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(audioButtonPressed(_:)))
         tapGestureRecognizer.require(toFail: longPressRecognizer)
         button.addGestureRecognizer(tapGestureRecognizer)
@@ -45,7 +45,7 @@ extension ConversationInputBarViewController {
         guard sender.state == .ended else {
             return
         }
-
+        
         if self.mode != .audioRecord {
             UIApplication.wr_requestOrWarnAboutMicrophoneAccess({ accepted in
                 if accepted {
@@ -110,13 +110,13 @@ extension ConversationInputBarViewController {
         guard let audioRecordViewController = self.audioRecordViewController else {
             return
         }
-
+        
         audioRecordViewController.setOverlayState(.hidden, animated: false)
         
         UIView.transition(with: inputBar, duration: 0.1, options: [.transitionCrossDissolve, .allowUserInteraction], animations: {
             audioRecordViewController.view.isHidden = false
-            }, completion: { _ in
-                audioRecordViewController.setOverlayState(.expanded(0), animated: true)
+        }, completion: { _ in
+            audioRecordViewController.setOverlayState(.expanded(0), animated: true)
         })
     }
     
@@ -144,7 +144,7 @@ extension ConversationInputBarViewController {
         
         UIView.transition(with: inputBar, duration: 0.2, options: .transitionCrossDissolve, animations: {
             audioRecordViewController.view.isHidden = true
-            }, completion: nil)
+        }, completion: nil)
     }
     
     public func hideCameraKeyboardViewController(_ completion: @escaping ()->()) {
@@ -188,18 +188,28 @@ extension ConversationInputBarViewController : WireCallCenterCallStateObserver {
     
     public func callCenterDidChange(callState: CallState, conversation: ZMConversation, caller: ZMUser, timestamp: Date?) {
         
-        if case .incoming = callState, self.audioRecordKeyboardViewController?.recorder.state == .recording, !self.wasRecordingBeforeCall {
+        let isRecording = self.audioRecordKeyboardViewController?.recorder.state == .recording
+        
+        switch callState {
+            
+        case .incoming(_, let shouldRing, _) where shouldRing && isRecording && !self.wasRecordingBeforeCall:
+            fallthrough
+        case .outgoing where isRecording && !self.wasRecordingBeforeCall:
             self.wasRecordingBeforeCall = true
-            self.audioRecordKeyboardViewController?.stopRecording()
+            
+        case .incoming(_, let shouldRing, _) where !shouldRing && self.wasRecordingBeforeCall:
+            fallthrough
+        case .terminating where self.wasRecordingBeforeCall:
+            displayRecordKeyboard()
+            
+        default: break
         }
-        
-        //better handle all the cases here (e.g. when you reply from another device)
-        
-        if case .terminating = callState, self.wasRecordingBeforeCall {
-            self.wasRecordingBeforeCall = false
-            self.mode = .audioRecord
-            self.inputBar.textView.becomeFirstResponder()
-        }
+    }
+    
+    private func displayRecordKeyboard() {
+        self.wasRecordingBeforeCall = false
+        self.mode = .audioRecord
+        self.inputBar.textView.becomeFirstResponder()
     }
     
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Private.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Private.h
@@ -40,6 +40,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic)           BOOL shouldRefocusKeyboardAfterImagePickerDismiss;
 @property (nonatomic)           BOOL inputBarOverlapsContent;
 @property (nonatomic)           NSUInteger videoSendContext;
+@property (nonatomic) id callStateObserverToken;
+@property (nonatomic) BOOL wasRecordingBeforeCall;
 
 @property (nonatomic, nonnull) ConversationInputBarButtonState *sendButtonState;
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -193,6 +193,8 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
 {
     [super viewDidLoad];
     
+    [self setupCallStateObserver];
+    
     [self createSingleTapGestureRecognizer];
     
     [self createInputBar]; // Creates all input bar buttons
@@ -795,9 +797,8 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
     }
 }
 
-- (void)keyboardDidHide:(NSNotification *)notification
-{
-    if (!self.inRotation) {
+- (void)keyboardDidHide:(NSNotification *)notification {
+    if (!self.inRotation && !self.audioRecordKeyboardViewController.isRecording) {
         self.mode = ConversationInputBarViewControllerModeTextInput;
     }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Audio recordings started before incoming or outgoing calls were deleted due to an unhandled case.

### Causes

This is because the keyboard got dismissed on `viewWillDisappear()`, but the continuation of the flow (adding effects on the registration and sending it) was not handled.

### Solutions

I'm now handling the cases where the keyboard should reappear after the call termination by monitoring changes on `WireCallCenterCallStateObserver` inside `ConversationInputBarViewController+Audio.swift`.