### PR TITLE
Feature/Show Data Usage dialogue when log in to a new device

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1102,6 +1102,7 @@
 		EF2127261FB9DFE300625A9B /* RegistrationRootViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = EF2127011FB9DFE300625A9B /* RegistrationRootViewController.m */; };
 		EF2127281FB9E06300625A9B /* LandingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2127271FB9E06300625A9B /* LandingViewController.swift */; };
 		EF2128EE2056D55400C1673B /* NetworkStatusViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2128EC2056D51600C1673B /* NetworkStatusViewControllerTests.swift */; };
+		EF218AC720A9DDEF004977BF /* ConversationListViewController+DataUsagePermissions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF218AC620A9DDEF004977BF /* ConversationListViewController+DataUsagePermissions.swift */; };
 		EF24036E20A1D581002813BE /* TermsOfUseStepViewController+Constraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF24036D20A1D581002813BE /* TermsOfUseStepViewController+Constraints.swift */; };
 		EF25F7DE1FC45F8E0040C3CC /* AccessoryTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF25F7DD1FC45F8E0040C3CC /* AccessoryTextField.swift */; };
 		EF25F8871FC57F320040C3CC /* AccessoryTextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF25F8851FC57EE90040C3CC /* AccessoryTextFieldTests.swift */; };
@@ -2778,6 +2779,7 @@
 		EF2127021FB9DFE300625A9B /* CheckmarkViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CheckmarkViewController.h; sourceTree = "<group>"; };
 		EF2127271FB9E06300625A9B /* LandingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LandingViewController.swift; sourceTree = "<group>"; };
 		EF2128EC2056D51600C1673B /* NetworkStatusViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkStatusViewControllerTests.swift; sourceTree = "<group>"; };
+		EF218AC620A9DDEF004977BF /* ConversationListViewController+DataUsagePermissions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationListViewController+DataUsagePermissions.swift"; sourceTree = "<group>"; };
 		EF24036D20A1D581002813BE /* TermsOfUseStepViewController+Constraints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TermsOfUseStepViewController+Constraints.swift"; sourceTree = "<group>"; };
 		EF24036F20A1E161002813BE /* TermsOfUseStepViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "TermsOfUseStepViewController+Private.h"; sourceTree = "<group>"; };
 		EF25F7DD1FC45F8E0040C3CC /* AccessoryTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessoryTextField.swift; sourceTree = "<group>"; };
@@ -4961,6 +4963,7 @@
 				8F8913E91A9F287E0056AB0C /* ListContent */,
 				875D48A51A6D087F00BB17B5 /* ConversationListViewController.h */,
 				875D48A61A6D087F00BB17B5 /* ConversationListViewController.m */,
+				EF218AC620A9DDEF004977BF /* ConversationListViewController+DataUsagePermissions.swift */,
 				BFAAB2381DEC6B2800CBC096 /* ConversationListViewController+Handles.swift */,
 				BFAAB2421DEDB21E00CBC096 /* ConversationListViewController+Transitions.swift */,
 				8784D4561E81832F007A6867 /* ConversationListViewController+TopBar.swift */,
@@ -6957,6 +6960,7 @@
 				871BC36D1D34F96000DF0793 /* DeviceOrientationObserver.m in Sources */,
 				8710673D1C0DC5570035603B /* SettingsCellDescriptor.swift in Sources */,
 				EEF28EEF1F168039007642E2 /* ConversationInputBarViewController+Markdown.swift in Sources */,
+				EF218AC720A9DDEF004977BF /* ConversationListViewController+DataUsagePermissions.swift in Sources */,
 				160A9CA81C3D62CD00B644AA /* ProfileDetailsViewController.m in Sources */,
 				871BC01C1D34F56300DF0793 /* AnalyticsTracker+Invitations.m in Sources */,
 				871BC0291D34F5D200DF0793 /* NSString+EmoticonSubstitution.m in Sources */,

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -27,6 +27,9 @@
 "general.edit" = "Edit";
 "general.done" = "Done";
 "general.confirm" = "OK";
+"general.skip" = "Not now";
+"general.accept" = "Accept";
+
 // Language like Chinese does not use space to sperate words or sentences.
 "general.space_between_words" = " ";
 
@@ -114,6 +117,10 @@
 "conversation_list.header.self_team.accessibility_value.inactive" = "Tap to activate.";
 "conversation_list.header.self_team.accessibility_value.active" = "Active now.";
 "conversation_list.header.self_team.accessibility_value.has_new_messages" = "Has new messages.";
+
+// Conversation List Data Usage Permission Dialog
+"conversation_list.date_usage_permission_alert.title" = "Help us make Wire better";
+"conversation_list.date_usage_permission_alert.message" = "Sending usage and crash reports helps us to improve our products and services. We do not use this information for anything else.";
 
 // Profile Header View
 "conversation.connection_view.in_address_book" = "in Contacts";

--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -256,6 +256,7 @@ class AppRootViewController: UIViewController {
             executeAuthenticatedBlocks()
             let clientViewController = ZClientViewController()
             clientViewController.isComingFromRegistration = completedRegistration
+            clientViewController.isComingFromLaunch = appStateController.lastAppState == .headless
 
             Analytics.shared().team = ZMUser.selfUser().team
 

--- a/Wire-iOS/Sources/AppStateController.swift
+++ b/Wire-iOS/Sources/AppStateController.swift
@@ -31,6 +31,7 @@ protocol AppStateControllerDelegate : class {
 class AppStateController : NSObject {
     
     private(set) var appState : AppState = .headless
+    private(set) var lastAppState : AppState = .headless
     private var authenticationObserverToken : ZMAuthenticationStatusObserver?
     public weak var delegate : AppStateControllerDelegate? = nil
     
@@ -101,6 +102,7 @@ class AppStateController : NSObject {
         
         if newAppState != appState {
             zmLog.debug("transitioning to app state: \(newAppState)")
+            lastAppState = appState
             appState = newAppState
             delegate?.appStateController(transitionedTo: appState) {
                 completion?()

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+DataUsagePermissions.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+DataUsagePermissions.swift
@@ -29,11 +29,11 @@ extension ConversationListViewController {
         let alertController = UIAlertController(title: "conversation_list.date_usage_permission_alert.title".localized, message: "conversation_list.date_usage_permission_alert.message".localized, preferredStyle: .alert)
 
         alertController.addAction(UIAlertAction(title: "general.accept".localized, style: .default, handler: { (_) in
-//            handler(false)
-            ///TODO: update setting
+            TrackingManager.shared.disableCrashAndAnalyticsSharing = false
         }))
 
         alertController.addAction(UIAlertAction(title: "general.skip".localized, style: .cancel, handler: { (_) in
+            ///TODO: save the timestamp and do not ask again in the future?
         }))
 
 

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+DataUsagePermissions.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+DataUsagePermissions.swift
@@ -33,12 +33,9 @@ extension ConversationListViewController {
         }))
 
         alertController.addAction(UIAlertAction(title: "general.skip".localized, style: .cancel, handler: { (_) in
-            ///TODO: save the timestamp and do not ask again in the future?
         }))
 
 
         ZClientViewController.shared()?.present(alertController, animated: true)
     }
-
-    ///TODO: test on device with notification permission dialogue
 }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+DataUsagePermissions.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+DataUsagePermissions.swift
@@ -1,0 +1,44 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension ConversationListViewController {
+    func showDataUsagePermissionDialogIfNeeded() {
+        guard !isComingFromRegistration,
+              ZMUser.selfUser().handle != nil,
+              !AutomationHelper.sharedHelper.skipFirstLoginAlerts else { return }
+
+        guard TrackingManager.shared.disableCrashAndAnalyticsSharing else { return }
+
+        let alertController = UIAlertController(title: "conversation_list.date_usage_permission_alert.title".localized, message: "conversation_list.date_usage_permission_alert.message".localized, preferredStyle: .alert)
+
+        alertController.addAction(UIAlertAction(title: "general.accept".localized, style: .default, handler: { (_) in
+//            handler(false)
+            ///TODO: update setting
+        }))
+
+        alertController.addAction(UIAlertAction(title: "general.skip".localized, style: .cancel, handler: { (_) in
+        }))
+
+
+        ZClientViewController.shared()?.present(alertController, animated: true)
+    }
+
+    ///TODO: test on device with notification permission dialogue
+}

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController.h
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController.h
@@ -38,6 +38,7 @@ typedef NS_ENUM(NSUInteger, ConversationListState) {
 @property (nonatomic, readonly) ZMConversation *selectedConversation;
 @property (nonatomic) UserNameTakeOverViewController *usernameTakeoverViewController;
 @property (nonatomic) BOOL isComingFromRegistration;
+@property (nonatomic) BOOL isComingFromLaunch;
 @property (nonatomic, readonly) UIView *contentContainer;
 @property (nonatomic) id startCallToken;
 

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController.m
@@ -175,6 +175,7 @@
     [self updateArchiveButtonVisibility];
     
     [self updateObserverTokensForActiveTeam];
+    [self showDataUsagePermissionDialogIfNeeded];
     [self showPushPermissionDeniedDialogIfNeeded];
 }
 

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.h
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.h
@@ -40,6 +40,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic) BOOL isComingFromRegistration;
 
+@property (nonatomic) BOOL isComingFromLaunch;
+
 @property (nonatomic, readonly) SplitViewController *splitViewController;
 
 @property (nonatomic, readonly) MediaPlaybackManager *mediaPlaybackManager;

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
@@ -261,6 +261,7 @@
 {
     self.conversationListViewController = [[ConversationListViewController alloc] init];
     self.conversationListViewController.isComingFromRegistration = self.isComingFromRegistration;
+    self.conversationListViewController.isComingFromLaunch = self.isComingFromLaunch;
     [self.conversationListViewController view];
 }
 
@@ -501,8 +502,15 @@
 - (void)setIsComingFromRegistration:(BOOL)isComingFromRegistration
 {
     _isComingFromRegistration = isComingFromRegistration;
-    
+
     self.conversationListViewController.isComingFromRegistration = self.isComingFromRegistration;
+}
+
+- (void)setIsComingFromLaunch:(BOOL)isComingFromLaunch
+{
+    _isComingFromLaunch = isComingFromLaunch;
+
+    self.conversationListViewController.isComingFromLaunch = self.isComingFromLaunch;
 }
 
 - (BOOL)isConversationViewVisible


### PR DESCRIPTION
## What's new in this PR?

Create a dialogue for the Crash and Usage reports when the user land on the List UI, before the Notifications dialogue.

## Notes
Test cases:
- [ ] When the user switching account, the dialogue should not be shown

### Attachments

![simulator screen shot - iphone x - 2018-05-14 at 17 32 02](https://user-images.githubusercontent.com/11852044/40010606-8637cde2-57a5-11e8-8f5b-bd1f5cfaa56b.png)
