### PR TITLE
Correctly erase the minimized call when ended

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Overlay/ActiveVoiceChannelViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/ActiveVoiceChannelViewController.swift
@@ -114,6 +114,18 @@ class ActiveVoiceChannelViewController : UIViewController {
         }
     }
     
+    fileprivate func updateMinimisedCall(with callState: CallState,
+                                         conversation: ZMConversation) {
+        switch callState {
+        case .terminating(_):
+            if minimisedCall == conversation.remoteIdentifier! {
+                minimisedCall = nil
+            }
+        default:
+            break
+        }
+    }
+    
     private func shouldPresentCallOverlay() -> Bool {
         switch (primaryCallingConversation?.voiceChannel?.state, SessionManager.shared?.callNotificationStyle) {
         case (.incoming?, .callKit?): return false
@@ -221,7 +233,8 @@ extension ActiveVoiceChannelViewController : WireCallCenterCallStateObserver {
     
     func callCenterDidChange(callState: CallState, conversation: ZMConversation, caller: ZMUser, timestamp: Date?) {
         updateVisibleVoiceChannelViewController()
-
+        updateMinimisedCall(with: callState, conversation: conversation)
+        
         let changeDate = Date()
 
         // Only show the survey in internal builds (review required)
@@ -235,10 +248,6 @@ extension ActiveVoiceChannelViewController : WireCallCenterCallStateObserver {
         switch callState {
         case .established:
             answeredCalls[conversation.remoteIdentifier!] = Date()
-        case .terminating(_):
-            if minimisedCall == conversation.remoteIdentifier! {
-                minimisedCall = nil
-            }
         default:
             break
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

The call stayed minimized after it was ended and restarted.

### Causes

The logic to set the current minimized call ID to nil was only called on internal builds where the tracking was enabled.

### Solutions

Move the logic before the guard.