### PR TITLE
Apply correct text attributes when editing message

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Views/MarkdownTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/MarkdownTextView.swift
@@ -57,8 +57,7 @@ extension Notification.Name {
     }
 
     func setText(_ newText: String, withMentions mentions: [Mention]) {
-        text = newText
-        let mutable = NSMutableAttributedString(attributedString: attributedText)
+        let mutable = NSMutableAttributedString(string: newText, attributes: currentAttributes)
 
         // We reverse to maintain correct ranges for subsequent inserts.
         for mention in mentions.reversed() {


### PR DESCRIPTION
## What's new in this PR?

### Issues

When editing a message the font would be much smaller than usual.

### Solutions

Apply default attributes from the text view to the contents. 
