### PR TITLE
Update copy for account switch warning

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -694,8 +694,9 @@
 
 "self.settings.add_account.error.title" = "Three accounts active";
 "self.settings.add_account.error.message" = "You can only be logged in with three accounts at once. Log out from one to add another.";
-"self.settings.add_account.switch_accounts.title" = "Are you sure you want to switch accounts?\nThis will hang up on your current call.";
-"self.settings.add_account.switch_accounts.action" = "Switch account";
+
+"self.settings.switch_account.title" = "Switching accounts will hang up the current call.";
+"self.settings.switch_account.action" = "Switch account";
 
 // Settings - Account details
 "self.settings.account_section" = "Account";

--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -552,8 +552,8 @@ extension AppRootViewController: SessionManagerSwitchingDelegate {
         guard let session = ZMUserSession.shared(), session.isCallOngoing else { return completion(true) }
         guard let topmostController = UIApplication.shared.wr_topmostController() else { return completion(false) }
         
-        let alert = UIAlertController(title: "self.settings.add_account.switch_accounts.title".localized, message: nil, preferredStyle: .actionSheet)
-        alert.addAction(UIAlertAction(title: "self.settings.add_account.switch_accounts.action".localized, style: .default, handler: { [weak self] (action) in
+        let alert = UIAlertController(title: "self.settings.switch_account.title".localized, message: nil, preferredStyle: .actionSheet)
+        alert.addAction(UIAlertAction(title: "self.settings.switch_account.action".localized, style: .default, handler: { [weak self] (action) in
             self?.sessionManager?.activeUserSession?.callCenter?.endAllCalls()
             completion(true)
         }))


### PR DESCRIPTION
## What's new in this PR?

Copy was outdated for warning when switching accounts.