### PR TITLE
Append mentions from keyboard only on iPad

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -270,6 +270,7 @@
 "conversation.connection_view.in_address_book" = "in Contacts";
 
 "conversation.input_bar.shortcut.send" = "Send Message";
+"conversation.input_bar.shortcut.newline" = "Insert line break";
 "conversation.input_bar.shortcut.edit_last_message" = "Edit Last Message";
 "conversation.input_bar.shortcut.cancel_editing_message" = "Cancel";
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+UITextViewDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+UITextViewDelegate.swift
@@ -53,7 +53,8 @@ extension ConversationInputBarViewController: UITextViewDelegate {
     public func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
         // send only if send key pressed
         if textView.returnKeyType == .send && (text == "\n") {
-            if canInsertMention {
+            if UIDevice.current.type == .iPad,
+                canInsertMention {
                 insertBestMatchMention()
             }
             else {
@@ -62,8 +63,12 @@ extension ConversationInputBarViewController: UITextViewDelegate {
             }
             return false
         }
-        
-        if text.count == 1, text.containsCharacters(from: CharacterSet.newlinesAndTabulation), canInsertMention {
+                
+        if UIDevice.current.type == .iPad,
+            text.count == 1,
+            text.containsCharacters(from: CharacterSet.newlinesAndTabulation),
+            canInsertMention {
+            
             insertBestMatchMention()
             return false
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -573,6 +573,14 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
 - (NSArray<UIKeyCommand *> *)keyCommands
 {
     NSMutableArray *commands = [[NSMutableArray alloc] init];
+    
+    if (IS_IPAD) {
+        [commands addObject:[UIKeyCommand keyCommandWithInput:@"\r"
+                                                modifierFlags:UIKeyModifierShift
+                                                       action:@selector(shiftReturnPressed)
+                                         discoverabilityTitle:NSLocalizedString(@"conversation.input_bar.shortcut.newline", nil)]];
+    }
+    
     [commands addObject:[UIKeyCommand keyCommandWithInput:@"\r"
                                             modifierFlags:UIKeyModifierCommand
                                                    action:@selector(commandReturnPressed)
@@ -601,6 +609,11 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
 - (void)commandReturnPressed
 {
     [self sendText];
+}
+
+- (void)shiftReturnPressed
+{
+    [self.inputBar.textView replaceRange:self.inputBar.textView.selectedTextRange withText:@"\n"];
 }
 
 - (void)upArrowPressed


### PR DESCRIPTION
## What's new in this PR?

### Issues

We agreed with design that pressing enter to insert mention should only work on iPad. Additionally, on iPad user can override the behavior by pressing Shift+Enter.