### PR TITLE
ZIOS-10618: Do not allow saving the mention from the input field

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+UITextViewDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+UITextViewDelegate.swift
@@ -42,6 +42,10 @@ extension ConversationInputBarViewController: UITextViewDelegate {
         updateRightAccessoryView()
     }
 
+    public func textView(_ textView: UITextView, shouldInteractWith textAttachment: NSTextAttachment, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
+        return textAttachment.image == nil
+    }
+
     public func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
         // send only if send key pressed
         if textView.returnKeyType == .send && (text == "\n") {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Mention tokens are represented as image text attachments. This means that by default, the user was able to long press the mention in the input field and save the image to the camera roll.

### Solutions

In the Conversation Input Bar, we specify that we don't allow the text view to interact with any image attachment.