### PR TITLE
ZIOS-10363: Fix SSO error alert not displayed

### DIFF
--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -19,6 +19,7 @@
 import Foundation
 import UIKit
 import Classy
+import SafariServices
 
 var defaultFontScheme: FontScheme = FontScheme(contentSizeCategory: UIApplication.shared.preferredContentSizeCategory)
 
@@ -648,7 +649,16 @@ extension AppRootViewController: SessionManagerURLHandlerDelegate {
                                           preferredStyle: .alert)
 
             alert.addAction(.ok { callback(false) })
-            self.present(alert, animated: true, completion: nil)
+
+            let presentAlert = {
+                self.present(alert, animated: true, completion: nil)
+            }
+
+            if let topmostViewController = UIApplication.shared.wr_topmostController() as? SFSafariViewController {
+                topmostViewController.dismiss(animated: true, completion: presentAlert)
+            } else {
+                presentAlert()
+            }
 
         case .companyLoginSuccess:
             defer {

--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -651,7 +651,7 @@ extension AppRootViewController: SessionManagerURLHandlerDelegate {
             alert.addAction(.ok { callback(false) })
 
             let presentAlert = {
-                self.present(alert, animated: true, completion: nil)
+                self.present(alert, animated: true)
             }
 
             if let topmostViewController = UIApplication.shared.wr_topmostController() as? SFSafariViewController {


### PR DESCRIPTION
## What's new in this PR?

### Issues

When Okta returns an error because it is wrongly configured, we wouldn't display an alert. It was expected to display an error alert with the code `8`.

### Causes

This happens because the Safari view controller calls the custom URL handler with the result before dismissing itself. Our handler attempts to present an alert on top of the app root view controller, which fails because it isn't the topmost view controller (Safari VC is still on top of the hierarchy).

### Solutions

We dismiss the Safari view controller before presenting the alert, if needed.