### PR TITLE
Fix: Audio message reproduction is interrupted by incoming call

### DIFF
--- a/Wire-iOS Tests/AppStateControllerTests.swift
+++ b/Wire-iOS Tests/AppStateControllerTests.swift
@@ -42,11 +42,6 @@ final class AppStateControllerTests: XCTestCase {
         super.tearDown()
     }
 
-    /// Example checker method which can be reused in different tests
-    fileprivate func checkerExample(file: StaticString = #file, line: UInt = #line) {
-        XCTAssert(true, file: file, line: line)
-    }
-
     // MARK: - tests for .unauthenticated state handling
 
     func testThatErrorIsIgnoredWhenTheAppFrashInstalled() {

--- a/Wire-iOS Tests/AudioMessageCellTests.swift
+++ b/Wire-iOS Tests/AudioMessageCellTests.swift
@@ -26,14 +26,9 @@ class AudioMessageCellTests: ZMSnapshotTestCase {
         
         
         let mediaPlayBackManager = MediaPlaybackManager(name: "conversationMedia")
-        let fileMessage = MockMessageFactory.fileTransferMessage()
-        fileMessage?.backingFileMessageData.mimeType = "audio/x-m4a"
-        fileMessage?.backingFileMessageData.filename = "sound.m4a"
-        
-        if let config = config {
-            config(fileMessage!)
-        }
-        
+
+        let fileMessage = MockMessageFactory.audioMessage(config: config)
+
         let cell = AudioMessageCell(style: .default, reuseIdentifier: "test")
         
         let layoutProperties = ConversationCellLayoutProperties()

--- a/Wire-iOS Tests/AudioMessageViewTests.swift
+++ b/Wire-iOS Tests/AudioMessageViewTests.swift
@@ -19,13 +19,42 @@
 import XCTest
 @testable import Wire
 
-final class AudioMessageViewTestsTests: XCTestCase {
+final class MockAudioTrack: NSObject, AudioTrack {
+    var title: String!
+
+    var author: String!
+
+    var artwork: UIImage!
+
+    var duration: TimeInterval = 0.0
+
+    var artworkURL: URL!
+
+    var streamURL: URL!
+
+    var previewStreamURL: URL!
+
+    var externalURL: URL!
+
+    var failedToLoad: Bool
+
+    func fetchArtwork() {
+        // no-op
+    }
+
+    override init() {
+        failedToLoad = false
+        super.init()
+    }
+}
+
+final class AudioMessageViewTests: XCTestCase {
     
-    var sut: AudioMessageViewTests!
+    var sut: AudioMessageView!
     
     override func setUp() {
         super.setUp()
-        sut = AudioMessageViewTests()
+        sut = AudioMessageView()
     }
     
     override func tearDown() {
@@ -42,8 +71,27 @@ final class AudioMessageViewTestsTests: XCTestCase {
 
     func testExample(){
         // GIVEN
+        let url = Bundle(for: type(of: self)).url(forResource: "audio_sample", withExtension: "m4a")!
+
+        let audioMessage = MockMessageFactory.audioMessage(config: {
+            $0.fileMessageData?.transferState = .downloaded
+            $0.backingFileMessageData.fileURL = url
+        })
+
+        let mediaPlayBackManager = MediaPlaybackManager(name: "conversationMedia")
+        sut.audioTrackPlayer = mediaPlayBackManager?.audioTrackPlayer
+        let audioTrack = MockAudioTrack()
+        sut.audioTrackPlayer?.load(audioTrack, sourceMessage: audioMessage, completionHandler: nil)
+        sut.configure(for: audioMessage, isInitial: true)
 
         // WHEN
+
+//        AudioTrack
+
+//        mediaPlayBackManager.con
+
+        sut.playButton.sendActions(for: .touchUpInside)
+        XCTAssert((sut.audioTrackPlayer?.isPlaying)!)
 
         // THEN
         checkerExample()

--- a/Wire-iOS Tests/AudioMessageViewTests.swift
+++ b/Wire-iOS Tests/AudioMessageViewTests.swift
@@ -16,26 +16,36 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
+import XCTest
+@testable import Wire
 
-extension MockMessageFactory {
-    class func passFileTransferMessage() -> MockMessage {
-        let message = MockMessageFactory.messageTemplate()
-        message?.backingFileMessageData = MockPassFileMessageData()
-
-        return message!
+final class AudioMessageViewTestsTests: XCTestCase {
+    
+    var sut: AudioMessageViewTests!
+    
+    override func setUp() {
+        super.setUp()
+        sut = AudioMessageViewTests()
+    }
+    
+    override func tearDown() {
+        sut = nil
+        super.tearDown()
     }
 
-    class func audioMessage(config: ((MockMessage) -> ())?) -> MockMessage {
-        let fileMessage = MockMessageFactory.fileTransferMessage()
-        fileMessage?.backingFileMessageData.mimeType = "audio/x-m4a"
-        fileMessage?.backingFileMessageData.filename = "sound.m4a"
 
-        if let config = config {
-            config(fileMessage!)
-        }
 
-        return fileMessage!
+    /// Example checker method which can be reused in different tests
+    fileprivate func checkerExample(file: StaticString = #file, line: UInt = #line) {
+        XCTAssert(true, file: file, line: line)
     }
 
+    func testExample(){
+        // GIVEN
+
+        // WHEN
+
+        // THEN
+        checkerExample()
+    }
 }

--- a/Wire-iOS Tests/AudioMessageViewTests.swift
+++ b/Wire-iOS Tests/AudioMessageViewTests.swift
@@ -109,16 +109,10 @@ final class AudioMessageViewTests: XCTestCase {
         super.tearDown()
     }
 
-    /// Example checker method which can be reused in different tests
-    fileprivate func checkerExample(file: StaticString = #file, line: UInt = #line) {
-        XCTAssert(true, file: file, line: line)
-    }
-
-
     func testThatAudioMessageIsResumedAfterIncomingCallIsTerminated() {
-        // GIVEN
+        // GIVEN & WHEN
 
-        // WHEN
+        // play
         sut.playButton.sendActions(for: .touchUpInside)
         XCTAssert((sut.audioTrackPlayer?.isPlaying)!)
 
@@ -134,12 +128,13 @@ final class AudioMessageViewTests: XCTestCase {
     }
 
     func testThatAudioMessageIsNotResumedIfItIsPausedAfterIncomingCallIsTerminated() {
-        // GIVEN
+        // GIVEN & WHEN
 
-        // WHEN
+        // play
         sut.playButton.sendActions(for: .touchUpInside)
         XCTAssert((sut.audioTrackPlayer?.isPlaying)!)
 
+        // pause
         sut.playButton.sendActions(for: .touchUpInside)
         XCTAssertFalse((sut.audioTrackPlayer?.isPlaying)!)
 

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1117,6 +1117,7 @@
 		EF27CD9F20C161500077FE55 /* ProfileClientViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF27CD9C20C161500077FE55 /* ProfileClientViewControllerTests.swift */; };
 		EF27CDA020C161500077FE55 /* ClientListViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF27CD9D20C161500077FE55 /* ClientListViewControllerTests.swift */; };
 		EF2971582099AD8700EFE6A4 /* SelfProfileViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2971552099AD3000EFE6A4 /* SelfProfileViewControllerTests.swift */; };
+		EF29E89C212302CD0023B80C /* AudioMessageViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF29E89B212302CD0023B80C /* AudioMessageViewTests.swift */; };
 		EF2C189E1FED0D6900E9F2FD /* ConversationCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2C189C1FED0D3000E9F2FD /* ConversationCellTests.swift */; };
 		EF2C18A01FED435600E9F2FD /* ConversationCell+BurstTimestamp.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2C189F1FED435600E9F2FD /* ConversationCell+BurstTimestamp.swift */; };
 		EF2C18A21FED541F00E9F2FD /* Timer+AllVersionCompatibleScheduledTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2C18A11FED541F00E9F2FD /* Timer+AllVersionCompatibleScheduledTimer.swift */; };
@@ -2777,6 +2778,7 @@
 		EF27CD9C20C161500077FE55 /* ProfileClientViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileClientViewControllerTests.swift; sourceTree = "<group>"; };
 		EF27CD9D20C161500077FE55 /* ClientListViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClientListViewControllerTests.swift; sourceTree = "<group>"; };
 		EF2971552099AD3000EFE6A4 /* SelfProfileViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelfProfileViewControllerTests.swift; sourceTree = "<group>"; };
+		EF29E89B212302CD0023B80C /* AudioMessageViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioMessageViewTests.swift; sourceTree = "<group>"; };
 		EF2C189C1FED0D3000E9F2FD /* ConversationCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationCellTests.swift; sourceTree = "<group>"; };
 		EF2C189F1FED435600E9F2FD /* ConversationCell+BurstTimestamp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationCell+BurstTimestamp.swift"; sourceTree = "<group>"; };
 		EF2C18A11FED541F00E9F2FD /* Timer+AllVersionCompatibleScheduledTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Timer+AllVersionCompatibleScheduledTimer.swift"; sourceTree = "<group>"; };
@@ -5281,6 +5283,7 @@
 				EF5741ED2102001A0041AD47 /* MessageTests.swift */,
 				87909075211DE898006219B4 /* EmptySearchResultsViewTests.swift */,
 				EF8DD90D211DE14300E970F1 /* MessagePresenterTests.swift */,
+				EF29E89B212302CD0023B80C /* AudioMessageViewTests.swift */,
 			);
 			path = "Wire-iOS Tests";
 			sourceTree = "<group>";
@@ -7433,6 +7436,7 @@
 				EF2971582099AD8700EFE6A4 /* SelfProfileViewControllerTests.swift in Sources */,
 				87C39A8E206BE83C008DA100 /* NoHistoryViewControllerTests.swift in Sources */,
 				BF7ED2DC1DF1D1CF003A4397 /* IncomingConnectionViewTests.swift in Sources */,
+				EF29E89C212302CD0023B80C /* AudioMessageViewTests.swift in Sources */,
 				BA79B0A91B62851F00F23AFB /* SoundEventRulesWatchDogTests.m in Sources */,
 				5EBC344220EE5EBF00AFB6DF /* DecodeImageOperationTests.swift in Sources */,
 				BF8EE5581D6351B100B0D6D7 /* InputBarEditViewTests.swift in Sources */,

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
@@ -493,10 +493,12 @@ extension AudioMessageView : WireCallCenterCallStateObserver {
         // Resume playing when the call is terminating (and the audio is paused by this method)
         switch (previousCallState, callState) {
         case (_, .incoming(_, _, _)):
-            player.pause()
-            isPausedForIncomingCall = true
+            if player.isPlaying {
+                player.pause()
+                isPausedForIncomingCall = true
+            }
         case (.incoming(_, _, _)?, .terminating(reason: _)):
-            if isPausedForIncomingCall {
+            if isPausedForIncomingCall && !player.isPlaying {
                 player.play()
             }
             isPausedForIncomingCall = false

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
@@ -492,12 +492,12 @@ extension AudioMessageView : WireCallCenterCallStateObserver {
         // Pause the audio player when call is incoming to prevent the audio player is reset.
         // Resume playing when the call is terminating (and the audio is paused by this method)
         switch (previousCallState, callState) {
-        case (_, .incoming(_, _, _)):
+        case (_, .incoming):
             if player.isPlaying {
                 player.pause()
                 isPausedForIncomingCall = true
             }
-        case (.incoming(_, _, _)?, .terminating(reason: _)):
+        case (.incoming?, .terminating):
             if isPausedForIncomingCall && !player.isPlaying {
                 player.play()
             }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
@@ -42,7 +42,7 @@ private let zmLog = ZMSLog(tag: "UI")
     }
     
     private let downloadProgressView = CircularProgressView()
-    private let playButton = IconButton()
+    let playButton = IconButton()
     private let timeLabel = UILabel()
     private let playerProgressView = ProgressView()
     private let waveformProgressView = WaveformProgressView()
@@ -319,7 +319,9 @@ private let zmLog = ZMSLog(tag: "UI")
     }
     
     private func playTrack() {
-        guard let fileMessage = self.fileMessage, let fileMessageData = fileMessage.fileMessageData, let audioTrackPlayer = self.audioTrackPlayer else {
+        guard let fileMessage = self.fileMessage,
+              let fileMessageData = fileMessage.fileMessageData,
+              let audioTrackPlayer = self.audioTrackPlayer else {
             return
         }
         


### PR DESCRIPTION
## What's new in this PR?

### Issues

When the user is playing an audio message and a call rings, the audio message is stopped and reset the start position after the user rejects a call.

### Causes

The AVPlayer is stopped and wiped when the call rings.

### Solutions

Pause the audio player when the call rings, then play it when the call is terminated and it was paused because of the incoming call.

### Todo

- [x] tests for the different cases which would pause the audio player.