### PR TITLE
ZIOS-10184: Timer is not updated if other user changed a value

### DIFF
--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
@@ -139,7 +139,7 @@ import Cartography
     }
     
     func conversationDidChange(_ changeInfo: ConversationChangeInfo) {
-        guard changeInfo.participantsChanged || changeInfo.nameChanged || changeInfo.allowGuestsChanged else { return }
+        guard changeInfo.participantsChanged || changeInfo.nameChanged || changeInfo.allowGuestsChanged || changeInfo.destructionTimeoutChanged else { return }
         collectionViewController.sections = computeVisibleSections()
     }
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

Timer was not updating correctly on `GroupDetailsViewController` because the `destructionTimeoutChanged` event was not considered.

### Solutions

I've added `destructionTimeoutChanged` to the list of allowed events that are able to trigger updates on the UI.
