### PR TITLE
Autofill the company login prompt when clicking button

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/RegistrationRootViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationPersonal/RegistrationRootViewController.m
@@ -270,7 +270,7 @@
 
 - (void)showCompanyLoginAlert
 {
-    [self.ssoController presentLoginAlertWithPrefilledCode:nil];
+    [self.ssoController displayLoginCodePrompt];
 }
 
 #pragma mark - FormStepDelegate

--- a/Wire-iOS/Sources/UserInterface/SSO/SingleSignOnController.swift
+++ b/Wire-iOS/Sources/UserInterface/SSO/SingleSignOnController.swift
@@ -77,9 +77,16 @@ import Foundation
             code.apply(presentLoginAlert)
         }
     }
-    
-    /// Presents the SSO login alert without an optional prefilled code.
-    @objc func presentLoginAlert(prefilledCode: String? = nil) {
+
+    /// Presents the SSO login alert. If the code is available in the clipboard, we pre-fill it.
+    @objc func displayLoginCodePrompt() {
+        detector.detectCopiedRequestCode { code in
+            self.presentLoginAlert(prefilledCode: code)
+        }
+    }
+
+    /// Presents the SSO login alert with an optional prefilled code.
+    private func presentLoginAlert(prefilledCode: String?) {
         let alertController = UIAlertController.companyLogin(
             prefilledCode: prefilledCode,
             validator: SharedIdentitySessionRequestDetector.isValidRequestCode,
@@ -88,7 +95,7 @@ import Foundation
         
         delegate?.controller(self, presentAlert: alertController)
     }
-    
+
     /// Attempt to login using the requester specified in `init`
     /// - parameter code: the code used to attempt the SSO login.
     private func attemptLogin(using code: String) {


### PR DESCRIPTION
## What's new in this PR?

### Issues

When the user manually clicks on the "for company" login button and there is a valid code in the pasteboard, we didn't autofill the text field of the manually displayed prompt.

### Solutions

Always check the contents of the pasteboard before displaying the alert.