### PR TITLE
Update guest banner state on conversation changes

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -270,7 +270,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
         BOOL isPresented = nil != self.guestsBarController.parentViewController;
         if (!isPresented || showIfNeeded) {
             [self.conversationBarController presentBar:self.guestsBarController];
-            [self.guestsBarController setState:self.conversation.guestBarState animated:NO];
+            [self.guestsBarController setState:state animated:NO];
         }
     }
     else {
@@ -827,6 +827,8 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
         [self.contentViewController updateTableViewHeaderView];
         [self updateInputBarVisibility];
         [self updateGuestsBarVisibilityAndShowIfNeeded:NO];
+    } else {
+        [self.guestsBarController configureTitleWithState: self.conversation.guestBarState];
     }
     
     if (note.nameChanged || note.securityLevelChanged || note.connectionStateChanged) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/GuestBar/GuestsBarController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/GuestBar/GuestsBarController.swift
@@ -80,8 +80,7 @@ class GuestsBarController: UIViewController {
         guard _state != state, isViewLoaded else { return }
         
         _state = state
-        label.accessibilityIdentifier = state.accessibilityIdentifier
-        label.text = state.displayString
+        configureTitle(with: state)
         let collapsed = state == .hidden
         
         let change = {
@@ -109,6 +108,12 @@ class GuestsBarController: UIViewController {
             change()
             completion(true)
         }
+    }
+    
+    @objc(configureTitleWithState:)
+    func configureTitle(with state: GuestBarState) {
+        label.accessibilityIdentifier = state.accessibilityIdentifier
+        label.text = state.displayString
     }
 
 }


### PR DESCRIPTION
## What's new in this PR?

* Update guest banner state on conversation changes.
* The conversation change info does not contain the info if it changed because a user inside of the conversation changed (only when they're added or removed), so we have to check the title is accurate manually.