### PR TITLE
crash fixed

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarButtonsView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarButtonsView.swift
@@ -136,7 +136,7 @@ public final class InputBarButtonsView: UIView {
         multilineLayout = numberOfButtons < buttons.count
         
         let (firstRow, secondRow): ([UIButton], [UIButton])
-        let customButtonCount = numberOfButtons - 1 // Last one is alway the expand button
+        let customButtonCount = numberOfButtons >= 1 ? numberOfButtons - 1 : 0 // Last one is alway the expand button
 
         expandRowButton.isHidden = !multilineLayout
 


### PR DESCRIPTION
## What's new in this PR?
This PR is a follow-up of https://github.com/wireapp/wire-ios/pull/2060

### Issues

App crashes when force touch a small image(30x30px) in conversation view

### Causes

When ConversationImagesViewController is going to layout its subviews, InputBarButtonsView crashes for the case only zero buttons is shown in the first row.

### Solutions

Prevent access minus item index in the intermediate layout state.