### PR TITLE
Update paragraph style after color scheme change

### DIFF
--- a/Wire-iOS Tests/CheckmarkCellTests.swift
+++ b/Wire-iOS Tests/CheckmarkCellTests.swift
@@ -33,7 +33,8 @@ class CheckmarkCellTests: ZMSnapshotTestCase {
     override func tearDown() {
         cell = nil
         conversation = nil
-        ColorScheme.default.variant = .light
+        resetColorScheme()
+
         super.tearDown()
     }
 

--- a/Wire-iOS Tests/CheckmarkCellTests.swift
+++ b/Wire-iOS Tests/CheckmarkCellTests.swift
@@ -33,6 +33,7 @@ class CheckmarkCellTests: ZMSnapshotTestCase {
     override func tearDown() {
         cell = nil
         conversation = nil
+        ColorScheme.default.variant = .light
         super.tearDown()
     }
 

--- a/Wire-iOS Tests/ColorSchemeControllerTests.swift
+++ b/Wire-iOS Tests/ColorSchemeControllerTests.swift
@@ -43,7 +43,8 @@ final class ColorSchemeControllerTests: XCTestCase {
         sut = nil
         UserDefaults.standard.set(originalColorScheme, forKey: UserDefaultColorScheme)
         ColorScheme.default.variant = originalVariant
-
+        NSAttributedString.invalidateMarkdownStyle()
+        NSAttributedString.invalidateParagraphStyle()
         super.tearDown()
     }
 

--- a/Wire-iOS Tests/ConversationCell/TextMessageMentionsTests.swift
+++ b/Wire-iOS Tests/ConversationCell/TextMessageMentionsTests.swift
@@ -52,6 +52,7 @@ final class TextMessageMentionsTests: CoreDataSnapshotTestCase {
     func createSUT(for variant: ColorSchemeVariant) {
         ColorScheme.default.variant = variant
         NSAttributedString.invalidateMarkdownStyle()
+        NSAttributedString.invalidateParagraphStyle()
 
         snapshotBackgroundColor = UIColor(scheme: .contentBackground)
         accentColor = .strongBlue

--- a/Wire-iOS Tests/ConversationCellTests.swift
+++ b/Wire-iOS Tests/ConversationCellTests.swift
@@ -30,8 +30,10 @@ final class ConversationCellTests: XCTestCase {
 
     override func tearDown() {
         sut = nil
-        super.tearDown()
         ColorScheme.default.variant = .light
+        NSAttributedString.invalidateMarkdownStyle()
+        NSAttributedString.invalidateParagraphStyle()
+        super.tearDown()
     }
 
     func testThatBurstTimestampViewColorIsCorrectInLightTheme() {

--- a/Wire-iOS Tests/DestructionCountdownViewTests.swift
+++ b/Wire-iOS Tests/DestructionCountdownViewTests.swift
@@ -31,7 +31,7 @@ class DestructionCountdownViewTests: ZMSnapshotTestCase {
     }
 
     override func tearDown() {
-        ColorScheme.default.variant = .light
+        resetColorScheme()
         sut = nil
         super.tearDown()
     }

--- a/Wire-iOS Tests/DeviceManagement/ClientListViewControllerTests.swift
+++ b/Wire-iOS Tests/DeviceManagement/ClientListViewControllerTests.swift
@@ -42,7 +42,7 @@ final class ClientListViewControllerTests: ZMSnapshotTestCase {
         client = nil
         selfClient = nil
 
-        ColorScheme.default.variant = .light
+        resetColorScheme()
 
         super.tearDown()
     }

--- a/Wire-iOS Tests/DeviceManagement/ProfileClientViewControllerTests.swift
+++ b/Wire-iOS Tests/DeviceManagement/ProfileClientViewControllerTests.swift
@@ -41,7 +41,7 @@ final class ProfileClientViewControllerTests: ZMSnapshotTestCase {
         user = nil
         client = nil
 
-        ColorScheme.default.variant = .light
+        resetColorScheme()
 
         super.tearDown()
     }

--- a/Wire-iOS Tests/GroupDetailsTimeoutOptionsCellTests.swift
+++ b/Wire-iOS Tests/GroupDetailsTimeoutOptionsCellTests.swift
@@ -33,7 +33,7 @@ class GroupDetailsTimeoutOptionsCellTests: CoreDataSnapshotTestCase {
     override func tearDown() {
         cell = nil
         conversation = nil
-        ColorScheme.default.variant = .light
+        resetColorScheme()
         super.tearDown()
     }
 

--- a/Wire-iOS Tests/GroupDetailsTimeoutOptionsCellTests.swift
+++ b/Wire-iOS Tests/GroupDetailsTimeoutOptionsCellTests.swift
@@ -33,6 +33,7 @@ class GroupDetailsTimeoutOptionsCellTests: CoreDataSnapshotTestCase {
     override func tearDown() {
         cell = nil
         conversation = nil
+        ColorScheme.default.variant = .light
         super.tearDown()
     }
 

--- a/Wire-iOS Tests/GroupParticipantsDetailViewControllerTests.swift
+++ b/Wire-iOS Tests/GroupParticipantsDetailViewControllerTests.swift
@@ -21,6 +21,11 @@ import XCTest
 
 class GroupParticipantsDetailViewControllerTests: CoreDataSnapshotTestCase {
     
+    override func tearDown() {
+        ColorScheme.default.variant = .light
+        super.tearDown()
+    }
+    
     func testThatItRendersALotOfUsers() {
         // given
         let users = (0..<20).map { createUser(name: "User #\($0)") }

--- a/Wire-iOS Tests/GroupParticipantsDetailViewControllerTests.swift
+++ b/Wire-iOS Tests/GroupParticipantsDetailViewControllerTests.swift
@@ -22,7 +22,7 @@ import XCTest
 class GroupParticipantsDetailViewControllerTests: CoreDataSnapshotTestCase {
     
     override func tearDown() {
-        ColorScheme.default.variant = .light
+        resetColorScheme()
         super.tearDown()
     }
     

--- a/Wire-iOS Tests/SearchResultLabelTests.swift
+++ b/Wire-iOS Tests/SearchResultLabelTests.swift
@@ -31,9 +31,8 @@ class SearchResultLabelTests: ZMSnapshotTestCase {
 
     override func tearDown() {
         sut = nil
+        resetColorScheme()
         super.tearDown()
-
-        ColorScheme.default.variant = .light
     }
 
     fileprivate func performTest(file: StaticString = #file, line: UInt = #line) {

--- a/Wire-iOS Tests/UserSearchResultsViewControllerTests.swift
+++ b/Wire-iOS Tests/UserSearchResultsViewControllerTests.swift
@@ -49,7 +49,7 @@ class UserSearchResultsViewControllerTests: CoreDataSnapshotTestCase {
     override func tearDown() {
         sut = nil
         serviceUser = nil
-        ColorScheme.default.variant = .light
+        resetColorScheme()
         super.tearDown()
     }
     

--- a/Wire-iOS Tests/Utils/ZMSnapshotTestCase+Swift.swift
+++ b/Wire-iOS Tests/Utils/ZMSnapshotTestCase+Swift.swift
@@ -136,4 +136,11 @@ extension ZMSnapshotTestCase {
         viewController.view.frame = CGRect(x: 0, y: 0, width: 375, height: 812)
         verify(view: viewController.view)
     }
+    
+    func resetColorScheme() {
+        ColorScheme.default.variant = .light
+
+        NSAttributedString.invalidateMarkdownStyle()
+        NSAttributedString.invalidateParagraphStyle()
+    }
 }

--- a/Wire-iOS/Sources/Managers/ColorSchemeController.swift
+++ b/Wire-iOS/Sources/Managers/ColorSchemeController.swift
@@ -46,8 +46,6 @@ class ColorSchemeController: NSObject {
     }
 
     @objc func settingsColorSchemeDidChange(notification: Notification?) {
-        NSAttributedString.invalidateMarkdownStyle()
-
         let colorScheme = ColorScheme.default
         switch Settings.shared().colorScheme {
         case .light:
@@ -55,6 +53,8 @@ class ColorSchemeController: NSObject {
         case .dark:
             colorScheme.variant = .dark
         }
+
+        NSAttributedString.invalidateMarkdownStyle()
 
         notifyColorSchemeChange()
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Conversation message's text color was not updated after the color scheme change.

### Causes

After this change: https://github.com/wireapp/wire-ios/pull/2741

We now immediately re-create the markdown style after we get the change notification. Before we just nullified the old style. However the notification is fired before the color scheme is actually changed, therefore we still pick the old color when we get the notification.

### Solutions

Post the notification after the change.