### PR TITLE
Fix: Put video button at the last of the input bar

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -306,7 +306,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
     self.mentionButton.hitAreaPadding = CGSizeZero;
     self.mentionButton.accessibilityIdentifier = @"mentionButton";
 
-    self.inputBar = [[InputBar alloc] initWithButtons:@[self.photoButton, self.mentionButton, self.sketchButton, self.gifButton, self.audioButton, self.pingButton, self.uploadFileButton, self.locationButton]];
+    self.inputBar = [[InputBar alloc] initWithButtons:@[self.photoButton, self.mentionButton, self.sketchButton, self.gifButton, self.audioButton, self.pingButton, self.uploadFileButton, self.locationButton, self.videoButton]];
     self.inputBar.translatesAutoresizingMaskIntoConstraints = NO;
     self.inputBar.textView.delegate = self;
     


### PR DESCRIPTION
## What's new in this PR?

Undo the video button removal.