### PR TITLE
Refer to mention by it's position

### DIFF
--- a/Wire-iOS Tests/Message+FormattingTests.swift
+++ b/Wire-iOS Tests/Message+FormattingTests.swift
@@ -168,7 +168,7 @@ class Message_FormattingTests: XCTestCase {
         
         // then
         XCTAssertEqual(formattedText.string, "\(previewURL)@mention")
-        XCTAssertEqual(formattedText.attributes(at: mention.range.location + 1, effectiveRange: nil)[.link] as! URL, Mention.link(for: 0))
+        XCTAssertEqual(formattedText.attributes(at: mention.range.location + 1, effectiveRange: nil)[.link] as! URL, mention.link)
     }
     
     func testMentionLinkOverridesDetectedLink_mentionBefore() {
@@ -185,7 +185,7 @@ class Message_FormattingTests: XCTestCase {
         
         // then
         XCTAssertEqual(formattedText.string, "@mention\(previewURL) lala")
-        XCTAssertEqual(formattedText.attributes(at: 0, effectiveRange: nil)[.link] as! URL, Mention.link(for: 0))
+        XCTAssertEqual(formattedText.attributes(at: 0, effectiveRange: nil)[.link] as! URL, mention.link)
         let linkDetected = formattedText.attributes(at: mention.range.location + mention.range.length + 1, effectiveRange: nil)[.link] as! URL
         XCTAssertEqual(linkDetected.absoluteString, previewURL)
     }
@@ -203,7 +203,7 @@ class Message_FormattingTests: XCTestCase {
         let formattedText = NSAttributedString.formattedString(with: Message.linkAttachments(textMessageData), forMessage: textMessageData, isGiphy: false, obfuscated: false, mentions: [mention])
         
         // then
-        XCTAssertEqual(formattedText.attributes(at: mention.range.location + 1, effectiveRange: nil)[.link] as! URL, Mention.link(for: 0))
+        XCTAssertEqual(formattedText.attributes(at: mention.range.location + 1, effectiveRange: nil)[.link] as! URL, mention.link)
     }
     
     func testThatItUsesCorrectUTF16OffsetForMention_Emoji() {
@@ -219,6 +219,6 @@ class Message_FormattingTests: XCTestCase {
         let formattedText = NSAttributedString.formattedString(with: Message.linkAttachments(textMessageData), forMessage: textMessageData, isGiphy: false, obfuscated: false, mentions: [mention])
         
         // then
-        XCTAssertEqual(formattedText.attributes(at: mention.range.location + 1, effectiveRange: nil)[.link] as! URL, Mention.link(for: 0))
+        XCTAssertEqual(formattedText.attributes(at: mention.range.location + 1, effectiveRange: nil)[.link] as! URL, mention.link)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/TextMessageCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/TextMessageCell.m
@@ -431,7 +431,13 @@
 - (BOOL)textView:(LinkInteractionTextView *)textView open:(NSURL *)url
 {
     if (url.isMentionURL) {
-        Mention *mention = self.message.textMessageData.mentions[url.mentionIndex];
+        Mention *mention = [self.message.textMessageData.mentions firstObjectMatchingWithBlock:^BOOL(Mention* mention) {
+            return mention.location == url.mentionLocation;
+        }];
+        
+        if (nil == mention) {
+            return NO;
+        }
         
         UITextRange *range = [textView rangeOfLinkToURL:url];
         


### PR DESCRIPTION
## What's new in this PR?

### Issues

To make sure the ordering of the mentions does not affect it's function, it's more robust to refer to the mention in the message by it's `range.location`.