### PR TITLE
Fix the status icons initial style

### DIFF
--- a/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
@@ -140,7 +140,6 @@ public class AddParticipantsViewController: UIViewController {
         searchGroupSelector = SearchGroupSelector(style: self.variant)
 
         searchResultsViewController = SearchResultsViewController(userSelection: userSelection,
-                                                                  variant: self.variant,
                                                                   isAddingParticipants: true,
                                                                   shouldIncludeGuests: viewModel.context.includeGuests)
 

--- a/Wire-iOS/Sources/UserInterface/Components/Views/UserCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/UserCell.swift
@@ -41,6 +41,8 @@ class UserCell: SeparatorCollectionViewCell {
     var titleStackView : UIStackView!
     var iconStackView : UIStackView!
     
+    weak var user: ZMBareUser? = nil
+    
     fileprivate static let boldFont: UIFont! = FontSpec.init(.small, .regular).font!
     fileprivate static let lightFont: UIFont! = FontSpec.init(.small, .light).font!
 
@@ -170,11 +172,21 @@ class UserCell: SeparatorCollectionViewCell {
         checkmarkIconView.layer.borderColor = UIColor(scheme: .iconNormal, variant: colorSchemeVariant).cgColor
         titleLabel.textColor = UIColor(scheme: .textForeground, variant: colorSchemeVariant)
         subtitleLabel.textColor = sectionTextColor
+        updateTitleLabel()
+    }
+    
+    private func updateTitleLabel() {
+        guard let user = self.user else {
+            return
+        }
+        titleLabel.attributedText = user.nameIncludingAvailability(color: UIColor(scheme: .textForeground, variant: colorSchemeVariant))
     }
     
     public func configure(with user: ZMBareUser, conversation: ZMConversation? = nil) {
+        self.user = user
+        
         avatar.user = user
-        titleLabel.attributedText = user.nameIncludingAvailability(color: UIColor(scheme: .textForeground, variant: colorSchemeVariant))
+        updateTitleLabel()
         
         if let conversation = conversation {
             guestIconView.isHidden = !user.isGuest(in: conversation)

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
@@ -321,10 +321,8 @@ extension UIViewController {
             teamContacts = teamContacts.filter({ !filteredParticpants.contains($0) })
         }
         
-        contactsSection.contacts = contacts.filter {
-            $0.displayName.starts(with: "B")
-        }
-
+        contactsSection.contacts = contacts
+        
         // Access mode is not set, or the guests are allowed.
         if shouldIncludeGuests {
             teamMemberAndContactsSection.contacts = Set(teamContacts + contacts).sorted {
@@ -332,14 +330,10 @@ extension UIViewController {
                 let name1 = $1.name ?? ""
 
                 return name0.compare(name1) == .orderedAscending
-                }.filter {
-                    $0.displayName.starts(with: "B")
-            }
+                }
         }
         else {
-            teamMemberAndContactsSection.contacts = teamContacts.filter {
-                $0.displayName.starts(with: "B")
-            }
+            teamMemberAndContactsSection.contacts = teamContacts
         }
         
         directorySection.suggestions = searchResult.directory

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
@@ -152,7 +152,7 @@ extension UIViewController {
     }
     
     @objc
-    public init(userSelection: UserSelection, variant: ColorSchemeVariant, isAddingParticipants: Bool = false, shouldIncludeGuests: Bool) {
+    public init(userSelection: UserSelection, isAddingParticipants: Bool = false, shouldIncludeGuests: Bool) {
         self.searchDirectory = SearchDirectory(userSession: ZMUserSession.shared()!)
         self.userSelection = userSelection
         self.isAddingParticipants = isAddingParticipants
@@ -321,7 +321,9 @@ extension UIViewController {
             teamContacts = teamContacts.filter({ !filteredParticpants.contains($0) })
         }
         
-        contactsSection.contacts = contacts
+        contactsSection.contacts = contacts.filter {
+            $0.displayName.starts(with: "B")
+        }
 
         // Access mode is not set, or the guests are allowed.
         if shouldIncludeGuests {
@@ -330,10 +332,14 @@ extension UIViewController {
                 let name1 = $1.name ?? ""
 
                 return name0.compare(name1) == .orderedAscending
-             }
+                }.filter {
+                    $0.displayName.starts(with: "B")
+            }
         }
         else {
-            teamMemberAndContactsSection.contacts = teamContacts
+            teamMemberAndContactsSection.contacts = teamContacts.filter {
+                $0.displayName.starts(with: "B")
+            }
         }
         
         directorySection.suggestions = searchResult.directory

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.m
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.m
@@ -132,7 +132,6 @@ static NSUInteger const StartUIInitiallyShowsKeyboardConversationThreshold = 10;
     }
 
     self.searchResultsViewController = [[SearchResultsViewController alloc] initWithUserSelection:self.userSelection
-                                                                                          variant:ColorSchemeVariantDark
                                                                              isAddingParticipants:NO
                                                                               shouldIncludeGuests:YES];
     self.searchResultsViewController.mode = SearchResultsViewControllerModeList;


### PR DESCRIPTION
## What's new in this PR?

### Issues

In the start UI, the status icons if user has the light color scheme are displayed dark on dark initially. If user scrolls the start UI then the icons are coming back to normal.

### Causes

The color scheme on the cells is set via `UIAppearance`. For the first rendered cells the setting of user is happening before the appearance is setting the color scheme.

### Solutions

When color scheme is set, re-render the user status icon with the correct color.

## Notes

`SearchResultsViewController` was still created with the color scheme variant.