### PR TITLE
Disable dialogs for automation tests

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+DataUsagePermissions.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+DataUsagePermissions.swift
@@ -20,6 +20,8 @@ import Foundation
 
 extension ConversationListViewController {
     func showDataUsagePermissionDialogIfNeeded() {
+        guard !AutomationHelper.sharedHelper.skipFirstLoginAlerts else { return }
+
         guard needToShowDataUsagePermissionDialog else { return }
 
         guard isComingFromRegistration ||

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/UIAlertController+Newsletter.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/UIAlertController+Newsletter.swift
@@ -26,6 +26,8 @@ extension UIAlertController {
     static var newsletterSubscriptionDialogWasDisplayed = false
 
     static func showNewsletterSubscriptionDialog() {
+        guard !AutomationHelper.sharedHelper.skipFirstLoginAlerts else { return }
+
         let alertController = UIAlertController(title: "news_offers.consent.title".localized,
                                                 message: "news_offers.consent.message".localized,
                                                 preferredStyle: .alert)


### PR DESCRIPTION
disable dialogs when AutomationHelper.sharedHelper.skipFirstLoginAlerts is set to true.