### PR TITLE
Give option to send logs to AVS [skip ci]

### DIFF
--- a/Wire-iOS/Sources/Developer/DeveloperOptionsController.swift
+++ b/Wire-iOS/Sources/Developer/DeveloperOptionsController.swift
@@ -86,10 +86,17 @@ extension DeveloperOptionsController {
     func forwardLogCell() -> UITableViewCell {
         return self.createCellWithButton(labelText: "Forward log records") {
             let alert = UIAlertController(title: "Add explanation", message: "Please explain the problem that made you send the logs", preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: "Send", style: .default, handler: { _ in
+            
+            alert.addAction(UIAlertAction(title: "Send to Devs", style: .default, handler: { _ in
                 guard let text = alert.textFields?.first?.text else { return }
                 DebugLogSender.sendLogsByEmail(message: text)
             }))
+            
+            alert.addAction(UIAlertAction(title: "Send to Devs & AVS", style: .default, handler: { _ in
+                guard let text = alert.textFields?.first?.text else { return }
+                DebugLogSender.sendLogsByEmail(message: text, shareWithAVS: true)
+            }))
+            
             alert.addTextField(configurationHandler: {(textField: UITextField!) in
                 textField.placeholder = "Please explain the problem"
             })


### PR DESCRIPTION
Small follow up to the log recipient changes:
- Instead of sending all logs to devs & AVS & support, give an option for devs only (as normal) or devs & AVS & support

Should help to reduce noise for the recipients.