### PR TITLE
ZIOS-10299: Add company login button to login flow

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -1204,6 +1204,7 @@
 "signin.use_one_password.label" = "Log in with 1Password";
 "signin.use_one_password.hint" = "Double tap to fill your password with 1Password";
 "signin.confirm" = "Log In";
+"signin.company_idp.button.title" = "For Companies";
 
 "registration.phone_country" = "Country";
 "registration.phone_code" = "Country Code";

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/RegistrationRootViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/RegistrationRootViewController.m
@@ -201,7 +201,7 @@
     self.contentHeightConstraint.active = YES;
     [self.registrationTabBarController.view.bottomAnchor constraintEqualToAnchor:self.safeBottomAnchor].active = YES;
 
-    [self.rightButtonsStack autoPinEdgeToSuperviewEdge:ALEdgeTop withInset:UIScreen.safeArea.top + 32];
+    [self.rightButtonsStack autoPinEdgeToSuperviewEdge:ALEdgeTop withInset:UIScreen.safeArea.top + 36];
     [self.rightButtonsStack autoPinEdgeToSuperviewEdge:ALEdgeRight withInset:28];
 
     if (self.backButton) {


### PR DESCRIPTION
## What's new in this PR?

We add the "For companies" login button to the first screen of the login flow.

- Listen to tab bar changes to detect when login screen appears and disappears
- Move the cancel button and company login button to avoid overlap

## Notes

This button needs to be integrated with the SSO controller that will actually display the alert and handle authentication in a subsequent PR.