### PR TITLE
Fix wrong tracking event used for the call quallity review

### DIFF
--- a/Wire-iOS/Sources/Analytics/AnalyticsMixpanelProvider.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsMixpanelProvider.swift
@@ -95,6 +95,7 @@ final class AnalyticsMixpanelProvider: NSObject, AnalyticsProvider {
         "calling.initiated_call",
         "calling.received_call",
         "calling.avs_metrics_ended_call",
+        "calling.call_quality_review",
         "notifications.processing",
         TeamInviteEvent.sentInvite(.teamCreation).name,
         "integration.added_service",

--- a/Wire-iOS/Sources/Analytics/CallQualityScoreProvider.swift
+++ b/Wire-iOS/Sources/Analytics/CallQualityScoreProvider.swift
@@ -35,7 +35,7 @@ final class CallQualityScoreProvider: NSObject, AnalyticsType {
         nextProvider?.tagEvent(type(of: self).callingEventName, attributes: attributes)
     }
 
-    private static let callingEventName = "calling.avs_metrics_ended_call"
+    private static let callingEventName = "calling.call_quality_review"
     
     public var nextProvider: AnalyticsType? = nil
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

Call quality review was tracked using the AVS metric event.

### Solutions

Rename tracking event to `calling.call_quality_review`