### PR TITLE
Remove join button from 1-on-1 conversations during a call

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
@@ -264,8 +264,8 @@ extension ZMConversation {
 
     /// Whether there is an incoming or inactive incoming call that can be joined.
     @objc var canJoinCall: Bool {
-        switch voiceChannel?.state {
-        case .incoming?: return true
+        switch (voiceChannel?.state, conversationType) {
+        case (.incoming?, .group): return true
         default: return false
         }
     }
@@ -294,7 +294,7 @@ extension ZMConversation {
 
     var isCallOngoing: Bool {
         switch voiceChannel?.state {
-        case .none?: return false
+        case .none?, .incoming?: return false
         default: return true
         }
     }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ZMConversation+Status.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ZMConversation+Status.swift
@@ -654,28 +654,19 @@ extension ZMConversation {
         else {
             hasMessages = true
         }
-        
-        
-        var isOngoingCall = false
-        if let state = voiceChannel?.state {
-            switch state {
-            case .none, .terminating:
-                break
-            default:
-                isOngoingCall = true
-            }
-        }
-        
-        return ConversationStatus(isGroup: self.conversationType == .group,
-                                  hasMessages: hasMessages,
-                                  hasUnsentMessages: self.hasUnreadUnsentMessage,
-                                  messagesRequiringAttention: messagesRequiringAttention,
-                                  messagesRequiringAttentionByType: messagesRequiringAttentionByType,
-                                  isTyping: self.typingUsers().count > 0,
-                                  isSilenced: self.isSilenced,
-                                  isOngoingCall: isOngoingCall,
-                                  isBlocked: isBlocked,
-                                  isSelfAnActiveMember: self.isSelfAnActiveMember)
+
+        return ConversationStatus(
+            isGroup: conversationType == .group,
+            hasMessages: hasMessages,
+            hasUnsentMessages: hasUnreadUnsentMessage,
+            messagesRequiringAttention: messagesRequiringAttention,
+            messagesRequiringAttentionByType: messagesRequiringAttentionByType,
+            isTyping: typingUsers().count > 0,
+            isSilenced: isSilenced,
+            isOngoingCall: canJoinCall,
+            isBlocked: isBlocked,
+            isSelfAnActiveMember: isSelfAnActiveMember
+        )
     }
 }
 


### PR DESCRIPTION
## What's new in this PR?

* Remove join button from 1-on-1 conversations during a call.