### PR TITLE
Fix: App crashes when force touch a small image in conversation view

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarButtonsView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarButtonsView.swift
@@ -124,7 +124,7 @@ public final class InputBarButtonsView: UIView {
     
     fileprivate func layoutAndConstrainButtonRows() {
         guard bounds.size.width > 0 else { return }
-        
+
         // Drop existing constraints
         buttons.forEach {
             $0.removeFromSuperview()
@@ -154,7 +154,8 @@ public final class InputBarButtonsView: UIView {
         
         guard !secondRow.isEmpty else { return }
         let filled = secondRow.count == numberOfButtons
-        constrainRowOfButtons(secondRow, inset: constants.buttonsBarHeight, rowIsFull: filled, referenceButton: firstRow[1])
+        let referenceButton = firstRow.count > 1 ? firstRow[1] : firstRow[0]
+        constrainRowOfButtons(secondRow, inset: constants.buttonsBarHeight, rowIsFull: filled, referenceButton: referenceButton)
     }
     
     fileprivate func constrainRowOfButtons(_ buttons: [UIButton], inset: CGFloat, rowIsFull: Bool, referenceButton: UIButton?) {

--- a/Wire-iOS/Sources/UserInterface/Sketchpad/CanvasViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Sketchpad/CanvasViewController.swift
@@ -190,7 +190,7 @@ class CanvasViewController: UIViewController, UINavigationControllerDelegate {
             separatorLine.right == colorPicker.right
             separatorLine.height == .hairline
             
-            canvas.top == container.top
+            canvas.top == colorPicker.bottom
             canvas.left == container.left
             canvas.right == container.right
             

--- a/Wire-iOS/Sources/UserInterface/Sketchpad/CanvasViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Sketchpad/CanvasViewController.swift
@@ -190,7 +190,7 @@ class CanvasViewController: UIViewController, UINavigationControllerDelegate {
             separatorLine.right == colorPicker.right
             separatorLine.height == .hairline
             
-            canvas.top == colorPicker.bottom
+            canvas.top == container.top
             canvas.left == container.left
             canvas.right == container.right
             


### PR DESCRIPTION
## What's new in this PR?

### Issues

App crashes when force touch a small image(e.g. 70x70px) in conversation view

### Causes

When ConversationImagesViewController is going to layout its subviews, InputBarButtonsView crashes for the case only one button is shown in first row.

### Solutions

Actually, InputBarButtonsView's layoutSubview method will be called several times before it is shown. Choose the first button (expandRowButton) as reference button for the intermediate state layout, which the InputBarButtonsView's width only allow one button per row.