### PR TITLE
Run headless when running the tests

### DIFF
--- a/Wire-iOS/Sources/AppStateController.swift
+++ b/Wire-iOS/Sources/AppStateController.swift
@@ -58,7 +58,7 @@ class AppStateController : NSObject {
     }
 
     func calculateAppState() -> AppState {
-        guard !isRunningTests || isRunningSelfUnitTest else { return .unauthenticated(error: nil) }
+        guard !isRunningTests || isRunningSelfUnitTest else { return .headless }
 
         if !hasEnteredForeground {
             return .headless


### PR DESCRIPTION
## What's new in this PR?

Don't load any UI when running the tests. This makes it easier to spot when view under test has breaking constraints.