### PR TITLE
Fix audio call overlay being visible during second call

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Audio.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Audio.swift
@@ -199,8 +199,7 @@ extension ConversationInputBarViewController: AudioRecordViewControllerDelegate 
     
 }
 
-// Counter keeping track of calls being made when the audio keyboard ewas visible before.
-private var callsInProgress = 0
+
 
 extension ConversationInputBarViewController: WireCallCenterCallStateObserver {
     
@@ -208,17 +207,17 @@ extension ConversationInputBarViewController: WireCallCenterCallStateObserver {
         let isRecording = audioRecordKeyboardViewController?.isRecording
 
         switch (callState, isRecording, wasRecordingBeforeCall) {
-        case (.incoming(_, true, _), true, _),     // receiving incoming call while audio keyboard is visible
-             (.outgoing, true, _):                 // making an outgoing call while audio keyboard is visible
-            wasRecordingBeforeCall = true          // -> remember that the audio keyboard was visible
-            callsInProgress += 1                   // -> increment calls in progress counter
-        case (.incoming(_, false, _), _, true),    // refusing an incoming call
-             (.terminating, _, true):              // terminating/closing the current call
-            callsInProgress -= 1                   // -> decrement calls in progress counter
+        case (.incoming(_, true, _), true, _),              // receiving incoming call while audio keyboard is visible
+             (.outgoing, true, _):                          // making an outgoing call while audio keyboard is visible
+            wasRecordingBeforeCall = true                   // -> remember that the audio keyboard was visible
+            callCountWhileCameraKeyboardWasVisible += 1     // -> increment calls in progress counter
+        case (.incoming(_, false, _), _, true),             // refusing an incoming call
+             (.terminating, _, true):                       // terminating/closing the current call
+            callCountWhileCameraKeyboardWasVisible -= 1     // -> decrement calls in progress counter
         default: break
         }
         
-        if 0 == callsInProgress, wasRecordingBeforeCall {
+        if 0 == callCountWhileCameraKeyboardWasVisible, wasRecordingBeforeCall {
             displayRecordKeyboard() // -> show the audio record keyboard again
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Audio.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Audio.swift
@@ -199,20 +199,27 @@ extension ConversationInputBarViewController: AudioRecordViewControllerDelegate 
     
 }
 
+// Counter keeping track of calls being made when the audio keyboard ewas visible before.
+private var callsInProgress = 0
+
 extension ConversationInputBarViewController: WireCallCenterCallStateObserver {
     
     public func callCenterDidChange(callState: CallState, conversation: ZMConversation, caller: ZMUser, timestamp: Date?) {
         let isRecording = audioRecordKeyboardViewController?.isRecording
-        
-        
-        switch (callState, isRecording, wasRecordingBeforeCall, ZMUserSession.shared()?.isCallOngoing) {
-        case (.incoming(_, true, _), true, false, _),         // receiving incoming call while audio keyboard is visible
-             (.outgoing, true, false, _):                     // making an outgoing call while audio keyboard is visible
-            wasRecordingBeforeCall = true                     // -> remember that the audio keyboard was visible
-        case (.incoming(_, false, _), _, true, false),        // refusing an incoming call
-             (.terminating, _, true, false):                  // terminating/closing the current call
-            displayRecordKeyboard()                           // -> show the audio record keyboard again
+
+        switch (callState, isRecording, wasRecordingBeforeCall) {
+        case (.incoming(_, true, _), true, _),     // receiving incoming call while audio keyboard is visible
+             (.outgoing, true, _):                 // making an outgoing call while audio keyboard is visible
+            wasRecordingBeforeCall = true          // -> remember that the audio keyboard was visible
+            callsInProgress += 1                   // -> increment calls in progress counter
+        case (.incoming(_, false, _), _, true),    // refusing an incoming call
+             (.terminating, _, true):              // terminating/closing the current call
+            callsInProgress -= 1                   // -> decrement calls in progress counter
         default: break
+        }
+        
+        if 0 == callsInProgress, wasRecordingBeforeCall {
+            displayRecordKeyboard() // -> show the audio record keyboard again
         }
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Private.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Private.h
@@ -42,8 +42,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic)           BOOL shouldRefocusKeyboardAfterImagePickerDismiss;
 @property (nonatomic)           BOOL inputBarOverlapsContent;
 @property (nonatomic)           NSUInteger videoSendContext;
-@property (nonatomic) id callStateObserverToken;
-@property (nonatomic) BOOL wasRecordingBeforeCall;
+
+// Counter keeping track of calls being made when the audio keyboard ewas visible before.
+@property (nonatomic)           NSInteger callCountWhileCameraKeyboardWasVisible;
+@property (nonatomic)           id callStateObserverToken;
+@property (nonatomic)           BOOL wasRecordingBeforeCall;
 
 @property (nonatomic, nonnull) ConversationInputBarButtonState *sendButtonState;
 


### PR DESCRIPTION
## What's in this PR?

* Fix audio call overlay being visible during second call.