### PR TITLE
Do not crash with expired ephemerals in collection

### DIFF
--- a/Wire-iOS/Sources/Analytics/Events/Analytics+Collection.swift
+++ b/Wire-iOS/Sources/Analytics/Events/Analytics+Collection.swift
@@ -25,7 +25,7 @@
 }
 
 extension CollectionItemType {
-    init(message: ZMConversationMessage) {
+    init?(message: ZMConversationMessage) {
         if message.isImage {
             self = .image
         }
@@ -42,7 +42,7 @@ extension CollectionItemType {
             self = .link
         }
         else {
-            fatal("Unknown message type")
+            return nil
         }
     }
 }
@@ -102,8 +102,11 @@ extension Analytics {
     }
     
     @objc(tagCollectionOpenItemForConversation:withItemType:)
-    func tagCollectionOpenItem(for conversation:ZMConversation, itemType:CollectionItemType)
+    func tagCollectionOpenItem(for conversation:ZMConversation, message: ZMConversationMessage)
     {
+        guard let itemType = CollectionItemType(message: message) else {
+            return
+        }
         var attributes = conversation.conversationAttributes
         attributes["type"] = string(for: itemType)
         
@@ -112,8 +115,11 @@ extension Analytics {
     }
     
     @objc(tagCollectionOpenItemMenyForConversation:withItemType:)
-    func tagCollectionOpenItemMenu(for conversation:ZMConversation, itemType: CollectionItemType)
+    func tagCollectionOpenItemMenu(for conversation:ZMConversation, message: ZMConversationMessage)
     {
+        guard let itemType = CollectionItemType(message: message) else {
+            return
+        }
         var attributes = conversation.conversationAttributes
         attributes["type"] = string(for: itemType)
         
@@ -121,8 +127,11 @@ extension Analytics {
     }
     
     @objc(tagCollectionDidItemActionForConversation:withItemType:actionType:)
-    func tagCollectionDidItemAction(for conversation:ZMConversation, itemType:CollectionItemType, action: CollectionActionType)
+    func tagCollectionDidItemAction(for conversation:ZMConversation, message: ZMConversationMessage, action: CollectionActionType)
     {
+        guard let itemType = CollectionItemType(message: message) else {
+            return
+        }
         var attributes = conversation.conversationAttributes
         
         attributes["type"] = string(for: itemType)

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionCell.swift
@@ -165,7 +165,7 @@ open class CollectionCell: UICollectionViewCell {
         menuController.setTargetRect(menuConfigurationProperties.targetRect, in: menuConfigurationProperties.targetView)
         menuController.setMenuVisible(true, animated: true)
         
-        Analytics.shared().tagCollectionOpenItemMenu(for: message.conversation!, itemType: CollectionItemType(message: message))
+        Analytics.shared().tagCollectionOpenItemMenu(for: message.conversation!, message: message)
     }
     
     override open var canBecomeFirstResponder: Bool {
@@ -205,7 +205,7 @@ open class CollectionCell: UICollectionViewCell {
         guard let message = self.message else {
             return
         }
-        Analytics.shared().tagCollectionDidItemAction(for: message.conversation!, itemType: CollectionItemType(message: message), action: .forward)
+        Analytics.shared().tagCollectionDidItemAction(for: message.conversation!, message: message, action: .forward)
     }
     
     @objc func showInConversation(_ sender: AnyObject!) {
@@ -213,7 +213,7 @@ open class CollectionCell: UICollectionViewCell {
         guard let message = self.message else {
             return
         }
-        Analytics.shared().tagCollectionDidItemAction(for: message.conversation!, itemType: CollectionItemType(message: message), action: .goto)
+        Analytics.shared().tagCollectionDidItemAction(for: message.conversation!, message: message, action: .goto)
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
@@ -309,7 +309,8 @@ public protocol CollectionsViewControllerDelegate: class {
             }
         case .present:
             self.selectedMessage = message
-            Analytics.shared().tagCollectionOpenItem(for: self.collection.conversation, itemType: CollectionItemType(message: message))
+            
+            Analytics.shared().tagCollectionOpenItem(for: self.collection.conversation, message: message)
             
             if message.isImage {
                 let imagesController = ConversationImagesViewController(collection: self.collection, initialMessage: message)

--- a/Wire-iOS/Sources/UserInterface/Collections/TextSearch/TextSearchResultCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/TextSearch/TextSearchResultCell.swift
@@ -25,42 +25,43 @@ import Cartography
     fileprivate let userImageViewContainer = UIView()
     fileprivate let userImageView = UserImageView()
     fileprivate let separatorView = UIView()
+    fileprivate var observerToken: Any?
     public let resultCountView = RoundedTextBadge()
     
     override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         
-        self.userImageView.userSession = ZMUserSession.shared()
-        self.userImageView.initials.font = UIFont.systemFont(ofSize: 11, weight: UIFont.Weight.light)
+        userImageView.userSession = ZMUserSession.shared()
+        userImageView.initials.font = UIFont.systemFont(ofSize: 11, weight: UIFont.Weight.light)
         
-        self.accessibilityIdentifier = "search result cell"
+        accessibilityIdentifier = "search result cell"
         
-        self.contentView.addSubview(self.footerView)
-        self.selectionStyle = .none
-        self.messageTextLabel.accessibilityIdentifier = "text search result"
-        self.messageTextLabel.numberOfLines = 1
-        self.messageTextLabel.setContentCompressionResistancePriority(UILayoutPriority.required, for: .vertical)
-        self.messageTextLabel.setContentHuggingPriority(UILayoutPriority.required, for: .vertical)
+        contentView.addSubview(footerView)
+        selectionStyle = .none
+        messageTextLabel.accessibilityIdentifier = "text search result"
+        messageTextLabel.numberOfLines = 1
+        messageTextLabel.setContentCompressionResistancePriority(UILayoutPriority.required, for: .vertical)
+        messageTextLabel.setContentHuggingPriority(UILayoutPriority.required, for: .vertical)
         
-        self.contentView.addSubview(self.messageTextLabel)
+        contentView.addSubview(messageTextLabel)
         
-        self.userImageViewContainer.addSubview(self.userImageView)
+        userImageViewContainer.addSubview(userImageView)
         
-        self.contentView.addSubview(self.userImageViewContainer)
+        contentView.addSubview(userImageViewContainer)
         
-        self.separatorView.cas_styleClass = "separator"
-        self.contentView.addSubview(self.separatorView)
+        separatorView.cas_styleClass = "separator"
+        contentView.addSubview(separatorView)
         
-        self.resultCountView.textLabel.accessibilityIdentifier = "count of matches"
-        self.contentView.addSubview(self.resultCountView)
+        resultCountView.textLabel.accessibilityIdentifier = "count of matches"
+        contentView.addSubview(resultCountView)
         
-        constrain(self.userImageView, self.userImageViewContainer) { userImageView, userImageViewContainer in
+        constrain(userImageView, userImageViewContainer) { userImageView, userImageViewContainer in
             userImageView.height == 24
             userImageView.width == userImageView.height
             userImageView.center == userImageViewContainer.center
         }
         
-        constrain(self.contentView, self.footerView, self.messageTextLabel, self.userImageViewContainer, self.resultCountView) { contentView, footerView, messageTextLabel, userImageViewContainer, resultCountView in
+        constrain(contentView, footerView, messageTextLabel, userImageViewContainer, resultCountView) { contentView, footerView, messageTextLabel, userImageViewContainer, resultCountView in
             userImageViewContainer.leading == contentView.leading
             userImageViewContainer.top == contentView.top
             userImageViewContainer.bottom == contentView.bottom
@@ -81,7 +82,7 @@ import Cartography
             resultCountView.width >= 24
         }
         
-        constrain(self.contentView, self.separatorView, self.userImageViewContainer) { contentView, separatorView, userImageViewContainer in
+        constrain(contentView, separatorView, userImageViewContainer) { contentView, separatorView, userImageViewContainer in
             separatorView.leading == userImageViewContainer.trailing
             separatorView.trailing == contentView.trailing
             separatorView.bottom == contentView.bottom
@@ -95,31 +96,38 @@ import Cartography
     
     override func prepareForReuse() {
         super.prepareForReuse()
-        self.message = .none
-        self.queries = []
+        message = .none
+        queries = []
     }
     
     private func updateTextView() {
-        guard let text = message?.textMessageData?.messageText else {
+        guard let message = message,
+              let text = message.textMessageData?.messageText,
+              !message.isObfuscated else {
+            messageTextLabel.configure(with: "", queries: [])
             return
         }
         
-        self.messageTextLabel.configure(with: text, queries: queries)
+        messageTextLabel.configure(with: text, queries: queries)
         
-        let totalMatches = self.messageTextLabel.estimatedMatchesCount
+        let totalMatches = messageTextLabel.estimatedMatchesCount
         
-        self.resultCountView.isHidden = totalMatches <= 1
-        self.resultCountView.textLabel.text = "\(totalMatches)"
+        resultCountView.isHidden = totalMatches <= 1
+        resultCountView.textLabel.text = "\(totalMatches)"
     }
     
-    public func configure(with message: ZMConversationMessage, queries: [String]) {
-        self.message = message
-        self.queries = queries
+    public func configure(with newMessage: ZMConversationMessage, queries newQueries: [String]) {
+        message = newMessage
+        queries = newQueries
         
-        self.userImageView.user = self.message?.sender
-        self.footerView.message = self.message
+        userImageView.user = newMessage.sender
+        footerView.message = newMessage
         
-        self.updateTextView()
+        observerToken = MessageChangeInfo.add(observer: self,
+                                              for: newMessage,
+                                              userSession: ZMUserSession.shared()!)
+        
+        updateTextView()
     }
     
     var message: ZMConversationMessage? = .none
@@ -131,6 +139,13 @@ import Cartography
         let backgroundColor = ColorScheme.default().color(withName: ColorSchemeColorContentBackground)
         let foregroundColor = ColorScheme.default().color(withName: ColorSchemeColorTextForeground)
         
-        self.contentView.backgroundColor = highlighted ? backgroundColor.mix(foregroundColor, amount: 0.1) : backgroundColor
+        contentView.backgroundColor = highlighted ? backgroundColor.mix(foregroundColor, amount: 0.1) : backgroundColor
+    }
+}
+
+extension TextSearchResultCell: ZMMessageObserver {
+    func messageDidChange(_ changeInfo: MessageChangeInfo) {
+        
+        updateTextView()
     }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Some issues connected to the fact that we are going to start showing the ephemeral messages in the collections UI.

- The text search continues to show the message content when the message is already obfuscated or expired.
- App crashes when clicking on the obfuscated image.

## Dependencies

Weak dependency on the data model bump.

## Notes

Made the cell selflsess.
