### PR TITLE
[Calling] Fixed type and copy of account switching alert controller

### DIFF
--- a/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
+++ b/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
@@ -116,7 +116,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-ZMBackendEnvironmentType staging"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-UseAnalytics 1"

--- a/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
+++ b/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
@@ -116,7 +116,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-ZMBackendEnvironmentType staging"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-UseAnalytics 1"

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -560,13 +560,12 @@
 "call.degraded.alert.message.unknown" = "Someone started using a new device.";
 "call.degraded.alert.action.continue" = "Call anyway";
 
-"call.alert.ongoing.start.alert_title" = "Start Call?";
-"call.alert.ongoing.join.alert_title" = "Join Call?";
+"call.alert.ongoing.alert_title" = "This will end your other call.";
 
 "call.alert.ongoing.start.message" = "A call is active in another conversation.\nCalling here will hang up the other call.";
 "call.alert.ongoing.join.message" = "A call is active in another conversation.\nJoining this call will hang up the other one.";
-"call.alert.ongoing.start.button" = "Call Anyway";
-"call.alert.ongoing.join.button" = "Join Anyway";
+"call.alert.ongoing.start.button" = "Call anyway";
+"call.alert.ongoing.join.button" = "Join anyway";
 
 // Call Actions (accessibility)
 
@@ -766,8 +765,8 @@
 "self.settings.add_account.error.title" = "Three accounts active";
 "self.settings.add_account.error.message" = "You can only be logged in with three accounts at once. Log out from one to add another.";
 
-"self.settings.switch_account.title" = "Switching accounts will hang up the current call.";
-"self.settings.switch_account.action" = "Switch account";
+"self.settings.switch_account.message" = "A call is active in this account.\nSwitching accounts will hang up the current call.";
+"self.settings.switch_account.action" = "Switch anyway";
 
 // Settings - Account details
 "self.settings.account_section" = "Account";

--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -538,8 +538,12 @@ extension AppRootViewController: SessionManagerSwitchingDelegate {
         guard let session = ZMUserSession.shared(), session.isCallOngoing else { return completion(true) }
         guard let topmostController = UIApplication.shared.wr_topmostController() else { return completion(false) }
         
-        let alert = UIAlertController(title: "self.settings.switch_account.title".localized, message: nil, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: "self.settings.switch_account.action".localized, style: .default, handler: { [weak self] (action) in
+        let alert = UIAlertController(title: "call.alert.ongoing.alert_title".localized,
+                                      message: "self.settings.switch_account.message".localized,
+                                      preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "self.settings.switch_account.action".localized,
+                                      style: .default,
+                                      handler: { [weak self] (action) in
             self?.sessionManager?.activeUserSession?.callCenter?.endAllCalls()
             completion(true)
         }))

--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -538,7 +538,7 @@ extension AppRootViewController: SessionManagerSwitchingDelegate {
         guard let session = ZMUserSession.shared(), session.isCallOngoing else { return completion(true) }
         guard let topmostController = UIApplication.shared.wr_topmostController() else { return completion(false) }
         
-        let alert = UIAlertController(title: "self.settings.switch_account.title".localized, message: nil, preferredStyle: .actionSheet)
+        let alert = UIAlertController(title: "self.settings.switch_account.title".localized, message: nil, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "self.settings.switch_account.action".localized, style: .default, handler: { [weak self] (action) in
             self?.sessionManager?.activeUserSession?.callCenter?.endAllCalls()
             completion(true)

--- a/Wire-iOS/Sources/UserInterface/Calling/Helper/UIAlertController+OngoingCall.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/Helper/UIAlertController+OngoingCall.swift
@@ -22,7 +22,7 @@ extension UIAlertController {
 
     static func ongoingCallJoinCallConfirmation(forceAlertModal: Bool = false, completion: @escaping (Bool) -> Void) -> UIAlertController {
         return ongoingCallConfirmation(
-            titleKey: "call.alert.ongoing.join.alert_title",
+            titleKey: "call.alert.ongoing.alert_title",
             messageKey: "call.alert.ongoing.join.message",
             buttonTitleKey: "call.alert.ongoing.join.button",
             forceAlertModal: forceAlertModal,
@@ -32,7 +32,7 @@ extension UIAlertController {
     
     static func ongoingCallStartCallConfirmation(completion: @escaping (Bool) -> Void) -> UIAlertController {
         return ongoingCallConfirmation(
-            titleKey: "call.alert.ongoing.start.alert_title",
+            titleKey: "call.alert.ongoing.alert_title",
             messageKey: "call.alert.ongoing.start.message",
             buttonTitleKey: "call.alert.ongoing.start.button",
             forceAlertModal: false,


### PR DESCRIPTION
## What's new in this PR?

- Converted the action sheet shown while calling and switching between accounts into alert.
- Fixed copy 