### PR TITLE
Fix ambiguous contraints

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Collections/TextSearch/TextSearchResultCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/TextSearch/TextSearchResultCell.swift
@@ -133,6 +133,7 @@ internal class TextSearchResultCell: UITableViewCell {
         
         resultCountView.isHidden = totalMatches <= 1
         resultCountView.textLabel.text = "\(totalMatches)"
+        resultCountView.updateCollapseConstraints(isCollapsed: false)
     }
     
     public func configure(with newMessage: ZMConversationMessage, queries newQueries: [String]) {


### PR DESCRIPTION
## What's new in this PR?

### Issues
The count badge in collections search was too wide and the label is not entered:

![wire 2018-09-06 at 8 28 50 png](https://user-images.githubusercontent.com/28632506/45687843-1641f800-bb50-11e8-863c-fb04f6222627.jpeg)


### Causes

The width of the badge is ambiguous because the trailing constraint of the badge's label to the container view is not activated. (The badge is collapsed by default, deactivating the trailing constraint)

### Solutions

Uncollapse the badge in order to activate the missing constraint.
