### PR TITLE
Respect markdown attributes for mentions in the inputbar

### DIFF
--- a/Wire-iOS Tests/MentionsHandlerTests.swift
+++ b/Wire-iOS Tests/MentionsHandlerTests.swift
@@ -100,7 +100,7 @@ class MentionsHandlerTests: XCTestCase {
         let handler = MentionsHandler(text: query, cursorPosition: 4)
         guard let sut = handler else { XCTFail(); return }
 
-        let replaced = sut.replace(mention: mockUser, in: query.attributedString)
+        let replaced = sut.replace(mention: mockUser, in: query.attributedString, typingAttributes: [:])
         let attachments = replaced.allAttachments
         XCTAssertEqual(attachments.count, 1)
         guard let mention = attachments.first else { XCTFail(); return}
@@ -115,7 +115,7 @@ class MentionsHandlerTests: XCTestCase {
         let handler = MentionsHandler(text: query, cursorPosition: 4)
         guard let sut = handler else { XCTFail(); return }
 
-        let replaced = sut.replace(mention: mockUser, in: query.attributedString)
+        let replaced = sut.replace(mention: mockUser, in: query.attributedString, typingAttributes: [:])
         let attachments = replaced.allAttachments
         XCTAssertEqual(attachments.count, 1)
         guard let mention = attachments.first else { XCTFail(); return}

--- a/Wire-iOS/Sources/UserInterface/Components/Views/MarkdownTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/MarkdownTextView.swift
@@ -63,7 +63,7 @@ extension Notification.Name {
         // We reverse to maintain correct ranges for subsequent inserts.
         for mention in mentions.reversed() {
             let attachment = MentionTextAttachment(user: mention.user)
-            let attributedString = NSAttributedString(attachment: attachment)
+            let attributedString = NSAttributedString(attachment: attachment) && typingAttributes
             mutable.replaceCharacters(in: mention.range, with: attributedString)
         }
         

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Mentions.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Mentions.swift
@@ -43,7 +43,7 @@ extension ConversationInputBarViewController {
         guard let handler = mentionsHandler else { return }
         
         let text = inputBar.textView.attributedText ?? NSAttributedString(string: inputBar.textView.text)
-        inputBar.textView.attributedText = handler.replace(mention: user, in: text)
+        inputBar.textView.attributedText = handler.replace(mention: user, in: text, typingAttributes: inputBar.textView.typingAttributes)
         dismissMentionsIfNeeded()
     }
     

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/MentionsHandler.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/MentionsHandler.swift
@@ -52,8 +52,8 @@ import Foundation
         return String(text[range])
     }
 
-    func replace(mention: UserType, in attributedString: NSAttributedString) -> NSAttributedString {
-        let mentionString = NSAttributedString(attachment: MentionTextAttachment(user: mention))
+    func replace(mention: UserType, in attributedString: NSAttributedString, typingAttributes: [NSAttributedString.Key: Any]) -> NSAttributedString {
+        let mentionString = NSAttributedString(attachment: MentionTextAttachment(user: mention)) && typingAttributes
         let mut = NSMutableAttributedString(attributedString: attributedString)
         let characterAfterMention = mentionMatchRange.upperBound
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/MentionsHandler.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/MentionsHandler.swift
@@ -53,7 +53,7 @@ import Foundation
     }
 
     func replace(mention: UserType, in attributedString: NSAttributedString, typingAttributes: [NSAttributedString.Key: Any]) -> NSAttributedString {
-        let mentionString = NSAttributedString(attachment: MentionTextAttachment(user: mention)) && typingAttributes
+        let mentionString = NSAttributedString(attachment: MentionTextAttachment(user: mention))
         let mut = NSMutableAttributedString(attributedString: attributedString)
         let characterAfterMention = mentionMatchRange.upperBound
 
@@ -61,7 +61,7 @@ import Foundation
         let endOfString = !mut.wholeRange.contains(characterAfterMention)
         let suffix = endOfString || !mut.hasSpaceAt(position: characterAfterMention) ? " " : ""
 
-        mut.replaceCharacters(in: mentionMatchRange, with: mentionString + suffix)
+        mut.replaceCharacters(in: mentionMatchRange, with: (mentionString + suffix) && typingAttributes)
 
         return mut
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

The input bar does not respect the selected markdown setting when rendering mentions.

### Causes

Mentions in the input bar are text attachment which have a fixed font.

### Solutions

Retrieve the correct from the associated text storage within the text attachment.