### PR TITLE
Fix wrong user image being displayed

### DIFF
--- a/WireExtensionComponents/Views/UserImageView.swift
+++ b/WireExtensionComponents/Views/UserImageView.swift
@@ -24,6 +24,8 @@ extension UserImageView {
     @objc
     func updateUserImage() {
         
+        guard let user = user else { return }
+        
         var profileImageSize: ProfileImageSize
         switch size {
         case .small, .normal, .first:
@@ -33,13 +35,14 @@ extension UserImageView {
         }
         
         var desaturate = false
-        if shouldDesaturate, let user = user {
+        if shouldDesaturate {
             desaturate = !user.isConnected && !user.isSelfUser && !user.isTeamMember || user.isServiceUser
         }
         
-        user?.fetchProfileImage(desaturate: desaturate, size: profileImageSize, completion: { (image) in
-            guard let image = image else { return }
-            self.setUserImage(image)
+        user.fetchProfileImage(desaturate: desaturate, size: profileImageSize, completion: { [weak self] (image) in
+            // Don't set image if nil or if user has changed during fetch
+            guard let image = image, user.isEqual(self?.user) else { return }
+            self?.setUserImage(image)
         })
         
     }


### PR DESCRIPTION
### Issues

Wrong user image could be displayed in some cases

### Causes

If a `UserImageView` was re-used while fetching the `UIImage` it could end up displaying the wrong image.

### Solutions

Verify that user hasn't changed in the completion handler.