### PR TITLE
Fix: Self profile screen UI issue on iOS9 

### DIFF
--- a/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
@@ -135,11 +135,16 @@ final internal class SelfProfileViewController: UIViewController {
             }
         }
 
-        constrain(view, accountSelectorController.view, profileContainerView) { selfView, accountSelectorControllerView, profileContainerView in
-            accountSelectorControllerView.height == 44
+        constrain(view, profileContainerView) { selfView, profileContainerView in
             profileContainerView.top == selfView.topMargin + selfViewTopMargin
         }
-        
+
+        constrain(accountSelectorController.view) {accountSelectorControllerView in
+            accountSelectorControllerView.height == 44
+            accountSelectorControllerView.centerX == accountSelectorControllerView.superview!.centerX
+            accountSelectorControllerView.centerY == accountSelectorControllerView.superview!.centerY
+        }
+
         let height = CGFloat(56 * settingsController.tableView.numberOfRows(inSection: 0))
         
         constrain(view, settingsController.view, profileView, profileContainerView, settingsController.tableView) { view, settingsControllerView, profileView, profileContainerView, tableView in

--- a/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
@@ -126,9 +126,18 @@ final internal class SelfProfileViewController: UIViewController {
     }
     
     private func createConstraints() {
+        var selfViewTopMargin: CGFloat = 12
+
+        if #available(iOS 10, *) {
+        } else {
+            if let naviBarHeight = self.navigationController?.navigationBar.frame.size.height {
+                selfViewTopMargin = 12 + naviBarHeight
+            }
+        }
+
         constrain(view, accountSelectorController.view, profileContainerView) { selfView, accountSelectorControllerView, profileContainerView in
             accountSelectorControllerView.height == 44
-            profileContainerView.top == selfView.topMargin + 12
+            profileContainerView.top == selfView.topMargin + selfViewTopMargin
         }
         
         let height = CGFloat(56 * settingsController.tableView.numberOfRows(inSection: 0))

--- a/Wire-iOS/Sources/UserInterface/Settings/SettingsTableViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/SettingsTableViewController.swift
@@ -80,8 +80,9 @@ class SettingsBaseTableViewController: UIViewController {
         footerContainer.addSubview(footerSeparator)
         footerSeparator.inverse = true
 
+        // do not set top inset for iOS 9 or 11
         if #available(iOS 11.0, *) {
-        } else {
+        } else if #available(iOS 10.0, *) {
             tableView.contentInset = UIEdgeInsets(top: -32, left: 0, bottom: 0, right: 0)
         }
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

On iOS, these issues are found in Self profile screen:

1. container view is covered by the navigation bar
2. table view top inset is negative 
3. accountSelectorControllerView is not center aligned

### Causes

The layout system of iOS9 is different from iOS11

### Solutions

Add iOS9 specific constraints for Self profile screen.