### PR TITLE
ZIOS-10490: Add flag to disable call quality survey in automation

### DIFF
--- a/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
+++ b/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
@@ -79,6 +79,10 @@
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
+            argument = "--disable-call-quality-survey"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "--debug-data-to-install=/Users/xxxxxxx/Database2.41"
             isEnabled = "NO">
          </CommandLineArgument>

--- a/Wire-iOS/Sources/UserInterface/Calling/CallQualityController/CallQualityController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallQualityController/CallQualityController.swift
@@ -61,7 +61,7 @@ class CallQualityController: NSObject {
      */
 
     var canPresentCallQualitySurvey: Bool {
-        return DeveloperMenuState.developerMenuEnabled()
+        return DeveloperMenuState.developerMenuEnabled() && !AutomationHelper.sharedHelper.disableCallQualitySurvey
     }
 
     // MARK: - Events
@@ -72,7 +72,7 @@ class CallQualityController: NSObject {
      * - parameter conversation: The conversation where the call is ongoing.
      */
 
-    func handleCallStart(in conversation: ZMConversation) {
+    private func handleCallStart(in conversation: ZMConversation) {
         answeredCalls[conversation.remoteIdentifier!] = Date()
     }
 
@@ -83,7 +83,7 @@ class CallQualityController: NSObject {
      * - parameter eventDate: The date when the call ended.
      */
 
-    func handleCallCompletion(in conversation: ZMConversation, reason: CallClosedReason, eventDate: Date) {
+    private func handleCallCompletion(in conversation: ZMConversation, reason: CallClosedReason, eventDate: Date) {
         // Check for the call start date (do not show feedback for unanswered calls)
         guard let callStartDate = answeredCalls[conversation.remoteIdentifier!] else {
             return
@@ -126,7 +126,7 @@ class CallQualityController: NSObject {
     }
 
     /// Presents the debug log prompt after a user quality rejection.
-    func handleCallQualityRejection() {
+    private func handleCallQualityRejection() {
         DebugAlert.showSendLogsMessage(message: "Sending the debug logs can help us improve the quality of calls.")
     }
 

--- a/WireExtensionComponents/Utilities/AutomationHelper.swift
+++ b/WireExtensionComponents/Utilities/AutomationHelper.swift
@@ -54,6 +54,9 @@ import WireSyncEngine
     
     /// Whether address book upload is enabled on simulator
     @objc public let uploadAddressbookOnSimulator : Bool
+
+    /// Whether we should disable the call quality survey.
+    public let disableCallQualitySurvey: Bool
     
     /// Delay in address book remote search override
     public let delayInAddressBookRemoteSearch : TimeInterval?
@@ -68,14 +71,16 @@ import WireSyncEngine
         let url = URL(string: NSTemporaryDirectory())?.appendingPathComponent(fileArgumentsName)
         let arguments: ArgumentsType = url.flatMap(FileArguments.init) ?? CommandLineArguments()
 
-        self.disablePushNotificationAlert = arguments.hasFlag(AutomationKey.disablePushNotificationAlert.rawValue)
-        self.disableAutocorrection = arguments.hasFlag(AutomationKey.disableAutocorrection.rawValue)
-        self.uploadAddressbookOnSimulator = arguments.hasFlag(AutomationKey.enableAddressBookOnSimulator.rawValue)
+        self.disablePushNotificationAlert = arguments.hasFlag(AutomationKey.disablePushNotificationAlert)
+        self.disableAutocorrection = arguments.hasFlag(AutomationKey.disableAutocorrection)
+        self.uploadAddressbookOnSimulator = arguments.hasFlag(AutomationKey.enableAddressBookOnSimulator)
+        self.disableCallQualitySurvey = arguments.hasFlag(AutomationKey.disableCallQualitySurvey)
+
         self.automationEmailCredentials = AutomationHelper.credentials(arguments)
-        if arguments.hasFlag(AutomationKey.logNetwork.rawValue) {
+        if arguments.hasFlag(AutomationKey.logNetwork) {
             ZMSLog.set(level: .debug, tag: "Network")
         }
-        if arguments.hasFlag(AutomationKey.logCalling.rawValue) {
+        if arguments.hasFlag(AutomationKey.logCalling) {
             ZMSLog.set(level: .debug, tag: "calling")
         }
         AutomationHelper.enableLogTags(arguments)
@@ -102,6 +107,7 @@ import WireSyncEngine
         case enableAddressBookOnSimulator = "addressbook-on-simulator"
         case addressBookRemoteSearchDelay = "addressbook-search-delay"
         case debugDataToInstall = "debug-data-to-install"
+        case disableCallQualitySurvey = "disable-call-quality-survey"
     }
     
     /// Returns the login email and password credentials if set in the given arguments
@@ -152,6 +158,10 @@ extension ArgumentsType {
 
     func hasFlag(_ name: String) -> Bool {
         return self.arguments.contains(flagPrefix + name)
+    }
+
+    func hasFlag<Flag: RawRepresentable>(_ flag: Flag) -> Bool where Flag.RawValue == String {
+        return hasFlag(flag.rawValue)
     }
 
     func flagValueIfPresent(_ commandLineArgument: String) -> String? {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Some automation tests were broken because of the call quality overlay.

### Solutions

We add the `--disable-call-quality-survey` command line switch to allow QA to disable this feature when needed.