### PR TITLE
Fix manage services button color scheme

### DIFF
--- a/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
@@ -233,6 +233,10 @@ public class AddParticipantsViewController: UIViewController {
         
         createConstraints()
         updateSelectionValues()
+        
+        if searchResultsViewController.isResultEmpty {
+            emptyResultView.updateStatus(searchingForServices: false, hasFilter: false)
+        }
     }
 
     func createConstraints() {

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
@@ -124,6 +124,8 @@
         [[SectionHeader appearanceWhenContainedInInstancesOfClasses:@[StartUIView.class]] setColorSchemeVariant:ColorSchemeVariantDark];
         [[GroupConversationCell appearanceWhenContainedInInstancesOfClasses:@[StartUIView.class]] setColorSchemeVariant:ColorSchemeVariantDark];
         [[GroupConversationCell appearanceWhenContainedInInstancesOfClasses:@[StartUIView.class]] setContentBackgroundColor:UIColor.clearColor];
+        [[OpenServicesAdminCell appearanceWhenContainedInInstancesOfClasses:@[StartUIView.class]] setColorSchemeVariant:ColorSchemeVariantDark];
+        [[OpenServicesAdminCell appearanceWhenContainedInInstancesOfClasses:@[StartUIView.class]] setContentBackgroundColor:UIColor.clearColor];
         [[UIView appearanceWhenContainedInInstancesOfClasses:@[UIAlertController.class]] setTintColor:[ColorScheme.defaultColorScheme colorWithName:ColorSchemeColorTextForeground variant:ColorSchemeVariantLight]];
 
         [self setupConversationListViewController];

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
@@ -118,19 +118,24 @@
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(contentSizeCategoryDidChange:) name:UIContentSizeCategoryDidChangeNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationWillEnterForeground:) name:UIApplicationWillEnterForegroundNotification object:nil];
                 
-        [[GuestIndicator appearanceWhenContainedInInstancesOfClasses:@[StartUIView.class]] setColorSchemeVariant:ColorSchemeVariantDark];
-        [[UserCell appearanceWhenContainedInInstancesOfClasses:@[StartUIView.class]] setColorSchemeVariant:ColorSchemeVariantDark];
-        [[UserCell appearanceWhenContainedInInstancesOfClasses:@[StartUIView.class]] setContentBackgroundColor:UIColor.clearColor];
-        [[SectionHeader appearanceWhenContainedInInstancesOfClasses:@[StartUIView.class]] setColorSchemeVariant:ColorSchemeVariantDark];
-        [[GroupConversationCell appearanceWhenContainedInInstancesOfClasses:@[StartUIView.class]] setColorSchemeVariant:ColorSchemeVariantDark];
-        [[GroupConversationCell appearanceWhenContainedInInstancesOfClasses:@[StartUIView.class]] setContentBackgroundColor:UIColor.clearColor];
-        [[OpenServicesAdminCell appearanceWhenContainedInInstancesOfClasses:@[StartUIView.class]] setColorSchemeVariant:ColorSchemeVariantDark];
-        [[OpenServicesAdminCell appearanceWhenContainedInInstancesOfClasses:@[StartUIView.class]] setContentBackgroundColor:UIColor.clearColor];
-        [[UIView appearanceWhenContainedInInstancesOfClasses:@[UIAlertController.class]] setTintColor:[ColorScheme.defaultColorScheme colorWithName:ColorSchemeColorTextForeground variant:ColorSchemeVariantLight]];
+        [self setupAppearance];
 
         [self setupConversationListViewController];
     }
     return self;
+}
+
+- (void)setupAppearance
+{
+    [[GuestIndicator appearanceWhenContainedInInstancesOfClasses:@[StartUIView.class]] setColorSchemeVariant:ColorSchemeVariantDark];
+    [[UserCell appearanceWhenContainedInInstancesOfClasses:@[StartUIView.class]] setColorSchemeVariant:ColorSchemeVariantDark];
+    [[UserCell appearanceWhenContainedInInstancesOfClasses:@[StartUIView.class]] setContentBackgroundColor:UIColor.clearColor];
+    [[SectionHeader appearanceWhenContainedInInstancesOfClasses:@[StartUIView.class]] setColorSchemeVariant:ColorSchemeVariantDark];
+    [[GroupConversationCell appearanceWhenContainedInInstancesOfClasses:@[StartUIView.class]] setColorSchemeVariant:ColorSchemeVariantDark];
+    [[GroupConversationCell appearanceWhenContainedInInstancesOfClasses:@[StartUIView.class]] setContentBackgroundColor:UIColor.clearColor];
+    [[OpenServicesAdminCell appearanceWhenContainedInInstancesOfClasses:@[StartUIView.class]] setColorSchemeVariant:ColorSchemeVariantDark];
+    [[OpenServicesAdminCell appearanceWhenContainedInInstancesOfClasses:@[StartUIView.class]] setContentBackgroundColor:UIColor.clearColor];
+    [[UIView appearanceWhenContainedInInstancesOfClasses:@[UIAlertController.class]] setTintColor:[ColorScheme.defaultColorScheme colorWithName:ColorSchemeColorTextForeground variant:ColorSchemeVariantLight]];
 }
 
 - (void)viewDidLoad

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/Cells/InviteTeamMemberCell.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/Cells/InviteTeamMemberCell.swift
@@ -21,9 +21,9 @@ import Cartography
 
 class StartUIIconCell: UICollectionViewCell {
     
-    private let iconView = UIImageView()
-    private let titleLabel = UILabel()
-    private let separator = UIView()
+    fileprivate let iconView = UIImageView()
+    fileprivate let titleLabel = UILabel()
+    fileprivate let separator = UIView()
     
     fileprivate var icon: ZetaIconType? {
         didSet {
@@ -120,7 +120,39 @@ final class CreateGuestRoomCell: StartUIIconCell  {
     
 }
 
-final class OpenServicesAdminCell: StartUIIconCell  {
+final class OpenServicesAdminCell: StartUIIconCell, Themeable  {
+    @objc dynamic var colorSchemeVariant: ColorSchemeVariant = ColorScheme.default.variant {
+        didSet {
+            guard oldValue != colorSchemeVariant else { return }
+            applyColorScheme(colorSchemeVariant)
+        }
+    }
+    
+    @objc dynamic var contentBackgroundColor: UIColor? = nil {
+        didSet {
+            guard oldValue != contentBackgroundColor else { return }
+            applyColorScheme(colorSchemeVariant)
+        }
+    }
+    
+    func applyColorScheme(_ colorSchemeVariant: ColorSchemeVariant) {
+        backgroundColor = contentBackgroundColor(for: colorSchemeVariant)
+        separator.backgroundColor = UIColor(scheme: .cellSeparator, variant: colorSchemeVariant)
+        titleLabel.textColor = UIColor(scheme: .textForeground, variant: colorSchemeVariant)
+        iconView.image = icon.map { UIImage.init(for: $0, iconSize: .tiny, color: UIColor(scheme: .iconNormal, variant: colorSchemeVariant)) }
+    }
+    
+    func contentBackgroundColor(for colorSchemeVariant: ColorSchemeVariant) -> UIColor {
+        return contentBackgroundColor ?? UIColor(scheme: .barBackground, variant: colorSchemeVariant)
+    }
+    
+    override var isHighlighted: Bool {
+        didSet {
+            backgroundColor = isHighlighted
+                ? UIColor(white: 0, alpha: 0.08)
+                : contentBackgroundColor(for: colorSchemeVariant)
+        }
+    }
     
     override func setupViews() {
         super.setupViews()
@@ -129,6 +161,7 @@ final class OpenServicesAdminCell: StartUIIconCell  {
         isAccessibilityElement = true
         accessibilityLabel = title
         accessibilityIdentifier = "button.searchui.open-services"
+        applyColorScheme(ColorScheme.default.variant)
     }
     
 }

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
@@ -217,7 +217,8 @@ extension UIViewController {
     
     private func performSearch(query: String, options: SearchOptions) {
         pendingSearchTask?.cancel()
-        
+        searchResultsView?.emptyResultContainer.isHidden = true
+
         let request = SearchRequest(query: query, searchOptions: options, team: ZMUser.selfUser().team)
         let task = searchDirectory.perform(request)
         


### PR DESCRIPTION
## What's new in this PR?

### Issues

The button to manage services appeared white on white in the conversation details.

### Causes

The button was not updated for the current color scheme via UIAppearance.

### Solutions

Make sure the button (the cell in particular) is functioning correctly.

Additionally updated the logic for initial state of the no results view.