### PR TITLE
fix: Remove the loading view of ConversationListViewController when setMarketingConsent is called

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+Handles.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+Handles.swift
@@ -133,11 +133,8 @@ extension ConversationListViewController: UserProfileUpdateObserver {
     public func didFindHandleSuggestion(handle: String) {
         showUsernameTakeover(with: handle)
         if let userSession = ZMUserSession.shared() {
-            self.showLoadingView = true
             UIAlertController.showNewsletterSubscriptionDialogIfNeeded() { marketingconsent in
-                ZMUser.selfUser().setMarketingConsent(to: marketingconsent, in: userSession, completion: { _ in
-                    self.showLoadingView = false
-                })
+                ZMUser.selfUser().setMarketingConsent(to: marketingconsent, in: userSession, completion: { _ in })
             }
         }
         UIAlertController.newsletterSubscriptionDialogWasDisplayed = false


### PR DESCRIPTION
## What's new in this PR?

### Issues

loading view does not dismiss as expected after setMarketingConsent is completed.

### Causes

### Solutions

Remove it for now. Will investigate it before next release.