### PR TITLE
Reduce the accessibility tree depth

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
@@ -153,6 +153,7 @@ static const CGFloat BurstContainerExpandedHeight = 40;
     self.messageContentView = [[UIView alloc] init];
     self.messageContentView.translatesAutoresizingMaskIntoConstraints = NO;
     self.messageContentView.accessibilityElementsHidden = NO;
+    self.messageContentView.shouldGroupAccessibilityChildren = YES;
     [self.contentView addSubview:self.messageContentView];
 
     self.authorLabel = [[UILabel alloc] init];


### PR DESCRIPTION
## What's new in this PR?

### Issues

Automation sees the message text twice in the accessibility tree. My speculation is that it's showing like that because the message is buried inside another view that is also visible in the tree.

### Solutions

Make message text view appear on the higher level of the accessibility hierarchy.