### PR TITLE
Dismiss overlay when it is visible on tap over floating preview

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -171,7 +171,7 @@ final class CallViewController: UIViewController {
         
         if let touch = touches.first,
             let overlay = videoGridViewController.previewOverlay,
-            overlay.point(inside: touch.location(in: overlay), with: event) {
+            overlay.point(inside: touch.location(in: overlay), with: event), !isOverlayVisible {
             return
         }
 


### PR DESCRIPTION
## What's new in this PR?

* Dismiss overlay when it is visible on tap over floating preview.