### PR TITLE
Fix async view change without animation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoPreviewView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoPreviewView.swift
@@ -90,8 +90,6 @@ final class VideoPreviewView: UIView, AVSIdentifierProvider {
     }
 
     private func updateState(animated: Bool = false) {
-        let duration: TimeInterval = animated ? 0.2 : 0
-        
         if isPaused {
             createSnapshotView()
             blurView.effect = nil
@@ -99,25 +97,45 @@ final class VideoPreviewView: UIView, AVSIdentifierProvider {
             blurView.isHidden = false
             pausedLabel.isHidden = false
 
-            UIView.animate(withDuration: duration, animations: { [weak self] in
+            let animationBlock = { [weak self] in
                 self?.blurView.effect = UIBlurEffect(style: .dark)
                 self?.pausedLabel.alpha = 1
-            }, completion: { [weak self] _ in
+            }
+            
+            let completionBlock = { [weak self] (_: Bool) -> () in
                 self?.previewView?.removeFromSuperview()
                 self?.previewView = nil
-            })
+            }
+            
+            if animated {
+                UIView.animate(withDuration: 0.2, animations: animationBlock, completion: completionBlock)
+            }
+            else {
+                animationBlock()
+                completionBlock(true)
+            }
         } else {
             createPreviewView()
-            UIView.animate(withDuration: duration, animations: { [weak self] in
+            let animationBlock = { [weak self] in
                 self?.blurView.effect = nil
                 self?.snapshotView?.alpha = 0
                 self?.pausedLabel.alpha = 0
-            }, completion: { [weak self] _ in
+            }
+            
+            let completionBlock =  { [weak self] (_: Bool) -> () in
                 self?.snapshotView?.removeFromSuperview()
                 self?.snapshotView = nil
                 self?.blurView.isHidden = true
                 self?.pausedLabel.isHidden = true
-            })
+            }
+            
+            if animated {
+                UIView.animate(withDuration: 0.2, animations: animationBlock, completion: completionBlock)
+            }
+            else {
+                animationBlock()
+                completionBlock(true)
+            }
         }
     }
 

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -43,19 +43,19 @@ extension ZClientViewController {
             else {
                 let heightConstraint = topOverlayContainer.heightAnchor.constraint(equalToConstant: 0)
 
-                UIView.wr_animate(easing: RBBEasingFunctionEaseInExpo, duration: 0.35, delay: 0, animations: {
+                UIView.animate(withDuration: 0.35, delay: 0, options: [.curveEaseIn, .beginFromCurrentState], animations: {
                     heightConstraint.isActive = true
                     
                     self.view.setNeedsLayout()
                     self.view.layoutIfNeeded()
-                }, options: .beginFromCurrentState, completion: { completed in
+                }) { _ in
                     heightConstraint.autoRemove()
                     
                     self.topOverlayViewController?.removeFromParentViewController()
                     previousViewController.view.removeFromSuperview()
                     self.topOverlayViewController = nil
                     self.updateSplitViewTopConstraint()
-                })
+                }
             }
         }
         else if let viewController = viewController {
@@ -79,13 +79,13 @@ extension ZClientViewController {
                 self.view.setNeedsLayout()
                 self.view.layoutIfNeeded()
                 
-                UIView.wr_animate(easing: RBBEasingFunctionEaseOutExpo, duration: 0.35, delay: 0.5, animations: {
+                UIView.animate(withDuration: 0.35, delay: 0, options: [.curveEaseOut, .beginFromCurrentState], animations: {
                     heightConstraint.autoRemove()
                     self.view.setNeedsLayout()
                     self.view.layoutIfNeeded()
-                }, options: .beginFromCurrentState, completion: { _ in
+                }) { _ in
                     UIApplication.shared.wr_updateStatusBarForCurrentControllerAnimated(animated)
-                })
+                }
             }
             else {
                 UIApplication.shared.wr_updateStatusBarForCurrentControllerAnimated(animated)


### PR DESCRIPTION
## What's new in this PR?

### Issues

QA noticed, that when user is switching from and to the call where the remote participant stopped the video, the label that says "video stopped" is disappearing.

### Causes

The update block was designed in the way that even when no animation was desired (for example when setting the initial state), the animation was still performed with duration of 0. This caused the unnecessary async update effect: the animation completion block was called on the Nth run loop after the update. The update of view is happening in 2 steps: first we set initial "default" state, where the video is not considered stopped, and then we update the view with the real values. The problem happened because we called two updates one by one, but the animation completion blocks for 1st update where called after the 2nd update (to the current actual state) was done.

### Solutions

Refactor the update method to do all updates inline when the animation was not desired.

## Notes

Also simplified the animation for the top bar, seems to cause the issues where the app becomes frozen.