### PR TITLE
Fix/zios 9982 [iPad] Cannot finish registeration due to untappable "I Agree" button

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -2684,6 +2684,7 @@
 		EF2127271FB9E06300625A9B /* LandingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LandingViewController.swift; sourceTree = "<group>"; };
 		EF2128EC2056D51600C1673B /* NetworkStatusViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkStatusViewControllerTests.swift; sourceTree = "<group>"; };
 		EF24036D20A1D581002813BE /* TermsOfUseStepViewController+Constraints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TermsOfUseStepViewController+Constraints.swift"; sourceTree = "<group>"; };
+		EF24036F20A1E161002813BE /* TermsOfUseStepViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "TermsOfUseStepViewController+Private.h"; sourceTree = "<group>"; };
 		EF25F7DD1FC45F8E0040C3CC /* AccessoryTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessoryTextField.swift; sourceTree = "<group>"; };
 		EF25F8851FC57EE90040C3CC /* AccessoryTextFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessoryTextFieldTests.swift; sourceTree = "<group>"; };
 		EF266C602003B75C00A8C136 /* BreathLoadingBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreathLoadingBar.swift; sourceTree = "<group>"; };
@@ -5457,6 +5458,7 @@
 				EF2126EA1FB9DFE300625A9B /* ProfilePictureStepViewController+Testing.h */,
 				EF2126EC1FB9DFE300625A9B /* ProfilePictureStepViewController.m */,
 				EF2126E41FB9DFE300625A9B /* TermsOfUseStepViewController.h */,
+				EF24036F20A1E161002813BE /* TermsOfUseStepViewController+Private.h */,
 				EF2126ED1FB9DFE300625A9B /* TermsOfUseStepViewController.m */,
 				EF24036D20A1D581002813BE /* TermsOfUseStepViewController+Constraints.swift */,
 			);

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1055,6 +1055,7 @@
 		EF2127261FB9DFE300625A9B /* RegistrationRootViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = EF2127011FB9DFE300625A9B /* RegistrationRootViewController.m */; };
 		EF2127281FB9E06300625A9B /* LandingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2127271FB9E06300625A9B /* LandingViewController.swift */; };
 		EF2128EE2056D55400C1673B /* NetworkStatusViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2128EC2056D51600C1673B /* NetworkStatusViewControllerTests.swift */; };
+		EF24036E20A1D581002813BE /* TermsOfUseStepViewController+Constraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF24036D20A1D581002813BE /* TermsOfUseStepViewController+Constraints.swift */; };
 		EF25F7DE1FC45F8E0040C3CC /* AccessoryTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF25F7DD1FC45F8E0040C3CC /* AccessoryTextField.swift */; };
 		EF25F8871FC57F320040C3CC /* AccessoryTextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF25F8851FC57EE90040C3CC /* AccessoryTextFieldTests.swift */; };
 		EF266C612003B75C00A8C136 /* BreathLoadingBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF266C602003B75C00A8C136 /* BreathLoadingBar.swift */; };
@@ -2682,6 +2683,7 @@
 		EF2127021FB9DFE300625A9B /* CheckmarkViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CheckmarkViewController.h; sourceTree = "<group>"; };
 		EF2127271FB9E06300625A9B /* LandingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LandingViewController.swift; sourceTree = "<group>"; };
 		EF2128EC2056D51600C1673B /* NetworkStatusViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkStatusViewControllerTests.swift; sourceTree = "<group>"; };
+		EF24036D20A1D581002813BE /* TermsOfUseStepViewController+Constraints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TermsOfUseStepViewController+Constraints.swift"; sourceTree = "<group>"; };
 		EF25F7DD1FC45F8E0040C3CC /* AccessoryTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessoryTextField.swift; sourceTree = "<group>"; };
 		EF25F8851FC57EE90040C3CC /* AccessoryTextFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessoryTextFieldTests.swift; sourceTree = "<group>"; };
 		EF266C602003B75C00A8C136 /* BreathLoadingBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreathLoadingBar.swift; sourceTree = "<group>"; };
@@ -5456,6 +5458,7 @@
 				EF2126EC1FB9DFE300625A9B /* ProfilePictureStepViewController.m */,
 				EF2126E41FB9DFE300625A9B /* TermsOfUseStepViewController.h */,
 				EF2126ED1FB9DFE300625A9B /* TermsOfUseStepViewController.m */,
+				EF24036D20A1D581002813BE /* TermsOfUseStepViewController+Constraints.swift */,
 			);
 			path = Steps;
 			sourceTree = "<group>";
@@ -6775,6 +6778,7 @@
 				8711A5A41E0D6C8800043ACF /* TwoLineTitleView.swift in Sources */,
 				871BC28B1D34F8F800DF0793 /* UIResponder+FirstResponder.m in Sources */,
 				871BC23A1D34F8F800DF0793 /* KeyboardFrameObserver+iOS.m in Sources */,
+				EF24036E20A1D581002813BE /* TermsOfUseStepViewController+Constraints.swift in Sources */,
 				8F41CFC9199297C600E3B032 /* Message+UI.m in Sources */,
 				EF2127031FB9DFE300625A9B /* CheckmarkView.m in Sources */,
 				EEE6310B1F7390D100E56803 /* ChatHeadsViewController.swift in Sources */,

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/Steps/TermsOfUseStepViewController+Constraints.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/Steps/TermsOfUseStepViewController+Constraints.swift
@@ -30,7 +30,6 @@ extension TermsOfUseStepViewController {
         let horizontalInset: CGFloat = 28
 
         constrain(titleLabel, termsOfUseText, agreeButton, containerView) { titleLabel, termsOfUseText, agreeButton, containerView in
-            titleLabel.top == containerView.top + horizontalInset
             titleLabel.right == containerView.right - horizontalInset
             titleLabel.left == containerView.left + horizontalInset
 
@@ -47,6 +46,7 @@ extension TermsOfUseStepViewController {
         if self.isIPadRegular(device: UIDevice.current) {
             constrain(containerView, self.view) { containerView, selfView in
                 containerView.width == self.registrationForm().maximumFormSize.width
+                containerView.height == self.registrationForm().maximumFormSize.height
 
                 containerView.center == selfView.center
             }

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/Steps/TermsOfUseStepViewController+Constraints.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/Steps/TermsOfUseStepViewController+Constraints.swift
@@ -30,6 +30,7 @@ extension TermsOfUseStepViewController {
         let horizontalInset: CGFloat = 28
 
         constrain(titleLabel, termsOfUseText, agreeButton, containerView) { titleLabel, termsOfUseText, agreeButton, containerView in
+            titleLabel.top == containerView.top + horizontalInset
             titleLabel.right == containerView.right - horizontalInset
             titleLabel.left == containerView.left + horizontalInset
 
@@ -46,7 +47,6 @@ extension TermsOfUseStepViewController {
         if self.isIPadRegular(device: UIDevice.current) {
             constrain(containerView, self.view) { containerView, selfView in
                 containerView.width == self.registrationForm().maximumFormSize.width
-                containerView.height == self.registrationForm().maximumFormSize.height
 
                 containerView.center == selfView.center
             }

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/Steps/TermsOfUseStepViewController+Constraints.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/Steps/TermsOfUseStepViewController+Constraints.swift
@@ -1,0 +1,59 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import Cartography
+
+extension TermsOfUseStepViewController {
+    override open func updateViewConstraints() {
+        super.updateViewConstraints()
+
+        guard false == self.initialConstraintsCreated else { return }
+
+        self.initialConstraintsCreated = true
+
+        let horizontalInset: CGFloat = 28
+
+        constrain(titleLabel, termsOfUseText, agreeButton, containerView) { titleLabel, termsOfUseText, agreeButton, containerView in
+            titleLabel.right == containerView.right - horizontalInset
+            titleLabel.left == containerView.left + horizontalInset
+
+            termsOfUseText.top == titleLabel.bottom + 5
+
+            agreeButton.top == termsOfUseText.bottom + 24
+            agreeButton.bottom == containerView.bottom - horizontalInset
+            agreeButton.height == 40
+
+            align(right: titleLabel, termsOfUseText, agreeButton)
+            align(left: titleLabel, termsOfUseText, agreeButton)
+        }
+
+        if self.isIPadRegular(device: UIDevice.current) {
+            constrain(containerView, self.view) { containerView, selfView in
+                containerView.width == self.registrationForm().maximumFormSize.width
+                containerView.height == self.registrationForm().maximumFormSize.height
+
+                containerView.center == selfView.center
+            }
+        } else {
+            constrain(containerView, self.view) { containerView, selfView in
+                containerView.edges == selfView.edges
+            }
+        }
+    }
+}

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/Steps/TermsOfUseStepViewController+Private.h
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/Steps/TermsOfUseStepViewController+Private.h
@@ -1,34 +1,29 @@
-// 
+////
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
-// 
+// Copyright (C) 2018 Wire Swiss GmbH
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
+//
 
+@class Button;
 
-#import "RegistrationStepViewController.h"
+@interface TermsOfUseStepViewController ()
 
-
-
-@class ZMIncompleteRegistrationUser;
-@class AnalyticsTracker;
-
-@interface TermsOfUseStepViewController : RegistrationStepViewController
-@property (nonatomic, readonly) ZMIncompleteRegistrationUser *unregisteredUser;
-
-- (instancetype)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
-- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil NS_UNAVAILABLE;
-- (instancetype)initWithUnregisteredUser:(ZMIncompleteRegistrationUser *)unregisteredUser NS_DESIGNATED_INITIALIZER;
+@property (nonatomic) UILabel *titleLabel;
+@property (nonatomic) UITextView *termsOfUseText;
+@property (nonatomic) Button *agreeButton;
+@property (nonatomic) UIView *containerView;
+@property (nonatomic) BOOL initialConstraintsCreated;
 
 @end

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/Steps/TermsOfUseStepViewController.h
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/Steps/TermsOfUseStepViewController.h
@@ -23,11 +23,18 @@
 
 @class ZMIncompleteRegistrationUser;
 @class AnalyticsTracker;
-
+//TODO: internal
+@class Button;
 
 
 @interface TermsOfUseStepViewController : RegistrationStepViewController
 @property (nonatomic, readonly) ZMIncompleteRegistrationUser *unregisteredUser;
+//TODO: internal
+@property (nonatomic) UILabel *titleLabel;
+@property (nonatomic) UITextView *termsOfUseText;
+@property (nonatomic) Button *agreeButton;
+@property (nonatomic) UIView *containerView;
+@property (nonatomic) BOOL initialConstraintsCreated;
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
 - (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil NS_UNAVAILABLE;

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/Steps/TermsOfUseStepViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/Steps/TermsOfUseStepViewController.m
@@ -34,11 +34,6 @@
 
 @interface TermsOfUseStepViewController () <UITextViewDelegate>
 
-@property (nonatomic) BOOL initialConstraintsCreated;
-@property (nonatomic) UILabel *titleLabel;
-@property (nonatomic) UITextView *termsOfUseText;
-@property (nonatomic) Button *agreeButton;
-@property (nonatomic) UIView *containerView;
 @property (nonatomic) ZMIncompleteRegistrationUser *unregisteredUser;
 
 @end
@@ -124,47 +119,6 @@
     [self.agreeButton addTarget:self action:@selector(agreeToTerms:) forControlEvents:UIControlEventTouchUpInside];
     
     [self.containerView addSubview:self.agreeButton];
-}
-
-- (void)updateViewConstraints
-{
-    [super updateViewConstraints];
-    
-    if (! self.initialConstraintsCreated) {
-        self.initialConstraintsCreated = YES;
-        
-        CGFloat inset = 28.0;
-        [self.titleLabel autoPinEdgeToSuperviewEdge:ALEdgeLeft withInset:inset];
-        [self.titleLabel autoPinEdgeToSuperviewEdge:ALEdgeRight withInset:inset];
-        
-        [self.termsOfUseText autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.titleLabel withOffset:5];
-        [self.termsOfUseText autoPinEdgeToSuperviewEdge:ALEdgeLeft withInset:inset];
-        [self.termsOfUseText autoPinEdgeToSuperviewEdge:ALEdgeRight withInset:inset];
-        
-        [self.agreeButton autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.termsOfUseText withOffset:24];
-        [self.agreeButton autoPinEdgeToSuperviewEdge:ALEdgeLeft withInset:inset];
-        [self.agreeButton autoPinEdgeToSuperviewEdge:ALEdgeRight withInset:inset];
-        [[self.agreeButton.bottomAnchor constraintEqualToAnchor:self.safeBottomAnchor constant:-inset] setActive:YES];
-        [self.agreeButton autoSetDimension:ALDimensionHeight toSize:40];
-        
-        if(IS_IPAD_FULLSCREEN) {
-             [NSLayoutConstraint autoSetPriority:UILayoutPriorityDefaultHigh + 1 forConstraints:^{
-                 [self.containerView autoSetDimension:ALDimensionWidth toSize:self.registrationFormViewController.maximumFormSize.width];
-                 [self.containerView autoSetDimension:ALDimensionHeight toSize:self.registrationFormViewController.maximumFormSize.height];
-             }];
-            
-            [NSLayoutConstraint autoSetPriority:UILayoutPriorityDefaultHigh - 1 forConstraints:^{
-                [self.containerView autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsZero];
-            }];
-            
-            [self.containerView autoPinEdgeToSuperviewEdge:ALEdgeTop withInset:0 relation:NSLayoutRelationGreaterThanOrEqual];
-            [self.containerView autoPinEdgeToSuperviewEdge:ALEdgeBottom withInset:0 relation:NSLayoutRelationGreaterThanOrEqual];
-            
-            [self.containerView autoCenterInSuperview];
-        } else {
-            [self.containerView autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsZero];
-        }
-    }
 }
 
 #pragma mark - Actions

--- a/Wire-iOS/WireBridgingHeader.h
+++ b/Wire-iOS/WireBridgingHeader.h
@@ -121,6 +121,7 @@
 #import "RegistrationFormController.h"
 #import "PhoneSignInViewController.h"
 #import "NoHistoryViewController.h"
+#import "TermsOfUseStepViewController.h"
 
 // Helper objects
 #import "PushTransition.h"

--- a/Wire-iOS/WireBridgingHeader.h
+++ b/Wire-iOS/WireBridgingHeader.h
@@ -122,6 +122,7 @@
 #import "PhoneSignInViewController.h"
 #import "NoHistoryViewController.h"
 #import "TermsOfUseStepViewController.h"
+#import "TermsOfUseStepViewController+Private.h"
 
 // Helper objects
 #import "PushTransition.h"


### PR DESCRIPTION
## What's new in this PR?

### Issues

Unable to finish the registration on iPad due to "I Agree" button is untappable.

### Causes

"I Agree" button is placed outside its container view.

### Solutions

Rewrite the constraints for iPad.