### PR TITLE
ZIOS-10608: Fix crash when opening push notification

### DIFF
--- a/Wire-iOS/Sources/Analytics/AnalyticsMixpanelProvider.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsMixpanelProvider.swift
@@ -88,7 +88,7 @@ final class AnalyticsMixpanelProvider: NSObject, AnalyticsProvider {
         self.defaults = defaults
 
         if !MixpanelAPIKey.isEmpty {
-            mixpanelInstance = Mixpanel.initialize(token: MixpanelAPIKey, optOutTrackingByDefault: true)
+            mixpanelInstance = Mixpanel.initialize(token: MixpanelAPIKey, automaticPushTracking: false, optOutTrackingByDefault: true)
         }
         super.init()
         mixpanelInstance?.distinctId = mixpanelDistinctId


### PR DESCRIPTION
## What's new in this PR?

### Issues

The app could crash when opening a push notification on iOS 12.

### Causes

This was caused by Mixpanel's "automatic push tracking" feature. It sent a `campaign_received` event to Mixpanel every time the user opened a notification (the feature is on by default). To work, it swizzles a method from `UNNotificationCenter` to inject tracking code; but there happens to be a crash in their swizzling implementation.

### Solutions

We disable this push tracking feature, as we are not making any use of it.