### PR TITLE
Corrected the code for making the copy of the ContinuousMaskLayer

### DIFF
--- a/WireExtensionComponents/Views/RoundedView/ContinuousMaskLayer.swift
+++ b/WireExtensionComponents/Views/RoundedView/ContinuousMaskLayer.swift
@@ -68,7 +68,14 @@ public class ContinuousMaskLayer: CALayer {
 
     public override init(layer: Any) {
         super.init(layer: layer)
-        self.mask = CAShapeLayer()
+        
+        if let otherMaskLayer = layer as? ContinuousMaskLayer {
+            self.shape = otherMaskLayer.shape
+            self.roundedCorners = otherMaskLayer.roundedCorners
+        }
+        else {
+            fatal("Cannot init with \(layer)")
+        }
     }
 
     public override init() {


### PR DESCRIPTION
## What's new in this PR?

### Issues

The app was crashing in the calling UI with the stack trace pointing to `ContinuousMaskLayer.initWithLayer:`

### Causes

The existing implementation was trying to assign the new layer to the `mask` property, which was the problem for iOS.

### Solutions

The method `initWithLayer:` [is called](https://developer.apple.com/documentation/quartzcore/calayer/1410842-initwithlayer) by iOS in order to create the copy of the current layer for building the shadow (displayLayer) layer hierarchy. The apple's `CALayer.initWithLayer:` implementation has the code to copy the mask already. Normally in this method it's important to copy all the custom properties of the layer, like [here](https://blog.pixelingene.com/2012/02/animating-pie-slices-using-a-custom-calayer/).

Fix adds the copying of the properties and removes recreation of the mask.