### PR TITLE
Do not play sounds that are played by AVS

### DIFF
--- a/Wire-iOS/Sources/Helpers/sound/AVSMediaManager+Additions.h
+++ b/Wire-iOS/Sources/Helpers/sound/AVSMediaManager+Additions.h
@@ -24,15 +24,10 @@
 
 extern NSString *const MediaManagerSoundOutgoingKnockSound;
 extern NSString *const MediaManagerSoundIncomingKnockSound;
-extern NSString *const MediaManagerSoundUserLeavesVoiceChannelSound;
 extern NSString *const MediaManagerSoundMessageReceivedSound;
 extern NSString *const MediaManagerSoundFirstMessageReceivedSound;
 extern NSString *const MediaManagerSoundSomeoneJoinsVoiceChannelSound;
-extern NSString *const MediaManagerSoundReadyToTalkSound;
 extern NSString *const MediaManagerSoundTransferVoiceToHereSound;
-extern NSString *const MediaManagerSoundUserJoinsVoiceChannelSound;
-extern NSString *const MediaManagerSoundRingingFromMeSound;
-extern NSString *const MediaManagerSoundRingingFromMeVideoSound;
 extern NSString *const MediaManagerSoundRingingFromThemSound;
 extern NSString *const MediaManagerSoundRingingFromThemInCallSound;
 extern NSString *const MediaManagerSoundCallDropped;

--- a/Wire-iOS/Sources/Helpers/sound/AVSMediaManager+Additions.m
+++ b/Wire-iOS/Sources/Helpers/sound/AVSMediaManager+Additions.m
@@ -25,15 +25,10 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
 
 NSString *const MediaManagerSoundOutgoingKnockSound = @"ping_from_me";
 NSString *const MediaManagerSoundIncomingKnockSound = @"ping_from_them";
-NSString *const MediaManagerSoundUserLeavesVoiceChannelSound = @"talk_later";
 NSString *const MediaManagerSoundMessageReceivedSound = @"new_message";
 NSString *const MediaManagerSoundFirstMessageReceivedSound = @"first_message";
 NSString *const MediaManagerSoundSomeoneJoinsVoiceChannelSound = @"talk";
-NSString *const MediaManagerSoundReadyToTalkSound = @"ready_to_talk";
 NSString *const MediaManagerSoundTransferVoiceToHereSound = @"pull_voice";
-NSString *const MediaManagerSoundUserJoinsVoiceChannelSound = @"ready_to_talk";
-NSString *const MediaManagerSoundRingingFromMeSound = @"ringing_from_me";
-NSString *const MediaManagerSoundRingingFromMeVideoSound = @"ringing_from_me_video";
 NSString *const MediaManagerSoundRingingFromThemSound = @"ringing_from_them";
 NSString *const MediaManagerSoundRingingFromThemInCallSound = @"ringing_from_them_incall";
 NSString *const MediaManagerSoundCallDropped = @"call_drop";

--- a/Wire-iOS/Sources/Managers/SoundEventListener.swift
+++ b/Wire-iOS/Sources/Managers/SoundEventListener.swift
@@ -163,14 +163,6 @@ extension SoundEventListener : WireCallCenterCallStateObserver {
         previousCallStates[conversationId] = callState
         
         switch callState {
-        case .outgoing:
-            if callCenter.isVideoCall(conversationId: conversationId) {
-                playSoundIfAllowed(MediaManagerSoundRingingFromMeVideoSound)
-            } else {
-                playSoundIfAllowed(MediaManagerSoundRingingFromMeSound)
-            }
-        case .established:
-            playSoundIfAllowed(MediaManagerSoundUserJoinsVoiceChannelSound)
         case .incoming(video: _, shouldRing: true, degraded: _):
             guard let sessionManager = SessionManager.shared, !conversation.isSilenced else { return }
             
@@ -189,7 +181,7 @@ extension SoundEventListener : WireCallCenterCallStateObserver {
         case .terminating(reason: let reason):
             switch reason {
             case .normal, .canceled:
-                playSoundIfAllowed(MediaManagerSoundUserLeavesVoiceChannelSound)
+                break
             default:
                 playSoundIfAllowed(MediaManagerSoundCallDropped)
             }
@@ -207,8 +199,6 @@ extension SoundEventListener : WireCallCenterCallStateObserver {
             
             mediaManager.stopSound(MediaManagerSoundRingingFromThemInCallSound)
             mediaManager.stopSound(MediaManagerSoundRingingFromThemSound)
-            mediaManager.stopSound(MediaManagerSoundRingingFromMeVideoSound)
-            mediaManager.stopSound(MediaManagerSoundRingingFromMeSound)
         }
         
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

It came out, that AVS is ignoring the calls to play certain sounds, since they started to manage those sounds in AVS internally.

The logic for playing those sounds was removed, since it is not used.