### PR TITLE
Fix interactions with input field

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Views/MarkdownTextView+Recognizers.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/MarkdownTextView+Recognizers.swift
@@ -21,6 +21,7 @@ import Foundation
 extension MarkdownTextView {
     func setupGestureRecognizer() {
         let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(didTapTextView(_:)))
+        tapRecognizer.delegate = self
         addGestureRecognizer(tapRecognizer)
     }
 
@@ -43,5 +44,11 @@ extension MarkdownTextView {
         guard let end = position(from: start, offset: 1) else { return }
 
         selectedTextRange = textRange(from: start, to: end)
+    }
+}
+
+extension MarkdownTextView: UIGestureRecognizerDelegate {
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        return true
     }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Interraction with input field was not working as expected: only double tap would make it active, changing selection would not work etc.

### Causes

In #2725 we added a `UITapGestureRecognizer` to the input field and it was blocking other recognizers from working correctly.

### Solutions

Allow other recognizers to detect touches simultaneously.
