### PR TITLE
Fix/desaturate unconnected users

### DIFF
--- a/WireExtensionComponents/Views/UserImageView.m
+++ b/WireExtensionComponents/Views/UserImageView.m
@@ -108,9 +108,6 @@
     self.containerView.layer.borderColor = [self borderColorForUser:user];
     self.containerView.layer.borderWidth = [self borderWidthForUser:user];
     self.imageView.backgroundColor = [self containerBackgroundColorForUser:user];
-    if (user.isServiceUser) {
-        self.shouldDesaturate = false;
-    }
 }
 
 - (AvatarImageViewShape)shapeForUser:(id <UserType>)user

--- a/WireExtensionComponents/Views/UserImageView.swift
+++ b/WireExtensionComponents/Views/UserImageView.swift
@@ -28,7 +28,7 @@ extension UserImageView {
         
         var desaturate = false
         if shouldDesaturate {
-            desaturate = !user.isConnected && !user.isSelfUser && !user.isTeamMember || user.isServiceUser
+            desaturate = !user.isConnected && !user.isSelfUser && !user.isTeamMember && !user.isServiceUser
         }
         
         user.fetchProfileImage(sizeLimit: Int(size.rawValue), desaturate: desaturate, completion: { [weak self] (image, cacheHit) in


### PR DESCRIPTION
## What's new in this PR?

### Issues

After going to the services tab, then searching for users, unconnected user avatars were not desaturated.

### Causes

When the `UserCell` was set with a service user, then the `shouldDesaturate` flag is set to false. When a non service user is set in the cell again, then the flag is not reset and so desaturation never occurs.

### Solutions

If the `shouldDesaturate` flag is set to true, it does not guarantee that the avatar will desaturate. Rather, there are further checks that the user on the user before deciding if desaturation should take place. Funny enough, it states that a service user avatar should desaturate, which contradicts the setting of `shouldDesaturate` to false (probably an adjustment to the code at a later date).

Anyway, the checks were adjusted in a way that we don't need to reset the `shouldDesaturate` flag to true after reseting the user. I chose to avoid this because perhaps there is a situation in which the cell should never desaturate the avatars, regardless of the user it represents.
