### PR TITLE
Fix: App crashes when sending a video from start UI or saving a video from a conversation.

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/CameraPicker.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/CameraPicker.swift
@@ -120,8 +120,8 @@ extension CameraPicker: UIImagePickerControllerDelegate, UINavigationControllerD
             try! fileManager.moveItem(at: videoURL, to: videoTempURL)
             
             if (picker.sourceType == .camera && UIVideoAtPathIsCompatibleWithSavedPhotosAlbum(videoTempPath)) {
-                let selector = "video:didFinishSavingWithError:contextInfo:"
-                UISaveVideoAtPathToSavedPhotosAlbum(videoTempPath, self, Selector(selector), nil)
+                let selector = #selector(self.video(_:didFinishSavingWithError:contextInfo:))
+                UISaveVideoAtPathToSavedPhotosAlbum(videoTempPath, self, selector, nil)
             }
             
             picker.showLoadingView = true
@@ -157,7 +157,7 @@ extension CameraPicker: UIImagePickerControllerDelegate, UINavigationControllerD
         }
     }
     
-    func video(_ videoPath: NSString, didFinishSavingWithError error: NSError?, contextInfo info: AnyObject) {
+    @objc func video(_ videoPath: NSString, didFinishSavingWithError error: NSError?, contextInfo info: AnyObject) {
         if let error = error {
             zmLog.error("Cannot save video: \(error)")
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/VideoMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/VideoMessageCell.swift
@@ -184,12 +184,12 @@ public final class VideoMessageCell: ConversationCell {
             let fileURL = fileMessageData.fileURL,
             self.message.videoCanBeSavedToCameraRoll() {
             
-            let selector = "video:didFinishSavingWithError:contextInfo:"
-            UISaveVideoAtPathToSavedPhotosAlbum(fileURL.path, self, Selector(selector), nil)
+            let selector = #selector(self.video(_:didFinishSavingWithError:contextInfo:))
+            UISaveVideoAtPathToSavedPhotosAlbum(fileURL.path, self, selector, nil)
         }
     }
     
-    func video(_ videoPath: NSString, didFinishSavingWithError error: NSError?, contextInfo info: AnyObject) {
+    @objc func video(_ videoPath: NSString, didFinishSavingWithError error: NSError?, contextInfo info: AnyObject) {
         if let error = error {
             zmLog.error("Cannot save video: \(error)")
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

App crashes when sending a video from start UI or saving a video from a conversation.

### Causes

Swift 2.0 style Selector does not work.

### Solutions

Update with #selector syntax.