### PR TITLE
ZIOS-10393: Allow adding phone number and email from settings

### DIFF
--- a/Wire-iOS/Sources/Authentication/RegistrationPersonal/CountryCode/Country.h
+++ b/Wire-iOS/Sources/Authentication/RegistrationPersonal/CountryCode/Country.h
@@ -29,6 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) NSString *displayName;
 @property (nonatomic, readonly) NSString *e164PrefixString;   // E.g. "+1", "+49", "+380"
 
+@property (class, nonatomic, readonly) Country *defaultCountry NS_SWIFT_NAME(default);
 
 + (instancetype)countryWithISO:(NSString *)ISO e164:(NSNumber *)e164;
 + (nullable instancetype)countryFromDevice;

--- a/Wire-iOS/Sources/Authentication/RegistrationPersonal/CountryCode/Country.m
+++ b/Wire-iOS/Sources/Authentication/RegistrationPersonal/CountryCode/Country.m
@@ -102,6 +102,10 @@ NS_ASSUME_NONNULL_BEGIN
 {
     NSDictionary *countryCodeDict = [NSDictionary dictionaryWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"CountryCodes" ofType:@"plist"]];
     NSMutableArray *countries = [NSMutableArray array];
+
+    #if WIRESTAN
+    [countries addObject:Country.countryWirestan];
+    #endif
     
     for (NSDictionary *countryData in [countryCodeDict objectForKey:@"countryCodes"]) {
         [countries addObject:[Country countryWithISO:[countryData valueForKey:@"iso"] e164:[countryData valueForKey:@"e164"]]];

--- a/Wire-iOS/Sources/Authentication/RegistrationPersonal/CountryCode/Country.m
+++ b/Wire-iOS/Sources/Authentication/RegistrationPersonal/CountryCode/Country.m
@@ -25,6 +25,24 @@
 NS_ASSUME_NONNULL_BEGIN
 @implementation Country
 
++ (Country *)defaultCountry
+{
+    Country *defaultCountry = nil;
+
+#if WIRESTAN
+    NSString *backendEnvironment = [[NSUserDefaults standardUserDefaults] stringForKey:@"ZMBackendEnvironmentType"];
+    if ([backendEnvironment isEqualToString:@"staging"]) {
+        defaultCountry = [Country countryWirestan];
+    }
+
+#endif
+    if (!defaultCountry) {
+        defaultCountry = [Country countryFromDevice] ?: [Country countryWithISO:@"us" e164:@1];
+    }
+
+    return defaultCountry;
+}
+
 + (nullable instancetype)countryFromDevice
 {
     CTTelephonyNetworkInfo *networkInfo = [[CTTelephonyNetworkInfo alloc] init];

--- a/Wire-iOS/Sources/Authentication/RegistrationPersonal/PhoneNumberViewController.m
+++ b/Wire-iOS/Sources/Authentication/RegistrationPersonal/PhoneNumberViewController.m
@@ -124,20 +124,7 @@ static CGFloat PhoneNumberFieldTopMargin = 16;
 
 - (void)selectInitialCountry
 {
-    Country *initialCountry = nil;
-
-#if WIRESTAN
-    NSString *backendEnvironment = [[NSUserDefaults standardUserDefaults] stringForKey:@"ZMBackendEnvironmentType"];
-    if ([backendEnvironment isEqualToString:@"staging"]) {
-            initialCountry = [Country countryWirestan];
-    }
-    
-#endif
-    if (! initialCountry) {
-        initialCountry = [Country countryFromDevice];
-    }
-
-    self.country = initialCountry;
+    self.country = [Country defaultCountry];
 }
 
 - (void)updateViewConstraints

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
@@ -112,24 +112,15 @@ extension SettingsCellDescriptorFactory {
             isDestructive: false,
             presentationStyle: .navigation,
             presentationAction: { () -> (UIViewController?) in
-             if let email = ZMUser.selfUser().emailAddress, !email.isEmpty {
                 return ChangeEmailViewController()
-             } else {
-                let addEmailController = AddEmailPasswordViewController()
-                let stepDelegate = DismissStepDelegate()
-                stepDelegate.strongCapture = stepDelegate
-
-                // TODO: Integrate with new login controller
-                return addEmailController
-            }
-        },
+            },
             previewGenerator: { _ in
                 if let email = ZMUser.selfUser().emailAddress, !email.isEmpty {
                     return SettingsCellPreview.text(email)
                 } else {
                     return SettingsCellPreview.text("self.add_email_password".localized)
                 }
-        },
+            },
             accessoryViewMode: .alwaysHide
         )
     }

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
@@ -139,19 +139,9 @@ extension SettingsCellDescriptorFactory {
             title: "self.settings.account_section.phone.title".localized,
             isDestructive: false,
             presentationStyle: .navigation,
-            presentationAction: { () -> (UIViewController?) in
-                if let phoneNumber = ZMUser.selfUser().phoneNumber, !phoneNumber.isEmpty {
-                    return ChangePhoneViewController()
-                } else {
-                    let addController = AddPhoneNumberViewController()
-                    addController.showsNavigationBar = false
-                    let stepDelegate = DismissStepDelegate()
-                    stepDelegate.strongCapture = stepDelegate
-                    
-//                    addController.formStepDelegate = stepDelegate
-                    return addController
-                }
-        },
+            presentationAction: {
+                return ChangePhoneViewController()
+            },
             previewGenerator: { _ in
                 if let phoneNumber = ZMUser.selfUser().phoneNumber, !phoneNumber.isEmpty {
                     return SettingsCellPreview.text(phoneNumber)

--- a/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ChangeEmailViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ChangeEmailViewController.swift
@@ -19,32 +19,63 @@
 import UIKit
 import Cartography
 
+enum ChangeEmailFlowType {
+    case changeExistingEmail
+    case setInitialEmail
+}
+
 struct ChangeEmailState {
-    let currentEmail: String
+    let flowType: ChangeEmailFlowType
+    let currentEmail: String?
     var newEmail: String?
+    var newPassword: String?
     
-    var visibleEmail: String {
+    var visibleEmail: String? {
         return newEmail ?? currentEmail
     }
     
     var validatedEmail: String? {
-        var validatedEmail = newEmail as AnyObject?
-        let pointer = AutoreleasingUnsafeMutablePointer<AnyObject?>(&validatedEmail)
-        do {
-            try ZMUser.editableSelf().validateValue(pointer, forKey: #keyPath(ZMUser.emailAddress))
-            return validatedEmail as? String
-        } catch {
+        guard let newEmail = self.newEmail else { return nil }
+
+        switch UnregisteredUser.normalizedEmailAddress(newEmail) {
+        case .valid(let value):
+            return value
+        default:
             return nil
         }
     }
-    
-    var isValid: Bool {
-        guard let email = validatedEmail, !email.isEmpty else { return false }
-        return email != currentEmail
+
+    var validatedPassword: String? {
+        guard let newPassword = self.newPassword else { return nil }
+
+        switch UnregisteredUser.normalizedPassword(newPassword) {
+        case .valid(let value):
+            return value
+        default:
+            return nil
+        }
+    }
+
+    var validatedCredentials: ZMEmailCredentials? {
+        guard let email = validatedEmail, let password = validatedPassword else {
+            return nil
+        }
+
+        return ZMEmailCredentials(email: email, password: password)
     }
     
-    init(currentEmail: String = ZMUser.selfUser().emailAddress!) {
+    var isValid: Bool {
+        switch flowType {
+        case .changeExistingEmail:
+            return validatedEmail != nil
+        case .setInitialEmail:
+            return validatedCredentials != nil
+        }
+    }
+    
+    init(currentEmail: String? = ZMUser.selfUser().emailAddress) {
         self.currentEmail = currentEmail
+        flowType = currentEmail != nil ? .changeExistingEmail : .setInitialEmail
     }
 
 }
@@ -54,6 +85,11 @@ struct ChangeEmailState {
     fileprivate weak var userProfile = ZMUserSession.shared()?.userProfile
     var state = ChangeEmailState()
     private var observerToken: Any?
+
+    enum Cell: Int {
+        case emailField
+        case passwordField
+    }
 
     init() {
         super.init(style: .grouped)
@@ -77,12 +113,12 @@ struct ChangeEmailState {
     internal func setupViews() {
         RegistrationTextFieldCell.register(in: tableView)
         
-        title = "self.settings.account_section.email.change.title".localized.localizedUppercase
+        title = "self.settings.account_section.email.change.title".localized(uppercased: true)
         view.backgroundColor = .clear
         tableView.isScrollEnabled = false
         
         navigationItem.rightBarButtonItem = UIBarButtonItem(
-            title: "self.settings.account_section.email.change.save".localized.localizedUppercase,
+            title: "self.settings.account_section.email.change.save".localized(uppercased: true),
             style: .done,
             target: self,
             action: #selector(saveButtonTapped)
@@ -100,11 +136,25 @@ struct ChangeEmailState {
     }
     
     @objc func saveButtonTapped(sender: UIBarButtonItem) {
-        guard let email = state.newEmail else { return }
+        requestEmailUpdate(showLoadingView: true)
+    }
+
+    func requestEmailUpdate(showLoadingView: Bool) {
+        let updateBlock: () throws -> Void
+
+        switch state.flowType {
+        case .setInitialEmail:
+            guard let credentials = state.validatedCredentials else { return }
+            updateBlock = { try self.userProfile?.requestSettingEmailAndPassword(credentials: credentials) }
+        case .changeExistingEmail:
+            guard let email = state.validatedEmail else { return }
+            updateBlock = { try self.userProfile?.requestEmailChange(email: email) }
+        }
+
         do {
-            try userProfile?.requestEmailChange(email: email)
+            try updateBlock()
             updateSaveButtonState(enabled: false)
-            showLoadingView = true
+            navigationController?.showLoadingView = showLoadingView
         } catch { }
     }
     
@@ -113,18 +163,44 @@ struct ChangeEmailState {
     }
     
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 1
+        switch state.flowType {
+        case .changeExistingEmail: return 1
+        case .setInitialEmail: return 2
+        }
     }
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: RegistrationTextFieldCell.zm_reuseIdentifier, for: indexPath) as! RegistrationTextFieldCell
-        cell.textField.accessibilityIdentifier = "EmailField"
-        cell.textField.keyboardType = .emailAddress
-        cell.textField.text = state.visibleEmail
-        cell.textField.becomeFirstResponder()
+
+        switch Cell(rawValue: indexPath.row)! {
+        case .emailField:
+            cell.textField.accessibilityIdentifier = "EmailField"
+            cell.textField.placeholder = "email.placeholder".localized
+            cell.textField.text = state.visibleEmail
+            cell.textField.keyboardType = .emailAddress
+            cell.textField.textContentType = .emailAddress
+            cell.textField.becomeFirstResponder()
+
+        case .passwordField:
+            cell.textField.accessibilityIdentifier = "PasswordField"
+            cell.textField.placeholder = "password.placeholder".localized
+            cell.textField.isSecureTextEntry = true
+            cell.textField.text = nil
+
+            if #available(iOS 12, *) {
+                cell.textField.textContentType = .newPassword
+            } else if #available(iOS 11, *) {
+                cell.textField.textContentType = .password
+            }
+        }
+
         cell.delegate = self
         updateSaveButtonState()
         return cell
+    }
+
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return 56
     }
 
 }
@@ -132,13 +208,13 @@ struct ChangeEmailState {
 extension ChangeEmailViewController: UserProfileUpdateObserver {
     
     func emailUpdateDidFail(_ error: Error!) {
-        showLoadingView = false
+        navigationController?.showLoadingView = false
         updateSaveButtonState()
         showAlert(forError: error)
     }
     
     func didSendVerificationEmail() {
-        showLoadingView = false
+        navigationController?.showLoadingView = false
         updateSaveButtonState()
         if let newEmail = state.newEmail {
             let confirmController = ConfirmEmailViewController(newEmail: newEmail, delegate: self)
@@ -153,15 +229,23 @@ extension ChangeEmailViewController: ConfirmEmailDelegate {
     }
     
     func resendVerification(inController controller: ConfirmEmailViewController) {
-        if let validatedEmail = state.validatedEmail {
-            try? userProfile?.requestEmailChange(email: validatedEmail)            
-        }
+        requestEmailUpdate(showLoadingView: false)
     }
 }
 
 extension ChangeEmailViewController: RegistrationTextFieldCellDelegate {
     func tableViewCellDidChangeText(cell: RegistrationTextFieldCell, text: String) {
-        state.newEmail = text
+        guard let index = tableView.indexPath(for: cell), let cellType = Cell(rawValue: index.row) else {
+            return
+        }
+
+        switch cellType {
+        case .emailField:
+            state.newEmail = text
+        case .passwordField:
+            state.newPassword = text
+        }
+
         updateSaveButtonState()
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ChangePhoneViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ChangePhoneViewController.swift
@@ -192,6 +192,7 @@ final class ChangePhoneViewController: SettingsBaseTableViewController {
         case .phoneNumber:
             let cell = tableView.dequeueReusableCell(withIdentifier: RegistrationTextFieldCell.zm_reuseIdentifier, for: indexPath) as! RegistrationTextFieldCell
             cell.textField.keyboardType = .phonePad
+            cell.textField.textContentType = .telephoneNumber
             cell.textField.leftAccessoryView = .countryCode
             cell.textField.accessibilityIdentifier = "PhoneNumberField"
             cell.textField.placeholder = "registration.enter_phone_number.placeholder".localized

--- a/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ChangePhoneViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ChangePhoneViewController.swift
@@ -145,12 +145,12 @@ final class ChangePhoneViewController: SettingsBaseTableViewController {
     fileprivate func setupViews() {
         RegistrationTextFieldCell.register(in: tableView)
         SettingsButtonCell.register(in: tableView)
-        title = "self.settings.account_section.phone_number.change.title".localized
+        title = "self.settings.account_section.phone_number.change.title".localized(uppercased: true)
         
         view.backgroundColor = .clear
         
         navigationItem.rightBarButtonItem = UIBarButtonItem(
-            title: "self.settings.account_section.phone_number.change.save".localized,
+            title: "self.settings.account_section.phone_number.change.save".localized(uppercased: true),
             style: .done,
             target: self,
             action: #selector(saveButtonTapped)
@@ -169,7 +169,7 @@ final class ChangePhoneViewController: SettingsBaseTableViewController {
         if let newNumber = state.newNumber?.fullNumber {
             userProfile?.requestPhoneVerificationCode(phoneNumber: newNumber)
             updateSaveButtonState(enabled: false)
-            showLoadingView = true
+            navigationController?.showLoadingView = true
         }
     }
     
@@ -226,7 +226,7 @@ final class ChangePhoneViewController: SettingsBaseTableViewController {
                 guard let `self` = self else { return }
                 self.userProfile?.requestPhoneNumberRemoval()
                 self.updateSaveButtonState(enabled: false)
-                self.showLoadingView = true
+                self.navigationController?.showLoadingView = true
             })
 
             present(alert, animated: true, completion: nil)
@@ -277,7 +277,7 @@ extension ChangePhoneViewController: CountryCodeTableViewControllerDelegate {
 
 extension ChangePhoneViewController: UserProfileUpdateObserver {
     func phoneNumberVerificationCodeRequestDidSucceed() {
-        showLoadingView = false
+        navigationController?.showLoadingView = false
         updateSaveButtonState()
         if let newNumber = state.newNumber?.fullNumber {
             let confirmController = ConfirmPhoneViewController(newNumber: newNumber, delegate: self)
@@ -286,19 +286,19 @@ extension ChangePhoneViewController: UserProfileUpdateObserver {
     }
     
     func phoneNumberVerificationCodeRequestDidFail(_ error: Error!) {
-        showLoadingView = false
+        navigationController?.showLoadingView = false
         updateSaveButtonState()
         showAlert(forError: error)
     }
     
     func emailUpdateDidFail(_ error: Error!) {
-        showLoadingView = false
+        navigationController?.showLoadingView = false
         updateSaveButtonState()
         showAlert(forError: error)
     }
     
     func phoneNumberRemovalDidFail(_ error: Error!) {
-        showLoadingView = false
+        navigationController?.showLoadingView = false
         updateSaveButtonState()
         showAlert(forError: error)
     }

--- a/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ChangePhoneViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ChangePhoneViewController.swift
@@ -101,8 +101,8 @@ fileprivate struct ChangePhoneNumberState {
         }
     }
     
-    init(currentPhoneNumber: String = ZMUser.selfUser().phoneNumber!) {
-        self.currentNumber = PhoneNumber(fullNumber: currentPhoneNumber)
+    init(currentPhoneNumber: String? = ZMUser.selfUser().phoneNumber) {
+        self.currentNumber = currentPhoneNumber.flatMap(PhoneNumber.init(fullNumber:))
     }
     
 }
@@ -174,7 +174,9 @@ final class ChangePhoneViewController: SettingsBaseTableViewController {
     }
     
     override func numberOfSections(in tableView: UITableView) -> Int {
-        if let email = ZMUser.selfUser().emailAddress, !email.isEmpty {
+        if ZMUser.selfUser()?.phoneNumber == nil {
+            return 1
+        } else if let email = ZMUser.selfUser().emailAddress, !email.isEmpty {
             return Section.count
         } else {
             return 1
@@ -192,9 +194,12 @@ final class ChangePhoneViewController: SettingsBaseTableViewController {
             cell.textField.keyboardType = .phonePad
             cell.textField.leftAccessoryView = .countryCode
             cell.textField.accessibilityIdentifier = "PhoneNumberField"
+            cell.textField.placeholder = "registration.enter_phone_number.placeholder".localized
             if let current = state.visibleNumber {
                 cell.textField.countryCode = current.countryCode
                 cell.textField.text = current.numberWithoutCode
+            } else {
+                cell.textField.countryCode = Country.default.e164.uintValue
             }
             cell.textField.becomeFirstResponder()
             cell.textField.delegate = self
@@ -304,6 +309,7 @@ extension ChangePhoneViewController: UserProfileUpdateObserver {
     }
     
     func didRemovePhoneNumber() {
+        navigationController?.showLoadingView = false
         _ = navigationController?.popToPrevious(of: self)
     }
 
@@ -317,6 +323,7 @@ extension ChangePhoneViewController: ConfirmPhoneDelegate {
     }
     
     func didConfirmPhone(inController controller: ConfirmPhoneViewController) {
+        self.navigationController?.showLoadingView = false
         _ = navigationController?.popToPrevious(of: self)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ConfirmEmailViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ConfirmEmailViewController.swift
@@ -86,7 +86,7 @@ extension UITableView {
     internal func setupViews() {
         SettingsButtonCell.register(in: tableView)
         
-        title = "self.settings.account_section.email.change.verify.title".localized
+        title = "self.settings.account_section.email.change.verify.title".localized(uppercased: true)
         view.backgroundColor = .clear
         tableView.isScrollEnabled = false
         

--- a/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ConfirmPhoneViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ConfirmPhoneViewController.swift
@@ -80,7 +80,7 @@ protocol ConfirmPhoneDelegate: class {
         RegistrationTextFieldCell.register(in: tableView)
         SettingsButtonCell.register(in: tableView)
         
-        title = "self.settings.account_section.phone_number.change.verify.title".localized
+        title = "self.settings.account_section.phone_number.change.verify.title".localized(uppercased: true)
         view.backgroundColor = .clear
         tableView.isScrollEnabled = false
         
@@ -88,7 +88,7 @@ protocol ConfirmPhoneDelegate: class {
         tableView.estimatedSectionHeaderHeight = 60
         
         navigationItem.rightBarButtonItem = UIBarButtonItem(
-            title: "self.settings.account_section.phone_number.change.verify.save".localized,
+            title: "self.settings.account_section.phone_number.change.verify.save".localized(uppercased: true),
             style: .done,
             target: self,
             action: #selector(saveButtonTapped)
@@ -123,7 +123,7 @@ protocol ConfirmPhoneDelegate: class {
         if let verificationCode = verificationCode {
             let credentials = ZMPhoneCredentials(phoneNumber: newNumber, verificationCode: verificationCode)
             userProfile?.requestPhoneNumberChange(credentials: credentials)
-            showLoadingView = true
+            navigationController?.showLoadingView = true
         }
     }
     
@@ -215,7 +215,7 @@ extension ConfirmPhoneViewController: ZMUserObserver {
             // we need to check if the notification really happened because
             // the phone got changed to what we expected
             if let currentPhoneNumber = ZMUser.selfUser().phoneNumber, currentPhoneNumber == newNumber {
-                showLoadingView = false
+                navigationController?.showLoadingView = false
                 delegate?.didConfirmPhone(inController: self)
             }
         }
@@ -224,7 +224,7 @@ extension ConfirmPhoneViewController: ZMUserObserver {
 
 extension ConfirmPhoneViewController: UserProfileUpdateObserver {
     func phoneNumberChangeDidFail(_ error: Error!) {
-        showLoadingView = false
+        navigationController?.showLoadingView = false
         showAlert(forError: error)
     }
 }

--- a/WireExtensionComponents/Utilities/AttributedStringOperators.swift
+++ b/WireExtensionComponents/Utilities/AttributedStringOperators.swift
@@ -186,12 +186,18 @@ extension PointOfView: CustomStringConvertible {
 
 public extension String {
     
-    // Returns the NSLocalizedString version of self
+    /// Returns the NSLocalizedString version of self
     public var localized: String {
         return NSLocalizedString(self, comment: "")
     }
+
+    /// Returns the text and uppercases it if needed.
+    public func localized(uppercased: Bool) -> String {
+        let text = NSLocalizedString(self, comment: "")
+        return uppercased ? text.localizedUppercase : text
+    }
    
-    // Used to generate localized strings with plural rules from the stringdict
+    /// Used to generate localized strings with plural rules from the stringdict
     public func localized(pov pointOfView: PointOfView = .none, args: CVarArg...) -> String {
         return withVaList(args) {
             return NSString(format: self.localized(pov: pointOfView), arguments: $0) as String


### PR DESCRIPTION
## What's new in this PR?

### Issues

View controllers used in the settings to change the email and phone number were altered in #2505 and could not be used as is, as they were not observing changes from SE or performing actions (those responsibilities were migrated to the Authentication Coordinator).

### Solutions

To add support for adding a phone number or an email/password, we change the view controllers already used for changing them to add support for setting the initial values.

In `ChangePhoneNumberViewController`, we add an extra check to detect when the phone number was not set, which hides the "remove phone" button.

In `ChangeEmailViewController', we add extra logic and state to detect when we are setting the initial email or changing an existing value. Depending on this state, we decide whether or not to show the password field, and call the appropriate method when the user hits save.

State observation for those classes didn't have to be changed in any way.

### Note

This will be merged in the #2505 branch, and not in develop directly.