### PR TITLE
Fix: mute indication visibility 

### DIFF
--- a/Wire-iOS Tests/VideoGridViewControllerSnapshotTests.swift
+++ b/Wire-iOS Tests/VideoGridViewControllerSnapshotTests.swift
@@ -30,25 +30,33 @@ final class MockVideoGridConfiguration: VideoGridConfiguration {
 final class VideoGridViewControllerSnapshotTests: ZMSnapshotTestCase {
     
     var sut: VideoGridViewController!
+    var mediaManager: ZMMockAVSMediaManager!
 
     override func setUp() {
         super.setUp()
+
+        mediaManager = ZMMockAVSMediaManager()
     }
     
     override func tearDown() {
         sut = nil
+        mediaManager = nil
+
         super.tearDown()
     }
 
     func createSut() {
         ZMUser.selfUser().remoteIdentifier = UUID()
-        sut = VideoGridViewController(configuration: MockVideoGridConfiguration())
+        sut = VideoGridViewController(configuration: MockVideoGridConfiguration(),
+                                      mediaManager: mediaManager)
 
         sut.view.backgroundColor = .black
     }
 
     func testForMuted(){
         createSut()
+
+        mediaManager.isMicrophoneMuted = true
 
         sut.isCovered = false
         verify(view: sut.view)

--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridView.swift
@@ -81,6 +81,7 @@ class VideoGridViewController: UIViewController {
                 return
             }
 
+            muteIndicatorView.isHidden = false
             muteIndicatorView.alpha = isCovered ? 1 : 0
 
             UIView.animate(

--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridView.swift
@@ -63,6 +63,7 @@ class VideoGridViewController: UIViewController {
     private let gridView = GridView()
     private let thumbnailViewController = PinnableThumbnailViewController()
     private let muteIndicatorView = MuteIndicatorView()
+    fileprivate let mediaManager: AVSMediaManagerInterface
 
     var previewOverlay: UIView? {
         return thumbnailViewController.contentView
@@ -75,23 +76,22 @@ class VideoGridViewController: UIViewController {
     var isCovered: Bool = true {
         didSet {
             guard oldValue != isCovered else { return }
-
-            if configuration.isMuted {
-                muteIndicatorView.isHidden = false
-                muteIndicatorView.alpha = self.isCovered ? 1 : 0
-
-                UIView.animate(
-                    withDuration: 0.2,
-                    delay: 0,
-                    options: .curveEaseInOut,
-                    animations: {
-                        self.muteIndicatorView.alpha = self.isCovered ? 0 : 1
-                },
-                    completion: nil
-                )
-            } else {
+            guard mediaManager.isMicrophoneMuted else {
                 muteIndicatorView.isHidden = true
+                return
             }
+
+            muteIndicatorView.alpha = isCovered ? 1 : 0
+
+            UIView.animate(
+                withDuration: 0.2,
+                delay: 0,
+                options: .curveEaseInOut,
+                animations: {
+                    self.muteIndicatorView.alpha = self.isCovered ? 0 : 1
+            },
+                completion: nil
+            )
         }
     }
 
@@ -102,8 +102,10 @@ class VideoGridViewController: UIViewController {
         }
     }
 
-    init(configuration: VideoGridConfiguration) {
+    init(configuration: VideoGridConfiguration,
+         mediaManager: AVSMediaManagerInterface = AVSMediaManager.sharedInstance()) {
         self.configuration = configuration
+        self.mediaManager = mediaManager
 
         muteIndicatorView.isHidden = true
 


### PR DESCRIPTION
## What's new in this PR?

The isMute property of VideoGridConfiguration is not updated immediately and cause the mute indication's incorrection animation.  Get mute status from AVSMediaManager.sharedInstance() instead.