### PR TITLE
undo the tapRecognizer

### DIFF
--- a/Wire-iOS Tests/CallViewControllerTests.swift
+++ b/Wire-iOS Tests/CallViewControllerTests.swift
@@ -88,9 +88,7 @@ final class CallViewControllerGestureTests: XCTestCase {
     }
 
     func tapOnSut() {
-        let mockTapGestureRecognizer = MockTapGestureRecognizer(location: CGPoint(x: sut.view.bounds.size.width / 2, y: sut.view.bounds.size.height / 2), state: .ended)
-
-        sut.didTapOnView(sender: mockTapGestureRecognizer)
+        sut.touchesBegan(Set(), with: nil)
     }
 
     func testThatOverlayDismissesAfterTapped() {

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -74,20 +74,15 @@ final class CallViewController: UIViewController {
         setupViews()
         createConstraints()
         updateConfiguration()
-
-        tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(didTapOnView))
-                tapRecognizer.numberOfTapsRequired = 1
-
-        view.addGestureRecognizer(tapRecognizer)
     }
 
-    @objc func didTapOnView(sender: UIGestureRecognizer) {
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesBegan(touches, with: event)
         guard canHideOverlay else { return }
 
-
-        if let overlay = videoGridViewController.previewOverlay,
-            overlay.point(inside: sender.location(ofTouch: 0, in: overlay), with: nil),
-            !isOverlayVisible {
+        if let touch = touches.first,
+            let overlay = videoGridViewController.previewOverlay,
+            overlay.point(inside: touch.location(in: overlay), with: event), !isOverlayVisible {
             return
         }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

After Double tap gesture recognizer is removed, tapping Show All has no effect on the call overlay.

### Causes

Unknown, I had tested this case when both single and double tap gesture recognizers are added.

### Solutions

Undo the tap gesture recognizer and restore the original touchesBegan method.