### PR TITLE
Fix: clean up cell snapshot tests

### DIFF
--- a/Wire-iOS Tests/CallSystemMessageTests.swift
+++ b/Wire-iOS Tests/CallSystemMessageTests.swift
@@ -27,49 +27,49 @@ class CallSystemMessageTests: CoreDataSnapshotTestCase {
 
     func testThatItRendersMissedCallFromSelfUser() {
         let missedCell = cell(for: .missedCall, fromSelf: true)
-        verify(view: missedCell.prepareForSnapshots())
+        verify(view: missedCell.prepareForSnapshots(width: .iPhone4))
     }
 
     func testThatItRendersMissedCallFromOtherUser() {
         let missedCell = cell(for: .missedCall, fromSelf: false)
-        verify(view: missedCell.prepareForSnapshots())
+        verify(view: missedCell.prepareForSnapshots(width: .iPhone4))
     }
 
     func testThatItRendersMissedCallFromOtherUser_Expanded() {
         let missedCell = cell(for: .missedCall, fromSelf: false, expanded: true)
-        verify(view: missedCell.prepareForSnapshots())
+        verify(view: missedCell.prepareForSnapshots(width: .iPhone4))
     }
-    
+
     func testThatItRendersMissedCallFromSelfUserInGroup() {
         let missedCell = cell(for: .missedCall, fromSelf: true, inGroup: true)
-        verify(view: missedCell.prepareForSnapshots())
+        verify(view: missedCell.prepareForSnapshots(width: .iPhone4))
     }
-    
+
     func testThatItRendersMissedCallFromOtherUserInGroup() {
         let missedCell = cell(for: .missedCall, fromSelf: false, inGroup: true)
-        verify(view: missedCell.prepareForSnapshots())
+        verify(view: missedCell.prepareForSnapshots(width: .iPhone4))
     }
-    
+
     func testThatItRendersMissedCallFromOtherUserInGroup_Expanded() {
         let missedCell = cell(for: .missedCall, fromSelf: false, expanded: true, inGroup: true)
-        verify(view: missedCell.prepareForSnapshots())
+        verify(view: missedCell.prepareForSnapshots(width: .iPhone4))
     }
 
     // MARK: - Performed Call
 
     func testThatItRendersPerformedCallFromSelfUser() {
         let missedCell = cell(for: .performedCall, fromSelf: true)
-        verify(view: missedCell.prepareForSnapshots())
+        verify(view: missedCell.prepareForSnapshots(width: .iPhone4))
     }
 
     func testThatItRendersPerformedCallFromOtherUser() {
         let missedCell = cell(for: .performedCall, fromSelf: false)
-        verify(view: missedCell.prepareForSnapshots())
+        verify(view: missedCell.prepareForSnapshots(width: .iPhone4))
     }
 
     func testThatItRendersPerformedCallFromOtherUser_Expanded() {
         let missedCell = cell(for: .performedCall, fromSelf: false, expanded: true)
-        verify(view: missedCell.prepareForSnapshots())
+        verify(view: missedCell.prepareForSnapshots(width: .iPhone4))
     }
 
     // MARK: - Helper
@@ -107,25 +107,6 @@ class CallSystemMessageTests: CoreDataSnapshotTestCase {
         } else {
             return PerformedCallCell(style: .default, reuseIdentifier: name)
         }
-    }
-
-}
-
-
-
-private extension UITableViewCell {
-
-    func prepareForSnapshots() -> UIView {
-        setNeedsLayout()
-        layoutIfNeeded()
-
-        bounds.size = systemLayoutSizeFitting(
-            CGSize(width: 320, height: 0),
-            withHorizontalFittingPriority: .required,
-            verticalFittingPriority: .fittingSizeLevel
-        )
-
-        return wrapInTableView()
     }
 
 }

--- a/Wire-iOS Tests/ConversationRenamedCellTests.swift
+++ b/Wire-iOS Tests/ConversationRenamedCellTests.swift
@@ -62,20 +62,3 @@ class ConversationRenamedCellTests: CoreDataSnapshotTestCase {
 
 }
 
-
-private extension UITableViewCell {
-
-    func prepareForSnapshots() -> UIView {
-        setNeedsLayout()
-        layoutIfNeeded()
-
-        bounds.size = systemLayoutSizeFitting(
-            CGSize(width: 375, height: 0),
-            withHorizontalFittingPriority: .required,
-            verticalFittingPriority: .fittingSizeLevel
-        )
-
-        return wrapInTableView()
-    }
-    
-}

--- a/Wire-iOS Tests/MessageTimerSystemMessageTests.swift
+++ b/Wire-iOS Tests/MessageTimerSystemMessageTests.swift
@@ -25,72 +25,72 @@ class MessageTimerSystemMessageTests: CoreDataSnapshotTestCase {
     
     func testThatItRendersMessageTimerSystemMessage_None_Other() {
         let timerCell = cell(fromSelf: false, messageTimer: .none)
-        verify(view: timerCell.prepareForSnapshots())
+        verify(view: timerCell.prepareForSnapshots(width: .iPhone4))
     }
     
     func testThatItRendersMessageTimerSystemMessage_TenSeconds_Other() {
         let timerCell = cell(fromSelf: false, messageTimer: .tenSeconds)
-        verify(view: timerCell.prepareForSnapshots())
+        verify(view: timerCell.prepareForSnapshots(width: .iPhone4))
     }
     
     func testThatItRendersMessageTimerSystemMessage_FiveMinutes_Other() {
         let timerCell = cell(fromSelf: false, messageTimer: .fiveMinutes)
-        verify(view: timerCell.prepareForSnapshots())
+        verify(view: timerCell.prepareForSnapshots(width: .iPhone4))
     }
     
     func testThatItRendersMessageTimerSystemMessage_OneHour_Other() {
         let timerCell = cell(fromSelf: false, messageTimer: .oneHour)
-        verify(view: timerCell.prepareForSnapshots())
+        verify(view: timerCell.prepareForSnapshots(width: .iPhone4))
     }
     
     func testThatItRendersMessageTimerSystemMessage_OneDay_Other() {
         let timerCell = cell(fromSelf: false, messageTimer: .oneDay)
-        verify(view: timerCell.prepareForSnapshots())
+        verify(view: timerCell.prepareForSnapshots(width: .iPhone4))
     }
     
     func testThatItRendersMessageTimerSystemMessage_OneWeek_Other() {
         let timerCell = cell(fromSelf: false, messageTimer: .oneWeek)
-        verify(view: timerCell.prepareForSnapshots())
+        verify(view: timerCell.prepareForSnapshots(width: .iPhone4))
     }
     
     func testThatItRendersMessageTimerSystemMessage_FourWeeks_Other() {
         let timerCell = cell(fromSelf: false, messageTimer: .fourWeeks)
-        verify(view: timerCell.prepareForSnapshots())
+        verify(view: timerCell.prepareForSnapshots(width: .iPhone4))
     }
     
     func testThatItRendersMessageTimerSystemMessage_None_Self() {
         let timerCell = cell(fromSelf: true, messageTimer: .none)
-        verify(view: timerCell.prepareForSnapshots())
+        verify(view: timerCell.prepareForSnapshots(width: .iPhone4))
     }
     
     func testThatItRendersMessageTimerSystemMessage_TenSeconds_Self() {
         let timerCell = cell(fromSelf: true, messageTimer: .tenSeconds)
-        verify(view: timerCell.prepareForSnapshots())
+        verify(view: timerCell.prepareForSnapshots(width: .iPhone4))
     }
     
     func testThatItRendersMessageTimerSystemMessage_FiveMinutes_Self() {
         let timerCell = cell(fromSelf: true, messageTimer: .fiveMinutes)
-        verify(view: timerCell.prepareForSnapshots())
+        verify(view: timerCell.prepareForSnapshots(width: .iPhone4))
     }
     
     func testThatItRendersMessageTimerSystemMessage_OneHour_Self() {
         let timerCell = cell(fromSelf: true, messageTimer: .oneHour)
-        verify(view: timerCell.prepareForSnapshots())
+        verify(view: timerCell.prepareForSnapshots(width: .iPhone4))
     }
     
     func testThatItRendersMessageTimerSystemMessage_OneDay_Self() {
         let timerCell = cell(fromSelf: true, messageTimer: .oneDay)
-        verify(view: timerCell.prepareForSnapshots())
+        verify(view: timerCell.prepareForSnapshots(width: .iPhone4))
     }
     
     func testThatItRendersMessageTimerSystemMessage_OneWeek_Self() {
         let timerCell = cell(fromSelf: true, messageTimer: .oneWeek)
-        verify(view: timerCell.prepareForSnapshots())
+        verify(view: timerCell.prepareForSnapshots(width: .iPhone4))
     }
     
     func testThatItRendersMessageTimerSystemMessage_FourWeeks_Self() {
         let timerCell = cell(fromSelf: true, messageTimer: .fourWeeks)
-        verify(view: timerCell.prepareForSnapshots())
+        verify(view: timerCell.prepareForSnapshots(width: .iPhone4))
     }
     
     // MARK: - Helper
@@ -106,23 +106,4 @@ class MessageTimerSystemMessageTests: CoreDataSnapshotTestCase {
         cell.configure(for: message, layoutProperties: props)
         return cell
     }
-}
-
-
-
-private extension UITableViewCell {
-    
-    func prepareForSnapshots() -> UIView {
-        setNeedsLayout()
-        layoutIfNeeded()
-        
-        bounds.size = systemLayoutSizeFitting(
-            CGSize(width: 320, height: 0),
-            withHorizontalFittingPriority: .required,
-            verticalFittingPriority: .fittingSizeLevel
-        )
-        
-        return wrapInTableView()
-    }
-    
 }

--- a/Wire-iOS Tests/ParticipantCellTests.swift
+++ b/Wire-iOS Tests/ParticipantCellTests.swift
@@ -260,20 +260,3 @@ private enum Users {
     case none, sender, one, some, many, justYou, youAndAnother, overflow, service
 }
 
-
-private extension UITableViewCell {
-
-    func prepareForSnapshots() -> UIView {
-        setNeedsLayout()
-        layoutIfNeeded()
-
-        bounds.size = systemLayoutSizeFitting(
-            CGSize(width: 375, height: 0),
-            withHorizontalFittingPriority: .required,
-            verticalFittingPriority: .fittingSizeLevel
-        )
-
-        return wrapInTableView()
-    }
-    
-}

--- a/Wire-iOS Tests/ShareDestinationCellTests.swift
+++ b/Wire-iOS Tests/ShareDestinationCellTests.swift
@@ -255,13 +255,4 @@ fileprivate extension UITableViewCell {
         return view
     }
 
-    func prepareForSnapshots() -> UITableView {
-        bounds.size = systemLayoutSizeFitting(
-            CGSize(width: 375, height: 0),
-            withHorizontalFittingPriority: .required,
-            verticalFittingPriority: .fittingSizeLevel
-        )
-        return wrapInTableView()
-    }
-
 }

--- a/Wire-iOS Tests/Utils/UITableViewCell+Snapshot.swift
+++ b/Wire-iOS Tests/Utils/UITableViewCell+Snapshot.swift
@@ -18,16 +18,24 @@
 
 import Foundation
 
-extension CGSize {
-    enum iPhoneSize {
-        static let iPhone4: CGSize = CGSize(width: 320, height: 568)
-        static let iPhone4_7: CGSize = CGSize(width: 375, height: 667)
-    }
+enum PhoneWidth: CGFloat {
+    case iPhone4 = 320
+    case iPhone4_7 = 375
 }
 
-extension UIViewController {
+extension UITableViewCell {
 
-    func setBoundsSizeAsIPhone4_7Inch() {
-        self.view.bounds.size = CGSize.iPhoneSize.iPhone4_7
+    func prepareForSnapshots(width: PhoneWidth = .iPhone4_7) -> UITableView {
+        setNeedsLayout()
+        layoutIfNeeded()
+
+        bounds.size = systemLayoutSizeFitting(
+            CGSize(width: width.rawValue, height: 0),
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel
+        )
+
+        return wrapInTableView()
     }
+
 }

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1154,6 +1154,7 @@
 		EF4172B12110A6E300FF85C7 /* SplitViewController+rightView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF4172B02110A6E300FF85C7 /* SplitViewController+rightView.swift */; };
 		EF44784F20906DDD00BD9827 /* FullscreenImageViewController+Zoom.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF44784E20906DDD00BD9827 /* FullscreenImageViewController+Zoom.swift */; };
 		EF4478522090BF8700BD9827 /* FullscreenImageViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF4478512090BF8700BD9827 /* FullscreenImageViewControllerTests.swift */; };
+		EF466567214FFA4100FB8A5D /* UITableViewCell+Snapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF466566214FFA4100FB8A5D /* UITableViewCell+Snapshot.swift */; };
 		EF4795AD2077847E00334E32 /* ConversationInputBarViewController+UITextViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF4795AC2077847E00334E32 /* ConversationInputBarViewController+UITextViewDelegate.swift */; };
 		EF47971E211E398000EDFC15 /* MessagePresenter+OpenFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF47971D211E398000EDFC15 /* MessagePresenter+OpenFile.swift */; };
 		EF51C2BF211B2CAF0099A599 /* Data+HEIF.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF51C2BE211B2CAF0099A599 /* Data+HEIF.swift */; };
@@ -2872,6 +2873,7 @@
 		EF44784E20906DDD00BD9827 /* FullscreenImageViewController+Zoom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FullscreenImageViewController+Zoom.swift"; sourceTree = "<group>"; };
 		EF4478502090BC1800BD9827 /* FullscreenImageViewController+internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "FullscreenImageViewController+internal.h"; sourceTree = "<group>"; };
 		EF4478512090BF8700BD9827 /* FullscreenImageViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullscreenImageViewControllerTests.swift; sourceTree = "<group>"; };
+		EF466566214FFA4100FB8A5D /* UITableViewCell+Snapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewCell+Snapshot.swift"; sourceTree = "<group>"; };
 		EF4795AC2077847E00334E32 /* ConversationInputBarViewController+UITextViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationInputBarViewController+UITextViewDelegate.swift"; sourceTree = "<group>"; };
 		EF47971D211E398000EDFC15 /* MessagePresenter+OpenFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MessagePresenter+OpenFile.swift"; sourceTree = "<group>"; };
 		EF51C2BE211B2CAF0099A599 /* Data+HEIF.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+HEIF.swift"; sourceTree = "<group>"; };
@@ -4367,6 +4369,7 @@
 				EF15A7B520BC34F700A045C7 /* XCTestCase+ImageFromBundle.swift */,
 				EF19209C20C6E4F700E4B92D /* XCTestCase+DayFormatter.swift */,
 				BF5127141CC9118F00F23DEA /* ZMSnapshotTestCase+Swift.swift */,
+				EF466566214FFA4100FB8A5D /* UITableViewCell+Snapshot.swift */,
 				BF29C9861C6E357100601EE7 /* ZMSnapshotTestCase.m */,
 				BFFE943D1E7839EB0025AD75 /* CoreDataSnapshotTestCase.swift */,
 			);
@@ -7815,6 +7818,7 @@
 				874941CD1DE458DF006CF32B /* CombinationTest.swift in Sources */,
 				EEA747A81FCEBAD1000B529E /* AnalyticsMixpanelProviderTests.swift in Sources */,
 				5E97C33120F5F17800C806B4 /* ExtensionSettingsTests.swift in Sources */,
+				EF466567214FFA4100FB8A5D /* UITableViewCell+Snapshot.swift in Sources */,
 				8742FB821E8BD23D00D046BC /* ConversationStatusLineTests.swift in Sources */,
 				1E8772231B0C8B0F005BDDC6 /* EmoticonSubstitutionConfigurationMocks.m in Sources */,
 				1651F9BC1D352C5700A9FAE8 /* ArticleViewTests.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

Clean up the duplicated prepareForSnapshots method in the cell snapshot tests.