### PR TITLE
Only allow GVC to team users in convo with <= 4 participants

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
@@ -114,8 +114,7 @@ public extension ConversationViewController {
             return [joinCallButton]
         }
 
-        // TODO add complete logic for when to show/hide video button
-        if conversation.conversationType == .oneOnOne || conversation.conversationType == .group {
+        if conversation.canStartVideoCall {
             return [audioCallButton, videoCallButton]
         }
 
@@ -303,5 +302,21 @@ extension ZMConversation {
             return false
         }
     }
-
+    
+    static let maxVideoCallParticipants: Int = 4
+    
+    var canStartVideoCall: Bool {
+        if self.conversationType == .oneOnOne {
+            return true
+        }
+        
+        if self.conversationType == .group &&
+           ZMUser.selfUser().isTeamMember &&
+           (self.lastServerSyncedActiveParticipants.count + 1) <= ZMConversation.maxVideoCallParticipants {
+            return true
+        }
+        
+        return false
+        
+    }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
@@ -312,7 +312,7 @@ extension ZMConversation {
         
         if self.conversationType == .group &&
            ZMUser.selfUser().isTeamMember &&
-           (self.lastServerSyncedActiveParticipants.count + 1) <= ZMConversation.maxVideoCallParticipants {
+           self.activeParticipants.count <= ZMConversation.maxVideoCallParticipants {
             return true
         }
         


### PR DESCRIPTION
## What's new in this PR?

### Issues

The button to initiate the the group call should be visible:
- For team users.
- If the conversation has 4 or less participants.
