### PR TITLE
fix: ZIOS-9967 app crash when opening Profile screen

### DIFF
--- a/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
@@ -133,6 +133,13 @@ final internal class SelfProfileViewController: UIViewController {
             if let naviBarHeight = self.navigationController?.navigationBar.frame.size.height {
                 selfViewTopMargin = 12 + naviBarHeight
             }
+
+            if let superview = accountSelectorController.view.superview {
+                constrain(accountSelectorController.view, superview) {accountSelectorControllerView, superview in
+                    accountSelectorControllerView.centerX == superview.centerX
+                    accountSelectorControllerView.centerY == superview.centerY
+                }
+            }
         }
 
         constrain(view, profileContainerView) { selfView, profileContainerView in
@@ -141,8 +148,6 @@ final internal class SelfProfileViewController: UIViewController {
 
         constrain(accountSelectorController.view) {accountSelectorControllerView in
             accountSelectorControllerView.height == 44
-            accountSelectorControllerView.centerX == accountSelectorControllerView.superview!.centerX
-            accountSelectorControllerView.centerY == accountSelectorControllerView.superview!.centerY
         }
 
         let height = CGFloat(56 * settingsController.tableView.numberOfRows(inSection: 0))


### PR DESCRIPTION
## What's new in this PR?

This PR is a fix for https://github.com/wireapp/wire-ios/pull/2064.

### Issues

app crash when opening Profile screen

### Causes

accountSelectorController.view.superview is nil on iOS > 9

### Solutions

unwrap superview and apply the fix only for iOS9