### PR TITLE
Fix: Not all the conversations are shown in the search UI 

### DIFF
--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
@@ -198,7 +198,13 @@ extension UIViewController {
         searchResultsView?.isContainedInPopover = isContainedInPopover()
         view = searchResultsView
     }
-    
+
+    override public func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        sectionController.collectionView?.reloadData()
+        sectionController.collectionView?.collectionViewLayout.invalidateLayout()
+    }
+
     public override func viewDidLoad() {
         super.viewDidLoad()
         


### PR DESCRIPTION
## What's new in this PR?

### Issues

Some collection view cells are not rendered in Search Screen when the user first-time login to Wire.

### Causes

Unknown, but it is more likely to occur when the system is busy.

### Solutions

Similar to https://github.com/wireapp/wire-ios/pull/2561, call collectionView.reloadData() when viewWillAppear.


## Notes

I will run the time-profiler for this case to monitor the activities in this case.

