### PR TITLE
Fix cut action with mentions

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Views/MarkdownTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/MarkdownTextView.swift
@@ -125,6 +125,17 @@ extension Notification.Name {
         }
     }
     
+    override func cut(_ sender: Any?) {
+        guard let selectedTextRange = selectedTextRange else { return }
+        
+        let copiedAttributedText = attributedText.attributedSubstring(from: selectedRange)
+        let copiedAttributedTextPlainText = replaceMentionAttachmentsWithPlainText(in: copiedAttributedText)
+        
+        UIPasteboard.general.setValue(copiedAttributedTextPlainText, forPasteboardType: kUTTypeUTF8PlainText as String)
+        
+        replace(selectedTextRange, withText: "")
+    }
+    
     override func copy(_ sender: Any?) {
         let copiedAttributedText = attributedText.attributedSubstring(from: selectedRange)
         let copiedAttributedTextPlainText = replaceMentionAttachmentsWithPlainText(in: copiedAttributedText)


### PR DESCRIPTION
## What's new in this PR?

### Issues

Performing cut action on mention would fail the cut action completely

### Solutions

When cutting text replace the mention with plain text similar to the copy action.
