### PR TITLE
Fix/foreground notifications

### DIFF
--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -460,9 +460,12 @@ extension AppRootViewController: ForegroundNotificationResponder {
             return false
         }
         
+        guard clientVC.isConversationViewVisible else {
+            return true
+        }
+        
         // conversation view is visible for another conversation
         guard
-            clientVC.isConversationViewVisible,
             let convID = userInfo.conversationID,
             convID != clientVC.currentConversation.remoteIdentifier
             else { return false }

--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -441,23 +441,33 @@ extension AppRootViewController: ShowContentDelegate {
 
 extension AppRootViewController: ForegroundNotificationResponder {
     func shouldPresentNotification(with userInfo: NotificationUserInfo) -> Bool {
-        
+        // user wants to see fg notifications
         guard !(Settings.shared()?.chatHeadsDisabled ?? false) else {
             return false
         }
         
+        // the concerned account is active
         guard
             let selfUserID = userInfo.selfUserID,
-            let selectedAccount = sessionManager?.accountManager.selectedAccount,
-            selectedAccount.userIdentifier == selfUserID
+            selfUserID == sessionManager?.accountManager.selectedAccount?.userIdentifier
             else { return true }
         
-        guard
-            let clientVC = ZClientViewController.shared(),
-            let convID = userInfo.conversationID
-            else { return true }
+        guard let clientVC = ZClientViewController.shared() else {
+            return true
+        }
 
-        return !clientVC.isConversationListVisible && !clientVC.isLastMessageVisible(for: convID)
+        if clientVC.isConversationListVisible {
+            return false
+        }
+        
+        // conversation view is visible for another conversation
+        guard
+            clientVC.isConversationViewVisible,
+            let convID = userInfo.conversationID,
+            convID != clientVC.currentConversation.remoteIdentifier
+            else { return false }
+        
+        return true
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
@@ -502,7 +502,7 @@
 
 - (BOOL)isConversationListVisible
 {
-    return IS_IPAD_LANDSCAPE_LAYOUT || self.splitViewController.leftViewControllerRevealed;
+    return IS_IPAD_LANDSCAPE_LAYOUT || (self.splitViewController.leftViewControllerRevealed && self.conversationListViewController.presentedViewController == NULL);
 }
 
 - (ZMUserSession *)context

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -195,21 +195,3 @@ extension ZClientViewController {
         }
     }
 }
-
-extension ZClientViewController {
-    
-    /// Returns true if the most recent message for the given conversation is
-    /// visible on screen.
-    public func isLastMessageVisible(for conversation: UUID) -> Bool {
-        guard
-            let conversationRoot = conversationRootViewController as? ConversationRootViewController,
-            let conversationContent = conversationRoot.conversationViewController?.contentViewController
-            else { return true }
-        
-        let conversationIsLoaded = conversation == currentConversation.remoteIdentifier
-        let conversationIsVisible = isConversationViewVisible
-        let isScrolledToBottom = conversationContent.isScrolledToBottom
-        
-        return conversationIsLoaded && conversationIsVisible && isScrolledToBottom
-    }
-}


### PR DESCRIPTION
## What's new in this PR?

This is one last revision for the foreground notifications changes: 
- FG notifications are no longer shown whilst the conversation for that notification is visible (even when scrolled up)
- FG notifications are shown in the profile and settings screens.