### PR TITLE
Fix: Audio message is stopped recording if device entering screenlock mode

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
@@ -82,7 +82,7 @@ private let zmLog = ZMSLog(tag: "UI")
     public override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         recorder.stopRecording()
-        delegate?.audioRecordViewControllerDidCancel(self)
+//        delegate?.audioRecordViewControllerDidCancel(self) ///TODO: prepare for resume the record process
     }
     
     func configureViews() {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
@@ -82,7 +82,6 @@ private let zmLog = ZMSLog(tag: "UI")
     public override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         recorder.stopRecording()
-//        delegate?.audioRecordViewControllerDidCancel(self) ///TODO: prepare for resume the record process
     }
     
     func configureViews() {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Audio.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Audio.swift
@@ -31,7 +31,7 @@ extension ConversationInputBarViewController {
         }
     }
 
-    @objc func setupAppStateObserver() {
+    @objc func setupAppLockedObserver() {
         NotificationCenter.default.addObserver(self,
         selector: #selector(ConversationInputBarViewController.appUnlocked),
         name: .appUnlocked,

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Audio.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Audio.swift
@@ -40,8 +40,9 @@ extension ConversationInputBarViewController {
 
     @objc func appUnlocked() {
         // show the record keyboard after it is hide after the app went to background
-        if mode == .audioRecord && !self.inputBar.textView.isFirstResponder {
-            ///TODO: delay after unlocked
+        if AppLock.isActive &&
+           mode == .audioRecord &&
+           !self.inputBar.textView.isFirstResponder {
             displayRecordKeyboard()
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Audio.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Audio.swift
@@ -33,12 +33,12 @@ extension ConversationInputBarViewController {
 
     @objc func setupAppStateObserver() {
         NotificationCenter.default.addObserver(self,
-        selector: #selector(ConversationInputBarViewController.applicationDidBecomeActive),
-        name: .UIApplicationDidBecomeActive,
+        selector: #selector(ConversationInputBarViewController.appUnlocked),
+        name: .appUnlocked,
         object: .none)
     }
 
-    @objc func applicationDidBecomeActive() {
+    @objc func appUnlocked() {
         // show the record keyboard after it is hide after the app went to background
         if mode == .audioRecord && !self.inputBar.textView.isFirstResponder {
             ///TODO: delay after unlocked

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Audio.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Audio.swift
@@ -30,7 +30,22 @@ extension ConversationInputBarViewController {
             callStateObserverToken = WireCallCenterV3.addCallStateObserver(observer: self, userSession:userSession)
         }
     }
-    
+
+    @objc func setupAppStateObserver() {
+        NotificationCenter.default.addObserver(self,
+        selector: #selector(ConversationInputBarViewController.applicationDidBecomeActive),
+        name: .UIApplicationDidBecomeActive,
+        object: .none)
+    }
+
+    @objc func applicationDidBecomeActive() {
+        // show the record keyboard after it is hide after the app went to background
+        if mode == .audioRecord && !self.inputBar.textView.isFirstResponder {
+            ///TODO: delay after unlocked
+            displayRecordKeyboard()
+        }
+    }
+
     @objc func configureAudioButton(_ button: IconButton) {
         let longPressRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(audioButtonLongPressed(_:)))
         longPressRecognizer.minimumPressDuration = 0.3

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -193,7 +193,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
     [super viewDidLoad];
     
     [self setupCallStateObserver];
-    [self setupAppStateObserver];
+    [self setupAppLockedObserver];
     
     [self createSingleTapGestureRecognizer];
     

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -193,6 +193,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
     [super viewDidLoad];
     
     [self setupCallStateObserver];
+    [self setupAppStateObserver];
     
     [self createSingleTapGestureRecognizer];
     

--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
@@ -22,6 +22,10 @@ import WireExtensionComponents
 
 private let zmLog = ZMSLog(tag: "UI")
 
+extension Notification.Name {
+    static let appUnlocked = Notification.Name("AppUnlocked")
+}
+
 @objcMembers final class AppLockViewController: UIViewController {
     fileprivate var lockView: AppLockView!
     fileprivate static let authenticationPersistancePeriod: TimeInterval = 10
@@ -137,6 +141,8 @@ private let zmLog = ZMSLog(tag: "UI")
                 callback(success)
                 if let success = success, success {
                     AppLock.lastUnlockedDate = Date()
+                    NotificationCenter.default.post(name: .appUnlocked, object: self, userInfo: nil)
+
                 } else {
                     zmLog.error("Local authentication error: \(String(describing: error?.localizedDescription))")
                 }
@@ -150,7 +156,7 @@ private let zmLog = ZMSLog(tag: "UI")
 extension AppLockViewController {
     @objc func applicationWillResignActive() {
         if AppLock.isActive {
-            self.resignKeyboard() ///TODO: remember the current keyboard
+            self.resignKeyboard()
             self.dimContents = true
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
@@ -150,7 +150,7 @@ private let zmLog = ZMSLog(tag: "UI")
 extension AppLockViewController {
     @objc func applicationWillResignActive() {
         if AppLock.isActive {
-            self.resignKeyboard()
+            self.resignKeyboard() ///TODO: remember the current keyboard
             self.dimContents = true
         }
     }
@@ -170,6 +170,5 @@ extension AppLockViewController {
     
     @objc func applicationDidBecomeActive() {
         self.showUnlockIfNeeded()
-        self.resignKeyboardIfNeeded()
     }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

The audio record keyboard is dismissed after the app is unlocked. The user can not save his audio record.

### Causes

Actually, the audio record keyboard is still present but not visible after the app called endEditing method. The user can not see the audio record keyboard with audio filter UI.

### Solutions

In ConversationInputBarViewController, observer the .appUnlocked notification form AppLockView. Display the audio record keyboard when the notification is observed. 

## Notes

This PR changes the keyboard visibility when the application is active and the lock setting is disabled. The app preserves the keyboard state instead of always resign the keyboard.