### PR TITLE
Allow setting the custom timer for the conversation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/EphemeralKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/EphemeralKeyboardViewController.swift
@@ -105,6 +105,44 @@ public extension ZMConversation {
 
 }
 
+extension UIAlertController {
+    enum AlertError: Error {
+        case userRejected
+    }
+    
+    static func requestCustomTimeInterval(over controller: UIViewController,
+                                          with completion: @escaping (Result<TimeInterval>)->()) {
+        let alertController = UIAlertController(title: "Custom timer", message: nil, preferredStyle: .alert)
+        alertController.addTextField { (textField: UITextField) in
+            textField.keyboardType = .decimalPad
+            textField.placeholder = "Time interval in seconds"
+        }
+        let confirmAction = UIAlertAction(title: "OK", style: .default) { [weak alertController] action in
+            guard let input = alertController?.textFields?.first,
+                let inputText = input.text,
+                let selectedTimeInterval = TimeInterval(inputText) else {
+                    return
+            }
+            
+            completion(.success(selectedTimeInterval))
+        }
+        
+        alertController.addAction(confirmAction)
+        
+        let cancelAction = UIAlertAction.cancel {
+            completion(.failure(AlertError.userRejected))
+        }
+        
+        alertController.addAction(cancelAction)
+        controller.present(alertController, animated: true) { [weak alertController] in
+            guard let input = alertController?.textFields?.first else {
+                return
+            }
+            
+            input.becomeFirstResponder()
+        }
+    }
+}
 
 @objcMembers public final class EphemeralKeyboardViewController: UIViewController {
 
@@ -186,32 +224,19 @@ public extension ZMConversation {
     fileprivate func displayCustomPicker() {
         delegate?.ephemeralKeyboardWantsToBeDismissed(self)
         
-        let alertController = UIAlertController(title: "Custom timer", message: nil, preferredStyle: .alert)
-        alertController.addTextField { (textField: UITextField) in
-            textField.keyboardType = .decimalPad
-            textField.placeholder = "Time interval in seconds"
-        }
-        let confirmAction = UIAlertAction(title: "OK", style: .default) { [weak alertController, weak self] action in
-            guard let input = alertController?.textFields?.first,
-                  let inputText = input.text,
-                  let selectedTimeInterval = TimeInterval(inputText),
-                  let `self` = self else {
+        UIAlertController.requestCustomTimeInterval(over: UIApplication.shared.wr_topmostController(onlyFullScreen: true)!) { [weak self] result in
+            
+            guard let `self` = self else {
                 return
             }
             
-            self.delegate?.ephemeralKeyboard(self, didSelectMessageTimeout: selectedTimeInterval)
-        }
-        
-        alertController.addAction(confirmAction)
-        
-        let cancelAction = UIAlertAction.cancel()
-        alertController.addAction(cancelAction)
-        UIApplication.shared.wr_topmostController(onlyFullScreen: true)!.present(alertController, animated: true) { [weak alertController] in
-            guard let input = alertController?.textFields?.first else {
-                return
+            switch result {
+            case .success(let value):
+                self.delegate?.ephemeralKeyboard(self, didSelectMessageTimeout: value)
+            default:
+                break
             }
             
-            input.becomeFirstResponder()
         }
     }
 }

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
@@ -195,7 +195,6 @@ extension GroupDetailsViewController: GroupDetailsSectionControllerDelegate, Gro
 
     func presentTimeoutOptions(animated: Bool) {
         let menu = ConversationTimeoutOptionsViewController(conversation: conversation,
-                                                            items: MessageDestructionTimeoutValue.all,
                                                             userSession: ZMUserSession.shared()!)
         navigationController?.pushViewController(menu, animated: animated)
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

It is not possible to test how future-proof the timer is. We need to be able to set the arbitrary timer to the conversation and see how the client would behave.

Also client must display the arbitrary value in the correct way.
