### PR TITLE
Share cell: compress title instead of the images

### DIFF
--- a/Wire-iOS/Sources/Components/ShareViewController/ShareDestinationCell.swift
+++ b/Wire-iOS/Sources/Components/ShareViewController/ShareDestinationCell.swift
@@ -90,6 +90,7 @@ final class ShareDestinationCell<D: ShareDestination>: UITableViewCell {
         self.titleLabel.cas_styleClass = "normal-light"
         self.titleLabel.backgroundColor = .clear
         self.titleLabel.textColor = .white
+        self.titleLabel.setContentCompressionResistancePriority(UILayoutPriorityDefaultLow, for: .horizontal)
         
         self.stackView.addArrangedSubview(self.titleLabel)
         


### PR DESCRIPTION
## What's new in this PR?

### Issues

In the share content screen, on the narrow screens, the title of the conversation is taking the maximum width in the stack view, pushing the icons on the right to be compressed.

### Causes

Default compression resistance is most likely the same between UILabel and UIImageView.

### Solutions

Explicitly lower the resistance for the title label.