### PR TITLE
Fix: undo ephemeralIndicatorButtonEnabled

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarButtonState.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarButtonState.swift
@@ -34,7 +34,7 @@ private let disableEphemeralSendingInGroups = false
     }
 
     public var ephemeralIndicatorButtonHidden: Bool {
-        return (conversationType != .oneOnOne && disableEphemeralSendingInGroups) || !ephemeral || disableEphemeralSending
+        return hasText || (conversationType != .oneOnOne && disableEphemeralSendingInGroups) || editing || !ephemeral || disableEphemeralSending
     }
 
     public var ephemeralIndicatorButtonEnabled: Bool {


### PR DESCRIPTION
## What's new in this PR?

Follow-up of https://github.com/wireapp/wire-ios/pull/2287. Undo changes of ephemeralIndicatorButtonHidden before a new PR is made for display timer button next to send button.