### PR TITLE
ZIOS-9944: Block video actions during a call

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -262,7 +262,8 @@
 "conversation.create.toggle.subtitle" = "Open this conversation to people outside your team. You can always change it later.";
 
 "conversation.input_bar.ongoing_call_alert.title" = "Ongoing call";
-"conversation.input_bar.ongoing_call_alert.message" = "You can't record an audio message while being on a call.";
+"conversation.input_bar.ongoing_call_alert.audio.message" = "You can't record an audio message while being on a call.";
+"conversation.input_bar.ongoing_call_alert.video.message" = "You can't record a video while being on a call.";
 
 "conversation.guests_present" = "Guests are present";
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Audio.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Audio.swift
@@ -68,7 +68,7 @@ extension ConversationInputBarViewController {
         guard ConversationViewController.shouldBlockCallingRelatedActions else { return false }
         
         let alert = UIAlertController(title: "conversation.input_bar.ongoing_call_alert.title".localized,
-                                      message: "conversation.input_bar.ongoing_call_alert.message".localized,
+                                      message: "conversation.input_bar.ongoing_call_alert.audio.message".localized,
                                       cancelButtonTitle: "general.ok".localized)
         self.present(alert, animated: true, completion: nil)
         return true

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -937,6 +937,15 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
 
 - (void)videoButtonPressed:(IconButton *)sender
 {
+    if([ConversationViewController shouldBlockCallingRelatedActions]) {
+    
+        UIAlertController *alert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"conversation.input_bar.ongoing_call_alert.title", @"")
+                                                                       message:NSLocalizedString(@"conversation.input_bar.ongoing_call_alert.video.message", @"")
+                                                             cancelButtonTitle:NSLocalizedString(@"general.ok", @"")];
+        [self presentViewController:alert animated:YES completion:nil];
+        return;
+    }
+    
     [Analytics.shared tagMediaAction:ConversationMediaActionVideoMessage inConversation:self.conversation];
     self.videoSendContext = ConversationMediaVideoContextCursorButton;
     [self presentImagePickerWithSourceType:UIImagePickerControllerSourceTypeCamera mediaTypes:@[(id)kUTTypeMovie] allowsEditing:false];


### PR DESCRIPTION
## What's new in this PR?

### Issues

It was possible to open the camera during a call.

### Solutions

I've implemented the same alert used to block interactions with audio messages during a call.