### PR TITLE
Select correct sourceType

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+ImagePicker.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+ImagePicker.swift
@@ -49,14 +49,14 @@ extension ConversationInputBarViewController {
             let context = ImagePickerPopoverPresentationContext(sourceRect:self.popoverSourceRectFromPhotoButton,
                                                     sourceView: sourceView,
                                                     presentViewController: self,
-                                                    sourceType: .photoLibrary)
+                                                    sourceType: sourceType)
 
             let pickerController = UIImagePickerController.popoverForIPadRegular(with: context)
             pickerController.delegate = self
             pickerController.allowsEditing = allowsEditing
             pickerController.mediaTypes = mediaTypes
             pickerController.videoMaximumDuration = TimeInterval(ConversationUploadMaxVideoDuration)
-
+            
             if sourceType == .camera {
                 switch Settings.shared().preferredCamera {
                 case .back:


### PR DESCRIPTION
## What's new in this PR?

### Issues

iOS app is crashing when selecting the fullscreen camera from the camera keyboard.

### Causes

We try to set the preferred camera in the code, but UIImagePickerController is configured for showing the camera roll. 

### Solutions

Correctly set the source type for the camera.
