### PR TITLE
Extract call overlay to use its own window to support chatheads above it

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -810,6 +810,8 @@
 		BF808B571DE71F3000718076 /* UserNameTakeOverViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF808B561DE71F3000718076 /* UserNameTakeOverViewController.swift */; };
 		BF808B591DE72B7100718076 /* UserNameTakeOverViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF808B581DE72B7100718076 /* UserNameTakeOverViewControllerTests.swift */; };
 		BF86E11B1C245BF9001D9430 /* UserClient+Fingerprint.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF86E11A1C245BF9001D9430 /* UserClient+Fingerprint.swift */; };
+		BF8C8C6920D8F8F000442833 /* CallWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF8C8C6820D8F8F000442833 /* CallWindow.swift */; };
+		BF8C8C6B20D9220300442833 /* CallWindowRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF8C8C6A20D9220300442833 /* CallWindowRootViewController.swift */; };
 		BF8ECC2D1E570A920015177D /* UIActivityViewController+FileSaving.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF8ECC2C1E570A920015177D /* UIActivityViewController+FileSaving.swift */; };
 		BF8ECC331E5AED6C0015177D /* UIMenuItem+MessageActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF8ECC321E5AED6C0015177D /* UIMenuItem+MessageActions.swift */; };
 		BF8EE5561D62FBCD00B0D6D7 /* ConversationInputBarViewController+Editing.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF8EE5551D62FBCD00B0D6D7 /* ConversationInputBarViewController+Editing.swift */; };
@@ -854,6 +856,7 @@
 		BFBAE9E31E041FB7003FCE49 /* ReactionsCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFBAE9E21E041FB7003FCE49 /* ReactionsCellTests.swift */; };
 		BFBB03061D5DF4CB0065AF4F /* InputBarButtonsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFBB03051D5DF4CB0065AF4F /* InputBarButtonsView.swift */; };
 		BFBB03081D61AF8D0065AF4F /* InputBarEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFBB03071D61AF8D0065AF4F /* InputBarEditView.swift */; };
+		BFBBD1ED20D9238B00BFC4AD /* NotificationWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFBBD1EC20D9238B00BFC4AD /* NotificationWindow.swift */; };
 		BFBC11E31ED84DB200502AF0 /* WireDataModel.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BFBC11E21ED84DB200502AF0 /* WireDataModel.framework */; };
 		BFBDDBC61DB0D51C00BEED02 /* ConversationInputBarButtonState.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFBDDBC51DB0D51C00BEED02 /* ConversationInputBarButtonState.swift */; };
 		BFBE45771E36205F009FBF60 /* Error+Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFBE45761E36205F009FBF60 /* Error+Logging.swift */; };
@@ -2403,6 +2406,8 @@
 		BF808B561DE71F3000718076 /* UserNameTakeOverViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserNameTakeOverViewController.swift; sourceTree = "<group>"; };
 		BF808B581DE72B7100718076 /* UserNameTakeOverViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserNameTakeOverViewControllerTests.swift; sourceTree = "<group>"; };
 		BF86E11A1C245BF9001D9430 /* UserClient+Fingerprint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UserClient+Fingerprint.swift"; sourceTree = "<group>"; };
+		BF8C8C6820D8F8F000442833 /* CallWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallWindow.swift; sourceTree = "<group>"; };
+		BF8C8C6A20D9220300442833 /* CallWindowRootViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallWindowRootViewController.swift; sourceTree = "<group>"; };
 		BF8ECC2C1E570A920015177D /* UIActivityViewController+FileSaving.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIActivityViewController+FileSaving.swift"; sourceTree = "<group>"; };
 		BF8ECC321E5AED6C0015177D /* UIMenuItem+MessageActions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIMenuItem+MessageActions.swift"; sourceTree = "<group>"; };
 		BF8EE5551D62FBCD00B0D6D7 /* ConversationInputBarViewController+Editing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ConversationInputBarViewController+Editing.swift"; sourceTree = "<group>"; };
@@ -2454,6 +2459,7 @@
 		BFBAE9E21E041FB7003FCE49 /* ReactionsCellTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReactionsCellTests.swift; sourceTree = "<group>"; };
 		BFBB03051D5DF4CB0065AF4F /* InputBarButtonsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InputBarButtonsView.swift; sourceTree = "<group>"; };
 		BFBB03071D61AF8D0065AF4F /* InputBarEditView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InputBarEditView.swift; sourceTree = "<group>"; };
+		BFBBD1EC20D9238B00BFC4AD /* NotificationWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationWindow.swift; sourceTree = "<group>"; };
 		BFBC11E21ED84DB200502AF0 /* WireDataModel.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WireDataModel.framework; path = Carthage/Build/iOS/WireDataModel.framework; sourceTree = "<group>"; };
 		BFBDDBC51DB0D51C00BEED02 /* ConversationInputBarButtonState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConversationInputBarButtonState.swift; sourceTree = "<group>"; };
 		BFBE45761E36205F009FBF60 /* Error+Logging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Error+Logging.swift"; sourceTree = "<group>"; };
@@ -4910,6 +4916,7 @@
 				87555C7E1A85021C00A43E2E /* InAppNotifications */,
 				8FC85247199245760008B66B /* MediaBar */,
 				8FC85255199245760008B66B /* NotificationWindowRootViewController.h */,
+				BFBBD1EC20D9238B00BFC4AD /* NotificationWindow.swift */,
 				8FC85256199245760008B66B /* NotificationWindowRootViewController.m */,
 				16E2A0991F6ADE75005F4DB1 /* ActiveVoiceChannelViewController.swift */,
 				872B3282209B208D005AC615 /* CallTopOverlayController.swift */,
@@ -5274,6 +5281,15 @@
 			path = Emoji/EmojiRessources;
 			sourceTree = "<group>";
 		};
+		BF8C8C6C20D9222700442833 /* CallWindow */ = {
+			isa = PBXGroup;
+			children = (
+				BF8C8C6820D8F8F000442833 /* CallWindow.swift */,
+				BF8C8C6A20D9220300442833 /* CallWindowRootViewController.swift */,
+			);
+			path = CallWindow;
+			sourceTree = "<group>";
+		};
 		BFAC71FC20A1CDFC002711C4 /* Helper */ = {
 			isa = PBXGroup;
 			children = (
@@ -5396,6 +5412,7 @@
 		D58191FE2091CB01003BA7EC /* Calling */ = {
 			isa = PBXGroup;
 			children = (
+				BF8C8C6C20D9222700442833 /* CallWindow */,
 				5E33F0D120AD637400414EA6 /* Permissions */,
 				16C4BDA120A57DDF00BCDB17 /* CallDegradationViewController */,
 				BFAC71FF20A1CE82002711C4 /* CallViewController */,
@@ -6481,6 +6498,7 @@
 				16F6BB101EDDA0BA009EA803 /* AddParticipantsViewController.swift in Sources */,
 				871BC0051D34F56300DF0793 /* AnalyticsTracker.m in Sources */,
 				EF2127241FB9DFE300625A9B /* CountryCodeView.m in Sources */,
+				BF8C8C6B20D9220300442833 /* CallWindowRootViewController.swift in Sources */,
 				87DCF4F31D34EA4500BB420F /* StartUIInviteActionBar.m in Sources */,
 				BFA25DC71D9A8C7B0086DEBD /* ConversationInputBarViewController+Emoji.swift in Sources */,
 				D5168F532010F20B00F8222A /* BlurEffectTransition.swift in Sources */,
@@ -6947,6 +6965,7 @@
 				7C6878DB201B3785003A0C7A /* StartUIViewController+SearchResults.swift in Sources */,
 				D5D65A0F2074CFBB00D7F3C3 /* AuthenticationType.swift in Sources */,
 				BF79B0FE20A99762001BF4FE /* VideoPreviewView.swift in Sources */,
+				BFBBD1ED20D9238B00BFC4AD /* NotificationWindow.swift in Sources */,
 				87A15FDF1E08318B00AED79B /* CollectionLoadingCell.swift in Sources */,
 				F19C3A8F20513532004387E4 /* DatabaseStatisticsController.swift in Sources */,
 				D50892FB2056BD51004D3AE2 /* ZMUser+ExpirationTimeFormatting.swift in Sources */,
@@ -7138,6 +7157,7 @@
 				16D68E9B1CEF99C7003AB9E0 /* WaveformProgressView.swift in Sources */,
 				87BEB0441D3E478500DE9575 /* AssetLibrary.swift in Sources */,
 				EE43324B1F1A785800096D90 /* PopUpIconButtonView.swift in Sources */,
+				BF8C8C6920D8F8F000442833 /* CallWindow.swift in Sources */,
 				879649002046EE5E00F46B4B /* BarController.swift in Sources */,
 				BFE57B4B1D52335A00CB0806 /* ConversationPreviewViewController.swift in Sources */,
 				871BC0171D34F56300DF0793 /* AnalyticsGroupConversationEvent.m in Sources */,

--- a/Wire-iOS/Sources/AppDelegate.h
+++ b/Wire-iOS/Sources/AppDelegate.h
@@ -23,7 +23,7 @@
 
 @class ZMUserSession;
 @class UnauthenticatedSession;
-@class NotificationWindowRootViewController;
+@class CallWindowRootViewController;
 @class FirstTimeUsageAgent;
 @class ZMConversation;
 @class MediaPlaybackManager;
@@ -41,7 +41,7 @@ FOUNDATION_EXPORT NSString * _Nonnull const ZMUserSessionDidBecomeAvailableNotif
 @property (readonly, nonnull) SessionManager *sessionManager;
 @property (readonly, nonnull) AppRootViewController *rootViewController;
 
-@property (readonly, nullable) NotificationWindowRootViewController *notificationWindowController;
+@property (readonly, nullable) CallWindowRootViewController *callWindowRootViewController;
 @property (readonly, nullable) UIWindow *notificationsWindow;
 @property (readonly, nullable) MediaPlaybackManager *mediaPlaybackManager;
 

--- a/Wire-iOS/Sources/AppDelegate.m
+++ b/Wire-iOS/Sources/AppDelegate.m
@@ -244,9 +244,9 @@ performActionForShortcutItem:(UIApplicationShortcutItem *)shortcutItem
     return [[SessionManager shared] unauthenticatedSession];
 }
 
-- (NotificationWindowRootViewController *)notificationWindowController
+- (CallWindowRootViewController *)callWindowRootViewController
 {
-    return (NotificationWindowRootViewController *)self.rootViewController.overlayWindow.rootViewController;
+    return (CallWindowRootViewController *)self.rootViewController.callWindow.rootViewController;
 }
 
 - (SessionManager *)sessionManager

--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -23,7 +23,9 @@ import Classy
 @objcMembers class AppRootViewController: UIViewController {
 
     public let mainWindow: UIWindow
-    public let overlayWindow: UIWindow
+    public let callWindow: CallWindow
+    public let overlayWindow: NotificationWindow
+
     public fileprivate(set) var sessionManager: SessionManager?
     public fileprivate(set) var quickActionsManager: QuickActionsManager?
     
@@ -77,13 +79,9 @@ import Classy
 
         mainWindow = UIWindow(frame: UIScreen.main.bounds)
         mainWindow.accessibilityIdentifier = "ZClientMainWindow"
-
-        overlayWindow = PassthroughWindow(frame: UIScreen.main.bounds)
-        overlayWindow.backgroundColor = .clear
-        overlayWindow.windowLevel = UIWindowLevelStatusBar - 1
-        overlayWindow.accessibilityIdentifier = "ZClientNotificationWindow"
-        overlayWindow.rootViewController = NotificationWindowRootViewController()
-        overlayWindow.accessibilityViewIsModal = true
+        
+        callWindow = CallWindow(frame: UIScreen.main.bounds)
+        overlayWindow = NotificationWindow(frame: UIScreen.main.bounds)
 
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
 
@@ -95,6 +93,7 @@ import Classy
         // not possible because it has to be below the status bar.
         mainWindow.rootViewController = self
         mainWindow.makeKeyAndVisible()
+        callWindow.makeKeyAndVisible()
         overlayWindow.makeKeyAndVisible()
         mainWindow.makeKey()
 
@@ -333,7 +332,7 @@ import Classy
     func prepare(for appState: AppState, completionHandler: @escaping () -> Void) {
 
         if appState == .authenticated(completedRegistration: false) {
-            (overlayWindow.rootViewController as? NotificationWindowRootViewController)?.transitionToLoggedInSession()
+            callWindow.callController.transitionToLoggedInSession()
         } else {
             overlayWindow.rootViewController = NotificationWindowRootViewController()
         }
@@ -341,7 +340,7 @@ import Classy
         if !isClassyInitialized && isClassyRequired(for: appState) {
             isClassyInitialized = true
 
-            let windows = [mainWindow, overlayWindow]
+            let windows = [mainWindow, callWindow, overlayWindow]
             DispatchQueue.main.async {
                 self.setupClassy(with: windows)
                 completionHandler()

--- a/Wire-iOS/Sources/UserInterface/Calling/CallWindow/CallWindow.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallWindow/CallWindow.swift
@@ -1,0 +1,39 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+public let UIWindowLevelNotification: UIWindowLevel = UIWindowLevelStatusBar - 1
+public let UIWindowLevelCallOverlay: UIWindowLevel = UIWindowLevelNotification - 1
+
+final class CallWindow: PassthroughWindow {
+    let callController = CallWindowRootViewController()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        rootViewController = callController
+        backgroundColor = .clear
+        accessibilityIdentifier = "ZClientCallWindow"
+        accessibilityViewIsModal = true
+        windowLevel = UIWindowLevelCallOverlay
+    }
+    
+    @available(*, unavailable) required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/Wire-iOS/Sources/UserInterface/Calling/CallWindow/CallWindowRootViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallWindow/CallWindowRootViewController.swift
@@ -1,0 +1,65 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+final class CallWindowRootViewController: UIViewController {
+    
+    private(set) var voiceChannelController: ActiveVoiceChannelViewController?
+    
+    @objc func minimizeOverlay(completion: @escaping () -> Void) {
+        guard let controller = voiceChannelController else { return completion() }
+        (controller as ViewControllerDismisser).dismiss(viewController: controller, completion: completion)
+    }
+    
+    override var prefersStatusBarHidden: Bool {
+        return voiceChannelController?.prefersStatusBarHidden ?? false
+    }
+    
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return voiceChannelController?.preferredStatusBarStyle ?? .default
+    }
+    
+    override var shouldAutorotate: Bool {
+        return topmostViewController()?.shouldAutorotate ?? true
+    }
+    
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return topmostViewController()?.supportedInterfaceOrientations ?? wr_supportedInterfaceOrientations
+    }
+    
+    override func loadView() {
+        view = PassthroughTouchesView()
+    }
+    
+    func transitionToLoggedInSession() {
+        let controller = ActiveVoiceChannelViewController()
+        controller.view.translatesAutoresizingMaskIntoConstraints = false
+        addToSelf(controller)
+        controller.view.fitInSuperview()
+        voiceChannelController = controller
+    }
+    
+    private func topmostViewController() -> UIViewController? {
+        guard let topmost = UIApplication.shared.wr_topmostViewController() else { return nil }
+        guard topmost != self, !topmost.isKind(of: CallWindowRootViewController.self) else { return nil }
+        return topmost
+    }
+    
+}
+

--- a/Wire-iOS/Sources/UserInterface/Helpers/UIApplication+StatusBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UIApplication+StatusBar.swift
@@ -70,9 +70,9 @@ public extension UIApplication {
             guard let controller = $0.rootViewController else {
                 return false
             }
-            
-            if let notificationWindowRootController = controller as? NotificationWindowRootViewController {
-                return notificationWindowRootController.voiceChannelController?.voiceChannelIsActive ?? false
+
+            if let callWindowRootController = controller as? CallWindowRootViewController {
+                return callWindowRootController.voiceChannelController?.voiceChannelIsActive ?? false
             } else if controller is AppRootViewController  {
                 return true
             } else {

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
@@ -426,31 +426,38 @@
 
 #pragma mark - Animated conversation switch
 
+- (void)minimizeCallOverlayWithCompletion:(dispatch_block_t)completion
+{
+    [AppDelegate.sharedAppDelegate.callWindowRootViewController minimizeOverlayWithCompletion:completion];
+}
+
 - (void)dismissAllModalControllersWithCallback:(dispatch_block_t)callback
 {
-    if (self.splitViewController.rightViewController.presentedViewController != nil) {
-        [self.splitViewController.rightViewController dismissViewControllerAnimated:NO completion:callback];
-    }
-    else if (self.conversationListViewController.presentedViewController != nil) {
-        // This is a workaround around the fact that the transitioningDelegate of the settings
-        // view controller is not called when the transition is not being performed animated.
-        // This sounds like a bug in UIKit (Radar incoming) as I would expect the custom animator
-        // being called with `transitionContext.isAnimated == false`. As this is not the case
-        // we have to restore the proper pre-presentation state here.
-        UIView *conversationView = self.conversationListViewController.view;
-        if (!CATransform3DIsIdentity(conversationView.layer.transform) || 1 != conversationView.alpha) {
-            conversationView.layer.transform = CATransform3DIdentity;
-            conversationView.alpha = 1;
+    [self minimizeCallOverlayWithCompletion:^{
+        if (self.splitViewController.rightViewController.presentedViewController != nil) {
+            [self.splitViewController.rightViewController dismissViewControllerAnimated:NO completion:callback];
         }
-        
-        [self.conversationListViewController.presentedViewController dismissViewControllerAnimated:NO completion:callback];
-    }
-    else if (self.presentedViewController != nil) {
-        [self dismissViewControllerAnimated:NO completion:callback];
-    }
-    else if (callback) {
-        callback();
-    }
+        else if (self.conversationListViewController.presentedViewController != nil) {
+            // This is a workaround around the fact that the transitioningDelegate of the settings
+            // view controller is not called when the transition is not being performed animated.
+            // This sounds like a bug in UIKit (Radar incoming) as I would expect the custom animator
+            // being called with `transitionContext.isAnimated == false`. As this is not the case
+            // we have to restore the proper pre-presentation state here.
+            UIView *conversationView = self.conversationListViewController.view;
+            if (!CATransform3DIsIdentity(conversationView.layer.transform) || 1 != conversationView.alpha) {
+                conversationView.layer.transform = CATransform3DIdentity;
+                conversationView.alpha = 1;
+            }
+            
+            [self.conversationListViewController.presentedViewController dismissViewControllerAnimated:NO completion:callback];
+        }
+        else if (self.presentedViewController != nil) {
+            [self dismissViewControllerAnimated:NO completion:callback];
+        }
+        else if (callback) {
+            callback();
+        }
+    }];
 }
 
 #pragma mark - Getters/Setters

--- a/Wire-iOS/Sources/UserInterface/Overlay/InAppNotifications/ChatHeadsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/InAppNotifications/ChatHeadsViewController.swift
@@ -127,10 +127,13 @@ class ChatHeadsViewController: UIViewController {
             return false
         }
         
-        let isCallOverlayVisible = AppDelegate.shared().callWindowRootViewController?.voiceChannelController?.voiceChannelIsActive ?? false
+        // Always show the notification when the call overlay is shown
+        if true == AppDelegate.shared().callWindowRootViewController?.voiceChannelController?.voiceChannelIsActive {
+            return true
+        }
         
-        // If current conversation contains message, is visible and no call overlay is shown
-        if clientVC.currentConversation.remoteIdentifier == conversationID && clientVC.isConversationViewVisible && !isCallOverlayVisible {
+        // If current conversation contains the notification message and is visible
+        if clientVC.currentConversation.remoteIdentifier == conversationID && clientVC.isConversationViewVisible {
             return false
         }
 

--- a/Wire-iOS/Sources/UserInterface/Overlay/InAppNotifications/ChatHeadsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/InAppNotifications/ChatHeadsViewController.swift
@@ -127,13 +127,11 @@ class ChatHeadsViewController: UIViewController {
             return false
         }
         
-        // if current conversation contains message & is visible
-        if clientVC.currentConversation.remoteIdentifier == conversationID && clientVC.isConversationViewVisible {
-            return false
-        }
+        let isCallOverlayVisible = AppDelegate.shared().callWindowRootViewController?.voiceChannelController?.voiceChannelIsActive ?? false
         
-        if AppDelegate.shared().notificationWindowController?.voiceChannelController?.voiceChannelIsActive ?? false {
-            return false;
+        // If current conversation contains message, is visible and no call overlay is shown
+        if clientVC.currentConversation.remoteIdentifier == conversationID && clientVC.isConversationViewVisible && !isCallOverlayVisible {
+            return false
         }
 
         return clientVC.splitViewController.shouldDisplayNotification(from: account)

--- a/Wire-iOS/Sources/UserInterface/Overlay/NotificationWindow.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/NotificationWindow.swift
@@ -1,35 +1,35 @@
-// 
+//
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
-// 
+// Copyright (C) 2018 Wire Swiss GmbH
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
+//
 
+import Foundation
 
-@import UIKit;
-@import WireSyncEngine;
-
-@class ActiveVoiceChannelViewController;
-@class BarController;
-@class AppLockViewController;
-@class ChatHeadsViewController;
-
-@interface NotificationWindowRootViewController : UIViewController
-
-@property (nonatomic, readonly, nullable) AppLockViewController *appLockViewController;
-@property (nonatomic, readonly, nullable) ChatHeadsViewController *chatHeadsViewController;
-
-- (void)show:(nonnull ZMLocalNotification *)notification;
-
-@end
+final class NotificationWindow: PassthroughWindow {
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        rootViewController = NotificationWindowRootViewController()
+        backgroundColor = .clear
+        accessibilityIdentifier = "ZClientNotificationWindow"
+        accessibilityViewIsModal = true
+        windowLevel = UIWindowLevelNotification // status bar level - 1
+    }
+    
+    @available(*, unavailable) required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/Wire-iOS/Sources/UserInterface/Overlay/NotificationWindowRootViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Overlay/NotificationWindowRootViewController.m
@@ -83,21 +83,9 @@
 
 - (BOOL)prefersStatusBarHidden
 {
-    return self.voiceChannelController.prefersStatusBarHidden;
+    return YES;
 }
 
-- (UIStatusBarStyle)preferredStatusBarStyle {
-    return self.voiceChannelController.preferredStatusBarStyle;
-}
-
-- (void)transitionToLoggedInSession
-{
-    _voiceChannelController = [[ActiveVoiceChannelViewController alloc] init];
-    self.voiceChannelController.view.translatesAutoresizingMaskIntoConstraints = NO;
-    [self addViewController:self.voiceChannelController toView:self.view];
-
-    [self.voiceChannelController.view autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsZero];
-}
 
 #pragma mark - In app custom notifications
 


### PR DESCRIPTION
## What's new in this PR?

* Extract call overlay to use its own window to support chatheads above it.
* Clean up window creation code.