### PR TITLE
Allow autocorrection when dictating

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Views/MarkdownTextStorage.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/MarkdownTextStorage.swift
@@ -54,6 +54,23 @@ class MarkdownTextStorage: NSTextStorage {
         endEditing()
     }
     
+    override func addAttributes(_ attrs: [NSAttributedStringKey : Any], range: NSRange) {
+        beginEditing()
+        storage.addAttributes(attrs, range: range)
+        
+        // This is a workaround for the case where the markdown id is missing
+        // after automatically inserts corrections or fullstops after a space.
+        // If the needsCheck flag is set (after characters are replaced) & the
+        // attrs is missing the markdown id, then we need to included it.
+        if  needsCheck, attrs[NSAttributedStringKey.markdownID] == nil {
+            needsCheck = false
+            storage.addAttribute(NSAttributedStringKey.markdownID, value: currentMarkdown, range: range)
+        }
+        
+        edited(.editedAttributes, range: range, changeInLength: 0)
+        endEditing()
+    }
+    
     override func replaceCharacters(in range: NSRange, with str: String) {
         beginEditing()
         storage.replaceCharacters(in: range, with: str)

--- a/Wire-iOS/Sources/UserInterface/Components/Views/MarkdownTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/MarkdownTextView.swift
@@ -297,7 +297,7 @@ extension Notification.Name {
         
         for (md, mdRange) in exisitngMarkdownRanges {
             let updatedAttributes = attributes(for: transform(md))
-            markdownTextStorage.setAttributes(updatedAttributes, range: mdRange)
+            markdownTextStorage.addAttributes(updatedAttributes, range: mdRange)
         }
     }
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

After the dictation, it's not possible to interact with the proposed autocorrection result.

### Causes

The autocorrection info was embedded into the obscure attributed string parameter, that we've been replacing when parsing the markdown.

### Solutions

Add or override the attributes instead of replacing them completely.

### Notes

May be @johnxnguyen can review it, since I am not sure if always only adding the attributes is error-prone in all cases.