### PR TITLE
Fix: Client list screen - loading spinner dismiss before client list screen is dismissed (rework)

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Helpers/UIViewController+SizeClass.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UIViewController+SizeClass.swift
@@ -19,7 +19,7 @@
 import Foundation
 
 extension UIViewController {
-    func isIPadRegular(device: DeviceProtocol) -> Bool {
+    func isIPadRegular(device: DeviceProtocol = UIDevice.current) -> Bool {
         return device.userInterfaceIdiom == .pad && self.traitCollection.horizontalSizeClass == .regular
     }
 

--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
@@ -24,9 +24,14 @@ import WireExtensionComponents
 
 private let zmLog = ZMSLog(tag: "UI")
 
+protocol ClientListViewControllerDelegate: class {
+    func finishedDeleting(_ clientListViewController: ClientListViewController)
+}
+
 @objc class ClientListViewController: UIViewController, UITableViewDelegate, UITableViewDataSource, ZMClientUpdateObserver {
     var clientsTableView: UITableView?
     let topSeparator = OverflowSeparatorView()
+    weak var delegate: ClientListViewControllerDelegate?
 
     override open var showLoadingView: Bool {
         set {
@@ -160,7 +165,7 @@ private let zmLog = ZMSLog(tag: "UI")
 
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        self.showLoadingView = false
+        showLoadingView = false
     }
 
     func openDetailsOfClient(_ client: UserClient) {
@@ -224,8 +229,10 @@ private let zmLog = ZMSLog(tag: "UI")
 
 
     func deleteUserClient(_ userClient: UserClient, credentials: ZMEmailCredentials) {
-        self.navigationController?.showLoadingView = true
+        showLoadingView = true
         ZMUserSession.shared()?.delete([userClient], with: credentials);
+
+        delegate?.finishedDeleting(self)
     }
 
     func displayError(_ message: String) {
@@ -257,6 +264,7 @@ private let zmLog = ZMSLog(tag: "UI")
         self.showLoadingView = false
 
         self.clients = remainingClients
+
         Analytics.shared().tagDeleteDevice()
     }
     

--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
@@ -28,6 +28,23 @@ private let zmLog = ZMSLog(tag: "UI")
     var clientsTableView: UITableView?
     let topSeparator = OverflowSeparatorView()
 
+    override open var showLoadingView: Bool {
+        set {
+            if let navigationController = self.navigationController {
+                navigationController.showLoadingView = newValue
+            } else {
+                super.showLoadingView = newValue
+            }
+        }
+        get{
+            if let navigationController = self.navigationController {
+                return navigationController.showLoadingView
+            } else {
+                return super.showLoadingView
+            }
+        }
+    }
+
     var editingList: Bool = false {
         didSet {
             if (self.editingList) {
@@ -203,9 +220,11 @@ private let zmLog = ZMSLog(tag: "UI")
     func backPressed(_ sender: AnyObject!) {
         self.navigationController?.presentingViewController?.dismiss(animated: true, completion: nil)
     }
-    
+
+
+
     func deleteUserClient(_ userClient: UserClient, credentials: ZMEmailCredentials) {
-        self.showLoadingView = true
+        self.navigationController?.showLoadingView = true
         ZMUserSession.shared()?.delete([userClient], with: credentials);
     }
 
@@ -235,6 +254,8 @@ private let zmLog = ZMSLog(tag: "UI")
     }
     
     func finishedDeleting(_ remainingClients: [UserClient]!) {
+        self.showLoadingView = false
+
         self.clients = remainingClients
         Analytics.shared().tagDeleteDevice()
     }

--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientUnregisterFlowViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientUnregisterFlowViewController.swift
@@ -119,8 +119,10 @@ class ClientUnregisterFlowViewController: FormFlowViewController, FormStepDelega
     
     func didCompleteFormStep(_ viewController: UIViewController!) {
         let clientsListController = ClientListViewController(clientsList: self.clients, credentials: self.credentials, showTemporary: false)
+        clientsListController.delegate = self
         clientsListController.view.backgroundColor = UIColor.black
-        if self.traitCollection.userInterfaceIdiom == .pad && UIApplication.shared.keyWindow?.traitCollection.horizontalSizeClass == .regular {
+
+        if isIPadRegular() {
             let navigationController = UINavigationController(rootViewController: clientsListController)
             navigationController.modalPresentationStyle = UIModalPresentationStyle.formSheet
             self.present(navigationController, animated: true, completion: nil)
@@ -160,4 +162,18 @@ extension ClientUnregisterFlowViewController: PostLoginAuthenticationObserver {
     func clientRegistrationDidSucceed(accountId : UUID) {
         self.delegate?.clientDeletionSucceeded()
     }
+}
+
+extension ClientUnregisterFlowViewController: ClientListViewControllerDelegate {
+    func finishedDeleting(_ clientListViewController: ClientListViewController) {
+//        clientListViewController.dismiss(animated: true, completion: nil)
+
+//        if self.isIPadRegular(device: UIDevice.current) {
+//        } else {
+            self.rootNavigationController?.popViewController(animated: true)
+//        }
+
+    }
+
+
 }

--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientUnregisterFlowViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientUnregisterFlowViewController.swift
@@ -166,14 +166,15 @@ extension ClientUnregisterFlowViewController: PostLoginAuthenticationObserver {
 
 extension ClientUnregisterFlowViewController: ClientListViewControllerDelegate {
     func finishedDeleting(_ clientListViewController: ClientListViewController) {
-//        clientListViewController.dismiss(animated: true, completion: nil)
 
-//        if self.isIPadRegular(device: UIDevice.current) {
-//        } else {
-            self.rootNavigationController?.popViewController(animated: true)
-//        }
+        let completion: (() -> Swift.Void)? = { [weak self] in
+            self?.showLoadingView = true
+        }
 
+        if isIPadRegular() {
+            clientListViewController.dismiss(animated: true, completion: completion)
+        } else {
+            rootNavigationController?.popViewController(animated: true, completion: completion)
+        }
     }
-
-
 }


### PR DESCRIPTION
## What's new in this PR?

This PR is a reworking of https://github.com/wireapp/wire-ios/pull/2182

### Issues

After removing a device in the settings screen, the spinner does not dismiss.

### Causes

In https://github.com/wireapp/wire-ios/pull/2182, I try to fix the issue by dismissing the spinner when view did disappear, which would not be triggered in the settings screen,.

### Solutions

Restore to the original pattern. Create a delegate method finishedDeleting and ClientUnregisterFlowViewController dismisses ClientListViewController when finishes device deletion. Show spinner on ClientUnregisterFlowViewController after that.

On ClientListViewController, show the spinner on the navigation controller to cover the navigation bar buttons.

