### PR TITLE
Fix self user image size in settings on iPad in small horizontal trait

### DIFF
--- a/Wire-iOS/Sources/UserInterface/SelfProfile/ProfileView.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/ProfileView.swift
@@ -104,11 +104,13 @@ import Cartography
     }
     
     private func createConstraints() {
-        constrain(self, stackView) { selfView, stackView in
+        constrain(self, stackView, imageView) { selfView, stackView, imageView in
             stackView.top == selfView.top
             stackView.bottom <= selfView.bottom
             stackView.leading == selfView.leading
             stackView.trailing == selfView.trailing
+            imageView.leading >= selfView.leading + 40
+            imageView.trailing <= selfView.trailing - 40
         }
     }
     


### PR DESCRIPTION
## What's new in this PR?

* Fix self user image size in settings on iPad in small horizontal trait.

<img width="739" alt="screen shot 2018-04-24 at 14 54 37" src="https://user-images.githubusercontent.com/4603353/39188191-7221963e-47cf-11e8-892e-08b759b6d181.png">
