### PR TITLE
Update “Full house” dialog title

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -102,7 +102,7 @@
 
 "add_participants.all_contacts_added" = "Everyone’s here.";
 
-"add_participants.alert.title" = "Full house";
+"add_participants.alert.title" = "The group is full";
 "add_participants.alert.message.new_conversation" = "Up to %d people can join a conversation.";
 "add_participants.alert.message.existing_conversation" = "Up to %1$d people can join a conversation. Currently there is only room for %2$d more.";
 


### PR DESCRIPTION
The “Full house” dialog title that appears when a conversation reaches the maximum number of participants is a remnant of our earlier informal tone.

This should be revised to adapt to our recent B2B tone.

See https://github.com/wireapp/copywriting/issues/37.