### PR TITLE
Set preferred status bar style

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ArchivedListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ArchivedListViewController.swift
@@ -31,6 +31,8 @@ import Cartography
 
 @objcMembers final class ArchivedListViewController: UIViewController {
     
+    override var preferredStatusBarStyle: UIStatusBarStyle { return .lightContent }
+    
     fileprivate var collectionView: UICollectionView!
     fileprivate let archivedNavigationBar = ArchivedNavigationBar(title: "archived_list.title".localized.uppercased())
     fileprivate let cellReuseIdentifier = "ConversationListCellArchivedIdentifier"


### PR DESCRIPTION
## What's new in this PR?

### Issues

Unarchiving a conversation would make the status bar black on a dark background.

### Causes

`ArchivedListViewController` didn't have a preferred status bar style, so default (dark content) was being used.

### Solutions

Set the preferred style to `.lightContent`