### PR TITLE
Fix: Team one-to-one show in group section

### DIFF
--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
@@ -347,7 +347,22 @@ extension UIViewController {
         }
 
         directorySection.suggestions = searchResult.directory
-        conversationsSection.groupConversations = searchResult.conversations
+
+        // Filter the 1 to 1 conversations which already exists in contacts section
+        let conversations = searchResult.conversations
+
+        let filteredGroups = conversations.filter{
+            if $0.conversationType != ZMConversationType.oneOnOne {
+                return true
+            }
+            if let user = $0.activeParticipants.array.first as? ZMUser {
+                return !teamContacts.contains(user)
+            }
+
+            return false
+        }
+
+        conversationsSection.groupConversations = filteredGroups
         servicesSection.services = searchResult.services
 
         sectionController.collectionView?.reloadData()


### PR DESCRIPTION
## What's new in this PR?

### Issues

1to1 conversation shows up in group section and in the contacts sections

### Causes

1to1 conversations are included in SearchResult.conversations array.

### Solutions

Filter SearchResult.conversations. Exclude the 1to1 conversations which have participants exists in teamContacts array.