### PR TITLE
Ignore all system windows when looking for the top most view controller

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Helpers/UIApplication+StatusBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UIApplication+StatusBar.swift
@@ -73,8 +73,10 @@ public extension UIApplication {
             
             if let notificationWindowRootController = controller as? NotificationWindowRootViewController {
                 return notificationWindowRootController.voiceChannelController?.voiceChannelIsActive ?? false
-            } else {
+            } else if controller is AppRootViewController  {
                 return true
+            } else {
+                return false
             }
         }
         

--- a/Wire-iOS/Sources/UserInterface/Overlay/NotificationWindowRootViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Overlay/NotificationWindowRootViewController.m
@@ -112,30 +112,11 @@
 
 #pragma mark - Rotation handling (should match up with root)
 
-/**
- guard against a stack overflow (when calling shouldAutorotate or supportedInterfaceOrientations)
-
- @return nil if UIApplication.sharedApplication.wr_topmostViewController is same as self or same class as self or it is a "UIInputWindowController"
- */
--(UIViewController *)topViewController
-{
-    UIViewController * topViewController = UIApplication.sharedApplication.wr_topmostViewController;
-    NSString *className = NSStringFromClass([topViewController class]);
-
-    if (self != topViewController &&
-        ![topViewController isKindOfClass: self.class] &&
-        [className compare:@"UIInputWindowController"] != NSOrderedSame) {
-        return topViewController;
-    }
-
-    return nil;
-}
-
 - (BOOL)shouldAutorotate
 {
-    UIViewController * topViewController = [self topViewController];
-    if (topViewController != nil) {
-        return topViewController.shouldAutorotate;
+    UIViewController * topmostViewController = UIApplication.sharedApplication.wr_topmostViewController;
+    if (topmostViewController != nil && topmostViewController != self) {
+        return topmostViewController.shouldAutorotate;
     } else {
         return YES;
     }
@@ -143,9 +124,9 @@
 
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations
 {
-    UIViewController * topViewController = [self topViewController];
-    if (topViewController != nil) {
-        return topViewController.supportedInterfaceOrientations;
+    UIViewController * topmostViewController = UIApplication.sharedApplication.wr_topmostViewController;
+    if (topmostViewController != nil && topmostViewController != self) {
+        return topmostViewController.supportedInterfaceOrientations;
     } else {
         return self.wr_supportedInterfaceOrientations;
     }

--- a/Wire-iOS/Sources/UserInterface/Overlay/NotificationWindowRootViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Overlay/NotificationWindowRootViewController.m
@@ -112,10 +112,21 @@
 
 #pragma mark - Rotation handling (should match up with root)
 
-- (BOOL)shouldAutorotate
+- (UIViewController *)topmostViewController
 {
     UIViewController * topmostViewController = UIApplication.sharedApplication.wr_topmostViewController;
-    if (topmostViewController != nil && topmostViewController != self) {
+    
+    if (topmostViewController != nil && topmostViewController != self && ![topmostViewController isKindOfClass:NotificationWindowRootViewController.class]) {
+        return topmostViewController;
+    } else {
+        return nil;
+    }
+}
+
+- (BOOL)shouldAutorotate
+{
+    UIViewController * topmostViewController = [self topmostViewController];
+    if (topmostViewController != nil) {
         return topmostViewController.shouldAutorotate;
     } else {
         return YES;
@@ -124,8 +135,8 @@
 
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations
 {
-    UIViewController * topmostViewController = UIApplication.sharedApplication.wr_topmostViewController;
-    if (topmostViewController != nil && topmostViewController != self) {
+    UIViewController * topmostViewController = [self topmostViewController];
+    if (topmostViewController != nil) {
         return topmostViewController.supportedInterfaceOrientations;
     } else {
         return self.wr_supportedInterfaceOrientations;


### PR DESCRIPTION
## What's new in this PR?

### Issues

App would get into an infinite loop when asking the `NotificationWindowRootViewController` if it `shouldAutorotate` and crash when long pressing on a message.

### Causes

Long pressing on message shows a context menu, which is displayed in a an window above all other windows. When this is window is displayed the `NotificationWindowRootViewController` would get asked if it `shouldAutorotate` which in turn looks for the top most controller in the front most window. This would after change from yesterday always pick an internal class from apple which displays the context menu.

### Solutions

Ignore all window not created by us when looking for the top most view controller.