### PR TITLE
Fix: add chevron to list item of services

### DIFF
--- a/Wire-iOS Tests/LicensesLoaderTests.swift
+++ b/Wire-iOS Tests/LicensesLoaderTests.swift
@@ -86,7 +86,7 @@ class LicensesLoaderTests: XCTestCase {
         }
 
         sendMemoryWarning()
-        wait(for: [deletedCacheExpectation], timeout: 1)
+        wait(for: [deletedCacheExpectation], timeout: 10)
 
         // THEN
         XCTAssertTrue(loader.cacheEmpty)

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/Services/SearchServicesSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/Services/SearchServicesSectionController.swift
@@ -80,6 +80,7 @@ class SearchServicesSectionController: SearchSectionController {
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: UserCell.zm_reuseIdentifier, for: indexPath) as! UserCell
             
             cell.configure(with: service)
+            cell.accessoryIconView.isHidden = false
             cell.showSeparator = (services.count - 1) != indexPath.row
             
             return cell


### PR DESCRIPTION
## What's new in this PR?

Since tapping a service in the start UI or the "add participants" screen open a details view, we need to add a chevron to the right side of each list item in both screens.

