### PR TITLE
Display the call overlay correctly on iPad

### DIFF
--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
@@ -156,7 +156,7 @@
     
     [self createTopViewConstraints];
     [self.splitViewController didMoveToParentViewController:self];
-    [self refreshSplitViewPositionForRegularContainer: self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular];
+    [self updateSplitViewTopConstraint];
 
     self.splitViewController.view.backgroundColor = [UIColor clearColor];
     
@@ -255,7 +255,7 @@
         }
     }
 
-    [self refreshSplitViewPositionForRegularContainer: self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular];
+    [self updateSplitViewTopConstraint];
     [[UIApplication sharedApplication] wr_updateStatusBarForCurrentControllerAnimated:YES onlyFullScreen:NO];
     [self.view setNeedsLayout];
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

On iPad, the calling overlay was not going under the status bar.

### Causes

Some simultaneous changes in the bar constraints code by me and @alexaubry caused the incorrect behavior when the call bar was pinned to the bottom of the status bar.

### Solutions

Refactor the code to move the logic to one method.
