### PR TITLE
Only save authentication errors if we have a selected account

### DIFF
--- a/Wire-iOS/Sources/AppStateController.swift
+++ b/Wire-iOS/Sources/AppStateController.swift
@@ -125,8 +125,12 @@ extension AppStateController : SessionManagerDelegate {
     
     func sessionManagerDidFailToLogin(account: Account?, error: Error) {
         loadingAccount = nil
+        
         // We only care about the error if it concerns the selected account.
-        authenticationError = SessionManager.shared?.accountManager.selectedAccount == account ? error as NSError : nil
+        if let selectedAccount = SessionManager.shared?.accountManager.selectedAccount, selectedAccount == account {
+            authenticationError = error as NSError
+        }
+        
         isLoggedIn = false
         isLoggedOut = true
         updateAppState()


### PR DESCRIPTION
### Issues

Fixing https://github.com/wireapp/wire-ios/pull/2058 had a side effect which caused a freshly installed client to always launch into the login screen.

### Causes

Even when launching without any accounts SessionManager will call the `sessionManagerDidFailToLogin` delegate method with an error which we were previously losing due to the bug which was fixed.

### Solutions

Only save the error if we have a selected account by unwrapping the optional.