### PR TITLE
ZIOS-9499: Fix status bar visual issue on iPad

### DIFF
--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController+Internal.h
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController+Internal.h
@@ -53,6 +53,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, nonnull) UIView *topOverlayContainer;
 @property (nonatomic, nullable) UIViewController *topOverlayViewController;
+@property (nonatomic) NSLayoutConstraint *contentTopRegularConstraint;
+@property (nonatomic) NSLayoutConstraint *contentTopCompactConstraint;
+
 
 @end
 

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
@@ -210,7 +210,7 @@
     if (nil != self.topOverlayViewController) {
         return self.topOverlayViewController.preferredStatusBarStyle;
     }
-    else if (self.splitViewController.layoutSize == SplitViewControllerLayoutSizeCompact) {
+    else if (self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact) {
         if (self.presentedViewController) {
             return self.presentedViewController.preferredStatusBarStyle;
         }
@@ -227,7 +227,7 @@
     if (nil != self.topOverlayViewController) {
         return self.topOverlayViewController.prefersStatusBarHidden;
     }
-    else if (self.splitViewController.layoutSize == SplitViewControllerLayoutSizeCompact) {
+    else if (self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact) {
         if (self.presentedViewController) {
             return self.presentedViewController.prefersStatusBarHidden;
         }
@@ -256,7 +256,7 @@
     }
 
     [self refreshSplitViewPositionForRegularContainer: self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular];
-    [self setNeedsStatusBarAppearanceUpdate];
+    [[UIApplication sharedApplication] wr_updateStatusBarForCurrentControllerAnimated:YES onlyFullScreen:NO];
     [self.view setNeedsLayout];
 }
 

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
@@ -156,7 +156,8 @@
     
     [self createTopViewConstraints];
     [self.splitViewController didMoveToParentViewController:self];
-    
+    [self refreshSplitViewPositionForRegularContainer: self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular];
+
     self.splitViewController.view.backgroundColor = [UIColor clearColor];
     
     [self createBackgroundViewController];
@@ -218,7 +219,7 @@
         }
     }
     else {
-        return UIStatusBarStyleDefault;
+        return UIStatusBarStyleLightContent;
     }
 }
 
@@ -253,7 +254,9 @@
             [self attemptToLoadLastViewedConversationWithFocus:NO animated:NO];
         }
     }
-    
+
+    [self refreshSplitViewPositionForRegularContainer: self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular];
+    [self setNeedsStatusBarAppearanceUpdate];
     [self.view setNeedsLayout];
 }
 

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -99,6 +99,9 @@ extension ZClientViewController {
         topOverlayContainer = UIView()
         topOverlayContainer.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(topOverlayContainer)
+
+        contentTopRegularConstraint = splitViewController.view.topAnchor.constraint(equalTo: safeTopAnchor)
+        contentTopCompactConstraint = splitViewController.view.topAnchor.constraint(equalTo: view.topAnchor)
         
         NSLayoutConstraint.activate([
             topOverlayContainer.topAnchor.constraint(equalTo: view.topAnchor),
@@ -108,10 +111,17 @@ extension ZClientViewController {
             splitViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             splitViewController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             splitViewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            ])
-        
+        ])
+
         let heightConstraint = topOverlayContainer.heightAnchor.constraint(equalToConstant: 0)
         heightConstraint.priority = UILayoutPriorityDefaultLow
         heightConstraint.isActive = true
     }
+
+    @objc(refreshSplitViewPositionForRegularContainer:)
+    func refreshSplitViewPosition(isRegularContainer: Bool) {
+        contentTopRegularConstraint.isActive = isRegularContainer
+        contentTopCompactConstraint.isActive = !isRegularContainer
+    }
+
 }

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -120,8 +120,15 @@ extension ZClientViewController {
 
     @objc(refreshSplitViewPositionForRegularContainer:)
     func refreshSplitViewPosition(isRegularContainer: Bool) {
-        contentTopRegularConstraint.isActive = isRegularContainer
-        contentTopCompactConstraint.isActive = !isRegularContainer
+
+        if isRegularContainer {
+            contentTopCompactConstraint.isActive = false
+            contentTopRegularConstraint.isActive = true
+        } else {
+            contentTopRegularConstraint.isActive = false
+            contentTopCompactConstraint.isActive = true
+        }
+
     }
 
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

This PR introduces the new design of the status bar on iPad, according to the spec.

### Solutions

To achieve the black status bar on iPad only, we pin the main split view controller to the bottom of the status bar when the size class is regular, and to the top of the client view controller when the size class is compact.

We also update the status according to the size class when the trait collection of the root client view controller changes.
 
The iPhone UI is not affected by this PR.

### Attachments

#### Before

![Old Status Bar Design](https://user-images.githubusercontent.com/16192914/40371702-5f752db4-5de3-11e8-9630-e7d4d454f99f.png)

#### After

![New Status Bar Design](https://user-images.githubusercontent.com/16192914/40371747-72a5b57a-5de3-11e8-95cf-f2824f8eebe4.png)