### PR TITLE
Store mixpanel ID to the file for simulator and automation

### DIFF
--- a/Wire-iOS/Sources/Analytics/AnalyticsMixpanelProvider.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsMixpanelProvider.swift
@@ -150,7 +150,7 @@ final class AnalyticsMixpanelProvider: NSObject, AnalyticsProvider {
             #if targetEnvironment(simulator)
             let tempFilePath = URL(fileURLWithPath: "/var/tmp/mixpanel_id.txt")
             try? FileManager.default.removeItem(at: tempFilePath)
-            try! uuidString.data(using: .utf8)?.write(to: tempFilePath)
+            try! Data(uuidString.utf8).write(to: tempFilePath)
             #endif
         }
         

--- a/Wire-iOS/Sources/Analytics/AnalyticsMixpanelProvider.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsMixpanelProvider.swift
@@ -146,6 +146,12 @@ final class AnalyticsMixpanelProvider: NSObject, AnalyticsProvider {
         if DeveloperMenuState.developerMenuEnabled(),
             let uuidString = mixpanelInstance?.distinctId {
             zmLog.error("Mixpanel distinctId = `\(uuidString)`")
+            
+            #if targetEnvironment(simulator)
+            let tempFilePath = URL(fileURLWithPath: "/var/tmp/mixpanel_id.txt")
+            try? FileManager.default.removeItem(at: tempFilePath)
+            try! uuidString.data(using: .utf8)?.write(to: tempFilePath)
+            #endif
         }
         
         self.setSuperProperty("app", stringValue: "ios")


### PR DESCRIPTION
## What's new in this PR?

### Issues

The automation cannot catch the Mixpanel client ID from the logs.

### Causes & Solutions

Not clear, but as the system showed itself fragile, it was decided to write the ID to the file instead.
