### PR TITLE
ZIOS-9804: No back button on email screen

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/Steps/EmailVerificationStepViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/Steps/EmailVerificationStepViewController.m
@@ -67,10 +67,15 @@
     [self createResendInstructions];
     [self createResendButton];
     
+    [self updateViewConstraints];
+}
+
+-(void)viewWillAppear:(BOOL)animated{
+    
+    [super viewWillAppear:animated];
+    
     self.registrationNavigationController.backButtonEnabled = YES;
     self.registrationNavigationController.wr_navigationController.logoEnabled = NO;
-    
-    [self updateViewConstraints];
 }
 
 - (void)viewWillDisappear:(BOOL)animated


### PR DESCRIPTION
## What's new in this PR?

### Issues

Back button wasn't visible when reaching `EmailVerificationStepViewController`, removing in this way the possibility to change email and password.

### Causes

This because the instructions for showing the back button and hiding the logo were called in the `viewDidLoad`, when the view controller was not in the navigation stack yet (there was only the previous view controller inside the stack)

### Solutions

I've moved the display logic inside `viewWillAppear`.
