### PR TITLE
Fix: incorrect conversation table header height after changing accent color

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1122,6 +1122,7 @@
 		EF7D75A6201B6149003A8AF8 /* DeviceNativeBoundsSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF7D75A5201B6149003A8AF8 /* DeviceNativeBoundsSize.swift */; };
 		EF7E53C7209765E900EA8357 /* TextView.m in Sources */ = {isa = PBXBuildFile; fileRef = 1EE9DCA91B5F9A6D00E347DF /* TextView.m */; };
 		EF7F74041FCC033D0059C13F /* EmailAdresssValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF7F74021FCC01140059C13F /* EmailAdresssValidatorTests.swift */; };
+		EF80461E20CA8B67001A1C53 /* ConversationContentViewController+TableHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF80461D20CA8B67001A1C53 /* ConversationContentViewController+TableHeader.swift */; };
 		EF80C0022097106D00E0040B /* ZMConversationMessageWindow+Formatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF80C0012097106D00E0040B /* ZMConversationMessageWindow+Formatting.swift */; };
 		EF80C0042097151C00E0040B /* ZMConversationMessageWindowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF80C0032097151C00E0040B /* ZMConversationMessageWindowTests.swift */; };
 		EF91A0561FF3A05A00FE2F53 /* GiphySearchViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF91A0541FF3A04700FE2F53 /* GiphySearchViewControllerTests.swift */; };
@@ -2765,6 +2766,7 @@
 		EF7CCAFC204E96390050325B /* MockUser+PointOfView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MockUser+PointOfView.swift"; sourceTree = "<group>"; };
 		EF7D75A5201B6149003A8AF8 /* DeviceNativeBoundsSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceNativeBoundsSize.swift; sourceTree = "<group>"; };
 		EF7F74021FCC01140059C13F /* EmailAdresssValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailAdresssValidatorTests.swift; sourceTree = "<group>"; };
+		EF80461D20CA8B67001A1C53 /* ConversationContentViewController+TableHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationContentViewController+TableHeader.swift"; sourceTree = "<group>"; };
 		EF80C0012097106D00E0040B /* ZMConversationMessageWindow+Formatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversationMessageWindow+Formatting.swift"; sourceTree = "<group>"; };
 		EF80C0032097151C00E0040B /* ZMConversationMessageWindowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMConversationMessageWindowTests.swift; sourceTree = "<group>"; };
 		EF91A0541FF3A04700FE2F53 /* GiphySearchViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiphySearchViewControllerTests.swift; sourceTree = "<group>"; };
@@ -4733,6 +4735,7 @@
 				8FC851A9199245760008B66B /* ConversationContentViewController.h */,
 				8FC851A6199245760008B66B /* ConversationContentViewController+Private.h */,
 				8FC851AA199245760008B66B /* ConversationContentViewController.m */,
+				EF80461D20CA8B67001A1C53 /* ConversationContentViewController+TableHeader.swift */,
 				EF15A7AF20BC08C000A045C7 /* ConversationContentViewController+SaveImage.swift */,
 				BFE277621D5B4FC50074DC6D /* ConversationContentViewController+MessageDeletion.swift */,
 				876113EA1DD1FEC4007F5969 /* ConversationContentViewController+Forward.swift */,
@@ -6567,6 +6570,7 @@
 				162936BF1F4714D200D4F386 /* AppRootViewController.swift in Sources */,
 				F12CDADE1E43868200CEFCEB /* ChangeEmailViewController.swift in Sources */,
 				87D679E81EBC8D1E005BEB4C /* ConversationListViewController+CameraPicker.swift in Sources */,
+				EF80461E20CA8B67001A1C53 /* ConversationContentViewController+TableHeader.swift in Sources */,
 				8715F22D1F86758E006F3935 /* AnalyticsMixpanelProvider.swift in Sources */,
 				8745476B1E9E54E600C206E5 /* SelfProfileViewController.swift in Sources */,
 				871BC2591D34F8F800DF0793 /* VerticalTransition.m in Sources */,

--- a/Wire-iOS/Sources/UserInterface/Components/Views/UpsideDownTableView.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/UpsideDownTableView.m
@@ -63,11 +63,21 @@
     [super setTableFooterView:tableHeaderView];
 }
 
+- (UIView *)tableHeaderView
+{
+    return super.tableFooterView;
+}
+
 - (void)setTableFooterView:(UIView *)tableFooterView
 {
     tableFooterView.transform = CGAffineTransformMakeScale(1, -1);
     
     [super setTableHeaderView:tableFooterView];
+}
+
+- (UIView *)tableFooterView
+{
+    return super.tableHeaderView;
 }
 
 - (id)dequeueReusableCellWithIdentifier:(NSString *)identifier

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Private.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Private.h
@@ -46,6 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)removeHighlightsAndMenu;
 - (nullable ConversationCell *)cellForMessage:(id<ZMConversationMessage>)message;
+- (CGFloat)headerHeight;
 
 @end
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+TableHeader.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+TableHeader.swift
@@ -27,7 +27,7 @@ extension ConversationContentViewController {
     }
 
     func updateHeaderHeight() {
-        if let headerView = tableView.tableFooterView {
+        if let headerView = tableView.tableHeaderView {
             headerView.frame = headerViewFrame(view: headerView)
             tableView.tableHeaderView = headerView
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+TableHeader.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+TableHeader.swift
@@ -1,0 +1,35 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import UIKit
+
+extension ConversationContentViewController {
+    @objc func headerRequiredSize(headerView: UIView) -> CGSize {
+        let fittingSize = CGSize(width: tableView.bounds.size.width, height: headerHeight())
+        let requiredSize = headerView.systemLayoutSizeFitting(fittingSize, withHorizontalFittingPriority: UILayoutPriorityRequired, verticalFittingPriority: UILayoutPriorityDefaultLow)
+
+        return requiredSize
+    }
+
+    func updateHeaderHeight() {
+        if let headerView = tableView.tableFooterView {
+            headerView.frame = CGRect(origin: .zero, size: headerRequiredSize(headerView: headerView))
+            tableView.tableHeaderView = headerView
+        }
+    }
+}

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+TableHeader.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+TableHeader.swift
@@ -19,16 +19,16 @@
 import UIKit
 
 extension ConversationContentViewController {
-    @objc func headerRequiredSize(headerView: UIView) -> CGSize {
+    @objc func headerViewFrame(view: UIView) -> CGRect {
         let fittingSize = CGSize(width: tableView.bounds.size.width, height: headerHeight())
-        let requiredSize = headerView.systemLayoutSizeFitting(fittingSize, withHorizontalFittingPriority: UILayoutPriorityRequired, verticalFittingPriority: UILayoutPriorityDefaultLow)
+        let requiredSize = view.systemLayoutSizeFitting(fittingSize, withHorizontalFittingPriority: UILayoutPriorityRequired, verticalFittingPriority: UILayoutPriorityDefaultLow)
 
-        return requiredSize
+        return CGRect(origin: .zero, size: requiredSize)
     }
 
     func updateHeaderHeight() {
         if let headerView = tableView.tableFooterView {
-            headerView.frame = CGRect(origin: .zero, size: headerRequiredSize(headerView: headerView))
+            headerView.frame = headerViewFrame(view: headerView)
             tableView.tableHeaderView = headerView
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -213,7 +213,6 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
 
     [self scrollToLastUnreadMessageIfNeeded];
     UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, nil);
-    [self updateHeaderHeight];
 }
 
 - (void)viewWillDisappear:(BOOL)animated

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -198,6 +198,8 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
     }
     
     self.messagePresenter.modalTargetController = self.parentViewController;
+
+    [self updateHeaderHeight];
 }
 
 - (void)viewDidAppear:(BOOL)animated
@@ -211,6 +213,7 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
 
     [self scrollToLastUnreadMessageIfNeeded];
     UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, nil);
+    [self updateHeaderHeight];
 }
 
 - (void)viewWillDisappear:(BOOL)animated
@@ -272,8 +275,8 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
 
 - (void)setConversationHeaderView:(UIView *)headerView
 {
-    CGSize fittingSize = CGSizeMake(self.tableView.bounds.size.width, self.headerHeight);
-    CGSize requiredSize = [headerView systemLayoutSizeFittingSize:fittingSize withHorizontalFittingPriority:UILayoutPriorityRequired verticalFittingPriority:UILayoutPriorityDefaultLow];
+    CGSize requiredSize = [self headerRequiredSizeWithHeaderView:headerView];
+
     headerView.frame = CGRectMake(0, 0, requiredSize.width, requiredSize.height);
     self.tableView.tableHeaderView = headerView;
 }
@@ -285,7 +288,12 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
         UITableViewCell *cell = [self cellForMessage:self.messageWindow.messages.firstObject];
         height += CGRectGetHeight(cell.bounds);
     }
-    
+
+    if (self.tableView.bounds.size.height <= 0) {
+        [self.tableView setNeedsLayout];
+        [self.tableView layoutIfNeeded];
+    }
+
     return self.tableView.bounds.size.height - height;
 }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -275,9 +275,7 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
 
 - (void)setConversationHeaderView:(UIView *)headerView
 {
-    CGSize requiredSize = [self headerRequiredSizeWithHeaderView:headerView];
-
-    headerView.frame = CGRectMake(0, 0, requiredSize.width, requiredSize.height);
+    headerView.frame = [self headerViewFrameWithView:headerView];
     self.tableView.tableHeaderView = headerView;
 }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

Conversation table 's table header's height is incorrect after accent color is updated.

### Causes

If ConversationContentViewController is created behind other views, its table view's frame is zero and the table view's header view's header is wrongly calculated.

### Solutions

Refresh table view's header view's height when viewWillAppear.

