### PR TITLE
Allow calling when video permissions are not granted

### DIFF
--- a/Wire-iOS/Sources/Helpers/syncengine/Message+UI.h
+++ b/Wire-iOS/Sources/Helpers/syncengine/Message+UI.h
@@ -31,8 +31,6 @@
 
 + (NSString *)formattedReceivedDateForMessage:(id<ZMConversationMessage>)message;
 
-+ (BOOL)isPresentableAsNotification:(id<ZMConversationMessage>)message;
-
 + (NSString *)nonNilImageDataIdentifier:(id<ZMConversationMessage>)message;
 
 + (BOOL)canBePrefetched:(id<ZMConversationMessage>)message;

--- a/Wire-iOS/Sources/Helpers/syncengine/Message+UI.m
+++ b/Wire-iOS/Sources/Helpers/syncengine/Message+UI.m
@@ -119,24 +119,6 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
     return longVersionTimeFormatter;
 }
 
-+ (BOOL)isPresentableAsNotification:(id<ZMConversationMessage>)message
-{
-    BOOL isChatHeadsDisabled = [[Settings sharedSettings] chatHeadsDisabled];
-    BOOL isConversationSilenced = message.conversation.isSilenced;
-    BOOL isSenderSelfUser = [message.sender isSelfUser];
-    BOOL isMessageUnread = (NSUInteger) message.serverTimestamp.timeIntervalSinceReferenceDate > message.conversation.lastReadMessage.serverTimestamp.timeIntervalSinceReferenceDate;
-    // only show a notification chathead if the message is new (recently sent)
-    BOOL isTimelyMessage = [[NSDate date] timeIntervalSinceDate:message.serverTimestamp] <= (0.5f);
-    BOOL isSystemMessage = [self isSystemMessage:message];
-
-    return ! isChatHeadsDisabled &&
-            ! isConversationSilenced &&
-            ! isSenderSelfUser &&
-            isMessageUnread &&
-            isTimelyMessage &&
-            ! isSystemMessage;
-}
-
 + (NSString *)nonNilImageDataIdentifier:(id<ZMConversationMessage>)message
 {
     NSString *identifier = message.imageMessageData.imageDataIdentifier;

--- a/Wire-iOS/Sources/Helpers/syncengine/ZMConversation+Calling.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMConversation+Calling.swift
@@ -69,9 +69,12 @@ extension ZMConversation {
             }
         }
         
-        UIApplication.wr_requestOrWarnAboutMicrophoneAccess { (granted) in
+        UIApplication.wr_requestOrWarnAboutMicrophoneAccess { granted in
             if video {
-                UIApplication.wr_requestOrWarnAboutVideoAccess(onGranted)
+                UIApplication.wr_requestOrWarnAboutVideoAccess { _ in
+                    // We still allow starting the call, even if the video permissions where not granted.
+                    onGranted(granted)
+                }
             } else {
                 onGranted(granted)
             }


### PR DESCRIPTION
- When user forbid the video permissions, but allow the audio permissions, we still want to allow the call to be started.
- Removed unused method: `isPresentableAsNotification`.