### PR TITLE
Fix: loadingView is not dismissed if the user has only one device

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
@@ -37,6 +37,11 @@ protocol ClientListViewControllerDelegate: class {
         set {
             if let navigationController = self.navigationController {
                 navigationController.showLoadingView = newValue
+
+                // dismiss the loading view that toggled before navigationController is created
+                if !newValue && super.showLoadingView {
+                    super.showLoadingView = newValue
+                }
             } else {
                 super.showLoadingView = newValue
             }


### PR DESCRIPTION
## What's new in this PR?

This PR is a follow up of https://github.com/wireapp/wire-ios/pull/2206.

### Issues

In setting screen, loadingView is not dismissed if the user has only one device

### Causes

showLoadingView is set to true before the view controller has a navigation controller. The overridden showLoadingView does not handle this case

### Solutions

Dismiss showLoadingView in both navigation controller and ClientListViewController in this case.