### PR TITLE
Display remain time with year unit

### DIFF
--- a/Wire-iOS Tests/EphemeralTimeoutFormatterTests.swift
+++ b/Wire-iOS Tests/EphemeralTimeoutFormatterTests.swift
@@ -34,6 +34,41 @@ final class EphemeralTimeoutFormatterTests: XCTestCase {
         super.tearDown()
     }
 
+    func testFor1Year11Months30DaysLeft(){
+        // GIVEN & WHEN
+        // minus one day to make sure it is less than 1 year 6 months
+        let formattedString = sut.string(from: 31536000 * 2 - 86400)
+
+        // THEN
+        XCTAssertEqual(formattedString, "1 year, 11 months, 30 days left")
+    }
+
+
+    func testForOneAndAHalfYearLeft(){
+        // GIVEN & WHEN
+        // minus one day to make sure it is less than 1 year 6 months
+        let formattedString = sut.string(from: 31536000 * 1.5 - 86400)
+
+        // THEN
+        XCTAssertEqual(formattedString, "1 year, 6 months left")
+    }
+
+    func testFor1YearLeft(){
+        // GIVEN & WHEN
+        let formattedString = sut.string(from: 31536000)
+
+        // THEN
+        XCTAssertEqual(formattedString, "1 year left")
+    }
+
+    func testFor1SecondLessThanAYearLeft(){
+        // GIVEN & WHEN
+        let formattedString = sut.string(from: 31535999)
+
+        // THEN
+        XCTAssertEqual(formattedString, "364 days, 23 hours left")
+    }
+
     func testFor4WeeksLeft(){
         // GIVEN & WHEN
         let formattedString = sut.string(from: 2419200)

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/EphemeralTimeoutFormatter.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/EphemeralTimeoutFormatter.swift
@@ -51,6 +51,16 @@ class EphemeralTimeoutFormatter {
         return formatter
     }()
 
+    private let yearFormatter: DateComponentsFormatter = {
+        let formatter = DateComponentsFormatter()
+
+        // no comma in time string
+        formatter.unitsStyle = .full
+        formatter.allowedUnits = [.year, .month, .day]
+        formatter.zeroFormattingBehavior = .dropAll
+        return formatter
+    }()
+
     func string(from interval: TimeInterval) -> String? {
         return timeString(from: interval).map {
             "content.system.ephemeral_time_remaining".localized(args: $0)
@@ -62,7 +72,8 @@ class EphemeralTimeoutFormatter {
         case 0..<60: return secondsFormatter.string(from: interval)
         case 60..<3600: return minuteFormatter.string(from: interval)
         case 3600..<86400: return hourFormatter.string(from: interval)
-        default: return dayFormatter.string(from: interval)
+        case 86400..<31536000: return dayFormatter.string(from: interval)
+        default: return yearFormatter.string(from: interval)
         }
     }
     


### PR DESCRIPTION
## What's new in this PR?

For time remain larger than 1 year, display it with year and month unit.