### PR TITLE
Do not desaturate the user image for service

### DIFF
--- a/WireExtensionComponents/Views/UserImageView.m
+++ b/WireExtensionComponents/Views/UserImageView.m
@@ -137,7 +137,9 @@ CGFloat PointSizeForUserImageSize(UserImageViewSize size)
     self.containerView.layer.borderColor = [self borderColorForUser:user];
     self.containerView.layer.borderWidth = [self borderWidthForUser:user];
     self.imageView.backgroundColor = [self containerBackgroundColorForUser:user];
-    self.shouldDesaturate |= user.isServiceUser;
+    if (user.isServiceUser) {
+        self.shouldDesaturate = false;
+    }
 }
 
 - (AvatarImageViewShape)shapeForUser:(id <UserType>)user


### PR DESCRIPTION
## What's new in this PR?

### Issues

Service users are considered connected, since they are enabled by the team admin. No reason to de-saturate their avatar.