### PR TITLE
Convert CallInfoConfiguration to stored properties

### DIFF
--- a/Wire-iOS Tests/CallInfoConfigurationTests.swift
+++ b/Wire-iOS Tests/CallInfoConfigurationTests.swift
@@ -19,25 +19,8 @@
 import XCTest
 @testable import Wire
 
-func ==(lhs: CallActionAppearance, rhs: CallActionAppearance) -> Bool {
-    switch (lhs, rhs) {
-    case (.light, .light): return true
-    case let (.dark(blurred: lhsBlurred), .dark(blurred: rhsBlurred)): return lhsBlurred == rhsBlurred
-    default: return false
-    }
-}
-
 func ==(lhs: CallInfoViewControllerInput, rhs: CallInfoViewControllerInput) -> Bool {
-    return lhs.degradationState == rhs.degradationState &&
-        lhs.accessoryType == rhs.accessoryType &&
-        lhs.appearance == rhs.appearance &&
-        lhs.canAccept == rhs.canAccept &&
-        lhs.canToggleMediaType == rhs.canToggleMediaType &&
-        lhs.displayString == rhs.displayString &&
-        lhs.isConstantBitRate == rhs.isConstantBitRate &&
-        lhs.state == rhs.state &&
-        lhs.mediaState == rhs.mediaState &&
-        lhs.disableIdleTimer == rhs.disableIdleTimer
+    return lhs.isEqual(toConfiguration: rhs)
 }
 
 class CallInfoConfigurationTests: XCTestCase {

--- a/Wire-iOS Tests/CallInfoConfigurationTests.swift
+++ b/Wire-iOS Tests/CallInfoConfigurationTests.swift
@@ -46,9 +46,8 @@ class CallInfoConfigurationTests: XCTestCase {
         mockOtherUser = nil
         selfUser = nil
         otherUser = nil
-        
         MockUser.setMockSelf(nil)
-        
+
         super.tearDown()
     }
     
@@ -244,7 +243,7 @@ class CallInfoConfigurationTests: XCTestCase {
         mockVoiceChannel.mockVideoState = .started
         
         // when
-        let configuration = CallInfoConfiguration(voiceChannel: mockVoiceChannel, preferedVideoPlaceholderState: .hidden, permissions: CallPermissions())
+        let configuration = CallInfoConfiguration(voiceChannel: mockVoiceChannel, preferedVideoPlaceholderState: .hidden, permissions: MockCallPermissions.videoAllowedForever)
         
         // then
         assertEquals(fixture.oneToOneOutgoingVideoRinging, configuration)
@@ -535,7 +534,7 @@ class CallInfoConfigurationTests: XCTestCase {
         mockVoiceChannel.videoState = .started
         
         // when
-        let configuration = CallInfoConfiguration(voiceChannel: mockVoiceChannel, preferedVideoPlaceholderState: .hidden, permissions: CallPermissions())
+        let configuration = CallInfoConfiguration(voiceChannel: mockVoiceChannel, preferedVideoPlaceholderState: .hidden, permissions: MockCallPermissions.videoAllowedForever)
         
         // then
         assertEquals(fixture.groupVideoConnecting, configuration)
@@ -579,8 +578,7 @@ class CallInfoConfigurationTests: XCTestCase {
         mockVoiceChannel.mockCallParticipantState = .connected(videoState: .started)
 
         // when
-        var configuration = CallInfoConfiguration(voiceChannel: mockVoiceChannel, preferedVideoPlaceholderState: .hidden, permissions: CallPermissions())
-        configuration.preferedVideoPlaceholderState = .statusTextHidden
+        let configuration = CallInfoConfiguration(voiceChannel: mockVoiceChannel, preferedVideoPlaceholderState: .statusTextHidden, permissions: CallPermissions())
 
         // then
         XCTAssertEqual(configuration.videoPlaceholderState, .statusTextHidden)
@@ -600,8 +598,7 @@ class CallInfoConfigurationTests: XCTestCase {
         mockVoiceChannel.mockCallParticipantState = .connected(videoState: .started)
 
         // when
-        var configuration = CallInfoConfiguration(voiceChannel: mockVoiceChannel, preferedVideoPlaceholderState: .hidden, permissions: CallPermissions())
-        configuration.preferedVideoPlaceholderState = .statusTextHidden
+        let configuration = CallInfoConfiguration(voiceChannel: mockVoiceChannel, preferedVideoPlaceholderState: .statusTextHidden, permissions: CallPermissions())
 
         // then
         XCTAssertEqual(configuration.videoPlaceholderState, .hidden)
@@ -622,8 +619,7 @@ class CallInfoConfigurationTests: XCTestCase {
         mockVoiceChannel.mockCallParticipantState = .connected(videoState: .started)
 
         // when
-        var configuration = CallInfoConfiguration(voiceChannel: mockVoiceChannel, preferedVideoPlaceholderState: .hidden, permissions: CallPermissions())
-        configuration.preferedVideoPlaceholderState = .statusTextHidden
+        let configuration = CallInfoConfiguration(voiceChannel: mockVoiceChannel, preferedVideoPlaceholderState: .statusTextHidden, permissions: CallPermissions())
 
         // then
         XCTAssertEqual(configuration.videoPlaceholderState, .hidden)

--- a/Wire-iOS Tests/CallInfoConfigurationTests.swift
+++ b/Wire-iOS Tests/CallInfoConfigurationTests.swift
@@ -226,7 +226,7 @@ class CallInfoConfigurationTests: XCTestCase {
         mockVoiceChannel.mockVideoState = .stopped
         
         // when
-        let configuration = CallInfoConfiguration(voiceChannel: mockVoiceChannel, preferedVideoPlaceholderState: .hidden, permissions: CallPermissions())
+        let configuration = CallInfoConfiguration(voiceChannel: mockVoiceChannel, preferedVideoPlaceholderState: .statusTextHidden, permissions: CallPermissions())
 
         // then
         assertEquals(fixture.oneToOneIncomingVideoRingingVideoTurnedOff, configuration)
@@ -244,7 +244,7 @@ class CallInfoConfigurationTests: XCTestCase {
         mockVoiceChannel.mockVideoState = .started
         
         // when
-        let configuration = CallInfoConfiguration(voiceChannel: mockVoiceChannel, preferedVideoPlaceholderState: .hidden, permissions: MockCallPermissions.videoAllowedForever)
+        let configuration = CallInfoConfiguration(voiceChannel: mockVoiceChannel, preferedVideoPlaceholderState: .hidden, permissions: CallPermissions())
         
         // then
         assertEquals(fixture.oneToOneOutgoingVideoRinging, configuration)
@@ -535,7 +535,7 @@ class CallInfoConfigurationTests: XCTestCase {
         mockVoiceChannel.videoState = .started
         
         // when
-        let configuration = CallInfoConfiguration(voiceChannel: mockVoiceChannel, preferedVideoPlaceholderState: .hidden, permissions: MockCallPermissions.videoAllowedForever)
+        let configuration = CallInfoConfiguration(voiceChannel: mockVoiceChannel, preferedVideoPlaceholderState: .hidden, permissions: CallPermissions())
         
         // then
         assertEquals(fixture.groupVideoConnecting, configuration)

--- a/Wire-iOS Tests/CallInfoTestFixture.swift
+++ b/Wire-iOS Tests/CallInfoTestFixture.swift
@@ -181,7 +181,7 @@ struct CallInfoTestFixture {
     var oneToOneOutgoingVideoRinging: CallInfoViewControllerInput {
         return MockCallInfoViewControllerInput(
             videoPlaceholderState: .hidden,
-            permissions: CallPermissions(),
+            permissions: MockCallPermissions.videoAllowedForever,
             degradationState: .none,
             accessoryType: .none,
             canToggleMediaType: false,
@@ -505,7 +505,7 @@ struct CallInfoTestFixture {
     var groupVideoConnecting: CallInfoViewControllerInput {
         return MockCallInfoViewControllerInput(
             videoPlaceholderState: .hidden,
-            permissions: CallPermissions(),
+            permissions: MockCallPermissions.videoAllowedForever,
             degradationState: .none,
             accessoryType: .none,
             canToggleMediaType: true,

--- a/Wire-iOS Tests/Mocks/MockCallInfoViewControllerInput.swift
+++ b/Wire-iOS Tests/Mocks/MockCallInfoViewControllerInput.swift
@@ -37,22 +37,4 @@ struct MockCallInfoViewControllerInput: CallInfoViewControllerInput {
     var disableIdleTimer: Bool
 }
 
-extension MockCallInfoViewControllerInput: CustomDebugStringConvertible  {
-    var debugDescription: String {
-        return """
-        <MockCallInfoConfiguration>
-        "degradationState: \(degradationState)"
-        accessoryType: \(accessoryType.showAvatar ? "avatar" : "participants (\(accessoryType.participants.count)")
-        canToggleMediaType: \(canToggleMediaType)
-        isMuted: \(isMuted)
-        isTerminating: \(isTerminating)
-        canAccept \(canAccept)
-        mediaState: \(mediaState)
-        state: \(state)
-        isConstantBitRate: \(isConstantBitRate)
-        title: \(title)
-        isVideoCall: \(isVideoCall)
-        variant: \(variant)
-        """
-    }
-}
+extension MockCallInfoViewControllerInput: CustomDebugStringConvertible  {}

--- a/Wire-iOS/Sources/UserInterface/Calling/CallActionsView/CallActionAppearance.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallActionsView/CallActionAppearance.swift
@@ -18,7 +18,7 @@
 
 import UIKit
 
-enum CallActionAppearance {
+enum CallActionAppearance: Equatable {
     case light, dark(blurred: Bool)
     
     var showBlur: Bool {
@@ -54,5 +54,13 @@ enum CallActionAppearance {
         case .light: return .wr_color(fromColorScheme: ColorSchemeColorIconNormal, variant: .dark)
         case .dark: return .wr_color(fromColorScheme: ColorSchemeColorIconNormal, variant: .light)
         }
+    }
+}
+
+func ==(lhs: CallActionAppearance, rhs: CallActionAppearance) -> Bool {
+    switch (lhs, rhs) {
+    case (.light, .light): return true
+    case let (.dark(blurred: lhsBlurred), .dark(blurred: rhsBlurred)): return lhsBlurred == rhsBlurred
+    default: return false
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoRootViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoRootViewController.swift
@@ -40,8 +40,9 @@ final class CallInfoRootViewController: UIViewController, UINavigationController
         }
     }
     
-    var configuration: CallInfoViewControllerInput {
+    var configuration: CallInfoViewControllerInput  {
         didSet {
+            guard !configuration.isEqual(toConfiguration: oldValue) else { return }
             updateConfiguration(animated: true)
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoRootViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoRootViewController.swift
@@ -40,7 +40,7 @@ final class CallInfoRootViewController: UIViewController, UINavigationController
         }
     }
     
-    var configuration: CallInfoViewControllerInput  {
+    var configuration: CallInfoViewControllerInput {
         didSet {
             guard !configuration.isEqual(toConfiguration: oldValue) else { return }
             updateConfiguration(animated: true)

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoViewController.swift
@@ -109,11 +109,9 @@ final class CallInfoViewController: UIViewController, CallActionsViewDelegate, C
         addChildViewController(statusViewController)
         [statusViewController.view, accessoryViewController.view, actionsView].forEach(stackView.addArrangedSubview)
         statusViewController.didMove(toParentViewController: self)
-
     }
 
     private func createConstraints() {
-
         NSLayoutConstraint.activate([
             stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             stackView.topAnchor.constraint(equalTo: safeTopAnchor),
@@ -126,14 +124,13 @@ final class CallInfoViewController: UIViewController, CallActionsViewDelegate, C
         ])
 
         backgroundViewController.view.fitInSuperview()
-
     }
     
     private func updateNavigationItem() {
-     navigationItem.leftBarButtonItem = UIBarButtonItem(
-        icon: .downArrow,
-        target: self,
-        action: #selector(minimizeCallOverlay)
+        navigationItem.leftBarButtonItem = UIBarButtonItem(
+            icon: .downArrow,
+            target: self,
+            action: #selector(minimizeCallOverlay)
         )
         navigationItem.leftBarButtonItem?.accessibilityIdentifier = "CallDismissOverlayButton"
     }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoViewController.swift
@@ -22,12 +22,36 @@ protocol CallInfoViewControllerDelegate: class {
     func infoViewController(_ viewController: CallInfoViewController, perform action: CallAction)
 }
 
-protocol CallInfoViewControllerInput: CallActionsViewInputType, CallStatusViewInputType  {
+protocol CallInfoViewControllerInput: CallActionsViewInputType, CallStatusViewInputType {
     var accessoryType: CallInfoViewControllerAccessoryType { get }
     var degradationState: CallDegradationState { get }
     var videoPlaceholderState: CallVideoPlaceholderState { get }
-    var permissions: CallPermissionsConfiguration { get }
     var disableIdleTimer: Bool { get }
+}
+
+// Workaround to make the protocol equatable, it might be possible to conform CallInfoConfiguration
+// to Equatable with Swift 4.1 and conditional conformances. Right now we would have to make
+// the `CallInfoRootViewController` generic to work around the `Self` requirement of
+// `Equatable` which we want to avoid.
+extension CallInfoViewControllerInput {
+    func isEqual(toConfiguration other: CallInfoViewControllerInput) -> Bool {
+        return accessoryType == other.accessoryType &&
+            degradationState == other.degradationState &&
+            videoPlaceholderState == other.videoPlaceholderState &&
+            permissions == other.permissions &&
+            disableIdleTimer == other.disableIdleTimer &&
+            canToggleMediaType == other.canToggleMediaType &&
+            isMuted == other.isMuted &&
+            isTerminating == other.isTerminating &&
+            canAccept == other.canAccept &&
+            mediaState == other.mediaState &&
+            appearance == other.appearance &&
+            isVideoCall == other.isVideoCall &&
+            variant == other.variant &&
+            state == other.state &&
+            isConstantBitRate == other.isConstantBitRate &&
+            title == other.title
+    }
 }
 
 final class CallInfoViewController: UIViewController, CallActionsViewDelegate, CallAccessoryViewControllerDelegate {

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallInfoConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallInfoConfiguration.swift
@@ -131,7 +131,8 @@ fileprivate extension VoiceChannel {
 }
 
 struct CallInfoConfiguration: CallInfoViewControllerInput  {
-    
+
+    let permissions: CallPermissionsConfiguration
     let state: CallStatusViewState
     let isConstantBitRate: Bool
     let title: String
@@ -147,15 +148,12 @@ struct CallInfoConfiguration: CallInfoViewControllerInput  {
     let videoPlaceholderState: CallVideoPlaceholderState
     let disableIdleTimer: Bool
 
-    let voiceChannel: VoiceChannel
-    let preferedVideoPlaceholderState: CallVideoPlaceholderState
-    let permissions: CallPermissionsConfiguration
-    
-    init(voiceChannel: VoiceChannel, preferedVideoPlaceholderState: CallVideoPlaceholderState, permissions: CallPermissionsConfiguration) {
-        self.voiceChannel = voiceChannel
-        self.preferedVideoPlaceholderState = preferedVideoPlaceholderState
+    init(
+        voiceChannel: VoiceChannel,
+        preferedVideoPlaceholderState: CallVideoPlaceholderState,
+        permissions: CallPermissionsConfiguration
+        ) {
         self.permissions = permissions
-        
         state = voiceChannel.statusViewState
         degradationState = voiceChannel.degradationState
         accessoryType = voiceChannel.accessoryType

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallInfoConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallInfoConfiguration.swift
@@ -35,7 +35,6 @@ extension CallInfoConfiguration: CallInfoViewControllerInput {
         default:
             return .none
         }
-        
     }
     
     var accessoryType: CallInfoViewControllerAccessoryType {

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallInfoConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallInfoConfiguration.swift
@@ -18,35 +18,26 @@
 
 import Foundation
 
-struct CallInfoConfiguration  {
-    let voiceChannel: VoiceChannel
-    var preferedVideoPlaceholderState: CallVideoPlaceholderState
-    let permissions: CallPermissionsConfiguration
-}
-
-extension CallInfoConfiguration: CallInfoViewControllerInput {
-    
+fileprivate extension VoiceChannel {
     var degradationState: CallDegradationState {
-        switch voiceChannel.state {
+        switch state {
         case .incoming(video: _, shouldRing: _, degraded: true):
-            return .incoming(degradedUser: voiceChannel.firstDegradedUser)
+            return .incoming(degradedUser: firstDegradedUser)
         case .answered(degraded: true), .outgoing(degraded: true):
-            return .outgoing(degradedUser: voiceChannel.firstDegradedUser)
+            return .outgoing(degradedUser: firstDegradedUser)
         default:
             return .none
         }
     }
     
     var accessoryType: CallInfoViewControllerAccessoryType {
-        let conversation = voiceChannel.conversation
-        
-        if isVideoCall, conversation?.conversationType == .oneOnOne {
+        if internalIsVideoCall, conversation?.conversationType == .oneOnOne {
             return .none
         }
         
-        switch voiceChannel.state {
+        switch state {
         case .incoming(video: false, shouldRing: true, degraded: _):
-            return voiceChannel.initiator.map { .avatar($0) } ?? .none
+            return initiator.map { .avatar($0) } ?? .none
         case .incoming(video: true, shouldRing: true, degraded: _):
             return .none
         case .answered, .establishedDataChannel, .outgoing:
@@ -57,7 +48,7 @@ extension CallInfoConfiguration: CallInfoViewControllerInput {
             }
         case .unknown, .none, .terminating, .established, .incoming(_, shouldRing: false, _):
             if conversation?.conversationType == .group {
-                return .participantsList(voiceChannel.connectedParticipants.map {
+                return .participantsList(connectedParticipants.map {
                     .callParticipant(user: $0.0, sendsVideo: $0.1.isSendingVideo)
                 })
             } else if let remoteParticipant = conversation?.connectedUser {
@@ -68,99 +59,117 @@ extension CallInfoConfiguration: CallInfoViewControllerInput {
         }
     }
     
-    var canToggleMediaType: Bool {
-        switch voiceChannel.state {
+    var internalIsVideoCall: Bool {
+        switch state {
+        case .established, .terminating: return isAnyParticipantSendingVideo
+        default: return isVideoCall
+        }
+    }
+    
+    func canToggleMediaType(with permissions: CallPermissionsConfiguration) -> Bool {
+        switch state {
         case .outgoing, .incoming(video: false, shouldRing: _, degraded: _):
             return false
         default:
-            guard !permissions.isVideoDisabledForever && !permissions.isAudioDisabledForever else {
-                return false
-            }
-
+            guard !permissions.isVideoDisabledForever && !permissions.isAudioDisabledForever else { return false }
+            
             // The user can only re-enable their video if the conversation allows GVC
-            if voiceChannel.videoState == .stopped {
-                return voiceChannel.canUpgradeToVideo
+            if videoState == .stopped {
+                return canUpgradeToVideo
             }
-
+            
             // If the user already enabled video, they should be able to disable it
             return true
         }
     }
     
-    var isMuted: Bool {
-        return AVSMediaManager.sharedInstance().isMicrophoneMuted
-    }
-    
     var isTerminating: Bool {
-        switch voiceChannel.state {
+        switch state {
         case .terminating, .incoming(video: _, shouldRing: false, degraded: _): return true
         default: return false
         }
     }
     
     var canAccept: Bool {
-        switch voiceChannel.state {
+        switch state {
         case .incoming(video: _, shouldRing: true, degraded: _): return true
         default: return false
         }
     }
     
-    var mediaState: MediaState {
-
+    func mediaState(with permissions: CallPermissionsConfiguration) -> MediaState {
         let isSpeakerEnabled = AVSMediaManager.sharedInstance().isSpeakerEnabled
-
-        guard permissions.canAcceptVideoCalls else {
-            return .notSendingVideo(speakerEnabled: isSpeakerEnabled)
-        }
-
-        guard !voiceChannel.videoState.isSending else { return .sendingVideo }
+        guard permissions.canAcceptVideoCalls else { return .notSendingVideo(speakerEnabled: isSpeakerEnabled) }
+        guard !videoState.isSending else { return .sendingVideo }
         return .notSendingVideo(speakerEnabled: isSpeakerEnabled)
-
     }
     
-    var state: CallStatusViewState {
-        switch voiceChannel.state {
-        case .incoming(_ , shouldRing: true, _): return .ringingIncoming(name: voiceChannel.initiator?.displayName ?? "")
+    var statusViewState: CallStatusViewState {
+        switch state {
+        case .incoming(_ , shouldRing: true, _): return .ringingIncoming(name: initiator?.displayName ?? "")
         case .outgoing: return .ringingOutgoing
         case .answered, .establishedDataChannel: return .connecting
-        case .established: return .established(duration: -(voiceChannel.callStartDate?.timeIntervalSinceNow.rounded() ?? 0))
+        case .established: return .established(duration: -(callStartDate?.timeIntervalSinceNow.rounded() ?? 0))
         case .terminating, .incoming(_ , shouldRing: false, _): return .terminating
         case .none, .unknown: return .none
         }
     }
     
-    var isConstantBitRate: Bool {
-        return voiceChannel.isConstantBitRateAudioActive
-    }
-    
-    var title: String {
-        return voiceChannel.conversation?.displayName ?? ""
-    }
-    
-    var isVideoCall: Bool {
-        switch voiceChannel.state {
-        case .established, .terminating:
-            return voiceChannel.isAnyParticipantSendingVideo
-        default:
-            return voiceChannel.isVideoCall
-        }
-    }
-    
-    var variant: ColorSchemeVariant {
-        return ColorScheme.default().variant
-    }
-
-    var videoPlaceholderState: CallVideoPlaceholderState {
-        guard voiceChannel.isVideoCall else { return .hidden }
-        guard case .incoming = voiceChannel.state else { return .hidden }
-        return preferedVideoPlaceholderState
+    var videoPlaceholderState: CallVideoPlaceholderState? {
+        guard internalIsVideoCall else { return .hidden }
+        guard case .incoming = state else { return .hidden }
+        return nil
     }
     
     var disableIdleTimer: Bool {
-        switch voiceChannel.state {
+        switch state {
         case .none: return false
-        default: return isVideoCall && !isTerminating
+        default: return internalIsVideoCall && !isTerminating
         }
+    }
+
+}
+
+struct CallInfoConfiguration: CallInfoViewControllerInput  {
+    
+    let state: CallStatusViewState
+    let isConstantBitRate: Bool
+    let title: String
+    let isVideoCall: Bool
+    let variant: ColorSchemeVariant
+    let canToggleMediaType: Bool
+    let isMuted: Bool
+    let isTerminating: Bool
+    let canAccept: Bool
+    let mediaState: MediaState
+    let accessoryType: CallInfoViewControllerAccessoryType
+    let degradationState: CallDegradationState
+    let videoPlaceholderState: CallVideoPlaceholderState
+    let disableIdleTimer: Bool
+
+    let voiceChannel: VoiceChannel
+    let preferedVideoPlaceholderState: CallVideoPlaceholderState
+    let permissions: CallPermissionsConfiguration
+    
+    init(voiceChannel: VoiceChannel, preferedVideoPlaceholderState: CallVideoPlaceholderState, permissions: CallPermissionsConfiguration) {
+        self.voiceChannel = voiceChannel
+        self.preferedVideoPlaceholderState = preferedVideoPlaceholderState
+        self.permissions = permissions
+        
+        state = voiceChannel.statusViewState
+        degradationState = voiceChannel.degradationState
+        accessoryType = voiceChannel.accessoryType
+        isMuted = AVSMediaManager.sharedInstance().isMicrophoneMuted
+        canToggleMediaType = voiceChannel.canToggleMediaType(with: permissions)
+        canAccept = voiceChannel.canAccept
+        isVideoCall = voiceChannel.internalIsVideoCall
+        isTerminating = voiceChannel.isTerminating
+        isConstantBitRate = voiceChannel.isConstantBitRateAudioActive
+        title = voiceChannel.conversation?.displayName ?? ""
+        variant = ColorScheme.default().variant
+        mediaState = voiceChannel.mediaState(with: permissions)
+        videoPlaceholderState = voiceChannel.videoPlaceholderState ?? preferedVideoPlaceholderState
+        disableIdleTimer = voiceChannel.disableIdleTimer
     }
     
 }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -348,12 +348,18 @@ extension CallViewController: OverlayVisibilityProvider {
         } else {
             stopOverlayTimer()
         }
+        
+        let animations = { [callInfoRootViewController, updateConfiguration] in
+            callInfoRootViewController.view.alpha = show ? 1 : 0
+            // We update the configuration here to ensure the mute overlay fade animation is in sync with the overlay
+            updateConfiguration()
+        }
 
         UIView.animate(
             withDuration: 0.2,
             delay: 0,
             options: .curveEaseInOut,
-            animations: { [callInfoRootViewController] in callInfoRootViewController.view.alpha = show ? 1 : 0 },
+            animations: animations,
             completion: { [updateConfiguration] _ in updateConfiguration() }
         )
     }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -25,6 +25,7 @@ final class CallViewController: UIViewController {
     
     fileprivate let voiceChannel: VoiceChannel
     fileprivate var callInfoConfiguration: CallInfoConfiguration
+    fileprivate var preferedVideoPlaceholderState: CallVideoPlaceholderState = .statusTextHidden
     fileprivate let callInfoRootViewController: CallInfoRootViewController
     fileprivate weak var overlayTimer: Timer?
 
@@ -32,6 +33,7 @@ final class CallViewController: UIViewController {
     private let videoConfiguration: VideoConfiguration
     private let videoGridViewController: VideoGridViewController
     private var cameraType: CaptureDevice = .front
+    
     
     var conversation: ZMConversation? {
         return voiceChannel.conversation
@@ -48,7 +50,7 @@ final class CallViewController: UIViewController {
     init(voiceChannel: VoiceChannel, mediaManager: AVSMediaManager = .sharedInstance(), permissionsConfiguration: CallPermissionsConfiguration = CallPermissions()) {
         self.voiceChannel = voiceChannel
         videoConfiguration = VideoConfiguration(voiceChannel: voiceChannel, mediaManager: mediaManager)
-        callInfoConfiguration = CallInfoConfiguration(voiceChannel: voiceChannel, preferedVideoPlaceholderState: .statusTextHidden, permissions: permissionsConfiguration)
+        callInfoConfiguration = CallInfoConfiguration(voiceChannel: voiceChannel, preferedVideoPlaceholderState: preferedVideoPlaceholderState, permissions: permissionsConfiguration)
         callInfoRootViewController = CallInfoRootViewController(configuration: callInfoConfiguration)
         videoGridViewController = VideoGridViewController(configuration: videoConfiguration)
         super.init(nibName: nil, bundle: nil)
@@ -142,6 +144,7 @@ final class CallViewController: UIViewController {
     }
 
     fileprivate func updateConfiguration() {
+        callInfoConfiguration = CallInfoConfiguration(voiceChannel: voiceChannel, preferedVideoPlaceholderState: preferedVideoPlaceholderState, permissions: permissions)
         callInfoRootViewController.configuration = callInfoConfiguration
         videoGridViewController.configuration = videoConfiguration
         updateOverlayAfterStateChanged()
@@ -180,7 +183,7 @@ final class CallViewController: UIViewController {
     }
     
     fileprivate func toggleVideoState() {
-        if permissions.canAcceptVideoCalls == false {
+        if !permissions.canAcceptVideoCalls {
             permissions.requestOrWarnAboutVideoPermission { _ in
                 self.disableVideoIfNeeded()
                 self.updateVideoStatusPlaceholder()
@@ -190,12 +193,7 @@ final class CallViewController: UIViewController {
         }
 
         let newState = voiceChannel.videoState.toggledState
-
-        switch newState {
-        case .stopped: callInfoConfiguration.preferedVideoPlaceholderState = .statusTextHidden
-        default: callInfoConfiguration.preferedVideoPlaceholderState = .hidden
-        }
-
+        preferedVideoPlaceholderState = newState == .stopped ? .statusTextHidden : .hidden
         voiceChannel.videoState = newState
         updateConfiguration()
     }
@@ -272,7 +270,7 @@ extension CallViewController {
     }
 
     fileprivate func updateVideoStatusPlaceholder() {
-        callInfoConfiguration.preferedVideoPlaceholderState = permissions.preferredVideoPlaceholderState
+        preferedVideoPlaceholderState = permissions.preferredVideoPlaceholderState
         updateConfiguration()
     }
 

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/VideoConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/VideoConfiguration.swift
@@ -62,8 +62,7 @@ extension VideoConfiguration: VideoGridConfiguration {
             default: return nil
             }
         }
-        Calling.log.debug("participants: \(otherParticipants.count)")
-        
+
         guard voiceChannel.isEstablished else { return (nil, selfStream.map { [$0] } ?? [] ) }
         
         if let selfStream = selfStream {

--- a/Wire-iOS/Sources/UserInterface/Calling/Helper/CallInfoConfiguration+Debug.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/Helper/CallInfoConfiguration+Debug.swift
@@ -16,22 +16,28 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-extension CallInfoConfiguration: CustomDebugStringConvertible  {
+extension CallInfoViewControllerInput  {
     var debugDescription: String {
         return """
-        <CallInfoConfiguration>
-        "degradationState: \(degradationState)"
-        accessoryType: \(accessoryType.showAvatar ? "avatar" : "participants (\(accessoryType.participants.count)")
+        <\(type(of: self))>
+        accessoryType: \(accessoryType.showAvatar ? "avatar" : "participants (\(accessoryType.participants.count))")
+        degradationState: \(degradationState)
+        videoPlaceholderState: \(videoPlaceholderState)
+        permissions: \(permissions.canAcceptAudioCalls) \(permissions.isPendingAudioPermissionRequest) \(permissions.canAcceptVideoCalls) \(permissions.isPendingVideoPermissionRequest)
+        disableIdleTimer: \(disableIdleTimer)
         canToggleMediaType: \(canToggleMediaType)
         isMuted: \(isMuted)
         isTerminating: \(isTerminating)
         canAccept \(canAccept)
         mediaState: \(mediaState)
+        appearance: \(appearance)
+        isVideoCall: \(isVideoCall)
+        variant: \(variant.rawValue)
         state: \(state)
         isConstantBitRate: \(isConstantBitRate)
         title: \(title)
-        isVideoCall: \(isVideoCall)
-        variant: \(variant)
         """
     }
 }
+
+extension CallInfoConfiguration: CustomDebugStringConvertible {}

--- a/Wire-iOS/Sources/UserInterface/Calling/Permissions/CallPermissionsConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/Permissions/CallPermissionsConfiguration.swift
@@ -19,7 +19,6 @@
 import Foundation
 
 protocol CallPermissionsConfiguration {
-
     var canAcceptAudioCalls: Bool { get }
     var isPendingAudioPermissionRequest: Bool { get }
 
@@ -29,7 +28,6 @@ protocol CallPermissionsConfiguration {
     func requestVideoPermissionWithoutWarning(resultHandler: @escaping (Bool) -> Void)
     func requestOrWarnAboutVideoPermission(resultHandler: @escaping (Bool) -> Void)
     func requestOrWarnAboutAudioPermission(resultHandler: @escaping (Bool) -> Void)
-
 }
 
 extension CallPermissionsConfiguration {
@@ -43,13 +41,15 @@ extension CallPermissionsConfiguration {
     }
 
     var preferredVideoPlaceholderState: CallVideoPlaceholderState {
-
-        guard !canAcceptVideoCalls else {
-            return .hidden
-        }
-
+        guard !canAcceptVideoCalls else { return .hidden }
         return isPendingVideoPermissionRequest ? .statusTextHidden : .statusTextDisplayed
-
     }
 
+}
+
+func ==(lhs: CallPermissionsConfiguration, rhs: CallPermissionsConfiguration) -> Bool {
+    return lhs.canAcceptAudioCalls == rhs.canAcceptAudioCalls &&
+           lhs.isPendingAudioPermissionRequest == rhs.isPendingAudioPermissionRequest &&
+           lhs.canAcceptVideoCalls == rhs.canAcceptVideoCalls &&
+           lhs.isPendingVideoPermissionRequest == rhs.isPendingVideoPermissionRequest
 }


### PR DESCRIPTION
## What's new in this PR?

I was trying to reduce the number of UI reloads we do when the call changes and then realized that when checking if two instances of `CallInfoConfiguration` are equal it always gets reported as `true`. 

This issue was due to the fact that all of the properties of `CallInfoConfiguration` are computed and based on the stored `VoiceChannel` reference type, so when comparing two different instances they will internally access the same voice channel and return the same results for all variables. As this was not what we had in mind and want a immutable struct to be passed down as configuration I now changed this and all properties are now stored and only once computed in init.

Besides that 9d050cc fixes an issue with the timing of the mute overlay animation in the self preview which is now in sync with the general UI overlay show / hide animation.