### PR TITLE
Fix: buttons to go to settings are not visible in self profile

### DIFF
--- a/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
@@ -157,6 +157,8 @@ final internal class SelfProfileViewController: UIViewController {
             accountSelectorControllerView.height == 44
         }
 
+        // Sometimes (i.e. after coming from background) the cells are not loaded yet. Reloading to calculate correct height.
+        settingsController.tableView.reloadData()
         let height = CGFloat(56 * settingsController.tableView.numberOfRows(inSection: 0))
         
         constrain(view, settingsController.view, profileView, profileContainerView, settingsController.tableView) { view, settingsControllerView, profileView, profileContainerView, tableView in


### PR DESCRIPTION
## What's new in this PR?

### Issues

Sometimes the self profile screen would not have the buttons to create team and go to settings anymore. It was happening after the app was coming to foreground

### Causes

The height of this section was pinned to the height of cells inside the child controller. At that point table view was thinking it still has 0 cells.

### Solutions

Reload the table view before asking for cell count.
