### PR TITLE
ZIOS-10701: Added more controls over unauthenticated accounts in Share Extension

### DIFF
--- a/Wire-iOS Share Extension/ShareExtensionViewController.swift
+++ b/Wire-iOS Share Extension/ShareExtensionViewController.swift
@@ -148,7 +148,7 @@ class ShareExtensionViewController: SLComposeServiceViewController {
 
     private var authenticatedAccounts: [Account] {
         guard let accountManager = accountManager else { return [] }
-        return accountManager.accounts.filter { $0.isAuthenticated }
+        return accountManager.accounts.filter(\.isAuthenticated)
     }
     
     private func recreateSharingSession(account: Account?) throws {
@@ -374,11 +374,8 @@ class ShareExtensionViewController: SLComposeServiceViewController {
         // If the current account is not authenticated (e.g. device removed from another client)
         // and there are other accounts authenticated, it switches to the first available.
         
-        if account == currentAccount && account?.isAuthenticated == false {
-            if let firstLogged = authenticated.first,
-                authenticated.count != accountManager?.accounts.count {
-                account = firstLogged
-            }
+        if let firstLogged = authenticated.first, account == currentAccount, account?.isAuthenticated == false {
+            account = firstLogged
         }
         
         do {

--- a/Wire-iOS Share Extension/ShareExtensionViewController.swift
+++ b/Wire-iOS Share Extension/ShareExtensionViewController.swift
@@ -123,7 +123,7 @@ class ShareExtensionViewController: SLComposeServiceViewController {
         ExtensionBackupExcluder.exclude()
         CrashReporter.setupHockeyIfNeeded()
         navigationController?.view.backgroundColor = .white
-        try? recreateSharingSession(account: currentAccount)
+        updateAccount(currentAccount)
         let activity = ExtensionActivity(attachments: extensionContext?.attachments.sorted)
         sharingSession?.analyticsEventPersistence.add(activity.openedEvent())
         extensionActivity = activity
@@ -146,6 +146,11 @@ class ShareExtensionViewController: SLComposeServiceViewController {
         item.titleView = UIImageView(image: UIImage(forLogoWith: .black, iconSize: .small))
     }
 
+    private var authenticatedAccounts: [Account] {
+        guard let accountManager = accountManager else { return [] }
+        return accountManager.accounts.filter { $0.isAuthenticated }
+    }
+    
     private func recreateSharingSession(account: Account?) throws {
         guard let applicationGroupIdentifier = applicationGroupIdentifier,
             let hostBundleIdentifier = hostBundleIdentifier,
@@ -176,7 +181,7 @@ class ShareExtensionViewController: SLComposeServiceViewController {
     }
 
     override func presentationAnimationDidFinish() {
-        guard let sharingSession = sharingSession, sharingSession.canShare else {
+        if authenticatedAccounts.count == 0 {
             return presentNotSignedInMessage()
         }
     }
@@ -362,8 +367,20 @@ class ShareExtensionViewController: SLComposeServiceViewController {
     }
     
     func updateAccount(_ account: Account?) {
-        guard let account = account, account != currentAccount else { return }
 
+        var account = account
+        let authenticated = authenticatedAccounts
+        
+        // If the current account is not authenticated (e.g. device removed from another client)
+        // and there are other accounts authenticated, it switches to the first available.
+        
+        if account == currentAccount && account?.isAuthenticated == false {
+            if let firstLogged = authenticated.first,
+                authenticated.count != accountManager?.accounts.count {
+                account = firstLogged
+            }
+        }
+        
         do {
             try recreateSharingSession(account: account)
         } catch let error as SharingSession.InitializationError {
@@ -378,8 +395,10 @@ class ShareExtensionViewController: SLComposeServiceViewController {
         }
         
         currentAccount = account
-        accountItem.value = account.shareExtensionDisplayName
+        accountItem.value = account?.shareExtensionDisplayName ?? ""
         conversationItem.value = "share_extension.conversation_selection.empty.value".localized
+        
+        guard account != currentAccount else { return }
         postContent?.target = nil
         extensionActivity?.conversation = nil
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

@billypchan reported an issue about unauthenticated accounts inside the list of the accounts list of the Share Extension. No message was shown during the selection of the desired account inside `ShareViewController`. I was not able to repro that, but I've tried to improve the sharing process.

### Solutions

The user was not able to share content if the current account was logged out. I'm now checking if there are other available authenticated accounts that are able to share, and I select automatically the first one available. Now, the "You're logged out" screen is visible only if there are no other available authenticated accounts. 