### PR TITLE
ZIOS-10545: Added allows arbitrary loads flag in the Share Extension Info.plist

### DIFF
--- a/Wire-iOS Share Extension/Info.plist
+++ b/Wire-iOS Share Extension/Info.plist
@@ -52,5 +52,10 @@
 	</dict>
 	<key>WireGroupId</key>
 	<string>${WIRE_BUNDLE_ID}</string>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsArbitraryLoads</key>
+        <true/>
+    </dict>
 </dict>
 </plist>


### PR DESCRIPTION
## What's new in this PR?

Share Extension was not loading link previews from `http`-based URLs. I've added the `NSAppTransportSecurity` flag inside the Share Extension Info.plist file, so now it reflects the same settings as the main container.