### PR TITLE
Fix: crash when saving a 20000x20000px image

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/SavableImage.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/SavableImage.swift
@@ -30,7 +30,15 @@ protocol AssetChangeRequestProtocol: class {
     @discardableResult static func creationRequestForAssetFromImage(atFileURL fileURL: URL) -> Self?
 }
 
+protocol AssetCreationRequestProtocol: class {
+    static func forAsset() -> Self
+    func addResource(with type: PHAssetResourceType,
+                     data: Data,
+                     options: PHAssetResourceCreationOptions?)
+}
+
 extension PHAssetChangeRequest: AssetChangeRequestProtocol {}
+extension PHAssetCreationRequest: AssetCreationRequestProtocol {}
 
 private let log = ZMSLog(tag: "SavableImage")
 
@@ -44,6 +52,7 @@ private let log = ZMSLog(tag: "SavableImage")
     /// Protocols used to inject mock photo services in tests
     var photoLibrary: PhotoLibraryProtocol = PHPhotoLibrary.shared()
     var assetChangeRequestType: AssetChangeRequestProtocol.Type = PHAssetChangeRequest.self
+    var assetCreationRequestType: AssetCreationRequestProtocol.Type = PHAssetCreationRequest.self
     var applicationType: ApplicationProtocol.Type = UIApplication.self
 
     public typealias ImageSaveCompletion = (Bool) -> Void
@@ -108,8 +117,7 @@ private let log = ZMSLog(tag: "SavableImage")
         case .gif(let url):
             _ = assetChangeRequestType.creationRequestForAssetFromImage(atFileURL: url)
         case .image(let data):
-            guard let image = UIImage(data: data) else { return log.error("failed to create image from data") }
-            assetChangeRequestType.creationRequestForAsset(from: image)
+            assetCreationRequestType.forAsset().addResource(with: .photo, data: data, options: PHAssetResourceCreationOptions())
         }
     }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

App crashes when saving a 0000x20000px image.

### Causes

When calling:
PHAssetChangeRequest.creationRequestForAsset(from: image)
System crashes if the image has a huge size.

### Solutions

Saving the image with PHAssetCreationRequest.addResource() method to simplify the saving process.