### PR TITLE
Fix crash caused by missing @objc annotation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController+Zoom.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController+Zoom.swift
@@ -59,7 +59,7 @@ extension FullscreenImageViewController {
 
     // MARK: - Gesture Handling
 
-    func handleDoubleTap(_ doubleTapper: UITapGestureRecognizer) {
+    @objc func handleDoubleTap(_ doubleTapper: UITapGestureRecognizer) {
         setSelectedByMenu(false, animated: false)
 
         guard let image = imageView?.image else { return }


### PR DESCRIPTION
## What's new in this PR?

* Fix crash cuased by missing @objc annotation.