### PR TITLE
Feature: Alert dialog for newsletter scription when the user creating a account with email

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1058,6 +1058,7 @@
 		EF2128EE2056D55400C1673B /* NetworkStatusViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2128EC2056D51600C1673B /* NetworkStatusViewControllerTests.swift */; };
 		EF218AC520A9C123004977BF /* SettingsCellDescriptorFactory+DataUsagePermissions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF218AC420A9C123004977BF /* SettingsCellDescriptorFactory+DataUsagePermissions.swift */; };
 		EF218AC720A9DDEF004977BF /* ConversationListViewController+DataUsagePermissions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF218AC620A9DDEF004977BF /* ConversationListViewController+DataUsagePermissions.swift */; };
+		EF218AC920AC76DB004977BF /* UIAlertController+Newsletter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF218AC820AC76DB004977BF /* UIAlertController+Newsletter.swift */; };
 		EF24036E20A1D581002813BE /* TermsOfUseStepViewController+Constraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF24036D20A1D581002813BE /* TermsOfUseStepViewController+Constraints.swift */; };
 		EF25F7DE1FC45F8E0040C3CC /* AccessoryTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF25F7DD1FC45F8E0040C3CC /* AccessoryTextField.swift */; };
 		EF25F8871FC57F320040C3CC /* AccessoryTextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF25F8851FC57EE90040C3CC /* AccessoryTextFieldTests.swift */; };
@@ -2690,6 +2691,7 @@
 		EF2128EC2056D51600C1673B /* NetworkStatusViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkStatusViewControllerTests.swift; sourceTree = "<group>"; };
 		EF218AC420A9C123004977BF /* SettingsCellDescriptorFactory+DataUsagePermissions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SettingsCellDescriptorFactory+DataUsagePermissions.swift"; sourceTree = "<group>"; };
 		EF218AC620A9DDEF004977BF /* ConversationListViewController+DataUsagePermissions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationListViewController+DataUsagePermissions.swift"; sourceTree = "<group>"; };
+		EF218AC820AC76DB004977BF /* UIAlertController+Newsletter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertController+Newsletter.swift"; sourceTree = "<group>"; };
 		EF24036D20A1D581002813BE /* TermsOfUseStepViewController+Constraints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TermsOfUseStepViewController+Constraints.swift"; sourceTree = "<group>"; };
 		EF24036F20A1E161002813BE /* TermsOfUseStepViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "TermsOfUseStepViewController+Private.h"; sourceTree = "<group>"; };
 		EF25F7DD1FC45F8E0040C3CC /* AccessoryTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessoryTextField.swift; sourceTree = "<group>"; };
@@ -5370,6 +5372,7 @@
 				EFFF9E841FBF335700491F9A /* UIColor+TeamCreation.swift */,
 				EF25F7DD1FC45F8E0040C3CC /* AccessoryTextField.swift */,
 				8759E2C41FC86090008E17C9 /* UIAlertController+TOS.swift */,
+				EF218AC820AC76DB004977BF /* UIAlertController+Newsletter.swift */,
 			);
 			path = RegistrationTeam;
 			sourceTree = "<group>";
@@ -6593,6 +6596,7 @@
 				5E3A6C25206A4E4A00907484 /* LocationPreviewController.swift in Sources */,
 				BF8ECC2D1E570A920015177D /* UIActivityViewController+FileSaving.swift in Sources */,
 				8708B8331DDDFF0D00310A53 /* UserConnectionView.swift in Sources */,
+				EF218AC920AC76DB004977BF /* UIAlertController+Newsletter.swift in Sources */,
 				D5168F4D2010B61D00F8222A /* URL+Wire.swift in Sources */,
 				8FC8543D199245770008B66B /* ConnectRequestsViewController.m in Sources */,
 				EF6777062073C6C20062F122 /* OfflineBar.swift in Sources */,

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -1288,3 +1288,9 @@
 "url_action.confirm" = "Confirm";
 "url_action.title" = "Confirm URL action";
 "url_action.connect_to_bot.message" = "Would you like to connect to the bot?";
+
+// +++++++++++++++++++++++++++++++++++++++++++++++++++++
+// News and offers consent prompt
+
+"news_offers.consent.title" = "News and offers";
+"news_offers.consent.message" = "We would like to send you more information about our product. To do so, we may use external services like Salesforce and Marketo.\nYou can unsubscribe at any time. We will not keep your data after that.";

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/Steps/EmailVerificationStepViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/Steps/EmailVerificationStepViewController.m
@@ -66,6 +66,8 @@
     [self createInstructionsLabel];
     [self createResendInstructions];
     [self createResendButton];
+
+    [UIAlertController showNewsletterSubscriptionDialog];
     
     [self updateViewConstraints];
 }

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationFlowController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationFlowController.swift
@@ -133,6 +133,7 @@ extension TeamCreationFlowController {
             stepDescription = SetEmailStepDescription(controller: navigationController)
         case let .verifyEmail(teamName: _, email: email):
             stepDescription = VerifyEmailStepDescription(email: email, delegate: self)
+            showNewsletterSubscriptionDialog()
         case .setFullName:
             stepDescription = SetFullNameStepDescription()
         case .setPassword:
@@ -180,6 +181,23 @@ extension TeamCreationFlowController {
             self.currentController = nil
             self.navigationController.popToRootViewController(animated: true)
         }
+    }
+}
+
+// MARK: - Newsletter subscription dialog
+extension TeamCreationFlowController {
+    func showNewsletterSubscriptionDialog() {
+        let alertController = UIAlertController(title: "news_offers.consent.title".localized, message: "news_offers.consent.message".localized, preferredStyle: .alert)
+
+        alertController.addAction(UIAlertAction(title: "general.accept".localized, style: .default, handler: { (_) in
+            // enable newsletter subscription
+        }))
+
+        alertController.addAction(UIAlertAction(title: "general.skip".localized, style: .cancel, handler: { (_) in
+            // disable newsletter subscription
+        }))
+
+        AppDelegate.shared().notificationsWindow?.rootViewController?.present(alertController, animated: true)
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationFlowController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationFlowController.swift
@@ -133,7 +133,7 @@ extension TeamCreationFlowController {
             stepDescription = SetEmailStepDescription(controller: navigationController)
         case let .verifyEmail(teamName: _, email: email):
             stepDescription = VerifyEmailStepDescription(email: email, delegate: self)
-            showNewsletterSubscriptionDialog()
+            UIAlertController.showNewsletterSubscriptionDialog()
         case .setFullName:
             stepDescription = SetFullNameStepDescription()
         case .setPassword:
@@ -181,23 +181,6 @@ extension TeamCreationFlowController {
             self.currentController = nil
             self.navigationController.popToRootViewController(animated: true)
         }
-    }
-}
-
-// MARK: - Newsletter subscription dialog
-extension TeamCreationFlowController {
-    func showNewsletterSubscriptionDialog() {
-        let alertController = UIAlertController(title: "news_offers.consent.title".localized, message: "news_offers.consent.message".localized, preferredStyle: .alert)
-
-        alertController.addAction(UIAlertAction(title: "general.accept".localized, style: .default, handler: { (_) in
-            // enable newsletter subscription
-        }))
-
-        alertController.addAction(UIAlertAction(title: "general.skip".localized, style: .cancel, handler: { (_) in
-            // disable newsletter subscription
-        }))
-
-        AppDelegate.shared().notificationsWindow?.rootViewController?.present(alertController, animated: true)
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/UIAlertController+Newsletter.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/UIAlertController+Newsletter.swift
@@ -1,0 +1,41 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension UIAlertController {
+    static func showNewsletterSubscriptionDialog() {
+        let alertController = UIAlertController(title: "news_offers.consent.title".localized,
+                                                message: "news_offers.consent.message".localized,
+                                                preferredStyle: .alert)
+
+        alertController.addAction(UIAlertAction(title: "general.accept".localized,
+                                                style: .default,
+                                                handler: { (_) in
+            // enable newsletter subscription
+        }))
+
+        alertController.addAction(UIAlertAction(title: "general.skip".localized,
+                                                style: .cancel,
+                                                handler: { (_) in
+            // disable newsletter subscription
+        }))
+
+        AppDelegate.shared().notificationsWindow?.rootViewController?.present(alertController, animated: true)
+    }
+}


### PR DESCRIPTION
## What's new in this PR?

Show an alert dialog over email verification screen when the user create a personal or team account with email address.

## Dependencies

Needs releases with:

- [ ] Backend support for "receive news and offers" setting option

### Attachments

Screenshot of alert dialog over personal account email verification screen:

<img src="https://user-images.githubusercontent.com/11852044/40124053-f1aaf878-5927-11e8-85eb-57d4d685aae3.png" width="200">

Screenshot of alert dialog over team account email verification screen:

<img src="https://user-images.githubusercontent.com/11852044/40124054-f1cac3ba-5927-11e8-9ba5-b90dbec434a9.png" width="200">
