### PR TITLE
Adding non-breaking space in full name

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Views/Mentions/MentionsTextAttachment.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/Mentions/MentionsTextAttachment.swift
@@ -30,7 +30,9 @@ final class MentionTextAttachment: NSTextAttachment {
     
     init(user: UserType, font: UIFont = .normalLightFont, color: UIColor = .accent()) {
         self.user = user
-        attributedText = "@" + (user.name ?? "") && font && color
+        // Replace all spaces with non-breaking space to avoid wrapping when displaying mention
+        let nameWithNonBreakingSpaces = user.name?.replacingOccurrences(of: " ", with: " ")
+        attributedText = "@" + (nameWithNonBreakingSpaces ?? "") && font && color
         super.init(data: nil, ofType: nil)
         refreshImage()
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

If we mention someone with long name we should avoid wrapping it to a new line. 

### Solutions

Replace all regular spaces with non-breaking space. Message cell will wrap the mention to new line only if it doesn't fit full next line.
