### PR TITLE
Add manual triggering of tests 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,10 +61,18 @@ jobs:
     - save_cache: *gems_cache
     - save_cache: *carthage_cache
 
+  approve:
+    <<: *defaults
+    steps:
+      - run: echo "Stopping until approved!"
+
 workflows:
   version: 2
   build_and_test:
     jobs:
-      - build:
+      - approve:
         type: approval
+      - build:
+          requires: 
+            - approve
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 
 defaults: &defaults
   environment:
-    - DEPENDENCIES_BASE_URL: "https://raw.githubusercontent.com/wireapp/wire-ios-shared-resources/fix/xcode-9.3"
+    - DEPENDENCIES_BASE_URL: "https://raw.githubusercontent.com/wireapp/wire-ios-shared-resources/master"
   macos:
     xcode: "9.3.0"
   shell: /bin/bash --login -eo pipefail
@@ -32,7 +32,6 @@ setup_environment: &setup_environment
 
 version: 2
 jobs:
-      
   build:
     <<: *defaults
     branches:
@@ -61,3 +60,11 @@ jobs:
         path: build/junit
     - save_cache: *gems_cache
     - save_cache: *carthage_cache
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build:
+        type: approval
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ setup_environment: &setup_environment
 
 version: 2
 jobs:
-  build:
+  build-manual:
     <<: *defaults
     branches:
       ignore:
@@ -72,7 +72,7 @@ workflows:
     jobs:
       - approve:
         type: approval
-      - build:
+      - build-manual:
           requires: 
             - approve
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

We are going quite a bit over our CircleCI build minutes budget. The UI project takes most of the time to build and also has most PRs. Sometimes we push more commits to the branch and the tests get rerun every time which is suboptimal.

### Solutions

CircleCI support manual triggering of builds. We should run it when the changes are approved and we are done with work on the branch.

### Notes

Reopening #2041 to trigger new build
