### PR TITLE
Correctly show the untrusted client when self user added the device

### DIFF
--- a/Wire-iOS/Sources/Helpers/syncengine/ZMUser+Additions.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMUser+Additions.swift
@@ -27,4 +27,8 @@ extension ZMUser {
     @objc var canManageTeam: Bool {
         return self.membership?.permissions.contains(.owner) ?? false || self.membership?.permissions.contains(.admin) ?? false
     }
+    
+    @objc var hasUntrustedClients: Bool {
+        return nil != self.clients.first { !$0.verified }
+    }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -858,27 +858,34 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
                 break;
             case ConversationDegradedResultShowDetails:
                 [self.conversation doNotResendMessagesThatCausedDegradation];
-                if (self.conversation.conversationType == ZMConversationTypeOneOnOne) {
-                    ZMUser *user = self.conversation.connectedUser;
-                    if (user.clients.count == 1) {
-                        ProfileClientViewController *userClientController = [[ProfileClientViewController alloc] initWithClient:user.clients.anyObject fromConversation:YES];
-                        userClientController.showBackButton = NO;
-                        UINavigationController *navigationController = userClientController.wrapInNavigationController;
-                        navigationController.modalPresentationStyle = UIModalPresentationFormSheet;
-                        userClientController.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithIcon:ZetaIconTypeX style:UIBarButtonItemStylePlain target:self action:@selector(dismissProfileClientViewController:)];
-                        [self presentViewController:navigationController animated:YES completion:nil];
-                    } else {
-                        ProfileViewController *profileViewController = [[ProfileViewController alloc] initWithUser:user context:ProfileViewControllerContextDeviceList];
-                        profileViewController.delegate = self;
-                        profileViewController.viewControllerDismisser = self;
-                        UINavigationController *navigationController = profileViewController.wrapInNavigationController;
-                        navigationController.modalPresentationStyle = UIModalPresentationFormSheet;
-                        [self presentViewController:navigationController animated:YES completion:nil];
-                    }
-                } else if (self.conversation.conversationType == ZMConversationTypeGroup) {
-                    UIViewController *participantsController = [self participantsController];
-                    [self presentViewController:participantsController animated:YES completion:nil];
+
+                if ([[ZMUser selfUser] hasUntrustedClients]) {
+                    [[ZClientViewController sharedZClientViewController] openClientListScreenForUser:[ZMUser selfUser]];
                 }
+                else {
+                    if (self.conversation.conversationType == ZMConversationTypeOneOnOne) {
+                        ZMUser *user = self.conversation.connectedUser;
+                        if (user.clients.count == 1) {
+                            ProfileClientViewController *userClientController = [[ProfileClientViewController alloc] initWithClient:user.clients.anyObject fromConversation:YES];
+                            userClientController.showBackButton = NO;
+                            UINavigationController *navigationController = userClientController.wrapInNavigationController;
+                            navigationController.modalPresentationStyle = UIModalPresentationFormSheet;
+                            userClientController.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithIcon:ZetaIconTypeX style:UIBarButtonItemStylePlain target:self action:@selector(dismissProfileClientViewController:)];
+                            [self presentViewController:navigationController animated:YES completion:nil];
+                        } else {
+                            ProfileViewController *profileViewController = [[ProfileViewController alloc] initWithUser:user context:ProfileViewControllerContextDeviceList];
+                            profileViewController.delegate = self;
+                            profileViewController.viewControllerDismisser = self;
+                            UINavigationController *navigationController = profileViewController.wrapInNavigationController;
+                            navigationController.modalPresentationStyle = UIModalPresentationFormSheet;
+                            [self presentViewController:navigationController animated:YES completion:nil];
+                        }
+                    } else if (self.conversation.conversationType == ZMConversationTypeGroup) {
+                        UIViewController *participantsController = [self participantsController];
+                        [self presentViewController:participantsController animated:YES completion:nil];
+                    }
+                }
+                
                 break;
         }
     }];

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -134,6 +134,7 @@ extension ZClientViewController {
     /// Open the user client list screen
     ///
     /// - Parameter user: the ZMUser with client list to show
+    @objc(openClientListScreenForUser:)
     func openClientListScreen(for user: ZMUser) {
         var viewController: UIViewController?
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

In verified conversation, when self user added the new device and trying to send the message we are showing the action sheet where user has to decide either to send the message or to review the new devices. We where always only showing the other party devices, which is not correct in case self user has the new device. Then we have to show the self user client list.

### Solutions

Show the self client list if necessary.
