### PR TITLE
Feature/zios 9990 as a person registering to wire account i want to be asked whether i want to send usage and crash reports to wire when i create any type of account

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+DataUsagePermissions.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+DataUsagePermissions.swift
@@ -21,10 +21,10 @@ import Foundation
 extension ConversationListViewController {
     func showDataUsagePermissionDialogIfNeeded() {
         guard needToShowDataUsagePermissionDialog,
-              ZMUser.selfUser().handle != nil,
               !AutomationHelper.sharedHelper.skipFirstLoginAlerts else { return }
 
-        guard TrackingManager.shared.disableCrashAndAnalyticsSharing else { return }
+        guard isComingFromRegistration ||
+              (!isComingFromRegistration && ZMUser.selfUser().handle != nil && TrackingManager.shared.disableCrashAndAnalyticsSharing) else { return }
 
         let alertController = UIAlertController(title: "conversation_list.date_usage_permission_alert.title".localized, message: "conversation_list.date_usage_permission_alert.message".localized, preferredStyle: .alert)
 
@@ -32,7 +32,12 @@ extension ConversationListViewController {
             TrackingManager.shared.disableCrashAndAnalyticsSharing = false
         }))
 
-        alertController.addAction(UIAlertAction(title: "general.skip".localized, style: .cancel, handler: nil))
+        alertController.addAction(UIAlertAction(title: "general.skip".localized, style: .cancel, handler: { (_) in
+            // When coming from registration and user click skip, set disableCrashAndAnalyticsSharing to true
+            if self.isComingFromRegistration {
+                TrackingManager.shared.disableCrashAndAnalyticsSharing = true
+            }
+        }))
 
 
         ZClientViewController.shared()?.present(alertController, animated: true)

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+DataUsagePermissions.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+DataUsagePermissions.swift
@@ -24,7 +24,7 @@ extension ConversationListViewController {
               !AutomationHelper.sharedHelper.skipFirstLoginAlerts else { return }
 
         guard isComingFromRegistration ||
-              (ZMUser.selfUser().handle != nil && TrackingManager.shared.disableCrashAndAnalyticsSharing) else { return }
+              TrackingManager.shared.disableCrashAndAnalyticsSharing else { return }
 
         let alertController = UIAlertController(title: "conversation_list.date_usage_permission_alert.title".localized, message: "conversation_list.date_usage_permission_alert.message".localized, preferredStyle: .alert)
 

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+DataUsagePermissions.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+DataUsagePermissions.swift
@@ -24,7 +24,7 @@ extension ConversationListViewController {
               !AutomationHelper.sharedHelper.skipFirstLoginAlerts else { return }
 
         guard isComingFromRegistration ||
-              (!isComingFromRegistration && ZMUser.selfUser().handle != nil && TrackingManager.shared.disableCrashAndAnalyticsSharing) else { return }
+              (ZMUser.selfUser().handle != nil && TrackingManager.shared.disableCrashAndAnalyticsSharing) else { return }
 
         let alertController = UIAlertController(title: "conversation_list.date_usage_permission_alert.title".localized, message: "conversation_list.date_usage_permission_alert.message".localized, preferredStyle: .alert)
 

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+DataUsagePermissions.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+DataUsagePermissions.swift
@@ -33,10 +33,7 @@ extension ConversationListViewController {
         }))
 
         alertController.addAction(UIAlertAction(title: "general.skip".localized, style: .cancel, handler: { (_) in
-            // When coming from registration and user click skip, set disableCrashAndAnalyticsSharing to true
-            if self.isComingFromRegistration {
-                TrackingManager.shared.disableCrashAndAnalyticsSharing = true
-            }
+            TrackingManager.shared.disableCrashAndAnalyticsSharing = true
         }))
 
 

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
@@ -130,6 +130,8 @@
         [[GroupConversationCell appearanceWhenContainedInInstancesOfClasses:@[StartUIView.class]] setColorSchemeVariant:ColorSchemeVariantDark];
         [[GroupConversationCell appearanceWhenContainedInInstancesOfClasses:@[StartUIView.class]] setContentBackgroundColor:UIColor.clearColor];
         [[UIView appearanceWhenContainedInInstancesOfClasses:@[UIAlertController.class]] setTintColor:[ColorScheme.defaultColorScheme colorWithName:ColorSchemeColorTextForeground variant:ColorSchemeVariantLight]];
+
+        [self setupConversationListViewController];
     }
     return self;
 }
@@ -143,8 +145,8 @@
     
     self.view.backgroundColor = [UIColor blackColor];
 
-    [self setupConversationListViewController];
-    
+    [self.conversationListViewController view];
+
     self.splitViewController = [[SplitViewController alloc] init];
     self.splitViewController.delegate = self;
     [self addChildViewController:self.splitViewController];
@@ -256,7 +258,6 @@
     self.conversationListViewController = [[ConversationListViewController alloc] init];
     self.conversationListViewController.isComingFromRegistration = self.isComingFromRegistration;
     self.conversationListViewController.needToShowDataUsagePermissionDialog = NO;
-    [self.conversationListViewController view];
 }
 
 #pragma mark - ZMUserObserver


### PR DESCRIPTION
## What's new in this PR?

Display the dialogue for the Crash and Usage reports at the moment that the user lands on the List UI.