### PR TITLE
Call VoiceOver: come back to the call activation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
@@ -49,6 +49,7 @@ public extension ConversationViewController {
     var audioCallButton: UIBarButtonItem {
         let button = UIBarButtonItem(icon: .callAudio, target: self, action: #selector(ConversationViewController.voiceCallItemTapped(_:)))
         button.accessibilityIdentifier = "audioCallBarButton"
+        button.accessibilityTraits = UIAccessibilityTraitStartsMediaSession
         button.accessibilityLabel = "call.actions.label.make_audio_call".localized
         return button
     }
@@ -56,6 +57,7 @@ public extension ConversationViewController {
     var videoCallButton: UIBarButtonItem {
         let button = UIBarButtonItem(icon: .callVideo, target: self, action: #selector(ConversationViewController.videoCallItemTapped(_:)))
         button.accessibilityIdentifier = "videoCallBarButton"
+        button.accessibilityTraits = UIAccessibilityTraitStartsMediaSession
         button.accessibilityLabel = "call.actions.label.make_video_call".localized
         return button
     }
@@ -66,6 +68,7 @@ public extension ConversationViewController {
         button.adjustBackgroundImageWhenHighlighted = true
         button.setTitle("conversation_list.right_accessory.join_button.title".localized.uppercased(), for: .normal)
         button.accessibilityLabel = "conversation.join_call.voiceover".localized
+        button.accessibilityTraits = UIAccessibilityTraitStartsMediaSession
         button.titleLabel?.font = FontSpec(.small, .semibold).font
         button.backgroundColor = UIColor(for: .strongLimeGreen)
         button.addTarget(self, action: #selector(joinCallButtonTapped), for: .touchUpInside)

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
@@ -49,7 +49,7 @@ public extension ConversationViewController {
     var audioCallButton: UIBarButtonItem {
         let button = UIBarButtonItem(icon: .callAudio, target: self, action: #selector(ConversationViewController.voiceCallItemTapped(_:)))
         button.accessibilityIdentifier = "audioCallBarButton"
-        button.accessibilityTraits = UIAccessibilityTraitStartsMediaSession
+        button.accessibilityTraits |= UIAccessibilityTraitStartsMediaSession
         button.accessibilityLabel = "call.actions.label.make_audio_call".localized
         return button
     }
@@ -57,7 +57,7 @@ public extension ConversationViewController {
     var videoCallButton: UIBarButtonItem {
         let button = UIBarButtonItem(icon: .callVideo, target: self, action: #selector(ConversationViewController.videoCallItemTapped(_:)))
         button.accessibilityIdentifier = "videoCallBarButton"
-        button.accessibilityTraits = UIAccessibilityTraitStartsMediaSession
+        button.accessibilityTraits |= UIAccessibilityTraitStartsMediaSession
         button.accessibilityLabel = "call.actions.label.make_video_call".localized
         return button
     }
@@ -68,7 +68,7 @@ public extension ConversationViewController {
         button.adjustBackgroundImageWhenHighlighted = true
         button.setTitle("conversation_list.right_accessory.join_button.title".localized.uppercased(), for: .normal)
         button.accessibilityLabel = "conversation.join_call.voiceover".localized
-        button.accessibilityTraits = UIAccessibilityTraitStartsMediaSession
+        button.accessibilityTraits |= UIAccessibilityTraitStartsMediaSession
         button.titleLabel?.font = FontSpec(.small, .semibold).font
         button.backgroundColor = UIColor(for: .strongLimeGreen)
         button.addTarget(self, action: #selector(joinCallButtonTapped), for: .touchUpInside)

--- a/Wire-iOS/Sources/UserInterface/Overlay/CallTopOverlayController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/CallTopOverlayController.swift
@@ -42,6 +42,25 @@ extension CallState: CustomStringConvertible {
 
 final class CallTopOverlayController: UIViewController {
     private let durationLabel = UILabel()
+    
+    class TapableAccessibleView: UIView {
+        let onAccessibilityActivate: ()->()
+        
+        init(onAccessibilityActivate: @escaping ()->()) {
+            self.onAccessibilityActivate = onAccessibilityActivate
+            super.init(frame: .zero)
+        }
+        
+        required init?(coder aDecoder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+        
+        override func accessibilityActivate() -> Bool {
+            onAccessibilityActivate()
+            return true
+        }
+    }
+    
     private let interactiveView = UIView()
     private var tapGestureRecognizer: UITapGestureRecognizer!
     private weak var callDurationTimer: Timer? = nil
@@ -81,6 +100,12 @@ final class CallTopOverlayController: UIViewController {
     
     override var prefersStatusBarHidden: Bool {
         return false
+    }
+    
+    override func loadView() {
+        view = TapableAccessibleView(onAccessibilityActivate: { [weak self] in
+            self?.openCall(nil)
+        })
     }
     
     override func viewDidLoad() {
@@ -171,11 +196,6 @@ final class CallTopOverlayController: UIViewController {
     func stopCallDurationTimer() {
         callDurationTimer?.invalidate()
         callDurationTimer = nil
-    }
-    
-    override func accessibilityActivate() -> Bool {
-        openCall(nil)
-        return true
     }
     
     @objc dynamic func openCall(_ sender: UITapGestureRecognizer?) {


### PR DESCRIPTION
## What's new in this PR?

### Issues

In VoiceOver, it was not possible to go back to the call.

### Causes

The `accessibilityActivate` method is not called on the view controller, but on it's view.