### PR TITLE
Fix: Missing "Guest is present" text in the gray bar after "allow guest" switch is on in conversation detail screen

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -828,11 +828,10 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
         [self updateOutgoingConnectionVisibility];
         [self.contentViewController updateTableViewHeaderView];
         [self updateInputBarVisibility];
-        [self updateGuestsBarVisibilityAndShowIfNeeded:NO];
-    } else {
-        [self.guestsBarController configureTitleWithState: self.conversation.guestBarState];
     }
-    
+
+    [self updateGuestsBarVisibilityAndShowIfNeeded:NO];
+
     if (note.nameChanged || note.securityLevelChanged || note.connectionStateChanged) {
         [self setupNavigatiomItem];
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Missing "Guest is present" text in the grey bar after "allow guest" switch is on in conversation detail screen

### Causes

The state of guestsBarController is not updated in that situation.

### Solutions

Call updateGuestsBarVisibilityAndShowIfNeeded in all cases, which also updates its label's text.

### Note

The animation of the guest bar reveal and dismissal does not run as expected when it is behind the conversation detail on iPad. I will check it later.