### PR TITLE
Fix video not being paused when multitasking after upgrade from audio to video

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -116,13 +116,13 @@ final class CallViewController: UIViewController {
     }
 
     @objc private func resumeVideoIfNeeded() {
-        guard voiceChannel.isVideoCall, voiceChannel.videoState.isPaused else { return }
+        guard voiceChannel.videoState.isPaused else { return }
         voiceChannel.videoState = .started
         updateConfiguration()
     }
 
     @objc private func pauseVideoIfNeeded() {
-        guard voiceChannel.isVideoCall, voiceChannel.videoState.isSending else { return }
+        guard voiceChannel.videoState.isSending else { return }
         voiceChannel.videoState = .paused
         updateConfiguration()
     }


### PR DESCRIPTION
## What's new in this PR?

* Don't rely on `VoiceChannel.isVideoCall` which only captures the initial state to decide to pause / start the self video feed.
