### PR TITLE
Manage conversation link: fix opening in SafariVC

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
@@ -68,7 +68,7 @@ import SafariServices
     func manageTeamCell() -> SettingsCellDescriptorType {
         return SettingsExternalScreenCellDescriptor(title: "self.settings.manage_team.title".localized,
                                                     isDestructive: false,
-                                                    presentationStyle: PresentationStyle.navigation,
+                                                    presentationStyle: PresentationStyle.modal,
                                                     identifier: nil,
                                                     presentationAction: { () -> (UIViewController?) in
                                                         Analytics.shared().tagOpenManageTeamURL()


### PR DESCRIPTION
## What's new in this PR?

### Issues

We moved to open all links in Safari View Controller, but in case of opening the manage team link we've been pushing the controller on the navigation stack, which seems to be not supported in the safari controller.

Changed to present the controller as modal.