### PR TITLE
Fix SCSiriWaveformView copyright header

### DIFF
--- a/Wire-iOS/Sources/Vendor/SCSiriWaveformView.h
+++ b/Wire-iOS/Sources/Vendor/SCSiriWaveformView.h
@@ -1,9 +1,48 @@
 //
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+// This module of the Wire Software uses software code from Stefan Ceriu
+// governed by the MIT license (https://github.com/stefanceriu/SCSiriWaveformView).
+//
+//
 //  SCSiriWaveformView.h
 //  SCSiriWaveformView
 //
 //  Created by Stefan Ceriu on 12/04/2014.
-//  Copyright (c) 2014 Stefan Ceriu. All rights reserved.
+//  Copyright (C) 2013 Stefan Ceriu.
+//  Released under the MIT license.
+//
+//
+//// Copyright (C) 2013 Stefan Ceriu
+////
+//// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+//// software and associated documentation files (the "Software"), to deal in the Software
+//// without restriction, including without limitation the rights to use, copy, modify, merge,
+//// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+//// to whom the Software is furnished to do so, subject to the following conditions:
+////
+//// The above copyright notice and this permission notice shall be included in all copies or substantial
+//// portions of the Software.
+////
+//// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+//// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
+//// AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+//// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
 @import UIKit;

--- a/Wire-iOS/Sources/Vendor/SCSiriWaveformView.m
+++ b/Wire-iOS/Sources/Vendor/SCSiriWaveformView.m
@@ -1,9 +1,48 @@
 //
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+// This module of the Wire Software uses software code from Stefan Ceriu
+// governed by the MIT license (https://github.com/stefanceriu/SCSiriWaveformView).
+//
+//
 //  SCSiriWaveformView.m
 //  SCSiriWaveformView
 //
 //  Created by Stefan Ceriu on 12/04/2014.
-//  Copyright (c) 2014 Stefan Ceriu. All rights reserved.
+//  Copyright (C) 2013 Stefan Ceriu.
+//  Released under the MIT license.
+//
+//
+//// Copyright (C) 2013 Stefan Ceriu
+////
+//// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+//// software and associated documentation files (the "Software"), to deal in the Software
+//// without restriction, including without limitation the rights to use, copy, modify, merge,
+//// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+//// to whom the Software is furnished to do so, subject to the following conditions:
+////
+//// The above copyright notice and this permission notice shall be included in all copies or substantial
+//// portions of the Software.
+////
+//// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+//// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
+//// AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+//// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
 #import "SCSiriWaveformView.h"


### PR DESCRIPTION
## What's new in this PR?

Use the correct header format for imported third party code in the` SCSiriWaveformView` file headers.