### PR TITLE
Disable video for calls in large groups

### DIFF
--- a/Wire-iOS Tests/CallInfoConfigurationTests.swift
+++ b/Wire-iOS Tests/CallInfoConfigurationTests.swift
@@ -388,6 +388,29 @@ class CallInfoConfigurationTests: XCTestCase {
         assertEquals(fixture.groupAudioEstablished, configuration)
     }
     
+    func testGroupAudioEstablishedLargeGroup() {
+        // given
+        let mockGroupConversation = MockConversation.groupConversation()
+        mockGroupConversation.canStartVideoCall = false
+        
+        let mockConversation = ((mockGroupConversation as Any) as! ZMConversation)
+        let mockVoiceChannel = MockVoiceChannel(conversation: mockConversation)
+        let mockUsers: [ZMUser] = MockUser.mockUsers()!
+        let fixture = CallInfoTestFixture(otherUser: otherUser)
+        
+        mockVoiceChannel.mockCallState = .established
+        mockVoiceChannel.mockCallDuration = 10
+        mockVoiceChannel.mockInitiator = selfUser
+        mockVoiceChannel.mockParticipants = NSOrderedSet(array: Array(mockUsers[0..<fixture.groupSize.rawValue]))
+        mockVoiceChannel.mockCallParticipantState = .connected(videoState: .stopped)
+        
+        // when
+        let configuration = CallInfoConfiguration(voiceChannel: mockVoiceChannel, preferedVideoPlaceholderState: .hidden, permissions: CallPermissions())
+        
+        // then
+        assertEquals(fixture.groupAudioEstablishedLargeGroup, configuration)
+    }
+    
     // MARK: - Group Video
     
     func testGroupIncomingVideoRinging() {

--- a/Wire-iOS Tests/CallInfoTestFixture.swift
+++ b/Wire-iOS Tests/CallInfoTestFixture.swift
@@ -344,6 +344,25 @@ struct CallInfoTestFixture {
         )
     }
     
+    var groupAudioEstablishedLargeGroup: CallInfoViewControllerInput {
+        return MockCallInfoViewControllerInput(
+            videoPlaceholderState: .hidden,
+            permissions: CallPermissions(),
+            degradationState: .none,
+            accessoryType: .participantsList(CallParticipantsViewTests.participants(count: groupSize.rawValue)),
+            canToggleMediaType: false,
+            isMuted: false,
+            isTerminating: false,
+            canAccept: false,
+            mediaState: .notSendingVideo(speakerEnabled: false),
+            state: .established(duration: 10),
+            isConstantBitRate: false,
+            title: otherUser.displayName,
+            isVideoCall: false,
+            variant: .light
+        )
+    }
+    
     var groupAudioEstablishedCBR: CallInfoViewControllerInput {
         return MockCallInfoViewControllerInput(
             videoPlaceholderState: .hidden,

--- a/Wire-iOS Tests/Mocks/MockConversation.h
+++ b/Wire-iOS Tests/Mocks/MockConversation.h
@@ -31,5 +31,6 @@
 @property (nonatomic) ZMConversationSecurityLevel securityLevel;
 @property (nonatomic) NSTimeInterval messageDestructionTimeout;
 @property (nonatomic) ZMConnectionStatus relatedConnectionState;
+@property (nonatomic) BOOL canStartVideoCall;
 
 @end

--- a/Wire-iOS Tests/Mocks/MockConversation.m
+++ b/Wire-iOS Tests/Mocks/MockConversation.m
@@ -26,7 +26,7 @@
 
 - (instancetype)initWithJSONObject:(NSDictionary *)jsonObject
 {
-    self = [super init];
+    self = [self init];
     
     if (self) {
         for (NSString *key in jsonObject.allKeys) {
@@ -34,6 +34,17 @@
             [self setValue:value forKey:key];
         }
     }
+    return self;
+}
+
+- (instancetype)init
+{
+    self = [super init];
+    
+    if (self) {
+        self.canStartVideoCall = YES;
+    }
+    
     return self;
 }
 

--- a/Wire-iOS/Sources/UserInterface/Calling/CallActionsView/CallActionsView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallActionsView/CallActionsView.swift
@@ -93,10 +93,12 @@ final class CallActionsView: UIView {
     private let bottomStackView = UIStackView(axis: .horizontal)
     
     private var lastInput: CallActionsViewInputType?
+    private var videoButtonDisabledTapRecognizer: UITapGestureRecognizer?
     
     // Buttons
     private let muteCallButton = IconLabelButton.muteCall()
     private let videoButton = IconLabelButton.video()
+    private let videoButtonDisabled = UIView()
     private let speakerButton = IconLabelButton.speaker()
     private let flipCameraButton = IconLabelButton.flipCamera()
     private let firstBottomRowSpacer = UIView()
@@ -112,6 +114,7 @@ final class CallActionsView: UIView {
     
     init() {
         super.init(frame: .zero)
+        videoButtonDisabledTapRecognizer = UITapGestureRecognizer(target: self, action: #selector(performButtonAction))
         setupViews()
         createConstraints()
     }
@@ -121,6 +124,8 @@ final class CallActionsView: UIView {
     }
     
     private func setupViews() {
+        videoButtonDisabled.translatesAutoresizingMaskIntoConstraints = false
+        videoButtonDisabled.addGestureRecognizer(videoButtonDisabledTapRecognizer!)
         topStackView.distribution = .equalSpacing
         bottomStackView.distribution = .equalSpacing
         bottomStackView.alignment = .top
@@ -129,6 +134,7 @@ final class CallActionsView: UIView {
         [firstBottomRowSpacer, endCallButton, secondBottomRowSpacer, acceptCallButton].forEach(bottomStackView.addArrangedSubview)
         [topStackView, bottomStackView].forEach(verticalStackView.addArrangedSubview)
         allButtons.forEach { $0.addTarget(self, action: #selector(performButtonAction), for: .touchUpInside) }
+        addSubview(videoButtonDisabled)
     }
     
     private func createConstraints() {
@@ -141,7 +147,11 @@ final class CallActionsView: UIView {
             firstBottomRowSpacer.widthAnchor.constraint(equalToConstant: IconButton.width),
             firstBottomRowSpacer.heightAnchor.constraint(equalToConstant: IconButton.height),
             secondBottomRowSpacer.widthAnchor.constraint(equalToConstant: IconButton.width),
-            secondBottomRowSpacer.heightAnchor.constraint(equalToConstant: IconButton.height)
+            secondBottomRowSpacer.heightAnchor.constraint(equalToConstant: IconButton.height),
+            videoButtonDisabled.leftAnchor.constraint(equalTo: videoButton.leftAnchor),
+            videoButtonDisabled.rightAnchor.constraint(equalTo: videoButton.rightAnchor),
+            videoButtonDisabled.topAnchor.constraint(equalTo: videoButton.topAnchor),
+            videoButtonDisabled.bottomAnchor.constraint(equalTo: videoButton.bottomAnchor),
         ])
     }
     
@@ -151,6 +161,8 @@ final class CallActionsView: UIView {
     // All side effects should be started from this method.
     func update(with input: CallActionsViewInputType) {
         muteCallButton.isSelected = input.isMuted
+        videoButtonDisabled.isUserInteractionEnabled = !input.canToggleMediaType
+        videoButtonDisabledTapRecognizer?.isEnabled = !input.canToggleMediaType
         videoButton.isEnabled = input.canToggleMediaType
         videoButton.isSelected = input.mediaState.isSendingVideo && input.permissions.canAcceptVideoCalls
         flipCameraButton.isEnabled = input.mediaState.isSendingVideo && input.permissions.canAcceptVideoCalls
@@ -190,6 +202,7 @@ final class CallActionsView: UIView {
         switch button {
         case muteCallButton: return .toggleMuteState
         case videoButton: return .toggleVideoState
+        case videoButtonDisabledTapRecognizer: return .alertVideoUnvailable
         case speakerButton: return .toggleSpeakerState
         case flipCameraButton: return .flipCamera
         case endCallButton: return .terminateCall

--- a/Wire-iOS/Sources/UserInterface/Calling/CallActionsView/CallActionsView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallActionsView/CallActionsView.swift
@@ -202,7 +202,7 @@ final class CallActionsView: UIView {
         switch button {
         case muteCallButton: return .toggleMuteState
         case videoButton: return .toggleVideoState
-        case videoButtonDisabledTapRecognizer: return .alertVideoUnvailable
+        case videoButtonDisabledTapRecognizer: return .alertVideoUnavailable
         case speakerButton: return .toggleSpeakerState
         case flipCameraButton: return .flipCamera
         case endCallButton: return .terminateCall

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallAction.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallAction.swift
@@ -20,7 +20,7 @@
 enum CallAction {
     case toggleMuteState
     case toggleVideoState
-    case alertVideoUnvailable
+    case alertVideoUnavailable
     case toggleSpeakerState
     case continueDegradedCall
     case acceptCall

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallAction.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallAction.swift
@@ -20,6 +20,7 @@
 enum CallAction {
     case toggleMuteState
     case toggleVideoState
+    case alertVideoUnvailable
     case toggleSpeakerState
     case continueDegradedCall
     case acceptCall

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallInfoConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallInfoConfiguration.swift
@@ -76,7 +76,11 @@ extension CallInfoConfiguration: CallInfoViewControllerInput {
         case .outgoing, .incoming(video: false, shouldRing: _, degraded: _):
             return false
         default:
-            return true
+            if voiceChannel.videoState == .stopped {
+                return voiceChannel.conversation?.canStartVideoCall ?? false
+            } else {
+                return true
+            }
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -159,17 +159,19 @@ final class CallViewController: UIViewController {
         toggleOverlayVisibility()
     }
     
+    fileprivate func alertVideoUnvailable() {
+        if voiceChannel.videoState == .stopped, voiceChannel.conversation?.activeParticipants.count > 4 {
+            showAlert(forMessage: "call.video.too_many.alert.message".localized, title: "call.video.too_many.alert.title".localized) { _ in }
+            return
+        }
+    }
+    
     fileprivate func toggleVideoState() {
 
         if permissions.canAcceptVideoCalls == false {
             permissions.requestOrWarnAboutVideoPermission { _ in
                 self.updateConfiguration()
             }
-            return
-        }
-
-        if voiceChannel.videoState == .stopped, voiceChannel.conversation?.activeParticipants.count > 4 {
-            showAlert(forMessage: "call.video.too_many.alert.message".localized, title: "call.video.too_many.alert.title".localized) { _ in }
             return
         }
 
@@ -184,7 +186,6 @@ final class CallViewController: UIViewController {
 
         voiceChannel.videoState = newState
         updateConfiguration()
-
     }
     
     fileprivate func toggleCameraAnimated() {
@@ -297,6 +298,7 @@ extension CallViewController: CallInfoRootViewControllerDelegate {
         case .toggleSpeakerState: AVSMediaManager.sharedInstance().toggleSpeaker()
         case .minimizeOverlay: minimizeOverlay()
         case .toggleVideoState: toggleVideoState()
+        case .alertVideoUnvailable: alertVideoUnvailable()
         case .flipCamera: toggleCameraAnimated()
         case .showParticipantsList: return // Handled in `CallInfoRootViewController`, we don't want to update.
         }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -159,7 +159,7 @@ final class CallViewController: UIViewController {
         toggleOverlayVisibility()
     }
     
-    fileprivate func alertVideoUnvailable() {
+    fileprivate func alertVideoUnavailable() {
         if voiceChannel.videoState == .stopped, voiceChannel.conversation?.activeParticipants.count > 4 {
             showAlert(forMessage: "call.video.too_many.alert.message".localized, title: "call.video.too_many.alert.title".localized) { _ in }
             return
@@ -298,7 +298,7 @@ extension CallViewController: CallInfoRootViewControllerDelegate {
         case .toggleSpeakerState: AVSMediaManager.sharedInstance().toggleSpeaker()
         case .minimizeOverlay: minimizeOverlay()
         case .toggleVideoState: toggleVideoState()
-        case .alertVideoUnvailable: alertVideoUnvailable()
+        case .alertVideoUnavailable: alertVideoUnavailable()
         case .flipCamera: toggleCameraAnimated()
         case .showParticipantsList: return // Handled in `CallInfoRootViewController`, we don't want to update.
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Design want the video button to be disabled in large group but still show an alert when it's tapped informing the user why video calling is not possible.

### Solutions

Since a disabled button is not responding to touches we place a ghost button on top of the video button which is only enabled when the video button is disabled.