### PR TITLE
ZIOS-9994: Username not visible in calling overlay during calls with users with a profile picture

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/UserImageViewContainer.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/UserImageViewContainer.swift
@@ -46,10 +46,16 @@ final class UserImageViewContainer: UIView {
     private func setupViews() {
         userImageView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(userImageView)
-        userImageView.setContentHuggingPriority(249, for: .vertical)
-        userImageView.setContentHuggingPriority(249, for: .horizontal)
-        userImageView.setContentCompressionResistancePriority(249, for: .vertical)
-        userImageView.setContentCompressionResistancePriority(249, for: .horizontal)
+        
+        let priority: Float = 249
+        userImageView.setContentHuggingPriority(priority, for: .vertical)
+        userImageView.setContentHuggingPriority(priority, for: .horizontal)
+        userImageView.setContentCompressionResistancePriority(priority, for: .vertical)
+        userImageView.setContentCompressionResistancePriority(priority, for: .horizontal)
+        userImageView.imageView.setContentHuggingPriority(priority, for: .vertical)
+        userImageView.imageView.setContentHuggingPriority(priority, for: .horizontal)
+        userImageView.imageView.setContentCompressionResistancePriority(priority, for: .vertical)
+        userImageView.imageView.setContentCompressionResistancePriority(priority, for: .horizontal)
     }
     
     private func createConstraints() {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Username and calling duration labels were not visible during a call with a contact that has a profile picture.

### Causes

This was caused by the internal `UIImageView` stretching priority settings, automatically set to 750 instead of the expected value (249).

### Solutions

I'm applying the new stretching priority to both views, the `userImageView` container and the inner `imageView`.
