### PR TITLE
Correctly check if Markdown contains a link

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Views/LinkInteractionTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/LinkInteractionTextView.swift
@@ -79,7 +79,7 @@ import UIKit
     /// link in the specified range is a markdown link.
     fileprivate func showAlertIfNeeded(for url: URL, in range: NSRange) -> Bool {
         // only show alert if the link is a markdown link
-        guard attributedText.ranges(of: .link, inRange: range) == [range] else { return false }
+        guard attributedText.ranges(containing: .link, inRange: range) == [range] else { return false }
         ZClientViewController.shared()?.present(confirmationAlert(for: url), animated: true, completion: nil)
         return true
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Sometimes tapping on a markdown link the alert with URL would not be shown.

### Causes

When a link is tapped we check if this is a markdown link. Markdown attributes are an option set and we were checking that attributes contains only a link. It would fail if there would be more attributes together with the link. 

### Solutions

Change the comparison method.
