### PR TITLE
Preserving cursor position after inserting mention

### DIFF
--- a/Wire-iOS Tests/MentionsHandlerTests.swift
+++ b/Wire-iOS Tests/MentionsHandlerTests.swift
@@ -100,7 +100,7 @@ class MentionsHandlerTests: XCTestCase {
         let handler = MentionsHandler(text: query, cursorPosition: 4)
         guard let sut = handler else { XCTFail(); return }
 
-        let (range, replacement) = sut.replacement(forMention: mockUser, in: query.attributedString, typingAttributes: [:])
+        let (range, replacement) = sut.replacement(forMention: mockUser, in: query.attributedString)
 
         let attachments = replacement.allAttachments
         XCTAssertEqual(attachments.count, 1)
@@ -118,7 +118,7 @@ class MentionsHandlerTests: XCTestCase {
         let handler = MentionsHandler(text: query, cursorPosition: 4)
         guard let sut = handler else { XCTFail(); return }
 
-        let (range, replacement) = sut.replacement(forMention: mockUser, in: query.attributedString, typingAttributes: [:])
+        let (range, replacement) = sut.replacement(forMention: mockUser, in: query.attributedString)
 
         let attachments = replacement.allAttachments
         XCTAssertEqual(attachments.count, 1)

--- a/Wire-iOS Tests/MentionsHandlerTests.swift
+++ b/Wire-iOS Tests/MentionsHandlerTests.swift
@@ -100,13 +100,16 @@ class MentionsHandlerTests: XCTestCase {
         let handler = MentionsHandler(text: query, cursorPosition: 4)
         guard let sut = handler else { XCTFail(); return }
 
-        let replaced = sut.replace(mention: mockUser, in: query.attributedString, typingAttributes: [:])
-        let attachments = replaced.allAttachments
-        XCTAssertEqual(attachments.count, 1)
-        guard let mention = attachments.first else { XCTFail(); return}
+        let (range, replacement) = sut.replacement(forMention: mockUser, in: query.attributedString, typingAttributes: [:])
 
-        let expected = "Hi ".attributedString + NSAttributedString(attachment: mention) + " how are you?".attributedString
-        XCTAssertEqual(replaced, expected)
+        let attachments = replacement.allAttachments
+        XCTAssertEqual(attachments.count, 1)
+        guard let mention = attachments.first as? MentionTextAttachment else { XCTFail(); return}
+        XCTAssertEqual(mention.user.name, mockUser.name)
+        XCTAssertEqual(range, (query as NSString).range(of: "@bill") )
+
+        let expected = NSAttributedString(attachment: mention)
+        XCTAssertEqual(replacement, expected)
     }
 
     func testThatItAppendsSpaceAfterMention() {
@@ -115,16 +118,17 @@ class MentionsHandlerTests: XCTestCase {
         let handler = MentionsHandler(text: query, cursorPosition: 4)
         guard let sut = handler else { XCTFail(); return }
 
-        let replaced = sut.replace(mention: mockUser, in: query.attributedString, typingAttributes: [:])
-        let attachments = replaced.allAttachments
+        let (range, replacement) = sut.replacement(forMention: mockUser, in: query.attributedString, typingAttributes: [:])
+
+        let attachments = replacement.allAttachments
         XCTAssertEqual(attachments.count, 1)
-        guard let mention = attachments.first else { XCTFail(); return}
+        guard let mention = attachments.first as? MentionTextAttachment else { XCTFail(); return}
+        XCTAssertEqual(mention.user.name, mockUser.name)
+        XCTAssertEqual(range, (query as NSString).range(of: "@bill") )
 
-        let expected = NSMutableAttributedString(string: query)
-        let rangeOfMention = (query as NSString).range(of: "@bill")
-        expected.replaceCharacters(in: rangeOfMention, with: NSAttributedString(attachment: mention) + " ")
+        let expected = NSAttributedString(attachment: mention) + " "
 
-        XCTAssertEqual(replaced, expected)
+        XCTAssertEqual(replacement, expected)
     }
 
 }

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1314,6 +1314,7 @@
 		F1CB5D27215A3011001CCF5D /* NSAttributedString+Space.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1CB5D26215A3011001CCF5D /* NSAttributedString+Space.swift */; };
 		F1CB5D29215A3108001CCF5D /* MentionsHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1CB5D28215A3108001CCF5D /* MentionsHandlerTests.swift */; };
 		F1CB5D38215CD462001CCF5D /* MarkdownTextView+Recognizers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1CB5D37215CD462001CCF5D /* MarkdownTextView+Recognizers.swift */; };
+		F1CB5D3A215E1D2F001CCF5D /* UITextView+Replace.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1CB5D39215E1D2F001CCF5D /* UITextView+Replace.swift */; };
 		F1CE2DF01EF0337F00631D8A /* PureLayout.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F1CE2DEF1EF0337F00631D8A /* PureLayout.framework */; };
 		F93D58431D7D9184003AE972 /* Analytics+ConversationEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93D58421D7D9184003AE972 /* Analytics+ConversationEvents.swift */; };
 		F93D58451D7DA865003AE972 /* ZMConversation+Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93D58441D7DA865003AE972 /* ZMConversation+Analytics.swift */; };
@@ -3075,6 +3076,7 @@
 		F1CB5D26215A3011001CCF5D /* NSAttributedString+Space.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Space.swift"; sourceTree = "<group>"; };
 		F1CB5D28215A3108001CCF5D /* MentionsHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MentionsHandlerTests.swift; sourceTree = "<group>"; };
 		F1CB5D37215CD462001CCF5D /* MarkdownTextView+Recognizers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MarkdownTextView+Recognizers.swift"; sourceTree = "<group>"; };
+		F1CB5D39215E1D2F001CCF5D /* UITextView+Replace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextView+Replace.swift"; sourceTree = "<group>"; };
 		F1CE2DEF1EF0337F00631D8A /* PureLayout.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PureLayout.framework; path = Carthage/Build/iOS/PureLayout.framework; sourceTree = "<group>"; };
 		F93D58421D7D9184003AE972 /* Analytics+ConversationEvents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Analytics+ConversationEvents.swift"; sourceTree = "<group>"; };
 		F93D58441D7DA865003AE972 /* ZMConversation+Analytics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMConversation+Analytics.swift"; sourceTree = "<group>"; };
@@ -4055,6 +4057,7 @@
 				F14FB862214941050012A131 /* Mentions */,
 				EE8E926D2024F085000F4752 /* MarkdownTextView.swift */,
 				F1CB5D37215CD462001CCF5D /* MarkdownTextView+Recognizers.swift */,
+				F1CB5D39215E1D2F001CCF5D /* UITextView+Replace.swift */,
 				EF3BA5D62107688D0093048F /* InputLanguageSettable.swift */,
 				EECDB2552029F5AB00D0D268 /* MarkdownTextStorage.swift */,
 				167961A8203F26E600B72ACC /* SectionHeader.swift */,
@@ -7244,6 +7247,7 @@
 				87D5E4421C3E79C600EB8289 /* NSData+Fingerprint.swift in Sources */,
 				871BC3511D34F94200DF0793 /* AccentColorChangeHandler.m in Sources */,
 				1682AEC120483FA5003A052A /* GroupDetailsSectionController.swift in Sources */,
+				F1CB5D3A215E1D2F001CCF5D /* UITextView+Replace.swift in Sources */,
 				CEEEAF071CB562BF00111759 /* PlaceholderConversationView.swift in Sources */,
 				872CB8B519E58816006752B4 /* ProfileIncomingConnectionRequestFooterView.m in Sources */,
 				EFDACABB20FF84B900791207 /* ConversationInputBarViewController+FilesPopover.swift in Sources */,

--- a/Wire-iOS/Sources/UserInterface/Components/Views/UITextView+Replace.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/UITextView+Replace.swift
@@ -1,0 +1,34 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension UITextView {
+    func replace(_ range: NSRange, withAttributedText replacement: NSAttributedString) {
+        let updatedString = NSMutableAttributedString(attributedString: attributedText)
+        updatedString.replaceCharacters(in: range, with: replacement)
+
+        let selectionOffset = range.location + replacement.length
+        attributedText = updatedString
+
+        guard let cursorPosition = position(from: beginningOfDocument, offset:
+            selectionOffset) else { return }
+        guard let updatedSelection = textRange(from: cursorPosition, to: cursorPosition) else { return }
+        selectedTextRange = updatedSelection
+    }
+}

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Mentions.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Mentions.swift
@@ -44,9 +44,9 @@ extension ConversationInputBarViewController {
         
         let text = inputBar.textView.attributedText ?? NSAttributedString(string: inputBar.textView.text)
 
-        let (range, attributedText) = handler.replacement(forMention: user, in: text, typingAttributes: inputBar.textView.typingAttributes)
+        let (range, attributedText) = handler.replacement(forMention: user, in: text)
 
-        inputBar.textView.replace(range, withAttributedText: attributedText)
+        inputBar.textView.replace(range, withAttributedText: (attributedText && inputBar.textView.typingAttributes))
         dismissMentionsIfNeeded()
     }
     

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Mentions.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Mentions.swift
@@ -43,7 +43,10 @@ extension ConversationInputBarViewController {
         guard let handler = mentionsHandler else { return }
         
         let text = inputBar.textView.attributedText ?? NSAttributedString(string: inputBar.textView.text)
-        inputBar.textView.attributedText = handler.replace(mention: user, in: text, typingAttributes: inputBar.textView.typingAttributes)
+
+        let (range, attributedText) = handler.replacement(forMention: user, in: text, typingAttributes: inputBar.textView.typingAttributes)
+
+        inputBar.textView.replace(range, withAttributedText: attributedText)
         dismissMentionsIfNeeded()
     }
     

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/MentionsHandler.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/MentionsHandler.swift
@@ -52,18 +52,17 @@ import Foundation
         return String(text[range])
     }
 
-    func replace(mention: UserType, in attributedString: NSAttributedString, typingAttributes: [NSAttributedString.Key: Any]) -> NSAttributedString {
+    func replacement(forMention mention: UserType, in attributedString: NSAttributedString, typingAttributes: [NSAttributedString.Key: Any]) -> (NSRange, NSAttributedString) {
+
         let mentionString = NSAttributedString(attachment: MentionTextAttachment(user: mention))
-        let mut = NSMutableAttributedString(attributedString: attributedString)
         let characterAfterMention = mentionMatchRange.upperBound
 
         // Add space after mention if it's not there
-        let endOfString = !mut.wholeRange.contains(characterAfterMention)
-        let suffix = endOfString || !mut.hasSpaceAt(position: characterAfterMention) ? " " : ""
+        let endOfString = !attributedString.wholeRange.contains(characterAfterMention)
+        let suffix = endOfString || !attributedString.hasSpaceAt(position: characterAfterMention) ? " " : ""
 
-        mut.replaceCharacters(in: mentionMatchRange, with: (mentionString + suffix) && typingAttributes)
-
-        return mut
+        return (mentionMatchRange, (mentionString + suffix) && typingAttributes)
     }
+
 }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/MentionsHandler.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/MentionsHandler.swift
@@ -52,8 +52,7 @@ import Foundation
         return String(text[range])
     }
 
-    func replacement(forMention mention: UserType, in attributedString: NSAttributedString, typingAttributes: [NSAttributedString.Key: Any]) -> (NSRange, NSAttributedString) {
-
+    func replacement(forMention mention: UserType, in attributedString: NSAttributedString) -> (NSRange, NSAttributedString) {
         let mentionString = NSAttributedString(attachment: MentionTextAttachment(user: mention))
         let characterAfterMention = mentionMatchRange.upperBound
 
@@ -61,7 +60,7 @@ import Foundation
         let endOfString = !attributedString.wholeRange.contains(characterAfterMention)
         let suffix = endOfString || !attributedString.hasSpaceAt(position: characterAfterMention) ? " " : ""
 
-        return (mentionMatchRange, (mentionString + suffix) && typingAttributes)
+        return (mentionMatchRange, (mentionString + suffix))
     }
 
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

When trying to insert a mention in the middle of the text the cursor would jump to the very end.

### Causes

Setting `attributedText` property for `UITextView` resets the cursor position to be at the end of text. 

### Solutions

There is a method `UITextView.replace(range:with:)` that preserves the cursor position, but it takes `String` as a parameter. This PR adds a similar method for `NSAttributedString` that tries to preserve the cursor position by putting it to the end of the replacement string.
