### PR TITLE
fix: Image in Sketch is covered by the color picker

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Sketchpad/CanvasViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Sketchpad/CanvasViewController.swift
@@ -190,7 +190,7 @@ class CanvasViewController: UIViewController, UINavigationControllerDelegate {
             separatorLine.right == colorPicker.right
             separatorLine.height == .hairline
             
-            canvas.top == container.top
+            canvas.top == colorPicker.bottom
             canvas.left == container.left
             canvas.right == container.right
             


### PR DESCRIPTION
## What's new in this PR?

### Issues

The image in Sketch is covered by the color picker.

### Causes

The canva's top is pinned to the container's top. If the image do not have an inset on top, the color picker covers the canvas

### Solutions

The canvas's top should be pinned to colorPicker's bottom instead of the container.

