### PR TITLE
Fix: archive screen rendering issue

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Views/RoundedBadge.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/RoundedBadge.swift
@@ -22,6 +22,7 @@ import Cartography
 public class RoundedBadge: UIView {
     public let containedView: UIView
     public var trailingConstraint: NSLayoutConstraint!
+    public var widthGreaterThanHeightConstraint: NSLayoutConstraint!
 
     init(view: UIView, contentInset: UIEdgeInsets = UIEdgeInsets(top: 2, left: 4, bottom: 2, right: 4)) {
         containedView = view
@@ -31,17 +32,29 @@ public class RoundedBadge: UIView {
         
         constrain(self, containedView) { selfView, containedView in
             containedView.leading == selfView.leading + contentInset.left
-            self.trailingConstraint = containedView.trailing == selfView.trailing - contentInset.right
+            trailingConstraint = containedView.trailing == selfView.trailing - contentInset.right
             containedView.top == selfView.top + contentInset.top
             containedView.bottom == selfView.bottom - contentInset.bottom
             
-            selfView.width >= selfView.height
+            widthGreaterThanHeightConstraint = selfView.width >= selfView.height
         }
-        
+
+        updateCollapseConstraints(isCollapsed: true)
+
         self.layer.masksToBounds = true
         updateCornerRadius()
     }
-    
+
+    func updateCollapseConstraints(isCollapsed: Bool){
+        if isCollapsed {
+            trailingConstraint.isActive = false
+            widthGreaterThanHeightConstraint.isActive = false
+        } else {
+            trailingConstraint.isActive = true
+            widthGreaterThanHeightConstraint.isActive = true
+        }
+    }
+
     func updateCornerRadius() {
         self.layer.cornerRadius = ceil(self.bounds.height / 2.0)
     }

--- a/Wire-iOS/Sources/UserInterface/Components/Views/RoundedBadge.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/RoundedBadge.swift
@@ -21,6 +21,8 @@ import Cartography
 
 public class RoundedBadge: UIView {
     public let containedView: UIView
+    public var trailingConstraint: NSLayoutConstraint!
+
     init(view: UIView, contentInset: UIEdgeInsets = UIEdgeInsets(top: 2, left: 4, bottom: 2, right: 4)) {
         containedView = view
         super.init(frame: .zero)
@@ -29,7 +31,7 @@ public class RoundedBadge: UIView {
         
         constrain(self, containedView) { selfView, containedView in
             containedView.leading == selfView.leading + contentInset.left
-            containedView.trailing == selfView.trailing - contentInset.right
+            self.trailingConstraint = containedView.trailing == selfView.trailing - contentInset.right
             containedView.top == selfView.top + contentInset.top
             containedView.bottom == selfView.bottom - contentInset.bottom
             

--- a/Wire-iOS/Sources/UserInterface/Conversation/ArchivedListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ArchivedListViewController.swift
@@ -61,6 +61,11 @@ import Cartography
             registerForPreviewing(with: self, sourceView: collectionView)
         }
     }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        collectionView.collectionViewLayout.invalidateLayout()
+    }
     
     func createViews() {
         let flowLayout = UICollectionViewFlowLayout()

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListAccessoryView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListAccessoryView.swift
@@ -33,7 +33,9 @@ import Cartography
     let textLabel = UILabel()
     let iconView = UIImageView()
     var collapseWidthConstraint: NSLayoutConstraint!
-    
+    var expandWidthConstraint: NSLayoutConstraint!
+    var expandTypingViewWidthConstraint: NSLayoutConstraint!
+
     @objc init(mediaPlaybackManager: MediaPlaybackManager) {
         self.mediaPlaybackManager = mediaPlaybackManager
         super.init(frame: .zero)
@@ -69,9 +71,9 @@ import Cartography
             typingView.trailing == selfView.trailing ~ 999.0
             typingView.top == selfView.top
             typingView.bottom == selfView.bottom
-            typingView.width >= 28
+            self.expandTypingViewWidthConstraint = typingView.width >= 28
             
-            selfView.width >= 28
+            self.expandWidthConstraint = selfView.width >= 28
             self.collapseWidthConstraint = selfView.width == 0
         }
         self.collapseWidthConstraint.isActive = false
@@ -130,6 +132,20 @@ import Cartography
             return .none
         }
     }
+
+    func updateCollapseConstraints(collapseSelf: Bool) {
+        if collapseSelf {
+            expandWidthConstraint.isActive = false
+            expandTypingViewWidthConstraint.isActive = false
+            badgeView.trailingConstraint.isActive = false
+            collapseWidthConstraint.isActive = true
+        } else {
+            collapseWidthConstraint.isActive = false
+            badgeView.trailingConstraint.isActive = true
+            expandWidthConstraint.isActive = true
+            expandTypingViewWidthConstraint.isActive = true
+        }
+    }
     
     public func updateForIcon() {
         self.badgeView.containedView.subviews.forEach { $0.removeFromSuperview() }
@@ -140,13 +156,12 @@ import Cartography
         
         self.textLabel.textColor = UIColor(scheme: .textForeground, variant: .dark)
         
-        self.collapseWidthConstraint.isActive = false
-        
         switch self.icon {
         case .none:
             self.badgeView.isHidden = true
             self.typingView.isHidden = true
-            self.collapseWidthConstraint.isActive = true
+
+            updateCollapseConstraints(collapseSelf: true)
 
             return
         case .activeCall(_):
@@ -172,6 +187,8 @@ import Cartography
             self.typingView.image = .none
         }
         
+        updateCollapseConstraints(collapseSelf: false)
+
         if let view = self.viewForState {
             self.badgeView.containedView.addSubview(view)
             

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListAccessoryView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListAccessoryView.swift
@@ -133,18 +133,18 @@ import Cartography
         }
     }
 
-    func updateCollapseConstraints(collapseSelf: Bool) {
-        if collapseSelf {
+    func updateCollapseConstraints(isCollapsed: Bool) {
+        if isCollapsed {
             expandWidthConstraint.isActive = false
             expandTypingViewWidthConstraint.isActive = false
-            badgeView.trailingConstraint.isActive = false
             collapseWidthConstraint.isActive = true
         } else {
             collapseWidthConstraint.isActive = false
-            badgeView.trailingConstraint.isActive = true
             expandWidthConstraint.isActive = true
             expandTypingViewWidthConstraint.isActive = true
         }
+
+        badgeView.updateCollapseConstraints(isCollapsed: isCollapsed)
     }
     
     public func updateForIcon() {
@@ -161,7 +161,7 @@ import Cartography
             self.badgeView.isHidden = true
             self.typingView.isHidden = true
 
-            updateCollapseConstraints(collapseSelf: true)
+            updateCollapseConstraints(isCollapsed: true)
 
             return
         case .activeCall(_):
@@ -187,7 +187,7 @@ import Cartography
             self.typingView.image = .none
         }
         
-        updateCollapseConstraints(collapseSelf: false)
+        updateCollapseConstraints(isCollapsed: false)
 
         if let view = self.viewForState {
             self.badgeView.containedView.addSubview(view)

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListCell.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListCell.m
@@ -142,7 +142,7 @@ static const NSTimeInterval OverscrollRatio = 2.5;
         self.hasCreatedInitialConstraints = YES;
         [self.itemView autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsZero];
 
-        [self.menuDotsView autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsZero];
+        [self.menuDotsView autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsZero excludingEdge:ALEdgeLeading];
         
         [self.menuDotsView autoPinEdgeToSuperviewEdge:ALEdgeLeading withInset:leftMarginConvList];
     }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListItemView.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListItemView.m
@@ -162,7 +162,7 @@ NSString * const ConversationListItemDidScrollNotification = @"ConversationListI
     }];
 
     [NSLayoutConstraint autoCreateConstraintsWithoutInstalling:^{
-        self.titleTwoLineConstraint = [self.labelsContainer autoAlignAxisToSuperviewAxis:ALAxisHorizontal]; ///TODO: doubled?
+        self.titleTwoLineConstraint = [self.labelsContainer autoAlignAxisToSuperviewAxis:ALAxisHorizontal];
     }];
 }
 

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListItemView.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListItemView.m
@@ -149,9 +149,7 @@ NSString * const ConversationListItemDidScrollNotification = @"ConversationListI
         [self.labelsContainer autoPinEdge:ALEdgeLeading toEdge:ALEdgeLeading ofView:self withOffset:leftMargin];
         [self.labelsContainer autoPinEdge:ALEdgeTrailing toEdge:ALEdgeLeading ofView:self.rightAccessory withOffset:-8.0];
         [self.labelsContainer autoPinEdgeToSuperviewEdge:ALEdgeBottom withInset:8 relation:NSLayoutRelationGreaterThanOrEqual];
-        
-        self.titleTwoLineConstraint = [self.labelsContainer autoAlignAxisToSuperviewAxis:ALAxisHorizontal];
-        self.titleTwoLineConstraint.active = NO;
+
         self.titleOneLineConstraint = [self.titleField autoAlignAxis:ALAxisHorizontal toSameAxisOfView:self];
         
         [self.rightAccessory autoAlignAxisToSuperviewAxis:ALAxisHorizontal];
@@ -161,6 +159,10 @@ NSString * const ConversationListItemDidScrollNotification = @"ConversationListI
         [self.lineView autoPinEdgeToSuperviewEdge:ALEdgeBottom];
         [self.lineView autoPinEdge:ALEdgeTrailing toEdge:ALEdgeTrailing ofView:self withOffset:0.0];
         [self.lineView autoPinEdge:ALEdgeLeading toEdge:ALEdgeLeading ofView:self.titleField];
+    }];
+
+    [NSLayoutConstraint autoCreateConstraintsWithoutInstalling:^{
+        self.titleTwoLineConstraint = [self.labelsContainer autoAlignAxisToSuperviewAxis:ALAxisHorizontal]; ///TODO: doubled?
     }];
 }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

Sometimes archive screen's collection view is not rendered completely or extra space is rendering at the bottom.

### Causes

The contentSize of the collectionView is incorrect. A possible reason is it is rendering the cell when the viewcontroller's view has zero frame size.

### Solutions

Call collectionView.collectionViewLayout.invalidateLayout() when viewWillAppear to refresh the contentSize.

## Notes

Fix all breaking constraints when some of  ConversationListCell's subitems have zero-size frames.