### PR TITLE
Fix: Launch screen not shown after new installation

### DIFF
--- a/Wire-iOS/Sources/AppStateController.swift
+++ b/Wire-iOS/Sources/AppStateController.swift
@@ -128,7 +128,8 @@ extension AppStateController : SessionManagerDelegate {
         let selectedAccount = SessionManager.shared?.accountManager.selectedAccount
 
         // We only care about the error if it concerns the selected account, or the loading account.
-        if selectedAccount == account || loadingAccount == account {
+        // ignore the error when account is nil (selectedAccount and loadingAccount are nil also) when app launchs
+        if account != nil && (selectedAccount == account || loadingAccount == account) {
             authenticationError = error as NSError
         }
 


### PR DESCRIPTION

## What's new in this PR?

This PR is a follow-up of https://github.com/wireapp/wire-ios/pull/2074

### Issues

Launch screen not shown after new installation

### Causes

Caused by https://github.com/wireapp/wire-ios/pull/2074, when the app first launch, selectedAccount, account & loadingAccount are nil.

### Solutions

Add a nil check for account object.
