### PR TITLE
Fix crash when calling without CallKit

### DIFF
--- a/Wire-iOS/Sources/Analytics/Events/Analytics+MediaActionEvents.swift
+++ b/Wire-iOS/Sources/Analytics/Events/Analytics+MediaActionEvents.swift
@@ -171,20 +171,6 @@ let videoDurationClusterizer: TimeIntervalClusterizer = {
     return TimeIntervalClusterizer.videoDuration()
 }()
 
-
-public extension ZMConversation {
-
-    var ephemeralTrackingAttributes: [String: Any] {
-        let ephemeral = destructionTimeout != .none
-        var attributes: [String:Any] = ["is_ephemeral": ephemeral]
-        guard ephemeral else { return attributes }
-        attributes["ephemeral_time"] = "\(Int(destructionTimeout.rawValue))"
-        return attributes
-    }
-
-}
-
-
 public extension Analytics {
 
     /// User clicked on any action in cursor, giphy button or audio / video call button from toolbar.


### PR DESCRIPTION
## What's new in this PR?

### Issues

The app crashes when trying to accept the non-callkit call.

### Causes

The tracking meta generation method `ephemeralTrackingAttributes` was implemented on the same class in extensions in UI and in SE. The problem was that the return type of the method was different, so in the run time the expected return was not matching with the real one.

### Solutions

Remove the implementation of the method from the UI and make the SE method public so there is no possibility of the return type mismatch.

## Dependencies

- [x] https://github.com/wireapp/wire-ios-sync-engine/pull/750