### PR TITLE
Disable video when no permissions granted: case when first answering the call

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -264,6 +264,7 @@ extension CallViewController {
 
             self.checkVideoPermissions { videoGranted in
                 self.conversation?.joinVoiceChannel(video: videoGranted)
+                self.disableVideoIfNeeded()
             }
         }
     }


### PR DESCRIPTION
## What's new in this PR?

In case user haven't granted the video permissions yet, the initial call to `disableVideoIfNeeded()` is happening before user have decided to reject the permissions, therefore it has no effect (isVideoDisabledForever is yet false).

Solution is to call the method once again when the call is answered.