### PR TITLE
ZIOS-9798: Add guest icon to guests in share screen, personal accounts

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
@@ -25,7 +25,10 @@ extension ZMConversation: ShareDestination {
     
     public var showsGuestIcon: Bool {
         return self.conversationType == .oneOnOne &&
-            self.activeParticipants.first { $0 is ZMUser && ($0 as! ZMUser).isGuest(in: self) } != nil
+            self.activeParticipants.first {
+                guard let user = $0 as? ZMUser else { return false }
+                return user.hasTeam && user.isGuest(in: self)
+            } != nil
     }
     
     public var avatarView: UIView? {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
@@ -24,11 +24,10 @@ import Cartography
 extension ZMConversation: ShareDestination {
     
     public var showsGuestIcon: Bool {
-        return self.conversationType == .oneOnOne &&
+        return ZMUser.selfUser().hasTeam &&
+            self.conversationType == .oneOnOne &&
             self.activeParticipants.first {
-                guard let user = $0 as? ZMUser else { return false }
-                return user.hasTeam && user.isGuest(in: self)
-            } != nil
+                $0 is ZMUser && ($0 as! ZMUser).isGuest(in: self) } != nil
     }
     
     public var avatarView: UIView? {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Personal accounts could see the Guest icon inside `ShareViewController`, which should be visible only to team accounts.

### Solutions

I've added a `hasTeam` clause to the conditions of the `showsGuestIcon` variable.
