### PR TITLE
Fix: Audio message is stopped recording if device entering screenlock mode 

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
@@ -78,10 +78,14 @@ private let zmLog = ZMSLog(tag: "UI")
             self.recorder.maxRecordingDuration = Settings.shared().maxRecordingDurationDebug
         }
     }
+
+    deinit {
+        recorder.stopRecording()
+    }
     
     public override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        recorder.stopRecording()
+        UIApplication.shared.keyWindow?.endEditing(true)
     }
     
     func configureViews() {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
@@ -79,13 +79,12 @@ private let zmLog = ZMSLog(tag: "UI")
         }
     }
 
-    deinit {
-        recorder.stopRecording()
-    }
-    
     public override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        UIApplication.shared.keyWindow?.endEditing(true)
+
+        if AppLock.isActive {
+            UIApplication.shared.keyWindow?.endEditing(true)
+        }
     }
     
     func configureViews() {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Audio.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Audio.swift
@@ -43,13 +43,12 @@ extension ConversationInputBarViewController {
     }
 
     @objc func revealRecordKeyboardWhenAppLocked() {
-        // show the record keyboard after it is hide after the app went to background
-        if AppLock.isActive &&
-            !AppLockViewController.isLocked &&
-            mode == .audioRecord &&
-            !self.inputBar.textView.isFirstResponder {///TODO: check lock screen is stll there?
-            displayRecordKeyboard()
-        }
+        guard AppLock.isActive,
+              !AppLockViewController.isLocked,
+              mode == .audioRecord,
+              !self.inputBar.textView.isFirstResponder else { return }
+
+        displayRecordKeyboard()
     }
 
     @objc func configureAudioButton(_ button: IconButton) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Audio.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Audio.swift
@@ -32,17 +32,22 @@ extension ConversationInputBarViewController {
     }
 
     @objc func setupAppLockedObserver() {
+
         NotificationCenter.default.addObserver(self,
-        selector: #selector(ConversationInputBarViewController.appUnlocked),
+        selector: #selector(revealRecordKeyboardWhenAppLocked),
         name: .appUnlocked,
         object: .none)
+
+        // If the app is locked and not yet reach the time to unlock and the app became active, reveal the keyboard (it was dismissed when app resign active)
+        NotificationCenter.default.addObserver(self, selector: #selector(revealRecordKeyboardWhenAppLocked), name: .UIApplicationDidBecomeActive, object: nil)
     }
 
-    @objc func appUnlocked() {
+    @objc func revealRecordKeyboardWhenAppLocked() {
         // show the record keyboard after it is hide after the app went to background
         if AppLock.isActive &&
-           mode == .audioRecord &&
-           !self.inputBar.textView.isFirstResponder {
+            !AppLockViewController.isLocked &&
+            mode == .audioRecord &&
+            !self.inputBar.textView.isFirstResponder {///TODO: check lock screen is stll there?
             displayRecordKeyboard()
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
@@ -31,7 +31,7 @@ extension Notification.Name {
     fileprivate static let authenticationPersistancePeriod: TimeInterval = 10
     fileprivate var localAuthenticationCancelled: Bool = false
     fileprivate var localAuthenticationNeeded: Bool = true
-    
+
     fileprivate var dimContents: Bool = false {
         didSet {
             self.view.isHidden = !self.dimContents
@@ -39,7 +39,10 @@ extension Notification.Name {
     }
     
     static let shared = AppLockViewController()
-    
+
+    static var isLocked: Bool {
+        return shared.dimContents
+    }
 
     convenience init() {
         self.init(nibName:nil, bundle:nil)


### PR DESCRIPTION
## What's new in this PR?

### Issues

When the screen lock is enabled, Audio recording stops after the screen is locked.

### Causes

In AudioRecordKeyboardViewController, when viewWillDisappear (triggered by the keyboard dismissal), the audio recording stops.

### Solutions

Do not stop recording when viewWillDisappear, hide the keyboard instead. When UIApplicationDidBecomeActive or appUnlocked notification is fired, reveal the audio record keyboard. 

