### PR TITLE
fix the missing bounce back animation issue

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListCell.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListCell.m
@@ -142,7 +142,7 @@ static const NSTimeInterval OverscrollRatio = 2.5;
         self.hasCreatedInitialConstraints = YES;
         [self.itemView autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsZero];
 
-        [self.menuDotsView autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsZero excludingEdge:ALEdgeLeading];
+        [self.menuDotsView autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsZero];
         
         [self.menuDotsView autoPinEdgeToSuperviewEdge:ALEdgeLeading withInset:leftMarginConvList];
     }


### PR DESCRIPTION
## What's new in this PR?

Undo a constraint fix which causes restore animation of sliding cell stops working.