### PR TITLE
Fix: iPad - photo picker popover size is not consistent

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1129,6 +1129,7 @@
 		EF6163A61FE9682700C6F5A9 /* TextMessageCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF8EE5591D636F4600B0D6D7 /* TextMessageCellTests.swift */; };
 		EF63528D209C4A9300F5E950 /* ConversationInputBarViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF63528C209C4A9300F5E950 /* ConversationInputBarViewControllerTests.swift */; };
 		EF6777062073C6C20062F122 /* OfflineBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF6777052073C6C20062F122 /* OfflineBar.swift */; };
+		EF68E71B20BD5B5A003F3594 /* IPadPopoverConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF68E71A20BD5B5A003F3594 /* IPadPopoverConstants.swift */; };
 		EF6E3C7A2089F232003F6752 /* animated.gif in Resources */ = {isa = PBXBuildFile; fileRef = EF6E3C792089F231003F6752 /* animated.gif */; };
 		EF6E3C7C208A02FE003F6752 /* GiphySearchViewControllerSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF6E3C7B208A02FE003F6752 /* GiphySearchViewControllerSnapshotTests.swift */; };
 		EF6E3C7E208A0355003F6752 /* MockConversation+factory.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF6E3C7D208A0355003F6752 /* MockConversation+factory.swift */; };
@@ -2809,6 +2810,7 @@
 		EF61B3411FC8508400D8E631 /* TextFieldValidator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFieldValidator.swift; sourceTree = "<group>"; };
 		EF63528C209C4A9300F5E950 /* ConversationInputBarViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationInputBarViewControllerTests.swift; sourceTree = "<group>"; };
 		EF6777052073C6C20062F122 /* OfflineBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineBar.swift; sourceTree = "<group>"; };
+		EF68E71A20BD5B5A003F3594 /* IPadPopoverConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPadPopoverConstants.swift; sourceTree = "<group>"; };
 		EF6E3C792089F231003F6752 /* animated.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = animated.gif; sourceTree = "<group>"; };
 		EF6E3C7B208A02FE003F6752 /* GiphySearchViewControllerSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiphySearchViewControllerSnapshotTests.swift; sourceTree = "<group>"; };
 		EF6E3C7D208A0355003F6752 /* MockConversation+factory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MockConversation+factory.swift"; sourceTree = "<group>"; };
@@ -3879,6 +3881,7 @@
 				871BC2041D34F8F800DF0793 /* UIImage+Transform.m */,
 				871BC2051D34F8F800DF0793 /* UIImagePickerController+GetImage.h */,
 				871BC2061D34F8F800DF0793 /* UIImagePickerController+GetImage.m */,
+				EF68E71A20BD5B5A003F3594 /* IPadPopoverConstants.swift */,
 				EF24036920A198CC002813BE /* UIImagePickerController+iPadPopover.swift */,
 				871BC2071D34F8F800DF0793 /* UIResponder+FirstResponder.h */,
 				871BC2081D34F8F800DF0793 /* UIResponder+FirstResponder.m */,
@@ -7324,6 +7327,7 @@
 				EF21271B1FB9DFE300625A9B /* TermsOfUseStepViewController.m in Sources */,
 				D525426B2093637D001C04C1 /* IconButton+CallActions.swift in Sources */,
 				871BC3691D34F94200DF0793 /* MediaPreviewViewController.m in Sources */,
+				EF68E71B20BD5B5A003F3594 /* IPadPopoverConstants.swift in Sources */,
 				D5F4387B206BBBB9003F1F14 /* Analytics+HistoryBackup.swift in Sources */,
 				BF606D6F1CAA8A78002BAC94 /* ConversationListBottomBar.swift in Sources */,
 				D5DBAAB020064E3B00E9F65B /* TeamMemberInviteTableViewCell.swift in Sources */,

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
@@ -164,7 +164,7 @@ extension ConversationContentViewController: UIAdaptivePresentationControllerDel
 
         let keyboardAvoiding = KeyboardAvoidingViewController(viewController: shareViewController)
         
-        keyboardAvoiding.preferredContentSize = CGSize(width: 320, height: 568)
+        keyboardAvoiding.preferredContentSize = CGSize.IPadPopover.preferredContentSize
         keyboardAvoiding.modalPresentationStyle = .popover
         
         if let popoverPresentationController = keyboardAvoiding.popoverPresentationController {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+ImagePicker.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+ImagePicker.swift
@@ -56,8 +56,6 @@ extension ConversationInputBarViewController {
             pickerController.allowsEditing = allowsEditing
             pickerController.mediaTypes = mediaTypes
             pickerController.videoMaximumDuration = TimeInterval(ConversationUploadMaxVideoDuration)
-            pickerController.preferredContentSize = sourceView.frame.size
-
 
             if sourceType == .camera {
                 switch Settings.shared().preferredCamera {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/UIImagePickerController+iPadPopover.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/UIImagePickerController+iPadPopover.swift
@@ -18,6 +18,13 @@
 
 import Foundation
 
+extension CGSize {
+    enum IPadPopover {
+        static let preferredContentSize: CGSize = CGSize(width: 320, height: 568)
+    }
+}
+
+
 struct ImagePickerPopoverPresentationContext {
     let sourceRect: CGRect
     let sourceView: UIView
@@ -29,6 +36,7 @@ extension UIImagePickerController {
     class func popoverForIPadRegular(with context: ImagePickerPopoverPresentationContext) -> UIImagePickerController {
         let picker = UIImagePickerController()
         picker.sourceType = context.sourceType
+        picker.preferredContentSize =  CGSize.IPadPopover.preferredContentSize
 
         if context.presentViewController.isIPadRegular(device: UIDevice.current) {
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/UIImagePickerController+iPadPopover.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/UIImagePickerController+iPadPopover.swift
@@ -18,13 +18,6 @@
 
 import Foundation
 
-extension CGSize {
-    enum IPadPopover {
-        static let preferredContentSize: CGSize = CGSize(width: 320, height: 568)
-    }
-}
-
-
 struct ImagePickerPopoverPresentationContext {
     let sourceRect: CGRect
     let sourceView: UIView

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+CameraPicker.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+CameraPicker.swift
@@ -122,7 +122,7 @@ extension ConversationListViewController {
         let shareViewController: ShareViewController<ZMConversation, UIImage> = ShareViewController(shareable: image, destinations: conversations)
         let keyboardAvoiding = KeyboardAvoidingViewController(viewController: shareViewController)
 
-        shareViewController.preferredContentSize = CGSize(width: 320, height: 568)
+        shareViewController.preferredContentSize = CGSize.IPadPopover.preferredContentSize
         shareViewController.onDismiss = { [weak self] (shareController: ShareViewController<ZMConversation, UIImage>, _) -> () in
             guard let `self` = self else {
                 return
@@ -139,7 +139,7 @@ extension ConversationListViewController {
         let shareViewController: ShareViewController<ZMConversation, URL> = ShareViewController(shareable: videoAtURL, destinations: conversations)
         let keyboardAvoiding = KeyboardAvoidingViewController(viewController: shareViewController)
 
-        shareViewController.preferredContentSize = CGSize(width: 320, height: 568)
+        shareViewController.preferredContentSize =  CGSize.IPadPopover.preferredContentSize
         shareViewController.onDismiss = { [weak self] (shareController: ShareViewController<ZMConversation, URL>, _) -> () in
             guard let `self` = self else {
                 return

--- a/Wire-iOS/Sources/UserInterface/Helpers/IPadPopoverConstants.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/IPadPopoverConstants.swift
@@ -1,0 +1,25 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension CGSize {
+    enum IPadPopover {
+        static let preferredContentSize: CGSize = CGSize(width: 320, height: 568)
+    }
+}


### PR DESCRIPTION
## What's new in this PR?

### Issues

Photo picker's size resize to 320px width after the user had selected the album

### Solutions

Set preferredContentSize to standard size (320x568) for photo picker popover on iPad.




