### PR TITLE
ZIOS-9899: Fix 3D Touch location preview glitch on iPhone X

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Previews/LocationPreviewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Previews/LocationPreviewController.swift
@@ -90,10 +90,7 @@ class LocationPreviewController: UIViewController {
 
     private func createConstraints() {
         constrain(view, containerView, mapView) { contentView, container, mapView in
-            container.left == contentView.left
-            container.right == contentView.right
-            container.top == contentView.top
-            container.bottom == contentView.bottom
+            container.edges == contentView.edges
             mapView.edges == container.edges
         }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Previews/LocationPreviewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Previews/LocationPreviewController.swift
@@ -90,8 +90,8 @@ class LocationPreviewController: UIViewController {
 
     private func createConstraints() {
         constrain(view, containerView, mapView) { contentView, container, mapView in
-            container.left == contentView.leftMargin
-            container.right == contentView.rightMargin
+            container.left == contentView.left
+            container.right == contentView.right
             container.top == contentView.top
             container.bottom == contentView.bottom
             mapView.edges == container.edges


### PR DESCRIPTION
## What's new in this PR?

### Issues

When swiping up on a location preview on iPhone X, the preview looses its rounded edges and becomes smaller.

### Causes

This is caused by a bug with Auto Layout on iPhone X. The safe area margins are changed when moving the preview up, which causes the frame of the map to change.

### Solutions

Constraining the map to the edges of the view fixes the issue.

### Attachments

![locpreview](https://user-images.githubusercontent.com/16192914/39181086-ddba7f62-47b8-11e8-800f-f9a89b31a8fe.jpg)

![iphonex-fix](https://user-images.githubusercontent.com/16192914/39181092-e0cddc26-47b8-11e8-8dce-82e8259fa95a.png)