### PR TITLE
Fix deprecated method calls

### DIFF
--- a/Wire-iOS/Sources/Components/CompanyLoginFlowOpener.swift
+++ b/Wire-iOS/Sources/Components/CompanyLoginFlowOpener.swift
@@ -57,7 +57,7 @@ class CompanyLoginFlowHandler {
     /// Opens the company login flow at the specified start URL.
     func open(authenticationURL: URL) {
         guard enableInAppBrowser else {
-            UIApplication.shared.openURL(authenticationURL)
+            UIApplication.shared.open(authenticationURL)
             return
         }
 

--- a/Wire-iOS/Sources/UserInterface/BlacklistViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/BlacklistViewController.swift
@@ -44,7 +44,7 @@ class BlacklistViewController : LaunchImageViewController {
         let alertController = UIAlertController(title: "force.update.title".localized, message: "force.update.message".localized, preferredStyle: .alert)
         let alertAction = UIAlertAction(title: "force.update.ok_button".localized, style: .default) { (_) in
             if let itunesURL = URL(string: "https://itunes.apple.com/us/app/wire/id930944768?mt=8") {
-                UIApplication.shared.openURL(itunesURL)
+                UIApplication.shared.open(itunesURL)
             }
         }
         

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/CannotDecryptCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/CannotDecryptCell.swift
@@ -95,7 +95,7 @@ private let IdentityString = ".identity"
         else if URL == type(of: self).remoteIDErrorURL {
             url = .wr_cannotDecryptNewRemoteIDHelp
         }
-        UIApplication.shared.openURL(url)
+        UIApplication.shared.open(url)
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/UnknownMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/UnknownMessageCell.swift
@@ -77,6 +77,6 @@ public class CustomMessageCell : ConversationCell {
 extension CustomMessageCell : TTTAttributedLabelDelegate {
 
     public func attributedLabel(_ label: TTTAttributedLabel!, didSelectLinkWith url: URL!) {
-        UIApplication.shared.openURL(url)
+        UIApplication.shared.open(url)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ArticleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ArticleView.swift
@@ -238,7 +238,7 @@ import Classy
 extension ArticleView : TTTAttributedLabelDelegate {
     
     func attributedLabel(_ label: TTTAttributedLabel!, didSelectLinkWith url: URL!) {
-        UIApplication.shared.openURL(url)
+        UIApplication.shared.open(url)
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardPermissionsCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardPermissionsCell.swift
@@ -93,7 +93,7 @@ open class CameraKeyboardPermissionsCell: UICollectionViewCell {
     
     @objc private func openSettings() {
         guard let url = URL(string:UIApplicationOpenSettingsURLString), UIApplication.shared.canOpenURL(url) else { return }
-        UIApplication.shared.openURL(url)
+        UIApplication.shared.open(url)
     }
     
     private func createConstraints(deniedAuthorization: DeniedAuthorizationType) {

--- a/Wire-iOS/Sources/UserInterface/Location/LocationSelectionViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Location/LocationSelectionViewController.swift
@@ -148,7 +148,7 @@ import CoreLocation
         let cancelAction = UIAlertAction(title: localize("cancel"), style: .cancel , handler: nil)
         let settingsAction = UIAlertAction(title: localize("settings"), style: .default) { _ in
             guard let url = URL(string: UIApplicationOpenSettingsURLString) else { return }
-            UIApplication.shared.openURL(url)
+            UIApplication.shared.open(url)
         }
         
         [cancelAction, settingsAction].forEach(alertController.addAction)

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Team Invites/TeamInviteTextFieldFooterView.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/Team Invites/TeamInviteTextFieldFooterView.swift
@@ -122,7 +122,7 @@ final class TeamInviteTextFieldFooterView: UIView {
     
     @objc private func showLearnMorePage() {
         let url = URL(string: "https://support.wire.com/hc/en-us/articles/115004082129-My-email-address-is-already-in-use-and-I-cannot-create-an-account-What-can-I-do-")!
-        UIApplication.shared.openURL(url)
+        UIApplication.shared.open(url)
     }
     
     private func updateLoadingState() {

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Options.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Options.swift
@@ -28,7 +28,7 @@ extension SettingsCellDescriptorFactory {
         
         let shareButtonTitleDisabled = "self.settings.privacy_contacts_menu.settings_button.title".localized
         let shareContactsDisabledSettingsButton = SettingsButtonCellDescriptor(title: shareButtonTitleDisabled, isDestructive: false, selectAction: { (descriptor: SettingsCellDescriptorType) -> () in
-            UIApplication.shared.openURL(URL(string:UIApplicationOpenSettingsURLString)!)
+            UIApplication.shared.open(URL(string:UIApplicationOpenSettingsURLString)!)
         }) { (descriptor: SettingsCellDescriptorType) -> (Bool) in
             if AddressBookHelper.sharedHelper.addressBookSearchPerformedAtLeastOnce {
                 if AddressBookHelper.sharedHelper.isAddressBookAccessDisabled || AddressBookHelper.sharedHelper.isAddressBookAccessUnknown {

--- a/Wire-iOS/Sources/UserInterface/Settings/LinkOpening/BrowserOpening.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/LinkOpening/BrowserOpening.swift
@@ -60,26 +60,29 @@ extension URL {
         log.debug("Trying to open \"\(self)\" in thrid party browser")
         let saved = BrowserOpeningOption.storedPreference()
         log.debug("Saved option to open a regular link: \(saved.displayString)")
+        let app = UIApplication.shared
 
         switch saved {
         case .safari: return false
         case .chrome:
-            guard let url = chromeURL else { return false }
+            guard let url = chromeURL, app.canOpenURL(url) else { return false }
             log.debug("Trying to open chrome app using \"\(url)\"")
-            return UIApplication.shared.openURL(url)
+            app.open(url)
         case .firefox:
-            guard let url = firefoxURL else { return false }
+            guard let url = firefoxURL, app.canOpenURL(url) else { return false }
             log.debug("Trying to open firefox app using \"\(url)\"")
-            return UIApplication.shared.openURL(url)
+            app.open(url)
         case .snowhaze:
-            guard let url = snowhazeURL else { return false }
+            guard let url = snowhazeURL, app.canOpenURL(url) else { return false }
             log.debug("Trying to open snowhaze app using \"\(url)\"")
-            return UIApplication.shared.openURL(url)
+            app.open(url)
         case .brave:
-            guard let url = braveURL else { return false }
+            guard let url = braveURL, app.canOpenURL(url) else { return false }
             log.debug("Trying to open brave app using \"\(url)\"")
-            return UIApplication.shared.openURL(url)
+            app.open(url)
         }
+        
+        return true
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/Settings/LinkOpening/LinkOpener.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/LinkOpening/LinkOpener.swift
@@ -48,13 +48,9 @@ public extension URL {
         }
         else {
             log.debug("Did not open \"\(self)\" in a twitter application or third party browser.")
-            if UIApplication.shared.canOpenURL(self) {
-                UIApplication.shared.openURL(self)
-                return true
-            }
-            else {
-                return false
-            }
+            guard UIApplication.shared.canOpenURL(self) else { return false }
+            UIApplication.shared.open(self)
+            return true
         }
     }
 

--- a/Wire-iOS/Sources/UserInterface/Settings/LinkOpening/MapOpening.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/LinkOpening/MapOpening.swift
@@ -60,7 +60,9 @@ extension URL {
         switch saved {
         case .apple: return false
         case .google:
-            return UIApplication.shared.openURL(self)
+            guard UIApplication.shared.canOpenURL(self) else { return false }
+            UIApplication.shared.open(self)
+            return true
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/Settings/LinkOpening/TweetOpening.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/LinkOpening/TweetOpening.swift
@@ -57,18 +57,21 @@ extension URL {
         guard isTweet else { return false }
         let saved = TweetOpeningOption.storedPreference()
         log.debug("Saved option to open a tweet: \(saved.displayString)")
-
+        let app = UIApplication.shared
+        
         switch saved {
         case .none: return false
         case .tweetbot:
-            guard let url = tweetbotURL else { return false }
+            guard let url = tweetbotURL, app.canOpenURL(url) else { return false }
             log.debug("Trying to open tweetbot app using \"\(url)\"")
-            return UIApplication.shared.openURL(url)
+            app.open(url)
         case .twitterrific:
-            guard let url = twitterrificURL else { return false }
+            guard let url = twitterrificURL, app.canOpenURL(url) else { return false }
             log.debug("Trying to open twitterific app using \"\(url)\"")
-            return UIApplication.shared.openURL(url)
+            app.open(url)
         }
+        
+        return true
     }
 
 }


### PR DESCRIPTION
## What's new in this PR?

Replaced calls to the deprecated `UIApplication` method `openURL(_ url: URL)`with `open(_:options:completionHandler:)`.