### PR TITLE
ZIOS-9838: Start UI title turns black

### DIFF
--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.m
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.m
@@ -154,9 +154,9 @@ static NSUInteger const StartUIInitiallyShowsKeyboardConversationThreshold = 10;
     [self.searchResultsViewController searchContactList];
 }
 
-- (void)viewWillAppear:(BOOL)animated
+- (void)viewDidAppear:(BOOL)animated
 {
-    [super viewWillAppear:animated];
+    [super viewDidAppear:animated];
     
     self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithIcon:ZetaIconTypeX
                                                                              style:UIBarButtonItemStylePlain


### PR DESCRIPTION
## What's new in this PR?

### Issues

Start UI title color wasn't updated while coming back from the group creation flow, probably because of some pending transitions in the pop operation.

### Solutions

I've moved the setting of the visual properties (including the `titleTextAttributes`) from `viewWillAppear` to `viewDidAppear`. This is causing a little delay, because the code is executed at the completion of the transition - comments to improve this part are welcome!