### PR TITLE
Fix verified shield being visible without own devices being verified

### DIFF
--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.m
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.m
@@ -222,9 +222,10 @@ typedef NS_ENUM(NSUInteger, ProfileViewControllerTabBarIndex) {
 {
     ZMUser *user = [self fullUser];
     if (nil != user) {
-        BOOL showShield = user.trusted && user.clients.count > 0 &&
-                        self.context != ProfileViewControllerContextDeviceList &&
-                        self.tabsController.selectedIndex != ProfileViewControllerTabBarIndexDevices;
+        BOOL showShield = user.trusted && user.clients.count > 0
+                       && self.context != ProfileViewControllerContextDeviceList
+                       && self.tabsController.selectedIndex != ProfileViewControllerTabBarIndexDevices
+                       && ZMUser.selfUser.trusted;
 
         self.profileTitleView.showVerifiedShield = showShield;
     }


### PR DESCRIPTION
## What's new in this PR?

* Fix verified shield being visible without own devices being verified.