### PR TITLE
Tear down the storage stack when closing the share extension

### DIFF
--- a/Wire-iOS Share Extension/ShareExtensionViewController.swift
+++ b/Wire-iOS Share Extension/ShareExtensionViewController.swift
@@ -82,7 +82,7 @@ class ShareExtensionViewController: SLComposeServiceViewController {
     }
 
     deinit {
-        NotificationCenter.default.removeObserver(self)
+        StorageStack.reset()
     }
     
     override func viewDidLoad() {


### PR DESCRIPTION
## What's new in this PR?

### Issues

The `SharingSession` is re-created in share extension when user is selecting the other account.

`tearDown()` method of `SharingSession` was calling `StorageStack.reset()`.

The implementation of `StorageStack.reset()` has changed in the way that it is turning down the managed object context directory: `StorageStack.currentStack?.managedObjectContextDirectory?.tearDown()`.

Generally, the storage stack must not be torn down when switching the accounts, so now we are going to call `StorageStack.reset()` when the share extension is torn down.

## Dependencies

Needs releases with:

- [ ] https://github.com/wireapp/wire-ios-share-engine/pull/60
