### PR TITLE
Fix floating self video preview on iPad

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/Thumbnail/PinnableThumbnailViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/Thumbnail/PinnableThumbnailViewController.swift
@@ -26,7 +26,7 @@ import UIKit
 
     // MARK: - Dynamics
 
-    fileprivate let edgeInsets = CGPoint(x: 0, y: 24)
+    fileprivate let edgeInsets = CGPoint(x: 16, y: 16)
     fileprivate var originalCenter: CGPoint = .zero
 
     fileprivate lazy var pinningBehavior: ThumbnailCornerPinningBehavior = {
@@ -165,8 +165,8 @@ import UIKit
     }
 
     private func updateThumbnailAfterLayoutUpdate() {
-        pinningBehavior.updateFields(in: thumbnailContainerView.bounds)
         updateThumbnailFrame(animated: false, parentSize: thumbnailContainerView.frame.size)
+        pinningBehavior.updateFields(in: thumbnailContainerView.bounds)
     }
 
     private func thumbnailPosition(for size: CGSize, parentSize: CGSize) -> CGPoint {

--- a/Wire-iOS/Sources/UserInterface/Calling/Thumbnail/PinnableThumbnailViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/Thumbnail/PinnableThumbnailViewController.swift
@@ -39,7 +39,7 @@ import UIKit
 
     // MARK: - Changing the Previewed Content
 
-    fileprivate(set) var thumbnailContentSize: CGSize = .zero
+    fileprivate(set) var thumbnailContentSize = CGSize(width: 100, height: 100)
     
     func removeCurrentThumbnailContentView() {
         contentView?.removeFromSuperview()
@@ -142,38 +142,21 @@ import UIKit
     }
 
     private func updateThumbnailFrame(animated: Bool, parentSize: CGSize) {
+        guard thumbnailContentSize != .zero else { return }
+        let size = thumbnailContentSize.withOrientation(UIDevice.current.orientation)
+        let position = thumbnailPosition(for: size, parentSize: parentSize)
 
-        let size: CGSize
-        view.layoutIfNeeded()
+        let changesBlock = { [thumbnailView, view] in
+            thumbnailView.frame = CGRect(
+                x: position.x - size.width / 2,
+                y: position.y - size.height / 2,
+                width: size.width,
+                height: size.height
+            )
 
-        switch thumbnailContentSize.aspectRatio {
-        case .square:
-            let sideLength = thumbnailContainerView.bounds.width * 1/3
-            size = CGSize(width: sideLength, height: sideLength)
-
-        case .portrait(let heightRatio):
-            let width = thumbnailContainerView.bounds.width * 1/4
-            let height = width * heightRatio
-            size = CGSize(width: width, height: height)
-
-        case .landscape(let heightRatio):
-            let width = thumbnailContainerView.bounds.width * 1/3
-            let height = width * heightRatio
-            size = CGSize(width: width, height: height)
+            view?.layoutIfNeeded()
         }
-
-        let position = self.thumbnailPosition(for: size, parentSize: parentSize)
-
-        let changesBlock = {
-
-            self.thumbnailView.frame = CGRect(x: position.x - size.width / 2,
-                                              y: position.y - size.height / 2,
-                                              width: size.width, height: size.height)
-
-            self.view.layoutIfNeeded()
-
-        }
-
+        
         if animated {
             UIView.animate(withDuration: 0.2, animations: changesBlock)
         } else {

--- a/Wire-iOS/Sources/UserInterface/Calling/Thumbnail/ThumbnailCornerPinningBehavior.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/Thumbnail/ThumbnailCornerPinningBehavior.swift
@@ -52,7 +52,6 @@ final class ThumbnailCornerPinningBehavior: UIDynamicBehavior {
         self.itemTransformBehavior.resistance = 10
         self.itemTransformBehavior.friction = 0.1
         self.itemTransformBehavior.allowsRotation = false
-
         super.init()
 
         // Add child behaviors

--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridView.swift
@@ -24,9 +24,16 @@ protocol VideoGridConfiguration {
     var isMuted: Bool { get }
 }
 
-extension CGSize {
-    static let floatingPreviewPortrait = CGSize(width: 108, height: 144)
-    static let floatingPreviewLandscape = CGSize(width: 144, height: 108)
+fileprivate extension CGSize {
+    static let floatingPreviewSmall = CGSize(width: 108, height: 144)
+    static let floatingPreviewLarge = CGSize(width: 120, height: 160)
+    
+    static func previewSize(for traitCollection: UITraitCollection) -> CGSize {
+        switch traitCollection.horizontalSizeClass {
+        case .regular: return .floatingPreviewLarge
+        case .compact, .unspecified: return .floatingPreviewSmall
+        }
+    }
 }
 
 class VideoGridViewController: UIViewController {
@@ -122,10 +129,15 @@ class VideoGridViewController: UIViewController {
         
         // We have a stream but don't have a preview view yet
         if nil == thumbnailViewController.contentView, let previewView = selfPreviewView {
-            // TODO: Calculate correct size based on device and orientation
             Calling.log.debug("Adding self video to floating preview")
-            thumbnailViewController.setThumbnailContentView(previewView, contentSize: .floatingPreviewPortrait)
+            thumbnailViewController.setThumbnailContentView(previewView, contentSize: .previewSize(for: traitCollection))
         }
+    }
+    
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        guard traitCollection.horizontalSizeClass != previousTraitCollection?.horizontalSizeClass else { return }
+        thumbnailViewController.updateThumbnailContentSize(.previewSize(for: traitCollection), animated: false)
     }
     
     private func videoConfigurationDescription() -> String {

--- a/Wire-iOS/Sources/UserInterface/Helpers/CGSize+AspectRatio.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/CGSize+AspectRatio.swift
@@ -19,25 +19,48 @@
 import CoreGraphics
 
 enum AspectRatio {
-
-    case portrait(CGFloat)
-    case landscape(CGFloat)
+    case portrait
+    case landscape
     case square
+}
 
+extension UIDeviceOrientation {
+    var aspectRatio: AspectRatio {
+        return isLandscape ? .landscape : .portrait
+    }
 }
 
 extension CGSize {
 
     var aspectRatio: AspectRatio {
-
         if width < height {
-            return .portrait(height / width)
+            return .portrait
         } else if width > height {
-            return .landscape(height / width)
+            return .landscape
         } else {
             return .square
         }
-
+    }
+    
+    var isLandscape: Bool {
+        return aspectRatio == .landscape
+    }
+    
+    var isPortrait: Bool {
+        return aspectRatio == .portrait
+    }
+    
+    var isSquare: Bool {
+        return aspectRatio == .square
+    }
+    
+    func flipped() -> CGSize {
+        return CGSize(width: height, height: width)
+    }
+    
+    func withOrientation(_ orientation: UIDeviceOrientation) -> CGSize {
+        guard orientation.aspectRatio != aspectRatio else { return self }
+        return flipped()
     }
 
 }


### PR DESCRIPTION
## What's new in this PR?

* Fix floating self preview margins.
* Use a larger preview view in regular width trait collections and update on changes.
* Update thumbnail content size before recalculating pinning behaviour anchor points.
* Fix floating self video preview on iPad, this was mostly caused by the preview size calculation on rotation. We now flip the thumbnail aspect ratio when needed.

