### PR TITLE
Fix: There is no Newsletter popup after team owner verified his email address

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Helpers/UINavigationController+Additions.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UINavigationController+Additions.swift
@@ -43,6 +43,20 @@ extension UINavigationController {
             completion?()
         }
     }
+
+    open func setViewControllers(_ viewControllers: [UIViewController],
+                                 animated: Bool,
+                                 completion: (() -> Void)?) {
+        setViewControllers(viewControllers, animated: animated)
+
+        if animated, let coordinator = transitionCoordinator {
+            coordinator.animate(alongsideTransition: nil) { _ in
+                completion?()
+            }
+        } else {
+            completion?()
+        }
+    }
     
     @discardableResult open func popViewController(animated: Bool,
                                                    completion: (() -> Void)?) -> UIViewController? {

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationFlowController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/TeamCreationFlowController.swift
@@ -159,18 +159,20 @@ extension TeamCreationFlowController {
         if let description = stepDescription {
             let controller = createViewController(for: description)
 
-            if needsToShowMarketingConsentDialog {
-                showMarketingConsentDialog(presentViewController: controller)
+            let completion = {
+                if needsToShowMarketingConsentDialog {
+                    self.showMarketingConsentDialog(presentViewController: self.navigationController)
+                }
             }
 
             if let current = currentController, current.stepDescription.shouldSkipFromNavigation() {
                 currentController = controller
                 let withoutLast = navigationController.viewControllers.dropLast()
                 let controllers = withoutLast + [controller]
-                navigationController.setViewControllers(Array(controllers), animated: true)
+                navigationController.setViewControllers(Array(controllers), animated: true, completion: completion)
             } else {
                 currentController = controller
-                navigationController.pushViewController(controller, animated: true)
+                navigationController.pushViewController(controller, animated: true, completion: completion)
             }
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/UIAlertController+Newsletter.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/UIAlertController+Newsletter.swift
@@ -64,7 +64,8 @@ extension UIAlertController {
         }
     }
 
-    static func showNewsletterSubscriptionDialogIfNeeded(presentViewController:UIViewController, completionHandler: @escaping (Bool) -> Void) {
+    static func showNewsletterSubscriptionDialogIfNeeded(presentViewController: UIViewController,
+                                                         completionHandler: @escaping (Bool) -> Void) {
         guard !UIAlertController.newsletterSubscriptionDialogWasDisplayed else { return }
 
         showNewsletterSubscriptionDialog(over: presentViewController, completionHandler: completionHandler)


### PR DESCRIPTION
## What's new in this PR?

### Issues

There is no Newsletter popup after team owner verified his email address.

### Causes

Related to https://github.com/wireapp/wire-ios/pull/2216.
After the fix for new BrowserViewController, we show the UIAlertContoller from the current viewController, which may be not yet in the view hierarchy and the alert may not appear.

### Solutions

Show the alert from the navigation controller after navigationController.pushViewController or navigationController.setViewControllers.
