### PR TITLE
ZIOS-10332: Do not allow single user to cancel login

### DIFF
--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -230,6 +230,7 @@ import Classy
             if needsToReauthenticate {
                 let registrationViewController = RegistrationViewController()
                 registrationViewController.delegate = appStateController
+                registrationViewController.shouldHideCancelButton = SessionManager.numberOfAccounts <= 1
                 registrationViewController.signInError = error
                 viewController = registrationViewController
             }
@@ -582,6 +583,11 @@ public extension SessionManager {
         
         return nil
     }
+
+    @objc static var numberOfAccounts: Int {
+        return SessionManager.shared?.accountManager.accounts.count ?? 0
+    }
+
 }
 
 extension AppRootViewController: SessionManagerURLHandlerDelegate {


### PR DESCRIPTION
## What's new in this PR?

### Issues

When creating the login view controller after the session becomes unauthenticated, we don't hide the close button if there is only one user. This causes the skeleton view to appear and stay on screen forever, until we force-quit the app.

### Solutions

We hide the cancel button if there is only one account registered.