### PR TITLE
Fix/foreground notifications setting

### DIFF
--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -441,6 +441,11 @@ extension AppRootViewController: ShowContentDelegate {
 
 extension AppRootViewController: ForegroundNotificationResponder {
     func shouldPresentNotification(with userInfo: NotificationUserInfo) -> Bool {
+        
+        guard !(Settings.shared()?.chatHeadsDisabled ?? false) else {
+            return false
+        }
+        
         guard
             let selfUserID = userInfo.selfUserID,
             let selectedAccount = sessionManager?.accountManager.selectedAccount,

--- a/WireExtensionComponents/Utilities/ColorScheme.h
+++ b/WireExtensionComponents/Utilities/ColorScheme.h
@@ -39,11 +39,6 @@ extern ColorSchemeColor ColorSchemeColorIconGuest;
 
 extern ColorSchemeColor ColorSchemeColorPopUpButtonOverlayShadow;
 
-extern ColorSchemeColor ColorSchemeColorChatHeadBackground;
-extern ColorSchemeColor ColorSchemeColorChatHeadBorder;
-extern ColorSchemeColor ColorSchemeColorChatHeadTitleText;
-extern ColorSchemeColor ColorSchemeColorChatHeadSubtitleText;
-
 extern ColorSchemeColor ColorSchemeColorButtonHighlighted;
 extern ColorSchemeColor ColorSchemeColorButtonFaded;
 

--- a/WireExtensionComponents/Utilities/ColorScheme.m
+++ b/WireExtensionComponents/Utilities/ColorScheme.m
@@ -43,11 +43,6 @@ NSString * const ColorSchemeColorIconGuest = @"icon-guest";
 
 NSString * const ColorSchemeColorPopUpButtonOverlayShadow = @"popup-button-overlay-shadow";
 
-NSString * const ColorSchemeColorChatHeadBackground = @"chat-head-background";
-NSString * const ColorSchemeColorChatHeadBorder = @"chat-head-border";
-NSString * const ColorSchemeColorChatHeadTitleText = @"chat-head-title-text";
-NSString * const ColorSchemeColorChatHeadSubtitleText = @"chat-head-subtitle-text";
-
 NSString * const ColorSchemeColorButtonHighlighted = @"button-highlighted";
 NSString * const ColorSchemeColorButtonEmptyText = @"button-empty-text";
 NSString * const ColorSchemeColorButtonFaded = @"button-faded";
@@ -222,8 +217,6 @@ static NSString* light(NSString *colorString) {
     UIColor *white = [UIColor whiteColor];
     UIColor *white97 = [UIColor colorWithWhite:0.97 alpha:1];
     UIColor *white98 = [UIColor colorWithWhite:0.98 alpha:1];
-    UIColor *white90 = [UIColor colorWithWhite:0.9 alpha:1];
-    UIColor *white60 = [UIColor colorWithWhite:0.6 alpha:1];
     UIColor *whiteAlpha8 = [UIColor wr_colorFromString:@"rgb(255, 255, 255, 0.08)"];
     UIColor *whiteAlpha16 = [UIColor wr_colorFromString:@"rgb(255, 255, 255, 0.16)"];
     UIColor *whiteAlpha24 = [UIColor wr_colorFromString:@"rgb(255, 255, 255, 0.24)"];
@@ -267,10 +260,6 @@ static NSString* light(NSString *colorString) {
                                    ColorSchemeColorIconBackgroundSelected: accentColor,
                                    ColorSchemeColorIconBackgroundSelectedNoAccent: graphite,
                                    ColorSchemeColorPopUpButtonOverlayShadow: blackAlpha24,
-                                   ColorSchemeColorChatHeadBackground: white,
-                                   ColorSchemeColorChatHeadBorder: white90,
-                                   ColorSchemeColorChatHeadTitleText: graphite,
-                                   ColorSchemeColorChatHeadSubtitleText: white60,
                                    ColorSchemeColorButtonHighlighted: whiteAlpha24,
                                    ColorSchemeColorButtonEmptyText: accentColor,
                                    ColorSchemeColorButtonFaded: graphiteAlpha40,
@@ -323,10 +312,6 @@ static NSString* light(NSString *colorString) {
                                   ColorSchemeColorIconBackgroundSelected: white,
                                   ColorSchemeColorIconBackgroundSelectedNoAccent: white,
                                   ColorSchemeColorPopUpButtonOverlayShadow: black,
-                                  ColorSchemeColorChatHeadBackground: graphite,
-                                  ColorSchemeColorChatHeadBorder: graphite,
-                                  ColorSchemeColorChatHeadTitleText: white,
-                                  ColorSchemeColorChatHeadSubtitleText: whiteAlpha40,
                                   ColorSchemeColorButtonHighlighted: blackAlpha24,
                                   ColorSchemeColorButtonEmptyText: white,
                                   ColorSchemeColorButtonFaded: whiteAlpha40,


### PR DESCRIPTION
## What's new in this PR?

When integrating the native foreground notifications, I forgot to consider the user setting to disable ChatHeads. I've decided not to replace the usage of the words _"ChatHeads"_ in variables with _"ForegroundNotifications"_, as doing so would require many little changes that would decrease readability.

Also, I removed the ChatHead related colors from the `ColorScheme`, since we don't use them anymore.
