### PR TITLE
Show services tab on all builds

### DIFF
--- a/Wire-iOS/Sources/Helpers/syncengine/ZMUser+Additions.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMUser+Additions.swift
@@ -31,4 +31,8 @@ extension ZMUser {
     @objc var hasUntrustedClients: Bool {
         return nil != self.clients.first { !$0.verified }
     }
+    
+    @objc var canSeeServices: Bool {
+        return self.hasTeam
+    }
 }

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchGroupSelector.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchGroupSelector.swift
@@ -23,7 +23,7 @@ import Cartography
 @objcMembers final class SearchGroupSelector: UIView, TabBarDelegate {
 
     @objc static var shouldShowBotResults: Bool {
-        return DeveloperMenuState.developerMenuEnabled() && ZMUser.selfUser().team != nil
+        return ZMUser.selfUser().team != nil
     }
 
     @objc public var onGroupSelected: ((SearchGroup)->())? = nil

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchGroupSelector.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchGroupSelector.swift
@@ -21,11 +21,6 @@ import Foundation
 import Cartography
 
 @objcMembers final class SearchGroupSelector: UIView, TabBarDelegate {
-
-    @objc static var shouldShowBotResults: Bool {
-        return ZMUser.selfUser().team != nil
-    }
-
     @objc public var onGroupSelected: ((SearchGroup)->())? = nil
 
     @objc public var group: SearchGroup = .people {

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.m
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.m
@@ -114,7 +114,7 @@ static NSUInteger const StartUIInitiallyShowsKeyboardConversationThreshold = 10;
         [self performSearch];
     };
 
-    if (SearchGroupSelector.shouldShowBotResults) {
+    if ([[ZMUser selfUser] canSeeServices]) {
         [self.view addSubview:self.groupSelector];
     }
 
@@ -169,7 +169,7 @@ static NSUInteger const StartUIInitiallyShowsKeyboardConversationThreshold = 10;
     [self.searchHeaderViewController.view autoPinEdgeToSuperviewEdge:ALEdgeLeading];
     [self.searchHeaderViewController.view autoPinEdgeToSuperviewEdge:ALEdgeTrailing];
 
-    if (SearchGroupSelector.shouldShowBotResults) {
+    if ([[ZMUser selfUser] canSeeServices]) {
         [self.groupSelector autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.searchHeaderViewController.view];
         [self.groupSelector autoPinEdgeToSuperviewEdge:ALEdgeLeading];
         [self.groupSelector autoPinEdgeToSuperviewEdge:ALEdgeTrailing];


### PR DESCRIPTION
## What's new in this PR?

### Issues

We've been also checking the `DeveloperMenuState` flag in the tab bar itself.