### PR TITLE
Don't provide haptic feedback when user changes in AvailabilityTitleView

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Availability/AvailabilityTitleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Availability/AvailabilityTitleView.swift
@@ -116,7 +116,6 @@ extension AvailabilityTitleView: ZMUserObserver {
     public func userDidChange(_ changeInfo: UserChangeInfo) {
         guard changeInfo.availabilityChanged || changeInfo.nameChanged,
             let user = changeInfo.user as? ZMUser else { return }
-        provideHapticFeedback()
         configure(user: user)
     }
 }
@@ -141,6 +140,7 @@ extension AvailabilityTitleView {
         ZMUserSession.shared()?.performChanges { [weak self] in
             ZMUser.selfUser().availability = availability
             self?.trackChanges(with: availability)
+            self?.provideHapticFeedback()
         }
     }
     


### PR DESCRIPTION
## What's new in this PR?

* There was an issue in which haptic feedback was provided when opening the user details for specific users.
* We were providing haptic feedback when the user changes in `AvailabilityTitleView`, which is not as designed. We should only provide feedback if the self user changes their status, not when the status of any user changes (which will happen when we show the status initially).
