### PR TITLE
ZIOS-10477: Dismiss the keyboard when maximizing the call UI

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/CallWindow/CallWindowRootViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallWindow/CallWindowRootViewController.swift
@@ -52,6 +52,10 @@ final class CallWindowRootViewController: UIViewController {
     override func loadView() {
         view = PassthroughTouchesView()
     }
+
+    override var canBecomeFirstResponder: Bool {
+        return true
+    }
     
     func transitionToLoggedInSession() {
         callController = CallController()


### PR DESCRIPTION
## What's new in this PR?

### Issues

If the user was editing text when the call UI was maximized (from the top overlay or at the initial incoming call), the keyboard was not dismissed and it was covering the call action buttons.

### Causes

iOS makes the presented modal view controller the first responder and dismisses the keyboard if it returns `true` for `canBecomeFirstResponder`. The call root view controller returned `false` here (the default value).

### Solutions

We explicitly allow the call window root view controller to become the first responder. 

When the active call view controller is presented, the keyboard is dismissed as the call window becomes the first responder. When the call window resigns first responder, the preview input field becomes the first responder again.