### PR TITLE
fix snapshot involving a cursor

### DIFF
--- a/Wire-iOS Tests/CanvasViewControllerTests.swift
+++ b/Wire-iOS Tests/CanvasViewControllerTests.swift
@@ -35,6 +35,7 @@ final class CanvasViewControllerTests: ZMSnapshotTestCase {
     }
 
     func testForInitState(){
+        sut.view.prepareForSnapshot()
         verify(view: sut.view)
     }
 }


### PR DESCRIPTION
## What's new in this PR?

Follow up of https://github.com/wireapp/wire-ios/pull/2392. Freeze the layer for fixing failed CanvasViewControllerTests's snapshot involve a cursor.