### PR TITLE
Fix: Setting: username text field has input character components when using Chinese Cangjie input method

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/TailEditingTextField.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/TailEditingTextField.swift
@@ -50,7 +50,12 @@ class TailEditingTextField: UITextField {
         if let isContainsNormalSpace = (self.text?.contains(type(of: self).normalSpace)), isContainsNormalSpace {
             self.text = self.text?.replacingOccurrences(of: type(of: self).normalSpace, with: type(of: self).nonBreakingSpace)
         } else {
-            self.text = self.text
+            // For iOS 11+, the hack for fixing text field width is no longer necessary.
+            // The hack would cause Chinese input method failed to input.
+            if #available(iOS 11, *) {
+            } else {
+                self.text = self.text
+            }
         }
     }
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

After https://github.com/wireapp/wire-ios/pull/1760, the fix https://github.com/wireapp/wire-ios/pull/1360 is no longer effective.

### Causes

The code self.text = self.text causes Chinese input method failing to combine character components to signal character.

### Solutions

After iOS 11 the fix in https://github.com/wireapp/wire-ios/pull/1760 is no longer necessary. Apply it only for iOS 10 devices.