### PR TITLE
ZIOS-10591 / ZIOS-10592: Update List UI Summary Rules

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.stringsdict
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.stringsdict
@@ -183,7 +183,7 @@
 			<string>new devices</string>
 		</dict>
 	</dict>
-	<key>conversation.silenced.status.message.text</key>
+	<key>conversation.silenced.status.message.generic_message</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
 		<string>%#@d_number_of_new@</string>
@@ -194,9 +194,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>new text message</string>
+			<string>1 new message</string>
 			<key>other</key>
-			<string>%d new text messages</string>
+			<string>%d new messages</string>
 		</dict>
 	</dict>
 	<key>conversation.silenced.status.message.mention</key>
@@ -215,86 +215,6 @@
 			<string>%d mentions</string>
 		</dict>
 	</dict>
-	<key>conversation.silenced.status.message.link</key>
-	<dict>
-		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@d_number_of_new@</string>
-		<key>d_number_of_new</key>
-		<dict>
-			<key>NSStringFormatSpecTypeKey</key>
-			<string>NSStringPluralRuleType</string>
-			<key>NSStringFormatValueTypeKey</key>
-			<string>d</string>
-			<key>one</key>
-			<string>new link</string>
-			<key>other</key>
-			<string>%d new links</string>
-		</dict>
-	</dict>
-	<key>conversation.silenced.status.message.image</key>
-	<dict>
-		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@d_number_of_new@</string>
-		<key>d_number_of_new</key>
-		<dict>
-			<key>NSStringFormatSpecTypeKey</key>
-			<string>NSStringPluralRuleType</string>
-			<key>NSStringFormatValueTypeKey</key>
-			<string>d</string>
-			<key>one</key>
-			<string>new image</string>
-			<key>other</key>
-			<string>%d new images</string>
-		</dict>
-	</dict>
-	<key>conversation.silenced.status.message.location</key>
-	<dict>
-		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@d_number_of_new@</string>
-		<key>d_number_of_new</key>
-		<dict>
-			<key>NSStringFormatSpecTypeKey</key>
-			<string>NSStringPluralRuleType</string>
-			<key>NSStringFormatValueTypeKey</key>
-			<string>d</string>
-			<key>one</key>
-			<string>new location</string>
-			<key>other</key>
-			<string>%d new locations</string>
-		</dict>
-	</dict>
-	<key>conversation.silenced.status.message.audio</key>
-	<dict>
-		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@d_number_of_new@</string>
-		<key>d_number_of_new</key>
-		<dict>
-			<key>NSStringFormatSpecTypeKey</key>
-			<string>NSStringPluralRuleType</string>
-			<key>NSStringFormatValueTypeKey</key>
-			<string>d</string>
-			<key>one</key>
-			<string>new audio message</string>
-			<key>other</key>
-			<string>%d new audio messages</string>
-		</dict>
-	</dict>
-	<key>conversation.silenced.status.message.video</key>
-	<dict>
-		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@d_number_of_new@</string>
-		<key>d_number_of_new</key>
-		<dict>
-			<key>NSStringFormatSpecTypeKey</key>
-			<string>NSStringPluralRuleType</string>
-			<key>NSStringFormatValueTypeKey</key>
-			<string>d</string>
-			<key>one</key>
-			<string>new video</string>
-			<key>other</key>
-			<string>%d new videos</string>
-		</dict>
-	</dict>
 	<key>conversation.silenced.status.message.knock</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -306,7 +226,7 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>new ping</string>
+			<string>1 new ping</string>
 			<key>other</key>
 			<string>%d new pings</string>
 		</dict>
@@ -322,25 +242,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>missed call</string>
+			<string>1 missed call</string>
 			<key>other</key>
 			<string>%d missed calls</string>
-		</dict>
-	</dict>
-	<key>conversation.silenced.status.message.file</key>
-	<dict>
-		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@d_number_of_new@</string>
-		<key>d_number_of_new</key>
-		<dict>
-			<key>NSStringFormatSpecTypeKey</key>
-			<string>NSStringPluralRuleType</string>
-			<key>NSStringFormatValueTypeKey</key>
-			<string>d</string>
-			<key>one</key>
-			<string>new file</string>
-			<key>other</key>
-			<string>%d new files</string>
 		</dict>
 	</dict>
 	<key>content.system.call.missed-call</key>


### PR DESCRIPTION
## What's new in this PR?

Following the spec updates from yesterday, we needed to update the list UI summarization rules.

We fixed the order of items in the summary. We now show mentions > calls > pings > all other messages (as generic "new message" umbrella).

We also needed to change the cases where the summary is shown:

- If there are 2 or more mentions
- If there are 1 or more mentions and at least 1 other message activity (call/ping/generic message)