### PR TITLE
Fix remote participant turning camera off

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridView.swift
@@ -75,6 +75,8 @@ class VideoGridViewController: UIViewController {
     }
     
     func updateState() {
+        Calling.log.debug("\nUpdating video configuration from:\n\(videoConfigurationDescription())")
+        
         let selfStreamId = ZMUser.selfUser().remoteIdentifier!
         let selfInGrid = configuration.videoStreams.contains { $0.stream == selfStreamId }
         let selfInFloatingOverlay = nil != configuration.floatingVideoStream
@@ -86,8 +88,14 @@ class VideoGridViewController: UIViewController {
             selfPreviewView?.translatesAutoresizingMaskIntoConstraints = false
         }
         
-        updateVideoGrid(with: configuration.videoStreams)
-        updateFloatingVideo(with: configuration.floatingVideoStream)
+        // It's important to remove remove the existing preview view before moving it to the grid/floating location
+        if selfInGrid {
+            updateFloatingVideo(with: configuration.floatingVideoStream)
+            updateVideoGrid(with: configuration.videoStreams)
+        } else {
+            updateVideoGrid(with: configuration.videoStreams)
+            updateFloatingVideo(with: configuration.floatingVideoStream)
+        }
         
         // Clear self preview we we shouldn't show it anymore
         if !isShowingSelf, let _ = selfPreviewView {
@@ -96,11 +104,14 @@ class VideoGridViewController: UIViewController {
         
         // Update mute status
         selfPreviewView?.isMuted = configuration.isMuted
+        
+        Calling.log.debug("\nUpdated video configuration to:\n\(videoConfigurationDescription())")
     }
     
     private func updateFloatingVideo(with state: ParticipantVideoState?) {
         // No stream, remove floating video if there is any
         guard let state = state else {
+            Calling.log.debug("Removing self video from floating preview")
             return thumbnailViewController.removeCurrentThumbnailContentView()
         }
         
@@ -112,8 +123,16 @@ class VideoGridViewController: UIViewController {
         // We have a stream but don't have a preview view yet
         if nil == thumbnailViewController.contentView, let previewView = selfPreviewView {
             // TODO: Calculate correct size based on device and orientation
+            Calling.log.debug("Adding self video to floating preview")
             thumbnailViewController.setThumbnailContentView(previewView, contentSize: .floatingPreviewPortrait)
         }
+    }
+    
+    private func videoConfigurationDescription() -> String {
+        return """
+        showing self preview: \(selfPreviewView != nil)
+        videos in grid: [\(gridVideoStreams)]\n
+        """
     }
     
     private func updateVideoGrid(with videoStreams: [ParticipantVideoState]) {
@@ -151,7 +170,9 @@ class VideoGridViewController: UIViewController {
 
     private func removeStream(_ streamId: UUID) {
         Calling.log.debug("Removing video stream: \(streamId)")
-        guard let videoView = streamView(for: streamId) else { return }
+        guard let videoView = streamView(for: streamId) else {
+            return Calling.log.debug("Failed to remove video stream \(streamId) since view was not found")
+        }
         gridView.remove(view: videoView)
         gridVideoStreams.index(of: streamId).apply { gridVideoStreams.remove(at: $0) }
     }

--- a/avs-versions
+++ b/avs-versions
@@ -17,4 +17,4 @@
 # along with this program. If not, see http://www.gnu.org/licenses/.
 #
 
-export APPSTORE_AVS_VERSION=4.4.22
+export APPSTORE_AVS_VERSION=4.4.24


### PR DESCRIPTION
## What's new in this PR?

### Issues

When the the remote participant turns his camera off the video feed goes blank.

### Causes

When the remote participant turns his camera off your own video preview should move into the grid, this failed because we performed the operations in the wrong order.

### Solutions

If the self preview is currently floating we need to perform the following:

1. Remove video from floating video container
2. Add video to grid

When the preview is moving from the grid to the floating container the order is reversed.