### PR TITLE
Fix the constraints for the top bar

### DIFF
--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -100,11 +100,10 @@ extension ZClientViewController {
         topOverlayContainer.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(topOverlayContainer)
 
-        contentTopRegularConstraint = splitViewController.view.topAnchor.constraint(equalTo: safeTopAnchor)
-        contentTopCompactConstraint = splitViewController.view.topAnchor.constraint(equalTo: view.topAnchor)
+        contentTopRegularConstraint = topOverlayContainer.topAnchor.constraint(equalTo: safeTopAnchor)
+        contentTopCompactConstraint = topOverlayContainer.topAnchor.constraint(equalTo: view.topAnchor)
         
         NSLayoutConstraint.activate([
-            topOverlayContainer.topAnchor.constraint(equalTo: view.topAnchor),
             topOverlayContainer.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             topOverlayContainer.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             topOverlayContainer.bottomAnchor.constraint(equalTo: splitViewController.view.topAnchor),


### PR DESCRIPTION
## What's new in this PR?

### Issues

The minimized call bar stopped appearing.

### Cause

The changes with the iOS status bar style are clashed with the changes from the call bar minimization:
 the new constraints logic was not taking the top overlay container in account.

### Fix

Take the top overlay in account when creating the constraints.
