### PR TITLE
Prevent alert being presented twice

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/CallDegradationViewController/CallDegradationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallDegradationViewController/CallDegradationController.swift
@@ -60,27 +60,29 @@ class CallDegradationController: UIViewController {
             })
         }
         
-        if let alertViewController = visisibleAlertController {
-            Log.calling.debug("Presenting alert about degraded call")
-            present(alertViewController, animated: !ProcessInfo.processInfo.isRunningTests)
-        }
+        presentAlertIfNeeded()
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
         view.isUserInteractionEnabled = false
     }
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        
-        if let alertViewController = visisibleAlertController, !alertViewController.isBeingPresented {
-            present(alertViewController, animated: true)
-        }
+        presentAlertIfNeeded()
     }
     
-    
+    private func presentAlertIfNeeded() {
+        guard
+            viewIfLoaded != nil,
+            let alertViewController = visisibleAlertController,
+            !alertViewController.isBeingPresented
+            else { return }
+        
+        Log.calling.debug("Presenting alert about degraded call")
+        present(alertViewController, animated: !ProcessInfo.processInfo.isRunningTests)
+    }
     
 }
 

--- a/Wire-iOS/Sources/UserInterface/Calling/CallDegradationViewController/CallDegradationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallDegradationViewController/CallDegradationController.swift
@@ -68,20 +68,14 @@ class CallDegradationController: UIViewController {
         view.isUserInteractionEnabled = false
     }
     
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        presentAlertIfNeeded()
-    }
-    
     private func presentAlertIfNeeded() {
         guard
-            viewIfLoaded != nil,
             let alertViewController = visisibleAlertController,
             !alertViewController.isBeingPresented
             else { return }
         
         Log.calling.debug("Presenting alert about degraded call")
-        present(alertViewController, animated: !ProcessInfo.processInfo.isRunningTests)
+        targetViewController?.present(alertViewController, animated: !ProcessInfo.processInfo.isRunningTests)
     }
     
 }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoRootViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoRootViewController.swift
@@ -56,7 +56,6 @@ final class CallInfoRootViewController: UIViewController, UINavigationController
         super.init(nibName: nil, bundle: nil)
         
         callDegradationController.targetViewController = self
-        callDegradationController.state = configuration.degradationState
     }
     
     required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Calling into a degraded conversation crashed the app.

### Causes

The state of the `CallDegradationController` was being set just after initialisation in `CallInfoRootViewController`, whereby it creates the alert view and presents it. Immediately afterwards, the `viewDidLoad` method is invoked, where the alert is presented if it's not already presented. Although we just called to present the alert, it is not yet registered as being presented, so we try to present a second time. This leads to an exception and crashes the app.

### Solutions

Refactor out presenting logic, and ensure that we don't try to present the alert before the view controllers view is loaded.