### PR TITLE
Fix theming when switching between audio and video

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallAccessoryViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallAccessoryViewController.swift
@@ -67,14 +67,16 @@ final class CallAccessoryViewController: UIViewController, CallParticipantsViewC
     
     private func updateState() {
         switch configuration.accessoryType {
-        case .avatar(let user): avatarView.user = user
-        case .participantsList(let participants): participantsViewController.participants = participants
+        case .avatar(let user):
+            avatarView.user = user
+        case .participantsList(let participants):
+            participantsViewController.variant = configuration.effectiveColorVariant
+            participantsViewController.participants = participants
         case .none: break
         }
         
         avatarView.isHidden = !configuration.accessoryType.showAvatar
         participantsViewController.view.isHidden = !configuration.accessoryType.showParticipantList
-        participantsViewController.variant = configuration.effectiveColorVariant
     }
     
     func callParticipantsViewControllerDidSelectShowMore(viewController: CallParticipantsViewController) {

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -132,6 +132,7 @@ final class CallViewController: UIViewController {
         videoGridViewController.configuration = videoConfiguration
         updateOverlayAfterStateChanged()
         updateAppearance()
+        UIApplication.shared.wr_updateStatusBarForCurrentControllerAnimated(true)
     }
     
     private func updateAppearance() {


### PR DESCRIPTION
## What's new in this PR?

### Issues

All the UI elements didn't update their color theme correctly when toggling between audio and video in a call.

### Solutions

- Trigger update of status bar when call configuration changes
- Fix call participant list not updating it's color variant correctly.