### PR TITLE
ZIOS-10502: Fix share extension not opening for links

### DIFF
--- a/Wire-iOS Share Extension/ShareExtensionViewController.swift
+++ b/Wire-iOS Share Extension/ShareExtensionViewController.swift
@@ -206,10 +206,12 @@ class ShareExtensionViewController: SLComposeServiceViewController {
         }
 
         urlItems.first?.fetchURL { url in
-            guard let url = url, !url.isFileURL else { return }
-            let separator = self.textView.text.isEmpty ? "" : "\n"
-            self.textView.text = self.textView.text + separator + url.absoluteString
-            self.textView.delegate?.textViewDidChange?(self.textView)
+            DispatchQueue.main.async {
+                guard let url = url, !url.isFileURL else { return }
+                let separator = self.textView.text.isEmpty ? "" : "\n"
+                self.textView.text = self.textView.text + separator + url.absoluteString
+                self.textView.delegate?.textViewDidChange?(self.textView)
+            }
         }
     }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

When the share extension was opened from Safari, Firefox or Twitter for sharing a link with text, the interface was never shown.

### Causes + Solutions

When setting up the UI, we fetch the URL attachment asynchronously. The callback is called from the background thread, but we didn't switch to the main thread to update the UI with the results.

This caused the share extension to crash silently before the share sheet was even presented.

## Notes

There is an issue with `WireLinkPreview` that causes the thumbnail for the web page to fail fetching instantly with a `-1004` (cannot connect to server) for any URL that is shared. That needs to be investigated separately.