### PR TITLE
Fix: compiler warning form wire-bot

### DIFF
--- a/Wire-iOS Tests/DeviceManagement/ProfileViewControllerTests.swift
+++ b/Wire-iOS Tests/DeviceManagement/ProfileViewControllerTests.swift
@@ -19,12 +19,6 @@
 import XCTest
 @testable import Wire
 
-extension MockUser: ZMSearchableUser {
-    public func requestMediumProfileImage(in userSession: ZMUserSession!) {}
-
-    public func requestSmallProfileImage(in userSession: ZMUserSession!) {}
-}
-
 final class ProfileViewControllerTests: ZMSnapshotTestCase {
 
     var sut: ProfileViewController!

--- a/Wire-iOS Tests/Mocks/MockUser+ProfileImage.swift
+++ b/Wire-iOS Tests/Mocks/MockUser+ProfileImage.swift
@@ -1,0 +1,29 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension MockUser: ZMSearchableUser {
+    public func requestMediumProfileImage(in userSession: ZMUserSession!) {
+        // no-op
+    }
+
+    public func requestSmallProfileImage(in userSession: ZMUserSession!) {
+        // no-op
+    }
+}

--- a/Wire-iOS Tests/Mocks/MockUser.m
+++ b/Wire-iOS Tests/Mocks/MockUser.m
@@ -222,16 +222,6 @@ static id<ZMBareUser> mockSelfUser = nil;
     }
 }
 
-- (void)requestSmallProfileImageInUserSession:(ZMUserSession *)userSession
-{
-    // no-op
-}
-
-- (void)requestMediumProfileImageInUserSession:(ZMUserSession *)userSession
-{
-    // no-op
-}
-
 - (NSString *)displayNameInConversation:(MockConversation *)conversation
 {
     return self.displayName;

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1090,6 +1090,7 @@
 		EF27CD9E20C161500077FE55 /* ProfileViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF27CD9B20C161500077FE55 /* ProfileViewControllerTests.swift */; };
 		EF27CD9F20C161500077FE55 /* ProfileClientViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF27CD9C20C161500077FE55 /* ProfileClientViewControllerTests.swift */; };
 		EF27CDA020C161500077FE55 /* ClientListViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF27CD9D20C161500077FE55 /* ClientListViewControllerTests.swift */; };
+		EF29431320C91D57000C16F3 /* MockUser+ProfileImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF29431220C91D57000C16F3 /* MockUser+ProfileImage.swift */; };
 		EF2971582099AD8700EFE6A4 /* SelfProfileViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2971552099AD3000EFE6A4 /* SelfProfileViewControllerTests.swift */; };
 		EF2C189E1FED0D6900E9F2FD /* ConversationCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2C189C1FED0D3000E9F2FD /* ConversationCellTests.swift */; };
 		EF2C18A01FED435600E9F2FD /* ConversationCell+BurstTimestamp.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2C189F1FED435600E9F2FD /* ConversationCell+BurstTimestamp.swift */; };
@@ -2727,6 +2728,7 @@
 		EF27CD9B20C161500077FE55 /* ProfileViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileViewControllerTests.swift; sourceTree = "<group>"; };
 		EF27CD9C20C161500077FE55 /* ProfileClientViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileClientViewControllerTests.swift; sourceTree = "<group>"; };
 		EF27CD9D20C161500077FE55 /* ClientListViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClientListViewControllerTests.swift; sourceTree = "<group>"; };
+		EF29431220C91D57000C16F3 /* MockUser+ProfileImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MockUser+ProfileImage.swift"; sourceTree = "<group>"; };
 		EF2971552099AD3000EFE6A4 /* SelfProfileViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelfProfileViewControllerTests.swift; sourceTree = "<group>"; };
 		EF2C189C1FED0D3000E9F2FD /* ConversationCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationCellTests.swift; sourceTree = "<group>"; };
 		EF2C189F1FED435600E9F2FD /* ConversationCell+BurstTimestamp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationCell+BurstTimestamp.swift"; sourceTree = "<group>"; };
@@ -4136,6 +4138,9 @@
 				87BEB0DA1C734D710094BFE9 /* MockUser.h */,
 				87BEB0DB1C734D710094BFE9 /* MockUser.m */,
 				EF9B950220BEBD4B000D4CA1 /* MockUser+AccentColorProvider.swift */,
+				EF1EA4611FB0934D00B53063 /* MockUser+filename.swift */,
+				EF7CCAFC204E96390050325B /* MockUser+PointOfView.swift */,
+				EF29431220C91D57000C16F3 /* MockUser+ProfileImage.swift */,
 				87BEB0DE1C734DA60094BFE9 /* MockLoader.h */,
 				87BEB0DF1C734DA60094BFE9 /* MockLoader.m */,
 				87BEB0E11C734DB60094BFE9 /* MockMessage.swift */,
@@ -4145,8 +4150,6 @@
 				87D553671C86F0450026573C /* MockUserClient.m */,
 				EF01AF8320BED38300E5E5B4 /* MockUserClient+RemoteIdentifier.swift */,
 				F127BD581E265FB40093B2F1 /* MockCollection.swift */,
-				EF1EA4611FB0934D00B53063 /* MockUser+filename.swift */,
-				EF7CCAFC204E96390050325B /* MockUser+PointOfView.swift */,
 				EF106E84204D8B4200B9F0F6 /* MockDevice.swift */,
 				EF4018BF2059761D00CFBCB0 /* MockApplication.swift */,
 				1658C19520A1E2FA00148F6D /* MockVoiceChannel.swift */,
@@ -7245,6 +7248,7 @@
 				7C9E291A2074F3F100827819 /* EmailVerificationStepViewControllerTests.swift in Sources */,
 				EF1EA4631FB0937000B53063 /* MockUser+filename.swift in Sources */,
 				AF65A25C1D7E202D00EBA38E /* ReactionsListViewControllerTests.swift in Sources */,
+				EF29431320C91D57000C16F3 /* MockUser+ProfileImage.swift in Sources */,
 				EF15A7B420BC304A00A045C7 /* SavableImageTests.swift in Sources */,
 				BFE2542720BE9EA200F62041 /* CallHapticsControllerTests.swift in Sources */,
 				D58192052091F34E003BA7EC /* CallActionsViewTests.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

Remove duplicated methods of MockUser.