### PR TITLE
Conversation: Disable custom value in timers selector

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Views/DetailsCollectionViewCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/DetailsCollectionViewCell.swift
@@ -50,6 +50,12 @@ class DetailsCollectionViewCell: SeparatorCollectionViewCell {
         get { return statusLabel.text }
         set { updateStatus(newValue) }
     }
+    
+    var disabled: Bool = false {
+        didSet {
+            updateDisabledState()
+        }
+    }
 
     // MARK: - Configuration
 
@@ -101,8 +107,8 @@ class DetailsCollectionViewCell: SeparatorCollectionViewCell {
         super.applyColorScheme(colorSchemeVariant)
         let sectionTextColor = UIColor(scheme: .sectionText, variant: colorSchemeVariant)
         backgroundColor = UIColor(scheme: .barBackground, variant: colorSchemeVariant)
-        titleLabel.textColor = UIColor(scheme: .textForeground, variant: colorSchemeVariant)
         statusLabel.textColor = sectionTextColor
+        updateDisabledState()
     }
 
     // MARK: - Layout
@@ -149,6 +155,10 @@ class DetailsCollectionViewCell: SeparatorCollectionViewCell {
         } else {
             accessoryIconView.isHidden = true
         }
+    }
+    
+    private func updateDisabledState() {
+        titleLabel.textColor = UIColor(scheme: disabled ? .textPlaceholder : .textForeground, variant: colorSchemeVariant)
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationTimeoutOptionsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationTimeoutOptionsViewController.swift
@@ -127,8 +127,9 @@ extension ConversationTimeoutOptionsViewController: UICollectionViewDelegateFlow
         let item = items[indexPath.row]
         let cell = collectionView.dequeueReusableCell(ofType: CheckmarkCell.self, for: indexPath)
 
-        func configure(_ cell: CheckmarkCell, for value: MessageDestructionTimeoutValue) {
+        func configure(_ cell: CheckmarkCell, for value: MessageDestructionTimeoutValue, disabled: Bool) {
             cell.title = value.displayString
+            cell.disabled = disabled
             
             switch conversation.messageDestructionTimeout {
             case .synced(let currentValue)?:
@@ -140,9 +141,9 @@ extension ConversationTimeoutOptionsViewController: UICollectionViewDelegateFlow
         
         switch item {
         case .supportedValue(let value):
-            configure(cell, for: value)
+            configure(cell, for: value, disabled: false)
         case .unsupportedValue(let value):
-            configure(cell, for: value)
+            configure(cell, for: value, disabled: true)
         case .customValue:
             cell.title = "Custom"
             cell.showCheckmark = false


### PR DESCRIPTION
## What's new in this PR?

### Issues

The custom value cannot be selected, so must appear as disabled.
