### PR TITLE
Feature/conversation overflow alerts

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -98,8 +98,8 @@
 "add_participants.all_contacts_added" = "Everyone’s here.";
 
 "add_participants.alert.title" = "Full house";
-"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
-"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+"add_participants.alert.message.new_conversation" = "Up to %d people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to %1$d people can join a conversation. Currently there is only room for %2$d more people.";
 
 // Contacts UI
 "contacts_ui.search_placeholder" = "Search by name";
@@ -587,7 +587,7 @@
 "participants.section.services" = "Services (%d)";
 "participants.section.settings" = "Options";
 "participants.footer.add_title" = "Add Participants";
-"participants.section.name.footer" = "Up to 300 people can join a group conversation. Video calls work with up to 3 other people and you.";
+"participants.section.name.footer" = "Up to %1$d people can join a group conversation. Video calls work with up to %2$d other people and you.";
 
 // Meta Menu
 "meta.menu.rename" = "Rename";

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -97,6 +97,10 @@
 
 "add_participants.all_contacts_added" = "Everyone’s here.";
 
+"add_participants.alert.title" = "Full house";
+"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+
 // Contacts UI
 "contacts_ui.search_placeholder" = "Search by name";
 "contacts_ui.invite_others" = "Invite others";

--- a/Wire-iOS/Resources/ar.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/ar.lproj/Localizable.strings
@@ -98,8 +98,8 @@
 "add_participants.all_contacts_added" = "الجميع حاضرون.";
 
 "add_participants.alert.title" = "Full house";
-"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
-"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+"add_participants.alert.message.new_conversation" = "Up to %d people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to %1$d people can join a conversation. Currently there is only room for %2$d more people.";
 
 // Contacts UI
 "contacts_ui.search_placeholder" = "البحث بحسب الاسم";
@@ -587,7 +587,7 @@
 "participants.section.services" = "خدمات (%d)";
 "participants.section.settings" = "الخيارات";
 "participants.footer.add_title" = "إضافة مشاركين";
-"participants.section.name.footer" = "Up to 300 people can join a group conversation. Video calls work with up to 3 other people and you.";
+"participants.section.name.footer" = "Up to %1$d people can join a group conversation. Video calls work with up to %2$d other people and you.";
 
 // Meta Menu
 "meta.menu.rename" = "إعادة التّسمية";

--- a/Wire-iOS/Resources/ar.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/ar.lproj/Localizable.strings
@@ -97,6 +97,10 @@
 
 "add_participants.all_contacts_added" = "الجميع حاضرون.";
 
+"add_participants.alert.title" = "Full house";
+"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+
 // Contacts UI
 "contacts_ui.search_placeholder" = "البحث بحسب الاسم";
 "contacts_ui.invite_others" = "ادعُ آخرين";

--- a/Wire-iOS/Resources/da.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/da.lproj/Localizable.strings
@@ -98,8 +98,8 @@
 "add_participants.all_contacts_added" = "Everyone’s here.";
 
 "add_participants.alert.title" = "Full house";
-"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
-"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+"add_participants.alert.message.new_conversation" = "Up to %d people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to %1$d people can join a conversation. Currently there is only room for %2$d more people.";
 
 // Contacts UI
 "contacts_ui.search_placeholder" = "Søg ved navn";
@@ -587,7 +587,7 @@
 "participants.section.services" = "Services (%d)";
 "participants.section.settings" = "Egenskaber";
 "participants.footer.add_title" = "Add Participants";
-"participants.section.name.footer" = "Up to 300 people can join a group conversation. Video calls work with up to 3 other people and you.";
+"participants.section.name.footer" = "Up to %1$d people can join a group conversation. Video calls work with up to %2$d other people and you.";
 
 // Meta Menu
 "meta.menu.rename" = "Omdøb";

--- a/Wire-iOS/Resources/da.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/da.lproj/Localizable.strings
@@ -97,6 +97,10 @@
 
 "add_participants.all_contacts_added" = "Everyone’s here.";
 
+"add_participants.alert.title" = "Full house";
+"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+
 // Contacts UI
 "contacts_ui.search_placeholder" = "Søg ved navn";
 "contacts_ui.invite_others" = "Invitér andre";

--- a/Wire-iOS/Resources/de.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/de.lproj/Localizable.strings
@@ -97,6 +97,10 @@
 
 "add_participants.all_contacts_added" = "Alle sind hier.";
 
+"add_participants.alert.title" = "Full house";
+"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+
 // Contacts UI
 "contacts_ui.search_placeholder" = "Nach Namen suchen";
 "contacts_ui.invite_others" = "Andere einladen";

--- a/Wire-iOS/Resources/de.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/de.lproj/Localizable.strings
@@ -98,8 +98,8 @@
 "add_participants.all_contacts_added" = "Alle sind hier.";
 
 "add_participants.alert.title" = "Full house";
-"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
-"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+"add_participants.alert.message.new_conversation" = "Up to %d people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to %1$d people can join a conversation. Currently there is only room for %2$d more people.";
 
 // Contacts UI
 "contacts_ui.search_placeholder" = "Nach Namen suchen";
@@ -587,7 +587,7 @@
 "participants.section.services" = "Dienste (%d)";
 "participants.section.settings" = "Optionen";
 "participants.footer.add_title" = "Teilnehmer hinzufügen";
-"participants.section.name.footer" = "Bis zu 300 Personen können an einer Unterhaltung teilnehmen. Videoanrufe funktionieren mit bis zu 3 anderen Personen und dir.";
+"participants.section.name.footer" = "Bis zu %1$d Personen können an einer Unterhaltung teilnehmen. Videoanrufe funktionieren mit bis zu %2$d anderen Personen und dir.";
 
 // Meta Menu
 "meta.menu.rename" = "Umbenennen";

--- a/Wire-iOS/Resources/es.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/es.lproj/Localizable.strings
@@ -97,6 +97,10 @@
 
 "add_participants.all_contacts_added" = "Todos están aquí.";
 
+"add_participants.alert.title" = "Full house";
+"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+
 // Contacts UI
 "contacts_ui.search_placeholder" = "Buscar por nombre";
 "contacts_ui.invite_others" = "Invitar a otros";

--- a/Wire-iOS/Resources/es.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/es.lproj/Localizable.strings
@@ -98,8 +98,8 @@
 "add_participants.all_contacts_added" = "Todos están aquí.";
 
 "add_participants.alert.title" = "Full house";
-"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
-"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+"add_participants.alert.message.new_conversation" = "Up to %d people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to %1$d people can join a conversation. Currently there is only room for %2$d more people.";
 
 // Contacts UI
 "contacts_ui.search_placeholder" = "Buscar por nombre";
@@ -587,7 +587,7 @@
 "participants.section.services" = "Services (%d)";
 "participants.section.settings" = "Opciones";
 "participants.footer.add_title" = "Añadir Participantes";
-"participants.section.name.footer" = "Up to 300 people can join a group conversation. Video calls work with up to 3 other people and you.";
+"participants.section.name.footer" = "Up to %1$d people can join a group conversation. Video calls work with up to %2$d other people and you.";
 
 // Meta Menu
 "meta.menu.rename" = "Renombrar";

--- a/Wire-iOS/Resources/et.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/et.lproj/Localizable.strings
@@ -98,8 +98,8 @@
 "add_participants.all_contacts_added" = "Kõik on siin.";
 
 "add_participants.alert.title" = "Full house";
-"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
-"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+"add_participants.alert.message.new_conversation" = "Up to %d people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to %1$d people can join a conversation. Currently there is only room for %2$d more people.";
 
 // Contacts UI
 "contacts_ui.search_placeholder" = "Otsi nime järgi";
@@ -587,7 +587,7 @@
 "participants.section.services" = "Teenused (%d)";
 "participants.section.settings" = "Seaded";
 "participants.footer.add_title" = "Lisa osalejaid";
-"participants.section.name.footer" = "Up to 300 people can join a group conversation. Video calls work with up to 3 other people and you.";
+"participants.section.name.footer" = "Up to %1$d people can join a group conversation. Video calls work with up to %2$d other people and you.";
 
 // Meta Menu
 "meta.menu.rename" = "Nimeta ümber";

--- a/Wire-iOS/Resources/et.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/et.lproj/Localizable.strings
@@ -97,6 +97,10 @@
 
 "add_participants.all_contacts_added" = "Kõik on siin.";
 
+"add_participants.alert.title" = "Full house";
+"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+
 // Contacts UI
 "contacts_ui.search_placeholder" = "Otsi nime järgi";
 "contacts_ui.invite_others" = "Kutsu teisi";

--- a/Wire-iOS/Resources/fi.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/fi.lproj/Localizable.strings
@@ -98,8 +98,8 @@
 "add_participants.all_contacts_added" = "Everyone’s here.";
 
 "add_participants.alert.title" = "Full house";
-"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
-"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+"add_participants.alert.message.new_conversation" = "Up to %d people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to %1$d people can join a conversation. Currently there is only room for %2$d more people.";
 
 // Contacts UI
 "contacts_ui.search_placeholder" = "Hae nimellä";
@@ -587,7 +587,7 @@
 "participants.section.services" = "Services (%d)";
 "participants.section.settings" = "Valinnat";
 "participants.footer.add_title" = "Add Participants";
-"participants.section.name.footer" = "Up to 300 people can join a group conversation. Video calls work with up to 3 other people and you.";
+"participants.section.name.footer" = "Up to %1$d people can join a group conversation. Video calls work with up to %2$d other people and you.";
 
 // Meta Menu
 "meta.menu.rename" = "Nimeä uudelleen";

--- a/Wire-iOS/Resources/fi.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/fi.lproj/Localizable.strings
@@ -97,6 +97,10 @@
 
 "add_participants.all_contacts_added" = "Everyone’s here.";
 
+"add_participants.alert.title" = "Full house";
+"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+
 // Contacts UI
 "contacts_ui.search_placeholder" = "Hae nimellä";
 "contacts_ui.invite_others" = "Kutsu muita";

--- a/Wire-iOS/Resources/fr.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/fr.lproj/Localizable.strings
@@ -98,8 +98,8 @@
 "add_participants.all_contacts_added" = "Tout le monde est là.";
 
 "add_participants.alert.title" = "Full house";
-"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
-"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+"add_participants.alert.message.new_conversation" = "Up to %d people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to %1$d people can join a conversation. Currently there is only room for %2$d more people.";
 
 // Contacts UI
 "contacts_ui.search_placeholder" = "Cherchez par nom";
@@ -587,7 +587,7 @@
 "participants.section.services" = "Services (%d)";
 "participants.section.settings" = "Options";
 "participants.footer.add_title" = "Ajouter des contacts";
-"participants.section.name.footer" = "Les conversations de groupe peuvent contenir jusqu'à 300 personnes. Les appels vidéos fonctionnent avec jusqu'à trois destinataires.";
+"participants.section.name.footer" = "Up to %1$d people can join a group conversation. Video calls work with up to %2$d other people and you.";
 
 // Meta Menu
 "meta.menu.rename" = "Renommer";

--- a/Wire-iOS/Resources/fr.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/fr.lproj/Localizable.strings
@@ -97,6 +97,10 @@
 
 "add_participants.all_contacts_added" = "Tout le monde est là.";
 
+"add_participants.alert.title" = "Full house";
+"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+
 // Contacts UI
 "contacts_ui.search_placeholder" = "Cherchez par nom";
 "contacts_ui.invite_others" = "Invitez d’autres personnes";

--- a/Wire-iOS/Resources/it.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/it.lproj/Localizable.strings
@@ -98,8 +98,8 @@
 "add_participants.all_contacts_added" = "Everyone’s here.";
 
 "add_participants.alert.title" = "Full house";
-"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
-"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+"add_participants.alert.message.new_conversation" = "Up to %d people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to %1$d people can join a conversation. Currently there is only room for %2$d more people.";
 
 // Contacts UI
 "contacts_ui.search_placeholder" = "Cerca per nome";
@@ -587,7 +587,7 @@
 "participants.section.services" = "Servizi (%d)";
 "participants.section.settings" = "Opzioni";
 "participants.footer.add_title" = "Aggiungi partecipanti";
-"participants.section.name.footer" = "Up to 300 people can join a group conversation. Video calls work with up to 3 other people and you.";
+"participants.section.name.footer" = "Up to %1$d people can join a group conversation. Video calls work with up to %2$d other people and you.";
 
 // Meta Menu
 "meta.menu.rename" = "Rinomina";

--- a/Wire-iOS/Resources/it.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/it.lproj/Localizable.strings
@@ -97,6 +97,10 @@
 
 "add_participants.all_contacts_added" = "Everyone’s here.";
 
+"add_participants.alert.title" = "Full house";
+"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+
 // Contacts UI
 "contacts_ui.search_placeholder" = "Cerca per nome";
 "contacts_ui.invite_others" = "Invita altri";

--- a/Wire-iOS/Resources/ja.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/ja.lproj/Localizable.strings
@@ -98,8 +98,8 @@
 "add_participants.all_contacts_added" = "Everyone’s here.";
 
 "add_participants.alert.title" = "Full house";
-"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
-"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+"add_participants.alert.message.new_conversation" = "Up to %d people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to %1$d people can join a conversation. Currently there is only room for %2$d more people.";
 
 // Contacts UI
 "contacts_ui.search_placeholder" = "名前で検索します";
@@ -587,7 +587,7 @@
 "participants.section.services" = "サービス (%d)";
 "participants.section.settings" = "オプション";
 "participants.footer.add_title" = "参加者を追加";
-"participants.section.name.footer" = "Up to 300 people can join a group conversation. Video calls work with up to 3 other people and you.";
+"participants.section.name.footer" = "Up to %1$d people can join a group conversation. Video calls work with up to %2$d other people and you.";
 
 // Meta Menu
 "meta.menu.rename" = "名前の変更";

--- a/Wire-iOS/Resources/ja.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/ja.lproj/Localizable.strings
@@ -97,6 +97,10 @@
 
 "add_participants.all_contacts_added" = "Everyone’s here.";
 
+"add_participants.alert.title" = "Full house";
+"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+
 // Contacts UI
 "contacts_ui.search_placeholder" = "名前で検索します";
 "contacts_ui.invite_others" = "他の人を招待します";

--- a/Wire-iOS/Resources/lt.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/lt.lproj/Localizable.strings
@@ -98,8 +98,8 @@
 "add_participants.all_contacts_added" = "Visi jau čia.";
 
 "add_participants.alert.title" = "Full house";
-"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
-"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+"add_participants.alert.message.new_conversation" = "Up to %d people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to %1$d people can join a conversation. Currently there is only room for %2$d more people.";
 
 // Contacts UI
 "contacts_ui.search_placeholder" = "Ieškokite pagal vardą";
@@ -587,7 +587,7 @@
 "participants.section.services" = "Paslaugos (%d)";
 "participants.section.settings" = "Parinktys";
 "participants.footer.add_title" = "Pridėti dalyvių";
-"participants.section.name.footer" = "Up to 300 people can join a group conversation. Video calls work with up to 3 other people and you.";
+"participants.section.name.footer" = "Up to %1$d people can join a group conversation. Video calls work with up to %2$d other people and you.";
 
 // Meta Menu
 "meta.menu.rename" = "Pervadinti";

--- a/Wire-iOS/Resources/lt.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/lt.lproj/Localizable.strings
@@ -97,6 +97,10 @@
 
 "add_participants.all_contacts_added" = "Visi jau čia.";
 
+"add_participants.alert.title" = "Full house";
+"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+
 // Contacts UI
 "contacts_ui.search_placeholder" = "Ieškokite pagal vardą";
 "contacts_ui.invite_others" = "Pakviesti kitus";

--- a/Wire-iOS/Resources/nl.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/nl.lproj/Localizable.strings
@@ -98,8 +98,8 @@
 "add_participants.all_contacts_added" = "Iedereen is hier.";
 
 "add_participants.alert.title" = "Full house";
-"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
-"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+"add_participants.alert.message.new_conversation" = "Up to %d people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to %1$d people can join a conversation. Currently there is only room for %2$d more people.";
 
 // Contacts UI
 "contacts_ui.search_placeholder" = "Zoeken op naam";
@@ -587,7 +587,7 @@
 "participants.section.services" = "Services (%d)";
 "participants.section.settings" = "Opties";
 "participants.footer.add_title" = "Deelnemers toevoegen";
-"participants.section.name.footer" = "Up to 300 people can join a group conversation. Video calls work with up to 3 other people and you.";
+"participants.section.name.footer" = "Up to %1$d people can join a group conversation. Video calls work with up to %2$d other people and you.";
 
 // Meta Menu
 "meta.menu.rename" = "Wijzig naam";

--- a/Wire-iOS/Resources/nl.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/nl.lproj/Localizable.strings
@@ -97,6 +97,10 @@
 
 "add_participants.all_contacts_added" = "Iedereen is hier.";
 
+"add_participants.alert.title" = "Full house";
+"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+
 // Contacts UI
 "contacts_ui.search_placeholder" = "Zoeken op naam";
 "contacts_ui.invite_others" = "Nodig anderen uit";

--- a/Wire-iOS/Resources/pl.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/pl.lproj/Localizable.strings
@@ -97,6 +97,10 @@
 
 "add_participants.all_contacts_added" = "Everyone’s here.";
 
+"add_participants.alert.title" = "Full house";
+"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+
 // Contacts UI
 "contacts_ui.search_placeholder" = "Szukaj według nazwy";
 "contacts_ui.invite_others" = "Zaproś inne osoby";

--- a/Wire-iOS/Resources/pl.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/pl.lproj/Localizable.strings
@@ -98,8 +98,8 @@
 "add_participants.all_contacts_added" = "Everyone’s here.";
 
 "add_participants.alert.title" = "Full house";
-"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
-"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+"add_participants.alert.message.new_conversation" = "Up to %d people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to %1$d people can join a conversation. Currently there is only room for %2$d more people.";
 
 // Contacts UI
 "contacts_ui.search_placeholder" = "Szukaj według nazwy";
@@ -587,7 +587,7 @@
 "participants.section.services" = "Services (%d)";
 "participants.section.settings" = "Opcje";
 "participants.footer.add_title" = "Add Participants";
-"participants.section.name.footer" = "Up to 300 people can join a group conversation. Video calls work with up to 3 other people and you.";
+"participants.section.name.footer" = "Up to %1$d people can join a group conversation. Video calls work with up to %2$d other people and you.";
 
 // Meta Menu
 "meta.menu.rename" = "Zmień nazwę";

--- a/Wire-iOS/Resources/pt-BR.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/pt-BR.lproj/Localizable.strings
@@ -98,8 +98,8 @@
 "add_participants.all_contacts_added" = "Todo mundo está aqui.";
 
 "add_participants.alert.title" = "Full house";
-"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
-"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+"add_participants.alert.message.new_conversation" = "Up to %d people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to %1$d people can join a conversation. Currently there is only room for %2$d more people.";
 
 // Contacts UI
 "contacts_ui.search_placeholder" = "Pesquisar por nome";
@@ -587,7 +587,7 @@
 "participants.section.services" = "Serviços (%d)";
 "participants.section.settings" = "Opções";
 "participants.footer.add_title" = "Adicionar Participantes";
-"participants.section.name.footer" = "Up to 300 people can join a group conversation. Video calls work with up to 3 other people and you.";
+"participants.section.name.footer" = "Up to %1$d people can join a group conversation. Video calls work with up to %2$d other people and you.";
 
 // Meta Menu
 "meta.menu.rename" = "Renomear";

--- a/Wire-iOS/Resources/pt-BR.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/pt-BR.lproj/Localizable.strings
@@ -97,6 +97,10 @@
 
 "add_participants.all_contacts_added" = "Todo mundo está aqui.";
 
+"add_participants.alert.title" = "Full house";
+"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+
 // Contacts UI
 "contacts_ui.search_placeholder" = "Pesquisar por nome";
 "contacts_ui.invite_others" = "Convidar outras pessoas";

--- a/Wire-iOS/Resources/ru.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/ru.lproj/Localizable.strings
@@ -97,6 +97,10 @@
 
 "add_participants.all_contacts_added" = "Все пользователи добавлены.";
 
+"add_participants.alert.title" = "Full house";
+"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+
 // Contacts UI
 "contacts_ui.search_placeholder" = "Поиск по имени";
 "contacts_ui.invite_others" = "Пригласить еще";

--- a/Wire-iOS/Resources/ru.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/ru.lproj/Localizable.strings
@@ -98,8 +98,8 @@
 "add_participants.all_contacts_added" = "Все пользователи добавлены.";
 
 "add_participants.alert.title" = "Full house";
-"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
-"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+"add_participants.alert.message.new_conversation" = "Up to %d people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to %1$d people can join a conversation. Currently there is only room for %2$d more people.";
 
 // Contacts UI
 "contacts_ui.search_placeholder" = "Поиск по имени";
@@ -587,7 +587,7 @@
 "participants.section.services" = "Сервисов (%d)";
 "participants.section.settings" = "Настройки";
 "participants.footer.add_title" = "Добавить участников";
-"participants.section.name.footer" = "К групповому разговору может присоединиться до 300 человек. Видеозвонки возможны между вами и еще тремя участниками.";
+"participants.section.name.footer" = "Up to %1$d people can join a group conversation. Video calls work with up to %2$d other people and you.";
 
 // Meta Menu
 "meta.menu.rename" = "Переименовать";

--- a/Wire-iOS/Resources/sl.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/sl.lproj/Localizable.strings
@@ -98,8 +98,8 @@
 "add_participants.all_contacts_added" = "Everyone’s here.";
 
 "add_participants.alert.title" = "Full house";
-"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
-"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+"add_participants.alert.message.new_conversation" = "Up to %d people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to %1$d people can join a conversation. Currently there is only room for %2$d more people.";
 
 // Contacts UI
 "contacts_ui.search_placeholder" = "Iskanje po imenu";
@@ -587,7 +587,7 @@
 "participants.section.services" = "Services (%d)";
 "participants.section.settings" = "Možnosti";
 "participants.footer.add_title" = "Add Participants";
-"participants.section.name.footer" = "Up to 300 people can join a group conversation. Video calls work with up to 3 other people and you.";
+"participants.section.name.footer" = "Up to %1$d people can join a group conversation. Video calls work with up to %2$d other people and you.";
 
 // Meta Menu
 "meta.menu.rename" = "Preimenuj";

--- a/Wire-iOS/Resources/sl.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/sl.lproj/Localizable.strings
@@ -97,6 +97,10 @@
 
 "add_participants.all_contacts_added" = "Everyone’s here.";
 
+"add_participants.alert.title" = "Full house";
+"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+
 // Contacts UI
 "contacts_ui.search_placeholder" = "Iskanje po imenu";
 "contacts_ui.invite_others" = "Povabi druge";

--- a/Wire-iOS/Resources/tr.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/tr.lproj/Localizable.strings
@@ -97,6 +97,10 @@
 
 "add_participants.all_contacts_added" = "Everyone’s here.";
 
+"add_participants.alert.title" = "Full house";
+"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+
 // Contacts UI
 "contacts_ui.search_placeholder" = "İsme göre ara";
 "contacts_ui.invite_others" = "Başkalarını davet et";

--- a/Wire-iOS/Resources/tr.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/tr.lproj/Localizable.strings
@@ -98,8 +98,8 @@
 "add_participants.all_contacts_added" = "Everyone’s here.";
 
 "add_participants.alert.title" = "Full house";
-"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
-"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+"add_participants.alert.message.new_conversation" = "Up to %d people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to %1$d people can join a conversation. Currently there is only room for %2$d more people.";
 
 // Contacts UI
 "contacts_ui.search_placeholder" = "İsme göre ara";
@@ -587,7 +587,7 @@
 "participants.section.services" = "Services (%d)";
 "participants.section.settings" = "Seçenekler";
 "participants.footer.add_title" = "Add Participants";
-"participants.section.name.footer" = "Up to 300 people can join a group conversation. Video calls work with up to 3 other people and you.";
+"participants.section.name.footer" = "Up to %1$d people can join a group conversation. Video calls work with up to %2$d other people and you.";
 
 // Meta Menu
 "meta.menu.rename" = "Yeniden adlandır";

--- a/Wire-iOS/Resources/uk.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/uk.lproj/Localizable.strings
@@ -98,8 +98,8 @@
 "add_participants.all_contacts_added" = "Всі вже тут.";
 
 "add_participants.alert.title" = "Full house";
-"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
-"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+"add_participants.alert.message.new_conversation" = "Up to %d people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to %1$d people can join a conversation. Currently there is only room for %2$d more people.";
 
 // Contacts UI
 "contacts_ui.search_placeholder" = "Пошук за іменем";
@@ -587,7 +587,7 @@
 "participants.section.services" = "Сервіси (%d)";
 "participants.section.settings" = "Налаштування";
 "participants.footer.add_title" = "Додати учасників";
-"participants.section.name.footer" = "Up to 300 people can join a group conversation. Video calls work with up to 3 other people and you.";
+"participants.section.name.footer" = "Up to %1$d people can join a group conversation. Video calls work with up to %2$d other people and you.";
 
 // Meta Menu
 "meta.menu.rename" = "Перейменувати";

--- a/Wire-iOS/Resources/uk.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/uk.lproj/Localizable.strings
@@ -97,6 +97,10 @@
 
 "add_participants.all_contacts_added" = "Всі вже тут.";
 
+"add_participants.alert.title" = "Full house";
+"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+
 // Contacts UI
 "contacts_ui.search_placeholder" = "Пошук за іменем";
 "contacts_ui.invite_others" = "Запросити інших користувачів";

--- a/Wire-iOS/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/zh-Hans.lproj/Localizable.strings
@@ -98,8 +98,8 @@
 "add_participants.all_contacts_added" = "所有用户已加入群聊";
 
 "add_participants.alert.title" = "Full house";
-"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
-"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+"add_participants.alert.message.new_conversation" = "Up to %d people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to %1$d people can join a conversation. Currently there is only room for %2$d more people.";
 
 // Contacts UI
 "contacts_ui.search_placeholder" = "按名称搜索";
@@ -587,7 +587,7 @@
 "participants.section.services" = "服务 (%d)";
 "participants.section.settings" = "选项";
 "participants.footer.add_title" = "添加参与者";
-"participants.section.name.footer" = "Up to 300 people can join a group conversation. Video calls work with up to 3 other people and you.";
+"participants.section.name.footer" = "Up to %1$d people can join a group conversation. Video calls work with up to %2$d other people and you.";
 
 // Meta Menu
 "meta.menu.rename" = "重新命名";

--- a/Wire-iOS/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/zh-Hans.lproj/Localizable.strings
@@ -97,6 +97,10 @@
 
 "add_participants.all_contacts_added" = "所有用户已加入群聊";
 
+"add_participants.alert.title" = "Full house";
+"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+
 // Contacts UI
 "contacts_ui.search_placeholder" = "按名称搜索";
 "contacts_ui.invite_others" = "邀请其他人";

--- a/Wire-iOS/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/zh-Hant.lproj/Localizable.strings
@@ -98,8 +98,8 @@
 "add_participants.all_contacts_added" = "大家都已加入";
 
 "add_participants.alert.title" = "Full house";
-"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
-"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+"add_participants.alert.message.new_conversation" = "Up to %d people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to %1$d people can join a conversation. Currently there is only room for %2$d more people.";
 
 // Contacts UI
 "contacts_ui.search_placeholder" = "按名稱搜尋";
@@ -587,7 +587,7 @@
 "participants.section.services" = "服務 (%d)";
 "participants.section.settings" = "選項";
 "participants.footer.add_title" = "加入參與者";
-"participants.section.name.footer" = "Up to 300 people can join a group conversation. Video calls work with up to 3 other people and you.";
+"participants.section.name.footer" = "Up to %1$d people can join a group conversation. Video calls work with up to %2$d other people and you.";
 
 // Meta Menu
 "meta.menu.rename" = "重新命名";

--- a/Wire-iOS/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/zh-Hant.lproj/Localizable.strings
@@ -97,6 +97,10 @@
 
 "add_participants.all_contacts_added" = "大家都已加入";
 
+"add_participants.alert.title" = "Full house";
+"add_participants.alert.message.new_conversation" = "Up to 300 people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to 300 people can join a conversation. Currently there is only room for %@ more people.";
+
 // Contacts UI
 "contacts_ui.search_placeholder" = "按名稱搜尋";
 "contacts_ui.invite_others" = "邀請其他人";

--- a/Wire-iOS/Sources/Helpers/syncengine/Conversation+Participants.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/Conversation+Participants.swift
@@ -28,8 +28,12 @@ extension ZMConversation {
     
     @objc static let maxParticipants: Int = 300
     
-    @objc static var maxParticipantsWithSelf: Int {
+    @objc static var maxParticipantsExcludingSelf: Int {
         return maxParticipants - 1
+    }
+    
+    @objc static var maxVideoCallParticipantsExcludingSelf: Int {
+        return maxVideoCallParticipants - 1
     }
     
     @objc var freeParticipantSlots: Int {

--- a/Wire-iOS/Sources/Helpers/syncengine/Conversation+Participants.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/Conversation+Participants.swift
@@ -24,6 +24,18 @@ extension ZMConversation {
         case offline
     }
     
+    @objc static let maxVideoCallParticipants: Int = 4
+    
+    @objc static let maxParticipants: Int = 300
+    
+    @objc static var maxParticipantsWithSelf: Int {
+        return maxParticipants - 1
+    }
+    
+    @objc var freeParticipantSlots: Int {
+        return type(of: self).maxParticipants - activeParticipants.count
+    }
+    
     @objc(addParticipantsOrShowError:)
     func addOrShowError(participants: Set<ZMUser>) {
         guard let session = ZMUserSession.shared(),

--- a/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
@@ -54,6 +54,35 @@ extension AddParticipantsViewController.Context {
             return creationValues.allowGuests
         }
     }
+    
+    var selectionLimit: Int {
+        switch self {
+        case .add(let conversation):
+            return conversation.freeParticipantSlots
+        case .create:
+            return ZMConversation.maxParticipantsWithSelf
+        }
+    }
+    
+    var alertForSelectionOverflow: UIAlertController {
+        let message: String
+        switch self {
+        case .add(let conversation):
+            let freeSpace = String(conversation.freeParticipantSlots)
+            message = "add_participants.alert.message.existing_conversation".localized(args: freeSpace)
+        case .create(_):
+            message = "add_participants.alert.message.new_conversation".localized
+        }
+        
+        let controller = UIAlertController(
+            title: "add_participants.alert.title".localized,
+            message: message,
+            preferredStyle: .alert
+        )
+        
+        controller.addAction(.ok())
+        return controller
+    }
 }
 
 public class AddParticipantsViewController: UIViewController {
@@ -144,6 +173,11 @@ public class AddParticipantsViewController: UIViewController {
                                                                   shouldIncludeGuests: viewModel.context.includeGuests)
 
         super.init(nibName: nil, bundle: nil)
+        
+        userSelection.setLimit(context.selectionLimit) {
+            self.present(context.alertForSelectionOverflow, animated: true)
+        }
+        
         updateValues()
 
         emptyResultLabel.text = everyoneHasBeenAddedText

--- a/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
@@ -60,7 +60,7 @@ extension AddParticipantsViewController.Context {
         case .add(let conversation):
             return conversation.freeParticipantSlots
         case .create:
-            return ZMConversation.maxParticipantsWithSelf
+            return ZMConversation.maxParticipantsExcludingSelf
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
@@ -65,13 +65,14 @@ extension AddParticipantsViewController.Context {
     }
     
     var alertForSelectionOverflow: UIAlertController {
+        let max = ZMConversation.maxParticipants
         let message: String
         switch self {
         case .add(let conversation):
-            let freeSpace = String(conversation.freeParticipantSlots)
-            message = "add_participants.alert.message.existing_conversation".localized(args: freeSpace)
+            let freeSpace = conversation.freeParticipantSlots
+            message = "add_participants.alert.message.existing_conversation".localized(args: max, freeSpace)
         case .create(_):
-            message = "add_participants.alert.message.new_conversation".localized
+            message = "add_participants.alert.message.new_conversation".localized(args: max)
         }
         
         let controller = UIAlertController(

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/SectionCollectionViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/SectionCollectionViewController.swift
@@ -63,6 +63,10 @@ class SectionCollectionViewController: NSObject {
 
 extension SectionCollectionViewController: UICollectionViewDelegate {
     
+    func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
+        return visibleSections[indexPath.section].collectionView?(collectionView, shouldSelectItemAt: indexPath) ?? true
+    }
+    
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         visibleSections[indexPath.section].collectionView?(collectionView, didSelectItemAt: indexPath)
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
@@ -252,8 +252,6 @@ extension ZMConversation {
         default: return false
         }
     }
-    
-    @objc static let maxVideoCallParticipants: Int = 4
 
     var canStartVideoCall: Bool {
         guard !isCallOngoing else { return false }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
@@ -152,7 +152,7 @@ final public class ConversationCreationValues {
         }
         
         toggleSubtitleLabel.text = "conversation.create.toggle.subtitle".localized
-        textFieldSubtitleLabel.text = "participants.section.name.footer".localized
+        textFieldSubtitleLabel.text = "participants.section.name.footer".localized(args: ZMConversation.maxParticipants, ZMConversation.maxVideoCallParticipantsExcludingSelf)
         
         [toggleView, toggleSubtitleLabel].forEach(bottomViewContainer.addSubview)
         [mainViewContainer, errorViewContainer, bottomViewContainer].forEach(view.addSubview)

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsFooterView.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsFooterView.swift
@@ -50,8 +50,10 @@ final class GroupDetailsFooterView: UIView {
             $0.translatesAutoresizingMaskIntoConstraints = false
             $0.setIconColor(UIColor(scheme: .iconNormal), for: .normal)
             $0.setIconColor(UIColor(scheme: .iconHighlighted), for: .highlighted)
+            $0.setIconColor(UIColor(scheme: .buttonFaded), for: .disabled)
             $0.setTitleColor(UIColor(scheme: .iconNormal), for: .normal)
             $0.setTitleColor(UIColor(scheme: .textDimmed), for: .highlighted)
+            $0.setTitleColor(UIColor(scheme: .buttonFaded), for: .disabled)
             $0.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
         }
         
@@ -88,5 +90,10 @@ final class GroupDetailsFooterView: UIView {
         case addButton: return .invite
         default: return nil
         }
+    }
+    
+    func update(for conversation: ZMConversation) {
+        addButton.isHidden = ZMUser.selfUser().isGuest(in: conversation)
+        addButton.isEnabled = conversation.freeParticipantSlots > 0
     }
 }

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
@@ -94,7 +94,7 @@ import Cartography
         
         collectionViewController.collectionView = collectionView
         footerView.delegate = self
-        footerView.addButton.isHidden = ZMUser.selfUser().isGuest(in: conversation)
+        footerView.update(for: conversation)
         collectionViewController.sections = computeVisibleSections()
     }
     
@@ -129,6 +129,7 @@ import Cartography
     func conversationDidChange(_ changeInfo: ConversationChangeInfo) {
         guard changeInfo.participantsChanged || changeInfo.nameChanged || changeInfo.allowGuestsChanged || changeInfo.destructionTimeoutChanged else { return }
         collectionViewController.sections = computeVisibleSections()
+        footerView.update(for: conversation)
     }
     
     func detailsView(_ view: GroupDetailsFooterView, performAction action: GroupDetailsFooterView.Action) {

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/RenameGroupSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/RenameGroupSectionController.swift
@@ -62,7 +62,7 @@ class RenameGroupSectionController: NSObject, CollectionViewSectionController {
     
     func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
         let view = collectionView.dequeueReusableSupplementaryView(ofKind: UICollectionElementKindSectionFooter, withReuseIdentifier: "SectionFooter", for: indexPath)
-        (view as? SectionFooter)?.titleLabel.text = "participants.section.name.footer".localized
+        (view as? SectionFooter)?.titleLabel.text = "participants.section.name.footer".localized(args: ZMConversation.maxParticipants, ZMConversation.maxVideoCallParticipantsExcludingSelf)
         return view
     }
     

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/Contacts/ContactsSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/Contacts/ContactsSectionController.swift
@@ -80,6 +80,10 @@ class ContactsSectionController : SearchSectionController {
         return cell
     }
     
+    func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
+        return !(selection?.hasReachedLimit ?? false)
+    }
+    
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let user = contacts[indexPath.row]
         selection?.add(user)

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/UserSelection.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/UserSelection.swift
@@ -63,4 +63,19 @@ public class UserSelection : NSObject {
         observers.remove(at: index)
     }
     
+    // MARK: - Limit
+    
+    public private(set) var limit: Int?
+    private var limitReachedHandler: (() -> Void)?
+    
+    public var hasReachedLimit: Bool {
+        guard let limit = limit, users.count >= limit else { return false }
+        limitReachedHandler?()
+        return true
+    }
+    
+    public func setLimit(_ limit: Int, handler: @escaping () -> Void) {
+        self.limit = limit
+        self.limitReachedHandler = handler
+    }
 }


### PR DESCRIPTION
## What's new in this PR?

This PR provides changes for dealing with participant overflow when creating a conversation and adding users to an existing conversation. These are:

1. When selecting participants for a new conversation, it is only possible to select 299 (other) participants. Selecting the 300th participant presents an alert.
2. When adding participants to an existing conversation, it is only possible to select `x` participants, where x is the number of remaining free spaces in the conversation. Selecting the `(x + 1)`'th participant also shows the alert.
3. If the conversation is full, the *add participants* button in the group details screen is disabled.