### PR TITLE
Fix: crash for missing method "[ConversationListViewController setNoConversationLabel:]"

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -2908,6 +2908,7 @@
 		EFABC921202085A6001F9866 /* UserDetailViewControllerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDetailViewControllerFactory.swift; sourceTree = "<group>"; };
 		EFABC92320208D80001F9866 /* UIViewController+removeUserConfirmationUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+removeUserConfirmationUI.swift"; sourceTree = "<group>"; };
 		EFAFCA812133FB59002B31A6 /* ArchivedNavigationBarTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArchivedNavigationBarTests.swift; sourceTree = "<group>"; };
+		EFAFCA8B21342A1E002B31A6 /* ConversationListViewController+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ConversationListViewController+Internal.h"; sourceTree = "<group>"; };
 		EFC7146D20DD471800FAA4B4 /* CountryCodeTableViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountryCodeTableViewControllerTests.swift; sourceTree = "<group>"; };
 		EFC8E216212C67E300BE7BBE /* PingCell+Style.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PingCell+Style.swift"; sourceTree = "<group>"; };
 		EFC8E218212C6AF500BE7BBE /* PingCellTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PingCellTests.swift; sourceTree = "<group>"; };
@@ -5068,6 +5069,7 @@
 				8F8913E91A9F287E0056AB0C /* ListContent */,
 				875D48A51A6D087F00BB17B5 /* ConversationListViewController.h */,
 				1E0737C31BD787D100D781EF /* ConversationListViewController+Private.h */,
+				EFAFCA8B21342A1E002B31A6 /* ConversationListViewController+Internal.h */,
 				875D48A61A6D087F00BB17B5 /* ConversationListViewController.m */,
 				EF218AC620A9DDEF004977BF /* ConversationListViewController+DataUsagePermissions.swift */,
 				BFAAB2381DEC6B2800CBC096 /* ConversationListViewController+Handles.swift */,

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+Internal.h
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+Internal.h
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+@interface ConversationListViewController ()
+
+@property (nonatomic) UILabel *noConversationLabel;
+
+@end

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+Private.h
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+Private.h
@@ -38,7 +38,6 @@ NS_ASSUME_NONNULL_BEGIN
 /// for NetworkStatusViewDelegate
 @property (nonatomic) BOOL shouldAnimateNetworkStatusView;
 @property (nonatomic) BOOL dataUsagePermissionDialogDisplayed;
-@property (nonatomic) UILabel *noConversationLabel;
 
 - (void)removeUserProfileObserver;
 - (void)presentSettings;

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+Private.h
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+Private.h
@@ -18,6 +18,7 @@
 
 
 #import "ConversationListViewController.h"
+@import WireSyncEngine;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController.m
@@ -19,6 +19,7 @@
 
 #import "ConversationListViewController.h"
 #import "ConversationListViewController+Private.h"
+#import "ConversationListViewController+Internal.h"
 #import "ConversationListViewController+StartUI.h"
 
 @import PureLayout;

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController.m
@@ -18,6 +18,7 @@
 
 
 #import "ConversationListViewController.h"
+#import "ConversationListViewController+Private.h"
 #import "ConversationListViewController+StartUI.h"
 
 @import PureLayout;

--- a/Wire-iOS/WireBridgingHeader.h
+++ b/Wire-iOS/WireBridgingHeader.h
@@ -114,6 +114,7 @@
 #import "SketchColorPickerController.h"
 #import "ConversationListViewController.h"
 #import "ConversationListViewController+Private.h"
+#import "ConversationListViewController+Internal.h"
 #import "FullscreenImageViewController.h"
 #import "FullscreenImageViewController+internal.h"
 #import "KeyboardAvoidingViewController.h"


### PR DESCRIPTION
## What's new in this PR?

### Issues

App crash when ConversationListViewController creating noConversationLabel.

### Causes

After moving property noConversationLabel to ConversationListViewController+Private.h, that property is not accessible from the .m file.

### Solutions

Put noConversationLabel in property in ConversationListViewController+Internal.h instead

## Notes

- [ ] creating snapshot test for empty ConversationListViewController