### PR TITLE
Fix: CI is not triggered when base is not develop

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,10 @@ pool:
    vmImage: 'macOS 10.13'
 
 trigger:
-  - develop
+  branches:
+    include:
+    - develop
+    - release/*
   
 steps:
 - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,15 +1,6 @@
 pool:
    vmImage: 'macOS 10.13'
 
-trigger:
-  batch: true
-  branches:
-    include:
-    - develop
-    - release/*
-    - feature/*
-    - fix/*
-
 steps:
 - script: |
     sudo xcode-select -switch /Applications/Xcode_10.app

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,9 @@
 pool:
    vmImage: 'macOS 10.13'
-  
+
+trigger:
+  batch: true
+    
 steps:
 - script: |
     sudo xcode-select -switch /Applications/Xcode_10.app

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,10 @@ pool:
 
 trigger:
   batch: true
-    
+  branches:
+    include:
+      *
+
 steps:
 - script: |
     sudo xcode-select -switch /Applications/Xcode_10.app

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,10 +1,5 @@
 pool:
    vmImage: 'macOS 10.13'
-
-trigger:
-  branches:
-    include:
-    - develop
   
 steps:
 - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,10 @@ trigger:
   batch: true
   branches:
     include:
-      *
+    - develop
+    - release/*
+    - feature/*
+    - fix/*
 
 steps:
 - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,6 @@ trigger:
   branches:
     include:
     - develop
-    - release/*
   
 steps:
 - script: |


### PR DESCRIPTION
## What's new in this PR?

### Issues

When making a PR that merges to release branch the CI was not triggered.

### Causes

The CI is run when source or target branch is listed in trigger branches. 

### Solutions

Remove the trigger branches - it will build commits in all branches (even without open PRs)