### PR TITLE
call deleteForEveryone when deleting ephemeral

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageDeletion.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageDeletion.swift
@@ -85,7 +85,14 @@ extension CollectionCell: SelectableView {
                 ZMUserSession.shared()?.enqueueChanges({ 
                     switch type {
                     case .local:
-                        ZMMessage.hideMessage(message)
+                        // when deleteing ephemeral, we must delete for everyone
+                        // (only self & sender will receieve delete message, see DM)
+                        // b/c deleting locally will void the destruction timer completion.
+                        if message.isEphemeral {
+                            ZMMessage.deleteForEveryone(message)
+                        } else {
+                            ZMMessage.hideMessage(message)
+                        }
                     case .everywhere:
                         ZMMessage.deleteForEveryone(message)
                     }


### PR DESCRIPTION
## What's new in this PR?

### Issues
If the receiver deletes an ephemeral message, then the message is not deleted on the sender side and they are stuck with the obfuscated message.

### Causes
When the deletion timer fires normally (on the receiver side), a call to `ZMMessage.deleteForEveryone(message:) is eventually invoked, which generates a delete message to be sent to participants in the client. This method name is misleading because in the case of ephemeral messages, we actually only delete for the self user and the original sender. See [here](https://github.com/wireapp/wire-ios-data-model/blob/68d5d5d5f385b15bb3cddbfe7facf12fecf5400a/Source/Model/Message/ZMClientMessage%2BEncryption.swift#L161) for details.

However, when the receiver deletes the ephemeral, they only delete the message locally. This means that when the destruction timer fires, it returns early because it finds that the ephemeral to delete is already deleted. As a result, the original sender never receives the delete message and is stuck with the obfuscated message. 

### Solutions
We simply need to delete the ephemeral message for everyone.