### PR TITLE
Fix incoming 1-to-1 call not being visible when app is launched via APNS

### DIFF
--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -171,9 +171,8 @@ var defaultFontScheme: FontScheme = FontScheme(contentSizeCategory: UIApplicatio
             transitionGroup.enter()
 
             DispatchQueue.main.async {
-                self.prepare(for: appState, completionHandler: {
-                    transitionGroup.leave()
-                })
+                self.applicationWillTransition(to: appState)
+                transitionGroup.leave()
             }
 
             transitionGroup.wait()
@@ -187,6 +186,7 @@ var defaultFontScheme: FontScheme = FontScheme(contentSizeCategory: UIApplicatio
             DispatchQueue.main.async {
                 self.transition(to: appState, completionHandler: {
                     transitionGroup.leave()
+                    self.applicationDidTransition(to: appState)
                     completion?()
                 })
             }
@@ -329,7 +329,7 @@ var defaultFontScheme: FontScheme = FontScheme(contentSizeCategory: UIApplicatio
         }
     }
 
-    func prepare(for appState: AppState, completionHandler: @escaping () -> Void) {
+    func applicationWillTransition(to appState: AppState) {
 
         if appState == .authenticated(completedRegistration: false) {
             callWindow.callController.transitionToLoggedInSession()
@@ -340,8 +340,12 @@ var defaultFontScheme: FontScheme = FontScheme(contentSizeCategory: UIApplicatio
         let colorScheme = ColorScheme.default
         colorScheme.accentColor = UIColor.accent()
         colorScheme.variant = ColorSchemeVariant(rawValue: Settings.shared().colorScheme.rawValue) ?? .light
-
-        completionHandler()
+    }
+    
+    func applicationDidTransition(to appState: AppState) {
+        if appState == .authenticated(completedRegistration: false) {
+            callWindow.callController.presentCallCurrentlyInProgress()
+        }
     }
 
     func configureMediaManager() {

--- a/Wire-iOS/Sources/UserInterface/Calling/CallController/CallController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallController/CallController.swift
@@ -54,6 +54,10 @@ class CallController: NSObject {
 extension CallController: WireCallCenterCallStateObserver {
     
     func callCenterDidChange(callState: CallState, conversation: ZMConversation, caller: ZMUser, timestamp: Date?, previousCallState: CallState?) {
+        updateState()
+    }
+    
+    func updateState() {
         guard let userSession = ZMUserSession.shared() else { return }
         
         if let priorityCallConversation = userSession.priorityCallConversation {

--- a/Wire-iOS/Sources/UserInterface/Calling/CallWindow/CallWindowRootViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallWindow/CallWindowRootViewController.swift
@@ -62,6 +62,10 @@ final class CallWindowRootViewController: UIViewController {
         callController?.targetViewController = self
     }
     
+    func presentCallCurrentlyInProgress() {
+        callController?.updateState()
+    }
+    
     private func topmostViewController() -> UIViewController? {
         guard let topmost = UIApplication.shared.wr_topmostViewController() else { return nil }
         guard topmost != self, !topmost.isKind(of: CallWindowRootViewController.self) else { return nil }


### PR DESCRIPTION
## What's new in this PR?

### Issues

If you receive an incoming call (without callkit) and the UI was not already launched, the incoming call screen will not appear.

### Causes

The app is launched in the background without the UI which will then miss the incoming call observers firing.

### Solutions

Check for any ongoing call when the UI has finished loading.