### PR TITLE
Don’t crash when audio message exceeds timer

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
@@ -289,8 +289,15 @@ extension ZMSystemMessageData {
         let showDestructionTimer = message.isEphemeral && !message.isObfuscated && nil != message.destructionDate
         if let destructionDate = message.destructionDate, showDestructionTimer {
             let remaining = destructionDate.timeIntervalSinceNow + 1 // We need to add one second to start with the correct value
-            requireInternal(remaining > 0, "invalid negative timeout value")
-            deliveryStateString = MessageToolboxView.ephemeralTimeFormatter.string(from: remaining)
+            
+            if remaining > 0 {
+                deliveryStateString = MessageToolboxView.ephemeralTimeFormatter.string(from: remaining)
+            } else if message.isAudio {
+                // do nothing, audio messages are allowed to extend the timer
+                // past the destruction date.
+            } else {
+                requireInternal(remaining > 0, "invalid negative timeout value")
+            }
         }
 
         let finalText: String


### PR DESCRIPTION
## What's new in this PR?

### Issues
When the timeout of an audio message is extended, the app crashes when the original timer would have fired.

### Causes
The timestamp label was still being updated in the extended period, however, to guard against a negative timer string, the client was force-crashed if the destruction date was exceeded. Extending the timer of an audio message doesn't change the original destruction date, it simply replaces the existing timer with a new one. Hence, one the destruction date was exceeded, the app was force-crashed.

### Solutions
Add extra conditions when constructing the timeout string: if the destruction date is exceeded and the message is an audio message, then fallback to the default timestamp string. If the destruction date is exceeded, but the message is not an audio message, force-crash the app.
