### PR TITLE
Sign in screen is shifted when using the custom keyboard

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/KeyboardAvoidingViewController+Animation.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/KeyboardAvoidingViewController+Animation.swift
@@ -59,8 +59,7 @@ extension KeyboardAvoidingViewController {
             else { return }
         
         let keyboardFrameInView = UIView.keyboardFrame(in: self.view, forKeyboardNotification: notification)
-        let bottomOffset: CGFloat = -keyboardFrameInView.size.height
-        
+        let bottomOffset: CGFloat = -abs(keyboardFrameInView.size.height)
         guard bottomEdgeConstraint.constant != bottomOffset else { return }
         
         // When the keyboard is dismissed and then quickly revealed again, then

--- a/Wire-iOS/Sources/UserInterface/Registration/NavigationController.m
+++ b/Wire-iOS/Sources/UserInterface/Registration/NavigationController.m
@@ -111,8 +111,7 @@
 
 - (void)setupLogo
 {
-    UIImage *logoImage = [[WireStyleKit imageOfWireWithColor:[UIColor whiteColor]] resizableImageWithCapInsets:UIEdgeInsetsZero
-                                                                                                  resizingMode:UIImageResizingModeStretch];
+    UIImage *logoImage = [WireStyleKit imageOfWireWithColor:[UIColor whiteColor]];
     self.logoImageView = [[UIImageView alloc] initWithImage:logoImage];
     self.logoImageView.contentMode = UIViewContentModeScaleAspectFit;
     [self.view addSubview:self.logoImageView];
@@ -199,6 +198,7 @@
         temporaryResponder.keyboardAppearance = activeTextField.keyboardAppearance;
         temporaryResponder.keyboardType = activeTextField.keyboardType;
         temporaryResponder.autocorrectionType = activeTextField.autocorrectionType;
+        temporaryResponder.secureTextEntry = activeTextField.secureTextEntry;
         
         [self.view addSubview:temporaryResponder];
         [temporaryResponder becomeFirstResponder];


### PR DESCRIPTION
## What's new in this PR?

### Issues

When using the custom keyboard, sometimes users cannot proceed with the sign in, since the UI is cut form the bottom, so the continue button is not visible.

### Causes

The registration and log in flow is designed to help user easily fill the account details. In order to achieve this, we want to persist the keyboard state while user is navigated from one page of registration to another. 

One of the ways to achieve this behavior is to create the temporary responder view that would retain the keyboard up during the transition (see `NavigationController.takeFirstResponderDuringTransition`).

In iOS, it's forbidden to use the custom keyboard to enter the secure data, such as the password. What happens in case of going from the email sign in screen to restore back up screen is the following:

1. The user is entering his email (with custom keyboard).
2. User is entering the password (iOS switches the keyboard to the integrated one).
3. User initiates the sign in (keyboard is still up, password field is the first responder).
4. Wire checks the sign in credentials and pushes the next controller.
5. `NavigationController` is intercepting the new controller push and is trying to keep the keyboard up. It creates the temporary input field that becomes the first responder during the transition. Unfortunately this temporary field is not for secure entry, so it changes the keyboard to the custom one once again during the transition.
6. UI explodes really bad 💥 💣 :hurtrealbad: 🤕  (notice the transform)

```
 <UIView: 0x10687c320; frame = (0 0; 320 568); opaque = NO; autoresize = W+H; layer = <CALayer: 0x170424ba0>>
   | <UILayoutContainerView: 0x10690b860; frame = (0 0; 320 568); opaque = NO; autoresize = W+H; gestureRecognizers = <NSArray: 0x17005b2a0>; layer = <CALayer: 0x170220560>>
    |    | <UINavigationTransitionView: 0x106855d10; frame = (0 0; 320 568); clipsToBounds = YES; autoresize = W+H; layer = <CALayer: 0x17023a0a0>>
    |    |    | <UIViewControllerWrapperView: 0x106889930; frame = (0 0; 320 568); autoresize = W+H; layer = <CALayer: 0x17042e780>>
   |    |    |    | <UIView: 0x10696a210; frame = (0 0; 320 568); transform = [1, 0, 0, 1, 114.08952713012695, 0]; autoresize = W+H; layer = <CALayer: 0x17423aa00>>
```

### Solutions

Initial fix is to make the keyboard respect the secure text entry setting of the initial first responder field. We need to make sure the issue is fixed in the new registration.
