### PR TITLE
ZIOS-10698: An incorrect status is shown for active call after it is minimized

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ZMConversation+Status.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ZMConversation+Status.swift
@@ -272,15 +272,15 @@ final internal class CallingMatcher: ConversationStatusMatcher {
     
     func icon(with status: ConversationStatus, conversation: ZMConversation) -> ConversationStatusIcon {
 
-        let state = conversation.voiceChannel?.state
-        switch state {
-        case .incoming(_, false, _)?:
-            return .activeCall(showJoin: true)
-        case .answered?, .established?, .establishedDataChannel?:
-            return .activeCall(showJoin: conversation.mutedMessageTypes != .all)
-        default:
+        if conversation.mutedMessageTypes != .none {
             return .none
+        } else if conversation.canJoinCall {
+            return .activeCall(showJoin: true)
+        } else if conversation.isCallOngoing {
+            return .activeCall(showJoin: false)
         }
+        
+        return .none
     }
     
     var combinesWith: [ConversationStatusMatcher] = []


### PR DESCRIPTION
## What's new in this PR?

Fixed the behavior of the calling indicator view in the conversation list. I'm now using the `canJoinCall` and `isCallOngoing` functions, already used in the handling of the navigation bar, in order to display the green "Join" button or the calling indicator properly. I've also added a preemptive check to the current status of the notifications, so I can discard any check if the user has chosen to mute the conversation.