### PR TITLE
Fix: in-app browser is blank when open marketing consent dialog's privacy web page

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/BrowserViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/BrowserViewController.swift
@@ -21,32 +21,13 @@ import SafariServices
 
 @objc class BrowserViewController: SFSafariViewController {
 
-    // MARK: - Events
-
-    private class BrowserDelegate: NSObject, SFSafariViewControllerDelegate {
-
-        var completion: () -> Void
-
-        init(completion: @escaping () -> Void) {
-            self.completion = completion
-        }
-
-        func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
-            completion()
-        }
-
-    }
-
     @objc var completion: (() -> Void)? {
-        get {
-            return (delegate as? BrowserDelegate)?.completion
-        }
-        set {
-            guard let block = newValue else {
+        didSet {
+            guard let _ = completion else {
                 delegate = nil
                 return
             }
-            delegate = BrowserDelegate(completion: block)
+            delegate = self
         }
     }
 
@@ -77,4 +58,10 @@ import SafariServices
         UIApplication.shared.wr_setStatusBarStyle(originalStatusBarStyle, animated: true)
     }
 
+}
+
+extension BrowserViewController: SFSafariViewControllerDelegate {
+    func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
+        completion?()
+    }
 }

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/BrowserViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/BrowserViewController.swift
@@ -21,15 +21,7 @@ import SafariServices
 
 @objc class BrowserViewController: SFSafariViewController {
 
-    @objc var completion: (() -> Void)? {
-        didSet {
-            guard let _ = completion else {
-                delegate = nil
-                return
-            }
-            delegate = self
-        }
-    }
+    @objc var completion: (() -> Void)?
 
     // MARK: - Tint Color
 
@@ -43,6 +35,8 @@ import SafariServices
         } else {
             view.tintColor = .wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: .light)
         }
+
+        delegate = self
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+Handles.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+Handles.swift
@@ -134,8 +134,8 @@ extension ConversationListViewController: UserProfileUpdateObserver {
     public func didFindHandleSuggestion(handle: String) {
         showUsernameTakeover(with: handle)
         if let userSession = ZMUserSession.shared() {
-            UIAlertController.showNewsletterSubscriptionDialogIfNeeded(presentViewController: self) { marketingconsent in
-                ZMUser.selfUser().setMarketingConsent(to: marketingconsent, in: userSession, completion: { _ in })
+            UIAlertController.showNewsletterSubscriptionDialogIfNeeded(presentViewController: self) { marketingConsent in
+                ZMUser.selfUser().setMarketingConsent(to: marketingConsent, in: userSession, completion: { _ in })
             }
         }
         UIAlertController.newsletterSubscriptionDialogWasDisplayed = false

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+Handles.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+Handles.swift
@@ -134,7 +134,7 @@ extension ConversationListViewController: UserProfileUpdateObserver {
     public func didFindHandleSuggestion(handle: String) {
         showUsernameTakeover(with: handle)
         if let userSession = ZMUserSession.shared() {
-            UIAlertController.showNewsletterSubscriptionDialogIfNeeded() { marketingconsent in
+            UIAlertController.showNewsletterSubscriptionDialogIfNeeded(presentViewController: self) { marketingconsent in
                 ZMUser.selfUser().setMarketingConsent(to: marketingconsent, in: userSession, completion: { _ in })
             }
         }

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/RegistrationEmailFlowViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/RegistrationEmailFlowViewController.m
@@ -157,7 +157,8 @@
         
         [self.navigationController pushViewController:emailVerificationStepViewController.registrationFormViewController animated:YES];
 
-        [UIAlertController showNewsletterSubscriptionDialogIfNeededWithCompletionHandler: ^(BOOL marketingConsent) {
+        [UIAlertController showNewsletterSubscriptionDialogWithPresentViewController: self
+                                                                   completionHandler: ^(BOOL marketingConsent) {
             self.marketingConsent = marketingConsent;
         }];
     }

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/RegistrationEmailFlowViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/RegistrationEmailFlowViewController.m
@@ -157,8 +157,8 @@
         
         [self.navigationController pushViewController:emailVerificationStepViewController.registrationFormViewController animated:YES];
 
-        [UIAlertController showNewsletterSubscriptionDialogWithPresentViewController: self
-                                                                   completionHandler: ^(BOOL marketingConsent) {
+        [UIAlertController showNewsletterSubscriptionDialogWithOver: self
+                                                  completionHandler: ^(BOOL marketingConsent) {
             self.marketingConsent = marketingConsent;
         }];
     }

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/RegistrationPhoneFlowViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/RegistrationPhoneFlowViewController.m
@@ -348,8 +348,8 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
     [self.analyticsTracker tagVerifiedPhone];
     self.navigationController.showLoadingView = NO;
 
-    [UIAlertController showNewsletterSubscriptionDialogWithPresentViewController: self
-                                                               completionHandler: ^(BOOL marketingConsent) {
+    [UIAlertController showNewsletterSubscriptionDialogWithOver: self
+                                              completionHandler: ^(BOOL marketingConsent) {
         self.marketingConsent = marketingConsent;
 
         [self presentTermsOfUseStepController];

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/RegistrationPhoneFlowViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/RegistrationPhoneFlowViewController.m
@@ -348,7 +348,8 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
     [self.analyticsTracker tagVerifiedPhone];
     self.navigationController.showLoadingView = NO;
 
-    [UIAlertController showNewsletterSubscriptionDialogIfNeededWithCompletionHandler: ^(BOOL marketingConsent) {
+    [UIAlertController showNewsletterSubscriptionDialogWithPresentViewController: self
+                                                               completionHandler: ^(BOOL marketingConsent) {
         self.marketingConsent = marketingConsent;
 
         [self presentTermsOfUseStepController];

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationFlowController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationFlowController.swift
@@ -125,15 +125,15 @@ extension TeamCreationFlowController {
 
     fileprivate func showMarketingConsentDialog(presentViewController: UIViewController) {
         UIAlertController.newsletterSubscriptionDialogWasDisplayed = false
-        UIAlertController.showNewsletterSubscriptionDialogIfNeeded(presentViewController: presentViewController) { [weak self] marketingconsent in
-            self?.marketingConsent = marketingconsent
+        UIAlertController.showNewsletterSubscriptionDialogIfNeeded(presentViewController: presentViewController) { [weak self] marketingConsent in
+            self?.marketingConsent = marketingConsent
         }
     }
 
     fileprivate func pushController(for state: TeamCreationState) {
 
         var stepDescription: TeamCreationStepDescription?
-        var needToShowMarketingConsentDialog = false
+        var needsToShowMarketingConsentDialog = false
 
         switch state {
         case .setTeamName:
@@ -144,7 +144,7 @@ extension TeamCreationFlowController {
             stepDescription = VerifyEmailStepDescription(email: email, delegate: self)
         case .setFullName:
             stepDescription = SetFullNameStepDescription()
-            needToShowMarketingConsentDialog = true
+            needsToShowMarketingConsentDialog = true
         case .setPassword:
             stepDescription = SetPasswordStepDescription()
         case .createTeam:
@@ -159,7 +159,7 @@ extension TeamCreationFlowController {
         if let description = stepDescription {
             let controller = createViewController(for: description)
 
-            if needToShowMarketingConsentDialog {
+            if needsToShowMarketingConsentDialog {
                 showMarketingConsentDialog(presentViewController: controller)
             }
 

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationFlowController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationFlowController.swift
@@ -123,9 +123,17 @@ extension TeamCreationFlowController {
         }
     }
 
+    fileprivate func showMarketingConsentDialog(presentViewController: UIViewController) {
+        UIAlertController.newsletterSubscriptionDialogWasDisplayed = false
+        UIAlertController.showNewsletterSubscriptionDialogIfNeeded(presentViewController: presentViewController) { [weak self] marketingconsent in
+            self?.marketingConsent = marketingconsent
+        }
+    }
+
     fileprivate func pushController(for state: TeamCreationState) {
 
         var stepDescription: TeamCreationStepDescription?
+        var needToShowMarketingConsentDialog = false
 
         switch state {
         case .setTeamName:
@@ -136,11 +144,7 @@ extension TeamCreationFlowController {
             stepDescription = VerifyEmailStepDescription(email: email, delegate: self)
         case .setFullName:
             stepDescription = SetFullNameStepDescription()
-
-            UIAlertController.newsletterSubscriptionDialogWasDisplayed = false
-            UIAlertController.showNewsletterSubscriptionDialogIfNeeded() { [weak self] marketingconsent in
-                self?.marketingConsent = marketingconsent
-            }
+            needToShowMarketingConsentDialog = true
         case .setPassword:
             stepDescription = SetPasswordStepDescription()
         case .createTeam:
@@ -154,6 +158,11 @@ extension TeamCreationFlowController {
 
         if let description = stepDescription {
             let controller = createViewController(for: description)
+
+            if needToShowMarketingConsentDialog {
+                showMarketingConsentDialog(presentViewController: controller)
+            }
+
             if let current = currentController, current.stepDescription.shouldSkipFromNavigation() {
                 currentController = controller
                 let withoutLast = navigationController.viewControllers.dropLast()

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/UIAlertController+Newsletter.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/UIAlertController+Newsletter.swift
@@ -25,7 +25,7 @@ extension UIAlertController {
     /// email regisration work flow: newsletter subscription dialog appears after conversation list is displayed.)
     static var newsletterSubscriptionDialogWasDisplayed = false
 
-    static func showNewsletterSubscriptionDialog(completionHandler: @escaping (Bool) -> Void) {
+    static func showNewsletterSubscriptionDialog(presentViewController:UIViewController, completionHandler: @escaping (Bool) -> Void) {
         guard !AutomationHelper.sharedHelper.skipFirstLoginAlerts else { return }
 
         let alertController = UIAlertController(title: "news_offers.consent.title".localized,
@@ -34,11 +34,12 @@ extension UIAlertController {
 
         let privacyPolicyActionHandler: ((UIAlertAction) -> Swift.Void) = { _ in
             let browserViewController = BrowserViewController(url: URL.wr_privacyPolicy.appendingLocaleParameter)
+            
             browserViewController.completion = { _ in
-                UIAlertController.showNewsletterSubscriptionDialog(completionHandler: completionHandler)
+                UIAlertController.showNewsletterSubscriptionDialog(presentViewController: presentViewController, completionHandler: completionHandler)
             }
 
-            AppDelegate.shared().notificationsWindow?.rootViewController?.present(browserViewController, animated: true)
+            presentViewController.present(browserViewController, animated: true)
         }
 
         alertController.addAction(UIAlertAction(title: "news_offers.consent.button.privacy_policy.title".localized,
@@ -58,14 +59,14 @@ extension UIAlertController {
         }))
 
         UIAlertController.newsletterSubscriptionDialogWasDisplayed = true
-        AppDelegate.shared().notificationsWindow?.rootViewController?.present(alertController, animated: true) {
+        presentViewController.present(alertController, animated: true) {
             UIApplication.shared.keyWindow?.endEditing(true)
         }
     }
 
-    static func showNewsletterSubscriptionDialogIfNeeded(completionHandler: @escaping (Bool) -> Void) {
+    static func showNewsletterSubscriptionDialogIfNeeded(presentViewController:UIViewController, completionHandler: @escaping (Bool) -> Void) {
         guard !UIAlertController.newsletterSubscriptionDialogWasDisplayed else { return }
 
-        showNewsletterSubscriptionDialog(completionHandler: completionHandler)
+        showNewsletterSubscriptionDialog(presentViewController: presentViewController, completionHandler: completionHandler)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/UIAlertController+Newsletter.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/UIAlertController+Newsletter.swift
@@ -25,7 +25,7 @@ extension UIAlertController {
     /// email regisration work flow: newsletter subscription dialog appears after conversation list is displayed.)
     static var newsletterSubscriptionDialogWasDisplayed = false
 
-    static func showNewsletterSubscriptionDialog(presentViewController:UIViewController, completionHandler: @escaping (Bool) -> Void) {
+    static func showNewsletterSubscriptionDialog(over viewController:UIViewController, completionHandler: @escaping (Bool) -> Void) {
         guard !AutomationHelper.sharedHelper.skipFirstLoginAlerts else { return }
 
         let alertController = UIAlertController(title: "news_offers.consent.title".localized,
@@ -36,10 +36,10 @@ extension UIAlertController {
             let browserViewController = BrowserViewController(url: URL.wr_privacyPolicy.appendingLocaleParameter)
             
             browserViewController.completion = { _ in
-                UIAlertController.showNewsletterSubscriptionDialog(presentViewController: presentViewController, completionHandler: completionHandler)
+                UIAlertController.showNewsletterSubscriptionDialog(over: viewController, completionHandler: completionHandler)
             }
 
-            presentViewController.present(browserViewController, animated: true)
+            viewController.present(browserViewController, animated: true)
         }
 
         alertController.addAction(UIAlertAction(title: "news_offers.consent.button.privacy_policy.title".localized,
@@ -59,7 +59,7 @@ extension UIAlertController {
         }))
 
         UIAlertController.newsletterSubscriptionDialogWasDisplayed = true
-        presentViewController.present(alertController, animated: true) {
+        viewController.present(alertController, animated: true) {
             UIApplication.shared.keyWindow?.endEditing(true)
         }
     }
@@ -67,6 +67,6 @@ extension UIAlertController {
     static func showNewsletterSubscriptionDialogIfNeeded(presentViewController:UIViewController, completionHandler: @escaping (Bool) -> Void) {
         guard !UIAlertController.newsletterSubscriptionDialogWasDisplayed else { return }
 
-        showNewsletterSubscriptionDialog(presentViewController: presentViewController, completionHandler: completionHandler)
+        showNewsletterSubscriptionDialog(over: presentViewController, completionHandler: completionHandler)
     }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues
After https://github.com/wireapp/wire-ios/pull/2205 is merged, In-app browser is blank when open marketing consent dialog's privacy web page.

### Causes

SFSafariViewController cannot render correctly if it is not presented with the same window as the current view controller.

### Solutions

Present BrowserViewController from the same view controller instead of notificationsWindow.rootViewController.

## Notes

After testing, I found that BrowserViewController does not call completion closure. Rewrite BrowserViewController in a simpler way to fix it.