### PR TITLE
Fix: Highlight best match in suggestions list when hardware keyboard is attached

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+UITextViewDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+UITextViewDelegate.swift
@@ -50,6 +50,15 @@ extension ConversationInputBarViewController: UITextViewDelegate {
         return textAttachment.image == nil
     }
 
+    var isMentionsViewKeyboardCollapsed: Bool {
+        /// press tab or enter to insert mention if iPhone keyboard is collapsed
+        if let isKeyboardCollapsed = mentionsView?.isKeyboardCollapsed {
+            return isKeyboardCollapsed
+        } else {
+            return false
+        }
+    }
+
     public func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
         // send only if send key pressed
         if textView.returnKeyType == .send && (text == "\n") {
@@ -64,18 +73,10 @@ extension ConversationInputBarViewController: UITextViewDelegate {
             return false
         }
 
-        /// press tab or enter to insert mention if iPhone keyboard is collapsed
-        let mentionsViewKeyboardCollapsed: Bool
-        if let isKeyboardCollapsed = mentionsView?.isKeyboardCollapsed {
-            mentionsViewKeyboardCollapsed = isKeyboardCollapsed
-        } else {
-            mentionsViewKeyboardCollapsed = false
-        }
-
-        if UIDevice.current.type == .iPad || mentionsViewKeyboardCollapsed,
-            text.count == 1,
+        if text.count == 1,
             text.containsCharacters(from: CharacterSet.newlinesAndTabulation),
-            canInsertMention {
+            canInsertMention,
+            UIDevice.current.type == .iPad || isMentionsViewKeyboardCollapsed {
             
             insertBestMatchMention()
             return false

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+UITextViewDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+UITextViewDelegate.swift
@@ -63,8 +63,16 @@ extension ConversationInputBarViewController: UITextViewDelegate {
             }
             return false
         }
-                
-        if UIDevice.current.type == .iPad,
+
+        /// press tab or enter to insert mention if iPhone keyboard is collapsed
+        let mentionsViewKeyboardCollapsed: Bool
+        if let isKeyboardCollapsed = mentionsView?.isKeyboardCollapsed {
+            mentionsViewKeyboardCollapsed = isKeyboardCollapsed
+        } else {
+            mentionsViewKeyboardCollapsed = false
+        }
+
+        if UIDevice.current.type == .iPad || mentionsViewKeyboardCollapsed,
             text.count == 1,
             text.containsCharacters(from: CharacterSet.newlinesAndTabulation),
             canInsertMention {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.h
@@ -28,9 +28,11 @@ NS_ASSUME_NONNULL_BEGIN
 @class ConversationInputBarViewController;
 @class AudioRecordViewController;
 @class MentionsHandler;
+@class KeyboardBlockObserver;
 @protocol ZMConversationMessage;
 @protocol Dismissable;
 @protocol UserList;
+@protocol KeyboardCollapseObserver;
 @protocol AVAudioSessionType;
 
 typedef NS_ENUM(NSUInteger, ConversationInputBarViewControllerMode) {
@@ -69,7 +71,7 @@ typedef NS_ENUM(NSUInteger, ConversationInputBarViewControllerMode) {
 @property (nonatomic) ConversationInputBarViewControllerMode mode;
 @property (nonatomic, readonly, nullable) UIViewController *inputController;
 @property (nonatomic, strong, nullable) MentionsHandler *mentionsHandler;
-@property (nonatomic, weak, nullable) id<Dismissable, UserList> mentionsView;
+@property (nonatomic, weak, nullable) id<Dismissable, UserList, KeyboardCollapseObserver> mentionsView;
 @property (nonatomic, strong, nullable) id textfieldObserverToken;
 @property (nonatomic, nonnull) id<AVAudioSessionType> audioSession;
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Mentions/UserSearchResultsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Mentions/UserSearchResultsViewController.swift
@@ -27,21 +27,24 @@ import Cartography
     func dismiss()
 }
 
+@objc protocol KeyboardCollapseObserver {
+    var isKeyboardCollapsed: Bool { get }
+}
+
 @objc protocol UserList {
     var users: [UserType] { get set }
 }
 
-class UserSearchResultsViewController: UIViewController {
+class UserSearchResultsViewController: UIViewController, KeyboardCollapseObserver {
 
     private let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewLayout())
     private var searchResults: [UserType] = []
     private var query: String = ""
     private var collectionViewHeight: NSLayoutConstraint?
     private let rowHeight: CGFloat = 56.0
-    private var isKeyboardCollapsed = true {
+    public private(set) var isKeyboardCollapsed: Bool = true {
         didSet {
             guard oldValue != isKeyboardCollapsed else { return }
-            print("🍔 isKeyboardCollapsed = \(isKeyboardCollapsed)")
             collectionView.reloadData()
         }
     }
@@ -66,13 +69,12 @@ class UserSearchResultsViewController: UIViewController {
 
     private func setupKeyboardObserver() {
         keyboardObserver = KeyboardBlockObserver { [weak self] info in
-            guard let weakSelf = self, let window = weakSelf.view.window else { return }
-//            print("🎹 info.kind = \(info.kind), frame = \(info.frame), w = \(window.frame)")
-
-            weakSelf.isKeyboardCollapsed = info.isKeyboardCollapsed(window: window)
+            guard let weakSelf = self else { return }
+            if let isKeyboardCollapsed = info.isKeyboardCollapsed {
+                weakSelf.isKeyboardCollapsed = isKeyboardCollapsed
+            }
         }
     }
-
     
     private func setupCollectionView() {
         view.isHidden = true

--- a/Wire-iOS/Sources/UserInterface/Conversation/Mentions/UserSearchResultsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Mentions/UserSearchResultsViewController.swift
@@ -38,9 +38,18 @@ class UserSearchResultsViewController: UIViewController {
     private var query: String = ""
     private var collectionViewHeight: NSLayoutConstraint?
     private let rowHeight: CGFloat = 56.0
+    private var isKeyboardCollapsed = true {
+        didSet {
+            guard oldValue != isKeyboardCollapsed else { return }
+            print("🍔 isKeyboardCollapsed = \(isKeyboardCollapsed)")
+            collectionView.reloadData()
+        }
+    }
     
     @objc public weak var delegate: UserSearchResultsViewControllerDelegate?
-    
+
+    private var keyboardObserver: KeyboardBlockObserver?
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -51,7 +60,19 @@ class UserSearchResultsViewController: UIViewController {
                                                selector: #selector(keyboardWillChangeFrame(_:)),
                                                name: UIResponder.keyboardWillChangeFrameNotification,
                                                object: nil)
+
+        setupKeyboardObserver()
     }
+
+    private func setupKeyboardObserver() {
+        keyboardObserver = KeyboardBlockObserver { [weak self] info in
+            guard let weakSelf = self, let window = weakSelf.view.window else { return }
+//            print("🎹 info.kind = \(info.kind), frame = \(info.frame), w = \(window.frame)")
+
+            weakSelf.isKeyboardCollapsed = info.isKeyboardCollapsed(window: window)
+        }
+    }
+
     
     private func setupCollectionView() {
         view.isHidden = true
@@ -127,7 +148,6 @@ class UserSearchResultsViewController: UIViewController {
             self.scrollToLastItem()
         }
     }
-
 }
 
 extension UserSearchResultsViewController: Dismissable {
@@ -171,6 +191,18 @@ extension UserSearchResultsViewController: UICollectionViewDataSource {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: UserCell.reuseIdentifier, for: indexPath) as! UserCell
         cell.configure(with: user)
         cell.showSeparator = false
+
+        // hightlight the lowest cell if keyboard is collapsed
+        if isKeyboardCollapsed {
+            if indexPath.item == searchResults.count - 1 {
+                cell.backgroundColor = .contentBackground
+            } else {
+                cell.backgroundColor = .background
+            }
+        } else {
+            cell.backgroundColor = .background
+        }
+
         return cell
     }
     

--- a/Wire-iOS/Sources/UserInterface/Conversation/Mentions/UserSearchResultsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Mentions/UserSearchResultsViewController.swift
@@ -42,10 +42,13 @@ class UserSearchResultsViewController: UIViewController, KeyboardCollapseObserve
     private var query: String = ""
     private var collectionViewHeight: NSLayoutConstraint?
     private let rowHeight: CGFloat = 56.0
+    private var isKeyboardCollapsedFirstCalled = true
     public private(set) var isKeyboardCollapsed: Bool = true {
         didSet {
-            guard oldValue != isKeyboardCollapsed else { return }
+            guard oldValue != isKeyboardCollapsed || isKeyboardCollapsedFirstCalled else { return }
             collectionView.reloadData()
+
+            isKeyboardCollapsedFirstCalled = false
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/Helpers/KeyboardBlockObserver.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/KeyboardBlockObserver.swift
@@ -41,6 +41,10 @@ final class KeyboardBlockObserver: NSObject {
         func animate(_ animations: @escaping () -> Void) {
             UIView.animate(withDuration: animationDuration, animations: animations)
         }
+
+        func isKeyboardCollapsed(window: UIWindow) -> Bool {
+            return self.frame.maxY > window.frame.maxY
+        }
     }
     
     typealias ChangeBlock = (ChangeInfo) -> Void

--- a/Wire-iOS/Sources/UserInterface/Helpers/KeyboardBlockObserver.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/KeyboardBlockObserver.swift
@@ -39,7 +39,12 @@ final class KeyboardBlockObserver: NSObject {
             self.kind = kind
 
             if let beginFrameValue = (info[UIResponder.keyboardFrameBeginUserInfoKey] as? NSValue)?.cgRectValue {
-                isKeyboardCollapsed = beginFrameValue.height > frameValue.cgRectValue.height
+                /// key board is collapsed if init height is 0
+                if frameValue.cgRectValue.height == 0 {
+                    isKeyboardCollapsed = true
+                } else {
+                    isKeyboardCollapsed = beginFrameValue.height > frameValue.cgRectValue.height && kind == .hide
+                }
             } else {
                 isKeyboardCollapsed = nil
             }

--- a/Wire-iOS/Sources/UserInterface/Helpers/KeyboardBlockObserver.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/KeyboardBlockObserver.swift
@@ -28,7 +28,8 @@ final class KeyboardBlockObserver: NSObject {
         let frame: CGRect
         let animationDuration: TimeInterval
         let kind: Kind
-        
+        let isKeyboardCollapsed: Bool?
+
         init?(_ note: Notification, kind: Kind) {
             guard let info = note.userInfo else { return nil }
             guard let frameValue = info[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue,
@@ -36,14 +37,16 @@ final class KeyboardBlockObserver: NSObject {
             frame = frameValue.cgRectValue
             animationDuration = duration
             self.kind = kind
+
+            if let beginFrameValue = (info[UIResponder.keyboardFrameBeginUserInfoKey] as? NSValue)?.cgRectValue {
+                isKeyboardCollapsed = beginFrameValue.height > frameValue.cgRectValue.height
+            } else {
+                isKeyboardCollapsed = nil
+            }
         }
         
         func animate(_ animations: @escaping () -> Void) {
             UIView.animate(withDuration: animationDuration, animations: animations)
-        }
-
-        func isKeyboardCollapsed(window: UIWindow) -> Bool {
-            return self.frame.maxY > window.frame.maxY
         }
     }
     


### PR DESCRIPTION
## What's new in this PR?

Highlight the best-matched mention search result when the external keyboard is connected. For such case on iPhones, the user can press return or tab to insert the best-matched mention.