### PR TITLE
Connect @ button to start mentioning flow

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1303,6 +1303,7 @@
 		F1B5EAC72029AB9A0081D402 /* SimpleTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1B5EAC62029AB9A0081D402 /* SimpleTextField.swift */; };
 		F1B5EAC92029AC7E0081D402 /* SimpleTextFieldValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1B5EAC82029AC7E0081D402 /* SimpleTextFieldValidator.swift */; };
 		F1C9E3601EAE008C006438D7 /* TestSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C9E35E1EADFFB8006438D7 /* TestSetup.swift */; };
+		F1CB5D252158FE1F001CCF5D /* MentionsHandler+TextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1CB5D242158FE1F001CCF5D /* MentionsHandler+TextView.swift */; };
 		F1CE2DF01EF0337F00631D8A /* PureLayout.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F1CE2DEF1EF0337F00631D8A /* PureLayout.framework */; };
 		F93D58431D7D9184003AE972 /* Analytics+ConversationEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93D58421D7D9184003AE972 /* Analytics+ConversationEvents.swift */; };
 		F93D58451D7DA865003AE972 /* ZMConversation+Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93D58441D7DA865003AE972 /* ZMConversation+Analytics.swift */; };
@@ -3054,6 +3055,7 @@
 		F1B5EAC62029AB9A0081D402 /* SimpleTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleTextField.swift; sourceTree = "<group>"; };
 		F1B5EAC82029AC7E0081D402 /* SimpleTextFieldValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleTextFieldValidator.swift; sourceTree = "<group>"; };
 		F1C9E35E1EADFFB8006438D7 /* TestSetup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSetup.swift; sourceTree = "<group>"; };
+		F1CB5D242158FE1F001CCF5D /* MentionsHandler+TextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MentionsHandler+TextView.swift"; sourceTree = "<group>"; };
 		F1CE2DEF1EF0337F00631D8A /* PureLayout.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PureLayout.framework; path = Carthage/Build/iOS/PureLayout.framework; sourceTree = "<group>"; };
 		F93D58421D7D9184003AE972 /* Analytics+ConversationEvents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Analytics+ConversationEvents.swift"; sourceTree = "<group>"; };
 		F93D58441D7DA865003AE972 /* ZMConversation+Analytics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMConversation+Analytics.swift"; sourceTree = "<group>"; };
@@ -5174,6 +5176,7 @@
 				EFDACAB820FF715A00791207 /* ConversationInputBarViewController+OrientationAndSize.swift */,
 				EF4795AC2077847E00334E32 /* ConversationInputBarViewController+UITextViewDelegate.swift */,
 				F12EAF72214FB6FE00B00AD9 /* MentionsHandler.swift */,
+				F1CB5D242158FE1F001CCF5D /* MentionsHandler+TextView.swift */,
 				EEF28EEE1F168039007642E2 /* ConversationInputBarViewController+Markdown.swift */,
 				F16E8EA7214A910F005ED9E2 /* ConversationInputBarViewController+Mentions.swift */,
 				BF8EE5551D62FBCD00B0D6D7 /* ConversationInputBarViewController+Editing.swift */,
@@ -7129,6 +7132,7 @@
 				BF27AE4B1E9E4CED00809A2B /* MessageDraft.swift in Sources */,
 				87E4D2CA1FC6E39800F3C664 /* CharacterInputField.swift in Sources */,
 				D5189475204ED04400C095C1 /* ParticipantsInvitePeopleView.swift in Sources */,
+				F1CB5D252158FE1F001CCF5D /* MentionsHandler+TextView.swift in Sources */,
 				8744489C1C22FCE500E7B947 /* LinkAttachment.m in Sources */,
 				5EA73D7920D900830001D106 /* GroupOptionsSectionController.swift in Sources */,
 				BF79B10220AB236A001BF4FE /* SectionFooter.swift in Sources */,

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Mentions.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Mentions.swift
@@ -19,13 +19,23 @@
 import Foundation
 
 extension ConversationInputBarViewController {
+    var isInMentionsFlow: Bool {
+        return mentionsHandler != nil
+    }
     
     @objc func configureMentionButton() {
         mentionButton.addTarget(self, action: #selector(ConversationInputBarViewController.mentionButtonTapped(sender:)), for: .touchUpInside)
     }
 
     @objc func mentionButtonTapped(sender: Any) {
-        // TODO: Trigger mentioning flow
+        guard !isInMentionsFlow else { return }
+
+        let textView = inputBar.textView
+        textView.becomeFirstResponder()
+
+        MentionsHandler.startMentioning(in: textView)
+        let position = MentionsHandler.cursorPosition(in: inputBar.textView) ?? 0
+        mentionsHandler = MentionsHandler(text: inputBar.textView.text, cursorPosition: position)
     }
 }
 
@@ -43,8 +53,7 @@ extension ConversationInputBarViewController: MentionsSearchResultsViewControlle
 extension ConversationInputBarViewController {
 
     func triggerMentionsIfNeeded(from textView: UITextView, with selection: UITextRange? = nil) {
-        if let selectedRange = selection ?? textView.selectedTextRange {
-            let position = textView.offset(from: textView.beginningOfDocument, to: selectedRange.start)
+        if let position = MentionsHandler.cursorPosition(in: textView, range: selection) {
             mentionsHandler = MentionsHandler(text: textView.text, cursorPosition: position)
         }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/MentionsHandler+TextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/MentionsHandler+TextView.swift
@@ -21,7 +21,9 @@ import Foundation
 fileprivate extension NSAttributedString {
     func hasSpaceAt(position: Int) -> Bool {
         guard wholeRange.contains(position) else { return false }
-        return attributedSubstring(from: NSRange(location: position, length: 1)).string == " "
+        let scalars = attributedSubstring(from: NSRange(location: position, length: 1)).string.unicodeScalars
+        let justSpaces = scalars.filter(NSCharacterSet.whitespacesAndNewlines.contains)
+        return !justSpaces.isEmpty
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/MentionsHandler+TextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/MentionsHandler+TextView.swift
@@ -63,19 +63,4 @@ extension MentionsHandler {
         let cursorOffset = prefix.isEmpty ? 1 : 2
         return (result, cursorOffset)
     }
-
-    static func attributedStringForMentioning(with text: NSAttributedString?, at cursorPosition: Int) -> NSAttributedString {
-        guard let text = text else { return "@".attributedString }
-        guard text.length > 0 else { return "@".attributedString }
-        guard text.wholeRange.contains(cursorPosition) else { return text }
-        if cursorPosition == 0 {
-            return "@ ".attributedString + text
-        } else {
-            let beforeCursor = NSRange(location: 0, length: cursorPosition)
-            let afterCursor = NSRange(location: cursorPosition, length: text.length - cursorPosition)
-            let before = text.attributedSubstring(from: beforeCursor)
-            let after = text.attributedSubstring(from: afterCursor)
-            return before + "@" + after
-        }
-    }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/MentionsHandler+TextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/MentionsHandler+TextView.swift
@@ -59,7 +59,7 @@ extension MentionsHandler {
 
         let result = prefix + "@" + suffix
 
-        // We need to change the selection depending if we insert only '@' or '@ '
+        // We need to change the selection depending if we insert only '@' or ' @'
         let cursorOffset = prefix.isEmpty ? 1 : 2
         return (result, cursorOffset)
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/MentionsHandler+TextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/MentionsHandler+TextView.swift
@@ -1,0 +1,85 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension MentionsHandler {
+
+    static func cursorPosition(in textView: UITextView, range: UITextRange? = nil) -> Int? {
+        if let range = (range ?? textView.selectedTextRange) {
+            let position = textView.offset(from: textView.beginningOfDocument, to: range.start)
+            return position
+
+        }
+        return nil
+    }
+
+    static func startMentioning(in textView: UITextView) {
+        let (text, cursorOffset) = mentionsTextToInsert(textView: textView)
+
+        let selectionPosition = textView.selectedTextRange?.start ?? textView.beginningOfDocument
+        let replacementRange = textView.textRange(from: selectionPosition, to: selectionPosition)!
+        textView.replace(replacementRange, withText: text)
+
+        let positionWithOffset = textView.position(from: selectionPosition, offset: cursorOffset) ?? textView.endOfDocument
+
+        let newSelectionRange = textView.textRange(from: positionWithOffset, to: positionWithOffset)
+        textView.selectedTextRange = newSelectionRange
+    }
+
+    static func mentionsTextToInsert(textView: UITextView) -> (String, Int) {
+        let text = textView.attributedText ?? "".attributedString
+
+        let selectionRange = textView.selectedRange
+        let cursorPosition = selectionRange.location
+        let beforeCursor = NSRange(location: 0, length: cursorPosition)
+        let afterCursor = NSRange(location: cursorPosition, length: text.length - cursorPosition)
+
+        var insertSpaceBefore = false
+        var insertSpaceAfter = false
+        if beforeCursor.length > 0 {
+            insertSpaceBefore = (text.attributedSubstring(from: NSRange(location: cursorPosition - 1, length: 1)).string != " ")
+        }
+        if afterCursor.length > 0 {
+            insertSpaceAfter = (text.attributedSubstring(from: NSRange(location: cursorPosition, length: 1)).string != " ")
+        }
+
+        let result =
+            (insertSpaceBefore ? " " : "") +
+            "@" +
+            (insertSpaceAfter ? " " : "")
+
+        let cursorOffset = insertSpaceBefore ? 2 : 1
+        return (result, cursorOffset)
+    }
+
+    static func attributedStringForMentioning(with text: NSAttributedString?, at cursorPosition: Int) -> NSAttributedString {
+        guard let text = text else { return "@".attributedString }
+        guard text.length > 0 else { return "@".attributedString }
+        guard text.wholeRange.contains(cursorPosition) else { return text }
+        if cursorPosition == 0 {
+            return "@ ".attributedString + text
+        } else {
+            let beforeCursor = NSRange(location: 0, length: cursorPosition)
+            let afterCursor = NSRange(location: cursorPosition, length: text.length - cursorPosition)
+            let before = text.attributedSubstring(from: beforeCursor)
+            let after = text.attributedSubstring(from: afterCursor)
+            return before + "@" + after
+        }
+    }
+}

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/MentionsHandler+TextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/MentionsHandler+TextView.swift
@@ -18,13 +18,19 @@
 
 import Foundation
 
+fileprivate extension NSAttributedString {
+    func hasSpaceAt(position: Int) -> Bool {
+        guard wholeRange.contains(position) else { return false }
+        return attributedSubstring(from: NSRange(location: position, length: 1)).string == " "
+    }
+}
+
 extension MentionsHandler {
 
     static func cursorPosition(in textView: UITextView, range: UITextRange? = nil) -> Int? {
         if let range = (range ?? textView.selectedTextRange) {
             let position = textView.offset(from: textView.beginningOfDocument, to: range.start)
             return position
-
         }
         return nil
     }
@@ -47,24 +53,14 @@ extension MentionsHandler {
 
         let selectionRange = textView.selectedRange
         let cursorPosition = selectionRange.location
-        let beforeCursor = NSRange(location: 0, length: cursorPosition)
-        let afterCursor = NSRange(location: cursorPosition, length: text.length - cursorPosition)
 
-        var insertSpaceBefore = false
-        var insertSpaceAfter = false
-        if beforeCursor.length > 0 {
-            insertSpaceBefore = (text.attributedSubstring(from: NSRange(location: cursorPosition - 1, length: 1)).string != " ")
-        }
-        if afterCursor.length > 0 {
-            insertSpaceAfter = (text.attributedSubstring(from: NSRange(location: cursorPosition, length: 1)).string != " ")
-        }
+        let prefix = text.hasSpaceAt(position: cursorPosition - 1) ? "" : " "
+        let suffix = text.hasSpaceAt(position: cursorPosition) ? "" : " "
 
-        let result =
-            (insertSpaceBefore ? " " : "") +
-            "@" +
-            (insertSpaceAfter ? " " : "")
+        let result = prefix + "@" + suffix
 
-        let cursorOffset = insertSpaceBefore ? 2 : 1
+        // We need to change the selection depending if we insert only '@' or '@ '
+        let cursorOffset = prefix.isEmpty ? 1 : 2
         return (result, cursorOffset)
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/MentionsHandler.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/MentionsHandler.swift
@@ -57,3 +57,4 @@ import Foundation
         return mut
     }
 }
+


### PR DESCRIPTION
## What's new in this PR?

### Issues

We have a button that should open the mentioning flow. Because we use regexps for parsing the string and find mentions we need to add additional spaces if needed. Also the cursor must be in the correct position after adding the @ sybmol.

To illustrate (`|` is the cursor position):

* `AB|CD` -> `AB @| CD`
* `AB| CD` -> `AB @| CD`
* `AB |CD` -> `AB @| CD`
