### PR TITLE
fix variant for login workflow

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientUnregisterFlowViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientUnregisterFlowViewController.swift
@@ -120,7 +120,8 @@ class ClientUnregisterFlowViewController: FormFlowViewController, FormStepDelega
     func didCompleteFormStep(_ viewController: UIViewController!) {
         let clientsListController = ClientListViewController(clientsList: self.clients,
                                                              credentials: self.credentials,
-                                                             showTemporary: false)
+                                                             showTemporary: false,
+                                                             variant: .dark)
         clientsListController.delegate = self
 
         if isIPadRegular() {


### PR DESCRIPTION
## What's new in this PR?

This PR is a follow-up of https://github.com/wireapp/wire-ios/pull/2228.

Apply dark variant for the ClientListViewController when it is shown in login workflow.

## need to fix
- [ ] color scheme of device detail screen (SettingsClientViewController)
