### PR TITLE
ZIOS-10329: UIMenuController still onscreen after coming back to Conversations List

### DIFF
--- a/Wire-iOS.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Wire-iOS.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Wire-iOS.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Wire-iOS.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>IDEDidComputeMac32BitWarning</key>
-	<true/>
-</dict>
-</plist>

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -212,6 +212,7 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
 - (void)viewWillDisappear:(BOOL)animated
 {
     self.onScreen = NO;
+    [self removeHighlightsAndMenu];
     [super viewWillDisappear:animated];
 }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

If I long press on a content inside a conversation and then I swipe back to the conversation list, the `UIMenuController` is still there.

### Causes

`UIMenuController` doesn't get dismissed during this transition.

### Solutions

I've added a call to the `removeHighlightsAndMenu` method, which hides the shared instance of `UIMenuController`.