### PR TITLE
Fix/zios 9977 after force touch a small image, the image toolbar shows only one button and unable to touch

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarButtonsView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarButtonsView.swift
@@ -130,10 +130,7 @@ public final class InputBarButtonsView: UIView {
         // Drop existing constraints
         buttons.forEach {
             $0.removeFromSuperview()
-            $0.frame = .zero
-//            $0.hitAreaPadding = .zero
             buttonInnerContainer.addSubview($0)
-//            NSLayoutConstraint.deactivate($0.constraints)
         }
 
         let numberOfButtons = Int(floorf(Float(bounds.width / minButtonWidth)))

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarButtonsView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarButtonsView.swift
@@ -123,15 +123,19 @@ public final class InputBarButtonsView: UIView {
     }
     
     fileprivate func layoutAndConstrainButtonRows() {
-        guard bounds.size.width > 0 else { return }
+        let minButtonWidth = constants.minimumButtonWidth(forWidth: bounds.width)
+
+        guard bounds.size.width >= minButtonWidth * 2 else { return }
 
         // Drop existing constraints
         buttons.forEach {
             $0.removeFromSuperview()
+            $0.frame = .zero
+//            $0.hitAreaPadding = .zero
             buttonInnerContainer.addSubview($0)
+//            NSLayoutConstraint.deactivate($0.constraints)
         }
-        
-        let minButtonWidth = constants.minimumButtonWidth(forWidth: bounds.width)
+
         let numberOfButtons = Int(floorf(Float(bounds.width / minButtonWidth)))
         multilineLayout = numberOfButtons < buttons.count
         


### PR DESCRIPTION
## What's new in this PR?

### Issues

When the user force touch a small image, the full-screen image viewer do not show all toolbar's buttons.

### Causes

Unnecessary constraints are created when the InputBarButtonsView is in the intermediate state.

### Solutions

Do not create the constraints during the intermediate state by checking the width is valid or not.