### PR TITLE
Fix: Archive conversations are not rendered

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ArchivedListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ArchivedListViewController.swift
@@ -65,6 +65,7 @@ import Cartography
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         collectionView.reloadData()
+        collectionView.collectionViewLayout.invalidateLayout()
     }
     
     func createViews() {
@@ -151,6 +152,7 @@ extension ArchivedListViewController: ArchivedListViewModelDelegate {
     internal func archivedListViewModel(_ model: ArchivedListViewModel, didUpdateArchivedConversationsWithChange change: ConversationListChangeInfo, applyChangesClosure: @escaping () -> ()) {
         applyChangesClosure()
         collectionView.reloadData()
+        collectionView.collectionViewLayout.invalidateLayout()
     }
     
     func archivedListViewModel(_ model: ArchivedListViewModel, didUpdateConversationWithChange change: ConversationChangeInfo) {


### PR DESCRIPTION
## What's new in this PR?

After several attempts, we still find that the collection view in Archive conversations screen is not refreshed after first loading. Debugging with view hierarchy and found that the cell is not created at all. It seems like an issue of layout and I added collectionView.collectionViewLayout.invalidateLayout() to fix this issue.