### PR TITLE
Observe and update UI when constant bit rate changes

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -49,7 +49,7 @@ final class CallViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
         callInfoRootViewController.delegate = self
         AVSMediaManagerClientChangeNotification.add(self)
-        observerTokens += [voiceChannel.addCallStateObserver(self), voiceChannel.addParticipantObserver(self)]
+        observerTokens += [voiceChannel.addCallStateObserver(self), voiceChannel.addParticipantObserver(self), voiceChannel.addConstantBitRateObserver(self)]
         proximityMonitorManager?.stateChanged = proximityStateDidChange
     }
     
@@ -196,6 +196,14 @@ extension CallViewController: WireCallCenterCallParticipantObserver {
 extension CallViewController: AVSMediaManagerClientObserver {
     
     func mediaManagerDidChange(_ notification: AVSMediaManagerClientChangeNotification!) {
+        updateConfiguration()
+    }
+    
+}
+
+extension CallViewController: ConstantBitRateAudioObserver {
+    
+    func callCenterDidChange(constantAudioBitRateAudioEnabled: Bool) {
         updateConfiguration()
     }
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

CBR label didn't appear reliably 

### Causes

We weren't observing when it changes.

### Solutions

Observe it.