### PR TITLE
Fix unresponsive action button in a video call

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/CallActionsView/IconLabelButton.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallActionsView/IconLabelButton.swift
@@ -59,6 +59,7 @@ class IconLabelButton: ButtonWithLargerHitArea {
         blurView.translatesAutoresizingMaskIntoConstraints = false
         blurView.clipsToBounds = true
         blurView.layer.cornerRadius = IconLabelButton.width / 2
+        blurView.isUserInteractionEnabled = false
         subtitleLabel.translatesAutoresizingMaskIntoConstraints = false
         subtitleLabel.textTransform = .upper
         subtitleLabel.textAlignment = .center


### PR DESCRIPTION
## What's new in this PR?

### Issues

Action buttons are not responding to touches in a video call

### Causes

Buttons have blur effect while in video call which steals the touches

### Solutions

Disable user interaction for the blur view.