### PR TITLE
ZIOS-10057: Fix VoiceOver and audio session for calls

### DIFF
--- a/Wire-iOS/Sources/Helpers/sound/AVSMediaManager+Additions.h
+++ b/Wire-iOS/Sources/Helpers/sound/AVSMediaManager+Additions.h
@@ -50,4 +50,7 @@ FOUNDATION_EXPORT void MediaManagerPlayAlert(void);
 - (void)configureSounds;
 - (void)configureDefaultSounds;
 
+- (void)enableCallingAudioSessionForVideoCall:(BOOL)isVideoCall;
+- (void)disableCallingAudioSession;
+
 @end

--- a/Wire-iOS/Sources/Helpers/sound/AVSMediaManager+Additions.m
+++ b/Wire-iOS/Sources/Helpers/sound/AVSMediaManager+Additions.m
@@ -90,4 +90,17 @@ static NSDictionary *MediaManagerSoundConfig = nil;
     [self configureCustomSounds];
 }
 
+- (void)enableCallingAudioSessionForVideoCall:(BOOL)isVideoCall
+{
+    NSString *mode = isVideoCall ? AVAudioSessionModeVideoChat : AVAudioSessionModeVoiceChat;
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord error:nil];
+    [[AVAudioSession sharedInstance] setMode:mode error:nil];
+}
+
+- (void)disableCallingAudioSession
+{
+    [[AVAudioSession sharedInstance] setMode:AVAudioSessionModeDefault error:nil];
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryAmbient error:nil];
+}
+
 @end

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -265,6 +265,7 @@ extension CallViewController {
             }
 
             self.checkVideoPermissions { videoGranted in
+                self.mediaManager.enableCallingAudioSession(forVideoCall: videoGranted)
                 self.conversation?.joinVoiceChannel(video: videoGranted)
                 self.disableVideoIfNeeded()
             }
@@ -318,7 +319,9 @@ extension CallViewController: CallInfoRootViewControllerDelegate {
         case .continueDegradedCall: userSession.enqueueChanges { self.voiceChannel.continueByDecreasingConversationSecurity(userSession: userSession) }
         case .acceptCall: acceptCallIfPossible()
         case .acceptDegradedCall: acceptDegradedCall()
-        case .terminateCall: voiceChannel.leave(userSession: userSession)
+        case .terminateCall:
+            voiceChannel.leave(userSession: userSession)
+            mediaManager.disableCallingAudioSession()
         case .terminateDegradedCall: userSession.enqueueChanges { self.voiceChannel.leaveAndKeepDegradedConversationSecurity(userSession: userSession) }
         case .toggleMuteState: voiceChannel.toggleMuteState(userSession: userSession)
         case .toggleSpeakerState: AVSMediaManager.sharedInstance().toggleSpeaker()


### PR DESCRIPTION
## What's new in this PR?

### Issues

When joining a call, the system will play the VoiceOver announcements at a very low level (basically inaudible unless you put the speaker next to your ear).

### Causes

After investigation, it appeared that the system audio was not mixed correctly with the call audio.

### Solutions

We set the system`AVAudioSession` mode to voice/video chat depending on the call type before joining the voice session. This allows the system to know it needs to mix important system announcements such as VoiceOver with the call audio.

We enable this mode when joining a call, and return to the default mode when terminating it.

## Notes

We need to check if we need to set the mode from `acceptDegradedCall` and `terminateDegradedCall`.