### PR TITLE
Fix: Remove the reduce alpha effect for message in last 10 seconds

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
@@ -708,10 +708,6 @@ static const CGFloat BurstContainerExpandedHeight = 40;
         self.countdownView.hidden = NO;
     }
 
-    if (duration <= 10 && self.messageContentView.alpha > 0.5) {
-        self.messageContentView.alpha = 0.5;
-    }
-
     [self.toolboxView updateTimestamp:self.message];
 }
 


### PR DESCRIPTION
## What's new in this PR?

Remove the message cell fade-out effect to match the latest design spec.