### PR TITLE
Fix/large group optimisations

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell+BurstTimestamp.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell+BurstTimestamp.swift
@@ -46,6 +46,10 @@ public extension ConversationCell {
 
         messageContentView.bringSubview(toFront: countdownContainerView)
     }
+    
+    @objc func cellDidEndBeingVisible() {
+        // no-op
+    }
 
     @objc public func updateBurstTimestamp() {
         if layoutProperties.showDayBurstTimestamp {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
@@ -225,6 +225,7 @@ static const CGFloat BurstContainerExpandedHeight = 40;
     [self.burstTimestampTimer invalidate];
     self.burstTimestampTimer = nil;
     [self tearDownCountdown];
+    [self cellDidEndBeingVisible];
 }
 
 - (void)createBaseConstraints

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ParticipantsCell/ParticipantsCellViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ParticipantsCell/ParticipantsCellViewModel.swift
@@ -63,7 +63,7 @@ extension ZMConversationMessage {
     }
 }
 
-struct ParticipantsCellViewModel {
+class ParticipantsCellViewModel {
     
     private typealias NameList = ParticipantsStringFormatter.NameList
     static let showMoreLinkURL = NSURL(string: "action://show-all")!
@@ -91,45 +91,53 @@ struct ParticipantsCellViewModel {
     
     /// Users displayed in the system message, up to 17 when not collapsed
     /// but only 15 when there are more than 15 users and we collapse them.
-    var shownUsers: [ZMUser] {
-        let users = sortedUsersWithoutSelf()
+    lazy var shownUsers: [ZMUser] = {
+        let users = sortedUsersWithoutSelf
         let boundary = users.count > maxShownUsers && action.allowsCollapsing ? maxShownUsersWhenCollapsed : users.count
         let result = users[..<boundary]
         return result + (isSelfIncludedInUsers ? [.selfUser()] : [])
-    }
+    }()
     
     /// Users not displayed in the system message but collapsed into a link.
     /// E.g. `and 5 others`.
-    private var collapsedUsers: [ZMUser] {
-        let users = sortedUsersWithoutSelf()
+    private lazy var collapsedUsers: [ZMUser] = {
+        let users = sortedUsersWithoutSelf
         guard users.count > maxShownUsers, action.allowsCollapsing else { return [] }
         return Array(users.dropFirst(maxShownUsersWhenCollapsed))
-    }
+    }()
     
     /// The users to display when opening the participants details screen.
     var selectedUsers: [ZMUser] {
         switch action {
-        case .added: return sortedUsers()
+        case .added: return sortedUsers
         default: return []
         }
     }
     
-    var isSelfIncludedInUsers: Bool {
-        return sortedUsers().any { $0.isSelfUser }
-    }
+    lazy var isSelfIncludedInUsers: Bool = {
+        return sortedUsers.any { $0.isSelfUser }
+    }()
     
     /// The users involved in the conversation action sorted alphabetically by
     /// name.
-    func sortedUsers() -> [ZMUser] {
+    lazy var sortedUsers: [ZMUser] = {
         guard let sender = message.sender else { return [] }
         guard action.involvesUsersOtherThanSender else { return [sender] }
         guard let systemMessage = message.systemMessageData else { return [] }
         return systemMessage.users.subtracting([sender]).sorted { name(for: $0) < name(for: $1) }
-    }
+    }()
 
-    func sortedUsersWithoutSelf() -> [ZMUser] {
-        return sortedUsers().filter { !$0.isSelfUser }
+    init(font: UIFont?, boldFont: UIFont?, largeFont: UIFont?, textColor: UIColor?, message: ZMConversationMessage) {
+        self.font = font
+        self.boldFont = boldFont
+        self.largeFont = largeFont
+        self.textColor = textColor
+        self.message = message
     }
+    
+    lazy var sortedUsersWithoutSelf: [ZMUser] = {
+        return sortedUsers.filter { !$0.isSelfUser }
+    }()
 
     private func name(for user: ZMUser) -> String {
         if user.isSelfUser {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ParticipantsCell/ParticipantsCellViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ParticipantsCell/ParticipantsCellViewModel.swift
@@ -135,11 +135,7 @@ struct ParticipantsCellViewModel {
         if user.isSelfUser {
             return "content.system.you_\(grammaticalCase(for: user))".localized
         }
-        if let conversation = message.conversation, conversation.activeParticipants.contains(user) {
-            return user.displayName(in: conversation)
-        } else {
-            return user.displayName
-        }
+        return user.displayName
     }
     
     private var nameList: NameList {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ParticipantsCell/ParticipantsCells.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ParticipantsCell/ParticipantsCells.swift
@@ -182,7 +182,7 @@ import TTTAttributedLabel
         attributedText = model.attributedTitle()
         nameLabel.attributedText = model.attributedHeading()
         topContainer.isHidden = nameLabel.attributedText == nil
-        bottomContainer.isHidden = model.sortedUsers().count == 0
+        bottomContainer.isHidden = model.sortedUsers.count == 0
         inviteView.isHidden = !model.showInviteButton
         viewModel = model
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ParticipantsCell/ParticipantsCells.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ParticipantsCell/ParticipantsCells.swift
@@ -34,6 +34,7 @@ import TTTAttributedLabel
     private var lineBaseLineConstraint: NSLayoutConstraint?
     private let inviteView = ParticipantsInvitePeopleView()
     private var viewModel: ParticipantsCellViewModel?
+    private var isVisible = true
     
     // Classy
     let lineView = UIView()
@@ -175,6 +176,20 @@ import TTTAttributedLabel
         super.configure(for: message, layoutProperties: layoutProperties)
         reloadInformation(for: message)
     }
+    
+    public override func willDisplayInTableView() {
+        super.willDisplayInTableView()
+        isVisible = true
+        reloadInformation(for: message)
+    }
+    
+    public override func cellDidEndBeingVisible() {
+        super.cellDidEndBeingVisible()
+        // this is an optimisation to avoid reloading the cell when it is not
+        // visible. Reloading in a large group conversation can be very expensive,
+        // as the set of users are sorted for each reload.
+        isVisible = false
+    }
 
     private func reloadInformation(for message: ZMConversationMessage) {
         let model = ParticipantsCellViewModel(font: labelFont, boldFont: labelBoldFont, largeFont: labelLargeFont, textColor: labelTextColor, message: message)
@@ -190,7 +205,7 @@ import TTTAttributedLabel
     open override func update(forMessage changeInfo: MessageChangeInfo!) -> Bool {
         let needsLayout = super.update(forMessage: changeInfo)
 
-        if changeInfo.usersChanged {
+        if true == changeInfo.userChangeInfo?.nameChanged, isVisible {
             reloadInformation(for: changeInfo.message)
             return true
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -216,6 +216,16 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
     [super viewWillDisappear:animated];
 }
 
+- (void)viewDidDisappear:(BOOL)animated
+{
+    [super viewDidDisappear:animated];
+    for (ConversationCell *cell in self.tableView.visibleCells) {
+        if ([cell isKindOfClass:ConversationCell.class]) {
+            [cell cellDidEndBeingVisible];
+        }
+    }
+}
+
 - (void)scrollToFirstUnreadMessageIfNeeded
 {
     if (! self.hasDoneInitialLayout) {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Scrolling the participants list in a large group conversation was unbearably sluggish.

### Causes

The performance issues is a combined result of the object-change notification system and expensive loading of the participants cell. When the user scrolls the participant list for the first time, the profile images are fetched for each user, which caused a `UserChangeInfo` object to propagate to the `ParticipantsCell`. This change then causes the cell to reload, which starts the process of sorting the users by their display name in the conversation (which in turn is an expensive task involving the `DisplayNameGenerator`).

### Solutions

A few optimisations have been implemented, namely:

1. We no longer invoke the `DisplayNameGenerator` when sorting the participants. Instead, we simply use the `displayName` property.
2. The properties referring to the array of sorted users are lazily loaded, so the sorting occurs only once.
3. The `ParticipantsCell` is only reloaded if it is visible on screen.

## Notes

A **BIG** thanks to @daehn and @mikeger for their help! 👍 