### PR TITLE
Update email address when sending calling debug report

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -962,7 +962,6 @@
 // Technical Report
 "self.settings.technical_report_section.title" = "Technical Report";
 "self.settings.technical_report.send_report" = "Send report to Wire";
-"self.settings.technical_report.mail.recipient" = "callingsupport@wire.com";
 "self.settings.technical_report.mail.subject" = "Wire Calling Report";
 "self.settings.technical_report.include_log" = "Include detailed log";
 "self.settings.technical_report.privacy_warning" = "Detailed logs could contain personal data";

--- a/Wire-iOS/Sources/UserInterface/Settings/SettingsTechnicalReportViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/SettingsTechnicalReportViewController.swift
@@ -66,15 +66,13 @@ class SettingsTechnicalReportViewController: UITableViewController, MFMailCompos
     
     
     func sendReport() {
-        let mailRecipient = NSLocalizedString("self.settings.technical_report.mail.recipient", comment: "")
+        let mailRecipient = "calling-ios@wire.com"
 
         guard MFMailComposeViewController.canSendMail() else {
-            DebugAlert.displayFallbackActivityController(logPaths: ZMSLog.pathsForExistingLogs, email: "calling-ios@wire.com", from: self)
+            DebugAlert.displayFallbackActivityController(logPaths: ZMSLog.pathsForExistingLogs, email: mailRecipient, from: self)
             return
         }
     
-        let report = "Calling report"
-
         let mailComposeViewController = MFMailComposeViewController()
         mailComposeViewController.mailComposeDelegate = self
         mailComposeViewController.setToRecipients([mailRecipient])
@@ -88,7 +86,7 @@ class SettingsTechnicalReportViewController: UITableViewController, MFMailCompos
                 mailComposeViewController.addAttachmentData(previousLog, mimeType: "text/plain", fileName: previousPath.lastPathComponent)
             }
         }
-        mailComposeViewController.setMessageBody(report, isHTML: false)
+        mailComposeViewController.setMessageBody("Calling report", isHTML: false)
         self.present(mailComposeViewController, animated: true, completion: nil)
     }
     

--- a/Wire-iOS/Sources/UserInterface/Settings/SettingsTechnicalReportViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/SettingsTechnicalReportViewController.swift
@@ -69,7 +69,7 @@ class SettingsTechnicalReportViewController: UITableViewController, MFMailCompos
         let mailRecipient = NSLocalizedString("self.settings.technical_report.mail.recipient", comment: "")
 
         guard MFMailComposeViewController.canSendMail() else {
-            DebugAlert.displayFallbackActivityController(logPaths: ZMSLog.pathsForExistingLogs, email: mailRecipient, from: self)
+            DebugAlert.displayFallbackActivityController(logPaths: ZMSLog.pathsForExistingLogs, email: "calling-ios@wire.com", from: self)
             return
         }
     


### PR DESCRIPTION
## What's new in this PR?

Send debug calling debug report to calling-ios@wire.com. Remove localization since they all go the same address.