### PR TITLE
ZIOS-10619: Show correct description in list UI for ephemeral ping

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/MentionsHandler.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/MentionsHandler.swift
@@ -58,10 +58,8 @@ import Foundation
         let characterAfterMention = mentionMatchRange.upperBound
 
         // Add space after mention if it's not there
-        if !mut.hasSpaceAt(position: characterAfterMention) {
-            mut.insert(" ".attributedString, at: characterAfterMention)
-        }
-        mut.replaceCharacters(in: mentionMatchRange, with: mentionString)
+        let suffix = mut.hasSpaceAt(position: characterAfterMention) ? "".attributedString : " ".attributedString
+        mut.replaceCharacters(in: mentionMatchRange, with: mentionString + suffix)
 
         return mut
     }


### PR DESCRIPTION
## What's new in this PR?

Before this PR, pings were shown as "Someone sent a message". We now give a dedicated copy for them, as "Someone pinged".