### PR TITLE
Fix: App crashes after confirm sending a large image from camera keyboard

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1144,6 +1144,7 @@
 		EF6163A61FE9682700C6F5A9 /* TextMessageCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF8EE5591D636F4600B0D6D7 /* TextMessageCellTests.swift */; };
 		EF63528D209C4A9300F5E950 /* ConversationInputBarViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF63528C209C4A9300F5E950 /* ConversationInputBarViewControllerTests.swift */; };
 		EF640EB82111EAAC00C1D1F0 /* unsplash_matterhorn_very_small_size_40x20.jpg in Resources */ = {isa = PBXBuildFile; fileRef = EF640EB72111EAAC00C1D1F0 /* unsplash_matterhorn_very_small_size_40x20.jpg */; };
+		EF66110F2121D00B00BDF57A /* UIImage+DownSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF66110E2121D00B00BDF57A /* UIImage+DownSize.swift */; };
 		EF6777062073C6C20062F122 /* OfflineBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF6777052073C6C20062F122 /* OfflineBar.swift */; };
 		EF68856820F611D50074CA0F /* CanvasViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF68856720F611D50074CA0F /* CanvasViewControllerTests.swift */; };
 		EF68856A20F622C60074CA0F /* DraftSendInputAccessoryViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF68856920F622C50074CA0F /* DraftSendInputAccessoryViewTests.swift */; };
@@ -2806,6 +2807,7 @@
 		EF61B3411FC8508400D8E631 /* TextFieldValidator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFieldValidator.swift; sourceTree = "<group>"; };
 		EF63528C209C4A9300F5E950 /* ConversationInputBarViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationInputBarViewControllerTests.swift; sourceTree = "<group>"; };
 		EF640EB72111EAAC00C1D1F0 /* unsplash_matterhorn_very_small_size_40x20.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = unsplash_matterhorn_very_small_size_40x20.jpg; sourceTree = "<group>"; };
+		EF66110E2121D00B00BDF57A /* UIImage+DownSize.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+DownSize.swift"; sourceTree = "<group>"; };
 		EF6777052073C6C20062F122 /* OfflineBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineBar.swift; sourceTree = "<group>"; };
 		EF68856720F611D50074CA0F /* CanvasViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasViewControllerTests.swift; sourceTree = "<group>"; };
 		EF68856920F622C50074CA0F /* DraftSendInputAccessoryViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DraftSendInputAccessoryViewTests.swift; path = "Wire-iOS Tests/DraftSendInputAccessoryViewTests.swift"; sourceTree = SOURCE_ROOT; };
@@ -3695,6 +3697,7 @@
 				871BC18D1D34F8F800DF0793 /* MediaAsset.h */,
 				871BC18E1D34F8F800DF0793 /* MediaAsset.m */,
 				EFF3DA422097548A007A3358 /* UIImage+MediaAssert.swift */,
+				EF66110E2121D00B00BDF57A /* UIImage+DownSize.swift */,
 				EFF3DA442097587F007A3358 /* UIPasteboard+MediaAsset.swift */,
 				871BC18F1D34F8F800DF0793 /* MediaPreview */,
 				871BC1971D34F8F800DF0793 /* Transitions */,
@@ -7262,6 +7265,7 @@
 				876113E01DD1DD19007F5969 /* ColorSchemeController.m in Sources */,
 				EF2127041FB9DFE300625A9B /* RegistrationViewController.m in Sources */,
 				EF3BA5D72107688D0093048F /* InputLanguageSettable.swift in Sources */,
+				EF66110F2121D00B00BDF57A /* UIImage+DownSize.swift in Sources */,
 				7CC085461F7AA30F0010F96B /* DotView.swift in Sources */,
 				16A94AFB209C553A008A5718 /* CallViewController.swift in Sources */,
 				87DCF4931D34E9BA00BB420F /* ContactsViewController.m in Sources */,

--- a/Wire-iOS/Sources/UserInterface/Components/MediaAsset.m
+++ b/Wire-iOS/Sources/UserInterface/Components/MediaAsset.m
@@ -75,7 +75,7 @@
         self.image = nil;
     }
     else if (![image isGIF]) {
-        self.image = (UIImage *)image;
+        self.image = [(UIImage *)image downsizedImage];
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Components/UIImage+DownSize.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/UIImage+DownSize.swift
@@ -18,27 +18,23 @@
 
 import Foundation
 
-extension UIImage: MediaAsset {
-    public func data() -> Data? {
-        if isTransparent() {
-            return UIImagePNGRepresentation(self)
-        } else {
-            return UIImageJPEGRepresentation(self, 1.0)
-        }
+
+extension CGFloat {
+    enum Image {
+        static public let maxSupportedLength: CGFloat = 5000
     }
+}
 
-    public func isGIF() -> Bool {
-        return false
-    }
+extension UIImage {
+    @objc func downsizedImage() -> UIImage {
+        let longestLength = self.size.longestLength
 
-    public func isTransparent() -> Bool {
-        guard let alpha: CGImageAlphaInfo = self.cgImage?.alphaInfo else { return false }
+        /// Maximum image size that would show in a UIImageView.
+        /// Tested on iPhone 5s and found that the image size limitation is ~5000px
+        let maxImageLength = CGFloat.Image.maxSupportedLength
+        guard longestLength > maxImageLength else { return self }
 
-        switch alpha {
-        case .first, .last, .premultipliedFirst, .premultipliedLast, .alphaOnly:
-            return true
-        default:
-            return false
-        }
+        let ratio = (maxImageLength / UIScreen.main.scale) / longestLength
+        return imageScaled(withFactor: ratio)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Components/UIImage+MediaAssert.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/UIImage+MediaAssert.swift
@@ -48,11 +48,11 @@ extension UIImage {
         let longestLength = self.size.longestLength
 
         /// Maximum image size that would show in a UIImageView.
-        /// (Tested on iPhone 5s, maxImageLength = 3000 may crash due to memory usage)
-        let maxImageLength = CGFloat(2500) * UIScreen.main.scale
+        /// Tested on iPhone 5s and found that the image size limitation is ~5000px
+        let maxImageLength = CGFloat(5000)
         guard longestLength > maxImageLength else { return self }
 
-        let ratio = maxImageLength / longestLength
+        let ratio = (maxImageLength / UIScreen.main.scale) / longestLength
         return imageScaled(withFactor: ratio)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
@@ -241,7 +241,15 @@ open class CameraKeyboardViewController: UIViewController {
                     completeBlock(data, info?["PHImageFileUTIKey"] as? String)
                 } else {
                     options.isSynchronous = true
+                    DispatchQueue.main.async(execute: {
+                        self.showLoadingView = true
+                    })
+
                     manager.requestImage(for: asset, targetSize: CGSize(width:limit, height:limit), contentMode: .aspectFit, options: options, resultHandler: { image, info in
+                        DispatchQueue.main.async(execute: {
+                            self.showLoadingView = false
+                        })
+
                         if let image = image {
                             let data = UIImageJPEGRepresentation(image, 0.9)
                             completeBlock(data, info?["PHImageFileUTIKey"] as? String)

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
@@ -209,53 +209,81 @@ open class CameraKeyboardViewController: UIViewController {
     fileprivate func forwardSelectedPhotoAsset(_ asset: PHAsset) {
         let manager = PHImageManager.default()
 
-        let options = PHImageRequestOptions()
-        options.deliveryMode = .highQualityFormat
-        options.isNetworkAccessAllowed = false
-        options.isSynchronous = false
-        manager.requestImageData(for: asset, options: options, resultHandler: { data, uti, orientation, info in
+        let completeBlock = { (data: Data?, uti: String?) in
+            guard let data = data else { return }
 
-            let completeBlock = { (data: Data) in
-                let returnData: Data
-                if (uti == "public.heif") ||
-                   (uti == "public.heic"),
-                   let convertedJPEGData = data.covertHEIFToJPG() {
-                    returnData = convertedJPEGData
+            let returnData: Data
+            if (uti == "public.heif") ||
+                (uti == "public.heic"),
+                let convertedJPEGData = data.covertHEIFToJPG() {
+                returnData = convertedJPEGData
+            } else {
+                returnData = data
+            }
+
+            DispatchQueue.main.async(execute: {
+                self.delegate?.cameraKeyboardViewController(self, didSelectImageData: returnData, isFromCamera: false)
+            })
+        }
+
+        let limit = CGFloat.Image.maxSupportedLength
+        if CGFloat(asset.pixelWidth) > limit || CGFloat(asset.pixelHeight) > limit {
+
+            let options = PHImageRequestOptions()
+            options.deliveryMode = .highQualityFormat
+            options.isNetworkAccessAllowed = false
+            options.resizeMode = .exact
+            options.isSynchronous = false
+
+            manager.requestImage(for: asset, targetSize: CGSize(width:limit, height:limit), contentMode: .aspectFit, options: options, resultHandler: { image, info in
+                if let image = image {
+                    let data = UIImageJPEGRepresentation(image, 0.9)
+                    completeBlock(data, info?["PHImageFileUTIKey"] as? String)
                 } else {
-                    returnData = data
+                    options.isSynchronous = true
+                    manager.requestImage(for: asset, targetSize: CGSize(width:limit, height:limit), contentMode: .aspectFit, options: options, resultHandler: { image, info in
+                        if let image = image {
+                            let data = UIImageJPEGRepresentation(image, 0.9)
+                            completeBlock(data, info?["PHImageFileUTIKey"] as? String)
+                        } else {
+                            zmLog.error("Failure: cannot fetch image")
+                        }
+                    })
                 }
 
-                DispatchQueue.main.async(execute: {
-                    self.delegate?.cameraKeyboardViewController(self, didSelectImageData: returnData, isFromCamera: false)
-                })
-            }
+            })
+        } else {
+            let options = PHImageRequestOptions()
+            options.deliveryMode = .highQualityFormat
+            options.isNetworkAccessAllowed = false
+            options.isSynchronous = false
 
-            guard let data = data else {
-                let options = PHImageRequestOptions()
-                options.deliveryMode = .highQualityFormat
-                options.isNetworkAccessAllowed = true
-                options.isSynchronous = false
-                DispatchQueue.main.async(execute: {
-                    self.showLoadingView = true
-                })
-                
-                manager.requestImageData(for: asset, options: options, resultHandler: { data, uti, orientation, info in
+            manager.requestImageData(for: asset, options: options, resultHandler: { data, uti, orientation, info in
+
+                guard let data = data else {
+                    options.isNetworkAccessAllowed = true
                     DispatchQueue.main.async(execute: {
-                        self.showLoadingView = false
+                        self.showLoadingView = true
                     })
-                    guard let data = data else {
-                        zmLog.error("Failure: cannot fetch image")
-                        return
-                    }
 
-                    completeBlock(data)
-                })
-                
-                return
-            }
+                    manager.requestImageData(for: asset, options: options, resultHandler: { data, uti, orientation, info in
+                        DispatchQueue.main.async(execute: {
+                            self.showLoadingView = false
+                        })
+                        guard let data = data else {
+                            zmLog.error("Failure: cannot fetch image")
+                            return
+                        }
 
-            completeBlock(data)
-        })
+                        completeBlock(data, uti)
+                    })
+
+                    return
+                }
+
+                completeBlock(data, uti)
+            })
+        }
     }
     
     fileprivate func forwardSelectedVideoAsset(_ asset: PHAsset) {


### PR DESCRIPTION
## What's new in this PR?

### Issues

App crashes after confirm sending a large image(42MB, 20000x20000px) from camera keyboard.

### Causes

When running this line WireImage module's wr_imageDataWithoutMetadata() method, app crash due to memory pressure:
CGImageDestinationFinalize(imageDestination)

### Solutions

After testing with the iPhone 5s, the limitation of image size is around 5000x5000px. If the image the user picked is over this size, request the image with limited size instead.

