### PR TITLE
Resize user images to the smallest possible size

### DIFF
--- a/Wire-iOS/Sources/Helpers/syncengine/ZMUser+Images.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMUser+Images.swift
@@ -24,23 +24,37 @@ public var defaultUserImageCache: ImageCache<UIImage> = ImageCache()
 
 extension UserType {
     
-    private func cacheKey(for size: ProfileImageSize, desaturate: Bool) -> String? {
+    private func cacheKey(for size: ProfileImageSize, sizeLimit: Int?, desaturate: Bool) -> String? {
         
         guard let baseKey = (size == .preview ? smallProfileImageCacheKey : mediumProfileImageCacheKey) else {
             return nil
         }
         
+        var derivedKey = baseKey
+        
         if desaturate {
-            return "\(baseKey)_desaturated"
-        } else {
-            return baseKey
+            derivedKey = "\(derivedKey)_desaturated"
         }
         
+        if let sizeLimit = sizeLimit {
+            derivedKey = "\(derivedKey)_\(sizeLimit)"
+        }
+        
+        return derivedKey
     }
-    
-    public func fetchProfileImage(cache: ImageCache<UIImage> = defaultUserImageCache, desaturate: Bool = false, size: ProfileImageSize, completion: @escaping (_ image: UIImage?) -> Void ) -> Void {
-            
-        guard let cacheKey = cacheKey(for: size, desaturate: desaturate) as NSString? else {
+        
+    public func fetchProfileImage(cache: ImageCache<UIImage> = defaultUserImageCache, sizeLimit: Int? = nil, desaturate: Bool = false, completion: @escaping (_ image: UIImage?) -> Void ) -> Void {
+        
+        let screenScale = UIScreen.main.scale
+        let previewSizeLimit: CGFloat = 280
+        let size: ProfileImageSize
+        if let sizeLimit = sizeLimit {
+            size = CGFloat(sizeLimit) * screenScale < previewSizeLimit ? .preview : .complete
+        } else {
+            size = .complete
+        }
+        
+        guard let cacheKey = cacheKey(for: size, sizeLimit: sizeLimit, desaturate: desaturate) as NSString? else {
             return completion(nil)
         }
         
@@ -56,17 +70,21 @@ extension UserType {
         }
         
         imageData(for: size, queue: cache.processingQueue) { (imageData) in
-            guard let imageData = imageData, let rawImage = UIImage(data: imageData) else {
+            guard let imageData = imageData else {
                 return DispatchQueue.main.async {
                     completion(nil)
                 }
             }
             
             var image: UIImage?
-            if desaturate {
-                image = rawImage.desaturatedImage(with: ciContext, saturation: 0)
+            if let sizeLimit = sizeLimit {
+                image = UIImage(from: imageData, withMaxSize: CGFloat(sizeLimit) * screenScale)
             } else {
-                image = rawImage.decoded
+                image = UIImage(data: imageData)?.decoded
+            }
+            
+            if desaturate {
+                image = image?.desaturatedImage(with: ciContext, saturation: 0)
             }
             
             if let image = image {

--- a/Wire-iOS/Sources/UserInterface/Components/Views/ConversationAvatarView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/ConversationAvatarView.swift
@@ -86,7 +86,7 @@ extension ZMConversation {
 }
 
 
-fileprivate enum Mode {
+fileprivate enum Mode: Equatable {
     /// 0 participants in conversation:
     /// /    \
     /// \    /
@@ -140,7 +140,7 @@ final public class ConversationAvatarView: UIView {
             self.userImages().forEach {
                 $0.userSession = ZMUserSession.shared()
                 $0.shouldDesaturate = false
-                $0.size = .tiny
+                $0.size = mode == .four ? .tiny : .small
                 if index < users.count {
                     $0.user = users[index]
                 }

--- a/Wire-iOS/Sources/UserInterface/Components/Views/UserCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/UserCell.swift
@@ -114,7 +114,7 @@ class UserCell: SeparatorCollectionViewCell {
         
         avatar.userSession = ZMUserSession.shared()
         avatar.initials.font = UIFont.systemFont(ofSize: 11, weight: .light)
-        avatar.size = .tiny
+        avatar.size = .small
         avatar.translatesAutoresizingMaskIntoConstraints = false
 
         avatarSpacer.addSubview(avatar)

--- a/Wire-iOS/Sources/UserInterface/Settings/ProfileSelfPictureViewController+UserObserver.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/ProfileSelfPictureViewController+UserObserver.swift
@@ -23,7 +23,7 @@ extension ProfileSelfPictureViewController: ZMUserObserver {
     public func userDidChange(_ changeInfo: UserChangeInfo) {
         guard changeInfo.imageMediumDataChanged else { return }
         
-        changeInfo.user.fetchProfileImage(size: .complete) { (image) in
+        changeInfo.user.fetchProfileImage { (image) in
             self.selfUserImageView.image = image
         }
     }

--- a/WireExtensionComponents/Views/UserImageView.h
+++ b/WireExtensionComponents/Views/UserImageView.h
@@ -23,13 +23,10 @@
 NS_ASSUME_NONNULL_BEGIN
 
 typedef NS_ENUM(NSUInteger, UserImageViewSize) {
-    UserImageViewSizeFirst,
-    UserImageViewSizeTiny = UserImageViewSizeFirst,
-    UserImageViewSizeSmall,
-    UserImageViewSizeNormal,
-    UserImageViewSizeBig,
-    UserImageViewSizeGiant,
-    UserImageViewSizeLast = UserImageViewSizeGiant
+    UserImageViewSizeTiny = 16,
+    UserImageViewSizeSmall = 32,
+    UserImageViewSizeNormal = 64,
+    UserImageViewSizeBig = 320
 };
 
 @class UserImageView, ZMUserSession, Team;

--- a/WireExtensionComponents/Views/UserImageView.m
+++ b/WireExtensionComponents/Views/UserImageView.m
@@ -27,35 +27,6 @@
 
 #import <WireExtensionComponents/WireExtensionComponents-Swift.h>
 
-CGFloat PixelSizeForUserImageSize(UserImageViewSize size);
-CGFloat PointSizeForUserImageSize(UserImageViewSize size);
-
-CGFloat PixelSizeForUserImageSize(UserImageViewSize size)
-{
-    return PointSizeForUserImageSize(size) * [UIScreen mainScreen].scale;
-}
-
-CGFloat PointSizeForUserImageSize(UserImageViewSize size)
-{
-    switch (size) {
-        case UserImageViewSizeTiny:
-            return 36.0f;
-            break;
-        case UserImageViewSizeSmall:
-            return 56.0f;
-            break;
-        case UserImageViewSizeNormal:
-            return 64.0f;
-            break;
-        case UserImageViewSizeBig:
-            return 320.0f;
-            break;
-        default:
-            break;
-    }
-    return 0;
-}
-
 @interface UserImageView ()
 
 @property (nonatomic) id userObserverToken;
@@ -99,7 +70,7 @@ CGFloat PointSizeForUserImageSize(UserImageViewSize size)
 - (void)setupBasicProperties
 {
     _shouldDesaturate = YES;
-    _size = UserImageViewSizeNormal;
+    _size = UserImageViewSizeSmall;
 
     self.accessibilityElementsHidden = YES;
     
@@ -109,7 +80,7 @@ CGFloat PointSizeForUserImageSize(UserImageViewSize size)
 
 - (CGSize)intrinsicContentSize
 {
-    CGFloat imageSize = PointSizeForUserImageSize(self.size);
+    CGFloat imageSize = self.size;
     return CGSizeMake(imageSize, imageSize);
 }
 

--- a/WireExtensionComponents/Views/UserImageView.swift
+++ b/WireExtensionComponents/Views/UserImageView.swift
@@ -26,20 +26,12 @@ extension UserImageView {
         
         guard let user = user else { return }
         
-        var profileImageSize: ProfileImageSize
-        switch size {
-        case .small, .normal, .first:
-            profileImageSize = .preview
-        default:
-            profileImageSize = .complete
-        }
-        
         var desaturate = false
         if shouldDesaturate {
             desaturate = !user.isConnected && !user.isSelfUser && !user.isTeamMember || user.isServiceUser
         }
         
-        user.fetchProfileImage(desaturate: desaturate, size: profileImageSize, completion: { [weak self] (image) in
+        user.fetchProfileImage(sizeLimit: Int(size.rawValue), desaturate: desaturate, completion: { [weak self] (image) in
             // Don't set image if nil or if user has changed during fetch
             guard let image = image, user.isEqual(self?.user) else { return }
             self?.setUserImage(image)


### PR DESCRIPTION
## What's new in this PR?

### Issues

Profile images were getting purged from the cache fairly frequently.

### Causes

- `UserImageView`with size  `.tiny` were erroneously downloading the complete profile image
- We weren't downscaling-scaling the profile images thus keeping unnecessarily big images in memory

### Solutions

Scale images based on  the given `UserImageProfileSize`

## Notes

I also deleted some cases from `UserImageProfileSize` which weren't used anymore.