### PR TITLE
Show participant list in group calls

### DIFF
--- a/Wire-iOS Tests/CallInfoViewControllerTests.swift
+++ b/Wire-iOS Tests/CallInfoViewControllerTests.swift
@@ -97,7 +97,7 @@ final class CallInfoViewControllerTests: CoreDataSnapshotTestCase {
     
     func testCallInfoViewController_Audio_NoCBR_SomeParticipants() {
         // Given
-        let participants = MockCallParticipantsViewModel.viewModel(withParticipantCount: 2)
+        let participants = CallParticipantsViewTests.participants(count: 2)
         
         sut.configuration = MockCallInfoViewControllerInput(
             accessoryType: .participantsList(participants),
@@ -121,7 +121,7 @@ final class CallInfoViewControllerTests: CoreDataSnapshotTestCase {
     
     func testCallInfoViewController_Audio_NoCBR_ManyParticipants() {
         // Given
-        let participants = MockCallParticipantsViewModel.viewModel(withParticipantCount: 4)
+        let participants = CallParticipantsViewTests.participants(count: 4)
         
         sut.configuration = MockCallInfoViewControllerInput(
             accessoryType: .participantsList(participants),
@@ -145,7 +145,7 @@ final class CallInfoViewControllerTests: CoreDataSnapshotTestCase {
     
     func testCallInfoViewController_Audio_NoCBR_ALotOfParticipants() {
         // Given
-        let participants = MockCallParticipantsViewModel.viewModel(withParticipantCount: 10)
+        let participants = CallParticipantsViewTests.participants(count: 10)
         
         sut.configuration = MockCallInfoViewControllerInput(
             accessoryType: .participantsList(participants),
@@ -214,7 +214,7 @@ final class CallInfoViewControllerTests: CoreDataSnapshotTestCase {
     
     func testCallInfoViewController_Video_NoCBR_SomeParticipants() {
         // Given
-        let participants = MockCallParticipantsViewModel.viewModel(withParticipantCount: 2)
+        let participants = CallParticipantsViewTests.participants(count: 2)
         
         sut.configuration = MockCallInfoViewControllerInput(
             accessoryType: .participantsList(participants),
@@ -238,7 +238,7 @@ final class CallInfoViewControllerTests: CoreDataSnapshotTestCase {
     
     func testCallInfoViewController_Video_NoCBR_ManyParticipants() {
         // Given
-        let participants = MockCallParticipantsViewModel.viewModel(withParticipantCount: 4)
+        let participants = CallParticipantsViewTests.participants(count: 4)
         
         sut.configuration = MockCallInfoViewControllerInput(
             accessoryType: .participantsList(participants),
@@ -262,7 +262,7 @@ final class CallInfoViewControllerTests: CoreDataSnapshotTestCase {
     
     func testCallInfoViewController_Video_NoCBR_ALotOfParticipants() {
         // Given
-        let participants = MockCallParticipantsViewModel.viewModel(withParticipantCount: 10)
+        let participants = CallParticipantsViewTests.participants(count: 10)
         
         sut.configuration = MockCallInfoViewControllerInput(
             accessoryType: .participantsList(participants),

--- a/Wire-iOS Tests/CallParticipantsViewTests.swift
+++ b/Wire-iOS Tests/CallParticipantsViewTests.swift
@@ -19,26 +19,6 @@
 import Foundation
 @testable import Wire
 
-class MockCallParticipantsViewModel: CallParticipantsViewModel {
-    
-    var rows: [CallParticipantsCellConfiguration]
-    
-    init(rows: [CallParticipantsCellConfiguration]) {
-        self.rows = rows
-    }
-    
-    static func viewModel(withParticipantCount participantCount: Int) -> CallParticipantsViewModel {
-        var rows: [CallParticipantsCellConfiguration] = []
-        
-        for index in 0..<participantCount {
-            rows.append(.callParticipant(user: MockUser.mockUsers()[index], sendsVideo: false))
-        }
-        
-        return MockCallParticipantsViewModel(rows: rows)
-    }
-    
-}
-
 class CallParticipantsViewTests: ZMSnapshotTestCase {
     
     var sut: CallParticipantsViewController!
@@ -53,22 +33,19 @@ class CallParticipantsViewTests: ZMSnapshotTestCase {
         super.tearDown()
     }
     
-    func viewModel(withParticipantCount participantCount: Int) -> CallParticipantsViewModel {
+    static func participants(count participantCount: Int) -> CallParticipantsList {
         var rows: [CallParticipantsCellConfiguration] = []
         
         for index in 0..<participantCount {
             rows.append(.callParticipant(user: MockUser.mockUsers()[index], sendsVideo: false))
         }
         
-        return MockCallParticipantsViewModel(rows: rows)
+        return rows
     }
     
     func testCallParticipants_overflowing() {
-        // Given
-        let viewModel = self.viewModel(withParticipantCount: 10)
-        
         // When
-        sut = CallParticipantsViewController(viewModel: viewModel, allowsScrolling: true)
+        sut = CallParticipantsViewController(participants: type(of: self).participants(count: 10), allowsScrolling: true)
         sut.view.frame = CGRect(x: 0, y: 0, width: 325, height: 336)
         sut.view.setNeedsLayout()
         sut.view.layoutIfNeeded()
@@ -78,11 +55,8 @@ class CallParticipantsViewTests: ZMSnapshotTestCase {
     }
     
     func testCallParticipants_truncated() {
-        // Given
-        let viewModel = self.viewModel(withParticipantCount: 10)
-        
         // When
-        sut = CallParticipantsViewController(viewModel: viewModel, allowsScrolling: false)
+        sut = CallParticipantsViewController(participants: type(of: self).participants(count: 10), allowsScrolling: false)
         sut.view.frame = CGRect(x: 0, y: 0, width: 325, height: 336)
         
         // Then

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoViewController.swift
@@ -53,9 +53,9 @@ final class CallInfoViewController: UIViewController, CallActionsViewDelegate {
     }
 
     init(configuration: CallInfoViewControllerInput) {
-        self.configuration = configuration
+        self.configuration = configuration        
         statusViewController = CallStatusViewController(configuration: configuration)
-        participantsViewController = CallParticipantsViewController(viewModel: configuration.accessoryType, allowsScrolling: false)
+        participantsViewController = CallParticipantsViewController(participants: configuration.accessoryType.participants, allowsScrolling: false)
         super.init(nibName: nil, bundle: nil)
         actionsView.delegate = self
     }
@@ -104,12 +104,20 @@ final class CallInfoViewController: UIViewController, CallActionsViewDelegate {
     private func updateState(animated: Bool = false) {
         actionsView.update(with: configuration)
         statusViewController.configuration = configuration
+        
+        switch configuration.accessoryType {
+        case .avatar(let user):
+            avatarView.user = user
+        case .participantsList(let participants):
+            participantsViewController.participants = participants
+        case .none:
+            break
+        }
+        
         avatarView.isHidden = !configuration.accessoryType.showAvatar
-        avatarView.user = configuration.accessoryType.user
-        participantsViewController.view.isHidden = configuration.accessoryType.showAvatar
-        participantsViewController.viewModel = configuration.accessoryType
+        participantsViewController.view.isHidden = !configuration.accessoryType.showParticipantList
         participantsViewController.variant = configuration.effectiveColorVariant
-
+        
         UIView.animate(withDuration: 0.2) { [view, configuration] in
             view?.backgroundColor = configuration.overlayBackgroundColor
         }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoViewControllerAccessoryType.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoViewControllerAccessoryType.swift
@@ -16,24 +16,34 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-enum CallInfoViewControllerAccessoryType: CallParticipantsViewModel {
+enum CallInfoViewControllerAccessoryType {
+    case none
     case avatar(ZMUser)
-    case participantsList(CallParticipantsViewModel)
+    case participantsList(CallParticipantsList)
     
-    var showAvatar: Bool {
-        return nil != user
-    }
-    
-    var user: ZMUser? {
-        guard case .avatar(let user) = self else { return nil }
-        return user
-    }
-    
-    var rows: [CallParticipantsCellConfiguration] {
-        switch self {
-        case .avatar: return []
-        case .participantsList(let model): return model.rows
+    var showParticipantList: Bool {
+        if case .participantsList = self {
+            return true
+        } else {
+            return false
         }
     }
-
+    
+    var showAvatar: Bool {
+        if case .avatar = self {
+            return true
+        } else {
+            return false
+        }
+    }
+    
+    var participants: CallParticipantsList {
+        switch self {
+        case .participantsList(let participants):
+            return participants
+        default:
+            return []
+        }
+    }
+    
 }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallParticipantsView/CallParticipantsView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallParticipantsView/CallParticipantsView.swift
@@ -18,9 +18,7 @@
 
 import Foundation
 
-protocol CallParticipantsViewModel {
-    var rows: [CallParticipantsCellConfiguration] { get }
-}
+typealias CallParticipantsList = [CallParticipantsCellConfiguration]
 
 protocol CallParticipantsCellConfigurationConfigurable: Reusable {
     
@@ -57,7 +55,7 @@ enum CallParticipantsCellConfiguration {
 
 class CallParticipantsView: UICollectionView, Themeable {
     
-    var rows = [CallParticipantsCellConfiguration]() {
+    var rows = CallParticipantsList() {
         didSet {
             reloadData()
         }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallParticipantsView/CallParticipantsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallParticipantsView/CallParticipantsViewController.swift
@@ -21,7 +21,7 @@ import Foundation
 class CallParticipantsViewController: UIViewController, UICollectionViewDelegateFlowLayout {
     
     let cellHeight: CGFloat = 56
-    var viewModel: CallParticipantsViewModel {
+    var participants: CallParticipantsList {
         didSet {
             updateRows()
         }
@@ -36,8 +36,8 @@ class CallParticipantsViewController: UIViewController, UICollectionViewDelegate
         }
     }
     
-    init(viewModel: CallParticipantsViewModel, allowsScrolling: Bool) {
-        self.viewModel = viewModel
+    init(participants: CallParticipantsList, allowsScrolling: Bool) {
+        self.participants = participants
         self.allowsScrolling = allowsScrolling
         super.init(nibName: nil, bundle: nil)
     }
@@ -91,16 +91,16 @@ class CallParticipantsViewController: UIViewController, UICollectionViewDelegate
         collectionView.rows = computeVisibleRows()
     }
 
-    func computeVisibleRows() -> [CallParticipantsCellConfiguration] {
-        guard !allowsScrolling else { return viewModel.rows }
+    func computeVisibleRows() -> CallParticipantsList {
+        guard !allowsScrolling else { return participants }
         
         let visibleRows = Int(collectionView.bounds.height / cellHeight)
         guard visibleRows > 0 else { return [] }
         
-        if viewModel.rows.count > visibleRows {
-            return viewModel.rows[0..<(visibleRows - 1)] + [.showAll(totalCount: viewModel.rows.count)]
+        if participants.count > visibleRows {
+            return participants[0..<(visibleRows - 1)] + [.showAll(totalCount: participants.count)]
         } else {
-            return viewModel.rows
+            return participants
         }
     }
     


### PR DESCRIPTION
## What's new in this PR?

Show list of participants in group calls.

- `CallParticipantsViewModel ` has been replaced by the typealias `CallParticipantList`
- Show no avatar for outgoing group calls / video calls