### PR TITLE
Improve interpolation of color scheme API in Swift

### DIFF
--- a/Wire-iOS Tests/AudioEffectsPickerViewControllerTests.swift
+++ b/Wire-iOS Tests/AudioEffectsPickerViewControllerTests.swift
@@ -45,7 +45,7 @@ class AudioEffectsPickerViewControllerTests: ZMSnapshotTestCase {
         
         let container = UIView()
         container.addSubview(self.sut.view)
-        container.backgroundColor = ColorScheme.default().color(withName: ColorSchemeColorTextForeground, variant: .light)
+        container.backgroundColor = UIColor(scheme: .textForeground, variant: .light)
 
         constrain(self.sut.view, container) { view, container in
             container.height == 216

--- a/Wire-iOS Tests/CameraKeyboardViewControllerTests.swift
+++ b/Wire-iOS Tests/CameraKeyboardViewControllerTests.swift
@@ -86,7 +86,7 @@ final class CameraKeyboardViewControllerTests: CoreDataSnapshotTestCase {
         
         let container = UIView()
         container.addSubview(self.sut.view)
-        container.backgroundColor = ColorScheme.default().color(withName: ColorSchemeColorTextForeground, variant: .light)
+        container.backgroundColor = UIColor(scheme: .textForeground, variant: .light)
         
         constrain(self.sut.view, container) { view, container in
             container.height == size.height

--- a/Wire-iOS Tests/DeviceManagement/ClientListViewControllerTests.swift
+++ b/Wire-iOS Tests/DeviceManagement/ClientListViewControllerTests.swift
@@ -42,7 +42,7 @@ final class ClientListViewControllerTests: ZMSnapshotTestCase {
         client = nil
         selfClient = nil
 
-        ColorScheme.default().variant = .light
+        ColorScheme.default.variant = .light
 
         super.tearDown()
     }

--- a/Wire-iOS Tests/DeviceManagement/ProfileClientViewControllerTests.swift
+++ b/Wire-iOS Tests/DeviceManagement/ProfileClientViewControllerTests.swift
@@ -40,13 +40,13 @@ final class ProfileClientViewControllerTests: ZMSnapshotTestCase {
         user = nil
         client = nil
 
-        ColorScheme.default().variant = .light
+        ColorScheme.default.variant = .light
 
         super.tearDown()
     }
 
     func testTestForLightTheme(){
-        ColorScheme.default().variant = .light
+        ColorScheme.default.variant = .light
         
         sut = ProfileClientViewController(client: client)
         sut.spinner.stopAnimating()
@@ -57,7 +57,7 @@ final class ProfileClientViewControllerTests: ZMSnapshotTestCase {
     }
 
     func testTestForDarkTheme(){
-        ColorScheme.default().variant = .dark
+        ColorScheme.default.variant = .dark
 
         sut = ProfileClientViewController(client: client)
         sut.spinner.stopAnimating()

--- a/Wire-iOS Tests/MarkdownTextViewTests.swift
+++ b/Wire-iOS Tests/MarkdownTextViewTests.swift
@@ -30,7 +30,7 @@ final class MarkdownTextViewTests: XCTestCase {
         super.setUp()
         style = DownStyle()
         style.baseFont = FontSpec(.normal, .regular).font!
-        style.baseFontColor = ColorScheme.default().color(withName: ColorSchemeColorTextForeground)
+        style.baseFontColor = UIColor(scheme: .textForeground)
         style.codeFont = UIFont(name: "Menlo", size: style.baseFont.pointSize) ?? style.baseFont
         style.codeColor = UIColor.red
         style.baseParagraphStyle = NSParagraphStyle.default

--- a/Wire-iOS Tests/TextMessageCellTests.swift
+++ b/Wire-iOS Tests/TextMessageCellTests.swift
@@ -35,7 +35,7 @@ class TextMessageCellTests: ZMSnapshotTestCase {
 
     override func setUp() {
         super.setUp()
-        snapshotBackgroundColor = ColorScheme.default().color(withName: ColorSchemeColorContentBackground)
+        snapshotBackgroundColor = UIColor(scheme: .contentBackground)
         accentColor = .strongBlue
         sut = TextMessageCell(style: .default, reuseIdentifier: name)
         sut.layer.speed = 0

--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -366,7 +366,7 @@ import Classy
 
     func setupClassy(with windows: [UIWindow]) {
 
-        let colorScheme = ColorScheme.default()
+        let colorScheme = ColorScheme.default
         colorScheme.accentColor = UIColor.accent()
         colorScheme.variant = ColorSchemeVariant(rawValue: Settings.shared().colorScheme.rawValue) ?? .light
 

--- a/Wire-iOS/Sources/Components/ShareViewController/ShareDestinationCell.swift
+++ b/Wire-iOS/Sources/Components/ShareViewController/ShareDestinationCell.swift
@@ -143,6 +143,6 @@ final class ShareDestinationCell<D: ShareDestination>: UITableViewCell {
         super.setSelected(selected, animated: animated)
         
         self.checkImageView.image = selected ? UIImage(for: .checkmark, iconSize: .like, color: .white) : nil
-        self.checkImageView.backgroundColor = selected ? ColorScheme.default().color(withName: ColorSchemeColorAccent) : UIColor.clear
+        self.checkImageView.backgroundColor = selected ? UIColor(scheme: .accent) : UIColor.clear
     }
 }

--- a/Wire-iOS/Sources/Components/ShareViewController/ShareViewController+Views.swift
+++ b/Wire-iOS/Sources/Components/ShareViewController/ShareViewController+Views.swift
@@ -43,8 +43,8 @@ extension ShareViewController {
         self.tokenField.textColor = .white
         self.tokenField.clipsToBounds = true
         self.tokenField.layer.cornerRadius = 4
-        self.tokenField.tokenTitleColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: .dark)
-        self.tokenField.tokenSelectedTitleColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: .dark)
+        self.tokenField.tokenTitleColor = UIColor(scheme: .textForeground, variant: .dark)
+        self.tokenField.tokenSelectedTitleColor = UIColor(scheme: .textForeground, variant: .dark)
         self.tokenField.tokenTitleVerticalAdjustment = 1
         self.tokenField.textView.placeholderTextAlignment = .natural
         self.tokenField.textView.accessibilityIdentifier = "textViewSearch"
@@ -53,7 +53,7 @@ extension ShareViewController {
         self.tokenField.textView.returnKeyType = .done
         self.tokenField.textView.autocorrectionType = .no
         self.tokenField.textView.textContainerInset = UIEdgeInsets(top: 9, left: 40, bottom: 11, right: 12)
-        self.tokenField.textView.backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTokenFieldBackground, variant: .dark)
+        self.tokenField.textView.backgroundColor = UIColor(scheme: .tokenFieldBackground, variant: .dark)
         self.tokenField.delegate = self
 
         self.destinationsTableView.backgroundColor = .clear

--- a/Wire-iOS/Sources/Helpers/UILabel+Convenience.swift
+++ b/Wire-iOS/Sources/Helpers/UILabel+Convenience.swift
@@ -23,12 +23,12 @@ extension UILabel {
         key: String? = nil,
         size: FontSize = .normal,
         weight: FontWeight = .regular,
-        color: String,
-        variant: ColorSchemeVariant = ColorScheme.default().variant
+        color: ColorSchemeColor,
+        variant: ColorSchemeVariant = ColorScheme.default.variant
         ) {
         self.init(frame: .zero)
         text = key.map { $0.localized }
         font = FontSpec(size, weight).font
-        textColor = ColorScheme.default().color(withName: color, variant: variant)
+        textColor = UIColor(scheme: color, variant: variant)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
@@ -102,7 +102,7 @@ public class AddParticipantsViewController: UIViewController {
         self.init(context: .add(conversation))
     }
         
-    public init(context: Context, variant: ColorSchemeVariant = ColorScheme.default().variant) {
+    public init(context: Context, variant: ColorSchemeVariant = ColorScheme.default.variant) {
         self.variant = variant
         
         viewModel = AddParticipantsViewModel(with: context, variant: variant)
@@ -121,10 +121,10 @@ public class AddParticipantsViewController: UIViewController {
 
         confirmButton = IconButton()
         confirmButton.setIcon(ZetaIconType.convMetaAddPerson, with: .tiny, for: .normal)
-        confirmButton.setIconColor(UIColor.wr_color(fromColorScheme: ColorSchemeColorIconNormal, variant: .dark), for: .normal)
-        confirmButton.setIconColor(UIColor.wr_color(fromColorScheme: ColorSchemeColorIconHighlighted, variant: .dark), for: .highlighted)
-        confirmButton.setTitleColor(UIColor.wr_color(fromColorScheme: ColorSchemeColorIconNormal, variant: .dark), for: .normal)
-        confirmButton.setTitleColor(UIColor.wr_color(fromColorScheme: ColorSchemeColorIconHighlighted, variant: .dark), for: .highlighted)
+        confirmButton.setIconColor(UIColor(scheme: .iconNormal, variant: .dark), for: .normal)
+        confirmButton.setIconColor(UIColor(scheme: .iconHighlighted, variant: .dark), for: .highlighted)
+        confirmButton.setTitleColor(UIColor(scheme: .iconNormal, variant: .dark), for: .normal)
+        confirmButton.setTitleColor(UIColor(scheme: .iconHighlighted, variant: .dark), for: .highlighted)
         confirmButton.titleLabel?.font = FontSpec(.small, .medium).font!
         confirmButton.backgroundColor = UIColor.accent()
         confirmButton.contentHorizontalAlignment = .left
@@ -148,7 +148,7 @@ public class AddParticipantsViewController: UIViewController {
         updateValues()
 
         emptyResultLabel.text = everyoneHasBeenAddedText
-        emptyResultLabel.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: self.variant)
+        emptyResultLabel.textColor = UIColor(scheme: .textForeground, variant: self.variant)
         emptyResultLabel.font = FontSpec(.normal, .none).font!
         
         confirmButton.addTarget(self, action: #selector(searchHeaderViewControllerDidConfirmAction(_:)), for: .touchUpInside)
@@ -193,10 +193,10 @@ public class AddParticipantsViewController: UIViewController {
         view.addSubview(searchResultsViewController.view)
         searchResultsViewController.didMove(toParentViewController: self)
         searchResultsViewController.searchResultsView?.emptyResultView = emptyResultLabel
-        searchResultsViewController.searchResultsView?.backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorContentBackground, variant: self.variant)
+        searchResultsViewController.searchResultsView?.backgroundColor = UIColor(scheme: .contentBackground, variant: self.variant)
         searchResultsViewController.searchResultsView?.collectionView.accessibilityIdentifier = "add_participants.list"
         
-        view.backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorContentBackground, variant: self.variant)
+        view.backgroundColor = UIColor(scheme: .contentBackground, variant: self.variant)
         
         createConstraints()
         updateSelectionValues()

--- a/Wire-iOS/Sources/UserInterface/Availability/AvailabilityStringBuilder.swift
+++ b/Wire-iOS/Sources/UserInterface/Availability/AvailabilityStringBuilder.swift
@@ -33,12 +33,12 @@
 
                 fontSize = .normal
                 if color == nil {
-                    color = ColorScheme.default().color(withName: ColorSchemeColorTextForeground, variant: .dark)
+                    color = UIColor(scheme: .textForeground, variant: .dark)
                 }
             }
             case .participants: do {
                 title = user.displayName.uppercased()
-                color = ColorScheme.default().color(withName: ColorSchemeColorTextForeground)
+                color = UIColor(scheme: .textForeground)
             }
             case .placeholder: do {
                 if availability != .none { //Should use the default placeholder string

--- a/Wire-iOS/Sources/UserInterface/Availability/AvailabilityTitleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Availability/AvailabilityTitleView.swift
@@ -37,12 +37,12 @@ import WireDataModel
         
         if style == .selfProfile || style == .header {
             let variant = ColorSchemeVariant.dark
-            titleColor = ColorScheme.default().color(withName: ColorSchemeColorTextForeground, variant: variant)
-            titleColorSelected = ColorScheme.default().color(withName: ColorSchemeColorTextDimmed, variant: variant)
+            titleColor = UIColor(scheme: .textForeground, variant: variant)
+            titleColorSelected = UIColor(scheme: .textDimmed, variant: variant)
         } else {
             //otherwise, take the default variant
-            titleColor = ColorScheme.default().color(withName: ColorSchemeColorTextForeground)
-            titleColorSelected = ColorScheme.default().color(withName: ColorSchemeColorTextDimmed)
+            titleColor = UIColor(scheme: .textForeground)
+            titleColorSelected = UIColor(scheme: .textDimmed)
         }
         
         var titleFont : UIFont?

--- a/Wire-iOS/Sources/UserInterface/Calling/CallActionsView/CallActionAppearance.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallActionsView/CallActionAppearance.swift
@@ -30,29 +30,29 @@ enum CallActionAppearance: Equatable {
     
     var backgroundColorNormal: UIColor {
         switch self {
-        case .light: return UIColor.wr_color(fromColorScheme: ColorSchemeColorGraphite, variant: .light).withAlphaComponent(0.08)
+        case .light: return UIColor(scheme: .graphite, variant: .light).withAlphaComponent(0.08)
         case .dark: return UIColor.white.withAlphaComponent(0.24)
         }
     }
     
     var backgroundColorSelected: UIColor {
         switch self {
-        case .light: return .wr_color(fromColorScheme: ColorSchemeColorIconNormal, variant: .light)
-        case .dark: return .wr_color(fromColorScheme: ColorSchemeColorIconNormal, variant: .dark)
+        case .light: return UIColor(scheme: .iconNormal, variant: .light)
+        case .dark: return UIColor(scheme: .iconNormal, variant: .dark)
         }
     }
     
     var iconColorNormal: UIColor {
         switch self {
-        case .light: return .wr_color(fromColorScheme: ColorSchemeColorIconNormal, variant: .light)
-        case .dark: return .wr_color(fromColorScheme: ColorSchemeColorIconNormal, variant: .dark)
+        case .light: return UIColor(scheme: .iconNormal, variant: .light)
+        case .dark: return UIColor(scheme: .iconNormal, variant: .dark)
         }
     }
     
     var iconColorSelected: UIColor {
         switch self {
-        case .light: return .wr_color(fromColorScheme: ColorSchemeColorIconNormal, variant: .dark)
-        case .dark: return .wr_color(fromColorScheme: ColorSchemeColorIconNormal, variant: .light)
+        case .light: return UIColor(scheme: .iconNormal, variant: .dark)
+        case .dark: return UIColor(scheme: .iconNormal, variant: .light)
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallAccessoryViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallAccessoryViewController.swift
@@ -31,7 +31,7 @@ final class CallAccessoryViewController: UIViewController, CallParticipantsViewC
         key: "video_call.camera_access.denied",
         size: .normal,
         weight: .semibold,
-        color: ColorSchemeColorTextForeground,
+        color: .textForeground,
         variant: .dark
     )
 

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoRootViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoRootViewController.swift
@@ -86,7 +86,7 @@ final class CallInfoRootViewController: UIViewController, UINavigationController
     private func updateConfiguration(animated: Bool = false) {
         callDegradationController.state = configuration.degradationState
         contentController.configuration = configuration
-        contentNavigationController.navigationBar.tintColor = .wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: configuration.effectiveColorVariant)
+        contentNavigationController.navigationBar.tintColor = UIColor(scheme: .textForeground, variant: configuration.effectiveColorVariant)
         contentNavigationController.navigationBar.isTranslucent = true
         contentNavigationController.navigationBar.barTintColor = .clear
         contentNavigationController.navigationBar.setBackgroundImage(UIImage.singlePixelImage(with: .clear), for: .default)

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallStatusView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallStatusView.swift
@@ -36,7 +36,7 @@ protocol ColorVariantProvider {
 extension CallStatusViewInputType {
     var overlayBackgroundColor: UIColor {
         switch (isVideoCall, state) {
-        case (false, _): return variant == .light ? .wr_color(fromColorScheme: ColorSchemeColorBackground, variant: .light) : .black
+        case (false, _): return variant == .light ? UIColor(scheme: .background, variant: .light) : .black
         case (true, .ringingOutgoing), (true, .ringingIncoming): return UIColor.black.withAlphaComponent(0.4)
         case (true, _): return UIColor.black.withAlphaComponent(0.64)
         }
@@ -137,7 +137,7 @@ final class CallStatusView: UIView {
         bitrateLabel.isHidden = !configuration.isConstantBitRate
 
         [titleLabel, subtitleLabel, bitrateLabel].forEach {
-            $0.textColor = .wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: configuration.effectiveColorVariant)
+            $0.textColor = UIColor(scheme: .textForeground, variant: configuration.effectiveColorVariant)
         }
 
         accessibilityLabel = stackView.arrangedSubviews.compactMap { $0.accessibilityLabel }.joined(separator: "\n")

--- a/Wire-iOS/Sources/UserInterface/Calling/CallParticipantsView/CallParticipantsView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallParticipantsView/CallParticipantsView.swift
@@ -82,7 +82,7 @@ class CallParticipantsView: UICollectionView, Themeable {
         }
     }
     
-    @objc dynamic var colorSchemeVariant: ColorSchemeVariant = ColorScheme.default().variant {
+    @objc dynamic var colorSchemeVariant: ColorSchemeVariant = ColorScheme.default.variant {
         didSet {
             guard oldValue != colorSchemeVariant else { return }
             applyColorScheme(colorSchemeVariant)

--- a/Wire-iOS/Sources/UserInterface/Calling/CallParticipantsView/ShowAllParticipantsCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallParticipantsView/ShowAllParticipantsCell.swift
@@ -33,7 +33,7 @@ class ShowAllParticipantsCell: UICollectionViewCell {
         }
     }
     
-    var variant : ColorSchemeVariant = ColorScheme.default().variant {
+    var variant : ColorSchemeVariant = ColorScheme.default.variant {
         didSet {
             guard oldValue != variant else { return }
             configureColors()
@@ -90,11 +90,11 @@ class ShowAllParticipantsCell: UICollectionViewCell {
     }
     
     private func configureColors() {
-        let sectionTextColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorSectionText, variant: variant)
+        let sectionTextColor = UIColor(scheme: .sectionText, variant: variant)
         backgroundColor = .clear
-        participantIconView.image = UIImage(for: .person, iconSize: .tiny, color: UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: variant))
+        participantIconView.image = UIImage(for: .person, iconSize: .tiny, color: UIColor(scheme: .textForeground, variant: variant))
         accessoryIconView.image = UIImage(for: .disclosureIndicator, iconSize: .like, color: sectionTextColor)
-        titleLabel.textColor = .wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: variant)
+        titleLabel.textColor = UIColor(scheme: .textForeground, variant: variant)
     }
     
 }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallInfoConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallInfoConfiguration.swift
@@ -164,7 +164,7 @@ struct CallInfoConfiguration: CallInfoViewControllerInput  {
         isTerminating = voiceChannel.isTerminating
         isConstantBitRate = voiceChannel.isConstantBitRateAudioActive
         title = voiceChannel.conversation?.displayName ?? ""
-        variant = ColorScheme.default().variant
+        variant = ColorScheme.default.variant
         mediaState = voiceChannel.mediaState(with: permissions)
         videoPlaceholderState = voiceChannel.videoPlaceholderState ?? preferedVideoPlaceholderState
         disableIdleTimer = voiceChannel.disableIdleTimer

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -179,7 +179,7 @@ final class CallViewController: UIViewController {
     }
 
     private func updateAppearance() {
-        view.backgroundColor = .wr_color(fromColorScheme: ColorSchemeColorBackground, variant: callInfoConfiguration.variant)
+        view.backgroundColor = UIColor(scheme: .background, variant: callInfoConfiguration.variant)
     }
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {

--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/SelfVideoPreviewView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/SelfVideoPreviewView.swift
@@ -62,7 +62,7 @@ final class SelfVideoPreviewView: UIView, AVSIdentifierProvider {
     private func setupViews() {
         mutedIconImageView.contentMode = .center
         mutedOverlayView.backgroundColor = UIColor.black.withAlphaComponent(0.16)
-        let iconColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: .dark)
+        let iconColor = UIColor(scheme: .textForeground, variant: .dark)
         mutedIconImageView.image = UIImage(for: .microphoneWithStrikethrough, iconSize: .tiny, color: iconColor)
         [previewView, mutedOverlayView].forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false

--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoPreviewView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoPreviewView.swift
@@ -34,7 +34,7 @@ final class VideoPreviewView: UIView, AVSIdentifierProvider {
         key: "call.video.paused",
         size: .normal,
         weight: .semibold,
-        color: ColorSchemeColorTextForeground,
+        color: .textForeground,
         variant: .dark
     )
 

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionHeaderView.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionHeaderView.swift
@@ -41,7 +41,7 @@ import Cartography
             default: fatal("Unknown section")
             }
             
-            let iconColor = ColorScheme.default().color(withName: ColorSchemeColorLightGraphite)
+            let iconColor = UIColor(scheme: .lightGraphite)
             self.iconImageView.image = UIImage(for: icon, iconSize: .tiny, color: iconColor)
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
@@ -260,7 +260,7 @@ public protocol CollectionsViewControllerDelegate: class {
     }
     
     open override var preferredStatusBarStyle : UIStatusBarStyle {
-        return ColorScheme.default().variant == .dark ? .lightContent : .default
+        return ColorScheme.default.variant == .dark ? .lightContent : .default
     }
     
     fileprivate func updateNoElementsState() {

--- a/Wire-iOS/Sources/UserInterface/Collections/ConversationImagesViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/ConversationImagesViewController.swift
@@ -128,7 +128,7 @@ final class ConversationImagesViewController: TintColorCorrectedViewController {
             let navigationBar = UINavigationBar()
             navigationBar.items = [navigationItem]
             navigationBar.isTranslucent = false
-            navigationBar.barTintColor = ColorScheme.default().color(withName: ColorSchemeColorBarBackground)
+            navigationBar.barTintColor = UIColor(scheme: .barBackground)
 
             navBarContainer = UINavigationBarContainer(navigationBar)
         }
@@ -272,8 +272,8 @@ final class ConversationImagesViewController: TintColorCorrectedViewController {
         
         self.buttonsBar = InputBarButtonsView(buttons: buttons)
         self.buttonsBar.clipsToBounds = true
-        self.buttonsBar.expandRowButton.setIconColor(ColorScheme.default().color(withName: ColorSchemeColorTextForeground), for: .normal)
-        self.buttonsBar.backgroundColor = ColorScheme.default().color(withName: ColorSchemeColorBarBackground)
+        self.buttonsBar.expandRowButton.setIconColor(UIColor(scheme: .textForeground), for: .normal)
+        self.buttonsBar.backgroundColor = UIColor(scheme: .barBackground)
         self.view.addSubview(self.buttonsBar)
         
         self.updateButtonsForMessage()

--- a/Wire-iOS/Sources/UserInterface/Collections/NoResultsView.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/NoResultsView.swift
@@ -30,8 +30,8 @@ import Cartography
     }
     
     public var placeholderColor: UIColor {
-        let backgroundColor = ColorScheme.default().color(withName: ColorSchemeColorBackground)
-        let placeholderColor = backgroundColor.mix(ColorScheme.default().color(withName: ColorSchemeColorTextForeground), amount: 0.16)
+        let backgroundColor = UIColor(scheme: .background)
+        let placeholderColor = backgroundColor.mix(UIColor(scheme: .textForeground), amount: 0.16)
         return placeholderColor!
     }
     

--- a/Wire-iOS/Sources/UserInterface/Collections/TextSearch/TextSearchResultCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/TextSearch/TextSearchResultCell.swift
@@ -128,8 +128,8 @@ import Cartography
     override func setHighlighted(_ highlighted: Bool, animated: Bool)  {
         super.setHighlighted(highlighted, animated: animated)
         
-        let backgroundColor = ColorScheme.default().color(withName: ColorSchemeColorContentBackground)
-        let foregroundColor = ColorScheme.default().color(withName: ColorSchemeColorTextForeground)
+        let backgroundColor = UIColor(scheme: .contentBackground)
+        let foregroundColor = UIColor(scheme: .textForeground)
         
         self.contentView.backgroundColor = highlighted ? backgroundColor.mix(foregroundColor, amount: 0.1) : backgroundColor
     }

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/BrowserViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/BrowserViewController.swift
@@ -31,9 +31,9 @@ import SafariServices
     override func viewDidLoad() {
         super.viewDidLoad()
         if #available(iOS 10, *) {
-            preferredControlTintColor = .wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: .light)
+            preferredControlTintColor = UIColor(scheme: .textForeground, variant: .light)
         } else {
-            view.tintColor = .wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: .light)
+            view.tintColor = UIColor(scheme: .textForeground, variant: .light)
         }
 
         delegate = self

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/DefaultNavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/DefaultNavigationBar.swift
@@ -34,20 +34,20 @@ import UIKit
     
     func configure() {
         isTranslucent = false
-        tintColor = ColorScheme.default().color(withName: ColorSchemeColorTextForeground)
-        barTintColor = ColorScheme.default().color(withName: ColorSchemeColorBarBackground)
-        setBackgroundImage(UIImage.singlePixelImage(with: ColorScheme.default().color(withName: ColorSchemeColorBarBackground)), for: .default)
+        tintColor = UIColor(scheme: .textForeground)
+        barTintColor = UIColor(scheme: .barBackground)
+        setBackgroundImage(UIImage.singlePixelImage(with: UIColor(scheme: .barBackground)), for: .default)
         shadowImage = UIImage.singlePixelImage(with: UIColor.clear)
-        titleTextAttributes = DefaultNavigationBar.titleTextAttributes(for: ColorScheme.default().variant)
+        titleTextAttributes = DefaultNavigationBar.titleTextAttributes(for: ColorScheme.default.variant)
         
         let backIndicatorInsets = UIEdgeInsets(top: 0, left: 4, bottom: 2.5, right: 0)
-        backIndicatorImage = UIImage(for: .backArrow, iconSize: .tiny, color: ColorScheme.default().color(withName: ColorSchemeColorTextForeground)).withInsets(backIndicatorInsets, backgroundColor: .clear)
+        backIndicatorImage = UIImage(for: .backArrow, iconSize: .tiny, color: UIColor(scheme: .textForeground)).withInsets(backIndicatorInsets, backgroundColor: .clear)
         backIndicatorTransitionMaskImage = UIImage(for: .backArrow, iconSize: .tiny, color: .black).withInsets(backIndicatorInsets, backgroundColor: .clear)
     }
     
     static func titleTextAttributes(for variant: ColorSchemeVariant) -> [NSAttributedStringKey : Any] {
         return [.font: UIFont.systemFont(ofSize: 11, weight: UIFont.Weight.semibold),
-                .foregroundColor: ColorScheme.default().color(withName: ColorSchemeColorTextForeground, variant: variant),
+                .foregroundColor: UIColor(scheme: .textForeground, variant: variant),
                 .baselineOffset: 1.0]
     }
     

--- a/Wire-iOS/Sources/UserInterface/Components/Giphy/GiphyConfirmationViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Giphy/GiphyConfirmationViewController.swift
@@ -69,7 +69,7 @@ class GiphyConfirmationViewController: UIViewController {
 
         let titleLabel = UILabel()
         titleLabel.font = FontSpec(.small, .semibold).font!
-        titleLabel.textColor = ColorScheme.default().color(withName: ColorSchemeColorTextForeground)
+        titleLabel.textColor = UIColor(scheme: .textForeground)
         titleLabel.text = title?.uppercased()
         titleLabel.sizeToFit()
         navigationItem.titleView = titleLabel

--- a/Wire-iOS/Sources/UserInterface/Components/Giphy/GiphySearchViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Giphy/GiphySearchViewController.swift
@@ -32,7 +32,7 @@ class GiphyNavigationController: UINavigationController {
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
-        return ColorScheme.default().variant == .dark ? .lightContent : .default
+        return ColorScheme.default.variant == .dark ? .lightContent : .default
     }
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
@@ -178,7 +178,7 @@ class GiphyCollectionViewCell: UICollectionViewCell {
         searchBar.delegate = self
         searchBar.tintColor = .accent()
         searchBar.placeholder = "giphy.search_placeholder".localized
-        searchBar.barStyle = ColorScheme.default().variant == .dark ? .black : .default
+        searchBar.barStyle = ColorScheme.default.variant == .dark ? .black : .default
         searchBar.searchBarStyle = .minimal
 
         let closeImage = UIImage(for: .X, iconSize: .tiny, color: .black)
@@ -204,9 +204,9 @@ class GiphyCollectionViewCell: UICollectionViewCell {
         navigationController.navigationBar.backIndicatorTransitionMaskImage = backButtonImage
 
         navigationController.navigationBar.backItem?.backBarButtonItem = UIBarButtonItem(title: " ", style: .plain, target: nil, action: nil)
-        navigationController.navigationBar.tintColor = ColorScheme.default().color(withName: ColorSchemeColorTextForeground)
-        navigationController.navigationBar.titleTextAttributes = DefaultNavigationBar.titleTextAttributes(for: ColorScheme.default().variant)
-        navigationController.navigationBar.barTintColor = ColorScheme.default().color(withName: ColorSchemeColorBackground)
+        navigationController.navigationBar.tintColor = UIColor(scheme: .textForeground)
+        navigationController.navigationBar.titleTextAttributes = DefaultNavigationBar.titleTextAttributes(for: ColorScheme.default.variant)
+        navigationController.navigationBar.barTintColor = UIColor(scheme: .background)
         navigationController.navigationBar.isTranslucent = false
 
         return navigationController

--- a/Wire-iOS/Sources/UserInterface/Components/TabBar/TabBarController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/TabBar/TabBarController.swift
@@ -49,7 +49,7 @@ class TabBarController: UIViewController {
     fileprivate(set) var viewControllers: [UIViewController]
     fileprivate(set) var selectedIndex: Int
 
-    var style: ColorSchemeVariant = ColorScheme.default().variant {
+    var style: ColorSchemeVariant = ColorScheme.default.variant {
         didSet {
             tabBar?.style = style
         }

--- a/Wire-iOS/Sources/UserInterface/Components/UINavigationBarContainer.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/UINavigationBarContainer.swift
@@ -32,7 +32,7 @@ class UINavigationBarContainer: UIViewController {
         self.navigationBar = navigationBar
         super.init(nibName: nil, bundle: nil)
         self.view.addSubview(navigationBar)
-        self.view.backgroundColor = ColorScheme.default().color(withName: ColorSchemeColorBarBackground)
+        self.view.backgroundColor = UIColor(scheme: .barBackground)
         createConstraints()
     }
 

--- a/Wire-iOS/Sources/UserInterface/Components/Views/GuestIndicator.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/GuestIndicator.swift
@@ -21,7 +21,7 @@ import Foundation
 
 public class GuestIndicator: UIImageView, Themeable {
     
-    @objc dynamic var colorSchemeVariant: ColorSchemeVariant = ColorScheme.default().variant {
+    @objc dynamic var colorSchemeVariant: ColorSchemeVariant = ColorScheme.default.variant {
         didSet {
             guard oldValue != colorSchemeVariant else { return }
             applyColorScheme(colorSchemeVariant)
@@ -29,7 +29,7 @@ public class GuestIndicator: UIImageView, Themeable {
     }
     
     func applyColorScheme(_ colorSchemeVariant: ColorSchemeVariant) {
-        image = UIImage(for: .guest, iconSize: .tiny, color: UIColor.wr_color(fromColorScheme: ColorSchemeColorIconGuest, variant: colorSchemeVariant))
+        image = UIImage(for: .guest, iconSize: .tiny, color: UIColor(scheme: .iconGuest, variant: colorSchemeVariant))
     }
     
     init() {
@@ -50,7 +50,7 @@ public class GuestIndicator: UIImageView, Themeable {
 
 public class GuestLabelIndicator: UIStackView, Themeable {
     
-    @objc dynamic var colorSchemeVariant: ColorSchemeVariant = ColorScheme.default().variant {
+    @objc dynamic var colorSchemeVariant: ColorSchemeVariant = ColorScheme.default.variant {
         didSet {
             guard oldValue != colorSchemeVariant else { return }
             applyColorSchemeOnSubviews(colorSchemeVariant)
@@ -59,8 +59,8 @@ public class GuestLabelIndicator: UIStackView, Themeable {
     }
     
     func applyColorScheme(_ colorSchemeVariant: ColorSchemeVariant) {
-        label.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: colorSchemeVariant)
-        guestIcon.image = UIImage(for: .guest, iconSize: .tiny, color: UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: colorSchemeVariant))
+        label.textColor = UIColor(scheme: .textForeground, variant: colorSchemeVariant)
+        guestIcon.image = UIImage(for: .guest, iconSize: .tiny, color: UIColor(scheme: .textForeground, variant: colorSchemeVariant))
     }
     
     private let guestIcon = UIImageView()
@@ -72,13 +72,13 @@ public class GuestLabelIndicator: UIStackView, Themeable {
         guestIcon.setContentCompressionResistancePriority(UILayoutPriority.required, for: .horizontal)
         guestIcon.setContentHuggingPriority(UILayoutPriority.required, for: .vertical)
         guestIcon.setContentHuggingPriority(UILayoutPriority.required, for: .horizontal)
-        guestIcon.image = UIImage(for: .guest, iconSize: .tiny, color: UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: colorSchemeVariant))
+        guestIcon.image = UIImage(for: .guest, iconSize: .tiny, color: UIColor(scheme: .textForeground, variant: colorSchemeVariant))
         guestIcon.accessibilityIdentifier = "img.guest"
 
         label.numberOfLines = 0
         label.textAlignment = .left
         label.font = FontSpec(.medium, .light).font
-        label.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: colorSchemeVariant)
+        label.textColor = UIColor(scheme: .textForeground, variant: colorSchemeVariant)
         label.setContentCompressionResistancePriority(UILayoutPriority.required, for: .vertical)
         label.setContentCompressionResistancePriority(UILayoutPriority.required, for: .horizontal)
         label.text = "profile.details.guest".localized

--- a/Wire-iOS/Sources/UserInterface/Components/Views/MarkdownTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/MarkdownTextView.swift
@@ -120,7 +120,7 @@ extension Notification.Name {
 
     /// Updates the color of the text.
     func updateTextColor(base: UIColor?) {
-        let baseColor = base ?? ColorScheme.default().color(withName: ColorSchemeColorTextForeground)
+        let baseColor = base ?? UIColor(scheme: .textForeground)
         self.textColor = baseColor
         self.style.baseFontColor = baseColor
     }
@@ -550,7 +550,7 @@ extension DownStyle {
     @objc static var normal: DownStyle = {
         let style = DownStyle()
         style.baseFont = FontSpec(.normal, .light).font!
-        style.baseFontColor = ColorScheme.default().color(withName: ColorSchemeColorTextForeground)
+        style.baseFontColor = UIColor(scheme: .textForeground)
         style.codeFont = UIFont(name: "Menlo", size: style.baseFont.pointSize) ?? style.baseFont
         style.baseParagraphStyle = NSParagraphStyle.default
         style.listItemPrefixSpacing = 8
@@ -561,7 +561,7 @@ extension DownStyle {
     @objc static var compact: DownStyle = {
         let style = DownStyle()
         style.baseFont = FontSpec(.normal, .light).font!
-        style.baseFontColor = ColorScheme.default().color(withName: ColorSchemeColorTextForeground)
+        style.baseFontColor = UIColor(scheme: .textForeground)
         style.codeFont = UIFont(name: "Menlo", size: style.baseFont.pointSize) ?? style.baseFont
         style.baseParagraphStyle = NSParagraphStyle.default
         style.listItemPrefixSpacing = 8

--- a/Wire-iOS/Sources/UserInterface/Components/Views/PopUpIconButtonView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/PopUpIconButtonView.swift
@@ -32,7 +32,6 @@ class PopUpIconButtonView: UIView {
     private let upperRect: CGRect
     private let itemWidth: CGFloat
     
-    private let color = ColorScheme.default().color(withName:)
     private let expandDirection: PopUpIconButtonExpandDirection
     
     init(withButton button: PopUpIconButton) {
@@ -87,13 +86,13 @@ class PopUpIconButtonView: UIView {
         context.saveGState()
         
         // overlay shadow
-        let shadowColor = color(ColorSchemeColorPopUpButtonOverlayShadow).cgColor
+        let shadowColor = UIColor(scheme: .popUpButtonOverlayShadow).cgColor
         let offset = CGSize(width: 0.0, height: 2.0)
         let blurRadius: CGFloat = 4.0
         context.setShadow(offset: offset, blur: blurRadius, color: shadowColor)
         
         // overlay fill
-        color(ColorSchemeColorBarBackground).set()
+        UIColor(scheme: .barBackground).set()
         path.fill()
         
         context.restoreGState()
@@ -102,7 +101,7 @@ class PopUpIconButtonView: UIView {
         if let imageView = button.imageView {
             // rect in window coordinates
             let imageRect = imageView.convert(button.imageView!.bounds, to: nil)
-            let image = UIImage(for: button.iconType(for: .normal), iconSize: .tiny, color: color(ColorSchemeColorIconNormal))!
+            let image = UIImage(for: button.iconType(for: .normal), iconSize: .tiny, color: UIColor(scheme: .iconNormal))!
             image.draw(in: imageRect)
         }
         
@@ -110,7 +109,7 @@ class PopUpIconButtonView: UIView {
         if let buttonImageView = button.imageView {
             for (index, icon) in button.itemIcons.enumerated() {
                 let itemRect = rectForItem(icon)!
-                let iconColor = index == selectedIndex ? color(ColorSchemeColorAccent) : color(ColorSchemeColorIconNormal)
+                let iconColor = index == selectedIndex ? UIColor(scheme: .accent) : UIColor(scheme: .iconNormal)
                 let image = UIImage(for: icon, iconSize: .medium, color: iconColor)!
                 // rect in window coordinates
                 var imageRect = buttonImageView.convert(buttonImageView.bounds, to: nil)

--- a/Wire-iOS/Sources/UserInterface/Components/Views/SearchResultLabel.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/SearchResultLabel.swift
@@ -85,7 +85,7 @@ import Foundation
             let nsRange = text.nsRange(from: range)
             
             let highlightedAttributes = [NSAttributedStringKey.font: font,
-                                         .backgroundColor: ColorScheme.default().color(withName: ColorSchemeColorAccentDarken)]
+                                         .backgroundColor: UIColor(scheme: .accentDarken)]
             
             if self.fits(attributedText: attributedText, fromRange: nsRange) {
                 self.attributedText = attributedText.highlightingAppearances(of: queries,

--- a/Wire-iOS/Sources/UserInterface/Components/Views/SectionFooter.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/SectionFooter.swift
@@ -22,7 +22,7 @@ final class SectionFooter: UICollectionReusableView, Themeable {
     
     let titleLabel = UILabel()
     
-    @objc dynamic var colorSchemeVariant: ColorSchemeVariant = ColorScheme.default().variant {
+    @objc dynamic var colorSchemeVariant: ColorSchemeVariant = ColorScheme.default.variant {
         didSet {
             guard oldValue != colorSchemeVariant else { return }
             applyColorScheme(colorSchemeVariant)
@@ -57,7 +57,7 @@ final class SectionFooter: UICollectionReusableView, Themeable {
     }
     
     func applyColorScheme(_ colorSchemeVariant: ColorSchemeVariant) {
-        titleLabel.textColor = .wr_color(fromColorScheme: ColorSchemeColorTextDimmed, variant: colorSchemeVariant)
+        titleLabel.textColor = UIColor(scheme: .textDimmed, variant: colorSchemeVariant)
     }
     
 }

--- a/Wire-iOS/Sources/UserInterface/Components/Views/SectionHeader.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/SectionHeader.swift
@@ -22,7 +22,7 @@ final class SectionHeader: UICollectionReusableView, Themeable {
     
     let titleLabel = UILabel()
  
-    @objc dynamic var colorSchemeVariant: ColorSchemeVariant = ColorScheme.default().variant {
+    @objc dynamic var colorSchemeVariant: ColorSchemeVariant = ColorScheme.default.variant {
         didSet {
             guard oldValue != colorSchemeVariant else { return }
             applyColorScheme(colorSchemeVariant)
@@ -57,7 +57,7 @@ final class SectionHeader: UICollectionReusableView, Themeable {
     }
     
     func applyColorScheme(_ colorSchemeVariant: ColorSchemeVariant) {
-        titleLabel.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorSectionText, variant: colorSchemeVariant)
+        titleLabel.textColor = UIColor(scheme: .sectionText, variant: colorSchemeVariant)
     }
     
 }

--- a/Wire-iOS/Sources/UserInterface/Components/Views/TextSearchInputView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/TextSearchInputView.swift
@@ -57,17 +57,16 @@ public protocol TextSearchInputViewDelegate: class {
     override init(frame: CGRect) {
         super.init(frame: frame)
         
-        let colorScheme = ColorScheme.default()
-        iconView.image = UIImage(for: .search, iconSize: .tiny, color: colorScheme.color(withName: ColorSchemeColorTextForeground))
+        iconView.image = UIImage(for: .search, iconSize: .tiny, color: UIColor(scheme: .textForeground))
         iconView.contentMode = .center
         
         searchInput.delegate = self
         searchInput.autocorrectionType = .no
         searchInput.accessibilityLabel = "Search"
         searchInput.accessibilityIdentifier = "search input"
-        searchInput.keyboardAppearance = ColorScheme.default().keyboardAppearance
+        searchInput.keyboardAppearance = ColorScheme.default.keyboardAppearance
         searchInput.layer.cornerRadius = 4
-        searchInput.backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTokenFieldBackground)
+        searchInput.backgroundColor = UIColor(scheme: .tokenFieldBackground)
         searchInput.textContainerInset = UIEdgeInsetsMake(10, 40, 10, 8)
         
         placeholderLabel.textAlignment = .natural
@@ -78,7 +77,7 @@ public protocol TextSearchInputViewDelegate: class {
         cancelButton.isHidden = true
         cancelButton.accessibilityIdentifier = "cancel search"
 
-        spinner.color = ColorScheme.default().color(withName: ColorSchemeColorTextDimmed, variant: .light)
+        spinner.color = UIColor(scheme: .textDimmed, variant: .light)
         spinner.iconSize = .tiny
         [iconView, searchInput, cancelButton, placeholderLabel, spinner].forEach(self.addSubview)
 

--- a/Wire-iOS/Sources/UserInterface/Components/Views/UserCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/UserCell.swift
@@ -21,7 +21,7 @@ import WireExtensionComponents
 
 class UserCell: UICollectionViewCell, Themeable {
     
-    @objc dynamic var colorSchemeVariant: ColorSchemeVariant = ColorScheme.default().variant {
+    @objc dynamic var colorSchemeVariant: ColorSchemeVariant = ColorScheme.default.variant {
         didSet {
             guard oldValue != colorSchemeVariant else { return }
             applyColorScheme(colorSchemeVariant)
@@ -61,7 +61,7 @@ class UserCell: UICollectionViewCell, Themeable {
     fileprivate static let lightFont: UIFont! = FontSpec.init(.small, .light).font!
     
     private func contentBackgroundColor(for colorSchemeVariant: ColorSchemeVariant) -> UIColor {
-        return contentBackgroundColor ?? UIColor.wr_color(fromColorScheme: ColorSchemeColorBarBackground, variant: colorSchemeVariant)
+        return contentBackgroundColor ?? UIColor(scheme: .barBackground, variant: colorSchemeVariant)
     }
     
     override var isHighlighted: Bool {
@@ -74,8 +74,8 @@ class UserCell: UICollectionViewCell, Themeable {
     
     override var isSelected: Bool {
         didSet {
-            let foregroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorBackground, variant: colorSchemeVariant)
-            let backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorIconNormal, variant: colorSchemeVariant)
+            let foregroundColor = UIColor(scheme: .background, variant: colorSchemeVariant)
+            let backgroundColor = UIColor(scheme: .iconNormal, variant: colorSchemeVariant)
             let borderColor = isSelected ? backgroundColor : backgroundColor.withAlphaComponent(0.64)
             checkmarkIconView.image = isSelected ? UIImage(for: .checkmark, iconSize: .like, color: foregroundColor) : nil
             checkmarkIconView.backgroundColor = isSelected ? backgroundColor : .clear
@@ -103,7 +103,7 @@ class UserCell: UICollectionViewCell, Themeable {
             connectButton.isHidden = true
             accessoryIconView.isHidden = false
             checkmarkIconView.image = nil
-            checkmarkIconView.layer.borderColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorIconNormal, variant: colorSchemeVariant).cgColor
+            checkmarkIconView.layer.borderColor = UIColor(scheme: .iconNormal, variant: colorSchemeVariant).cgColor
             checkmarkIconView.isHidden = true
         }
     }
@@ -205,21 +205,21 @@ class UserCell: UICollectionViewCell, Themeable {
     }
     
     func applyColorScheme(_ colorSchemeVariant: ColorSchemeVariant) {
-        let sectionTextColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorSectionText, variant: colorSchemeVariant)
+        let sectionTextColor = UIColor(scheme: .sectionText, variant: colorSchemeVariant)
         backgroundColor = contentBackgroundColor(for: colorSchemeVariant)
-        separator.backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorCellSeparator, variant: colorSchemeVariant)
-        videoIconView.image = UIImage(for: .videoCall, iconSize: .tiny, color: UIColor.wr_color(fromColorScheme: ColorSchemeColorIconGuest, variant: colorSchemeVariant))
-        guestIconView.image = UIImage(for: .guest, iconSize: .tiny, color: UIColor.wr_color(fromColorScheme: ColorSchemeColorIconGuest, variant: colorSchemeVariant))
+        separator.backgroundColor = UIColor(scheme: .cellSeparator, variant: colorSchemeVariant)
+        videoIconView.image = UIImage(for: .videoCall, iconSize: .tiny, color: UIColor(scheme: .iconGuest, variant: colorSchemeVariant))
+        guestIconView.image = UIImage(for: .guest, iconSize: .tiny, color: UIColor(scheme: .iconGuest, variant: colorSchemeVariant))
         accessoryIconView.image = UIImage(for: .disclosureIndicator, iconSize: .like, color: sectionTextColor)
         connectButton.setIconColor(sectionTextColor, for: .normal)
-        checkmarkIconView.layer.borderColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorIconNormal, variant: colorSchemeVariant).cgColor
-        titleLabel.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: colorSchemeVariant)
+        checkmarkIconView.layer.borderColor = UIColor(scheme: .iconNormal, variant: colorSchemeVariant).cgColor
+        titleLabel.textColor = UIColor(scheme: .textForeground, variant: colorSchemeVariant)
         subtitleLabel.textColor = sectionTextColor
     }
     
     public func configure(with user: ZMBareUser, conversation: ZMConversation? = nil) {
         avatar.user = user
-        titleLabel.attributedText = user.nameIncludingAvailability(color: UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: colorSchemeVariant))
+        titleLabel.attributedText = user.nameIncludingAvailability(color: UIColor(scheme: .textForeground, variant: colorSchemeVariant))
         
         if let conversation = conversation {
             guestIconView.isHidden = !user.isGuest(in: conversation)
@@ -286,7 +286,7 @@ extension UserCell {
             return formatter
         }
         
-        let color = UIColor.wr_color(fromColorScheme: ColorSchemeColorSectionText, variant: colorSchemeVariant)
+        let color = UIColor(scheme: .sectionText, variant: colorSchemeVariant)
         let formatter = AddressBookCorrelationFormatter(lightFont: lightFont, boldFont: boldFont, color: color)
         
         correlationFormatters[colorSchemeVariant] = formatter

--- a/Wire-iOS/Sources/UserInterface/ConnectRequests/IncomingConnectionView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConnectRequests/IncomingConnectionView.swift
@@ -26,7 +26,7 @@ public final class IncomingConnectionView: UIView {
         return AddressBookCorrelationFormatter(
             lightFont: FontSpec(.small, .light).font!,
             boldFont: FontSpec(.small, .medium).font!,
-            color: ColorScheme.default().color(withName: ColorSchemeColorTextDimmed)
+            color: UIColor(scheme: .textDimmed)
         )
     }()
 

--- a/Wire-iOS/Sources/UserInterface/ConnectRequests/OutgoingConnectionBottomBar.swift
+++ b/Wire-iOS/Sources/UserInterface/ConnectRequests/OutgoingConnectionBottomBar.swift
@@ -54,7 +54,7 @@ import Cartography
         cancelButton.setIcon(.undo, with: .tiny, for: .normal)
         cancelButton.setTitle("profile.cancel_connection_button_title".localized.uppercased(), for: .normal)
         cancelButton.titleLabel?.font = FontSpec(.small, .light).font!
-        cancelButton.setTitleColor(ColorScheme.default().color(withName: ColorSchemeColorTextForeground), for: .normal)
+        cancelButton.setTitleColor(UIColor(scheme: .textForeground), for: .normal)
         cancelButton.titleImageSpacing = 24
         cancelButton.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
     }

--- a/Wire-iOS/Sources/UserInterface/ConnectRequests/UserConnectionView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConnectRequests/UserConnectionView.swift
@@ -30,7 +30,7 @@ public final class UserConnectionView: UIView, Copyable {
         return AddressBookCorrelationFormatter(
             lightFont: FontSpec(.small, .light).font!,
             boldFont: FontSpec(.small, .medium).font!,
-            color: ColorScheme.default().color(withName: ColorSchemeColorTextDimmed)
+            color: UIColor(scheme: .textDimmed)
         )
     }()
 
@@ -98,7 +98,7 @@ public final class UserConnectionView: UIView, Copyable {
     private var handleLabelText: NSAttributedString? {
         guard let handle = user.handle, handle.count > 0 else { return nil }
         return ("@" + handle) && [
-            .foregroundColor: ColorScheme.default().color(withName: ColorSchemeColorTextDimmed),
+            .foregroundColor: UIColor(scheme: .textDimmed),
             .font: FontSpec(.small, .semibold).font!
         ]
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation Options/ActionCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/ActionCell.swift
@@ -65,6 +65,6 @@ final class ActionCell: UITableViewCell, CellConfigurationConfigurable {
         guard case let .leadingButton(title, identifier, _) = configuration else { preconditionFailure() }
         accessibilityIdentifier = identifier
         label.text = title
-        backgroundColor = ColorScheme.default().color(withName: ColorSchemeColorBarBackground, variant: variant)
+        backgroundColor = UIColor(scheme: .barBackground, variant: variant)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationOptionsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationOptionsViewController.swift
@@ -35,7 +35,7 @@ final class ConversationOptionsViewController: UIViewController, UITableViewDele
         )
         self.init(
             viewModel: .init(configuration: configuration),
-            variant: ColorScheme.default().variant
+            variant: ColorScheme.default.variant
         )
     }
     
@@ -66,7 +66,7 @@ final class ConversationOptionsViewController: UIViewController, UITableViewDele
         tableView.separatorStyle = .none
         tableView.delegate = self
         tableView.dataSource = self
-        tableView.backgroundColor = ColorScheme.default().color(withName: ColorSchemeColorContentBackground, variant: variant)
+        tableView.backgroundColor = UIColor(scheme: .contentBackground, variant: variant)
         if #available(iOS 11.0, *) {
             tableView.contentInsetAdjustmentBehavior = .never
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation Options/IconActionCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/IconActionCell.swift
@@ -69,11 +69,11 @@ final class IconActionCell: UITableViewCell, CellConfigurationConfigurable {
     
     func configure(with configuration: CellConfiguration, variant: ColorSchemeVariant) {
         guard case let .iconAction(title, icon, color, _) = configuration else { preconditionFailure() }
-        let mainColor = color ?? .wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: variant)
+        let mainColor = color ?? UIColor(scheme: .textForeground, variant: variant)
         iconImageView.image = UIImage(for: icon, iconSize: .tiny, color: mainColor)
         label.textColor = mainColor
         label.text = title
-        separator.backgroundColor = .wr_color(fromColorScheme: ColorSchemeColorCellSeparator, variant: variant)
+        separator.backgroundColor = UIColor(scheme: .cellSeparator, variant: variant)
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation Options/LinkHeaderCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/LinkHeaderCell.swift
@@ -70,8 +70,8 @@ final class LinkHeaderCell: UITableViewCell, CellConfigurationConfigurable {
     }
     
     private func styleViews() {
-        let color = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextDimmed, variant: variant)
-        topSeparator.backgroundColor = .wr_color(fromColorScheme: ColorSchemeColorCellSeparator, variant: variant)
+        let color = UIColor(scheme: .textDimmed, variant: variant)
+        topSeparator.backgroundColor = UIColor(scheme: .cellSeparator, variant: variant)
         titleLabel.textColor = color
         subtitleLabel.textColor = color
         backgroundColor = .clear

--- a/Wire-iOS/Sources/UserInterface/Conversation Options/LoadingIndicatorCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/LoadingIndicatorCell.swift
@@ -39,7 +39,7 @@ final class LoadingIndicatorCell: UITableViewCell, CellConfigurationConfigurable
     }
     
     func configure(with configuration: CellConfiguration, variant: ColorSchemeVariant) {
-        spinner.color = ColorScheme.default().color(withName: ColorSchemeColorTextForeground, variant: variant)
+        spinner.color = UIColor(scheme: .textForeground, variant: variant)
         spinner.isAnimating = false
         spinner.isAnimating = true
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation Options/TextCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/TextCell.swift
@@ -51,8 +51,8 @@ final class TextCell: UITableViewCell, CellConfigurationConfigurable {
     func configure(with configuration: CellConfiguration, variant: ColorSchemeVariant) {
         guard case let .text(text) = configuration else { preconditionFailure() }
         label.attributedText = text && .lineSpacing(8)
-        label.textColor = .wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: variant)
-        container.backgroundColor = .wr_color(fromColorScheme: ColorSchemeColorBarBackground, variant: variant)
+        label.textColor = UIColor(scheme: .textForeground, variant: variant)
+        container.backgroundColor = UIColor(scheme: .barBackground, variant: variant)
     }
     
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation Options/ToggleSubtitleCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/ToggleSubtitleCell.swift
@@ -74,12 +74,9 @@ final class ToggleSubtitleCell: UITableViewCell, CellConfigurationConfigurable {
     }
     
     private func styleViews() {
-        func color(_ name: String) -> UIColor {
-            return ColorScheme.default().color(withName: name, variant: variant)
-        }
-        topContainer.backgroundColor = color(ColorSchemeColorBarBackground)
-        titleLabel.textColor = color(ColorSchemeColorTextForeground)
-        subtitleLabel.textColor = color(ColorSchemeColorTextDimmed)
+        topContainer.backgroundColor = UIColor(scheme: .barBackground, variant: variant)
+        titleLabel.textColor = UIColor(scheme: .textForeground, variant: variant)
+        subtitleLabel.textColor = UIColor(scheme: .textDimmed, variant: variant)
         backgroundColor = .clear
     }
     

--- a/Wire-iOS/Sources/UserInterface/Conversation Options/UIAlertController+ConfirmRemovingGuests.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/UIAlertController+ConfirmRemovingGuests.swift
@@ -27,7 +27,7 @@ extension UIAlertController {
             preferredStyle: .alert
         )
         controller.addAction(.ok())
-        controller.view.tintColor = ColorScheme.default().color(withName: ColorSchemeColorTextForeground, variant: .light)
+        controller.view.tintColor = UIColor(scheme: .textForeground, variant: .light)
         return controller
     }
     
@@ -54,7 +54,7 @@ extension UIAlertController {
         }
         controller.addAction(removeAction)
         controller.addAction(.cancel { completion(false) })
-        controller.view.tintColor = ColorScheme.default().color(withName: ColorSchemeColorTextForeground, variant: .light)
+        controller.view.tintColor = UIColor(scheme: .textForeground, variant: .light)
         return controller
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell+Like.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell+Like.swift
@@ -27,7 +27,7 @@ public extension ConversationCell {
         self.likeButton.accessibilityLabel = "likeButton"
         self.likeButton.addTarget(self, action: #selector(ConversationCell.likeMessage(_:)), for: .touchUpInside)
         self.likeButton.setIcon(.liked, with: .like, for: .normal)
-        self.likeButton.setIconColor(ColorScheme.default().color(withName: ColorSchemeColorTextDimmed), for: .normal)
+        self.likeButton.setIconColor(UIColor(scheme: .textDimmed), for: .normal)
         self.likeButton.setIcon(.liked, with: .like, for: .selected)
         self.likeButton.setIconColor(UIColor(for: .vividRed), for: .selected)
         self.likeButton.hitAreaPadding = CGSize(width: 20, height: 20)

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell+Sender.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell+Sender.swift
@@ -30,9 +30,9 @@ public extension ConversationCell {
             case let .userName(accent: accent):
                 return accent
             case .botName:
-                return ColorScheme.default().color(withName: ColorSchemeColorTextForeground)
+                return UIColor(scheme: .textForeground)
             case .botSuffix:
-                return ColorScheme.default().color(withName: ColorSchemeColorTextDimmed)
+                return UIColor(scheme: .textDimmed)
             }
         }
 
@@ -57,7 +57,7 @@ public extension ConversationCell {
             let name = attributedName(for: .botName, string: name)
             attributedString = name + " ".attributedString + bot
         } else {
-            let accentColor = ColorScheme.default().nameAccent(for: sender.accentColorValue, variant: ColorScheme.default().variant)
+            let accentColor = ColorScheme.default.nameAccent(for: sender.accentColorValue, variant: ColorScheme.default.variant)
             attributedString = attributedName(for: .userName(accent: accentColor), string: name)
         }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/VideoMessageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/VideoMessageView.swift
@@ -46,7 +46,7 @@ import Classy
 
         self.previewImageView.contentMode = .scaleAspectFill
         self.previewImageView.clipsToBounds = true
-        self.previewImageView.backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorPlaceholderBackground)
+        self.previewImageView.backgroundColor = UIColor(scheme: .placeholderBackground)
 
         self.playButton.addTarget(self, action: #selector(VideoMessageView.onActionButtonPressed(_:)), for: .touchUpInside)
         self.playButton.accessibilityIdentifier = "VideoActionButton"
@@ -126,11 +126,11 @@ import Classy
             if let previewData = fileMessageData.previewData {
                 visibleViews.append(contentsOf: [previewImageView, bottomGradientView, playButton])
                 self.previewImageView.image = UIImage(data: previewData)
-                self.timeLabel.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: .dark)
+                self.timeLabel.textColor = UIColor(scheme: .textForeground, variant: .dark)
             } else {
                 visibleViews.append(contentsOf: [previewImageView, playButton])
                 self.previewImageView.image = nil
-                self.timeLabel.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground)
+                self.timeLabel.textColor = UIColor(scheme: .textForeground)
             }
             
             if !self.timeLabelHidden {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ParticipantsInvitePeopleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ParticipantsInvitePeopleView.swift
@@ -48,10 +48,10 @@ protocol ParticipantsInvitePeopleViewDelegate: class {
         [titleLabel, inviteButton].forEach(stackView.addArrangedSubview)
         titleLabel.numberOfLines = 0
         titleLabel.text = "content.system.conversation.invite.title".localized
-        titleLabel.textColor = .wr_color(fromColorScheme: ColorSchemeColorTextForeground)
+        titleLabel.textColor = UIColor(scheme: .textForeground)
         titleLabel.font = FontSpec(.medium, .none).font
         inviteButton.setTitle("content.system.conversation.invite.button".localized, for: .normal)
-        inviteButton.setTitleColor(.wr_color(fromColorScheme: ColorSchemeColorTextForeground), for: .normal)
+        inviteButton.setTitleColor(UIColor(scheme: .textForeground), for: .normal)
         inviteButton.adjustsTitleWhenHighlighted = true
         inviteButton.setBackgroundImageColor(.init(red: 0.612, green: 0.655, blue: 0.686, alpha: 0.2), for: .normal)
         inviteButton.clipsToBounds = true

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ArticleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ArticleView.swift
@@ -52,7 +52,7 @@ import Classy
     var loadingView: ThreeDotsLoadingView?
     var linkPreview: LinkPreview?
     private let obfuscationView = ObfuscationView(icon: .link)
-    private let ephemeralColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorAccent)
+    private let ephemeralColor = UIColor(scheme: .accent)
     private var imageHeightConstraint: NSLayoutConstraint!
     weak var delegate: ArticleViewDelegate?
     
@@ -189,7 +189,7 @@ import Classy
 
             if obfuscated {
                 ArticleView.imageCache.removeImage(forCacheKey: imageDataIdentifier)
-                imageView.image = UIImage.init(for: .link, iconSize: .tiny, color: ColorScheme.default().color(withName: ColorSchemeColorBackground))
+                imageView.image = UIImage(for: .link, iconSize: .tiny, color: UIColor(scheme: .background))
                 setContentMode(isObfuscated: true)
             } else {
                 imageView.image = nil

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/DestructionCountdownView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/DestructionCountdownView.swift
@@ -41,10 +41,17 @@ import Cartography
     private func configureSublayers() {
         layer.addSublayer(remainingTimeLayer)
         layer.addSublayer(elapsedTimeLayer)
+
         elapsedTimeLayer.strokeEnd = 0
         elapsedTimeLayer.isOpaque = false
         remainingTimeLayer.isOpaque = false
-        setDefaultColors()
+
+        elapsedTimeColor = ColorScheme.default
+            .color(named: .graphite)
+            .withAlphaComponent(0.16)
+            .removeAlphaByBlending(with: .white)
+
+        remainingTimeColor = UIColor(scheme: .lightGraphite)
     }
 
     // MARK: - Layout
@@ -64,17 +71,6 @@ import Cartography
         let path = CGMutablePath()
         path.addArc(center: CGPoint(x: bounds.midX, y: bounds.midY), radius: min(bounds.height, bounds.width) / 4, startAngle: -.pi / 2, endAngle: 3 * .pi / 2, clockwise: false)
         return path
-    }
-
-    @objc public func setDefaultColors() {
-
-        remainingTimeColor = ColorScheme.default().color(withName: ColorSchemeColorLightGraphite)
-
-        elapsedTimeColor = ColorScheme.default()
-            .color(withName: ColorSchemeColorGraphite)
-            .withAlphaComponent(0.16)
-            .removeAlphaByBlending(with: .white)
-
     }
 
     // MARK: - Animation

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ObfuscationView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ObfuscationView.swift
@@ -21,10 +21,10 @@ import Foundation
 @objcMembers final class ObfuscationView: UIImageView {
     @objc init(icon: ZetaIconType) {
         super.init(frame: .zero)
-        self.backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorAccentDimmedFlat)
+        self.backgroundColor = UIColor(scheme: .accentDimmedFlat)
         self.isOpaque = true
         self.contentMode = .center
-        self.image = UIImage.init(for: icon, iconSize: .tiny, color: ColorScheme.default().color(withName: ColorSchemeColorBackground))
+        self.image = UIImage.init(for: icon, iconSize: .tiny, color: UIColor(scheme: .background))
     }
     
     required init(coder: NSCoder) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ReactionsView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ReactionsView.swift
@@ -53,7 +53,7 @@ import Cartography
             }
             
             if shouldDisplayEllipsis {
-                let iconColor = ColorScheme.default().color(withName: ColorSchemeColorTextForeground)
+                let iconColor = UIColor(scheme: .textForeground)
                 let imageView = UIImageView(image: UIImage(for: .ellipsis, iconSize: .like, color:iconColor))
                 imageView.contentMode = .center
                 constrain(imageView) { imageView in

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/TintColorCorrectedViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/TintColorCorrectedViewController.swift
@@ -24,7 +24,7 @@ class TintColorOverrider: NSObject {
     
     func override() {
         windowTintColor = UIApplication.shared.delegate?.window??.tintColor
-        UIApplication.shared.delegate?.window??.tintColor = .wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: .light)
+        UIApplication.shared.delegate?.window??.tintColor = UIColor(scheme: .textForeground, variant: .light)
     }
     
     func restore() {

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationListBottomBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationListBottomBar.swift
@@ -75,7 +75,7 @@ import Cartography
 
 
     private func createViews() {
-        separator.backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorSeparator, variant: .light)
+        separator.backgroundColor = UIColor(scheme: .separator, variant: .light)
         
         archivedButton.setIcon(.archive, with: .tiny, for: UIControlState())
         archivedButton.addTarget(self, action: #selector(archivedButtonTapped), for: .touchUpInside)
@@ -102,7 +102,7 @@ import Cartography
         cameraButton.accessibilityHint = "conversation_list.voiceover.bottom_bar.camera_button.hint".localized
 
         [archivedButton, startUIButton, composeButton, cameraButton].forEach { button in
-            button.setIconColor(UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: .dark), for: .normal)
+            button.setIconColor(UIColor(scheme: .textForeground, variant: .dark), for: .normal)
         }
 
         addSubviews()

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationRootViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationRootViewController.swift
@@ -46,8 +46,8 @@ import Cartography
         navbar.isOpaque = true
         navbar.setBackgroundImage(UIImage(), for: .any, barMetrics: .default)
         navbar.shadowImage = UIImage()
-        navbar.barTintColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorBarBackground)
-        navbar.tintColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground)
+        navbar.barTintColor = UIColor(scheme: .barBackground)
+        navbar.tintColor = UIColor(scheme: .textForeground)
 
         navBarContainer = UINavigationBarContainer(navbar)
 
@@ -73,7 +73,7 @@ import Cartography
             return
         }
 
-        self.view.backgroundColor = ColorScheme.default().color(withName: ColorSchemeColorBarBackground)
+        self.view.backgroundColor = UIColor(scheme: .barBackground)
 
         self.addToSelf(navBarContainer)
         self.view.addSubview(self.contentView)
@@ -113,7 +113,7 @@ import Cartography
     }
 
     open override var preferredStatusBarStyle: UIStatusBarStyle {
-        switch ColorScheme.default().variant {
+        switch ColorScheme.default.variant {
         case .light:
             return .default
         case .dark:

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationTitleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationTitleView.swift
@@ -36,8 +36,8 @@ class ConversationTitleView: TitleView {
     }
     
     @objc func configure() {
-        titleColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground)
-        titleColorSelected = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextDimmed)
+        titleColor = UIColor(scheme: .textForeground)
+        titleColorSelected = UIColor(scheme: .textDimmed)
         titleFont = FontSpec(.medium, .semibold).font!
         
         var attachment : NSTextAttachment?

--- a/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
@@ -51,7 +51,7 @@ final public class ConversationCreationValues {
 
     fileprivate let errorLabel = UILabel()
     fileprivate let errorViewContainer = UIView()
-    fileprivate let colorSchemeVariant = ColorScheme.default().variant
+    fileprivate let colorSchemeVariant = ColorScheme.default.variant
     private let mainViewContainer = UIView()
     private let bottomViewContainer = UIView()
     private let toggleSubtitleLabel = UILabel()
@@ -94,7 +94,7 @@ final public class ConversationCreationValues {
         super.viewDidLoad()
         Analytics.shared().tagLinearGroupOpened(with: self.source)
 
-        view.backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorContentBackground, variant: colorSchemeVariant)
+        view.backgroundColor = UIColor(scheme: .contentBackground, variant: colorSchemeVariant)
         title = "conversation.create.group_name.title".localized.uppercased()
         
         setupNavigationBar()
@@ -123,7 +123,7 @@ final public class ConversationCreationValues {
 
     private func setupViews() {
         mainViewContainer.translatesAutoresizingMaskIntoConstraints = false
-        navigationBarBackgroundView.backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorBarBackground, variant: colorSchemeVariant)
+        navigationBarBackgroundView.backgroundColor = UIColor(scheme: .barBackground, variant: colorSchemeVariant)
         mainViewContainer.addSubview(navigationBarBackgroundView)
         
         textField = SimpleTextField()
@@ -148,7 +148,7 @@ final public class ConversationCreationValues {
         [toggleSubtitleLabel, textFieldSubtitleLabel].forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false
             $0.font = .preferredFont(forTextStyle: .footnote)
-            $0.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextDimmed)
+            $0.textColor = UIColor(scheme: .textDimmed)
         }
         
         toggleSubtitleLabel.text = "conversation.create.toggle.subtitle".localized
@@ -169,7 +169,7 @@ final public class ConversationCreationValues {
     }
 
     private func setupNavigationBar() {
-        self.navigationController?.navigationBar.tintColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: colorSchemeVariant)
+        self.navigationController?.navigationBar.tintColor = UIColor(scheme: .textForeground, variant: colorSchemeVariant)
         self.navigationController?.navigationBar.titleTextAttributes = DefaultNavigationBar.titleTextAttributes(for: colorSchemeVariant)
         
         if navigationController?.viewControllers.count ?? 0 <= 1 {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Create/SimpleTextField.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Create/SimpleTextField.swift
@@ -37,7 +37,7 @@ extension Optional where Wrapped == String {
 
 class SimpleTextField: UITextField, Themeable {
     
-    @objc var colorSchemeVariant: ColorSchemeVariant  = ColorScheme.default().variant {
+    @objc var colorSchemeVariant: ColorSchemeVariant  = ColorScheme.default.variant {
         didSet {
             guard colorSchemeVariant != oldValue else { return }
             applyColorScheme(colorSchemeVariant)
@@ -104,8 +104,8 @@ class SimpleTextField: UITextField, Themeable {
     
     func applyColorScheme(_ colorSchemeVariant: ColorSchemeVariant) {
         keyboardAppearance = ColorScheme.keyboardAppearance(for: colorSchemeVariant)
-        textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: colorSchemeVariant)
-        backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorBarBackground, variant: colorSchemeVariant)
+        textColor = UIColor(scheme: .textForeground, variant: colorSchemeVariant)
+        backgroundColor = UIColor(scheme: .barBackground, variant: colorSchemeVariant)
     }
 
     override func textRect(forBounds bounds: CGRect) -> CGRect {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Create/ToggleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Create/ToggleView.swift
@@ -21,7 +21,7 @@ import Cartography
 
 final class ToggleView: UIView, Themeable {
     
-    @objc dynamic var colorSchemeVariant: ColorSchemeVariant  = ColorScheme.default().variant {
+    @objc dynamic var colorSchemeVariant: ColorSchemeVariant  = ColorScheme.default.variant {
         didSet {
             guard colorSchemeVariant != oldValue else { return }
             applyColorScheme(colorSchemeVariant)
@@ -60,8 +60,8 @@ final class ToggleView: UIView, Themeable {
     }
 
     func applyColorScheme(_ colorSchemeVariant: ColorSchemeVariant) {
-        backgroundColor = .wr_color(fromColorScheme: ColorSchemeColorBarBackground, variant: colorSchemeVariant)
-        titleLabel.textColor = .wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: colorSchemeVariant)
+        backgroundColor = UIColor(scheme: .barBackground, variant: colorSchemeVariant)
+        titleLabel.textColor = UIColor(scheme: .textForeground, variant: colorSchemeVariant)
     }
     
     private func createConstraints() {

--- a/Wire-iOS/Sources/UserInterface/Conversation/GuestsBarController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/GuestsBarController.swift
@@ -88,7 +88,7 @@ class GuestsBarController: UIViewController {
         
         view.backgroundColor = .clear
         
-        container.backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorLightGraphite, variant: .dark)
+        container.backgroundColor = UIColor(scheme: .lightGraphite, variant: .dark)
         container.clipsToBounds = true
         
         label.font = FontSpec(.small, .semibold).font!

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioButtonOverlay.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioButtonOverlay.swift
@@ -40,11 +40,11 @@ import Cartography
     fileprivate var heightConstraint: NSLayoutConstraint?
     fileprivate var widthConstraint: NSLayoutConstraint?
     
-    let darkColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground)
-    let brightColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextBackground)
+    let darkColor = UIColor(scheme: .textForeground)
+    let brightColor = UIColor(scheme: .textBackground)
     let greenColor = ZMAccentColor.strongLimeGreen.color;
-    let grayColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorAudioButtonOverlay)
-    let superviewColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorBackground)
+    let grayColor = UIColor(scheme: .audioButtonOverlay)
+    let superviewColor = UIColor(scheme: .background)
     
     let audioButton = IconButton()
     let playButton = IconButton()

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioEffectsPickerViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioEffectsPickerViewController.swift
@@ -230,7 +230,7 @@ import Cartography
         switch self.state {
         case .tip:
             self.subtitleLabel.text = "conversation.input_bar.audio_message.keyboard.filter_tip".localized.uppercased()
-            self.subtitleLabel.textColor = colorScheme.color(withName: ColorSchemeColorTextForeground)
+            self.subtitleLabel.textColor = colorScheme.color(named: .textForeground)
         case .time:
             let duration: Int
             if let player = self.audioPlayerController?.player {
@@ -243,7 +243,7 @@ import Cartography
             let (seconds, minutes) = (duration % 60, duration / 60)
             self.subtitleLabel.text = String(format: "%d:%02d", minutes, seconds)
             self.subtitleLabel.accessibilityValue = self.subtitleLabel.text
-            self.subtitleLabel.textColor = colorScheme.color(withName: ColorSchemeColorTextForeground)
+            self.subtitleLabel.textColor = colorScheme.color(named: .textForeground)
         default:
             // no-op
             break

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
@@ -89,7 +89,7 @@ private let zmLog = ZMSLog(tag: "UI")
         let colorScheme = ColorScheme()
         colorScheme.variant = .light
         
-        self.view.backgroundColor = colorScheme.color(withName: ColorSchemeColorTextForeground)
+        self.view.backgroundColor = colorScheme.color(named: .textForeground)
         
         self.recordTapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(recordButtonPressed(_:)))
         self.view.addGestureRecognizer(self.recordTapGestureRecognizer)
@@ -101,14 +101,14 @@ private let zmLog = ZMSLog(tag: "UI")
         [self.audioPreviewView, self.timeLabel, self.tipLabel, self.recordButton, self.stopRecordButton, self.confirmButton, self.redoButton, self.cancelButton, self.bottomToolbar, self.topContainer, self.topSeparator].forEach { $0.translatesAutoresizingMaskIntoConstraints = false }
         
         self.audioPreviewView.gradientWidth = 20
-        self.audioPreviewView.gradientColor = colorScheme.color(withName: ColorSchemeColorTextForeground)
+        self.audioPreviewView.gradientColor = colorScheme.color(named: .textForeground)
         
-        self.topSeparator.backgroundColor = colorScheme.color(withName: ColorSchemeColorSeparator)
+        self.topSeparator.backgroundColor = colorScheme.color(named: .separator)
         
         self.createTipLabel()
         
         self.timeLabel.font = FontSpec(.small, .light).font!
-        self.timeLabel.textColor = colorScheme.color(withName: ColorSchemeColorTextForeground, variant: .dark)
+        self.timeLabel.textColor = colorScheme.color(named: .textForeground, variant: .dark)
         
         [self.audioPreviewView, self.timeLabel, self.tipLabel].forEach(self.topContainer.addSubview)
         
@@ -167,7 +167,7 @@ private let zmLog = ZMSLog(tag: "UI")
             
             let maxEffect : UInt32 = UInt32(suitableEffects.count)
             let randomEffect = suitableEffects[Int(arc4random_uniform(maxEffect))]
-            let randomEffectImage = UIImage(for: randomEffect.icon, iconSize: .searchBar, color: colorScheme.color(withName: ColorSchemeColorTextDimmed))
+            let randomEffectImage = UIImage(for: randomEffect.icon, iconSize: .searchBar, color: colorScheme.color(named: .textDimmed))
             
             let tipEffectImageAttachment = NSTextAttachment()
             tipEffectImageAttachment.image = randomEffectImage
@@ -183,7 +183,7 @@ private let zmLog = ZMSLog(tag: "UI")
         self.tipLabel.attributedText = NSAttributedString(attributedString: attributedTipText)
         self.tipLabel.numberOfLines = 2
         self.tipLabel.font = FontSpec(.small, .light).font!
-        self.tipLabel.textColor = colorScheme.color(withName: ColorSchemeColorTextDimmed)
+        self.tipLabel.textColor = colorScheme.color(named: .textDimmed)
         self.tipLabel.textAlignment = .center
         
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordViewController.swift
@@ -131,11 +131,11 @@ private let zmLog = ZMSLog(tag: "UI")
             self.audioPreviewView.color = color
         }
         
-        topContainerView.backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorBackground)
-        bottomContainerView.backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorBackground)
+        topContainerView.backgroundColor = UIColor(scheme: .background)
+        bottomContainerView.backgroundColor = UIColor(scheme: .background)
         
-        topSeparator.backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorSeparator)
-        rightSeparator.backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorSeparator)
+        topSeparator.backgroundColor = UIColor(scheme: .separator)
+        rightSeparator.backgroundColor = UIColor(scheme: .separator)
         
         let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(topContainerTapped))
         topContainerView.addGestureRecognizer(tapRecognizer)
@@ -146,15 +146,15 @@ private let zmLog = ZMSLog(tag: "UI")
         
         timeLabel.accessibilityLabel = "audioRecorderTimeLabel"
         timeLabel.font = FontSpec(.small, .none).font!
-        timeLabel.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground)
+        timeLabel.textColor = UIColor(scheme: .textForeground)
         
         topTooltipLabel.text = "conversation.input_bar.audio_message.tooltip.pull_send".localized.uppercased()
         topTooltipLabel.accessibilityLabel = "audioRecorderTopTooltipLabel"
         topTooltipLabel.font = FontSpec(.small, .none).font!
-        topTooltipLabel.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextDimmed)
+        topTooltipLabel.textColor = UIColor(scheme: .textDimmed)
         
         cancelButton.setIcon(.cancel, with: .tiny, for: UIControlState())
-        cancelButton.setIconColor(UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground), for: .normal)
+        cancelButton.setIconColor(UIColor(scheme: .textForeground), for: .normal)
         cancelButton.addTarget(self, action: #selector(cancelButtonPressed(_:)), for: .touchUpInside)
         cancelButton.accessibilityLabel = "audioRecorderCancel"
         updateRecordingState(recordingState)

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardPermissionsCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardPermissionsCell.swift
@@ -38,7 +38,7 @@ open class CameraKeyboardPermissionsCell: UICollectionViewCell {
     
     public override init(frame: CGRect) {
         super.init(frame: frame)
-        self.backgroundColor = ColorScheme.default().color(withName: ColorSchemeColorGraphite)
+        self.backgroundColor = UIColor(scheme: .graphite)
         
         cameraIcon.setIcon(.cameraLens, with: .tiny, for: .normal)
         cameraIcon.setIconColor(.white, for: .normal)

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
@@ -308,7 +308,7 @@ open class CameraKeyboardViewController: UIViewController {
             self.view.backgroundColor = .white
             self.collectionView.delaysContentTouches = true
         } else {
-            self.view.backgroundColor = ColorScheme.default().color(withName: ColorSchemeColorGraphite)
+            self.view.backgroundColor = UIColor(scheme: .graphite)
             self.collectionView.delaysContentTouches = false
         }
         

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Markdown.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Markdown.swift
@@ -25,7 +25,7 @@ extension ConversationInputBarViewController {
         
         markdownButton.addTarget(self, action: #selector(markdownButtonTapped), for: .touchUpInside)
         markdownButton.setIcon(.markdownToggle, with: .tiny, for: .normal)
-        markdownButton.setIconColor(ColorScheme.default().color(withName: ColorSchemeColorIconNormal), for: .normal)
+        markdownButton.setIconColor(UIColor(scheme: .iconNormal), for: .normal)
     }
     
     @objc public func updateMarkdownButton() {
@@ -33,9 +33,9 @@ extension ConversationInputBarViewController {
         let color: UIColor
         
         if inputBar.isMarkingDown {
-            color = ColorScheme.default().color(withName: ColorSchemeColorAccent)
+            color = UIColor(scheme: .accent)
         } else {
-            color = ColorScheme.default().color(withName: ColorSchemeColorIconNormal)
+            color = UIColor(scheme: .iconNormal)
         }
         
         markdownButton.setIconColor(color, for: .normal)

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/Emoji/ConversationInputBarViewController+Emoji.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/Emoji/ConversationInputBarViewController+Emoji.swift
@@ -48,24 +48,24 @@ extension ConversationInputBarViewController {
             if self.sendButtonState.ephemeral {
                 type = ZetaIconType.textEphemeral
                 style = "ephemeral"
-                color = ColorScheme.default().color(withName: ColorSchemeColorAccent)
+                color = UIColor(scheme: .accent)
             }
             else {
                 type = ZetaIconType.text
                 style = .none
-                color = ColorScheme.default().color(withName: ColorSchemeColorIconNormal)
+                color = UIColor(scheme: .iconNormal)
             }
         }
         else {
             if self.sendButtonState.ephemeral {
                 type = ZetaIconType.emojiEphemeral
                 style = "ephemeral"
-                color = ColorScheme.default().color(withName: ColorSchemeColorAccent)
+                color = UIColor(scheme: .accent)
             }
             else {
                 type = ZetaIconType.emoji
                 style = .none
-                color = ColorScheme.default().color(withName: ColorSchemeColorIconNormal)
+                color = UIColor(scheme:.iconNormal)
             }
         }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/Emoji/EmojiKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/Emoji/EmojiKeyboardViewController.swift
@@ -71,7 +71,7 @@ protocol EmojiKeyboardViewControllerDelegate: class {
     func setupViews() {
         let colorScheme = ColorScheme()
         colorScheme.variant = .light
-        view.backgroundColor = colorScheme.color(withName: ColorSchemeColorTextForeground)
+        view.backgroundColor = colorScheme.color(named: .textForeground)
         view.addSubview(collectionView)
 
         addChildViewController(sectionViewController)

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
@@ -194,7 +194,7 @@ private struct InputBarConstants {
         textView.textContainerInset = UIEdgeInsetsMake(inputBarVerticalInset / 2, 0, inputBarVerticalInset / 2, 4)
         textView.placeholderTextContainerInset = UIEdgeInsetsMake(21, 10, 21, 0)
         textView.keyboardType = .default
-        textView.keyboardAppearance = ColorScheme.default().keyboardAppearance
+        textView.keyboardAppearance = ColorScheme.default.keyboardAppearance
         textView.placeholderTextTransform = .upper
         textView.tintAdjustmentMode = .automatic
         
@@ -403,11 +403,11 @@ private struct InputBarConstants {
             
             if self.inputBarState.isEphemeral {
                 button.setIconColor(UIColor.accent(), for: .normal)
-                button.setIconColor(ColorScheme.default().color(withName: ColorSchemeColorIconNormal), for: .highlighted)
+                button.setIconColor(UIColor(scheme: .iconNormal), for: .highlighted)
             }
             else {
-                button.setIconColor(ColorScheme.default().color(withName: ColorSchemeColorIconNormal), for: .normal)
-                button.setIconColor(ColorScheme.default().color(withName: ColorSchemeColorIconHighlighted), for: .highlighted)
+                button.setIconColor(UIColor(scheme: .iconNormal), for: .normal)
+                button.setIconColor(UIColor(scheme: .iconHighlighted), for: .highlighted)
             }
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarButtonsView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarButtonsView.swift
@@ -80,7 +80,7 @@ public final class InputBarButtonsView: UIView {
         buttonOuterContainer.clipsToBounds = true
         addSubview(buttonOuterContainer)
         addSubview(expandRowButton)
-        self.backgroundColor = ColorScheme.default().color(withName: ColorSchemeColorBarBackground)
+        self.backgroundColor = UIColor(scheme: .barBackground)
     }
     
     func createConstraints() {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/TypingIndicatorView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/TypingIndicatorView.swift
@@ -40,8 +40,8 @@ class AnimatedPenView : UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         
-        let iconColor = ColorScheme.default().color(withName: ColorSchemeColorTextForeground)
-        let backgroundColor = ColorScheme.default().color(withName: ColorSchemeColorBackground)
+        let iconColor = UIColor(scheme: .textForeground)
+        let backgroundColor = UIColor(scheme: .background)
         
         dots.image = UIImage(for: .typingDots, fontSize: 8, color: iconColor)
         pen.image = UIImage(for: .pencil, fontSize: 8, color: iconColor)

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/WaveFormView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/WaveFormView.swift
@@ -37,7 +37,7 @@ final class WaveFormView: UIView {
         }
     }
     
-    var gradientColor: UIColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorBackground) {
+    var gradientColor: UIColor = UIColor(scheme: .background) {
         didSet {
             updateWaveFormColor()
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/PlaceholderConversationView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/PlaceholderConversationView.swift
@@ -27,7 +27,7 @@ import Cartography
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        self.backgroundColor = ColorScheme.default().color(withName: ColorSchemeColorBackground)
+        self.backgroundColor = UIColor(scheme: .background)
         
         let image = WireStyleKit.imageOfShield(with: UIColor(rgb: 0xbac8d1, alpha: 0.24))
         shieldImageView = UIImageView(image: image)

--- a/Wire-iOS/Sources/UserInterface/ConversationList/BackgroundViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/BackgroundViewController.swift
@@ -166,7 +166,7 @@ final public class BackgroundViewController: UIViewController {
     }
     
     private func updateForColorScheme() {
-        self.darkMode = (ColorScheme.default().variant == .dark)
+        self.darkMode = (ColorScheme.default.variant == .dark)
     }
     
     internal func updateFor(imageMediumDataChanged: Bool, accentColorValueChanged: Bool) {

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListTopBar.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListTopBar.swift
@@ -42,7 +42,7 @@ final class ConversationListTopBar: TopBar {
             let titleLabel = UILabel()
             
             titleLabel.font = FontSpec(.normal, .semibold).font
-            titleLabel.textColor = ColorScheme.default().color(withName: ColorSchemeColorTextForeground, variant: .dark)
+            titleLabel.textColor = UIColor(scheme: .textForeground, variant: .dark)
             titleLabel.accessibilityTraits = UIAccessibilityTraitHeader
             titleLabel.setContentCompressionResistancePriority(UILayoutPriority.required, for: .horizontal)
             titleLabel.setContentCompressionResistancePriority(UILayoutPriority.required, for: .vertical)

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListAccessoryView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListAccessoryView.swift
@@ -138,7 +138,7 @@ import Cartography
         self.badgeView.isHidden = false
         self.typingView.isHidden = true
         
-        self.textLabel.textColor = ColorScheme.default().color(withName: ColorSchemeColorTextForeground, variant: .dark)
+        self.textLabel.textColor = UIColor(scheme: .textForeground, variant: .dark)
         
         self.collapseWidthConstraint.isActive = false
         
@@ -159,14 +159,14 @@ import Cartography
             
         case .unreadMessages(_):
             self.badgeView.backgroundColor = UIColor(white: 0, alpha: 0.16)
-            self.textLabel.textColor = ColorScheme.default().color(withName: ColorSchemeColorTextForeground, variant: .light)
-            self.badgeView.backgroundColor = ColorScheme.default().color(withName: ColorSchemeColorTextBackground, variant: .light)
+            self.textLabel.textColor = UIColor(scheme: .textForeground, variant: .light)
+            self.badgeView.backgroundColor = UIColor(scheme: .textBackground, variant: .light)
             
         case .unreadPing:
-            self.badgeView.backgroundColor = ColorScheme.default().color(withName: ColorSchemeColorTextBackground, variant: .light)
+            self.badgeView.backgroundColor = UIColor(scheme: .textBackground, variant: .light)
 
         case .missedCall:
-            self.badgeView.backgroundColor = ColorScheme.default().color(withName: ColorSchemeColorTextBackground, variant: .light)
+            self.badgeView.backgroundColor = UIColor(scheme: .textBackground, variant: .light)
 
         default:
             self.typingView.image = .none

--- a/Wire-iOS/Sources/UserInterface/ConversationList/UserNameTakeOverViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/UserNameTakeOverViewController.swift
@@ -74,12 +74,12 @@ final class UserNameTakeOverViewController: UIViewController {
         [topContainer, subtitleLabel, chooseOwnButton, keepSuggestedButton].forEach(contentView.addSubview)
         
         displayNameLabel.font = FontSpec(.large, .thin).font!
-        displayNameLabel.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextDimmed, variant: .light)
+        displayNameLabel.textColor = UIColor(scheme: .textDimmed, variant: .light)
         displayNameLabel.text = name
         displayNameLabel.textAlignment = .center
         
         suggestedHandleLabel.font = FontSpec(.large, .none).font!
-        suggestedHandleLabel.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: .dark)
+        suggestedHandleLabel.textColor = UIColor(scheme: .textForeground, variant: .dark)
         suggestedHandleLabel.text = "@" + suggestedHandle
         suggestedHandleLabel.textAlignment = .center
 
@@ -101,7 +101,7 @@ final class UserNameTakeOverViewController: UIViewController {
         
         let font = FontSpec(.large, .thin).font!
         let linkFont = FontSpec(.large, .none).font!
-        let color = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: .dark)
+        let color = UIColor(scheme: .textForeground, variant: .dark)
 
         let subtitle = "registration.select_handle.takeover.subtitle".localized
         let linkAttributes: [NSAttributedStringKey: Any] = [

--- a/Wire-iOS/Sources/UserInterface/DraftListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/DraftListViewController.swift
@@ -64,13 +64,13 @@ final class DraftListViewController: CoreDataTableViewController<MessageDraft, D
         paragraphStyle.alignment = .center
         paragraphStyle.paragraphSpacing = 4
         let paragraphAttributes = [NSAttributedStringKey.paragraphStyle: paragraphStyle]
-        let color = ColorScheme.default().color(withName: ColorSchemeColorTextDimmed)
+        let color = UIColor(scheme: .textDimmed)
         let title = "compose.drafts.empty.title".localized.uppercased() && FontSpec(.small, .semibold).font!
         let subtitle = "compose.drafts.empty.subtitle".localized.uppercased() && FontSpec(.small, .light).font!
         emptyLabel.attributedText = (title + "\n" + subtitle) && color && paragraphAttributes
         emptyLabel.numberOfLines = 0
         view.addSubview(emptyLabel)
-        view.backgroundColor = ColorScheme.default().color(withName: ColorSchemeColorBackground)
+        view.backgroundColor = UIColor(scheme: .background)
 
         constrain(view, emptyLabel) { view, emptyLabel in
             emptyLabel.centerY == view.centerY - 20
@@ -88,7 +88,7 @@ final class DraftListViewController: CoreDataTableViewController<MessageDraft, D
 
     private func setupViews() {
         title = "compose.drafts.title".localized.uppercased()
-        tableView.backgroundColor = ColorScheme.default().color(withName: ColorSchemeColorBackground)
+        tableView.backgroundColor = UIColor(scheme: .background)
         navigationItem.rightBarButtonItem = UIBarButtonItem(icon: .X, style: .done, target: self, action: #selector(closeTapped))
         navigationItem.rightBarButtonItem?.accessibilityLabel = "closeButton"
         navigationItem.leftBarButtonItem = UIBarButtonItem(icon: .plus, target: self, action: #selector(newDraftTapped))

--- a/Wire-iOS/Sources/UserInterface/DraftMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/DraftMessageCell.swift
@@ -34,7 +34,6 @@ final class DraftMessageCell: UITableViewCell {
     private let titleLabel = UILabel()
     private let dateLabel = UILabel()
     private let separator = UIView()
-    private let color = ColorScheme.default().color(withName:)
 
     override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -44,14 +43,14 @@ final class DraftMessageCell: UITableViewCell {
 
     private func setupViews() {
         titleLabel.font = FontSpec(.normal, .light).font!
-        titleLabel.textColor = color(ColorSchemeColorTextForeground)
+        titleLabel.textColor = UIColor(scheme: .textForeground)
         dateLabel.font = FontSpec(.medium, .regular).font!
-        dateLabel.textColor = color(ColorSchemeColorTextDimmed)
-        backgroundColor = color(ColorSchemeColorBackground)
+        dateLabel.textColor = UIColor(scheme: .textDimmed)
+        backgroundColor = UIColor(scheme: .background)
         let selectedView = UIView()
-        selectedView.backgroundColor = color(ColorSchemeColorTokenFieldBackground)
+        selectedView.backgroundColor = UIColor(scheme: .tokenFieldBackground)
         selectedBackgroundView = selectedView
-        separator.backgroundColor = color(ColorSchemeColorSeparator)
+        separator.backgroundColor = UIColor(scheme: .separator)
         [titleLabel, dateLabel, separator].forEach(addSubview)
     }
 

--- a/Wire-iOS/Sources/UserInterface/DraftNavigationController.swift
+++ b/Wire-iOS/Sources/UserInterface/DraftNavigationController.swift
@@ -26,14 +26,14 @@ final class DraftNavigationController: UINavigationController {
         super.viewDidLoad()
         navigationBar.isTranslucent = false
         navigationBar.isOpaque = true
-        let textColor = ColorScheme.default().color(withName: ColorSchemeColorTextForeground)
+        let textColor = UIColor(scheme: .textForeground)
         navigationBar.tintColor = textColor
 
-        let image = UIImage.shadowImage(withInset: 0, color: ColorScheme.default().color(withName: ColorSchemeColorSeparator))
+        let image = UIImage.shadowImage(withInset: 0, color: UIColor(scheme: .separator))
         let scaleImage = UIImage(cgImage: image.cgImage!, scale: UIScreen.main.scale, orientation: .up)
         navigationBar.shadowImage = scaleImage.stretchableImage(withLeftCapWidth: 20, topCapHeight: 0)
 
-        navigationBar.barTintColor = ColorScheme.default().color(withName: ColorSchemeColorBackground)
+        navigationBar.barTintColor = UIColor(scheme: .background)
         navigationBar.titleTextAttributes = [
             .font: FontSpec(.medium, .semibold).font!,
             .foregroundColor: textColor

--- a/Wire-iOS/Sources/UserInterface/DraftSendInputAccessoryView.swift
+++ b/Wire-iOS/Sources/UserInterface/DraftSendInputAccessoryView.swift
@@ -48,7 +48,7 @@ final class DraftSendInputAccessoryView: UIView {
     func setupViews() {
         backgroundColor = UIColor.clear
         [sendButton, separator].forEach(addSubview)
-        separator.backgroundColor = ColorScheme.default().color(withName: ColorSchemeColorSeparator)
+        separator.backgroundColor = UIColor(scheme: .separator)
         sendButton.cas_styleClass = "send-button"
         sendButton.adjustsImageWhenHighlighted = false
         sendButton.adjustBackgroundImageWhenHighlighted = true

--- a/Wire-iOS/Sources/UserInterface/DraftsRootViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/DraftsRootViewController.swift
@@ -62,7 +62,7 @@ final class DraftsRootViewController: UISplitViewController {
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
-        return ColorScheme.default().statusBarStyle
+        return ColorScheme.default.statusBarStyle
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsFooterView.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsFooterView.swift
@@ -33,7 +33,7 @@ final class GroupDetailsFooterView: UIView {
     public let moreButton = IconButton()
     public let addButton = IconButton()
     
-    init(variant: ColorSchemeVariant = ColorScheme.default().variant) {
+    init(variant: ColorSchemeVariant = ColorScheme.default.variant) {
         self.variant = variant
         super.init(frame: .zero)
         setupViews()
@@ -45,14 +45,13 @@ final class GroupDetailsFooterView: UIView {
     }
     
     private func setupViews() {
-        func color(_ name: String) -> UIColor { return .wr_color(fromColorScheme: name, variant: variant) }
         [addButton, moreButton].forEach {
             addSubview($0)
             $0.translatesAutoresizingMaskIntoConstraints = false
-            $0.setIconColor(color(ColorSchemeColorIconNormal), for: .normal)
-            $0.setIconColor(color(ColorSchemeColorIconHighlighted), for: .highlighted)
-            $0.setTitleColor(color(ColorSchemeColorIconNormal), for: .normal)
-            $0.setTitleColor(color(ColorSchemeColorTextDimmed), for: .highlighted)
+            $0.setIconColor(UIColor(scheme: .iconNormal), for: .normal)
+            $0.setIconColor(UIColor(scheme: .iconHighlighted), for: .highlighted)
+            $0.setTitleColor(UIColor(scheme: .iconNormal), for: .normal)
+            $0.setTitleColor(UIColor(scheme: .textDimmed), for: .highlighted)
             $0.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
         }
         
@@ -61,7 +60,7 @@ final class GroupDetailsFooterView: UIView {
         addButton.setTitle("participants.footer.add_title".localized.uppercased(), for: .normal)
         addButton.titleImageSpacing = 16
         addButton.titleLabel?.font = FontSpec(.small, .regular).font
-        backgroundColor = color(ColorSchemeColorBarBackground)
+        backgroundColor = UIColor(scheme: .barBackground)
         addButton.accessibilityIdentifier = "OtherUserMetaControllerLeftButton"
         moreButton.accessibilityIdentifier = "OtherUserMetaControllerRightButton"
     }

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsGuestOptionsCell.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsGuestOptionsCell.swift
@@ -38,11 +38,11 @@ class GroupDetailsGuestOptionsCell: UICollectionViewCell {
         didSet {
             backgroundColor = isHighlighted
                 ? .init(white: 0, alpha: 0.08)
-                : .wr_color(fromColorScheme: ColorSchemeColorBarBackground, variant: variant)
+                : UIColor(scheme: .barBackground, variant: variant)
         }
     }
     
-    var variant : ColorSchemeVariant = ColorScheme.default().variant {
+    var variant : ColorSchemeVariant = ColorScheme.default.variant {
         didSet {
             guard oldValue != variant else { return }
             configureColors()
@@ -104,11 +104,11 @@ class GroupDetailsGuestOptionsCell: UICollectionViewCell {
     }
     
     private func configureColors() {
-        let sectionTextColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorSectionText, variant: variant)
-        backgroundColor = .wr_color(fromColorScheme: ColorSchemeColorBarBackground, variant: variant)
-        guestIconView.image = UIImage(for: .guest, iconSize: .tiny, color: UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: variant))
+        let sectionTextColor = UIColor(scheme: .sectionText, variant: variant)
+        backgroundColor = UIColor(scheme: .barBackground, variant: variant)
+        guestIconView.image = UIImage(for: .guest, iconSize: .tiny, color: UIColor(scheme: .textForeground, variant: variant))
         accessoryIconView.image = UIImage(for: .disclosureIndicator, iconSize: .like, color: sectionTextColor)
-        titleLabel.textColor = .wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: variant)
+        titleLabel.textColor = UIColor(scheme: .textForeground, variant: variant)
         statusLabel.textColor = sectionTextColor
     }
     

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsRenameCell.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsRenameCell.swift
@@ -26,7 +26,7 @@ class GroupDetailsRenameCell : UICollectionViewCell {
     let titleTextField = SimpleTextField()
     var contentStackView: UIStackView!
     
-    var variant : ColorSchemeVariant = ColorScheme.default().variant {
+    var variant : ColorSchemeVariant = ColorScheme.default.variant {
         didSet {
             guard oldValue != variant else { return }
             configureColors()
@@ -54,7 +54,7 @@ class GroupDetailsRenameCell : UICollectionViewCell {
         verifiedIconView.setContentCompressionResistancePriority(UILayoutPriority.required, for: .horizontal)
         verifiedIconView.accessibilityIdentifier = "img.shield"
         
-        accessoryIconView.image = UIImage(for: .pencil, iconSize: .like, color: .wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: variant))
+        accessoryIconView.image = UIImage(for: .pencil, iconSize: .like, color: UIColor(scheme: .textForeground, variant: variant))
         accessoryIconView.translatesAutoresizingMaskIntoConstraints = false
         accessoryIconView.contentMode = .scaleAspectFit
         accessoryIconView.setContentHuggingPriority(UILayoutPriority.required, for: .horizontal)
@@ -65,7 +65,7 @@ class GroupDetailsRenameCell : UICollectionViewCell {
         titleTextField.returnKeyType = .done
         titleTextField.backgroundColor = .clear
         titleTextField.textInsets = UIEdgeInsets.zero
-        titleTextField.keyboardAppearance = ColorScheme.default().keyboardAppearance
+        titleTextField.keyboardAppearance = ColorScheme.default.keyboardAppearance
 
         contentStackView = UIStackView(arrangedSubviews: [verifiedIconView, titleTextField, accessoryIconView])
         contentStackView.axis = .horizontal
@@ -89,9 +89,9 @@ class GroupDetailsRenameCell : UICollectionViewCell {
     }
     
     private func configureColors() {
-        backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorBarBackground, variant: variant)
-        accessoryIconView.image = UIImage(for: .pencil, iconSize: .tiny, color: UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: variant))
-        titleTextField.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: variant)
+        backgroundColor = UIColor(scheme: .barBackground, variant: variant)
+        accessoryIconView.image = UIImage(for: .pencil, iconSize: .tiny, color: UIColor(scheme: .textForeground, variant: variant))
+        titleTextField.textColor = UIColor(scheme: .textForeground, variant: variant)
     }
     
 }

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
@@ -41,7 +41,7 @@ import Cartography
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
-        return ColorScheme.default().statusBarStyle
+        return ColorScheme.default.statusBarStyle
     }
     
     public init(conversation: ZMConversation) {
@@ -61,7 +61,7 @@ import Cartography
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "participants.title".localized.uppercased()
-        view.backgroundColor = .wr_color(fromColorScheme: ColorSchemeColorContentBackground)
+        view.backgroundColor = UIColor(scheme: .contentBackground)
         
         let collectionViewLayout = UICollectionViewFlowLayout()
         collectionViewLayout.scrollDirection = .vertical
@@ -82,7 +82,7 @@ import Cartography
         }
         
         [collectionView, footerView, bottomSpacer].forEach(view.addSubview)
-        bottomSpacer.backgroundColor = .wr_color(fromColorScheme: ColorSchemeColorBarBackground)
+        bottomSpacer.backgroundColor = UIColor(scheme: .barBackground)
         
         constrain(view, collectionView, footerView, bottomSpacer) { container, collectionView, footerView, bottomSpacer in
             collectionView.top == container.top

--- a/Wire-iOS/Sources/UserInterface/Helpers/UserDetailViewControllerFactory.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UserDetailViewControllerFactory.swift
@@ -32,7 +32,7 @@ final class UserDetailViewControllerFactory: NSObject {
                                                      profileViewControllerDelegate: ProfileViewControllerDelegate,
                                                      viewControllerDismisser: ViewControllerDismisser) -> UIViewController {
         if user.isServiceUser {
-            let variant = ServiceDetailVariant(colorScheme: ColorScheme.default().variant, opaque: true)
+            let variant = ServiceDetailVariant(colorScheme: ColorScheme.default.variant, opaque: true)
             let serviceDetailViewController = ServiceDetailViewController(serviceUser: user, destinationConversation: conversation, actionType: .removeService, variant: variant)
             serviceDetailViewController.viewControllerDismisser = viewControllerDismisser
             return serviceDetailViewController

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -138,7 +138,7 @@ extension ZClientViewController {
         var viewController: UIViewController?
 
         if user.isSelfUser {
-            let clientListViewController = ClientListViewController(clientsList: Array(user.clients), credentials: nil, detailedView: true, showTemporary: true, variant: ColorScheme.default().variant)
+            let clientListViewController = ClientListViewController(clientsList: Array(user.clients), credentials: nil, detailedView: true, showTemporary: true, variant: ColorScheme.default.variant)
             clientListViewController.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(dismissClientListController(_:)))
             viewController = clientListViewController
         } else {

--- a/Wire-iOS/Sources/UserInterface/MarkdownBarView.swift
+++ b/Wire-iOS/Sources/UserInterface/MarkdownBarView.swift
@@ -31,8 +31,8 @@ public final class MarkdownBarView: UIView {
     weak var delegate: MarkdownBarViewDelegate?
     
     private let stackView =  UIStackView()
-    private let accentColor = ColorScheme.default().accentColor
-    private let normalColor = ColorScheme.default().color(withName: ColorSchemeColorIconNormal)
+    private let accentColor = ColorScheme.default.accentColor
+    private let normalColor = UIColor(scheme: .iconNormal)
     
     public let headerButton         = PopUpIconButton()
     public let boldButton           = IconButton()

--- a/Wire-iOS/Sources/UserInterface/MessageComposeViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/MessageComposeViewController.swift
@@ -33,7 +33,6 @@ final class MessageComposeViewController: UIViewController {
 
     private let subjectTextField = UITextField()
     fileprivate let messageTextView = MarkdownTextView()
-    private let color = ColorScheme.default().color(withName:)
     private let sendButtonView = DraftSendInputAccessoryView()
     fileprivate let markdownBarView = MarkdownBarView()
     private var bottomEdgeConstraint : NSLayoutConstraint?
@@ -82,7 +81,7 @@ final class MessageComposeViewController: UIViewController {
     }
 
     private func setupViews() {
-        view.backgroundColor = color(ColorSchemeColorBackground)
+        view.backgroundColor = UIColor(scheme: .background)
         [messageTextView, sendButtonView, markdownBarView].forEach(view.addSubview)
         setupInputAccessoryView()
         setupNavigationItem()
@@ -104,9 +103,9 @@ final class MessageComposeViewController: UIViewController {
         messageTextView.textContainer.lineFragmentPadding = 0
         messageTextView.backgroundColor = .clear
         messageTextView.delegate = self
-        messageTextView.indicatorStyle = ColorScheme.default().indicatorStyle
+        messageTextView.indicatorStyle = ColorScheme.default.indicatorStyle
         messageTextView.accessibilityLabel = "messageTextField"
-        messageTextView.keyboardAppearance = ColorScheme.default().keyboardAppearance
+        messageTextView.keyboardAppearance = ColorScheme.default.keyboardAppearance
         markdownBarView.delegate = messageTextView
     }
 
@@ -116,16 +115,16 @@ final class MessageComposeViewController: UIViewController {
 
     private func setupNavigationItem() {
         subjectTextField.delegate = self
-        subjectTextField.textColor = color(ColorSchemeColorTextForeground)
+        subjectTextField.textColor = UIColor(scheme: .textForeground)
         subjectTextField.tintColor = .accent()
         subjectTextField.textAlignment = .center
         subjectTextField.font = FontSpec(.medium, .semibold).font!
         let placeholder = "compose.drafts.compose.subject.placeholder".localized.uppercased()
-        subjectTextField.attributedPlaceholder = placeholder && color(ColorSchemeColorSeparator) && FontSpec(.medium, .semibold).font!
+        subjectTextField.attributedPlaceholder = placeholder && UIColor(scheme: .separator) && FontSpec(.medium, .semibold).font!
         subjectTextField.bounds = CGRect(x: 0, y: 0, width: 200, height: 44)
         subjectTextField.accessibilityLabel = "subjectTextField"
         subjectTextField.alpha = 0
-        subjectTextField.keyboardAppearance = ColorScheme.default().keyboardAppearance
+        subjectTextField.keyboardAppearance = ColorScheme.default.keyboardAppearance
         navigationItem.titleView = subjectTextField
     }
 
@@ -152,8 +151,8 @@ final class MessageComposeViewController: UIViewController {
         draftsBackButton.setIcon(.compose, with: .tiny, for: .normal)
         draftsBackButton.frame = CGRect(x: 0, y: 0, width: 40, height: 20)
         draftsBackButton.titleLabel?.font = FontSpec(.medium, .semibold).font
-        draftsBackButton.setIconColor(color(ColorSchemeColorTextForeground), for: .normal)
-        draftsBackButton.setTitleColor(color(ColorSchemeColorSeparator), for: .normal)
+        draftsBackButton.setIconColor(UIColor(scheme: .textForeground), for: .normal)
+        draftsBackButton.setTitleColor(UIColor(scheme: .separator), for: .normal)
         draftsBackButton.accessibilityIdentifier = "back"
 
         let count = persistence.numberOfStoredDrafts()

--- a/Wire-iOS/Sources/UserInterface/Overlay/InAppNotifications/ChatHeadView.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/InAppNotifications/ChatHeadView.swift
@@ -40,11 +40,11 @@ class ChatHeadView: UIView {
     
     private let titleRegularAttributes: [NSAttributedStringKey: AnyObject] = [
         .font: FontSpec(.medium, .none).font!.withSize(14),
-        .foregroundColor: ColorScheme.default().color(withName: ColorSchemeColorChatHeadTitleText)
+        .foregroundColor: UIColor(scheme: .chatHeadTitleText)
     ]
     private let titleMediumAttributes: [NSAttributedStringKey: AnyObject] = [
         .font: FontSpec(.medium, .medium).font!.withSize(14),
-        .foregroundColor: ColorScheme.default().color(withName: ColorSchemeColorChatHeadTitleText)
+        .foregroundColor: UIColor(scheme: .chatHeadTitleText)
     ]
     
     private lazy var bodyFont: UIFont = {
@@ -59,11 +59,7 @@ class ChatHeadView: UIView {
         let height = imageDiameter + 2 * padding
         return CGSize(width: UIViewNoIntrinsicMetric, height: height)
     }
-    
-    private func color(withName name: String) -> UIColor {
-        return ColorScheme.default().color(withName: name)
-    }
-    
+
     init(title: String?, body: String, userID: UUID, sender: ZMUser?, userInfo: [AnyHashable : Any]? = nil, isEphemeral: Bool = false) {
         self.title = title
         self.body = body
@@ -82,10 +78,10 @@ class ChatHeadView: UIView {
     // MARK: - Setup
     
     private func setup() {
-        backgroundColor = color(withName: ColorSchemeColorChatHeadBackground)
+        backgroundColor = UIColor(scheme: .chatHeadBackground)
         layer.cornerRadius = 6
         layer.borderWidth = 0.5
-        layer.borderColor = color(withName: ColorSchemeColorChatHeadBorder).cgColor
+        layer.borderColor = UIColor(scheme: .chatHeadBorder).cgColor
         
         layer.shadowColor = UIColor.black.cgColor
         layer.shadowOpacity = 0.12
@@ -110,7 +106,7 @@ class ChatHeadView: UIView {
             label.backgroundColor = .clear
             label.isUserInteractionEnabled = false
             label.attributedText = attributedTitleText(title)
-            label.textColor = color(withName: ColorSchemeColorChatHeadTitleText)
+            label.textColor = UIColor(scheme: .chatHeadTitleText)
             label.lineBreakMode = .byTruncatingTail
             titleLabel = label
             labelContainer.addSubview(label)
@@ -122,7 +118,7 @@ class ChatHeadView: UIView {
         
         let bodyAttributes = (!isEphemeral && titleLabel == nil) ? titleMediumAttributes : [
             .font: bodyFont,
-            .foregroundColor: color(withName: ColorSchemeColorChatHeadSubtitleText)
+            .foregroundColor: UIColor(scheme: .chatHeadSubtitleText)
         ]
         
         subtitleLabel.attributedText = NSAttributedString(string: body, attributes: bodyAttributes)

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/ViewDescriptions/BackButtonDescription.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Flow/ViewDescriptions/BackButtonDescription.swift
@@ -27,8 +27,8 @@ extension BackButtonDescription: ViewDescriptor {
     func create() -> UIView {
         let button = IconButton()
         button.frame = CGRect(x: 0, y: 0, width: 40, height: 20)
-        button.setIconColor(UIColor.wr_color(fromColorScheme: ColorSchemeColorIconNormal, variant: .light), for: .normal)
-        button.setIconColor(UIColor.wr_color(fromColorScheme: ColorSchemeColorTextDimmed, variant: .light), for: .highlighted)
+        button.setIconColor(UIColor(scheme: .iconNormal, variant: .light), for: .normal)
+        button.setIconColor(UIColor(scheme: .textDimmed, variant: .light), for: .highlighted)
         let iconType: ZetaIconType = UIApplication.isLeftToRightLayout ? .chevronLeft : .chevronRight
         button.setIcon(iconType, with: .tiny, for: .normal)
         button.accessibilityIdentifier = accessibilityIdentifier

--- a/Wire-iOS/Sources/UserInterface/SelfProfile/ProfileView.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/ProfileView.swift
@@ -56,19 +56,19 @@ import Cartography
         nameLabel.accessibilityIdentifier = "name"
         nameLabel.setContentHuggingPriority(UILayoutPriority.required, for: .vertical)
         nameLabel.setContentCompressionResistancePriority(UILayoutPriority.required, for: .vertical)
-        nameLabel.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: .dark)
+        nameLabel.textColor = UIColor(scheme: .textForeground, variant: .dark)
         nameLabel.font = FontSpec(.large, .light).font!
         handleLabel.accessibilityLabel = "profile_view.accessibility.handle".localized
         handleLabel.accessibilityIdentifier = "username"
         handleLabel.setContentHuggingPriority(UILayoutPriority.required, for: .vertical)
         handleLabel.setContentCompressionResistancePriority(UILayoutPriority.required, for: .vertical)
-        handleLabel.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: .dark)
+        handleLabel.textColor = UIColor(scheme: .textForeground, variant: .dark)
         handleLabel.font = FontSpec(.small, .regular).font!
         teamNameLabel.accessibilityLabel = "profile_view.accessibility.team_name".localized
         teamNameLabel.accessibilityIdentifier = "team name"
         teamNameLabel.setContentHuggingPriority(UILayoutPriority.required, for: .vertical)
         teamNameLabel.setContentCompressionResistancePriority(UILayoutPriority.required, for: .vertical)
-        teamNameLabel.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: .dark)
+        teamNameLabel.textColor = UIColor(scheme: .textForeground, variant: .dark)
         teamNameLabel.font = FontSpec(.small, .regular).font!
         
         nameLabel.text = user.name

--- a/Wire-iOS/Sources/UserInterface/Services/ServiceDetailViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Services/ServiceDetailViewController.swift
@@ -228,8 +228,8 @@ final class ServiceDetailViewController: UIViewController {
         }
 
         if self.variant.opaque {
-            view.backgroundColor = ColorScheme.default().color(withName: ColorSchemeColorBackground,
-                                                               variant: self.variant.colorScheme)
+            view.backgroundColor = UIColor(scheme: .background,
+                                                             variant: self.variant.colorScheme)
         }
         else {
             view.backgroundColor = .clear

--- a/Wire-iOS/Sources/UserInterface/Services/ServiceView.swift
+++ b/Wire-iOS/Sources/UserInterface/Services/ServiceView.swift
@@ -60,7 +60,7 @@ final class ServiceDetailView: UIView {
         
         descriptionTextView.backgroundColor = .clear
         descriptionTextView.textContainerInset = .zero
-        descriptionTextView.textColor = ColorScheme.default().color(withName: ColorSchemeColorTextForeground, variant: variant)
+        descriptionTextView.textColor = UIColor(scheme: .textForeground, variant: variant)
         descriptionTextView.font = FontSpec(.normal, .light).font
         descriptionTextView.isEditable = false
         updateForService()
@@ -113,11 +113,11 @@ final class ServiceView: UIView {
         backgroundColor = .clear
         
         nameLabel.font = FontSpec(.large, .regular).font
-        nameLabel.textColor = ColorScheme.default().color(withName: ColorSchemeColorTextForeground, variant: variant)
+        nameLabel.textColor = UIColor(scheme: .textForeground, variant: variant)
         nameLabel.backgroundColor = .clear
         
         providerLabel.font = FontSpec(.medium, .regular).font
-        providerLabel.textColor = ColorScheme.default().color(withName: ColorSchemeColorTextForeground, variant: variant)
+        providerLabel.textColor = UIColor(scheme: .textForeground, variant: variant)
         providerLabel.backgroundColor = .clear
         updateForService()
     }

--- a/Wire-iOS/Sources/UserInterface/Settings/BackupPasswordViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/BackupPasswordViewController.swift
@@ -62,7 +62,7 @@ final class BackupPasswordViewController: UIViewController {
         key: "self.settings.history_backup.password.description",
         size: .medium,
         weight: .regular,
-        color: ColorSchemeColorTextForeground,
+        color: .textForeground,
         variant: .light
     )
     
@@ -89,10 +89,10 @@ final class BackupPasswordViewController: UIViewController {
     }
 
     private func setupViews() {
-        view.backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorContentBackground, variant: .light)
+        view.backgroundColor = UIColor(scheme: .contentBackground, variant: .light)
         
         subtitleLabel.numberOfLines = 0
-        subtitleLabel.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextDimmed, variant: .light)
+        subtitleLabel.textColor = UIColor(scheme: .textDimmed, variant: .light)
         [passwordView, subtitleLabel].forEach {
             view.addSubview($0)
             $0.translatesAutoresizingMaskIntoConstraints = false
@@ -119,10 +119,10 @@ final class BackupPasswordViewController: UIViewController {
     }
     
     private func setupNavigationBar() {
-        navigationController?.navigationBar.backgroundColor = .wr_color(fromColorScheme: ColorSchemeColorBarBackground, variant: .light)
-        navigationController?.navigationBar.setBackgroundImage(.singlePixelImage(with: ColorScheme.default().color(withName: ColorSchemeColorBarBackground, variant: .light)), for: .default)
-        navigationController?.navigationBar.tintColor = .wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: .light)
-        navigationController?.navigationBar.barTintColor = .wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: .light)
+        navigationController?.navigationBar.backgroundColor = UIColor(scheme: .barBackground, variant: .light)
+        navigationController?.navigationBar.setBackgroundImage(.singlePixelImage(with: UIColor(scheme: .barBackground, variant: .light)), for: .default)
+        navigationController?.navigationBar.tintColor = UIColor(scheme: .textForeground, variant: .light)
+        navigationController?.navigationBar.barTintColor = UIColor(scheme: .textForeground, variant: .light)
         navigationController?.navigationBar.titleTextAttributes = DefaultNavigationBar.titleTextAttributes(for: .light)
         
         title = "self.settings.history_backup.password.title".localized.uppercased()

--- a/Wire-iOS/Sources/UserInterface/Settings/BackupViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/BackupViewController.swift
@@ -31,7 +31,7 @@ final class BackupStatusCell: UITableViewCell {
         backgroundColor = .clear
         contentView.backgroundColor = .clear
         
-        let color = ColorScheme.default().color(withName: ColorSchemeColorTextForeground, variant: .dark)
+        let color = UIColor(scheme: .textForeground, variant: .dark)
         
         iconView.image = .imageForRestore(with: color, size: .large)
         iconView.contentMode = .center
@@ -82,7 +82,7 @@ final class BackupActionCell: UITableViewCell {
         
         actionTitleLabel.text = "self.settings.history_backup.action".localized
         actionTitleLabel.font = FontSpec(.normal, .regular).font
-        actionTitleLabel.textColor = ColorScheme.default().color(withName: ColorSchemeColorTextForeground, variant: .dark)
+        actionTitleLabel.textColor = UIColor(scheme: .textForeground, variant: .dark)
     }
     
     required init?(coder aDecoder: NSCoder) {

--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientColorVariantProtocol.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientColorVariantProtocol.swift
@@ -37,7 +37,7 @@ extension ClientColorVariantProtocol where Self: UIViewController {
             case .none, .dark?:
                 return UIColor(white: 1, alpha: 0.4)
             case .light?:
-                return UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: .light)
+                return UIColor(scheme: .textForeground, variant: .light)
             }
         }
     }
@@ -48,7 +48,7 @@ extension ClientColorVariantProtocol where Self: UIViewController {
             case .none, .dark?:
                 return UIColor(white: 1, alpha: 0.1)
             case .light?:
-                return UIColor.wr_color(fromColorScheme: ColorSchemeColorSeparator, variant: .light)
+                return UIColor(scheme: .separator, variant: .light)
             }
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientTableViewCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientTableViewCell.swift
@@ -109,7 +109,7 @@ import Classy
                 labelLabel.textColor = .white
                 activationLabel.textColor = .white
             case .light?:
-                let textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: .light)
+                let textColor = UIColor(scheme: .textForeground, variant: .light)
                 self.verifiedLabel.textColor = textColor
                 fingerprintTextColor = textColor
                 nameLabel.textColor = textColor

--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientUnregisterInvitationViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientUnregisterInvitationViewController.swift
@@ -51,7 +51,7 @@ class ClientUnregisterInvitationViewController: RegistrationStepViewController {
         let heroLabel = UILabel()
         heroLabel.translatesAutoresizingMaskIntoConstraints = false
         heroLabel.font = FontSpec(.large, .semibold).font!
-        heroLabel.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: .dark)
+        heroLabel.textColor = UIColor(scheme: .textForeground, variant: .dark)
         heroLabel.numberOfLines = 0
         heroLabel.text = String(format:NSLocalizedString("registration.signin.too_many_devices.title", comment:""), ZMUser.selfUser().displayName)
         
@@ -63,7 +63,7 @@ class ClientUnregisterInvitationViewController: RegistrationStepViewController {
         let subtitleLabel = UILabel()
         subtitleLabel.translatesAutoresizingMaskIntoConstraints = false
         subtitleLabel.font = FontSpec(.large, .light).font!
-        subtitleLabel.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: .dark)
+        subtitleLabel.textColor = UIColor(scheme: .textForeground, variant: .dark)
         subtitleLabel.numberOfLines = 0
         subtitleLabel.text = NSLocalizedString("registration.signin.too_many_devices.subtitle", comment:"")
         

--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/FingerprintTableViewCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/FingerprintTableViewCell.swift
@@ -34,7 +34,7 @@ import Classy
             case .dark?, .none:
                 color = .white
             case .light?:
-                color = .wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: .light)
+                color = UIColor(scheme: .textForeground, variant: .light)
             }
 
             fingerprintLabel.textColor = color

--- a/Wire-iOS/Sources/UserInterface/Settings/SettingsCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/SettingsCell.swift
@@ -54,7 +54,7 @@ protocol SettingsCellType: class {
             case .dark?, .none:
                 self.titleColor = .white
             case .light?:
-                self.titleColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: .light)
+                self.titleColor = UIColor(scheme: .textForeground, variant: .light)
             }
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Settings/SettingsTechnicalReportViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/SettingsTechnicalReportViewController.swift
@@ -117,7 +117,7 @@ class SettingsTechnicalReportViewController: UITableViewController, MFMailCompos
     override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         let label = UILabel()
         label.text = "self.settings.technical_report.privacy_warning".localized
-        label.textColor = ColorScheme.default().color(withName: ColorSchemeColorTextDimmed)
+        label.textColor = UIColor(scheme: .textDimmed)
         label.backgroundColor = .clear
         label.font = FontSpec(.small, .light).font!
         

--- a/Wire-iOS/Sources/UserInterface/Sketchpad/CanvasViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Sketchpad/CanvasViewController.swift
@@ -88,14 +88,14 @@ import Cartography
         emojiKeyboardViewController.backspaceHidden = true
     
         toolbar = SketchToolbar(buttons: [photoButton, drawButton, emojiButton, sendButton])
-        separatorLine.backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorSeparator)
-        hintImageView.image = UIImage(for: .brush, fontSize: 172, color: .wr_color(fromColorScheme: ColorSchemeColorPlaceholderBackground, variant: .light))
+        separatorLine.backgroundColor = UIColor(scheme: .separator)
+        hintImageView.image = UIImage(for: .brush, fontSize: 172, color: UIColor(scheme: .placeholderBackground, variant: .light))
         hintLabel.text = "sketchpad.initial_hint".localized.uppercased(with: Locale.current)
         hintLabel.numberOfLines = 0
         hintLabel.font = FontSpec(.small, .regular).font!
         hintLabel.textAlignment = .center
-        hintLabel.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextPlaceholder)
-        self.view.backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorBackground)
+        hintLabel.textColor = UIColor(scheme: .textPlaceholder)
+        self.view.backgroundColor = UIColor(scheme: .background)
         
         [canvas, hintLabel, hintImageView, toolbar].forEach(view.addSubview)
         

--- a/Wire-iOS/Sources/UserInterface/Sketchpad/SketchToolbar.swift
+++ b/Wire-iOS/Sources/UserInterface/Sketchpad/SketchToolbar.swift
@@ -34,8 +34,8 @@ class SketchToolbar : UIView {
         
         buttons.forEach { button in
             let iconButton = button as? IconButton
-            iconButton?.setIconColor(UIColor.wr_color(fromColorScheme: ColorSchemeColorIconNormal), for: .normal)
-            iconButton?.setIconColor(UIColor.wr_color(fromColorScheme: ColorSchemeColorIconHighlighted), for: .highlighted)
+            iconButton?.setIconColor(UIColor(scheme: .iconNormal), for: .normal)
+            iconButton?.setIconColor(UIColor(scheme: .iconHighlighted), for: .highlighted)
             iconButton?.setIconColor(UIColor.accent(), for: .selected)
         }
         
@@ -44,7 +44,7 @@ class SketchToolbar : UIView {
         leftButton = unassignedButtons.removeFirst()
         rightButton = unassignedButtons.removeLast()
         centerButtons = unassignedButtons
-        separatorLine.backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorSeparator)
+        separatorLine.backgroundColor = UIColor(scheme: .separator)
         
         super.init(frame: CGRect.zero)
         
@@ -58,7 +58,7 @@ class SketchToolbar : UIView {
     }
     
     func setupSubviews() {
-        backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorBackground)
+        backgroundColor = UIColor(scheme: .background)
         addSubview(containerView)
         centerButtons.forEach(centerButtonContainer.addSubview)
         [leftButton, centerButtonContainer, rightButton, separatorLine].forEach(containerView.addSubview)

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/Cells/GroupConversationCell.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/Cells/GroupConversationCell.swift
@@ -28,7 +28,7 @@ class GroupConversationCell: UICollectionViewCell, Themeable {
     var contentStackView : UIStackView!
     var titleStackView : UIStackView!
     
-    @objc dynamic var colorSchemeVariant: ColorSchemeVariant = ColorScheme.default().variant {
+    @objc dynamic var colorSchemeVariant: ColorSchemeVariant = ColorScheme.default.variant {
         didSet {
             guard oldValue != colorSchemeVariant else { return }
             applyColorScheme(colorSchemeVariant)
@@ -60,7 +60,7 @@ class GroupConversationCell: UICollectionViewCell, Themeable {
     }
     
     fileprivate func contentBackgroundColor(for colorSchemeVariant: ColorSchemeVariant) -> UIColor {
-        return contentBackgroundColor ?? UIColor.wr_color(fromColorScheme: ColorSchemeColorBarBackground, variant: colorSchemeVariant)
+        return contentBackgroundColor ?? UIColor(scheme: .barBackground, variant: colorSchemeVariant)
     }
     
     fileprivate func setup() {
@@ -118,10 +118,10 @@ class GroupConversationCell: UICollectionViewCell, Themeable {
     }
     
     func applyColorScheme(_ colorSchemeVariant: ColorSchemeVariant) {
-        let sectionTextColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorSectionText, variant: colorSchemeVariant)
+        let sectionTextColor = UIColor(scheme: .sectionText, variant: colorSchemeVariant)
         backgroundColor = contentBackgroundColor(for: colorSchemeVariant)
-        separator.backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorCellSeparator, variant: colorSchemeVariant)
-        titleLabel.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: colorSchemeVariant)
+        separator.backgroundColor = UIColor(scheme: .cellSeparator, variant: colorSchemeVariant)
+        titleLabel.textColor = UIColor(scheme: .textForeground, variant: colorSchemeVariant)
         subtitleLabel.textColor = sectionTextColor
     }
     

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/Cells/InviteTeamMemberCell.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/Cells/InviteTeamMemberCell.swift
@@ -58,7 +58,7 @@ class StartUIIconCell: UICollectionViewCell {
         titleLabel.font = FontSpec(.normal, .light).font
         titleLabel.textColor = .white
         [iconView, titleLabel, separator].forEach(contentView.addSubview)
-        separator.backgroundColor = ColorScheme.default().color(withName: ColorSchemeColorCellSeparator, variant: .dark)
+        separator.backgroundColor = UIColor(scheme: .cellSeparator, variant: .dark)
     }
     
     fileprivate  func createConstraints() {

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchGroupSelector.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchGroupSelector.swift
@@ -66,7 +66,7 @@ import Cartography
 
     private func configureViews() {
         tabBar.delegate = self
-        backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorBarBackground, variant: style)
+        backgroundColor = UIColor(scheme: .barBackground, variant: style)
         addSubview(tabBar)
     }
 

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchHeaderViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchHeaderViewController.swift
@@ -60,9 +60,9 @@ public protocol SearchHeaderViewControllerDelegate : class {
     public override func viewDidLoad() {
         super.viewDidLoad()
 
-        view.backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorBarBackground, variant: colorSchemeVariant)
+        view.backgroundColor = UIColor(scheme: .barBackground, variant: colorSchemeVariant)
 
-        searchIcon.image = UIImage(for: .search, iconSize: .tiny, color: UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: colorSchemeVariant))
+        searchIcon.image = UIImage(for: .search, iconSize: .tiny, color: UIColor(scheme: .textForeground, variant: colorSchemeVariant))
         
         clearButton.accessibilityLabel = "clear"
         clearButton.setIcon(.clearInput, with: .tiny, for: .normal)
@@ -71,12 +71,12 @@ public protocol SearchHeaderViewControllerDelegate : class {
         clearButton.isHidden = true
         
         tokenField.layer.cornerRadius = 4
-        tokenField.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: colorSchemeVariant)
-        tokenField.tokenTitleColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: colorSchemeVariant)
-        tokenField.tokenSelectedTitleColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: colorSchemeVariant)
+        tokenField.textColor = UIColor(scheme: .textForeground, variant: colorSchemeVariant)
+        tokenField.tokenTitleColor = UIColor(scheme: .textForeground, variant: colorSchemeVariant)
+        tokenField.tokenSelectedTitleColor = UIColor(scheme: .textForeground, variant: colorSchemeVariant)
         tokenField.clipsToBounds = true
-        tokenField.textView.placeholderTextColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTokenFieldTextPlaceHolder, variant: colorSchemeVariant)
-        tokenField.textView.backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTokenFieldBackground, variant: colorSchemeVariant)
+        tokenField.textView.placeholderTextColor = UIColor(scheme: .tokenFieldTextPlaceHolder, variant: colorSchemeVariant)
+        tokenField.textView.backgroundColor = UIColor(scheme: .tokenFieldBackground, variant: colorSchemeVariant)
         tokenField.textView.accessibilityIdentifier = "textViewSearch"
         tokenField.textView.placeholder = "peoplepicker.search_placeholder".localized.uppercased()
         tokenField.textView.keyboardAppearance = ColorScheme.keyboardAppearance(for: colorSchemeVariant)

--- a/Wire-iOS/Sources/UserInterface/UIBarButtonItem+ZetaIcon.swift
+++ b/Wire-iOS/Sources/UserInterface/UIBarButtonItem+ZetaIcon.swift
@@ -21,7 +21,7 @@ extension UIBarButtonItem {
 
     @objc convenience init(icon: ZetaIconType, style: UIBarButtonItemStyle = .plain, target: Any?, action: Selector?) {
         self.init(
-            image: UIImage(for: icon, iconSize: .tiny, color: ColorScheme.default().color(withName: ColorSchemeColorTextForeground)),
+            image: UIImage(for: icon, iconSize: .tiny, color: UIColor(scheme: .textForeground)),
             style: style,
             target: target,
             action: action

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileClientViewController.swift
@@ -92,7 +92,7 @@ import Classy
     }
 
     func setupViews() {
-        view.backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorBackground)
+        view.backgroundColor = UIColor(scheme: .background)
 
         self.setupContentView()
         self.setupBackButton()
@@ -141,15 +141,15 @@ import Classy
         descriptionTextView.isScrollEnabled = false
         descriptionTextView.isEditable = false
         descriptionTextView.delegate = self
-        descriptionTextView.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground)
-        descriptionTextView.backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextBackground)
+        descriptionTextView.textColor = UIColor(scheme: .textForeground)
+        descriptionTextView.backgroundColor = UIColor(scheme: .textBackground)
         
         let descriptionTextFont = FontSpec(.normal, .light).font!
 
         if let user = self.userClient.user {
             descriptionTextView.attributedText = (String(format: "profile.devices.detail.verify_message".localized, user.displayName) &&
                 descriptionTextFont &&
-                UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground)) +
+                UIColor(scheme: .textForeground)) +
                 "\n" +
                 ("profile.devices.detail.verify_message.link".localized &&
                     [.font: descriptionTextFont, .link: URL.wr_fingerprintHowToVerify])
@@ -158,7 +158,7 @@ import Classy
     }
     
     private func setupSeparatorLineView() {
-        separatorLineView.backgroundColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorSeparator)
+        separatorLineView.backgroundColor = UIColor(scheme: .separator)
         self.contentView.addSubview(separatorLineView)
     }
     
@@ -166,13 +166,13 @@ import Classy
         typeLabel.text = self.userClient.deviceClass?.uppercased()
         typeLabel.numberOfLines = 1
         typeLabel.font = FontSpec(.small, .semibold).font!
-        typeLabel.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground)
+        typeLabel.textColor = UIColor(scheme: .textForeground)
         self.contentView.addSubview(typeLabel)
     }
     
     private func setupIDLabel() {
         IDLabel.numberOfLines = 1
-        IDLabel.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground)
+        IDLabel.textColor = UIColor(scheme: .textForeground)
         self.contentView.addSubview(IDLabel)
         self.updateIDLabel()
     }
@@ -190,7 +190,7 @@ import Classy
 
     private func setupFullIDLabel() {
         fullIDLabel.numberOfLines = 0
-        fullIDLabel.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground)
+        fullIDLabel.textColor = UIColor(scheme: .textForeground)
         self.contentView.addSubview(fullIDLabel)
     }
     
@@ -227,7 +227,7 @@ import Classy
     
     private func setupVerifiedToggleLabel() {
         verifiedToggleLabel.font = FontSpec(.small, .light).font!
-        verifiedToggleLabel.textColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground)
+        verifiedToggleLabel.textColor = UIColor(scheme: .textForeground)
         verifiedToggleLabel.text = NSLocalizedString("device.verified", comment: "").uppercased()
         verifiedToggleLabel.numberOfLines = 0
         self.contentView.addSubview(verifiedToggleLabel)
@@ -323,7 +323,7 @@ import Classy
     @objc private func onShowMyDeviceTapped(_ sender: AnyObject) {
         let selfClientController = SettingsClientViewController(userClient: ZMUserSession.shared()!.selfUserClient(),
                                                                 fromConversation:self.fromConversation,
-                                                                variant: ColorScheme.default().variant)
+                                                                variant: ColorScheme.default.variant)
 
         let navigationControllerWrapper = selfClientController.wrapInNavigationController()
 

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Views/UserNameDetailView.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Views/UserNameDetailView.swift
@@ -90,7 +90,7 @@ fileprivate let normalBoldFont = FontSpec(.normal, .medium).font!
     }
 
     static var formatter: AddressBookCorrelationFormatter = {
-        AddressBookCorrelationFormatter(lightFont: smallLightFont, boldFont: smallBoldFont, color: UIColor.wr_color(fromColorScheme: ColorSchemeColorTextDimmed))
+        AddressBookCorrelationFormatter(lightFont: smallLightFont, boldFont: smallBoldFont, color: UIColor(scheme: .textDimmed))
     }()
 
     init(user: ZMBareUser?, fallbackName fallback: String, addressBookName: String?) {
@@ -100,12 +100,12 @@ fileprivate let normalBoldFont = FontSpec(.normal, .medium).font!
     }
 
     static func attributedTitle(for user: ZMBareUser?, fallback: String) -> NSAttributedString {
-        return (user?.name ?? fallback) && normalBoldFont && UIColor.wr_color(fromColorScheme: ColorSchemeColorTextForeground)
+        return (user?.name ?? fallback) && normalBoldFont && UIColor(scheme: .textForeground)
     }
 
     static func attributedSubtitle(for user: ZMBareUser?) -> NSAttributedString? {
         guard let handle = user?.handle, handle.count > 0 else { return nil }
-        return ("@" + handle) && smallBoldFont && UIColor.wr_color(fromColorScheme: ColorSchemeColorTextDimmed)
+        return ("@" + handle) && smallBoldFont && UIColor(scheme: .textDimmed)
     }
 
     static func attributedCorrelationText(for user: ZMBareUser?, addressBookName: String?) -> NSAttributedString? {

--- a/WireExtensionComponents/Utilities/ColorScheme.h
+++ b/WireExtensionComponents/Utilities/ColorScheme.h
@@ -16,78 +16,77 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
-#import <Foundation/Foundation.h>
-#import <UIKit/UIKit.h>
+@import UIKit;
 @import WireSyncEngine;
 
 NS_ASSUME_NONNULL_BEGIN
 
-extern NSString * const ColorSchemeColorTextForeground;
-extern NSString * const ColorSchemeColorTextBackground;
-extern NSString * const ColorSchemeColorTextDimmed;
-extern NSString * const ColorSchemeColorTextPlaceholder;
+typedef NSString *const ColorSchemeColor NS_STRING_ENUM;
 
-extern NSString * const ColorSchemeColorAccent;
-extern NSString * const ColorSchemeColorAccentDimmed;
-extern NSString * const ColorSchemeColorAccentDimmedFlat;
-extern NSString * const ColorSchemeColorAccentDarken;
+extern ColorSchemeColor ColorSchemeColorTextForeground;
+extern ColorSchemeColor ColorSchemeColorTextBackground;
+extern ColorSchemeColor ColorSchemeColorTextDimmed;
+extern ColorSchemeColor ColorSchemeColorTextPlaceholder;
 
-extern NSString * const ColorSchemeColorIconNormal;
-extern NSString * const ColorSchemeColorIconSelected;
-extern NSString * const ColorSchemeColorIconHighlighted;
-extern NSString * const ColorSchemeColorIconBackgroundSelected;
-extern NSString * const ColorSchemeColorIconBackgroundSelectedNoAccent;
-extern NSString * const ColorSchemeColorIconShadow;
-extern NSString * const ColorSchemeColorIconHighlight;
-extern NSString * const ColorSchemeColorIconGuest;
+extern ColorSchemeColor ColorSchemeColorAccent;
+extern ColorSchemeColor ColorSchemeColorAccentDimmed;
+extern ColorSchemeColor ColorSchemeColorAccentDimmedFlat;
+extern ColorSchemeColor ColorSchemeColorAccentDarken;
 
-extern NSString * const ColorSchemeColorPopUpButtonOverlayShadow;
+extern ColorSchemeColor ColorSchemeColorIconNormal;
+extern ColorSchemeColor ColorSchemeColorIconSelected;
+extern ColorSchemeColor ColorSchemeColorIconHighlighted;
+extern ColorSchemeColor ColorSchemeColorIconBackgroundSelected;
+extern ColorSchemeColor ColorSchemeColorIconBackgroundSelectedNoAccent;
+extern ColorSchemeColor ColorSchemeColorIconShadow;
+extern ColorSchemeColor ColorSchemeColorIconHighlight;
+extern ColorSchemeColor ColorSchemeColorIconGuest;
 
-extern NSString * const ColorSchemeColorChatHeadBackground;
-extern NSString * const ColorSchemeColorChatHeadBorder;
-extern NSString * const ColorSchemeColorChatHeadTitleText;
-extern NSString * const ColorSchemeColorChatHeadSubtitleText;
+extern ColorSchemeColor ColorSchemeColorPopUpButtonOverlayShadow;
 
-extern NSString * const ColorSchemeColorButtonFaded;
+extern ColorSchemeColor ColorSchemeColorChatHeadBackground;
+extern ColorSchemeColor ColorSchemeColorChatHeadBorder;
+extern ColorSchemeColor ColorSchemeColorChatHeadTitleText;
+extern ColorSchemeColor ColorSchemeColorChatHeadSubtitleText;
 
-extern NSString * const ColorSchemeColorTabNormal;
-extern NSString * const ColorSchemeColorTabSelected;
-extern NSString * const ColorSchemeColorTabHighlighted;
+extern ColorSchemeColor ColorSchemeColorButtonFaded;
 
-extern NSString * const ColorSchemeColorBackground;
-extern NSString * const ColorSchemeColorContentBackground;
-extern NSString * const ColorSchemeColorBarBackground;
-extern NSString * const ColorSchemeColorSearchBarBackground;
-extern NSString * const ColorSchemeColorSeparator;
-extern NSString * const ColorSchemeColorCellSeparator;
-extern NSString * const ColorSchemeColorBackgroundOverlay;
-extern NSString * const ColorSchemeColorBackgroundOverlayWithoutPicture;
-extern NSString * const ColorSchemeColorPlaceholderBackground;
-extern NSString * const ColorSchemeColorAvatarBorder;
-extern NSString * const ColorSchemeColorLoadingDotActive;
-extern NSString * const ColorSchemeColorLoadingDotInactive;
+extern ColorSchemeColor ColorSchemeColorTabNormal;
+extern ColorSchemeColor ColorSchemeColorTabSelected;
+extern ColorSchemeColor ColorSchemeColorTabHighlighted;
 
-extern NSString * const ColorSchemeColorPaleSeparator;
-extern NSString * const ColorSchemeColorListAvatarInitials;
-extern NSString * const ColorSchemeColorAudioButtonOverlay;
+extern ColorSchemeColor ColorSchemeColorBackground;
+extern ColorSchemeColor ColorSchemeColorContentBackground;
+extern ColorSchemeColor ColorSchemeColorBarBackground;
+extern ColorSchemeColor ColorSchemeColorSearchBarBackground;
+extern ColorSchemeColor ColorSchemeColorSeparator;
+extern ColorSchemeColor ColorSchemeColorCellSeparator;
+extern ColorSchemeColor ColorSchemeColorBackgroundOverlay;
+extern ColorSchemeColor ColorSchemeColorBackgroundOverlayWithoutPicture;
+extern ColorSchemeColor ColorSchemeColorPlaceholderBackground;
+extern ColorSchemeColor ColorSchemeColorAvatarBorder;
+extern ColorSchemeColor ColorSchemeColorLoadingDotActive;
+extern ColorSchemeColor ColorSchemeColorLoadingDotInactive;
 
-extern NSString * const ColorSchemeColorNameAccentPrefix;
+extern ColorSchemeColor ColorSchemeColorPaleSeparator;
+extern ColorSchemeColor ColorSchemeColorListAvatarInitials;
+extern ColorSchemeColor ColorSchemeColorAudioButtonOverlay;
 
-extern NSString * const ColorSchemeColorGraphite;
-extern NSString * const ColorSchemeColorLightGraphite;
+extern ColorSchemeColor ColorSchemeColorNameAccentPrefix;
 
-extern NSString * const ColorSchemeColorSectionBackground;
-extern NSString * const ColorSchemeColorSectionText;
+extern ColorSchemeColor ColorSchemeColorGraphite;
+extern ColorSchemeColor ColorSchemeColorLightGraphite;
 
-extern NSString * const ColorSchemeColorTokenFieldBackground;
-extern NSString * const ColorSchemeColorTokenFieldTextPlaceHolder;
+extern ColorSchemeColor ColorSchemeColorSectionBackground;
+extern ColorSchemeColor ColorSchemeColorSectionText;
+
+extern ColorSchemeColor ColorSchemeColorTokenFieldBackground;
+extern ColorSchemeColor ColorSchemeColorTokenFieldTextPlaceHolder;
 
 typedef NS_ENUM(NSUInteger, ColorSchemeVariant) {
     ColorSchemeVariantLight,
     ColorSchemeVariantDark
 };
-
 
 @interface ColorScheme : NSObject
 
@@ -98,15 +97,16 @@ typedef NS_ENUM(NSUInteger, ColorSchemeVariant) {
 @property (nonatomic) UIColor *accentColor;
 @property (nonatomic) ColorSchemeVariant variant;
 
-+ (instancetype)defaultColorScheme;
+@property (class, readonly, strong) ColorScheme *defaultColorScheme;
 
 + (UIKeyboardAppearance)keyboardAppearanceForVariant:(ColorSchemeVariant)variant;
 + (UIBlurEffectStyle)blurEffectStyleForVariant:(ColorSchemeVariant)variant;
 
-- (UIColor *)colorWithName:(NSString *)colorName;
-- (UIColor *)colorWithName:(NSString *)colorName variant:(ColorSchemeVariant)variant;
+- (UIColor *)colorWithName:(ColorSchemeColor)colorName NS_SWIFT_NAME(color(named:));
+- (UIColor *)colorWithName:(ColorSchemeColor)colorName variant:(ColorSchemeVariant)variant NS_SWIFT_NAME(color(named:variant:));
 
 - (UIColor *)nameAccentForColor:(ZMAccentColor)color variant:(ColorSchemeVariant)variant;
+
 @end
 
 @interface UIColor (ColorScheme)

--- a/WireExtensionComponents/Utilities/ColorScheme.m
+++ b/WireExtensionComponents/Utilities/ColorScheme.m
@@ -14,13 +14,11 @@
 // 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
-
+//
 
 #import "ColorScheme.h"
 #import "UIColor+Mixing.h"
 #import "UIColor+WAZExtensions.h"
-
 
 NSString * const ColorSchemeColorAccent = @"accent-current";
 NSString * const ColorSchemeColorAccentDimmed = @"accent-current-dimmed";
@@ -198,12 +196,12 @@ static NSString* light(NSString *colorString) {
     return defaultColorScheme;
 }
 
-- (UIColor *)colorWithName:(NSString *)colorName
+- (UIColor *)colorWithName:(ColorSchemeColor)colorName
 {
     return [self.colors objectForKey:colorName];
 }
 
-- (UIColor *)colorWithName:(NSString *)colorName variant:(ColorSchemeVariant)variant
+- (UIColor *)colorWithName:(ColorSchemeColor)colorName variant:(ColorSchemeVariant)variant
 {
     return [self.colors objectForKey:variant == ColorSchemeVariantLight ? light(colorName) : dark(colorName)];
 }
@@ -417,4 +415,3 @@ static NSString* light(NSString *colorString) {
 }
 
 @end
-

--- a/WireExtensionComponents/Utilities/UIColor+WR_ColorScheme.h
+++ b/WireExtensionComponents/Utilities/UIColor+WR_ColorScheme.h
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 #import <UIKit/UIKit.h>
 #import "ColorScheme.h"
 
@@ -24,8 +23,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface UIColor (WR_ColorScheme)
 
-+ (UIColor *)wr_colorFromColorScheme:(NSString *)colorSchemeColor;
-+ (UIColor *)wr_colorFromColorScheme:(NSString *)colorSchemeColor variant:(enum ColorSchemeVariant)variant;
++ (UIColor *)wr_colorFromColorScheme:(ColorSchemeColor)colorSchemeColor NS_SWIFT_NAME(init(scheme:));
++ (UIColor *)wr_colorFromColorScheme:(ColorSchemeColor)colorSchemeColor variant:(enum ColorSchemeVariant)variant NS_SWIFT_NAME(init(scheme:variant:));
 
 @end
 

--- a/WireExtensionComponents/Utilities/UIColor+WR_ColorScheme.m
+++ b/WireExtensionComponents/Utilities/UIColor+WR_ColorScheme.m
@@ -14,21 +14,18 @@
 // 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
-
+//
 
 #import "UIColor+WR_ColorScheme.h"
 
-
-
 @implementation UIColor (WR_ColorScheme)
 
-+ (UIColor *)wr_colorFromColorScheme:(NSString *)colorSchemeColor
++ (UIColor *)wr_colorFromColorScheme:(ColorSchemeColor)colorSchemeColor
 {
     return [[ColorScheme defaultColorScheme] colorWithName:colorSchemeColor];
 }
 
-+ (UIColor *)wr_colorFromColorScheme:(NSString *)colorSchemeColor variant:(ColorSchemeVariant)variant
++ (UIColor *)wr_colorFromColorScheme:(ColorSchemeColor)colorSchemeColor variant:(ColorSchemeVariant)variant
 {
     return [[ColorScheme defaultColorScheme] colorWithName:colorSchemeColor variant:variant];
 }

--- a/WireExtensionComponents/Views/Loading/SpinnerSubtitleView.swift
+++ b/WireExtensionComponents/Views/Loading/SpinnerSubtitleView.swift
@@ -44,7 +44,7 @@ import UIKit
         alignment = .center
         spacing = 20
         distribution = .fillProportionally
-        label.textColor = .wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: .dark)
+        label.textColor = UIColor(scheme: .textForeground, variant: .dark)
         label.font = FontSpec(.small, .regular).fontWithoutDynamicType
         [spinner, label].forEach(addArrangedSubview)
     }

--- a/WireExtensionComponents/Views/OverflowSeparatorView.swift
+++ b/WireExtensionComponents/Views/OverflowSeparatorView.swift
@@ -37,7 +37,7 @@ import Classy
     }
     
     private func applyStyle() {
-        self.backgroundColor = ColorScheme.default().color(withName: ColorSchemeColorSeparator)
+        self.backgroundColor = UIColor(scheme: .separator)
         self.alpha = 0
     }
     

--- a/WireExtensionComponents/Views/ThreeDotsLoadingView.swift
+++ b/WireExtensionComponents/Views/ThreeDotsLoadingView.swift
@@ -25,8 +25,8 @@ import Cartography
     
     @objc let loadingAnimationKey = "loading"
     @objc let dotRadius = 2
-    @objc let activeColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorLoadingDotActive)
-    @objc let inactiveColor = UIColor.wr_color(fromColorScheme: ColorSchemeColorLoadingDotInactive)
+    @objc let activeColor = UIColor(scheme: .loadingDotActive)
+    @objc let inactiveColor = UIColor(scheme: .loadingDotInactive)
     
     @objc let dot1 = UIView()
     @objc let dot2 = UIView()


### PR DESCRIPTION
## What's new in this PR?

### Issues

The list of colors was previously imported as String constants, which could potentially lead to problems with invalid strings. We were also using a factory method to create the colors from these standard colors, which does not really conform with the Swift style guide.

### Solutions

- We tagged the color named with `NS_STRING_ENUM`, which means all color scheme names are imported as the `ColorSchemeColor` enum in Swift, and can be accessed with the dot syntax
- We mapped `wr_colorFromColorScheme` as an an initializer
- We made the default color scheme a class property (other singletons in the SDK are declared as class properties, such as `NSFileManager.defaultFileManager`)
- We renamed the color scheme methods in Swift to comply with the style guide

**Before**

```swift
let colorA = UIColor. wr_color(fromColorScheme: ColorSchemeColorTextForeground, variant: .dark)
let colorB = ColorScheme.default().color(withName: ColorSchemeColorBackground, variant: .light)
```

**After**

```swift
let colorA = UIColor(scheme: .textForeground, variant: .dark)
let colorB = ColorScheme.default.color(named: .background, variant: .light)
```