### PR TITLE
Permit only left and right arrows for iPad popup

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
@@ -205,7 +205,7 @@ extension ConversationContentViewController: UIAdaptivePresentationControllerDel
             }
 
             popoverPresentationController.backgroundColor = UIColor(white: 0, alpha: 0.5)
-            popoverPresentationController.permittedArrowDirections = [.up, .down]
+            popoverPresentationController.permittedArrowDirections = [.left, .right]
         }
         
         keyboardAvoiding.presentationController?.delegate = self


### PR DESCRIPTION
## What's new in this PR?

### Issues

The share popover on iPad was sometimes rendered so small that the table view containing conversations was not visible.

### Causes

The popover was always being rendered above or below the message to be shared and depending on the location of this message in the screen, the popover was awkwardly positioned.

### Solutions

Force the popover to be rendered to the left or right of the message.

### Attachments

![wire 2018-08-22 at 13 34 42](https://user-images.githubusercontent.com/28632506/44461730-4b6f2f00-a612-11e8-996c-0fd87c600636.png)