### PR TITLE
Remove iOS 9 version checking

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
@@ -202,12 +202,10 @@ private struct InputBarConstants {
         
     override public func didMoveToWindow() {
         super.didMoveToWindow()
-        // This is a workaround for UITextView truncating long contents.
-        // However, this breaks the text view on iOS 8 ¯\_(ツ)_/¯.
-        if #available(iOS 9, *) {
-            textView.isScrollEnabled = false
-            textView.isScrollEnabled = true
-        }
+
+        textView.isScrollEnabled = false
+        textView.isScrollEnabled = true
+
         startCursorBlinkAnimation()
     }
     

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
@@ -203,6 +203,8 @@ private struct InputBarConstants {
     override public func didMoveToWindow() {
         super.didMoveToWindow()
 
+        // This is a workaround for UITextView truncating long contents.
+        // However, this breaks the text view on iOS 8 ¯\_(ツ)_/¯.
         textView.isScrollEnabled = false
         textView.isScrollEnabled = true
 

--- a/Wire-iOS/Sources/UserInterface/Helpers/UIView+RightToLeft.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UIView+RightToLeft.swift
@@ -33,11 +33,7 @@ public extension UIView {
     }
 
     var isRightToLeft: Bool {
-        if #available(iOS 9.0, *) {
-            return UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) == .rightToLeft
-        } else {
-            return UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft
-        }
+        return UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) == .rightToLeft
     }
     
 }

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Options.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Options.swift
@@ -179,15 +179,13 @@ extension SettingsCellDescriptorFactory {
         
         cellDescriptors.append(byPopularDemandSection)
         
-        if #available(iOS 9.0, *) {
-            let context: LAContext = LAContext()
-            var error: NSError?
-            
-            if context.canEvaluatePolicy(LAPolicy.deviceOwnerAuthentication, error: &error) {
-                let lockApp = SettingsPropertyToggleCellDescriptor(settingsProperty: self.settingsPropertyFactory.property(.lockApp))
-                let section = SettingsSectionDescriptor(cellDescriptors: [lockApp], header: .none, footer: appLockSectionSubtitle)
-                cellDescriptors.append(section)
-            }
+        let context: LAContext = LAContext()
+        var error: NSError?
+        
+        if context.canEvaluatePolicy(LAPolicy.deviceOwnerAuthentication, error: &error) {
+            let lockApp = SettingsPropertyToggleCellDescriptor(settingsProperty: self.settingsPropertyFactory.property(.lockApp))
+            let section = SettingsSectionDescriptor(cellDescriptors: [lockApp], header: .none, footer: appLockSectionSubtitle)
+            cellDescriptors.append(section)
         }
         
         let linkPreviewDescriptor = SettingsPropertyToggleCellDescriptor(settingsProperty: settingsPropertyFactory.property(.disableLinkPreviews), inverse: true)

--- a/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ChangeHandleViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ChangeHandleViewController.swift
@@ -362,13 +362,7 @@ extension ChangeHandleViewController: UserProfileUpdateObserver {
 fileprivate extension String {
 
     var isEqualToUnicodeName: Bool {
-        if #available(iOS 9, *) {
-            return applyingTransform(.toUnicodeName, reverse: false) == self
-        } else {
-            let ref = NSMutableString(string: self) as CFMutableString
-            CFStringTransform(ref, nil, kCFStringTransformToUnicodeName, false)
-            return ref as String == self
-        }
+        return applyingTransform(.toUnicodeName, reverse: false) == self
     }
     
 }


### PR DESCRIPTION
## What's new in this PR?

Remove the unnecessary iOS version checking for the iOS8 era.