### PR TITLE
Remove Mixpanel event whitelisting

### DIFF
--- a/Wire-iOS/Sources/Analytics/AnalyticsMixpanelProvider.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsMixpanelProvider.swift
@@ -72,53 +72,6 @@ final class AnalyticsMixpanelProvider: NSObject, AnalyticsProvider {
     private var mixpanelInstance: MixpanelInstance? = .none
     private let defaults: UserDefaults
     
-    // INFO: this list has to go after we are sure that we are not sending any unexpected events.
-    private static let enabledEvents = Set<String>([
-        conversationMediaCompleteActionEventName,
-        "settings.opted_in_tracking",
-        "settings.opted_out_tracking",
-        "settings.changed_status",
-        "start.opened_start_screen",
-        "start.opened_person_registration",
-        "start.opened_team_registration",
-        "start.opened_login",
-        "team.verified",
-        "team.accepted_terms",
-        "team.created",
-        "team.added_team_name",
-        "team.finished_invite_step",
-        "settings.opened_manage_team",
-        "registration.succeeded",
-        "calling.joined_call",
-        "calling.established_call",
-        "calling.ended_call",
-        "calling.initiated_call",
-        "calling.received_call",
-        "calling.avs_metrics_ended_call",
-        "calling.call_quality_review",
-        "notifications.processing",
-        TeamInviteEvent.sentInvite(.teamCreation).name,
-        "integration.added_service",
-        "integration.removed_service",
-        LinearGroupCreationFlowEvent.openedGroupCreationName,
-        LinearGroupCreationFlowEvent.openedSelectParticipantsName,
-        LinearGroupCreationFlowEvent.groupCreationSucceededName,
-        LinearGroupCreationFlowEvent.addParticipantsName,
-        ConversationEvent.toggleAllowGuestsName,
-        GuestLinkEvent.created.name,
-        GuestLinkEvent.copied.name,
-        GuestLinkEvent.revoked.name,
-        GuestLinkEvent.shared.name,
-        GuestRoomEvent.created.name,
-        BackupEvent.importSucceeded.name,
-        BackupEvent.importFailed.name,
-        BackupEvent.exportSucceeded.name,
-        BackupEvent.exportFailed.name,
-        "e2ee.failed_message_decyption",
-        "request.loop",
-        "debug.database_context_save_failure"
-        ])
-    
     private static let enabledSuperProperties = Set<String>([
         "app",
         "team.in_team",
@@ -182,9 +135,7 @@ final class AnalyticsMixpanelProvider: NSObject, AnalyticsProvider {
         guard let mixpanelInstance = self.mixpanelInstance else {
             return
         }
-        
-        assert(AnalyticsMixpanelProvider.enabledEvents.contains(event), "Analytics: event \(event) is disabled")
-        
+                
         mixpanelInstance.track(event: event, properties: attributes.propertiesRemovingLocation())
     }
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

The event whitelisting is not necessary, since all unnecessary events where removed.