### PR TITLE
Fix: image viewer toolbar not refreshed after scrolling form a timed image to non timed image or vice versa

### DIFF
--- a/Wire-iOS Tests/ConversationImagesViewControllerTests.swift
+++ b/Wire-iOS Tests/ConversationImagesViewControllerTests.swift
@@ -56,4 +56,27 @@ class ConversationImagesViewControllerTests: CoreDataSnapshotTestCase {
         sut.setBoundsSizeAsIPhone4_7Inch()
         verify(view: sut.view)
     }
+
+    // MARK: - Update toolbar buttons for switching between ephemeral/normal messages
+    func testThatToolBarIsUpdateAfterScollToAnEphemeralImage() {
+        // GIVEN
+        let image = self.image(inTestBundleNamed: "unsplash_matterhorn.jpg")
+        let message = MockMessageFactory.imageMessage(with: image)!
+        message.isEphemeral = false
+        sut.currentMessage = message
+
+        // WHEN
+        sut.viewDidLoad()
+
+        // THEN
+        XCTAssertEqual(sut.buttonsBar.buttons.count, 8)
+
+        // WHEN
+        message.isEphemeral = true
+        sut.pageViewController(UIPageViewController(), didFinishAnimating: true, previousViewControllers: [], transitionCompleted: true)
+
+        // THEN
+        XCTAssertEqual(sut.buttonsBar.buttons.count, 1)
+
+    }
 }

--- a/Wire-iOS/Sources/UserInterface/Collections/ConversationImagesViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/ConversationImagesViewController.swift
@@ -47,7 +47,7 @@ final class ConversationImagesViewController: TintColorCorrectedViewController {
     
     fileprivate var navBarContainer: UINavigationBarContainer?
     var pageViewController: UIPageViewController = UIPageViewController(transitionStyle:.scroll, navigationOrientation:.horizontal, options: [:])
-    var buttonsBar: InputBarButtonsView! ///TODO refresh
+    var buttonsBar: InputBarButtonsView!
     let deleteButton = IconButton.iconButtonDefault()
     let overlay = FeedbackOverlayView()
     let separator = UIView()

--- a/Wire-iOS/Sources/UserInterface/Collections/ConversationImagesViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/ConversationImagesViewController.swift
@@ -218,7 +218,7 @@ final class ConversationImagesViewController: TintColorCorrectedViewController {
         return nextIndex
     }
 
-    private var controlsBarButtons: [IconButton] {
+    private func createControlsBarButtons() -> [IconButton] {
         var buttons = [IconButton]()
 
         // ephemermal images should not contain these buttons.
@@ -273,7 +273,7 @@ final class ConversationImagesViewController: TintColorCorrectedViewController {
     }
     
     private func createControlsBar() {
-        let buttons = controlsBarButtons
+        let buttons = createControlsBarButtons()
 
         self.buttonsBar = InputBarButtonsView(buttons: buttons)
         self.buttonsBar.clipsToBounds = true
@@ -462,7 +462,7 @@ extension ConversationImagesViewController: UIPageViewControllerDelegate, UIPage
             completed {
             
             self.currentMessage = currentController.message
-            self.buttonsBar.buttons = self.controlsBarButtons
+            self.buttonsBar.buttons = createControlsBarButtons()
             updateLikeButton()
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Collections/ConversationImagesViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/ConversationImagesViewController.swift
@@ -47,7 +47,7 @@ final class ConversationImagesViewController: TintColorCorrectedViewController {
     
     fileprivate var navBarContainer: UINavigationBarContainer?
     var pageViewController: UIPageViewController = UIPageViewController(transitionStyle:.scroll, navigationOrientation:.horizontal, options: [:])
-    var buttonsBar: InputBarButtonsView!
+    var buttonsBar: InputBarButtonsView! ///TODO refresh
     let deleteButton = IconButton.iconButtonDefault()
     let overlay = FeedbackOverlayView()
     let separator = UIView()
@@ -217,44 +217,43 @@ final class ConversationImagesViewController: TintColorCorrectedViewController {
         
         return nextIndex
     }
-    
-    private func createControlsBar() {
-        
+
+    private var controlsBarButtons: [IconButton] {
         var buttons = [IconButton]()
-        
+
         // ephemermal images should not contain these buttons.
         // if the current message is ephemeral, then it will be the only
         // message b/c ephemeral messages are excluded in the collection.
         if !currentMessage.isEphemeral {
-            
+
             let copyButton = IconButton.iconButtonDefault()
             copyButton.setIcon(.copy, with: .tiny, for: .normal)
             copyButton.accessibilityLabel = "copy"
             copyButton.addTarget(self, action: #selector(ConversationImagesViewController.copyCurrent(_:)), for: .touchUpInside)
-            
+
             likeButton.addTarget(self, action: #selector(likeCurrent), for: .touchUpInside)
             updateLikeButton()
-            
+
             let saveButton = IconButton.iconButtonDefault()
             saveButton.setIcon(.save, with: .tiny, for: .normal)
             saveButton.accessibilityLabel = "save"
             saveButton.addTarget(self, action: #selector(ConversationImagesViewController.saveCurrent(_:)), for: .touchUpInside)
-            
+
             let shareButton = IconButton.iconButtonDefault()
             shareButton.setIcon(.export, with: .tiny, for: .normal)
             shareButton.accessibilityLabel = "share"
             shareButton.addTarget(self, action: #selector(ConversationImagesViewController.shareCurrent(_:)), for: .touchUpInside)
-            
+
             let sketchButton = IconButton.iconButtonDefault()
             sketchButton.setIcon(.brush, with: .tiny, for: .normal)
             sketchButton.accessibilityLabel = "sketch over image"
             sketchButton.addTarget(self, action: #selector(ConversationImagesViewController.sketchCurrent(_:)), for: .touchUpInside)
-            
+
             let emojiSketchButton = IconButton.iconButtonDefault()
             emojiSketchButton.setIcon(.emoji, with: .tiny, for: .normal)
             emojiSketchButton.accessibilityLabel = "sketch emoji over image"
             emojiSketchButton.addTarget(self, action: #selector(ConversationImagesViewController.sketchCurrentEmoji(_:)), for: .touchUpInside)
-            
+
             let revealButton = IconButton.iconButtonDefault()
             revealButton.setIcon(.eye, with: .tiny, for: .normal)
             revealButton.accessibilityLabel = "reveal in conversation"
@@ -262,14 +261,20 @@ final class ConversationImagesViewController: TintColorCorrectedViewController {
 
             buttons = [likeButton, shareButton, sketchButton, emojiSketchButton, copyButton, saveButton, revealButton]
         }
-        
+
         deleteButton.setIcon(.trash, with: .tiny, for: .normal)
         deleteButton.accessibilityLabel = "delete"
         deleteButton.addTarget(self, action: #selector(deleteCurrent), for: .touchUpInside)
-        
+
         buttons.append(deleteButton)
         buttons.forEach { $0.hitAreaPadding = .zero }
-        
+
+        return buttons
+    }
+    
+    private func createControlsBar() {
+        let buttons = controlsBarButtons
+
         self.buttonsBar = InputBarButtonsView(buttons: buttons)
         self.buttonsBar.clipsToBounds = true
         self.buttonsBar.expandRowButton.setIconColor(UIColor(scheme: .textForeground), for: .normal)
@@ -457,6 +462,7 @@ extension ConversationImagesViewController: UIPageViewControllerDelegate, UIPage
             completed {
             
             self.currentMessage = currentController.message
+            self.buttonsBar.buttons = self.controlsBarButtons
             updateLikeButton()
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarButtonsView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarButtonsView.swift
@@ -47,7 +47,12 @@ public final class InputBarButtonsView: UIView {
     fileprivate var lastLayoutWidth: CGFloat = 0
     
     public let expandRowButton = IconButton()
-    public let buttons: [UIButton]
+    public var buttons: [UIButton] {
+        didSet {
+            buttonInnerContainer.subviews.forEach({ $0.removeFromSuperview() })
+            layoutAndConstrainButtonRows()
+        }
+    }
     fileprivate let buttonInnerContainer = UIView()
     fileprivate let buttonOuterContainer = UIView()
     fileprivate let constants = InputBarRowConstants()


### PR DESCRIPTION
## What's new in this PR?

### Issues

In ConversationImagesViewController, its toolbar is not refreshed and the user can still perform actions such as like/download a timed image, which should not be allowed.

### Causes

Buttons should be refreshed according to the image message is ephemeral or not.

### Solutions

When the user scroll to next page in ConversationImagesViewController, refresh the buttonsBar's buttons.

