### PR TITLE
Equatable and Hashable clean up

### DIFF
--- a/Wire-iOS/Sources/AppState.swift
+++ b/Wire-iOS/Sources/AppState.swift
@@ -26,26 +26,4 @@ enum AppState : Equatable {
     case blacklisted
     case migrating
     case loading(account: Account, from: Account?)
-
-    public static func ==(lhs: AppState, rhs: AppState) -> Bool {
-        
-        switch (lhs, rhs) {
-        case let (.unauthenticated(lhs_error), .unauthenticated(rhs_error)):
-            return lhs_error == rhs_error
-        
-        case let (.authenticated(lhs), .authenticated(rhs)):
-            return lhs == rhs
-            
-        case let (.loading(account: lhs1, from: lhs2), .loading(account: rhs1, from: rhs2)):
-            return lhs1 == rhs1 && lhs2 == rhs2
-            
-        case (.headless, .headless),
-             (.blacklisted, .blacklisted),
-             (.migrating, .migrating):
-            return true
-        default:
-            return false
-        }   
-    }
-    
 }

--- a/Wire-iOS/Sources/Components/Settings/SettingsProperty.swift
+++ b/Wire-iOS/Sources/Components/Settings/SettingsProperty.swift
@@ -21,7 +21,7 @@ import WireExtensionComponents
 enum SettingsPropertyValue: Equatable {
     case bool(value: Bool)
     case number(value: NSNumber)
-    case string(value: Swift.String)
+    case string(value: String)
     case none
 
     init(_ bool: Bool) {
@@ -68,15 +68,6 @@ enum SettingsPropertyValue: Equatable {
         case .none:
             return .none
         }
-    }
-}
-
-func ==(a: SettingsPropertyValue, b: SettingsPropertyValue) -> Bool {
-    switch (a, b) {
-    case (.string(let a), .string(let b)): return a == b
-    case (.number(let a), .number(let b)): return a == b
-    case (.none, .none): return true
-    default: return false
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Calling/CallActionsView/CallActionAppearance.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallActionsView/CallActionAppearance.swift
@@ -63,11 +63,3 @@ enum CallActionAppearance: Equatable {
         }
     }
 }
-
-func ==(lhs: CallActionAppearance, rhs: CallActionAppearance) -> Bool {
-    switch (lhs, rhs) {
-    case (.light, .light): return true
-    case let (.dark(blurred: lhsBlurred), .dark(blurred: rhsBlurred)): return lhsBlurred == rhsBlurred
-    default: return false
-    }
-}

--- a/Wire-iOS/Sources/UserInterface/Calling/CallActionsView/CallActionsView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallActionsView/CallActionsView.swift
@@ -22,8 +22,8 @@ protocol CallActionsViewDelegate: class {
     func callActionsView(_ callActionsView: CallActionsView, perform action: CallAction)
 }
 
-enum MediaState {
-    struct SpeakerState {
+enum MediaState: Equatable {
+    struct SpeakerState: Equatable {
         let isEnabled: Bool
         let canBeToggled: Bool
     }
@@ -48,21 +48,6 @@ enum MediaState {
         guard case .notSendingVideo(let state) = self else { return false }
         return state.canBeToggled
     }
-}
-
-extension MediaState: Equatable {
-    
-    static func ==(lhs: MediaState, rhs: MediaState) -> Bool {
-        switch (lhs, rhs) {
-        case (.sendingVideo, .sendingVideo):
-            return true
-        case (.notSendingVideo(let lhsState), .notSendingVideo(let rhsState)):
-            return (lhsState.isEnabled, lhsState.canBeToggled) == (rhsState.isEnabled, rhsState.canBeToggled)
-        default:
-            return false
-        }
-    }
-    
 }
 
 // This protocol describes the input for a `CallActionsView`.

--- a/Wire-iOS/Sources/UserInterface/Calling/CallDegradationViewController/CallDegradationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallDegradationViewController/CallDegradationController.swift
@@ -18,28 +18,11 @@
 
 import Foundation
 
-enum CallDegradationState {
+enum CallDegradationState: Equatable {
     
     case none
     case incoming(degradedUser: ZMUser?)
     case outgoing(degradedUser: ZMUser?)
-    
-}
-
-extension CallDegradationState: Equatable {
-    
-    static func ==(lhs: CallDegradationState, rhs: CallDegradationState) -> Bool {
-        switch (lhs, rhs) {
-        case (.none, .none):
-            return true
-        case (.incoming(degradedUser: let lhsDegradedUser), .incoming(degradedUser: let rhsDegradedUser)):
-            return lhsDegradedUser == rhsDegradedUser
-        case (.outgoing(degradedUser: let lhsDegradedUser), .outgoing(degradedUser: let rhsDegradedUser)):
-            return lhsDegradedUser == rhsDegradedUser
-        default:
-            return false
-        }
-    }
     
 }
 

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoViewControllerAccessoryType.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoViewControllerAccessoryType.swift
@@ -16,7 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-enum CallInfoViewControllerAccessoryType {
+enum CallInfoViewControllerAccessoryType: Equatable {
     case none
     case avatar(ZMUser)
     case participantsList(CallParticipantsList)
@@ -43,23 +43,6 @@ enum CallInfoViewControllerAccessoryType {
             return participants
         default:
             return []
-        }
-    }
-    
-}
-
-extension CallInfoViewControllerAccessoryType: Equatable {
-    
-    static func ==(lhs: CallInfoViewControllerAccessoryType, rhs: CallInfoViewControllerAccessoryType) -> Bool {
-        switch (lhs, rhs) {
-        case (.none, .none):
-            return true
-        case (.avatar(let lhsUser), .avatar(let rhsUser)):
-            return lhsUser == rhsUser
-        case (.participantsList(let lhsParticipants), .participantsList(let rhsParticipants)):
-            return lhsParticipants == rhsParticipants
-        default:
-            return false
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallStatusView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallStatusView.swift
@@ -43,7 +43,7 @@ extension CallStatusViewInputType {
     }
 }
 
-enum CallStatusViewState {
+enum CallStatusViewState: Equatable {
     case none
     case connecting
     case ringingIncoming(name: String?) // Caller name + call type "XYZ is calling..."
@@ -51,23 +51,6 @@ enum CallStatusViewState {
     case established(duration: TimeInterval) // Call duration in seconds "04:18"
     case reconnecting // "Reconnecting..."
     case terminating // "Ending call..."
-}
-
-extension CallStatusViewState: Equatable {
-    
-    static func ==(lhs: CallStatusViewState, rhs: CallStatusViewState) -> Bool {
-        switch (lhs, rhs) {
-        case (.none, .none), (.connecting, .connecting), (.reconnecting, .reconnecting), (.terminating, .terminating), (.ringingOutgoing, .ringingOutgoing):
-            return true
-        case (.ringingIncoming(let lhsName), .ringingIncoming(let rhsName)):
-            return lhsName == rhsName
-        case (.established(let lhsDuration), .established(let rhsDuration)):
-            return lhsDuration == rhsDuration
-        default:
-            return false
-        }
-    }
-    
 }
 
 final class CallStatusView: UIView {

--- a/Wire-iOS/Sources/UserInterface/Calling/CallParticipantsView/CallParticipantsView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallParticipantsView/CallParticipantsView.swift
@@ -49,29 +49,6 @@ enum CallParticipantsCellConfiguration: Hashable {
             collectionView.register($0, forCellWithReuseIdentifier: $0.reuseIdentifier)
         }
     }
-    
-    var hashValue: Int {
-        switch self {
-        case let .callParticipant(user: user, sendsVideo: sendsVideo): return user.hashValue ^ sendsVideo.hashValue
-        case let .showAll(totalCount: count): return count.hashValue
-        }
-    }
-
-}
-
-extension CallParticipantsCellConfiguration: Equatable {
-    
-    static func ==(lhs: CallParticipantsCellConfiguration, rhs: CallParticipantsCellConfiguration) -> Bool {
-        switch (lhs, rhs) {
-        case (.showAll(let lhsCount), .showAll(let rhsCount)):
-            return lhsCount == rhsCount
-        case (.callParticipant(let lhsUser), .callParticipant(let rhsUser)):
-            return lhsUser == rhsUser
-        default:
-            return false
-        }
-    }
-    
 }
 
 class CallParticipantsView: UICollectionView, Themeable {

--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridView.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 
-struct ParticipantVideoState {
+struct ParticipantVideoState: Equatable {
     let stream: UUID
     let isPaused: Bool
 }
@@ -27,14 +27,6 @@ protocol VideoGridConfiguration {
     var floatingVideoStream: ParticipantVideoState? { get }
     var videoStreams: [ParticipantVideoState] { get }
     var isMuted: Bool { get }
-}
-
-extension ParticipantVideoState: Equatable {
-    
-    static func ==(lhs: ParticipantVideoState, rhs: ParticipantVideoState) -> Bool {
-        return lhs.isPaused == rhs.isPaused && lhs.stream == rhs.stream
-    }
-    
 }
 
 // Workaround to make the protocol equatable, it might be possible to conform VideoGridConfiguration

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionsSectionSet.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionsSectionSet.swift
@@ -44,12 +44,4 @@ public struct CollectionsSectionSet: OptionSet, Hashable {
     
     /// Returns visible sections in the display order
     public static let visible: [CollectionsSectionSet] = [images, videos, links, filesAndAudio, loading]
-    
-    public var hashValue: Int {
-        return Int(self.rawValue)
-    }
-}
-
-public func ==(lhs: CollectionsSectionSet, rhs: CollectionsSectionSet) -> Bool {
-    return lhs.rawValue == rhs.rawValue
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
@@ -99,14 +99,6 @@ public enum InputBarState: Equatable {
     }
 }
 
-public func ==(lhs: InputBarState, rhs: InputBarState) -> Bool {
-    switch (lhs, rhs) {
-    case (.writing, .writing): return true
-    case (.editing(let lhsText), .editing(let rhsText)): return lhsText == rhsText
-    default: return false
-    }
-}
-
 private struct InputBarConstants {
     let buttonsBarHeight: CGFloat = 56
 }

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/AccessoryTextField.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/AccessoryTextField.swift
@@ -30,7 +30,7 @@ protocol TextFieldValidationDelegate: class {
 }
 
 class AccessoryTextField: UITextField {
-    enum Kind {
+    enum Kind: Equatable {
         case email
         case name
         case password

--- a/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/TextFieldValidator.swift
+++ b/Wire-iOS/Sources/UserInterface/Registration/RegistrationTeam/TextFieldValidator.swift
@@ -28,22 +28,6 @@ class TextFieldValidator {
         case invalidEmail
         case custom(String)
         case none
-
-
-        static func ==(lhs: ValidationError, rhs: ValidationError) -> Bool {
-            switch (lhs, rhs) {
-            case let (.tooShort(l), .tooShort(r)),
-                 let (.tooLong(l), .tooLong(r)):
-                return l == r
-            case (.invalidEmail, .invalidEmail),
-                 (.none, .none):
-                return true
-            case (.custom(let lhs), .custom(let rhs)):
-                return lhs == rhs
-            default:
-                return false
-            }
-        }
     }
 
     func validate(text: String?, kind: AccessoryTextField.Kind) -> TextFieldValidator.ValidationError {

--- a/Wire-iOS/Sources/UserInterface/Services/ServiceDetailViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Services/ServiceDetailViewController.swift
@@ -25,7 +25,7 @@ extension ZMConversation {
     }
 }
 
-public enum ServiceConversation {
+public enum ServiceConversation: Hashable {
     case existing(ZMConversation)
     case new
 }
@@ -41,22 +41,6 @@ extension Service {
         self.serviceUser = serviceUser
         self.serviceUserDetails = nil
         self.provider = nil
-    }
-}
-
-extension ServiceConversation: Hashable {
-
-    public static func ==(lhs: ServiceConversation, rhs: ServiceConversation) -> Bool {
-        return lhs.hashValue == rhs.hashValue
-    }
-
-    public var hashValue: Int {
-        switch self {
-        case .new:
-            return 0
-        case .existing(let conversation):
-            return conversation.hashValue
-        }
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ChangePhoneViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ChangePhoneViewController.swift
@@ -21,7 +21,7 @@ import Cartography
 import WireUtilities
 import WireSyncEngine
 
-fileprivate struct PhoneNumber {
+fileprivate struct PhoneNumber: Equatable {
     enum ValidationResult {
         case valid
         case tooLong
@@ -81,12 +81,6 @@ fileprivate struct PhoneNumber {
     }
 }
 
-extension PhoneNumber: Equatable {
-    static func ==(lhs: PhoneNumber, rhs: PhoneNumber) -> Bool {
-        return lhs.fullNumber == rhs.fullNumber
-    }
-}
-
 fileprivate struct ChangePhoneNumberState {
     let currentNumber: PhoneNumber?
     var newNumber: PhoneNumber?
@@ -99,7 +93,9 @@ fileprivate struct ChangePhoneNumberState {
         guard let phoneNumber = visibleNumber else { return false }
         switch phoneNumber.validate() {
         case .valid:
-            return phoneNumber != currentNumber
+            // No current number -> it's a valid change
+            guard let current = currentNumber else { return true }
+            return phoneNumber != current
         default:
             return false
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Recent Swift version can automatically synthesize `Equatable` and `Hashable` implementation. This PR removes our custom implementations where possible

## Notes

There are still some cases where we keep custom implementation:
* "Fake" equality by just defining `==` operator on protocols to make it possible to compare them (e.g. https://github.com/wireapp/wire-ios/blob/develop/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptor.swift#L51). It is a bit of a weird pattern, but seems to be used in several places.
* `FontScheme`. We have to define our own `Hashable` because only from Swift 4.2 it gained ability to synthesize `hashValue` for classes/structs with optional properties. 