### PR TITLE
ZIOS-10619: Update copy for ephemeral messages in list UI

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -209,8 +209,9 @@
 "conversation.status.message.knock" = "Pinged";
 "conversation.status.message.missedcall" = "Missed call";
 "conversation.status.message.missedcall.groups" = "Missed call from %@";
-"conversation.status.message.ephemeral" = "Timed message";
 "conversation.status.message.mention" = "%@";
+"conversation.status.message.ephemeral" = "Sent a message";
+"conversation.status.message.ephemeral.group" = "Someone sent a message";
 "conversation.status.message.ephemeral.mention" = "Mentioned you";
 "conversation.status.message.ephemeral.mention.group" = "Someone mentioned you";
 

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ZMConversation+Status.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ZMConversation+Status.swift
@@ -438,6 +438,8 @@ final internal class NewMessagesMatcher: TypedConversationStatusMatcher {
                 var typeSuffix = ".ephemeral"
                 if type == .mention {
                     typeSuffix += status.isGroup ? ".mention.group" : ".mention"
+                } else if status.isGroup {
+                    typeSuffix += ".group"
                 }
                 messageDescription = (localizationRootPath + typeSuffix).localized
             }
@@ -452,7 +454,7 @@ final internal class NewMessagesMatcher: TypedConversationStatusMatcher {
                 messageDescription = String(format: format.localized, message.textMessageData?.messageText ?? "")
             }
             
-            if status.isGroup {
+            if status.isGroup && !message.isEphemeral {
                 return ((sender.displayName(in: conversation) + ": ") && Swift.type(of: self).emphasisStyle) +
                         (messageDescription && Swift.type(of: self).regularStyle)
             }


### PR DESCRIPTION
## What's new in this PR?

We change the copy of ephemeral messages and mentions in the list UI (outside of summary):

**New description text chart**

| | 1:1 Chat | Group Chat |
|----------|--------|-------------|
| Message  | Sent a message | Someone sent a message |
| Mention   | Mentioned you | Someone mentioned you |

We also remove the name of the user that sent the ephemeral message from the description.