### PR TITLE
ZIOS-10059: Soundcloud still plays when switching accounts

### DIFF
--- a/Wire-iOS/Sources/Components/AudioPlayer/AudioTrackPlayer.m
+++ b/Wire-iOS/Sources/Components/AudioPlayer/AudioTrackPlayer.m
@@ -57,8 +57,6 @@ static NSString* EmptyStringIfNil(NSString *string) {
     [self.avPlayer removeObserver:self forKeyPath:@"status"];
     [self.avPlayer removeObserver:self forKeyPath:@"rate"];
     [self.avPlayer removeObserver:self forKeyPath:@"currentItem"];
-    
-    [self.avPlayer.currentItem removeObserver:self forKeyPath:@"status"];
 }
 
 - (instancetype)init

--- a/Wire-iOS/Sources/UserInterface/SelfProfile/AccountSelectorController.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/AccountSelectorController.swift
@@ -71,6 +71,7 @@ extension AccountSelectorController: AccountSelectorViewDelegate {
             AppDelegate.shared().rootViewController.confirmSwitchingAccount { (confirmed) in
                 if confirmed {
                     ZClientViewController.shared()?.conversationListViewController.dismiss(animated: true, completion: {
+                        AppDelegate.shared().mediaPlaybackManager?.stop()
                         SessionManager.shared?.select(account)
                     })
                 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

1. If Soundcloud is playing and the user wants to switch to other accounts, the player still plays the song. If the user comes back to the previous account is not possible to stop the music.
2. In that case, Soundcloud crashes when the song ends.

### Causes

1. We weren't specifying the song to stop playing on account switch
2. We are trying to remove the observer for keypath `status` in `self.avPlayer.currentItem`, which wasn't added before in any point of the code (but still calls the observation methods).

### Solutions

1. I'm calling `stop()` on the shared instance of `mediaPlaybackManager`.
2. I've removed the call to `removeObserver` on `self.avPlayer.currentItem`. Question: is it enough removing the observer about `currentItem` inside `avPlayer`, like we're doing in the line before?
