### PR TITLE
Fix: self mention background color is not updated

### DIFF
--- a/Wire-iOS Tests/Mocks/MockConversation+TimedMessage.swift
+++ b/Wire-iOS Tests/Mocks/MockConversation+TimedMessage.swift
@@ -17,6 +17,7 @@
 //
 
 import Foundation
+@testable import Wire
 
 extension MockConversation {
 
@@ -25,7 +26,7 @@ extension MockConversation {
     }
 
     @objc var timeoutImage: UIImage? {
-        return WireStyleKit.imageOfWeek(with: UIColor.accent())
+        return WireStyleKit.imageOfWeek(with: .accent())
     }
 
 }

--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -338,7 +338,7 @@ var defaultFontScheme: FontScheme = FontScheme(contentSizeCategory: UIApplicatio
         }
 
         let colorScheme = ColorScheme.default
-        colorScheme.accentColor = UIColor.accent()
+        colorScheme.setAccentColor(.accent())
         colorScheme.variant = ColorSchemeVariant(rawValue: Settings.shared().colorScheme.rawValue) ?? .light
     }
     

--- a/Wire-iOS/Sources/Components/AccentColorChangeHandler.m
+++ b/Wire-iOS/Sources/Components/AccentColorChangeHandler.m
@@ -21,7 +21,7 @@
 
 #import "WireSyncEngine+iOS.h"
 #import "UIColor+WAZExtensions.h"
-
+#import "Wire-Swift.h"
 
 
 @interface AccentColorChangeHandler () <ZMUserObserver>

--- a/Wire-iOS/Sources/Managers/ColorSchemeController.swift
+++ b/Wire-iOS/Sources/Managers/ColorSchemeController.swift
@@ -66,8 +66,7 @@ extension ColorSchemeController: ZMUserObserver {
 
         let colorScheme = ColorScheme.default
 
-        if let newAccentColor = UIColor.accent(),
-           !colorScheme.isCurrentAccentColor(newAccentColor) {
+        if !colorScheme.isCurrentAccentColor(UIColor.accent()) {
             notifyColorSchemeChange()
         }
     }

--- a/Wire-iOS/Sources/Managers/ColorSchemeController.swift
+++ b/Wire-iOS/Sources/Managers/ColorSchemeController.swift
@@ -65,8 +65,9 @@ extension ColorSchemeController: ZMUserObserver {
         guard note.accentColorValueChanged else { return }
 
         let colorScheme = ColorScheme.default
-        let newAccentColor = UIColor.accent()
-        if !(colorScheme.accentColor == newAccentColor) {
+
+        if let newAccentColor = UIColor.accent(),
+           !colorScheme.isCurrentAccentColor(newAccentColor) {
             notifyColorSchemeChange()
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/NSAttributedString+Mentions.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/NSAttributedString+Mentions.swift
@@ -106,7 +106,7 @@ extension NSMutableAttributedString {
             }
         }
         else {
-            color = ColorScheme.default.accentColor
+            color = .accent()
             backgroundColor = .clear
         }
         

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/NSAttributedString+Mentions.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/NSAttributedString+Mentions.swift
@@ -97,10 +97,12 @@ extension NSMutableAttributedString {
         if user.isSelfUser {
             color = ColorScheme.default.color(named: .textForeground)
             if ColorScheme.default.variant == .dark {
-                backgroundColor = ColorScheme.default.accentColor.withAlphaComponent(0.48)
+//                backgroundColor = ColorScheme.default.accentColor.withAlphaComponent(0.48)
+                backgroundColor = UIColor.accent().withAlphaComponent(0.48)
             }
             else {
-                backgroundColor = ColorScheme.default.accentColor.withAlphaComponent(0.16)
+//                backgroundColor = ColorScheme.default.accentColor.withAlphaComponent(0.16)
+                backgroundColor = UIColor.accent().withAlphaComponent(0.16)
             }
         }
         else {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/NSAttributedString+Mentions.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/NSAttributedString+Mentions.swift
@@ -97,11 +97,9 @@ extension NSMutableAttributedString {
         if user.isSelfUser {
             color = ColorScheme.default.color(named: .textForeground)
             if ColorScheme.default.variant == .dark {
-//                backgroundColor = ColorScheme.default.accentColor.withAlphaComponent(0.48)
                 backgroundColor = UIColor.accent().withAlphaComponent(0.48)
             }
             else {
-//                backgroundColor = ColorScheme.default.accentColor.withAlphaComponent(0.16)
                 backgroundColor = UIColor.accent().withAlphaComponent(0.16)
             }
         }

--- a/Wire-iOS/Sources/UserInterface/Helpers/UIColor+Accent.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UIColor+Accent.swift
@@ -27,6 +27,12 @@ extension UIColor {
         return accent().withAlphaComponent(0.16).removeAlphaByBlending(with: .white)
     }
 
+    @objc (accentColor)
+    class func accent() -> UIColor {
+        return UIColor(for: indexedAccentColor())
+    }
+
+
     @objc static func buttonEmptyText(variant: ColorSchemeVariant) -> UIColor {
         switch variant {
         case .dark:

--- a/Wire-iOS/Sources/UserInterface/Helpers/UIColor+WAZExtensions.h
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UIColor+WAZExtensions.h
@@ -29,7 +29,6 @@
 
 /// Set accent color on self user to this index.
 + (void)setAccentColor:(ZMAccentColor)accentColor;
-+ (instancetype)accentColor;
 
 + (ZMAccentColor)indexedAccentColor;
 

--- a/Wire-iOS/Sources/UserInterface/Helpers/UIColor+WAZExtensions.m
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UIColor+WAZExtensions.m
@@ -30,11 +30,6 @@ static ZMAccentColor overridenAccentColor = ZMAccentColorUndefined;
 
 @implementation UIColor (WAZExtensions)
 
-+ (instancetype)accentColor
-{
-	return [self colorForZMAccentColor:[self indexedAccentColor]];
-}
-
 + (void)setAccentColor:(ZMAccentColor)accentColor
 {
     id<ZMEditableUser> editableSelf = [ZMUser editableSelfUser];

--- a/Wire-iOS/Sources/UserInterface/MarkdownBarView.swift
+++ b/Wire-iOS/Sources/UserInterface/MarkdownBarView.swift
@@ -31,7 +31,7 @@ public final class MarkdownBarView: UIView {
     weak var delegate: MarkdownBarViewDelegate?
     
     private let stackView =  UIStackView()
-    private let accentColor: UIColor = UIColor.accent()! ///TODO
+    private let accentColor: UIColor = UIColor.accent()
     private let normalColor = UIColor(scheme: .iconNormal)
     
     public let headerButton         = PopUpIconButton()

--- a/Wire-iOS/Sources/UserInterface/MarkdownBarView.swift
+++ b/Wire-iOS/Sources/UserInterface/MarkdownBarView.swift
@@ -31,7 +31,7 @@ public final class MarkdownBarView: UIView {
     weak var delegate: MarkdownBarViewDelegate?
     
     private let stackView =  UIStackView()
-    private let accentColor = ColorScheme.default.accentColor
+    private let accentColor: UIColor = UIColor.accent()! ///TODO
     private let normalColor = UIColor(scheme: .iconNormal)
     
     public let headerButton         = PopUpIconButton()

--- a/WireExtensionComponents/Utilities/ColorScheme.h
+++ b/WireExtensionComponents/Utilities/ColorScheme.h
@@ -90,7 +90,6 @@ typedef NS_ENUM(NSUInteger, ColorSchemeVariant) {
 @property (nonatomic, readonly) UIKeyboardAppearance keyboardAppearance;
 @property (nonatomic, readonly) UIBlurEffectStyle blurEffectStyle;
 
-@property (nonatomic) UIColor *accentColor;
 @property (nonatomic) ColorSchemeVariant variant;
 
 @property (class, readonly, strong) ColorScheme *defaultColorScheme;
@@ -103,6 +102,8 @@ typedef NS_ENUM(NSUInteger, ColorSchemeVariant) {
 
 - (UIColor *)nameAccentForColor:(ZMAccentColor)color variant:(ColorSchemeVariant)variant;
 
+- (void)setAccentColor:(UIColor *)accentColor;
+- (BOOL)isCurrentAccentColor:(UIColor *)accentColor;
 @end
 
 @interface UIColor (ColorScheme)

--- a/WireExtensionComponents/Utilities/ColorScheme.m
+++ b/WireExtensionComponents/Utilities/ColorScheme.m
@@ -123,6 +123,7 @@ static NSString* light(NSString *colorString) {
 @interface ColorScheme ()
 
 @property (nonatomic) NSDictionary *colors;
+@property (nonatomic) UIColor *accentColor;
 
 @end
 
@@ -167,6 +168,11 @@ static NSString* light(NSString *colorString) {
 {
     _accentColor = accentColor;
     [self updateColors];
+}
+
+- (BOOL)isCurrentAccentColor:(UIColor *)accentColor
+{
+    return _accentColor == accentColor;
 }
 
 - (void)setVariant:(ColorSchemeVariant)variant


### PR DESCRIPTION
## What's new in this PR?

### Issues

Self mention background color is not updated after my accent color is changed.

### Causes

Used ColorScheme.default.accentColor for the background color, which is not updated after accent color is changed.

### Solutions

Use UIColor.accent() instead.

This PR also removed the ColorScheme accentColor getter. UIColor accentColor property is translated to Swift to mark it as non-optional.