### PR TITLE
Fix: copy change on the Marketing consent dialogue

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -29,6 +29,7 @@
 "general.confirm" = "OK";
 "general.skip" = "Not now";
 "general.accept" = "Accept";
+"general.decline" = "Decline";
 
 // Language like Chinese does not use space to sperate words or sentences.
 "general.space_between_words" = " ";

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/UIAlertController+Newsletter.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/UIAlertController+Newsletter.swift
@@ -46,7 +46,7 @@ extension UIAlertController {
                                                 style: .default,
                                                 handler: privacyPolicyActionHandler))
 
-        alertController.addAction(UIAlertAction(title: "general.skip".localized,
+        alertController.addAction(UIAlertAction(title: "general.deline".localized,
                                                 style: .default,
                                                 handler: { (_) in
                                                     completionHandler(false)

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/UIAlertController+Newsletter.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/UIAlertController+Newsletter.swift
@@ -46,7 +46,7 @@ extension UIAlertController {
                                                 style: .default,
                                                 handler: privacyPolicyActionHandler))
 
-        alertController.addAction(UIAlertAction(title: "general.deline".localized,
+        alertController.addAction(UIAlertAction(title: "general.decline".localized,
                                                 style: .default,
                                                 handler: { (_) in
                                                     completionHandler(false)


### PR DESCRIPTION
## What's new in this PR?

Change marketing consent dialog's cancel button's text form "Not now" to "Decline"