### PR TITLE
Fix/select before delete

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+UITextViewDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+UITextViewDelegate.swift
@@ -50,6 +50,17 @@ extension ConversationInputBarViewController: UITextViewDelegate {
             return false
         }
 
+        // we are deleting text one by one
+        if text == "" && range.length == 1 {
+            if let selection = textView.selectedTextRange, let start = textView.position(from: selection.start, offset: -1) {
+                if selection.start == selection.end && // We have only caret, no selected text
+                    textView.attributedText.containsAttachments(in: range) { // Text to be deleted has text attachment
+                    textView.selectedTextRange = textView.textRange(from: start, to: selection.start) // Select the text to be deleted and ignore the backspace
+                    return false
+                }
+            }
+        }
+
         inputBar.textView.respondToChange(text, inRange: range)
         return true
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+UITextViewDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+UITextViewDelegate.swift
@@ -52,10 +52,10 @@ extension ConversationInputBarViewController: UITextViewDelegate {
 
         // we are deleting text one by one
         if text == "" && range.length == 1 {
-            if let selection = textView.selectedTextRange, let start = textView.position(from: selection.start, offset: -1) {
-                if selection.start == selection.end && // We have only caret, no selected text
+            if let cursor = textView.selectedTextRange, let deletionStart = textView.position(from: cursor.start, offset: -1) {
+                if cursor.start == cursor.end && // We have only caret, no selected text
                     textView.attributedText.containsAttachments(in: range) { // Text to be deleted has text attachment
-                    textView.selectedTextRange = textView.textRange(from: start, to: selection.start) // Select the text to be deleted and ignore the backspace
+                    textView.selectedTextRange = textView.textRange(from: deletionStart, to: cursor.start) // Select the text to be deleted and ignore the backspace
                     return false
                 }
             }


### PR DESCRIPTION
## What's new in this PR?

### Issues

When we have a mention token in the input bar and backspace is tapped we should not delete it immediately. Instead it should become selected and then deleted on the second tap.
