### PR TITLE
Remove code for hiding back button

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -680,8 +680,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
         if ([navigationController.topViewController isKindOfClass:GroupDetailsViewController.class]) {
             [(GroupDetailsViewController *)navigationController.topViewController presentParticipantsDetailsWithUsers:self.conversation.sortedOtherParticipants
                                                                                                         selectedUsers:selectedUsers
-                                                                                                             animated:NO
-                                                                                                       hideBackButton:YES];
+                                                                                                             animated:NO];
         }
     }
     [self presentParticipantsViewController:participantsController fromView:sourceView];

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
@@ -144,18 +144,13 @@ import Cartography
         }
     }
     
-    @objc(presentParticipantsDetailsWithUsers:selectedUsers:animated:hideBackButton:)
-    func presentParticipantsDetails(with users: [UserType], selectedUsers: [UserType], animated: Bool, hideBackButton: Bool = false) {
+    @objc(presentParticipantsDetailsWithUsers:selectedUsers:animated:)
+    func presentParticipantsDetails(with users: [UserType], selectedUsers: [UserType], animated: Bool) {
         let detailsViewController = GroupParticipantsDetailViewController(
             participants: users,
             selectedParticipants: selectedUsers,
             conversation: conversation
         )
-
-        // we sometimes present this vc directly from the conversation (when tapping
-        // on system message links). In this case we it doesn't make sense to navigate
-        // "back" to the group details vc.
-        detailsViewController.navigationItem.hidesBackButton = hideBackButton
 
         detailsViewController.delegate = self
         navigationController?.pushViewController(detailsViewController, animated: animated)


### PR DESCRIPTION
## What's new in this PR?

Design removed the back button for the participants detail screen (when opening from the system message link), now they want it back.