### PR TITLE
freeze the layer for snapshot

### DIFF
--- a/Wire-iOS Tests/ConversationCell/ImageMessageCellTests.swift
+++ b/Wire-iOS Tests/ConversationCell/ImageMessageCellTests.swift
@@ -145,7 +145,7 @@ internal extension ImageMessageCell {
             setImage(image)
         }
 
-        layer.speed = 0
+        prepareForSnapshot()
 
         return self.wrapInTableView()
     }

--- a/Wire-iOS Tests/ConversationInputBarViewControllerTests.swift
+++ b/Wire-iOS Tests/ConversationInputBarViewControllerTests.swift
@@ -115,7 +115,8 @@ extension ConversationInputBarViewControllerTests {
         sut.mode = .timeoutConfguration
 
         // THEN
-        self.verifyInAllPhoneWidths(view: sut.view.snapshotView)
+        sut.view.prepareForSnapshot()
+        self.verifyInAllPhoneWidths(view: sut.view)
     }
     
     func testEphemeralTime10Second() {
@@ -131,7 +132,8 @@ extension ConversationInputBarViewControllerTests {
         sut.inputBar.setInputBarState(.writing(ephemeral: .message), animated: false)
         
         // THEN
-        self.verifyInAllPhoneWidths(view: sut.view.snapshotView)
+        sut.view.prepareForSnapshot()
+        self.verifyInAllPhoneWidths(view: sut.view)
     }
     
     func testEphemeralTime5Minutes() {
@@ -147,7 +149,8 @@ extension ConversationInputBarViewControllerTests {
         sut.inputBar.setInputBarState(.writing(ephemeral: .message), animated: false)
         
         // THEN
-        self.verifyInAllPhoneWidths(view: sut.view.snapshotView)
+        sut.view.prepareForSnapshot()
+        self.verifyInAllPhoneWidths(view: sut.view)
     }
     
     func testEphemeralTime2Hours() {
@@ -163,7 +166,8 @@ extension ConversationInputBarViewControllerTests {
         sut.inputBar.setInputBarState(.writing(ephemeral: .message), animated: false)
         
         // THEN
-        self.verifyInAllPhoneWidths(view: sut.view.snapshotView)
+        sut.view.prepareForSnapshot()
+        self.verifyInAllPhoneWidths(view: sut.view)
     }
     
     func testEphemeralTime3Days() {
@@ -179,7 +183,8 @@ extension ConversationInputBarViewControllerTests {
         sut.inputBar.setInputBarState(.writing(ephemeral: .message), animated: false)
         
         // THEN
-        self.verifyInAllPhoneWidths(view: sut.view.snapshotView)
+        sut.view.prepareForSnapshot()
+        self.verifyInAllPhoneWidths(view: sut.view)
     }
 
     func testEphemeralTime4Weeks(){
@@ -195,7 +200,8 @@ extension ConversationInputBarViewControllerTests {
         sut.inputBar.setInputBarState(.writing(ephemeral: .message), animated: false)
 
         // THEN
-        self.verifyInAllPhoneWidths(view: sut.view.snapshotView)
+        sut.view.prepareForSnapshot()
+        self.verifyInAllPhoneWidths(view: sut.view)
     }
     
     func testEphemeralTime1Year() {
@@ -211,7 +217,8 @@ extension ConversationInputBarViewControllerTests {
         sut.inputBar.setInputBarState(.writing(ephemeral: .message), animated: false)
         
         // THEN
-        self.verifyInAllPhoneWidths(view: sut.view.snapshotView)
+        sut.view.prepareForSnapshot()
+        self.verifyInAllPhoneWidths(view: sut.view)
     }
 
     func testEphemeralModeWhenTyping() {
@@ -229,15 +236,7 @@ extension ConversationInputBarViewControllerTests {
         sut.inputBar.textView.text = shortText
 
         // THEN
-        self.verifyInAllPhoneWidths(view: sut.view.snapshotView)
-    }
-}
-
-fileprivate extension UIView {
-    var snapshotView: UIView {
-        self.layer.speed = 0
-        self.setNeedsLayout()
-        self.layoutIfNeeded()
-        return self
+        sut.view.prepareForSnapshot()
+        self.verifyInAllPhoneWidths(view: sut.view)
     }
 }

--- a/Wire-iOS Tests/UIView+Snapshot.swift
+++ b/Wire-iOS Tests/UIView+Snapshot.swift
@@ -16,27 +16,12 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import XCTest
-@testable import Wire
+import Foundation
 
-final class DraftSendInputAccessoryViewTests: ZMSnapshotTestCase {
-    
-    var sut: DraftSendInputAccessoryView!
-    
-    override func setUp() {
-        super.setUp()
-        sut = DraftSendInputAccessoryView()
-        sut.frame = CGRect(x: 0, y: 0, width: 375, height: 56)
-    }
-    
-    override func tearDown() {
-        sut = nil
-        super.tearDown()
-    }
-
-    func testForInitState(){
-        sut.prepareForSnapshot()
-        verify(view: sut)
+extension UIView {
+    func prepareForSnapshot() {
+        self.layer.speed = 0
+        self.setNeedsLayout()
+        self.layoutIfNeeded()
     }
 }
-

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1160,6 +1160,7 @@
 		EF6777062073C6C20062F122 /* OfflineBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF6777052073C6C20062F122 /* OfflineBar.swift */; };
 		EF68856820F611D50074CA0F /* CanvasViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF68856720F611D50074CA0F /* CanvasViewControllerTests.swift */; };
 		EF68856A20F622C60074CA0F /* DraftSendInputAccessoryViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF68856920F622C50074CA0F /* DraftSendInputAccessoryViewTests.swift */; };
+		EF68856D20F63D260074CA0F /* UIView+Snapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF68856B20F63CFC0074CA0F /* UIView+Snapshot.swift */; };
 		EF68E71B20BD5B5A003F3594 /* IPadPopoverConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF68E71A20BD5B5A003F3594 /* IPadPopoverConstants.swift */; };
 		EF6E3C7A2089F232003F6752 /* animated.gif in Resources */ = {isa = PBXBuildFile; fileRef = EF6E3C792089F231003F6752 /* animated.gif */; };
 		EF6E3C7C208A02FE003F6752 /* GiphySearchViewControllerSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF6E3C7B208A02FE003F6752 /* GiphySearchViewControllerSnapshotTests.swift */; };
@@ -2853,6 +2854,7 @@
 		EF6777052073C6C20062F122 /* OfflineBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineBar.swift; sourceTree = "<group>"; };
 		EF68856720F611D50074CA0F /* CanvasViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasViewControllerTests.swift; sourceTree = "<group>"; };
 		EF68856920F622C50074CA0F /* DraftSendInputAccessoryViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DraftSendInputAccessoryViewTests.swift; path = "Wire-iOS Tests/DraftSendInputAccessoryViewTests.swift"; sourceTree = SOURCE_ROOT; };
+		EF68856B20F63CFC0074CA0F /* UIView+Snapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Snapshot.swift"; sourceTree = "<group>"; };
 		EF68E71A20BD5B5A003F3594 /* IPadPopoverConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPadPopoverConstants.swift; sourceTree = "<group>"; };
 		EF6E3C792089F231003F6752 /* animated.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = animated.gif; sourceTree = "<group>"; };
 		EF6E3C7B208A02FE003F6752 /* GiphySearchViewControllerSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiphySearchViewControllerSnapshotTests.swift; sourceTree = "<group>"; };
@@ -5384,6 +5386,7 @@
 				5E97C32F20F5F17200C806B4 /* ExtensionSettingsTests.swift */,
 				EF68856720F611D50074CA0F /* CanvasViewControllerTests.swift */,
 				EF68856920F622C50074CA0F /* DraftSendInputAccessoryViewTests.swift */,
+				EF68856B20F63CFC0074CA0F /* UIView+Snapshot.swift */,
 			);
 			path = "Wire-iOS Tests";
 			sourceTree = "<group>";
@@ -7535,6 +7538,7 @@
 				AF65A25C1D7E202D00EBA38E /* ReactionsListViewControllerTests.swift in Sources */,
 				EF29431320C91D57000C16F3 /* MockUser+ProfileImage.swift in Sources */,
 				EF15A7B420BC304A00A045C7 /* SavableImageTests.swift in Sources */,
+				EF68856D20F63D260074CA0F /* UIView+Snapshot.swift in Sources */,
 				BFE2542720BE9EA200F62041 /* CallHapticsControllerTests.swift in Sources */,
 				D58192052091F34E003BA7EC /* CallActionsViewTests.swift in Sources */,
 				BF5DF5CA20F4C7C2002BCB67 /* GroupParticipantsDetailViewControllerTests.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

Freeze the layer for fixing failed DraftSendInputAccessoryViewTests's snapshot involve a cursor.