### PR TITLE
Limit video group calling for non-team users

### DIFF
--- a/Wire-iOS Tests/CallInfoConfigurationTests.swift
+++ b/Wire-iOS Tests/CallInfoConfigurationTests.swift
@@ -440,7 +440,6 @@ class CallInfoConfigurationTests: XCTestCase {
         let fixture = CallInfoTestFixture(otherUser: otherUser, groupSize: .large)
         
         let mockGroupConversation = MockConversation.groupConversation()
-        mockGroupConversation.canStartVideoCall = false
         mockGroupConversation.activeParticipants = NSOrderedSet(array: Array(mockUsers[0..<fixture.groupSize.rawValue]))
         
         let mockConversation = ((mockGroupConversation as Any) as! ZMConversation)

--- a/Wire-iOS Tests/CallInfoTestFixture.swift
+++ b/Wire-iOS Tests/CallInfoTestFixture.swift
@@ -344,7 +344,26 @@ struct CallInfoTestFixture {
         )
     }
     
-    var groupAudioEstablishedLargeGroup: CallInfoViewControllerInput {
+    var groupAudioEstablishedRemoteTurnedVideoOn: CallInfoViewControllerInput {
+        return MockCallInfoViewControllerInput(
+            videoPlaceholderState: .hidden,
+            permissions: CallPermissions(),
+            degradationState: .none,
+            accessoryType: .participantsList(CallParticipantsViewTests.participants(count: groupSize.rawValue, sendsVideo: true)),
+            canToggleMediaType: true,
+            isMuted: false,
+            isTerminating: false,
+            canAccept: false,
+            mediaState: .notSendingVideo(speakerEnabled: false),
+            state: .established(duration: 10),
+            isConstantBitRate: false,
+            title: otherUser.displayName,
+            isVideoCall: true,
+            variant: .light
+        )
+    }
+    
+    var groupAudioEstablishedVideoUnavailable: CallInfoViewControllerInput {
         return MockCallInfoViewControllerInput(
             videoPlaceholderState: .hidden,
             permissions: CallPermissions(),

--- a/Wire-iOS Tests/Mocks/MockUser.m
+++ b/Wire-iOS Tests/Mocks/MockUser.m
@@ -55,14 +55,13 @@ static id<ZMBareUser> mockSelfUser = nil;
 
 + (MockUser *)mockSelfUser
 {
-    static MockUser *selfUser = nil;
-
-    if (selfUser == nil) {
-        selfUser = (MockUser *)self.mockUsers.lastObject;
-        selfUser.isSelfUser = YES;
+    if (mockSelfUser == nil) {
+        MockUser *mockUser = (MockUser *)self.mockUsers.lastObject;
+        mockUser.isSelfUser = YES;
+        mockSelfUser = (MockUser *)mockUser;
     }
     
-    return selfUser;
+    return (MockUser *)mockSelfUser;
 }
 
 + (void)setMockSelfUser:(id<ZMBareUser>)newMockUser

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallInfoConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallInfoConfiguration.swift
@@ -77,7 +77,7 @@ extension CallInfoConfiguration: CallInfoViewControllerInput {
             return false
         default:
             if voiceChannel.videoState == .stopped {
-                return voiceChannel.conversation?.canStartVideoCall ?? false
+                return voiceChannel.canUpgradeToVideo
             } else {
                 return true
             }
@@ -174,6 +174,13 @@ extension CallParticipantState {
 fileprivate typealias UserWithParticipantState = (ZMUser, CallParticipantState)
 
 fileprivate extension VoiceChannel {
+    
+    var canUpgradeToVideo: Bool {
+        guard let conversation = conversation, conversation.conversationType != .oneOnOne else { return true }
+        guard conversation.activeParticipants.count <= ZMConversation.maxVideoCallParticipants else { return false }
+        
+        return ZMUser.selfUser().isTeamMember || isAnyParticipantSendingVideo
+    }
     
     var isAnyParticipantSendingVideo: Bool {
         return videoState.isSending || connectedParticipants.any({ $0.1.isSendingVideo })


### PR DESCRIPTION
## What's new in this PR?

Introduce a restriction that non team users can only video call if someone initiates the video call.