### PR TITLE
clean up icon buttons' states

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
@@ -82,6 +82,7 @@ private let zmLog = ZMSLog(tag: "UI")
     public override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         recorder.stopRecording()
+        delegate?.audioRecordViewControllerDidCancel(self)
     }
     
     func configureViews() {


### PR DESCRIPTION
## What's new in this PR?

### Issues

When the audio keyboard is dismissed, the audio button is still highlighted with the accent color.

### Causes

Missing the code to tell the delegate(ConversationInputBarViewController) to reset the button state

### Solutions

Add the delegate call.