### PR TITLE
Make VideoConfiguration immutable

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -23,6 +23,7 @@ final class CallViewController: UIViewController {
     
     weak var dismisser: ViewControllerDismisser? = nil
     
+    fileprivate let mediaManager: AVSMediaManager
     fileprivate let voiceChannel: VoiceChannel
     fileprivate var callInfoConfiguration: CallInfoConfiguration
     fileprivate var preferedVideoPlaceholderState: CallVideoPlaceholderState = .statusTextHidden
@@ -30,7 +31,7 @@ final class CallViewController: UIViewController {
     fileprivate weak var overlayTimer: Timer?
 
     private var observerTokens: [Any] = []
-    private let videoConfiguration: VideoConfiguration
+    private var videoConfiguration: VideoConfiguration
     private let videoGridViewController: VideoGridViewController
     private var cameraType: CaptureDevice = .front
     
@@ -49,7 +50,8 @@ final class CallViewController: UIViewController {
     
     init(voiceChannel: VoiceChannel, mediaManager: AVSMediaManager = .sharedInstance(), permissionsConfiguration: CallPermissionsConfiguration = CallPermissions()) {
         self.voiceChannel = voiceChannel
-        videoConfiguration = VideoConfiguration(voiceChannel: voiceChannel, mediaManager: mediaManager)
+        self.mediaManager = mediaManager
+        videoConfiguration = VideoConfiguration(voiceChannel: voiceChannel, mediaManager: mediaManager,  isOverlayVisible: true)
         callInfoConfiguration = CallInfoConfiguration(voiceChannel: voiceChannel, preferedVideoPlaceholderState: preferedVideoPlaceholderState, permissions: permissionsConfiguration)
         callInfoRootViewController = CallInfoRootViewController(configuration: callInfoConfiguration)
         videoGridViewController = VideoGridViewController(configuration: videoConfiguration)
@@ -58,7 +60,6 @@ final class CallViewController: UIViewController {
         AVSMediaManagerClientChangeNotification.add(self)
         observerTokens += [voiceChannel.addCallStateObserver(self), voiceChannel.addParticipantObserver(self), voiceChannel.addConstantBitRateObserver(self)]
         proximityMonitorManager?.stateChanged = proximityStateDidChange
-        videoConfiguration.overlayVisibilityProvider = self
         disableVideoIfNeeded()
     }
     
@@ -146,6 +147,7 @@ final class CallViewController: UIViewController {
     fileprivate func updateConfiguration() {
         callInfoConfiguration = CallInfoConfiguration(voiceChannel: voiceChannel, preferedVideoPlaceholderState: preferedVideoPlaceholderState, permissions: permissions)
         callInfoRootViewController.configuration = callInfoConfiguration
+        videoConfiguration = VideoConfiguration(voiceChannel: voiceChannel, mediaManager: mediaManager, isOverlayVisible: isOverlayVisible)
         videoGridViewController.configuration = videoConfiguration
         updateOverlayAfterStateChanged()
         updateAppearance()
@@ -327,7 +329,7 @@ extension CallViewController: CallInfoRootViewControllerDelegate {
 
 // MARK: - Hide + Show Overlay
 
-extension CallViewController: OverlayVisibilityProvider {
+extension CallViewController {
     
     var isOverlayVisible: Bool {
         return callInfoRootViewController.view.alpha > 0

--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridView.swift
@@ -18,10 +18,37 @@
 
 import Foundation
 
+struct ParticipantVideoState {
+    let stream: UUID
+    let isPaused: Bool
+}
+
 protocol VideoGridConfiguration {
     var floatingVideoStream: ParticipantVideoState? { get }
     var videoStreams: [ParticipantVideoState] { get }
     var isMuted: Bool { get }
+}
+
+extension ParticipantVideoState: Equatable {
+    
+    static func ==(lhs: ParticipantVideoState, rhs: ParticipantVideoState) -> Bool {
+        return lhs.isPaused == rhs.isPaused && lhs.stream == rhs.stream
+    }
+    
+}
+
+// Workaround to make the protocol equatable, it might be possible to conform VideoGridConfiguration
+// to Equatable with Swift 4.1 and conditional conformances. Right now we would have to make
+// the `VideoGridViewController` generic to work around the `Self` requirement of
+// `Equatable` which we want to avoid.
+extension VideoGridConfiguration {
+    
+    func isEqual(toConfiguration other: VideoGridConfiguration) -> Bool {
+        return floatingVideoStream == other.floatingVideoStream &&
+            videoStreams == other.videoStreams &&
+            isMuted == other.isMuted
+    }
+    
 }
 
 fileprivate extension CGSize {
@@ -50,6 +77,7 @@ class VideoGridViewController: UIViewController {
     
     var configuration: VideoGridConfiguration {
         didSet {
+            guard !configuration.isEqual(toConfiguration: oldValue) else { return }
             updateState()
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridView.swift
@@ -95,6 +95,7 @@ class VideoGridViewController: UIViewController {
         super.viewDidLoad()
         setupViews()
         createConstraints()
+        updateState()
     }
     
     func setupViews() {


### PR DESCRIPTION
## What's new in this PR?

The `VideoConfiguration` is re-calculated fairly frequently but most the time it doesn't result in any necessary update for the views. This PR makes the `VideoConfiguration` immutable and only update the views if the configuration actually changed.