### PR TITLE
undo viewWillLayoutSubviews

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.m
@@ -174,6 +174,12 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
     }
 }
 
+- (void)viewWillLayoutSubviews
+{
+    [super viewWillLayoutSubviews];
+    [self updateZoom];
+}
+
 - (BOOL)prefersStatusBarHidden
 {
     return NO;


### PR DESCRIPTION
## What's new in this PR?

### Issues

Force-touch image preview and full-screen image view's image zoom level is invalid after https://github.com/wireapp/wire-ios/pull/2022.

### Causes

Zoom ratio is not recalculated force-touch image preview and full-screen image view

### Solutions

Undo the changes in https://github.com/wireapp/wire-ios/pull/2022. The ticket will be restarted.

