### PR TITLE
Calculate correct offsets for mentions when editing in markdown mode

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -10,4 +10,4 @@ github "wireapp/HockeySDK-iOS" ~> 5.0
 github "wireapp/FLAnimatedImage" "1.0.12-wire"
 github "wireapp/PureLayout" "v3.0.0"
 github "wireapp/mixpanel-swift" "v2.4.4-xcode10"
-github "wireapp/Down" "v2.0.3"
+github "wireapp/Down" "v2.0.4"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 github "wireapp/Cartography" "3.0.2-xcode10"
-github "wireapp/Down" "v2.0.3"
+github "wireapp/Down" "feature/attributed-output"
 github "wireapp/FLAnimatedImage" "1.0.12-wire"
 github "wireapp/FormatterKit" "1.8.1-swift3.0.2"
 github "wireapp/HTMLString" "4.0.2-xcode_10"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 github "wireapp/Cartography" "3.0.2-xcode10"
-github "wireapp/Down" "feature/attributed-output"
+github "wireapp/Down" "v2.0.4"
 github "wireapp/FLAnimatedImage" "1.0.12-wire"
 github "wireapp/FormatterKit" "1.8.1-swift3.0.2"
 github "wireapp/HTMLString" "4.0.2-xcode_10"

--- a/Wire-iOS/Sources/Helpers/String+WireLocales.swift
+++ b/Wire-iOS/Sources/Helpers/String+WireLocales.swift
@@ -36,24 +36,4 @@ extension NSString {
         return lowercased(with: NSLocale.current)
     }
     
-    private var slashCommandMatcher: NSRegularExpression? {
-        struct Singleton {
-            static let sharedInstance = try? NSRegularExpression(pattern: "^\\/", options: [])
-        }
-        return Singleton.sharedInstance
-    }
-    
-    @objc var matchesSlashCommand: Bool {
-        let range = NSMakeRange(0, length)
-        return slashCommandMatcher?.matches(in: self as String, options: [], range: range).count > 0
-    }
-    
-    @objc var args: [String]? {
-        guard self.matchesSlashCommand else {
-            return []
-        }
-        
-        let slashlessString = replacingCharacters(in: NSMakeRange(0, 1), with: "")
-        return slashlessString.components(separatedBy: CharacterSet.whitespaces)
-    }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -723,6 +723,11 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
 
 @implementation ConversationViewController (InputBar)
 
+- (void)conversationInputBarViewControllerDidComposeText:(NSString *)text mentions:(NSArray<Mention *> *)mentions
+{
+    [self.inputBarController.sendController sendTextMessage:text mentions:mentions];
+}
+
 - (BOOL)conversationInputBarViewControllerShouldBeginEditing:(ConversationInputBarViewController *)controller isEditingMessage:(BOOL)isEditing
 {
     if (! self.contentViewController.isScrolledToBottom && !isEditing) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarSendController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarSendController.m
@@ -73,7 +73,7 @@
     __block id<ZMConversationMessage> textMessage = nil;
     [[ZMUserSession sharedSession] enqueueChanges:^{
         
-        if([Settings sharedSettings].shouldSend500Messages) {
+        if ([Settings sharedSettings].shouldSend500Messages) {
             [Settings sharedSettings].shouldSend500Messages = NO;
             // This is a debug function to stress-load the client
             for(int i = 0; i < 500; ++i) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Editing.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Editing.swift
@@ -24,14 +24,6 @@ private let endEditingNotificationName = "ConversationInputBarViewControllerShou
 
 
 extension ConversationInputBarViewController {
-
-    @objc func sendEditedMessageAndUpdateState(withText text: String, mentions: [Mention]) {
-        if let message = editingMessage {
-            delegate?.conversationInputBarViewControllerDidFinishEditing?(message, withText: text, mentions: mentions)
-        }
-        editingMessage = nil
-        updateWritingState(animated: true)
-    }
     
     @objc func editMessage(_ message: ZMConversationMessage) {
         guard let text = message.textMessageData?.messageText else { return }
@@ -87,7 +79,8 @@ extension ConversationInputBarViewController: InputBarEditViewDelegate {
         switch buttonType {
         case .undo: inputBar.undo()
         case .cancel: endEditingMessageIfNeeded()
-        case .confirm: sendOrEditText(inputBar.textView.preparedText, mentions: inputBar.textView.mentions)
+        case .confirm:
+            sendText()
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Private.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Private.h
@@ -61,11 +61,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable, weak) UIView *popoverPointToView;
 
 - (void)createAudioRecordViewController;
-- (void)sendOrEditText:(NSString *)text mentions:(NSArray <Mention *> *)mentions;
 - (void)updateRightAccessoryView;
 - (void)updateButtonIcons;
 - (void)updateAccessoryViews;
 - (void)updateNewButtonTitleLabel;
+- (void)clearInputBar;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+SendButton.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+SendButton.swift
@@ -33,4 +33,32 @@ extension ConversationInputBarViewController {
         inputBar.rightAccessoryStackView.addArrangedSubview(sendButton)
         createSendButtonConstraints()
     }
+        
+    @objc func sendText() {
+        let (text, mentions) = inputBar.textView.preparedText
+        
+        guard !showAlertIfTextIsTooLong(text: text) else { return }
+        
+        if inputBar.isEditing, let message = editingMessage {
+            guard message.textMessageData?.messageText != text else { return }
+            
+            delegate?.conversationInputBarViewControllerDidFinishEditing?(message, withText: text, mentions: mentions)
+            editingMessage = nil
+            updateWritingState(animated: true)
+        } else {
+            clearInputBar()
+            delegate?.conversationInputBarViewControllerDidComposeText(text, mentions: mentions)
+        }
+    }
+    
+    func showAlertIfTextIsTooLong(text: String) -> Bool {
+        guard text.count > SharedConstants.maximumMessageLength else { return false }
+        
+        self.showAlert(forMessage: "conversation.input_bar.message_too_long.message".localized,
+                       title: "conversation.input_bar.message_too_long.title".localized,
+                       handler: nil)
+        
+        return true
+    }
+    
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+UITextViewDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+UITextViewDelegate.swift
@@ -45,8 +45,7 @@ extension ConversationInputBarViewController: UITextViewDelegate {
         // send only if send key pressed
         if textView.returnKeyType == .send && (text == "\n") {
             inputBar.textView.autocorrectLastWord()
-            let candidateText = inputBar.textView.preparedText
-            sendOrEditText(candidateText, mentions: inputBar.textView.mentions)
+            sendText()
             return false
         }
         
@@ -110,9 +109,10 @@ extension ConversationInputBarViewController: UITextViewDelegate {
         guard let textView = textView as? MarkdownTextView else { preconditionFailure("Invalid textView class") }
 
         ZMUserSession.shared()?.enqueueChanges {
+            let (text, mentions) = textView.preparedText
             self.conversation.draftMessage = DraftMessage(
-                text: textView.preparedText,
-                mentions: textView.mentions
+                text: text,
+                mentions: mentions
             )
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.h
@@ -42,6 +42,8 @@ typedef NS_ENUM(NSUInteger, ConversationInputBarViewControllerMode) {
 
 @protocol ConversationInputBarViewControllerDelegate <NSObject>
 
+- (void)conversationInputBarViewControllerDidComposeText:(NSString *)text mentions:(NSArray<Mention *> *)mentions;
+
 @optional
 - (BOOL)conversationInputBarViewControllerShouldBeginEditing:(ConversationInputBarViewController *)controller isEditingMessage:(BOOL)isEditing;
 - (BOOL)conversationInputBarViewControllerShouldEndEditing:(ConversationInputBarViewController *)controller;

--- a/Wire-iOS/Sources/UserInterface/MessageDraft.swift
+++ b/Wire-iOS/Sources/UserInterface/MessageDraft.swift
@@ -58,7 +58,7 @@ import Down
         
         if let attributedMessage = attributedMessage, !attributedMessage.string.isEmpty {
             let parser = AttributedStringParser()
-            text += parser.parse(attributedString: attributedMessage.withDecodedMarkdownIDs)
+            text += parser.parse(attributedString: attributedMessage.withDecodedMarkdownIDs).string
         }
         else if let message = message, !message.isEmpty {
             text += message


### PR DESCRIPTION
### Issues

Any mentions inserted in markdown editing mode would have the wrong offsets.

### Causes

Offsets didn't take the additional markdown syntax into account, which is inserted after the attributed string containing markdown attributes is parsed.

### Solutions

Calculate the offsets after the text has gone through the markdown parser. To make this possible the markdown parser now keeps any non-markdown attributes in the resulting string.

## Dependencies

Needs releases with:

- [x] https://github.com/wireapp/Down/pull/12
