### PR TITLE
Stripping mentions when forwarding message

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
@@ -57,7 +57,10 @@ func forward(_ message: ZMMessage, to: [AnyObject]) {
     if message.isText {
         let fetchLinkPreview = !Settings.shared().disableLinkPreviews
         ZMUserSession.shared()?.performChanges {
-            conversations.forEachNonEphemeral { _ = $0.append(text: message.textMessageData!.messageText!, mentions: message.textMessageData!.mentions, fetchLinkPreview: fetchLinkPreview) }
+            conversations.forEachNonEphemeral {
+                // We should not forward any mentions to other conversations
+                _ = $0.append(text: message.textMessageData!.messageText!, mentions: [], fetchLinkPreview: fetchLinkPreview)
+            }
         }
     }
     else if message.isImage, let imageData = message.imageMessageData?.imageData {


### PR DESCRIPTION
## What's new in this PR?

When forwarding a message we should remove mentions because those users might not be part of the target conversation.
