### PR TITLE
Conversation status: typing must have the higher priority than mention

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ZMConversation+Status.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ZMConversation+Status.swift
@@ -288,7 +288,7 @@ final internal class CallingMatcher: ConversationStatusMatcher {
 // "A, B, C: typing a message..."
 final internal class TypingMatcher: ConversationStatusMatcher {
     func isMatching(with status: ConversationStatus) -> Bool {
-        return status.isTyping && !status.hasSelfMention && !status.isSilenced
+        return status.isTyping && !status.isSilenced
     }
     
     func description(with status: ConversationStatus, conversation: ZMConversation) -> NSAttributedString? {


### PR DESCRIPTION
## What's new in this PR?

### Issues

It was noticed that the typing is not visible in case the mention was posted in the chat. Typing must have the higher priority.