### PR TITLE
Fix crash when adding mention

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/MentionsHandler.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/MentionsHandler.swift
@@ -58,10 +58,8 @@ import Foundation
         let characterAfterMention = mentionMatchRange.upperBound
 
         // Add space after mention if it's not there
-        if !mut.hasSpaceAt(position: characterAfterMention) {
-            mut.insert(" ".attributedString, at: characterAfterMention)
-        }
-        mut.replaceCharacters(in: mentionMatchRange, with: mentionString)
+        let suffix = mut.hasSpaceAt(position: characterAfterMention) ? "".attributedString : " ".attributedString
+        mut.replaceCharacters(in: mentionMatchRange, with: mentionString + suffix)
 
         return mut
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Sometimes when inserting a mention the app would crash.

### Causes

It was not reproduced, but crash log shows out of bounds access when inserting space symbol.

### Solutions

Rewrote this place in a safer way, but appending space to the mention text attachment if needed.
