### PR TITLE
ZIOS-10341: Tracking is set to No after accessing New Team page

### DIFF
--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -240,7 +240,6 @@ var defaultFontScheme: FontScheme = FontScheme(contentSizeCategory: UIApplicatio
                 // When we show the landing controller we want it to be nested in navigation controller
                 let landingViewController = LandingViewController()
                 landingViewController.delegate = self
-                TrackingManager.shared.disableCrashAndAnalyticsSharing = true
                 
                 let navigationController = NavigationController(rootViewController: landingViewController)
                 navigationController.backButtonEnabled = false

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/LandingViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/LandingViewController.swift
@@ -285,6 +285,7 @@ final class LandingViewController: UIViewController, CompanyLoginControllerDeleg
     private func updateBarButtonItem() {
         if SessionManager.shared?.firstAuthenticatedAccount == nil {
             navigationBar.topItem?.rightBarButtonItem = nil
+            TrackingManager.shared.disableCrashAndAnalyticsSharing = true
         } else {
             let cancelItem = UIBarButtonItem(icon: .cancel, target: self, action: #selector(cancelButtonTapped))
             cancelItem.accessibilityIdentifier = "CancelButton"

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/LandingViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/LandingViewController.swift
@@ -166,11 +166,15 @@ final class LandingViewController: UIViewController, CompanyLoginControllerDeleg
         updateStackViewAxis()
         updateConstraintsForIPad()
         updateBarButtonItem()
+        disableTrackingIfNeeded()
 
         NotificationCenter.default.addObserver(
             forName: AccountManagerDidUpdateAccountsNotificationName,
             object: SessionManager.shared?.accountManager,
-            queue: nil) { _ in self.updateBarButtonItem()  }
+            queue: nil) { _ in
+                self.updateBarButtonItem()
+                self.disableTrackingIfNeeded()
+        }
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -285,12 +289,17 @@ final class LandingViewController: UIViewController, CompanyLoginControllerDeleg
     private func updateBarButtonItem() {
         if SessionManager.shared?.firstAuthenticatedAccount == nil {
             navigationBar.topItem?.rightBarButtonItem = nil
-            TrackingManager.shared.disableCrashAndAnalyticsSharing = true
         } else {
             let cancelItem = UIBarButtonItem(icon: .cancel, target: self, action: #selector(cancelButtonTapped))
             cancelItem.accessibilityIdentifier = "CancelButton"
             cancelItem.accessibilityLabel = "general.cancel".localized
             navigationBar.topItem?.rightBarButtonItem = cancelItem
+        }
+    }
+    
+    private func disableTrackingIfNeeded() {
+        if SessionManager.shared?.firstAuthenticatedAccount == nil {
+            TrackingManager.shared.disableCrashAndAnalyticsSharing = true
         }
     }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

Tracking was disabled every time the team creation flow was shown.

### Solutions

I've moved the deactivation to `LandingViewController` only in the case there are no accounts left logged into the app.