### PR TITLE
Fix: After sending an image, the top avatar image's height is reduced

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConnectRequests/UserConnectionView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConnectRequests/UserConnectionView.swift
@@ -116,17 +116,22 @@ public final class UserConnectionView: UIView, Copyable {
             labelContainer.top == selfView.top
             labelContainer.left >= selfView.left
 
+            userImageView.top >= labelContainer.bottom
             userImageView.center == selfView.center
             userImageView.left >= selfView.left + 54
             userImageView.width == userImageView.height
             userImageView.height <= 264
+            userImageView.bottom <= selfView.bottom
         }
 
+        let verticalMargin = CGFloat(16)
+
         constrain(labelContainer, firstLabel, secondLabel) { labelContainer, handleLabel, correlationLabel in
-            handleLabel.top == labelContainer.top + 16
+            handleLabel.top == labelContainer.top + verticalMargin
             handleLabel.height == 16
             correlationLabel.top == handleLabel.bottom
             handleLabel.height == 16
+            correlationLabel.bottom == labelContainer.bottom - verticalMargin
 
             [handleLabel, correlationLabel].forEach {
                 $0.leading == labelContainer.leading

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Private.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Private.h
@@ -46,7 +46,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)removeHighlightsAndMenu;
 - (nullable ConversationCell *)cellForMessage:(id<ZMConversationMessage>)message;
-- (CGFloat)headerHeight;
 
 @end
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+TableHeader.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+TableHeader.swift
@@ -19,8 +19,25 @@
 import UIKit
 
 extension ConversationContentViewController {
+    @objc var headerHeight: CGFloat {
+        var height: CGFloat = 20
+        if messageWindow.messages.count == 1,
+            let message = messageWindow.messages.firstObject as? ZMConversationMessage,
+            let cell = self.cell(for:message) {
+
+            height += cell.bounds.height
+        }
+
+        if tableView.bounds.size.height <= 0 {
+            tableView.setNeedsLayout()
+            tableView.layoutIfNeeded()
+        }
+
+        return tableView.bounds.size.height - height
+    }
+
     @objc func headerViewFrame(view: UIView) -> CGRect {
-        let fittingSize = CGSize(width: tableView.bounds.size.width, height: headerHeight())
+        let fittingSize = CGSize(width: tableView.bounds.size.width, height: headerHeight)
         let requiredSize = view.systemLayoutSizeFitting(fittingSize, withHorizontalFittingPriority: UILayoutPriority.required, verticalFittingPriority: UILayoutPriority.defaultLow)
 
         return CGRect(origin: .zero, size: requiredSize)

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+TableHeader.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+TableHeader.swift
@@ -19,7 +19,7 @@
 import UIKit
 
 extension ConversationContentViewController {
-    @objc var headerHeight: CGFloat {
+    var headerHeight: CGFloat {
         var height: CGFloat = 20
         if messageWindow.messages.count == 1,
             let message = messageWindow.messages.firstObject as? ZMConversationMessage,

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -278,22 +278,6 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
     self.tableView.tableHeaderView = headerView;
 }
 
-- (CGFloat)headerHeight
-{
-    CGFloat height = 20;
-    if (self.messageWindow.messages.count == 1) {
-        UITableViewCell *cell = [self cellForMessage:self.messageWindow.messages.firstObject];
-        height += CGRectGetHeight(cell.bounds);
-    }
-
-    if (self.tableView.bounds.size.height <= 0) {
-        [self.tableView setNeedsLayout];
-        [self.tableView layoutIfNeeded];
-    }
-
-    return self.tableView.bounds.size.height - height;
-}
-
 - (void)setSearchQueries:(NSArray<NSString *> *)searchQueries
 {
     if (_searchQueries.count == 0 && searchQueries.count == 0) {


### PR DESCRIPTION
## What's new in this PR?

This PR is a follow-up of https://github.com/wireapp/wire-ios/pull/2377.

### Issues

When a user sent the first portrait photo in a new conversation, the header view's avatar image overlaps the photo.

### Causes

The header view misses constraints to maintain its minimum height.

### Solutions

Add the constraints to maintain its minimum height.