### PR TITLE
Fix call icons disappearing in blocked 1-1 conversations

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
@@ -100,7 +100,7 @@ public extension ConversationViewController {
     }
 
     @objc public func rightNavigationItems(forConversation conversation: ZMConversation) -> [UIBarButtonItem] {
-        guard !conversation.isReadOnly, conversation.lastServerSyncedActiveParticipants.count != 0 else { return [] }
+        guard !conversation.isReadOnly, conversation.activeParticipants.count != 0 else { return [] }
 
         if conversation.canJoinCall {
             return [joinCallButton]


### PR DESCRIPTION
## What's new in this PR?

* Fix call icons disappearing in 1-1 conversation in which the connected user blocked you.