### PR TITLE
Fix the check for adding bot to conversation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Services/ServiceDetailViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Services/ServiceDetailViewController.swift
@@ -21,7 +21,7 @@ import Cartography
 
 extension ZMConversation {
     var botCanBeAdded: Bool {
-        return self.conversationType != .oneOnOne && self.team != nil
+        return DeveloperMenuState.developerMenuEnabled() && self.conversationType != .oneOnOne && self.team != nil
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Services/ServiceDetailViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Services/ServiceDetailViewController.swift
@@ -21,7 +21,7 @@ import Cartography
 
 extension ZMConversation {
     var botCanBeAdded: Bool {
-        return self.conversationType != .oneOnOne && canAddGuest
+        return self.conversationType != .oneOnOne && self.team != nil
     }
 }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

We were able to add services to non-team conversations

### Causes

The check was checking if you can add guests instead.

### Notes

Same as #2033, but using correct base branch