### PR TITLE
Dismiss mention flow upon sending a text message

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Mentions.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Mentions.swift
@@ -45,12 +45,16 @@ extension ConversationInputBarViewController: MentionsSearchResultsViewControlle
 
         let text = inputBar.textView.attributedText ?? NSAttributedString(string: inputBar.textView.text)
         inputBar.textView.attributedText = handler.replace(mention: user, in: text)
-        mentionsHandler = nil
-        mentionsView?.dismissIfVisible()
+        dismissMentionsIfNeeded()
     }
 }
 
 extension ConversationInputBarViewController {
+    
+    func dismissMentionsIfNeeded() {
+        mentionsHandler = nil
+        mentionsView?.dismissIfVisible()
+    }
 
     func triggerMentionsIfNeeded(from textView: UITextView, with selection: UITextRange? = nil) {
         if let position = MentionsHandler.cursorPosition(in: textView, range: selection) {
@@ -61,8 +65,7 @@ extension ConversationInputBarViewController {
             let participants = conversation.activeParticipants.array as! [ZMUser]
             mentionsView?.search(in: participants, with: searchString)
         } else {
-            mentionsHandler = nil
-            mentionsView?.dismissIfVisible()
+            dismissMentionsIfNeeded()
         }
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+SendButton.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+SendButton.swift
@@ -49,6 +49,8 @@ extension ConversationInputBarViewController {
             clearInputBar()
             delegate?.conversationInputBarViewControllerDidComposeText(text, mentions: mentions)
         }
+        
+        dismissMentionsIfNeeded()
     }
     
     func showAlertIfTextIsTooLong(text: String) -> Bool {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Sending a message while in the mention suggestion flow would not cancel the mention suggestion.

### Solutions

Aways dismiss the mention flow when sending a text message.