### PR TITLE
Link UI to marketing consent backend

### DIFF
--- a/Wire-iOS/Sources/Components/Settings/SettingsPropertyFactory.swift
+++ b/Wire-iOS/Sources/Components/Settings/SettingsPropertyFactory.swift
@@ -194,16 +194,17 @@ class SettingsPropertyFactory {
             }
             return SettingsBlockProperty(propertyName: propertyName, getAction: getAction, setAction: setAction)
         case .receiveNewsAndOffers:
-            ///TODO: wait for backend support
-            
+
             let getAction : GetAction = { /*[unowned self]*/ (property: SettingsBlockProperty) -> SettingsPropertyValue in
+                ///TODO: wait for backend support
                 return .none
             }
 
-            let setAction : SetAction = { /*[unowned self]*/ (property: SettingsBlockProperty, value: SettingsPropertyValue) throws -> () in
+            let setAction : SetAction = { [unowned self] (property: SettingsBlockProperty, value: SettingsPropertyValue) throws -> () in
                 switch value {
-                case .number(_ /* let number*/):
+                case .number(let number):
                     self.userSession?.performChanges {
+                        ZMUser.selfUser().setMarketingConsent(to: number.boolValue, in: ZMUserSession.shared()!, completion: {_ in})
                     }
 
                 default:

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+Handles.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+Handles.swift
@@ -132,7 +132,11 @@ extension ConversationListViewController: UserProfileUpdateObserver {
 
     public func didFindHandleSuggestion(handle: String) {
         showUsernameTakeover(with: handle)
-        UIAlertController.showNewsletterSubscriptionDialogIfNeeded()
+        UIAlertController.showNewsletterSubscriptionDialogIfNeeded() { _ in
+            if let userSession = ZMUserSession.shared() {
+                ZMUser.selfUser().setMarketingConsent(to: true, in: userSession, completion: { _ in })
+            }
+        }
         UIAlertController.newsletterSubscriptionDialogWasDisplayed = false
 
         // When the user have to set user name, i.e. the user is a invited team user, show data usage permission dialog

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationFlowController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationFlowController.swift
@@ -42,6 +42,7 @@ final class TeamCreationFlowController: NSObject {
     var syncToken: Any?
     var sessionManagerToken: Any?
     let tracker = AnalyticsTracker(context: AnalyticsContextRegistrationEmail)!
+    var marketingConsent: Bool?
 
     init(navigationController: UINavigationController, registrationStatus: RegistrationStatus) {
         self.navigationController = navigationController
@@ -135,7 +136,11 @@ extension TeamCreationFlowController {
             stepDescription = VerifyEmailStepDescription(email: email, delegate: self)
         case .setFullName:
             stepDescription = SetFullNameStepDescription()
-            UIAlertController.showNewsletterSubscriptionDialogIfNeeded()
+
+            UIAlertController.newsletterSubscriptionDialogWasDisplayed = false
+            UIAlertController.showNewsletterSubscriptionDialogIfNeeded() { [weak self] marketingconset in
+                self?.marketingConsent = marketingconset
+            }
         case .setPassword:
             stepDescription = SetPasswordStepDescription()
         case .createTeam:
@@ -264,6 +269,10 @@ extension TeamCreationFlowController: TeamMemberInviteViewControllerDelegate {
     
     func teamInviteViewControllerDidFinish(_ controller: TeamMemberInviteViewController) {
         registrationDelegate?.registrationViewControllerDidCompleteRegistration()
+
+        if let marketingConsent = self.marketingConsent, let user = ZMUser.selfUser(), let userSession = ZMUserSession.shared() {
+            user.setMarketingConsent(to: marketingConsent, in: userSession, completion: { _ in })
+        }
     }
     
 }

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/UIAlertController+Newsletter.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/UIAlertController+Newsletter.swift
@@ -25,7 +25,7 @@ extension UIAlertController {
     /// email regisration work flow: newsletter subscription dialog appears after conversation list is displayed.)
     static var newsletterSubscriptionDialogWasDisplayed = false
 
-    static func showNewsletterSubscriptionDialog() {
+    static func showNewsletterSubscriptionDialog(completionHandler: @escaping (Bool) -> Void) {
         guard !AutomationHelper.sharedHelper.skipFirstLoginAlerts else { return }
 
         let alertController = UIAlertController(title: "news_offers.consent.title".localized,
@@ -35,7 +35,7 @@ extension UIAlertController {
         let privacyPolicyActionHandler: ((UIAlertAction) -> Swift.Void) = { _ in
             if let browserViewController = BrowserViewController(url: (NSURL.wr_privacyPolicy() as NSURL).wr_URLByAppendingLocaleParameter() as URL) {
                 browserViewController.completion = { _ in
-                    UIAlertController.showNewsletterSubscriptionDialog()
+                    UIAlertController.showNewsletterSubscriptionDialog(completionHandler: completionHandler)
                 }
 
                 AppDelegate.shared().notificationsWindow?.rootViewController?.present(browserViewController, animated: true)
@@ -49,15 +49,13 @@ extension UIAlertController {
         alertController.addAction(UIAlertAction(title: "general.skip".localized,
                                                 style: .default,
                                                 handler: { (_) in
-                                                    // disable newsletter subscription
-                                                    ZMUser.selfUser().setMarketingConsent(to: false, in: ZMUserSession.shared()!, completion: {_ in})
+                                                    completionHandler(false)
         }))
 
         alertController.addAction(UIAlertAction(title: "general.accept".localized,
                                                 style: .cancel,
                                                 handler: { (_) in
-                                                    // enable newsletter subscription
-                                                    ZMUser.selfUser().setMarketingConsent(to: true, in: ZMUserSession.shared()!, completion: {_ in})
+                                                    completionHandler(true)
         }))
 
         AppDelegate.shared().notificationsWindow?.rootViewController?.present(alertController, animated: true) {
@@ -66,9 +64,9 @@ extension UIAlertController {
         }
     }
 
-    static func showNewsletterSubscriptionDialogIfNeeded() {
+    static func showNewsletterSubscriptionDialogIfNeeded(completionHandler: @escaping (Bool) -> Void) {
         guard !UIAlertController.newsletterSubscriptionDialogWasDisplayed else { return }
 
-        showNewsletterSubscriptionDialog()
+        showNewsletterSubscriptionDialog(completionHandler: completionHandler)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/UIAlertController+Newsletter.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/UIAlertController+Newsletter.swift
@@ -50,12 +50,14 @@ extension UIAlertController {
                                                 style: .default,
                                                 handler: { (_) in
                                                     // disable newsletter subscription
+                                                    ZMUser.selfUser().setMarketingConsent(to: false, in: ZMUserSession.shared()!, completion: {_ in})
         }))
 
         alertController.addAction(UIAlertAction(title: "general.accept".localized,
                                                 style: .cancel,
                                                 handler: { (_) in
                                                     // enable newsletter subscription
+                                                    ZMUser.selfUser().setMarketingConsent(to: true, in: ZMUserSession.shared()!, completion: {_ in})
         }))
 
         AppDelegate.shared().notificationsWindow?.rootViewController?.present(alertController, animated: true) {

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+DataUsagePermissions.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+DataUsagePermissions.swift
@@ -25,7 +25,7 @@ extension SettingsCellDescriptorFactory {
         let sendAnonymousData = SettingsPropertyToggleCellDescriptor(settingsProperty: self.settingsPropertyFactory.property(.disableCrashAndAnalyticsSharing), inverse: true)
         let sendAnonymousDataSection = SettingsSectionDescriptor(cellDescriptors: [sendAnonymousData], footer: "self.settings.privacy_analytics_menu.description.title".localized)
 
-        let receiveNewsAndOffersData = SettingsPropertyToggleCellDescriptor(settingsProperty: self.settingsPropertyFactory.property(.receiveNewsAndOffers), inverse: true)
+        let receiveNewsAndOffersData = SettingsPropertyToggleCellDescriptor(settingsProperty: self.settingsPropertyFactory.property(.receiveNewsAndOffers))
         let receiveNewsAndOffersSection = SettingsSectionDescriptor(cellDescriptors: [receiveNewsAndOffersData], footer: "self.settings.receiveNews_and_offers.description.title".localized)
 
         items.append(contentsOf: [sendAnonymousDataSection, receiveNewsAndOffersSection])


### PR DESCRIPTION
## What's new in this PR?

Link marketing consent related UI to backend.

## Note
case tested:
 - Register as a team user
 - Login with a normal account and toggle marketing consent setting
