### PR TITLE
ZIOS-10319: Improve share extension for links

### DIFF
--- a/Wire-iOS Share Extension/ShareExtensionViewController.swift
+++ b/Wire-iOS Share Extension/ShareExtensionViewController.swift
@@ -177,6 +177,8 @@ class ShareExtensionViewController: SLComposeServiceViewController {
     @objc func appendPostTapped() {
         navigationController?.navigationBar.items?.first?.rightBarButtonItem?.isEnabled = false
 
+        updateUrlAttachments()
+        
         postContent?.send(text: contentText, sharingSession: sharingSession!) { [weak self] progress in
             guard let `self` = self, let postContent = self.postContent else { return }
 
@@ -222,6 +224,15 @@ class ShareExtensionViewController: SLComposeServiceViewController {
                 self.present(alert, animated: true, completion: nil)
             }
         }
+    }
+    
+    private func updateUrlAttachments() {
+        let urlDetector = try! NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
+        let matches = urlDetector.matches(in: contentText, options: [], range: NSMakeRange(0, contentText.count))
+        
+        var attachments = self.allAttachments.filter{ !$0.hasURL }
+        attachments.append(contentsOf: matches.compactMap { NSItemProvider(contentsOf: $0.url) })
+        postContent?.attachments = attachments
     }
 
     override func cancel() {

--- a/Wire-iOS Share Extension/ShareExtensionViewController.swift
+++ b/Wire-iOS Share Extension/ShareExtensionViewController.swift
@@ -228,7 +228,9 @@ class ShareExtensionViewController: SLComposeServiceViewController {
     
     private func updateUrlAttachments() {
         let urlDetector = try! NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
-        let matches = urlDetector.matches(in: contentText, options: [], range: NSMakeRange(0, contentText.count))
+        let matches = urlDetector.matches(in: contentText,
+                                          options: [],
+                                          range: NSMakeRange(0, (contentText as NSString).length))
         
         var attachments = self.allAttachments.filter{ !$0.hasURL }
         attachments.append(contentsOf: matches.compactMap { NSItemProvider(contentsOf: $0.url) })

--- a/Wire-iOS Share Extension/UnsentSendable.swift
+++ b/Wire-iOS Share Extension/UnsentSendable.swift
@@ -96,24 +96,10 @@ class UnsentTextSendable: UnsentSendableBase, UnsentSendable {
         if let attachment = self.attachment, attachment.hasURL {
             
             self.attachment?.fetchURL(completion: { (url) in
-                self.appendURLToTextIfNotAlreadyPresent(url)
                 completion()
             })
         } else {
             completion()
-        }
-    }
-    
-    func appendURLToTextIfNotAlreadyPresent(_ url: URL?) {
-        
-        if let url = url?.absoluteString, !self.text.contains(url)  {
-            var separator = ""
-            
-            if !self.text.isEmpty && self.text.last != " " {
-                separator = " "
-            }
-            
-            self.text += separator + url
         }
     }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Currently, the Share Extension appends the original URL to the content shared through the extension, even if the user decides to hide or change it. 

### Solutions

I'm updating the URL attachments of the current `PostContent` object before sending it. I've also removed the old code that appends the original URL.