### PR TITLE
Fix call not being dimissed when dropped

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/CallQualityController/CallQualityController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallQualityController/CallQualityController.swift
@@ -22,6 +22,7 @@ import WireSyncEngine
 protocol CallQualityControllerDelegate: class {
     func dismissCurrentSurveyIfNeeded()
     func callQualityControllerDidScheduleSurvey(with controller: CallQualityViewController)
+    func callQualityControllerDidScheduleDebugAlert()
 }
 
 /**
@@ -122,7 +123,7 @@ class CallQualityController: NSObject {
 
     /// Presents the debug log prompt after a call failure.
     private func handleCallFailure() {
-        DebugAlert.showSendLogsMessage(message: "The call failed. Sending the debug logs can help us troubleshoot the issue.")
+        delegate?.callQualityControllerDidScheduleDebugAlert()
     }
 
     /// Presents the debug log prompt after a user quality rejection.


### PR DESCRIPTION
## What's new in this PR?

### Issues

If a call was dropped it would not dismiss.

### Causes

On internal builds we show an alert for sending logs when a call drops. This alert was dismissed instead of the call view controller since it was presented just before the attempt to dismiss the call was made.

### Solutions

Present the alert after the call has been dismissed.