### PR TITLE
Fix: iPad - when marketing consent setting is toggled, loading view appears behind the setting popover

### DIFF
--- a/Wire-iOS/Sources/Components/Settings/SettingsPropertyFactory.swift
+++ b/Wire-iOS/Sources/Components/Settings/SettingsPropertyFactory.swift
@@ -222,14 +222,10 @@ class SettingsPropertyFactory {
             let setAction : SetAction = { [unowned self] (property: SettingsBlockProperty, value: SettingsPropertyValue) throws -> () in
                 switch value {
                 case .number(let number):
-                    AppDelegate.shared().window.rootViewController?.showLoadingView = true
-
                     self.userSession?.performChanges {
                         if let userSession = self.userSession as? ZMUserSession {
                             self.delegate?.asyncMethodDidStart(self)
                             (self.selfUser as? ZMUser)?.setMarketingConsent(to: number.boolValue, in: userSession, completion: { [weak self] _ in
-                                AppDelegate.shared().window.rootViewController?.showLoadingView = false
-
                                 if let weakSelf = self {
                                     weakSelf.marketingConsent = SettingsPropertyValue.number(value: number)
                                     weakSelf.delegate?.asyncMethodDidComplete(weakSelf)

--- a/Wire-iOS/Sources/Components/Settings/SettingsPropertyFactory.swift
+++ b/Wire-iOS/Sources/Components/Settings/SettingsPropertyFactory.swift
@@ -205,6 +205,7 @@ class SettingsPropertyFactory {
                 }
             }
             return SettingsBlockProperty(propertyName: propertyName, getAction: getAction, setAction: setAction)
+
         case .receiveNewsAndOffers:
 
             let getAction : GetAction = { [unowned self] (property: SettingsBlockProperty) -> SettingsPropertyValue in
@@ -217,11 +218,13 @@ class SettingsPropertyFactory {
                     AppDelegate.shared().window.rootViewController?.showLoadingView = true
 
                     self.userSession?.performChanges {
-                        ZMUser.selfUser().setMarketingConsent(to: number.boolValue, in: ZMUserSession.shared()!, completion: { [weak self] _ in
-                            AppDelegate.shared().window.rootViewController?.showLoadingView = false
+                        if let userSession = self.userSession as? ZMUserSession {
+                            (self.selfUser as? ZMUser)?.setMarketingConsent(to: number.boolValue, in: userSession, completion: { [weak self] _ in
+                                AppDelegate.shared().window.rootViewController?.showLoadingView = false
 
-                            self?.marketingConsent = SettingsPropertyValue.number(value: number)
-                        })
+                                self?.marketingConsent = SettingsPropertyValue.number(value: number)
+                            })
+                        }
                     }
 
                 default:

--- a/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
@@ -48,6 +48,8 @@ final internal class SelfProfileViewController: UIViewController {
 
     convenience init() {
         let settingsPropertyFactory = SettingsPropertyFactory(userSession: SessionManager.shared?.activeUserSession, selfUser: ZMUser.selfUser())
+
+        ///TODO: delegate for spinner start/stop
         let settingsCellDescriptorFactory = SettingsCellDescriptorFactory(settingsPropertyFactory: settingsPropertyFactory)
         let rootGroup = settingsCellDescriptorFactory.rootGroup()
         

--- a/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
@@ -36,11 +36,11 @@ extension Notification.Name {
 
 extension SelfProfileViewController: SettingsPropertyFactoryDelegate {
     func asyncMethodDidStart(_ settingsPropertyFactory: SettingsPropertyFactory) {
-        self.showLoadingView = true
+        self.navigationController?.topViewController?.showLoadingView = true
     }
 
     func asyncMethodDidComplete(_ settingsPropertyFactory: SettingsPropertyFactory) {
-        self.showLoadingView = false
+        self.navigationController?.topViewController?.showLoadingView = false
     }
 
 

--- a/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
@@ -34,6 +34,18 @@ extension Notification.Name {
     static let DismissSettings = Notification.Name("DismissSettings")
 }
 
+extension SelfProfileViewController: SettingsPropertyFactoryDelegate {
+    func asyncMethodDidStart(_ settingsPropertyFactory: SettingsPropertyFactory) {
+        self.showLoadingView = true
+    }
+
+    func asyncMethodDidComplete(_ settingsPropertyFactory: SettingsPropertyFactory) {
+        self.showLoadingView = false
+    }
+
+
+}
+
 final internal class SelfProfileViewController: UIViewController {
     
      static let dismissNotificationName = "SettingsNavigationControllerDismissNotificationName"
@@ -49,13 +61,14 @@ final internal class SelfProfileViewController: UIViewController {
     convenience init() {
         let settingsPropertyFactory = SettingsPropertyFactory(userSession: SessionManager.shared?.activeUserSession, selfUser: ZMUser.selfUser())
 
-        ///TODO: delegate for spinner start/stop
         let settingsCellDescriptorFactory = SettingsCellDescriptorFactory(settingsPropertyFactory: settingsPropertyFactory)
         let rootGroup = settingsCellDescriptorFactory.rootGroup()
         
         self.init(rootGroup: settingsCellDescriptorFactory.rootGroup())
         self.settingsCellDescriptorFactory = settingsCellDescriptorFactory
         self.rootGroup = rootGroup
+
+        settingsPropertyFactory.delegate = self
     }
     
     init(rootGroup: SettingsControllerGeneratorType & SettingsInternalGroupCellDescriptorType) {


### PR DESCRIPTION
## What's new in this PR?

### Issues

When marketing consent setting is toggled, loading view appears behind the setting popover.

### Causes

The loading view was shown on rootViewController.

### Solutions

Show the loading view was shown on SelfProfileViewController.

