### PR TITLE
fix: crash when generate preview in ShareViewController

### DIFF
--- a/Wire-iOS/Sources/UserInterface/MessageDraft.swift
+++ b/Wire-iOS/Sources/UserInterface/MessageDraft.swift
@@ -95,7 +95,7 @@ extension MessageDraft: Shareable {
         Don't forget to return the height of the view in `height(forPreviewView:)`.
      */
     public func previewView() -> UIView? {
-        return nil
+        return UIView()
     }
 }
 


### PR DESCRIPTION
## What's new in this PR?

Fix the crash related nil previewView generation in ShareViewController.

## Note 
Consider removing ShareViewController and related classes if it is not going to release to the public.