### PR TITLE
Settings: Removed unnecessary top bar inset

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController.m
@@ -598,7 +598,6 @@
     KeyboardAvoidingViewController *keyboardAvoidingWrapperController = [[KeyboardAvoidingViewController alloc] initWithViewController:settingsViewController];
     
     if (self.wr_splitViewController.layoutSize == SplitViewControllerLayoutSizeCompact) {
-        keyboardAvoidingWrapperController.topInset = UIScreen.safeArea.top;
         keyboardAvoidingWrapperController.modalPresentationStyle = UIModalPresentationCurrentContext;
         keyboardAvoidingWrapperController.transitioningDelegate = self;
         [self presentViewController:keyboardAvoidingWrapperController animated:YES completion:nil];


### PR DESCRIPTION
## What's new in this PR?

### Issues

If user during the call minimizes the call overlay and navigate to the settings, the settings navigation bar is shifted down.

### Causes

The additional inset was added for the case of iPhone X device.

### Solutions

This inset is now automatically inserted with the constraints, so the setting is removed as unnecessary.