### PR TITLE
Fix anchoring to status bar on iOS 10 in call UI

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoViewController.swift
@@ -83,7 +83,7 @@ final class CallInfoViewController: UIViewController, CallActionsViewDelegate, C
     private func createConstraints() {
         NSLayoutConstraint.activate([
             stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            stackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuideOrFallback.topAnchor),
+            stackView.topAnchor.constraint(equalTo: safeTopAnchor),
             stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             stackView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuideOrFallback.bottomAnchor, constant: -40),
             actionsView.widthAnchor.constraint(equalToConstant: 288),


### PR DESCRIPTION
## What's new in this PR?

### Issues

Call UI would be displayed under the status bar on iOS 10 and earlier.

### Causes

On iOS 10 we were falling back to `layoutMarginsGuide`  since `safeAreaLayoutGuide` isn't available but it doesn't take the status bar into account.

### Solutions

Use `topLayoutGuide` instead.
