### PR TITLE
ZIOS-10165: Fix for 25MB audio limit

### DIFF
--- a/Wire-iOS.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Wire-iOS.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Wire-iOS.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Wire-iOS.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>IDEDidComputeMac32BitWarning</key>
-	<true/>
-</dict>
-</plist>

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecorder.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecorder.swift
@@ -162,13 +162,10 @@ public final class AudioRecorder: NSObject, AudioRecorderType {
     // MARK: Recording
     
     public func startRecording() {
-        startRecording(true)
-    }
-    
-    public func startRecording(_ useAvs: Bool = true) {
         guard let audioRecorder = self.audioRecorder else { return }
 
-        func startRecordingBlock() {
+        AVSMediaManager.sharedInstance().startRecording {
+                
             self.state = .recording
             self.recordTimerCallback?(0)
             self.setupDisplayLink()
@@ -186,14 +183,6 @@ public final class AudioRecorder: NSObject, AudioRecorderType {
             }
             
             self.recordingStartTime = successfullyStarted ? audioRecorder.deviceCurrentTime : nil
-        }
-        
-        if useAvs {
-            AVSMediaManager.sharedInstance().startRecording {
-                startRecordingBlock()
-            }
-        } else {
-            startRecordingBlock()
         }
     }
     
@@ -326,7 +315,7 @@ public final class AudioRecorder: NSObject, AudioRecorderType {
             alertMessage = "conversation.input_bar.audio_message.too_long.message".localized(args: durationLimit)
         }
         
-        if error == .toMaxSize, let maxSize = maxRecordingDuration {
+        if error == .toMaxSize, let maxSize = maxFileSize {
             let size = ByteCountFormatter.string(fromByteCount: Int64(maxSize), countStyle: .binary)
             
             alertMessage = "conversation.input_bar.audio_message.too_long_size.message".localized(args: size)


### PR DESCRIPTION
## What's new in this PR?

- Fixed a condition to the file size for audio messages - I was checking for the duration instead of file size
- Removed test code inside `startRecording()`, restored to the previous version