### PR TITLE
fix: ZIOS-9960 unable to switch account

### DIFF
--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -207,7 +207,7 @@ class AppRootViewController: UIViewController {
             let launchImageViewController = LaunchImageViewController()
             launchImageViewController.showLoadingScreen()
             viewController = launchImageViewController
-        case .unauthenticated(error: let error):
+        case .unauthenticated(error: let error, userIdentifier: _):
             UIColor.setAccentOverride(ZMUser.pickRandomAcceptableAccentColor())
             mainWindow.tintColor = UIColor.accent()
             

--- a/Wire-iOS/Sources/AppState.swift
+++ b/Wire-iOS/Sources/AppState.swift
@@ -22,7 +22,7 @@ enum AppState : Equatable {
     
     case headless
     case authenticated(completedRegistration: Bool)
-    case unauthenticated(error : NSError?)
+    case unauthenticated(error : NSError?, userIdentifier : UUID?)
     case blacklisted
     case migrating
     case loading(account: Account, from: Account?)


### PR DESCRIPTION
## What's new in this PR?

### Issues

The app stays in loading state when a user fails to switch to an account 

### Causes

.unauthenticated enum value's error associated value is nil. The UI loading workflow does not execute.

### Solutions

Record in account.userIdentifier info in .unauthenticated. Handle the error cases (account is selectedAccount or not) in the same way.