### PR TITLE
ZIOS-10245: Make GIF grid cells available in the accessibility engine

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Giphy/GiphySearchViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Giphy/GiphySearchViewController.swift
@@ -232,6 +232,8 @@ class GiphyCollectionViewCell: UICollectionViewCell {
             cell.ziph = ziph
             cell.representation = representation
             cell.backgroundColor = UIColor(for: ZMUser.pickRandomAccentColor())
+            cell.isAccessibilityElement = true
+            cell.accessibilityTraits |= UIAccessibilityTraitImage
 
             searchResultsController.fetchImageData(forZiph: ziph, imageType: representation.imageType) { (imageData, imageRepresentation, error) in
                 if cell.representation == imageRepresentation {


### PR DESCRIPTION
## What's new in this PR?

### Issues

GIFs displayed in the column layout were not accessible in the accessibility engine (eg. VoiceOver and automation).

### Causes

The layout change caused the cells to be marked as non accessible.

### Solutions

We marked the cells as accessible images.