### PR TITLE
Prevent enabling video in calls in groups large than 4

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -504,6 +504,9 @@
 
 "call.video.paused" = "Video paused";
 
+"call.video.too_many.alert.title" = "Too many people for Video";
+"call.video.too_many.alert.message" = "Video calls only work in groups of 4 or less.";
+
 "call.degraded.alert.title" = "New Device";
 "call.degraded.alert.message.self" = "You started using a new device.";
 "call.degraded.alert.message.user" = "%@ started using a new device.";

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -125,6 +125,11 @@ final class CallViewController: UIViewController {
     }
     
     fileprivate func toggleVideoState() {
+        if voiceChannel.videoState == .stopped, voiceChannel.conversation?.activeParticipants.count > 4 {
+            showAlert(forMessage: "call.video.too_many.alert.message".localized, title: "call.video.too_many.alert.title".localized) { _ in }
+            return
+        }
+        
         voiceChannel.videoState = voiceChannel.videoState.toggledState
         updateConfiguration()
     }


### PR DESCRIPTION
## What's new in this PR?

Prevent enabling video in calls in groups large than 4