### PR TITLE
Remove double tap to switch video fill mode feature

### DIFF
--- a/Wire-iOS Tests/CallViewControllerTests.swift
+++ b/Wire-iOS Tests/CallViewControllerTests.swift
@@ -93,20 +93,6 @@ final class CallViewControllerGestureTests: XCTestCase {
         sut.didTapOnView(sender: mockTapGestureRecognizer)
     }
 
-    func testThatOverlayDoesnotDismissAfterDoubleTap() {
-        // GIVEN
-        mediaManager.isMicrophoneMuted = true
-
-        // WHEN
-        // call overlay is visible at the beginning
-        XCTAssert(sut.isOverlayVisible)
-
-        sut.didDoubleTapOnView(sender: MockTapGestureRecognizer(location: CGPoint(x: sut.view.bounds.size.width / 2, y: sut.view.bounds.size.height / 2), state: .ended))
-
-        // call overlay is still visible after double-tapped
-        XCTAssert(sut.isOverlayVisible)
-    }
-
     func testThatOverlayDismissesAfterTapped() {
         // GIVEN
         mediaManager.isMicrophoneMuted = true

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -23,7 +23,6 @@ final class CallViewController: UIViewController {
     
     weak var dismisser: ViewControllerDismisser? = nil
     fileprivate var tapRecognizer: UITapGestureRecognizer!
-    fileprivate var doubleTapRecognizer: UITapGestureRecognizer!
     fileprivate let mediaManager: AVSMediaManagerInterface
     fileprivate let voiceChannel: VoiceChannel
     fileprivate var callInfoConfiguration: CallInfoConfiguration
@@ -81,13 +80,6 @@ final class CallViewController: UIViewController {
                 tapRecognizer.numberOfTapsRequired = 1
 
         view.addGestureRecognizer(tapRecognizer)
-
-        doubleTapRecognizer = UITapGestureRecognizer(target: self, action: #selector(didDoubleTapOnView))
-        doubleTapRecognizer.numberOfTapsRequired = 2
-        tapRecognizer.require(toFail: doubleTapRecognizer)
-
-        view.addGestureRecognizer(doubleTapRecognizer)
-
     }
 
     @objc func didTapOnView(sender: UIGestureRecognizer) {
@@ -101,11 +93,6 @@ final class CallViewController: UIViewController {
         }
 
         toggleOverlayVisibility()
-    }
-
-    @objc func didDoubleTapOnView(sender: UIGestureRecognizer) {
-        let location = sender.location(ofTouch: 0 , in: videoGridViewController.view)
-        videoGridViewController.switchFillMode(location: location)
     }
 
     deinit {


### PR DESCRIPTION
## What's new in this PR?

Remove double tap to switch video fill mode feature after discussed with the design team.