### PR TITLE
Bump AVS to 4.3.16

### DIFF
--- a/avs-versions
+++ b/avs-versions
@@ -17,4 +17,4 @@
 # along with this program. If not, see http://www.gnu.org/licenses/.
 #
 
-export APPSTORE_AVS_VERSION=4.2.28
+export APPSTORE_AVS_VERSION=4.3.16


### PR DESCRIPTION
With the new message recording API we are asking AVS to prepare the audio session for the recording, AVS then is setting the session category and waiting for the confirmation from the operating system. Unfortunately on the Simulator the confirmation never arrives, so AVS is never telling us that it is ready to start the recording.

AVS fixed the issue from their side in the way that on the simulator they are immediately calling the callback without waiting for the iOS confirmation.