### PR TITLE
Integrate SSO controller with "companies" login button

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -5613,7 +5613,6 @@
 				EF2126C31FB9DFE300625A9B /* RegistrationFormController.h */,
 				EF2126C41FB9DFE300625A9B /* CheckmarkViewController.m */,
 				EF2126C51FB9DFE300625A9B /* FormStepDelegate.h */,
-				EF2126C61FB9DFE300625A9B /* RegistrationRootViewController.h */,
 				EF2126D11FB9DFE300625A9B /* GuidanceDotView.h */,
 				EF2126D21FB9DFE300625A9B /* RegistrationTextField.h */,
 				EF2126D31FB9DFE300625A9B /* RegistrationViewController.h */,
@@ -5626,6 +5625,7 @@
 				EF2126FE1FB9DFE300625A9B /* RegistrationFormController.m */,
 				EF2126FF1FB9DFE300625A9B /* CountryCodeView.m */,
 				EF2127001FB9DFE300625A9B /* RegistrationPhoneFlowViewController.m */,
+				EF2126C61FB9DFE300625A9B /* RegistrationRootViewController.h */,
 				EF2127011FB9DFE300625A9B /* RegistrationRootViewController.m */,
 				EF2127021FB9DFE300625A9B /* CheckmarkViewController.h */,
 			);

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/RegistrationRootViewController.h
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/RegistrationRootViewController.h
@@ -27,7 +27,7 @@ typedef NS_ENUM(NSUInteger, AuthenticationFlowType) {
     AuthenticationFlowOnlyRegistration
 };
 
-@class ZMIncompleteRegistrationUser, LoginCredentials;
+@class ZMIncompleteRegistrationUser, LoginCredentials, SingleSignOnController;
 
 @interface RegistrationRootViewController : FormFlowViewController
 

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/RegistrationRootViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/RegistrationRootViewController.m
@@ -29,7 +29,9 @@
 
 #import "Wire-Swift.h"
 
-@interface RegistrationRootViewController () <FormStepDelegate, RegistrationFlowViewControllerDelegate, TabBarControllerDelegate>
+@interface RegistrationRootViewController () <FormStepDelegate, RegistrationFlowViewControllerDelegate, TabBarControllerDelegate, SingleSignOnControllerDelegate>
+
+@property (nonatomic) SingleSignOnController *ssoController;
 
 @property (nonatomic) TabBarController *registrationTabBarController;
 @property (nonatomic) ZMIncompleteRegistrationUser *unregisteredUser;
@@ -58,6 +60,7 @@
 
     if (self) {
         self.unregisteredUser = unregisteredUser;
+        self.ssoController = [[SingleSignOnController alloc] init];
         self.flowType = flow;
     }
 
@@ -67,7 +70,8 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-    
+    self.ssoController.delegate = self;
+
     self.view.opaque = NO;
     self.view.backgroundColor = [UIColor clearColor];
     
@@ -258,7 +262,7 @@
 
 - (void)showCompanyLoginAlert
 {
-    // no-op
+    [self.ssoController presentLoginAlertWithPrefilledCode:nil];
 }
 
 #pragma mark - FormStepDelegate
@@ -279,6 +283,12 @@
 - (void)tabBarController:(TabBarController *)controller tabBarDidSelectIndex:(NSInteger)tabBarDidSelectIndex
 {
     [self updateCompanyLoginButton];
+}
+
+#pragma mark - SingleSignOnControllerDelegate
+
+- (void)controller:(SingleSignOnController * _Nonnull)controller presentAlert:(UIAlertController * _Nonnull)presentAlert {
+    [self presentViewController:presentAlert animated:YES completion:nil];
 }
 
 @end

--- a/Wire-iOS/Sources/UserInterface/SSO/UIAlertController+CompanyLogin.swift
+++ b/Wire-iOS/Sources/UserInterface/SSO/UIAlertController+CompanyLogin.swift
@@ -23,7 +23,7 @@ extension UIAlertController {
     /// Creates an `UIAlertController` with a textfield to get a SSO login code from the user.
     /// - parameter prefilledCode: A code which should be used to prefill the textfield of the controller (or `nil`).
     /// - parameter completion: The completion closure which will be called with the provided code or nil if cancelled.
-    static func companyLogin(prefilledCode: String?, completion: @escaping (String?) -> Void) -> UIAlertController {
+    @objc static func companyLogin(prefilledCode: String?, completion: @escaping (String?) -> Void) -> UIAlertController {
         var token: Any?
 
         func complete(_ result: String?) {


### PR DESCRIPTION
## What's new in this PR?

We present the SSO code input alert when tapping the "For Companies" button in the login screen.

### Solutions

When initializing the root registration/login controller we assign it a SSO controller that uses the default shared identity requester.

We call the `presentLoginAlertWithPrefilledCode` with `nil` when the user taps the button.

### To-Do

- [ ] We need to display the blocking wheel when waiting for the invalid code alert
- [ ] We need to get the result of the operation with a delegate method (to discuss)
- [ ] Improve pre-filling
