### PR TITLE
Added accessibility element that wraps the iOS controllers

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -693,6 +693,7 @@
 		87F6B6361D2E9CF500F057A5 /* EmojiOnlyStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F6B6351D2E9CF500F057A5 /* EmojiOnlyStringTests.swift */; };
 		87F6D1BB1C1590B7000AB4D2 /* RequestPasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F6D1BA1C1590B7000AB4D2 /* RequestPasswordViewController.swift */; };
 		87FC0AEB1FC71C020036E029 /* CharacterInputFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87FC0AE91FC719E80036E029 /* CharacterInputFieldTests.swift */; };
+		87FC98472090AC6B00015C34 /* AccessibilityWrapperController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87FC98462090AC6B00015C34 /* AccessibilityWrapperController.swift */; };
 		8F0DEDD51A693F58003F0ACC /* PingCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 8F0DEDD41A693F58003F0ACC /* PingCell.m */; };
 		8F41CFC319926B7A00E3B032 /* ZMUser+Additions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8F41CFC219926B7A00E3B032 /* ZMUser+Additions.m */; };
 		8F41CFC8199297C600E3B032 /* ZMConversation+Additions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8F41CFC5199297C600E3B032 /* ZMConversation+Additions.m */; };
@@ -2132,6 +2133,7 @@
 		87F6B6351D2E9CF500F057A5 /* EmojiOnlyStringTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmojiOnlyStringTests.swift; sourceTree = "<group>"; };
 		87F6D1BA1C1590B7000AB4D2 /* RequestPasswordViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestPasswordViewController.swift; sourceTree = "<group>"; };
 		87FC0AE91FC719E80036E029 /* CharacterInputFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterInputFieldTests.swift; sourceTree = "<group>"; };
+		87FC98462090AC6B00015C34 /* AccessibilityWrapperController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityWrapperController.swift; sourceTree = "<group>"; };
 		8F0DEDD31A693F58003F0ACC /* PingCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PingCell.h; sourceTree = "<group>"; };
 		8F0DEDD41A693F58003F0ACC /* PingCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PingCell.m; sourceTree = "<group>"; };
 		8F41CFC119926B7A00E3B032 /* ZMUser+Additions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ZMUser+Additions.h"; sourceTree = "<group>"; };
@@ -3539,6 +3541,7 @@
 				871BC1461D34F8F800DF0793 /* SplitViewController.m */,
 				87A1F9DA200CEDCA0040E9A9 /* ClearBackgroundNavigationController.swift */,
 				1682AEC2204840E7003A052A /* SectionCollectionViewController.swift */,
+				87FC98462090AC6B00015C34 /* AccessibilityWrapperController.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -6858,6 +6861,7 @@
 				EF1F9A021FBB1FD800969DD1 /* LandingButton.swift in Sources */,
 				8733378A1DF5B43A006AE609 /* SwiftDependencies.swift in Sources */,
 				8759E2C11FC828ED008E17C9 /* CAAnimation+Cursor.swift in Sources */,
+				87FC98472090AC6B00015C34 /* AccessibilityWrapperController.swift in Sources */,
 				1660F23A1FBF32D400A0EE54 /* MediaPlayerController.swift in Sources */,
 				167961AF20445FB400B72ACC /* ProfileTitleView.swift in Sources */,
 				87A15FE11E08339500AED79B /* CollectionLinkCell.swift in Sources */,

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/AccessibilityWrapperController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/AccessibilityWrapperController.swift
@@ -1,0 +1,46 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+final class AccessibilityWrapperController: UIViewController {
+    let wrappedController: UIViewController
+    
+    init(wrappedController: UIViewController) {
+        self.wrappedController = wrappedController
+        super.init(nibName: nil, bundle: nil)
+        
+        view.isAccessibilityElement = true
+        view.accessibilityIdentifier = "accessibilityWrapper"
+        
+        addToSelf(self.wrappedController)
+    }
+    
+    override var modalPresentationStyle: UIModalPresentationStyle {
+        get {
+            return wrappedController.modalPresentationStyle
+        }
+        set {
+            wrappedController.modalPresentationStyle = newValue
+        }
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Files.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Files.m
@@ -135,11 +135,13 @@ const NSTimeInterval ConversationUploadMaxVideoDuration = 4.0f * 60.0f; // 4 min
                                   [self presentImagePickerWithSourceType:UIImagePickerControllerSourceTypeCamera mediaTypes:@[(id)kUTTypeMovie] allowsEditing:false];
                               }];
     
-    UIPopoverPresentationController* popover = docController.popoverPresentationController;
+    UIViewController *accessibilityWrapper = [[AccessibilityWrapperController alloc] initWithWrappedController:docController];
+
+    UIPopoverPresentationController* popover = accessibilityWrapper.popoverPresentationController;
     popover.delegate = self;
     popover.sourceView = sender.superview;
     popover.sourceRect = sender.frame;
-    [self.parentViewController presentViewController:docController animated:YES completion:^() {
+    [self.parentViewController presentViewController:accessibilityWrapper animated:YES completion:^() {
         [[UIApplication sharedApplication] wr_updateStatusBarForCurrentControllerAnimated:YES];
     }];
 }

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/Steps/ProfilePictureStepViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/Steps/ProfilePictureStepViewController.m
@@ -232,7 +232,9 @@ NSString * const UnsplashRandomImageLowQualityURL = @"https://source.unsplash.co
     picker.sourceType = UIImagePickerControllerSourceTypePhotoLibrary;
     picker.delegate = self;
     
-    [self showController:picker inPopoverFromView:sender];
+    UIViewController *accessibilityWrapper = [[AccessibilityWrapperController alloc] initWithWrappedController:picker];
+    
+    [self showController:accessibilityWrapper inPopoverFromView:sender];
 }
 
 - (IBAction)keepPicture:(id)sender


### PR DESCRIPTION
It was requested to add the intermediate view that would wrap some controllers in order to calculate the elements positions:

 - Camera picker in the registration.
 - Documents picker.


@mykola-mokhnach name is "accessibilityWrapper".