### PR TITLE
Fix: Client list screen - loading spinner dismiss before client list screen is dismissed

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
@@ -140,7 +140,12 @@ private let zmLog = ZMSLog(tag: "UI")
         super.viewWillAppear(animated)
         self.clientsTableView?.reloadData()
     }
-    
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        self.showLoadingView = false
+    }
+
     func openDetailsOfClient(_ client: UserClient) {
         if let navigationController = self.navigationController {
             let clientViewController = SettingsClientViewController(userClient: client, credentials: self.credentials)
@@ -230,7 +235,6 @@ private let zmLog = ZMSLog(tag: "UI")
     }
     
     func finishedDeleting(_ remainingClients: [UserClient]!) {
-        self.showLoadingView = false
         self.clients = remainingClients
         Analytics.shared().tagDeleteDevice()
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

When client list screen is shown during login, the loading spinner dismiss before client list screen is dismissed and the user may remove another device which is not necessary.

### Causes

Loading view is dismissed when finishedDeleting is called, but client list screen is not yet dismissed.

### Solutions

Hide loading view when viewDidDisappear instead of finishedDeleting.