### PR TITLE
ZIOS-10088: Fix implicit avatar animation

### DIFF
--- a/WireExtensionComponents/Views/RoundedView/ContinuousMaskLayer.swift
+++ b/WireExtensionComponents/Views/RoundedView/ContinuousMaskLayer.swift
@@ -18,20 +18,6 @@
 
 import UIKit
 
-private class AnimatingShapeLayer: CAShapeLayer {
-
-    override class func defaultAction(forKey event: String) -> CAAction? {
-
-        if event == "path" {
-            return CABasicAnimation(keyPath: event)
-        } else {
-            return super.defaultAction(forKey: event)
-        }
-
-    }
-
-}
-
 /**
  * The dimension to use when calculating relative radii.
  */
@@ -82,12 +68,12 @@ public class ContinuousMaskLayer: CALayer {
 
     public override init(layer: Any) {
         super.init(layer: layer)
-        self.mask = AnimatingShapeLayer()
+        self.mask = CAShapeLayer()
     }
 
     public override init() {
         super.init()
-        self.mask = AnimatingShapeLayer()
+        self.mask = CAShapeLayer()
     }
 
     public required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
## What's new in this PR?

### Issues

This fixes the implicit animation of the avatar performed when swiping in the conversation view.

### Causes

The rounded mask layer was starting a basic animation. This is not required, since the size of the avatar element does not change; so that behavior was removed.