### PR TITLE
Fix: Archive conversations are not rendered

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ArchivedListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ArchivedListViewController.swift
@@ -64,7 +64,7 @@ import Cartography
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        collectionView.collectionViewLayout.invalidateLayout()
+        collectionView.reloadData()
     }
     
     func createViews() {


### PR DESCRIPTION
## What's new in this PR?

Fixing some collection view cells are not rendered by adding the missing reloadData call. 