### PR TITLE
Fix: Timer pie UI's progress should be calculated with the message's first read time

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1160,7 +1160,8 @@
 		EF80466520D17130001A1C53 /* MessageDestructionTimeoutValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF80466320D1712B001A1C53 /* MessageDestructionTimeoutValueTests.swift */; };
 		EF80C0022097106D00E0040B /* ZMConversationMessageWindow+Formatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF80C0012097106D00E0040B /* ZMConversationMessageWindow+Formatting.swift */; };
 		EF80C0042097151C00E0040B /* ZMConversationMessageWindowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF80C0032097151C00E0040B /* ZMConversationMessageWindowTests.swift */; };
-		EF82E1C020EE79EC001B5196 /* ZMConversationMessage+Ephemeral.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF82E1BF20EE79EC001B5196 /* ZMConversationMessage+Ephemeral.swift */; };
+		EF82E1C020EE79EC001B5196 /* ZMConversationMessage+CountDown.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF82E1BF20EE79EC001B5196 /* ZMConversationMessage+CountDown.swift */; };
+		EF82E1C220EF6152001B5196 /* ConversationCell+CountDown.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF82E1C120EF6152001B5196 /* ConversationCell+CountDown.swift */; };
 		EF8D7D4920D8FCA500F98666 /* MockConversation+TimedMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF8D7D4720D8FC7100F98666 /* MockConversation+TimedMessage.swift */; };
 		EF91A0561FF3A05A00FE2F53 /* GiphySearchViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF91A0541FF3A04700FE2F53 /* GiphySearchViewControllerTests.swift */; };
 		EF98987220C5A47A005680C5 /* SettingsClientViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF98987120C5A47A005680C5 /* SettingsClientViewControllerTests.swift */; };
@@ -2836,7 +2837,8 @@
 		EF80466320D1712B001A1C53 /* MessageDestructionTimeoutValueTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageDestructionTimeoutValueTests.swift; sourceTree = "<group>"; };
 		EF80C0012097106D00E0040B /* ZMConversationMessageWindow+Formatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversationMessageWindow+Formatting.swift"; sourceTree = "<group>"; };
 		EF80C0032097151C00E0040B /* ZMConversationMessageWindowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMConversationMessageWindowTests.swift; sourceTree = "<group>"; };
-		EF82E1BF20EE79EC001B5196 /* ZMConversationMessage+Ephemeral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversationMessage+Ephemeral.swift"; sourceTree = "<group>"; };
+		EF82E1BF20EE79EC001B5196 /* ZMConversationMessage+CountDown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversationMessage+CountDown.swift"; sourceTree = "<group>"; };
+		EF82E1C120EF6152001B5196 /* ConversationCell+CountDown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationCell+CountDown.swift"; sourceTree = "<group>"; };
 		EF8D7D4720D8FC7100F98666 /* MockConversation+TimedMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MockConversation+TimedMessage.swift"; sourceTree = "<group>"; };
 		EF91A0541FF3A04700FE2F53 /* GiphySearchViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiphySearchViewControllerTests.swift; sourceTree = "<group>"; };
 		EF98987120C5A47A005680C5 /* SettingsClientViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsClientViewControllerTests.swift; sourceTree = "<group>"; };
@@ -4910,7 +4912,8 @@
 				BF989D071E896D210052BF8F /* ConversationCellBurstTimestampView.swift */,
 				87CB36BB1D7480F6007AB4E5 /* ConversationCell+Like.swift */,
 				F187D6C720162A4300A2DA8F /* ConversationCell+Sender.swift */,
-				EF82E1BF20EE79EC001B5196 /* ZMConversationMessage+Ephemeral.swift */,
+				EF82E1C120EF6152001B5196 /* ConversationCell+CountDown.swift */,
+				EF82E1BF20EE79EC001B5196 /* ZMConversationMessage+CountDown.swift */,
 				16E311C71A5FEAE200FF2C9E /* TextMessageCell.h */,
 				874AE9B51DDCC98B00D3C830 /* TextMessageCell+Internal.h */,
 				16E311C81A5FEAE200FF2C9E /* TextMessageCell.m */,
@@ -6746,7 +6749,7 @@
 				BFBB03061D5DF4CB0065AF4F /* InputBarButtonsView.swift in Sources */,
 				7C5836641FD5ABE7001CC843 /* AvailabilityTitleView.swift in Sources */,
 				163FB98F20514DB700E74F83 /* UIView+LayoutMargins.swift in Sources */,
-				EF82E1C020EE79EC001B5196 /* ZMConversationMessage+Ephemeral.swift in Sources */,
+				EF82E1C020EE79EC001B5196 /* ZMConversationMessage+CountDown.swift in Sources */,
 				D5CA8E572045718900D2F16E /* UINavigationController+CloseButton.swift in Sources */,
 				F95E08B41D0EAFE80098A9EE /* TTTAttributedLabel+Links.swift in Sources */,
 				87DCF48D1D34E9BA00BB420F /* ContactsCell.m in Sources */,
@@ -6851,6 +6854,7 @@
 				871BC2971D34F8F800DF0793 /* UIViewController+WR_Additions.m in Sources */,
 				87EB6B871E2FCE080019B3C5 /* ZMConversationMessage+File.swift in Sources */,
 				87F18BBA1E01551600C69D9B /* VideoMessageView.swift in Sources */,
+				EF82E1C220EF6152001B5196 /* ConversationCell+CountDown.swift in Sources */,
 				BF3A3DD41EAA09C6005477F8 /* UIAlertController+DraftDeletion.swift in Sources */,
 				8FC8549D199245770008B66B /* NotificationWindowRootViewController.m in Sources */,
 				871BC3531D34F94200DF0793 /* AudioErrorView.m in Sources */,

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1160,6 +1160,7 @@
 		EF80466520D17130001A1C53 /* MessageDestructionTimeoutValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF80466320D1712B001A1C53 /* MessageDestructionTimeoutValueTests.swift */; };
 		EF80C0022097106D00E0040B /* ZMConversationMessageWindow+Formatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF80C0012097106D00E0040B /* ZMConversationMessageWindow+Formatting.swift */; };
 		EF80C0042097151C00E0040B /* ZMConversationMessageWindowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF80C0032097151C00E0040B /* ZMConversationMessageWindowTests.swift */; };
+		EF82E1C020EE79EC001B5196 /* ZMConversationMessage+Ephemeral.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF82E1BF20EE79EC001B5196 /* ZMConversationMessage+Ephemeral.swift */; };
 		EF8D7D4920D8FCA500F98666 /* MockConversation+TimedMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF8D7D4720D8FC7100F98666 /* MockConversation+TimedMessage.swift */; };
 		EF91A0561FF3A05A00FE2F53 /* GiphySearchViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF91A0541FF3A04700FE2F53 /* GiphySearchViewControllerTests.swift */; };
 		EF98987220C5A47A005680C5 /* SettingsClientViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF98987120C5A47A005680C5 /* SettingsClientViewControllerTests.swift */; };
@@ -2835,6 +2836,7 @@
 		EF80466320D1712B001A1C53 /* MessageDestructionTimeoutValueTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageDestructionTimeoutValueTests.swift; sourceTree = "<group>"; };
 		EF80C0012097106D00E0040B /* ZMConversationMessageWindow+Formatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversationMessageWindow+Formatting.swift"; sourceTree = "<group>"; };
 		EF80C0032097151C00E0040B /* ZMConversationMessageWindowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMConversationMessageWindowTests.swift; sourceTree = "<group>"; };
+		EF82E1BF20EE79EC001B5196 /* ZMConversationMessage+Ephemeral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversationMessage+Ephemeral.swift"; sourceTree = "<group>"; };
 		EF8D7D4720D8FC7100F98666 /* MockConversation+TimedMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MockConversation+TimedMessage.swift"; sourceTree = "<group>"; };
 		EF91A0541FF3A04700FE2F53 /* GiphySearchViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiphySearchViewControllerTests.swift; sourceTree = "<group>"; };
 		EF98987120C5A47A005680C5 /* SettingsClientViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsClientViewControllerTests.swift; sourceTree = "<group>"; };
@@ -4908,6 +4910,7 @@
 				BF989D071E896D210052BF8F /* ConversationCellBurstTimestampView.swift */,
 				87CB36BB1D7480F6007AB4E5 /* ConversationCell+Like.swift */,
 				F187D6C720162A4300A2DA8F /* ConversationCell+Sender.swift */,
+				EF82E1BF20EE79EC001B5196 /* ZMConversationMessage+Ephemeral.swift */,
 				16E311C71A5FEAE200FF2C9E /* TextMessageCell.h */,
 				874AE9B51DDCC98B00D3C830 /* TextMessageCell+Internal.h */,
 				16E311C81A5FEAE200FF2C9E /* TextMessageCell.m */,
@@ -6743,6 +6746,7 @@
 				BFBB03061D5DF4CB0065AF4F /* InputBarButtonsView.swift in Sources */,
 				7C5836641FD5ABE7001CC843 /* AvailabilityTitleView.swift in Sources */,
 				163FB98F20514DB700E74F83 /* UIView+LayoutMargins.swift in Sources */,
+				EF82E1C020EE79EC001B5196 /* ZMConversationMessage+Ephemeral.swift in Sources */,
 				D5CA8E572045718900D2F16E /* UINavigationController+CloseButton.swift in Sources */,
 				F95E08B41D0EAFE80098A9EE /* TTTAttributedLabel+Links.swift in Sources */,
 				87DCF48D1D34E9BA00BB420F /* ContactsCell.m in Sources */,

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell+CountDown.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell+CountDown.swift
@@ -31,18 +31,11 @@ extension ConversationCell {
 
         let duration = destructionDate.timeIntervalSinceNow
 
-        if !countdownView.isAnimatingProgress && duration >= 1 {
-            let progress = message.calculateCurrentCountdownProgress
+        if !countdownView.isAnimatingProgress && duration >= 1,
+            let progress = message.countdownProgress {
             countdownView.startAnimating(duration: duration, currentProgress: CGFloat(progress))
             countdownView.isHidden = false
         }
         toolboxView.updateTimestamp(message)
-    }
-
-}
-
-extension ZMConversationMessage {
-    var calculateCurrentCountdownProgress: Double {
-        return 1 - destructionDate!.timeIntervalSinceNow / deletionTimeout
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell+Private.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell+Private.h
@@ -18,12 +18,19 @@
 
 #import "ConversationCell.h"
 
+@class DestructionCountdownView;
+
 @interface ConversationCell ()
 
 @property (nonatomic) BOOL showsPreview;
 
-- (void)updateCountdownView;
 - (void)startCountdownAnimationIfNeeded:(id<ZMConversationMessage>)message;
+- (BOOL)showDestructionCountdown;
+- (void)tearDownCountdown;
+
+@property (nonatomic) BOOL countdownContainerViewHidden;
+@property (nonatomic) CADisplayLink *destructionLink;
+@property (nonatomic) DestructionCountdownView *countdownView;
 
 @end
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
@@ -78,10 +78,7 @@ static const CGFloat BurstContainerExpandedHeight = 40;
 
 @property (nonatomic) NSLayoutConstraint *toolboxCollapseConstraint;
 
-@property (nonatomic) BOOL countdownContainerViewHidden;
 @property (nonatomic) UIView *countdownContainerView;
-@property (nonatomic) DestructionCountdownView *countdownView;
-@property (nonatomic) CADisplayLink *destructionLink;
 
 @end
 
@@ -687,38 +684,6 @@ static const CGFloat BurstContainerExpandedHeight = 40;
 - (BOOL)showDestructionCountdown
 {
     return !self.message.hasBeenDeleted && self.message.isEphemeral && !self.message.isObfuscated && ![Message isKnockMessage:self.message];
-}
-
-- (void)updateCountdownView
-{
-    self.countdownContainerViewHidden = !self.showDestructionCountdown;
-
-    if (!self.showDestructionCountdown && nil != self.destructionLink) {
-        [self tearDownCountdown];
-        return;
-    }
-
-    if (!self.showDestructionCountdown || !self.message.destructionDate) {
-        return;
-    }
-
-    NSTimeInterval duration = self.message.destructionDate.timeIntervalSinceNow;
-
-    if (!self.countdownView.isAnimatingProgress && duration >= 1) {
-        NSTimeInterval progress = [self calculateCurrentCountdownProgress];
-        [self.countdownView startAnimatingWithDuration:duration currentProgress:progress];
-        self.countdownView.hidden = NO;
-    }
-
-    [self.toolboxView updateTimestamp:self.message];
-}
-
-- (NSTimeInterval)calculateCurrentCountdownProgress
-{
-    NSTimeInterval start = self.message.serverTimestamp.timeIntervalSinceReferenceDate;
-    NSTimeInterval current = [NSDate date].timeIntervalSinceReferenceDate;
-    NSTimeInterval end = self.message.destructionDate.timeIntervalSinceReferenceDate;
-    return (current - start) / (end - start);
 }
 
 @end

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ZMConversationMessage+CountDown.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ZMConversationMessage+CountDown.swift
@@ -1,0 +1,30 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension ZMConversationMessage {
+
+
+    /// Return the percentage (range: 0 to 1) to destruct of a ephemeral message. Return if self is not a ephemeral message or invalid deletionTimeout
+    var countdownProgress: Double? {
+        guard let destructionDate = destructionDate, deletionTimeout > 0 else { return nil }
+
+        return 1 - destructionDate.timeIntervalSinceNow / deletionTimeout
+    }
+}

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ZMConversationMessage+Ephemeral.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ZMConversationMessage+Ephemeral.swift
@@ -20,53 +20,29 @@ import Foundation
 
 extension ConversationCell {
     @objc func updateCountdownView() {
-
         countdownContainerViewHidden = !showDestructionCountdown()
-        if !showDestructionCountdown() && nil != destructionLink {
+
+        guard !(countdownContainerViewHidden && nil != destructionLink) else {
             tearDownCountdown()
             return
         }
 
         guard showDestructionCountdown(), let destructionDate = message.destructionDate else { return }
+
         let duration = destructionDate.timeIntervalSinceNow
 
         if !countdownView.isAnimatingProgress && duration >= 1 {
-            let progress = calculateCurrentCountdownProgress()
-            countdownView.startAnimating(duration: duration, currentProgress: progress)
+            let progress = message.calculateCurrentCountdownProgress
+            countdownView.startAnimating(duration: duration, currentProgress: CGFloat(progress))
             countdownView.isHidden = false
         }
         toolboxView.updateTimestamp(message)
     }
 
-    func calculateCurrentCountdownProgress() -> CGFloat {
-        let progress = CGFloat(1 - message.destructionDate!.timeIntervalSinceNow / message.deletionTimeout)
-        return progress
+}
+
+extension ZMConversationMessage {
+    var calculateCurrentCountdownProgress: Double {
+        return 1 - destructionDate!.timeIntervalSinceNow / deletionTimeout
     }
 }
-
-/*
-- (void)updateCountdownView
-    {
-        self.countdownContainerViewHidden = !self.showDestructionCountdown;
-
-        if (!self.showDestructionCountdown && nil != self.destructionLink) {
-            [self tearDownCountdown];
-            return;
-        }
-
-        if (!self.showDestructionCountdown || !self.message.destructionDate) {
-            return;
-        }
-
-        NSTimeInterval duration = self.message.destructionDate.timeIntervalSinceNow;
-
-        if (!self.countdownView.isAnimatingProgress && duration >= 1) {
-            NSTimeInterval progress = self.calculateCurrentCountdownProgress;
-
-            [self.countdownView startAnimatingWithDuration:duration currentProgress:progress];
-            self.countdownView.hidden = NO;
-        }
-
-        [self.toolboxView updateTimestamp:self.message];
-}
-*/

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ZMConversationMessage+Ephemeral.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ZMConversationMessage+Ephemeral.swift
@@ -1,0 +1,72 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension ConversationCell {
+    @objc func updateCountdownView() {
+
+        countdownContainerViewHidden = !showDestructionCountdown()
+        if !showDestructionCountdown() && nil != destructionLink {
+            tearDownCountdown()
+            return
+        }
+
+        guard showDestructionCountdown(), let destructionDate = message.destructionDate else { return }
+        let duration = destructionDate.timeIntervalSinceNow
+
+        if !countdownView.isAnimatingProgress && duration >= 1 {
+            let progress = calculateCurrentCountdownProgress()
+            countdownView.startAnimating(duration: duration, currentProgress: progress)
+            countdownView.isHidden = false
+        }
+        toolboxView.updateTimestamp(message)
+    }
+
+    func calculateCurrentCountdownProgress() -> CGFloat {
+        let progress = CGFloat(1 - message.destructionDate!.timeIntervalSinceNow / message.deletionTimeout)
+        return progress
+    }
+}
+
+/*
+- (void)updateCountdownView
+    {
+        self.countdownContainerViewHidden = !self.showDestructionCountdown;
+
+        if (!self.showDestructionCountdown && nil != self.destructionLink) {
+            [self tearDownCountdown];
+            return;
+        }
+
+        if (!self.showDestructionCountdown || !self.message.destructionDate) {
+            return;
+        }
+
+        NSTimeInterval duration = self.message.destructionDate.timeIntervalSinceNow;
+
+        if (!self.countdownView.isAnimatingProgress && duration >= 1) {
+            NSTimeInterval progress = self.calculateCurrentCountdownProgress;
+
+            [self.countdownView startAnimatingWithDuration:duration currentProgress:progress];
+            self.countdownView.hidden = NO;
+        }
+
+        [self.toolboxView updateTimestamp:self.message];
+}
+*/


### PR DESCRIPTION
## What's new in this PR?

### Issues

The pie countdown UI's percentage is wrongly calculated, the progress is to finish is higher than expected.

### Causes

The calculation logic is different from the original dot style countdown UI.

### Solutions

Restore the logic to the original version. Refactor the logic as a ZMConversationMessage's property. 