### PR TITLE
fix: Newsletter popup shows after entering incorrect code from sms

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/RegistrationPhoneFlowViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/RegistrationPhoneFlowViewController.m
@@ -181,10 +181,6 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
 
         [[UnauthenticatedSession sharedSession] verifyPhoneNumberForRegistration:phoneVerificationStepViewController.phoneNumber
                                                        verificationCode:phoneVerificationStepViewController.verificationCode];
-
-        [UIAlertController showNewsletterSubscriptionDialogIfNeededWithCompletionHandler: ^(BOOL marketingConsent) {
-            self.marketingConsent = marketingConsent;
-        }];
     }
     else if ([viewController isKindOfClass:[TermsOfUseStepViewController class]]) {
         [self.analyticsTracker tagAcceptedTermsOfUse];
@@ -351,7 +347,12 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
 {
     [self.analyticsTracker tagVerifiedPhone];
     self.navigationController.showLoadingView = NO;
-    [self presentTermsOfUseStepController];
+
+    [UIAlertController showNewsletterSubscriptionDialogIfNeededWithCompletionHandler: ^(BOOL marketingConsent) {
+        self.marketingConsent = marketingConsent;
+
+        [self presentTermsOfUseStepController];
+    }];
 }
 
 - (void)phoneVerificationDidFail:(NSError *)error


### PR DESCRIPTION
## What's new in this PR?

### Issues

Newsletter popup shows after entering the incorrect code from SMS. It hides the code error alert.

### Causes

Newsletter popup was shown whatever verification was succeeded or failed

### Solutions

Show marketing consent dialog after the code is verified successfully.

