### PR TITLE
[WIP] Implement custom in-app browser for SSO purposes

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -199,6 +199,7 @@
 		54FF9E281E813BA500323D2E /* DebugAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54FF9E271E813BA500323D2E /* DebugAlert.swift */; };
 		55A42A701FC872600056752F /* CallQualityScoreProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A42A6F1FC872600056752F /* CallQualityScoreProvider.swift */; };
 		55DD5C341FA236F60082170C /* CallQualityController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DD5C331FA236F60082170C /* CallQualityController.swift */; };
+		5E0EB1ED20FF6DAB00B5DC2B /* TaskBrowserViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0EB1EC20FF6DAB00B5DC2B /* TaskBrowserViewController.swift */; };
 		5E0FB21B2057F50C00FD9867 /* CallQualitySurveyReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0FB21A2057F50C00FD9867 /* CallQualitySurveyReview.swift */; };
 		5E2B13E820E67EA7002F27E2 /* VerticalColumnCollectionViewLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E2B13E620E67EA1002F27E2 /* VerticalColumnCollectionViewLayoutTests.swift */; };
 		5E33F0CC20AC39C800414EA6 /* CallVideoPlaceholderState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E33F0CB20AC39C800414EA6 /* CallVideoPlaceholderState.swift */; };
@@ -1513,6 +1514,7 @@
 		54FF9E271E813BA500323D2E /* DebugAlert.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DebugAlert.swift; sourceTree = "<group>"; };
 		55A42A6F1FC872600056752F /* CallQualityScoreProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallQualityScoreProvider.swift; sourceTree = "<group>"; };
 		55DD5C331FA236F60082170C /* CallQualityController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallQualityController.swift; sourceTree = "<group>"; };
+		5E0EB1EC20FF6DAB00B5DC2B /* TaskBrowserViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskBrowserViewController.swift; sourceTree = "<group>"; };
 		5E0FB21A2057F50C00FD9867 /* CallQualitySurveyReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallQualitySurveyReview.swift; sourceTree = "<group>"; };
 		5E2B13E320E658EC002F27E2 /* VerticalColumnCollectionViewLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalColumnCollectionViewLayout.swift; sourceTree = "<group>"; };
 		5E2B13E620E67EA1002F27E2 /* VerticalColumnCollectionViewLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalColumnCollectionViewLayoutTests.swift; sourceTree = "<group>"; };
@@ -3351,12 +3353,13 @@
 			path = CallQualityController;
 			sourceTree = "<group>";
 		};
-		5E0EAFD120FDDE9100B5DC2B /* SharedIdentity */ = {
+		5E0EAFD120FDDE9100B5DC2B /* Company */ = {
 			isa = PBXGroup;
 			children = (
+				5E0EB1EC20FF6DAB00B5DC2B /* TaskBrowserViewController.swift */,
 				5E8EE1F420FCFEA200DB1F9B /* TimeoutIdentitySessionRequester.swift */,
 			);
-			path = SharedIdentity;
+			path = Company;
 			sourceTree = "<group>";
 		};
 		5E2B13E520E67206002F27E2 /* CollectionLayouts */ = {
@@ -5533,7 +5536,7 @@
 			children = (
 				EF2126C01FB9DFE300625A9B /* NavigationController.h */,
 				EF2126F81FB9DFE300625A9B /* NavigationController.m */,
-				5E0EAFD120FDDE9100B5DC2B /* SharedIdentity */,
+				5E0EAFD120FDDE9100B5DC2B /* Company */,
 				EF2126B51FB9DFE300625A9B /* RegistrationTeam */,
 				EF2126B61FB9DFE300625A9B /* RegistrationPersonal */,
 			);
@@ -6548,6 +6551,7 @@
 				D5168F2A2008F3EF00F8222A /* UIEdgeInsets+Adjusting.swift in Sources */,
 				BFE4185D209B06D600503C7C /* AVSMediaManager+Helper.swift in Sources */,
 				5E3FB06E206BC7B40075E910 /* Tab.swift in Sources */,
+				5E0EB1ED20FF6DAB00B5DC2B /* TaskBrowserViewController.swift in Sources */,
 				D5189473204D543C00C095C1 /* InitialSyncObserver.swift in Sources */,
 				871BC3611D34F94200DF0793 /* Settings+ColorScheme.m in Sources */,
 				87DCF49E1D34E9E600BB420F /* ModalTopBar.swift in Sources */,

--- a/Wire-iOS/Sources/UserInterface/Registration/Company/TaskBrowserViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/Company/TaskBrowserViewController.swift
@@ -37,7 +37,6 @@ class TaskBrowserViewController: UIViewController, WKNavigationDelegate {
 
     private let webView = WKWebView()
     private let loadIndicator = UIActivityIndicatorView(activityIndicatorStyle: .gray)
-    private var titleObservationToken: NSKeyValueObservation?
     private var loadObservationToken: NSKeyValueObservation?
 
     // MARK: - Configuration
@@ -58,10 +57,6 @@ class TaskBrowserViewController: UIViewController, WKNavigationDelegate {
 
     private func setUpObservers() {
         webView.navigationDelegate = self
-
-        titleObservationToken = webView.observe(\WKWebView.title) { webView, _ in
-            self.title = webView.title
-        }
 
         loadObservationToken = webView.observe(\.isLoading) { webView, _ in
             if webView.isLoading {
@@ -92,7 +87,6 @@ class TaskBrowserViewController: UIViewController, WKNavigationDelegate {
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        titleObservationToken?.invalidate()
         loadObservationToken?.invalidate()
         webView.navigationDelegate = nil
     }
@@ -103,6 +97,17 @@ class TaskBrowserViewController: UIViewController, WKNavigationDelegate {
     func open(_ url: URL) {
         let request = URLRequest(url: url)
         self.webView.load(request)
+    }
+
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+
+        guard let url = navigationAction.request.url, let host = url.host else {
+            decisionHandler(.allow)
+            return
+        }
+
+        self.title = host
+        decisionHandler(.allow)
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/Registration/Company/TaskBrowserViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/Company/TaskBrowserViewController.swift
@@ -1,0 +1,108 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import UIKit
+import WebKit
+
+/// The delegate of a task browser.
+protocol TaskBrowserViewControllerDelegate: class {
+
+    /// Browsing was cancelled by the user.
+    func taskBrowserViewControllerDidCancel(_ controller: TaskBrowserViewController)
+}
+
+/**
+ * A browser view controller that allows completing the task depending on the
+ * response provided by the server.
+ */
+
+class TaskBrowserViewController: UIViewController, WKNavigationDelegate {
+
+    weak var delegate: TaskBrowserViewControllerDelegate?
+
+    private let webView = WKWebView()
+    private let loadIndicator = UIActivityIndicatorView(activityIndicatorStyle: .gray)
+    private var titleObservationToken: NSKeyValueObservation?
+    private var loadObservationToken: NSKeyValueObservation?
+
+    // MARK: - Configuration
+
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return .default
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(cancel))
+        navigationItem.rightBarButtonItem = UIBarButtonItem(customView: loadIndicator)
+
+        setUpSubviews()
+        setUpObservers()
+    }
+
+    private func setUpObservers() {
+        webView.navigationDelegate = self
+
+        titleObservationToken = webView.observe(\WKWebView.title) { webView, _ in
+            self.title = webView.title
+        }
+
+        loadObservationToken = webView.observe(\.isLoading) { webView, _ in
+            if webView.isLoading {
+                self.loadIndicator.startAnimating()
+            } else {
+                self.loadIndicator.stopAnimating()
+            }
+        }
+    }
+
+    private func setUpSubviews() {
+        view.addSubview(webView)
+        webView.translatesAutoresizingMaskIntoConstraints = false
+
+        webView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
+        webView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
+        webView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
+        webView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
+    }
+
+    // MARK: - Tear Down
+
+    @objc private func cancel() {
+        self.dismiss(animated: true) {
+            self.delegate?.taskBrowserViewControllerDidCancel(self)
+        }
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        titleObservationToken?.invalidate()
+        loadObservationToken?.invalidate()
+        webView.navigationDelegate = nil
+    }
+
+    // MARK: - Web View
+
+    /// Opens the website at the given URL.
+    func open(_ url: URL) {
+        let request = URLRequest(url: url)
+        self.webView.load(request)
+    }
+
+}

--- a/Wire-iOS/Sources/UserInterface/Registration/Company/TimeoutIdentitySessionRequester.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/Company/TimeoutIdentitySessionRequester.swift
@@ -35,6 +35,14 @@ class TimeoutIdentitySessionRequester: SharedIdentitySessionRequester {
     }
 
     func requestIdentity(for token: UUID, _ completion: @escaping (SharedIdentitySessionResponse) -> Void) {
+//        let browser = TaskBrowserViewController(nibName: nil, bundle: nil)
+//        let controller = UINavigationController(rootViewController: browser)
+//
+//        UIApplication.shared.wr_topmostController(onlyFullScreen: true)?.present(controller, animated: true) {
+//            UIApplication.shared.wr_updateStatusBarForCurrentControllerAnimated(true)
+//            browser.open(URL(string: "https://sso.wire.com/initiate-login/\(token.transportString())")!)
+//        }
+
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
             completion(.error(SharedIdentitySessionRequesterTimeoutError()))
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

The app needs a custom browser to perform the single sign-on requests, instead of using the system authentication session.

### Solutions

We define a view controller that wraps a `WKWebView`. We can use the delegate methods to observe navigation events, e.g. cookies or redirections.

This is not an optimal solution regarding user experience, as in-app browsers do not share login sessions with the system (which means users will have to login with their IdP every tiume), but there is no way around it.