### PR TITLE
Do not autodismiss the calling overlay after selecting the push

### DIFF
--- a/Wire-iOS/Sources/Helpers/syncengine/ZMUserSession+Calling.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMUserSession+Calling.swift
@@ -26,4 +26,33 @@ extension ZMUserSession {
         return !callCenter.activeCallConversations(in: self).isEmpty
     }
     
+    @objc var ongoingCallConversation: ZMConversation? {
+        guard let callCenter = self.callCenter else { return nil }
+        
+        return callCenter.nonIdleCallConversations(in: self).first { (conversation) -> Bool in
+            guard let callState = conversation.voiceChannel?.state else { return false }
+            
+            switch callState {
+            case .answered, .established, .establishedDataChannel, .outgoing:
+                return true
+            default:
+                return false
+            }
+        }
+    }
+    
+    @objc var ringingCallConversation: ZMConversation? {
+        guard let callCenter = self.callCenter else { return nil }
+        
+        return callCenter.nonIdleCallConversations(in: self).first { (conversation) -> Bool in
+            guard let callState = conversation.voiceChannel?.state else { return false }
+            
+            switch callState {
+            case .incoming, .outgoing:
+                return true
+            default:
+                return false
+            }
+        }
+    }
 }

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
@@ -426,7 +426,7 @@
 
 - (void)dismissAllModalControllersWithCallback:(dispatch_block_t)callback
 {
-    [self minimizeCallOverlayWithCompletion:^{
+    dispatch_block_t dismissAction = ^{
         if (self.splitViewController.rightViewController.presentedViewController != nil) {
             [self.splitViewController.rightViewController dismissViewControllerAnimated:NO completion:callback];
         }
@@ -450,7 +450,18 @@
         else if (callback) {
             callback();
         }
-    }];
+    };
+
+    ZMConversation *ringingCallConversation = [[ZMUserSession sharedSession] ringingCallConversation];
+    
+    if (ringingCallConversation != nil) {
+        dismissAction();
+    }
+    else {
+        [self minimizeCallOverlayWithCompletion:^{
+            dismissAction();
+        }];
+    }
 }
 
 #pragma mark - Getters/Setters

--- a/Wire-iOS/Sources/UserInterface/Overlay/ActiveVoiceChannelViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/ActiveVoiceChannelViewController.swift
@@ -212,19 +212,7 @@ class ActiveVoiceChannelViewController : UIViewController {
     
     
     var ongoingCallConversation : ZMConversation? {
-        guard let userSession = ZMUserSession.shared(), let callCenter = userSession.callCenter else { return nil }
-        
-        return callCenter.nonIdleCallConversations(in: userSession).first { (conversation) -> Bool in
-            guard let callState = conversation.voiceChannel?.state else { return false }
-            
-            switch callState {
-            case .answered, .established, .establishedDataChannel, .outgoing:
-                return true
-            default:
-                return false
-            }
-        }
-        
+        return ZMUserSession.shared()?.ongoingCallConversation
     }
     
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

When user selects the call notification, the user session is asking to show the given conversation. The code by default is dismissing all overlays, including the calling overlay.

### Solutions

Check if the call is ringing, and in this case do not dismiss the overlay.