### PR TITLE
ZIOS-10230: Fix error when selecting the current conversation timeout again

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationTimeoutOptionsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationTimeoutOptionsViewController.swift
@@ -202,12 +202,29 @@ extension ConversationTimeoutOptionsViewController: UICollectionViewDelegateFlow
     
     // MARK: Saving Changes
 
+    private func canSelectItem(with value: MessageDestructionTimeoutValue) -> Bool {
+
+        guard let currentTimeout = conversation.messageDestructionTimeout else {
+            return value != .none
+        }
+
+        guard case .synced(let currentValue) = currentTimeout else {
+            return value != .none
+        }
+
+        return value != currentValue
+
+    }
+
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         collectionView.deselectItem(at: indexPath, animated: true)
         let selectedItem = items[indexPath.row]
         
         switch selectedItem {
         case .supportedValue(let value):
+            guard canSelectItem(with: value) else {
+                break
+            }
             updateTimeout(value)
         case .customValue:
             requestCustomValue()


### PR DESCRIPTION
## What's new in this PR?

### Issues

When the user selects the current timeout in the conversation details (or "Off" if the synced timeout is disabled), an error will be displayed after we attempt to update the value on the server.

### Causes

We shouldn't be sending the request to update the value if the user selection didn't change.

### Solutions

We check if it makes sense to send the update request before sending it when the user selects a timeout.

| Current state | Allow selection & updates unless... |
|---------------|-------------|
| Timeout off | User selects "Off" |
| Local timeout on | User selects "Off" |
| Synced timeout on | User selects the current timeout again |