### PR TITLE
Start UI: make bottom bar opaque, same color as top bar

### DIFF
--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsView.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsView.swift
@@ -68,7 +68,7 @@ class SearchResultsView : UIView {
             collectionView.top == container.top
             collectionView.left == container.left
             collectionView.right == container.right
-            collectionView.bottom == container.bottom
+            collectionView.bottom == accessoryContainer.top
 
             accessoryContainer.left == container.left
             accessoryContainer.right == container.right

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIInviteActionBar.m
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIInviteActionBar.m
@@ -27,9 +27,9 @@
 
 @interface StartUIInviteActionBar ()
 
+@property (nonatomic) UIVisualEffectView *backgroundView;
 @property (nonatomic, readwrite) Button *inviteButton;
 @property (nonatomic) NSLayoutConstraint *bottomEdgeConstraint;
-@property (nonatomic) UIView *lineView;
 
 @end
 
@@ -42,10 +42,8 @@ static const CGFloat padding = 12;
 {
     self = [super init];
     if (self) {
-        [self setOpaque:NO];
-        self.backgroundColor = [UIColor colorWithRed:0 green:0 blue:0 alpha:0.24];
+        self.backgroundColor = [UIColor wr_colorFromColorScheme:ColorSchemeColorSearchBarBackground variant:ColorSchemeVariantDark];
 
-        [self createLineView];
         [self createInviteButton];
         [self createConstraints];
         
@@ -66,13 +64,6 @@ static const CGFloat padding = 12;
     [self.inviteButton setTitle:NSLocalizedString(@"peoplepicker.invite_more_people", @"") forState:UIControlStateNormal];
 }
 
-- (void)createLineView
-{
-    self.lineView = [[UIView alloc] initForAutoLayout];
-    self.lineView.backgroundColor = [UIColor wr_colorFromColorScheme:ColorSchemeColorSeparator variant:ColorSchemeVariantDark];
-    [self addSubview:self.lineView];
-}
-
 - (void)setHidden:(BOOL)hidden
 {
     [super setHidden:hidden];
@@ -91,11 +82,6 @@ static const CGFloat padding = 12;
     [self.inviteButton autoPinEdgeToSuperviewEdge:ALEdgeTrailing withInset: padding*2];
     [self.inviteButton autoSetDimension:ALDimensionHeight toSize:28];
     self.bottomEdgeConstraint = [self.inviteButton autoPinEdgeToSuperviewEdge:ALEdgeBottom withInset: padding + UIScreen.safeArea.bottom];
-    
-    [self.lineView autoPinEdgeToSuperviewEdge:ALEdgeTop];
-    [self.lineView autoPinEdgeToSuperviewEdge:ALEdgeLeft];
-    [self.lineView autoPinEdgeToSuperviewEdge:ALEdgeRight];
-    [self.lineView autoSetDimension:ALDimensionHeight toSize:0.5];
 }
 
 #pragma mark - UIKeyboard notifications


### PR DESCRIPTION
## What's new in this PR?

### Issues

The bottom bar, that is visible for non-team users only, was transparent, creating the unnecessary text overlap with the content of the start UI.

### Fix

Make the bar opaque and resize the table view, so it ends just before the bar.