### PR TITLE
Fix: iPad - in self client list screen, left navigation bar button is Done, not Back

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
@@ -101,7 +101,7 @@ class ClientListViewController: UIViewController,
     var userObserverToken : NSObjectProtocol?
 
     var leftBarButtonItem: UIBarButtonItem? {
-        if self.traitCollection.userInterfaceIdiom == .pad && UIApplication.shared.keyWindow?.traitCollection.horizontalSizeClass == .regular {
+        if self.isIPadRegular() {
             return UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(ClientListViewController.backPressed(_:)))
         }
 


### PR DESCRIPTION
## What's new in this PR?

self.traitCollection.userInterfaceIdiom is .unspecified when it is checked in init. Replace it with UIDevice.currentuserInterfaceIdiom gives correct idiom.
