### PR TITLE
Fix self preview being positioned off screen

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/Thumbnail/PinnableThumbnailViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/Thumbnail/PinnableThumbnailViewController.swift
@@ -28,6 +28,8 @@ import UIKit
 
     fileprivate let edgeInsets = CGPoint(x: 16, y: 16)
     fileprivate var originalCenter: CGPoint = .zero
+    fileprivate var hasDoneInitialLayout = false
+    fileprivate var hasEnabledPinningBehavior = false
 
     fileprivate lazy var pinningBehavior: ThumbnailCornerPinningBehavior = {
         return ThumbnailCornerPinningBehavior(item: self.thumbnailView, edgeInsets: self.edgeInsets)
@@ -76,11 +78,22 @@ import UIKit
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        view.layoutIfNeeded()
-        view.backgroundColor = .clear
-
-        updateThumbnailAfterLayoutUpdate()
-        animator.addBehavior(self.pinningBehavior)
+        if !hasDoneInitialLayout {
+            view.layoutIfNeeded()
+            view.backgroundColor = .clear
+            
+            updateThumbnailAfterLayoutUpdate()
+            hasDoneInitialLayout = true
+        }
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        if !hasEnabledPinningBehavior {
+            animator.addBehavior(self.pinningBehavior)
+            hasEnabledPinningBehavior = true
+        }
     }
 
     private func configureViews() {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Self preview would disappear on the first interaction.

### Causes

- Physics behaviours added multiple times in `viewWillAppear`, which is now called multiple times because we have the. interactive dismissal.

- Physics behaviours were added to early making the configuration wrong.

### Solutions

Only run setup once and delay physics setup to `viewDidAppear`.
