### PR TITLE
Fix issue of input field still having content after deleting @

### DIFF
--- a/Wire-iOS Tests/MentionsHandlerTests.swift
+++ b/Wire-iOS Tests/MentionsHandlerTests.swift
@@ -120,7 +120,10 @@ class MentionsHandlerTests: XCTestCase {
         XCTAssertEqual(attachments.count, 1)
         guard let mention = attachments.first else { XCTFail(); return}
 
-        let expected = "Hi ".attributedString + NSAttributedString(attachment: mention) + " ".attributedString
+        let expected = NSMutableAttributedString(string: query)
+        let rangeOfMention = (query as NSString).range(of: "@bill")
+        expected.replaceCharacters(in: rangeOfMention, with: NSAttributedString(attachment: mention) + " ")
+
         XCTAssertEqual(replaced, expected)
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/MentionsHandler+TextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/MentionsHandler+TextView.swift
@@ -47,13 +47,18 @@ extension MentionsHandler {
         let selectionRange = textView.selectedRange
         let cursorPosition = selectionRange.location
 
-        let prefix = text.hasSpaceAt(position: cursorPosition - 1) ? "" : " "
-        let suffix = text.hasSpaceAt(position: cursorPosition) ? "" : " "
+        let prefix = needsSpace(text: text, position: cursorPosition - 1) ? " " : ""
+        let suffix = needsSpace(text: text, position: cursorPosition) ? " " : ""
 
         let result = prefix + "@" + suffix
 
         // We need to change the selection depending if we insert only '@' or ' @'
         let cursorOffset = prefix.isEmpty ? 1 : 2
         return (result, cursorOffset)
+    }
+
+    fileprivate static func needsSpace(text: NSAttributedString, position: Int) -> Bool {
+        guard text.wholeRange.contains(position) else { return false }
+        return !text.hasSpaceAt(position: position)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/MentionsHandler.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/MentionsHandler.swift
@@ -58,8 +58,8 @@ import Foundation
         let characterAfterMention = mentionMatchRange.upperBound
 
         // Add space after mention if it's not there
-        let spaceAlreadyExists = mut.wholeRange.contains(characterAfterMention) && mut.hasSpaceAt(position: characterAfterMention)
-        let suffix = spaceAlreadyExists ? "" : " "
+        let endOfString = !mut.wholeRange.contains(characterAfterMention)
+        let suffix = endOfString || !mut.hasSpaceAt(position: characterAfterMention) ? " " : ""
 
         mut.replaceCharacters(in: mentionMatchRange, with: mentionString + suffix)
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/MentionsHandler.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/MentionsHandler.swift
@@ -58,7 +58,9 @@ import Foundation
         let characterAfterMention = mentionMatchRange.upperBound
 
         // Add space after mention if it's not there
-        let suffix = mut.hasSpaceAt(position: characterAfterMention) ? "".attributedString : " ".attributedString
+        let spaceAlreadyExists = mut.wholeRange.contains(characterAfterMention) && mut.hasSpaceAt(position: characterAfterMention)
+        let suffix = spaceAlreadyExists ? "" : " "
+
         mut.replaceCharacters(in: mentionMatchRange, with: mentionString + suffix)
 
         return mut

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/NSAttributedString+Space.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/NSAttributedString+Space.swift
@@ -20,7 +20,6 @@ import Foundation
 
 extension NSAttributedString {
     func hasSpaceAt(position: Int) -> Bool {
-        guard wholeRange.contains(position) else { return false }
         let scalars = attributedSubstring(from: NSRange(location: position, length: 1)).string.unicodeScalars
         let justSpaces = scalars.filter(NSCharacterSet.whitespacesAndNewlines.contains)
         return !justSpaces.isEmpty


### PR DESCRIPTION
## What's new in this PR?

### Issues

After tapping @ button and deleting the symbol the text field would still have content (i.e. placeholder text would not appear).

### Causes

After tapping @ symbol we would unnecessary insert spaces before and after @ symbol. It would lead to a problem (`|` is cursor position and `_` is space):
1. Tap @ button - `_@|_`
2. Delete once - `_|_`
3. Delete twice - `|_`
4. Delete mamy more times - `|_`

Basically we would not able to delete contents of text field because there is whitespace after the cursor.  

### Solutions

Do not add whitespace when there is no text before/after the @ symbol.
