### PR TITLE
Fixed landscape picture taking in the camera keyboard

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Camera/CameraController.m
+++ b/Wire-iOS/Sources/UserInterface/Camera/CameraController.m
@@ -549,7 +549,9 @@ NSString * const CameraSettingExposureTargetBias = @"exposureTargetBias";
         __block AVCaptureVideoOrientation videoOrientation = (AVCaptureVideoOrientation)deviceOrientation;
 
 
-        if (deviceOrientation == UIDeviceOrientationFaceDown || deviceOrientation == UIDeviceOrientationFaceUp) {
+        if (deviceOrientation == UIDeviceOrientationFaceDown ||
+            deviceOrientation == UIDeviceOrientationFaceUp ||
+            deviceOrientation == UIDeviceOrientationUnknown) {
             // Face up/down can't be translated into a video orientation so we fall back to the orientation of the user interface
             dispatch_group_t group = dispatch_group_create();
             dispatch_group_enter(group);

--- a/Wire-iOS/Sources/UserInterface/Components/DeviceOrientationObserver.m
+++ b/Wire-iOS/Sources/UserInterface/Components/DeviceOrientationObserver.m
@@ -35,6 +35,7 @@ static DeviceOrientationObserver *sharedInstance = nil;
 @property (nonatomic) CMMotionManager *motionManager;
 @property (nonatomic) NSOperationQueue *operationQueue;
 @property (nonatomic) UIDeviceOrientation currentDeviceOrientation;
+@property (nonatomic) UIDeviceOrientation deviceOrientation;
 
 @end
 
@@ -75,7 +76,7 @@ static DeviceOrientationObserver *sharedInstance = nil;
                 ZM_WEAK(self);
                 [[NSOperationQueue mainQueue] addOperationWithBlock:^{
                     ZM_STRONG(self);
-                    self.currentDeviceOrientation = newDeviceOrientation;
+                    self.deviceOrientation = newDeviceOrientation;
                     [self notifyAboutRotationToDeviceOrientation:newDeviceOrientation];
                 }];
             }

--- a/Wire-iOS/Sources/UserInterface/Components/DeviceOrientationObserver.m
+++ b/Wire-iOS/Sources/UserInterface/Components/DeviceOrientationObserver.m
@@ -34,7 +34,7 @@ static DeviceOrientationObserver *sharedInstance = nil;
 
 @property (nonatomic) CMMotionManager *motionManager;
 @property (nonatomic) NSOperationQueue *operationQueue;
-@property (nonatomic) UIDeviceOrientation currentDeviceOrientation;
+@property (nonatomic) UIDeviceOrientation backgroundThreadDeviceOrientation;
 @property (nonatomic) UIDeviceOrientation deviceOrientation;
 
 @end
@@ -71,8 +71,8 @@ static DeviceOrientationObserver *sharedInstance = nil;
         [self.motionManager startDeviceMotionUpdatesToQueue:self.operationQueue withHandler:^(CMDeviceMotion *motion, NSError *error) {
             UIDeviceOrientation newDeviceOrientation = [self deviceOrientationFromMotion:motion];
             
-            if (newDeviceOrientation != self.currentDeviceOrientation) {
-                self.currentDeviceOrientation = newDeviceOrientation;
+            if (newDeviceOrientation != self.backgroundThreadDeviceOrientation) {
+                self.backgroundThreadDeviceOrientation = newDeviceOrientation;
                 ZM_WEAK(self);
                 [[NSOperationQueue mainQueue] addOperationWithBlock:^{
                     ZM_STRONG(self);
@@ -106,7 +106,7 @@ static DeviceOrientationObserver *sharedInstance = nil;
     CGFloat planeAngle = acos(dotProduct);
     const CGFloat deadSector = M_PI / 8;
     
-    UIDeviceOrientation deviceOrientation = self.currentDeviceOrientation;
+    UIDeviceOrientation deviceOrientation = self.backgroundThreadDeviceOrientation;
     
     if (planeAngle >= M_PI - M_PI / 8)
     {


### PR DESCRIPTION
## What's new in this PR?

### Issues

When user takes the picture in the camera keyboard in landscape, the picture appears rotated on the confirmation screen.

### Causes

During the migration to the Xcode 9.3, we changed the orientation observer code so that it was not setting the outer accessible variable that indicates the orientation to the correct value.

