### PR TITLE
ZIOS-10592: The sequence of subtitle items is wrong

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ZMConversation+Status.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ZMConversation+Status.swift
@@ -344,7 +344,7 @@ extension ConversationStatus {
 // In not silenced: "[Sender:] <message text>"
 // Ephemeral: "Ephemeral message"
 final internal class NewMessagesMatcher: TypedConversationStatusMatcher {
-    let matchedTypes: [StatusMessageType] = [.mention, .text, .link, .image, .location, .audio, .video, .file, .knock, .missedCall]
+    let matchedTypes: [StatusMessageType] = [.mention, .missedCall, .knock, .text, .link, .image, .location, .audio, .video, .file]
     let localizationSilencedRootPath = "conversation.silenced.status.message"
     let localizationRootPath = "conversation.status.message"
 


### PR DESCRIPTION
## What's new in this PR?

The order of importance for the subtitle items in the conversation list is wrong.
Current one is mentions, messages, pings, missed calls. It should be mentions, missed calls, pings, messages.