### PR TITLE
ZIOS-10391: Increase video and audio duration limits for team accounts

### DIFF
--- a/Wire-iOS/Sources/Helpers/syncengine/ZMUserSession+iOS.h
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMUserSession+iOS.h
@@ -25,5 +25,7 @@ extern NSString * __nonnull const UserSessionDidRequestAuthenticationNotificatio
 
 + (instancetype __nullable)sharedSession;
 - (unsigned long long)maxUploadFileSize;
+- (NSTimeInterval)maxAudioLength;
+- (NSTimeInterval)maxVideoLength;
 
 @end

--- a/Wire-iOS/Sources/Helpers/syncengine/ZMUserSession+iOS.m
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMUserSession+iOS.m
@@ -22,8 +22,11 @@
 #import "Wire-Swift.h"
 
 const static unsigned long long MaxFileSize = 25 * 1024 * 1024; // 25 megabytes
-
 const static unsigned long long MaxTeamFileSize = 100 * 1024 * 1024; // 100 megabytes
+const static NSTimeInterval MaxAudioLength = 25 * 60.0f; // 25 minutes
+const static NSTimeInterval MaxTeamAudioLength = 100 * 60.0f; // 100 minutes
+const static NSTimeInterval MaxVideoLength = 4.0f * 60.0f; // 4 minutes
+const static NSTimeInterval MaxTeamVideoLength = 4.0f * 60.0f; // 16 minutes
 
 @implementation ZMUserSession (iOS)
 
@@ -37,9 +40,28 @@ const static unsigned long long MaxTeamFileSize = 100 * 1024 * 1024; // 100 mega
     ZMUser *selfUser = [ZMUser selfUserInUserSession:self];
     if (selfUser.hasTeam) {
         return MaxTeamFileSize;
-    }
-    else {
+    } else {
         return MaxFileSize;
+    }
+}
+
+- (NSTimeInterval)maxAudioLength
+{
+    ZMUser *selfUser = [ZMUser selfUserInUserSession:self];
+    if (selfUser.hasTeam) {
+        return MaxTeamAudioLength;
+    } else {
+        return MaxAudioLength;
+    }
+}
+
+- (NSTimeInterval)maxVideoLength
+{
+    ZMUser *selfUser = [ZMUser selfUserInUserSession:self];
+    if (selfUser.hasTeam) {
+        return MaxTeamVideoLength;
+    } else {
+        return MaxVideoLength;
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Components/CameraPicker.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/CameraPicker.swift
@@ -57,7 +57,7 @@ final public class CameraPicker: NSObject {
         pickerController.delegate = self
         pickerController.allowsEditing = false
         pickerController.mediaTypes = [kUTTypeImage as String, kUTTypeMovie as String]
-        pickerController.videoMaximumDuration = ConversationUploadMaxVideoDuration
+        pickerController.videoMaximumDuration = ZMUserSession.shared()!.maxVideoLength()
         pickerController.transitioningDelegate = FastTransitioningDelegate.sharedDelegate
         
         if sourceType == .camera {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
@@ -64,7 +64,9 @@ private let zmLog = ZMSLog(tag: "UI")
     }
     
     @objc convenience init() {
-        self.init(audioRecorder: AudioRecorder(format: .wav, maxRecordingDuration: 25.0 * 60.0, maxFileSize: ZMUserSession.shared()?.maxUploadFileSize() )!)
+        self.init(audioRecorder: AudioRecorder(format: .wav,
+                                               maxRecordingDuration: ZMUserSession.shared()?.maxAudioLength() ,
+                                               maxFileSize: ZMUserSession.shared()?.maxUploadFileSize() )!)
     }
     
     init(audioRecorder: AudioRecorderType) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordViewController.swift
@@ -57,8 +57,8 @@ private let zmLog = ZMSLog(tag: "UI")
     var recordingDotViewHidden: ConstraintGroup?
 
     public let recorder = AudioRecorder(format: .wav,
-                                        maxRecordingDuration: 25.0 * 60.0,
-                                        maxFileSize: ZMUserSession.shared()?.maxUploadFileSize())! // 25 Minutes || 25 Mb
+                                        maxRecordingDuration: ZMUserSession.shared()?.maxAudioLength(),
+                                        maxFileSize: ZMUserSession.shared()?.maxUploadFileSize())!
     
     weak public var delegate: AudioRecordViewControllerDelegate?
     

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
@@ -62,11 +62,11 @@ extension ConversationInputBarViewController: CameraKeyboardViewControllerDelega
     
     public func cameraKeyboardViewController(_ controller: CameraKeyboardViewController, didSelectVideo videoURL: URL, duration: TimeInterval) {
         // Video can be longer than allowed to be uploaded. Then we need to add user the possibility to trim it.
-        if duration > ConversationUploadMaxVideoDuration {
+        if duration > ZMUserSession.shared()!.maxVideoLength() {
             let videoEditor = StatusBarVideoEditorController()
             videoEditor.transitioningDelegate = FastTransitioningDelegate.sharedDelegate
             videoEditor.delegate = self
-            videoEditor.videoMaximumDuration = ConversationUploadMaxVideoDuration
+            videoEditor.videoMaximumDuration = ZMUserSession.shared()!.maxVideoLength()
             videoEditor.videoPath = videoURL.path
             videoEditor.videoQuality = UIImagePickerControllerQualityType.typeMedium
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Files.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Files.h
@@ -19,9 +19,6 @@
 
 #import <UIKit/UIKit.h>
 
-FOUNDATION_EXPORT NSTimeInterval const ConversationUploadMaxVideoDuration;
-
-
 @interface ConversationInputBarViewController (Files) <UIDocumentMenuDelegate, UIDocumentPickerDelegate, UIImagePickerControllerDelegate, UINavigationControllerDelegate>
 
 - (void)docUploadPressed:(IconButton *)sender;

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Files.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Files.m
@@ -31,8 +31,6 @@
 
 static NSString* ZMLogTag ZM_UNUSED = @"UI";
 
-const NSTimeInterval ConversationUploadMaxVideoDuration = 4.0f * 60.0f; // 4 minutes
-
 @implementation ConversationInputBarViewController (Files)
 
 - (void)docUploadPressed:(IconButton *)sender

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+ImagePicker.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+ImagePicker.swift
@@ -49,7 +49,7 @@ extension ConversationInputBarViewController {
                 pickerController.delegate = self
                 pickerController.allowsEditing = allowsEditing
                 pickerController.mediaTypes = mediaTypes
-                pickerController.videoMaximumDuration = TimeInterval(ConversationUploadMaxVideoDuration)
+                pickerController.videoMaximumDuration = ZMUserSession.shared()!.maxVideoLength()
 
                 if let popover = pickerController.popoverPresentationController, let imageView = self.photoButton.imageView {
                     popover.config(from: self,


### PR DESCRIPTION
## What's new in this PR?

- Increased video and audio duration limits for team accounts
- New constants are now reachable by calling `ZMUserSession.shared().max{Video|Audio}Length`