### PR TITLE
Disable drag & drop for mentions

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Views/LinkInteractionTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/LinkInteractionTextView.swift
@@ -35,6 +35,10 @@ import UIKit
     override init(frame: CGRect, textContainer: NSTextContainer?) {
         super.init(frame: frame, textContainer: textContainer)
         delegate = self
+        
+        if #available(iOS 11.0, *) {
+            textDragDelegate = self
+        }
     }
     
     required public init?(coder aDecoder: NSCoder) {
@@ -105,4 +109,24 @@ extension LinkInteractionTextView: UITextViewDelegate {
             return !showAlertIfNeeded(for: URL, in: characterRange)
         }
     }
+}
+
+@available(iOS 11.0, *)
+extension LinkInteractionTextView: UITextDragDelegate {
+    
+    public func textDraggableView(_ textDraggableView: UIView & UITextDraggable, itemsForDrag dragRequest: UITextDragRequest) -> [UIDragItem] {
+        
+        func isMentionLink(_ attributeTuple: (NSAttributedString.Key, Any)) -> Bool {
+            return attributeTuple.0 == NSAttributedString.Key.link && (attributeTuple.1 as? NSURL)?.scheme ==  Mention.mentionScheme
+        }
+        
+        if let attributes = textStyling(at: dragRequest.dragRange.start, in: .forward) {
+            if attributes.contains(where: isMentionLink) {
+                return []
+            }
+        }
+        
+        return dragRequest.suggestedItems
+    }
+    
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

It is possible to drag & drop mentions in messages which doesn't make sense.

### Solutions

Disable drag & drop for links which refer to mentions.