### PR TITLE
Fix terminating state when hanging up

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallInfoConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallInfoConfiguration.swift
@@ -82,13 +82,15 @@ extension CallInfoConfiguration: CallInfoViewControllerInput {
     }
     
     var isTerminating: Bool {
-        guard case .terminating = voiceChannel.state else { return false }
-        return true
+        switch voiceChannel.state {
+        case .terminating, .incoming(video: _, shouldRing: false, degraded: _): return true
+        default: return false
+        }
     }
     
     var canAccept: Bool {
         switch voiceChannel.state {
-        case .incoming: return true
+        case .incoming(video: _, shouldRing: true, degraded: _): return true
         default: return false
         }
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

When hanging up a call the call UI would switch to the incoming call layout for the action buttons.

### Causes

When leaving a call SE will treat it as having the state `.incoming(video: false, shouldRing: false, degraded: false)`.

### Solutions

Display incoming calls with `shouldRing = false` as terminating