### PR TITLE
Fix: After sending an image, the top avatar image's height is reduced

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+TableHeader.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+TableHeader.swift
@@ -27,9 +27,9 @@ extension ConversationContentViewController {
     }
 
     @objc func updateHeaderHeight() {
-        if let headerView = tableView.tableHeaderView {
-            headerView.frame = headerViewFrame(view: headerView)
-            tableView.tableHeaderView = headerView
-        }
+        guard let headerView = tableView.tableHeaderView else { return }
+
+        headerView.frame = headerViewFrame(view: headerView)
+        tableView.tableHeaderView = headerView
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -898,6 +898,8 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
 
 - (void)conversationWindowDidChange:(MessageWindowChangeInfo *)note
 {
+    [self updateHeaderHeight];
+
     // Clear selectedMessage if it is going to be deleted.
     if ([note.deletedObjects containsObject:self.conversationMessageWindowTableViewAdapter.selectedMessage]) {
         self.conversationMessageWindowTableViewAdapter.selectedMessage = nil;


### PR DESCRIPTION
## What's new in this PR?

### Issues

After sending an image, the top avatar image's height is reduced and overlaps the username.

### Causes

The table view header's height is compressed after a cell is inserted

### Solutions

Refresh table view header height in conversationWindowDidChange.