### PR TITLE
Dismiss keyboard when newsletter alert appears 

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/UIAlertController+Newsletter.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/UIAlertController+Newsletter.swift
@@ -48,16 +48,20 @@ extension UIAlertController {
                                                 style: .default,
                                                 handler: { (_) in
                                                     // disable newsletter subscription
+
+                                                    ///show keyboard
         }))
 
         alertController.addAction(UIAlertAction(title: "general.accept".localized,
                                                 style: .cancel,
                                                 handler: { (_) in
                                                     // enable newsletter subscription
+                                                    ///show keyboard
         }))
 
         AppDelegate.shared().notificationsWindow?.rootViewController?.present(alertController, animated: true) {
             UIAlertController.newsletterSubscriptionDialogWasDisplayed = true
+                    UIApplication.shared.keyWindow?.endEditing(true)
         }
     }
 

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/UIAlertController+Newsletter.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/UIAlertController+Newsletter.swift
@@ -48,20 +48,17 @@ extension UIAlertController {
                                                 style: .default,
                                                 handler: { (_) in
                                                     // disable newsletter subscription
-
-                                                    ///show keyboard
         }))
 
         alertController.addAction(UIAlertAction(title: "general.accept".localized,
                                                 style: .cancel,
                                                 handler: { (_) in
                                                     // enable newsletter subscription
-                                                    ///show keyboard
         }))
 
         AppDelegate.shared().notificationsWindow?.rootViewController?.present(alertController, animated: true) {
             UIAlertController.newsletterSubscriptionDialogWasDisplayed = true
-                    UIApplication.shared.keyWindow?.endEditing(true)
+            UIApplication.shared.keyWindow?.endEditing(true)
         }
     }
 


### PR DESCRIPTION
## What's new in this PR?

Prevent keyboard hides alert in name input screen.