### PR TITLE
Hide status bar together with call info overlay

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -104,6 +104,10 @@ final class CallViewController: UIViewController {
     override var preferredStatusBarStyle: UIStatusBarStyle {
         return callInfoConfiguration.effectiveColorVariant == .light ? .default : .lightContent
     }
+    
+    override var prefersStatusBarHidden: Bool {
+        return !isOverlayVisible
+    }
 
     @objc private func resumeVideoIfNeeded() {
         guard voiceChannel.isVideoCall, voiceChannel.videoState.isPaused else { return }

--- a/Wire-iOS/Sources/UserInterface/Overlay/ActiveVoiceChannelViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/ActiveVoiceChannelViewController.swift
@@ -76,7 +76,7 @@ class ActiveVoiceChannelViewController : UIViewController {
     }
 
     override var prefersStatusBarHidden: Bool {
-        return false
+        return visibleVoiceChannelViewController?.prefersStatusBarHidden ?? false
     }
     
     override var preferredStatusBarStyle: UIStatusBarStyle {

--- a/Wire-iOS/Sources/UserInterface/Overlay/NotificationWindowRootViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Overlay/NotificationWindowRootViewController.m
@@ -87,7 +87,7 @@
 
 - (BOOL)prefersStatusBarHidden
 {
-    return NO;
+    return self.voiceChannelController.prefersStatusBarHidden;
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {


### PR DESCRIPTION
## What's new in this PR?

Hide status bar when the call info overlay fades away in a video call.
