### PR TITLE
Fix draft being reset on upon entering foreground

### DIFF
--- a/WireExtensionComponents/Utilities/ColorScheme.m
+++ b/WireExtensionComponents/Utilities/ColorScheme.m
@@ -172,7 +172,7 @@ static NSString* light(NSString *colorString) {
 
 - (BOOL)isCurrentAccentColor:(UIColor *)accentColor
 {
-    return _accentColor == accentColor;
+    return [self.accentColor isEqualTo:accentColor];
 }
 
 - (void)setVariant:(ColorSchemeVariant)variant


### PR DESCRIPTION
## What's new in this PR?

### Issues

The draft was reset when putting the app into the background and back into foreground again.

### Causes

Upon entering the foreground the notification system is activated and all observers are called so they can setup the initial state. In this case color scheme controller was observing the self user and triggering a reload of the UI if the accent color changed. Due to this bug this was always happening and since the draft wasn't saved (happens when editing ends) it was being reset.

### Solutions

Use `isEqual` instead of comparing instances.
