### PR TITLE
Fix: Audio recorder overlay is shown on top of calling overlay if I accept the second call

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Audio.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Audio.swift
@@ -239,7 +239,7 @@ extension ConversationInputBarViewController: WireCallCenterCallStateObserver {
               let rightViewController = splitViewController.rightViewController,
               splitViewController.isRightViewControllerRevealed,
               rightViewController.isVisible,
-              UIApplication.shared.topMostWindow == AppDelegate.shared().window
+              UIApplication.shared.topMostVisibleWindow == AppDelegate.shared().window
             else { return }
 
         self.wasRecordingBeforeCall = false

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Audio.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Audio.swift
@@ -238,7 +238,9 @@ extension ConversationInputBarViewController: WireCallCenterCallStateObserver {
         guard let splitViewController = self.wr_splitViewController,
               let rightViewController = splitViewController.rightViewController,
               splitViewController.isRightViewControllerRevealed,
-              rightViewController.isVisible else { return }
+              rightViewController.isVisible,
+              UIApplication.shared.topMostWindow == AppDelegate.shared().window
+            else { return }
 
         self.wasRecordingBeforeCall = false
         self.mode = .audioRecord

--- a/Wire-iOS/Sources/UserInterface/Helpers/UIApplication+StatusBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UIApplication+StatusBar.swift
@@ -60,12 +60,12 @@ public extension UIApplication {
     @objc func wr_topmostViewController() -> UIViewController? {
         return wr_topmostController()
     }
-    
-    public func wr_topmostController(onlyFullScreen: Bool = true) -> UIViewController? {
+
+    public var topMostWindow: UIWindow? {
         let orderedWindows = self.windows.sorted { win1, win2 in
             win1.windowLevel < win2.windowLevel
         }
-        
+
         let visibleWindow = orderedWindows.filter {
             guard let controller = $0.rootViewController else {
                 return false
@@ -79,8 +79,13 @@ public extension UIApplication {
                 return false
             }
         }
-        
-        guard let window = visibleWindow.last,
+
+        return visibleWindow.last
+    }
+    
+    public func wr_topmostController(onlyFullScreen: Bool = true) -> UIViewController? {
+
+        guard let window = topMostWindow,
             var topController = window.rootViewController else {
                 return .none
         }

--- a/Wire-iOS/Sources/UserInterface/Helpers/UIApplication+StatusBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UIApplication+StatusBar.swift
@@ -61,7 +61,12 @@ public extension UIApplication {
         return wr_topmostController()
     }
 
-    public var topMostWindow: UIWindow? {
+
+    /// return the visible window on the top most which fulfills these conditions:
+    /// 1. the windows has rootViewController
+    /// 2. CallWindowRootViewController is in use and voice channel controller is active
+    /// 3. the window's rootViewController is AppRootViewController
+    public var topMostVisibleWindow: UIWindow? {
         let orderedWindows = self.windows.sorted { win1, win2 in
             win1.windowLevel < win2.windowLevel
         }
@@ -85,7 +90,7 @@ public extension UIApplication {
     
     public func wr_topmostController(onlyFullScreen: Bool = true) -> UIViewController? {
 
-        guard let window = topMostWindow,
+        guard let window = topMostVisibleWindow,
             var topController = window.rootViewController else {
                 return .none
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Audio keyboard reveals over the call window.

### Causes

When the call terminates, missing a checking for mainWindow is the top window or not before restoring audio keyboard.

### Solutions

Add the checking for the current top window is the main window before revealing the keyboard.