### PR TITLE
ZIOS-10730: Fix email login prefill after logging in with phone

### DIFF
--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -562,20 +562,6 @@ public extension SessionManager {
         return SessionManager.shared?.accountManager.accounts.count ?? 0
     }
 
-    @objc(removeAccountWithCredentials:)
-    func removeAccount(with credentials: LoginCredentials) {
-        guard let accountToRemove = accountManager.accounts.first(where: { $0.loginCredentials == credentials }) else {
-            return
-        }
-
-        guard let fallbackAccount = firstAuthenticatedAccount(excludingCredentials: credentials) else {
-            return
-        }
-
-        delete(account: accountToRemove)
-        select(fallbackAccount)
-    }
-
 }
 
 extension AppRootViewController: SessionManagerURLHandlerDelegate {

--- a/Wire-iOS/Sources/Authentication/Authentication/Event Handlers/Post-Login/Registration Error/AuthenticationNeedsReauthenticationErrorHandler.swift
+++ b/Wire-iOS/Sources/Authentication/Authentication/Event Handlers/Post-Login/Registration Error/AuthenticationNeedsReauthenticationErrorHandler.swift
@@ -36,7 +36,9 @@ class AuthenticationNeedsReauthenticationErrorHandler: AuthenticationEventHandle
         }
 
         let numberOfAccounts = statusProvider?.numberOfAccounts ?? 0
-        let nextStep = AuthenticationFlowStep.reauthenticate(credentials: nil, numberOfAccounts: numberOfAccounts)
+        let credentials = error.userInfo[ZMUserLoginCredentialsKey] as? LoginCredentials
+
+        let nextStep = AuthenticationFlowStep.reauthenticate(credentials: credentials, numberOfAccounts: numberOfAccounts)
 
         let alert = AuthenticationCoordinatorAlert(title: "registration.signin.alert.password_needed.title".localized,
                                                    message: "registration.signin.alert.password_needed.message".localized,

--- a/Wire-iOS/Sources/Authentication/RegistrationPersonal/RegistrationRootViewController.m
+++ b/Wire-iOS/Sources/Authentication/RegistrationPersonal/RegistrationRootViewController.m
@@ -220,9 +220,9 @@
 
 - (void)cancelAddAccount
 {
-    if (self.loginCredentials) {
-        [SessionManager.shared removeAccountWithCredentials:self.loginCredentials];
-    }
+    [SessionManager.shared select:[[SessionManager shared] firstAuthenticatedAccountExcludingCredentials:self.loginCredentials]
+                       completion:nil
+               tearDownCompletion:nil];
 }
 
 - (void)executeErrorFeedbackAction:(AuthenticationErrorFeedbackAction)feedbackAction

--- a/Wire-iOS/Sources/Authentication/RegistrationPersonal/RegistrationRootViewController.m
+++ b/Wire-iOS/Sources/Authentication/RegistrationPersonal/RegistrationRootViewController.m
@@ -146,7 +146,7 @@
     [self.cancelButton setIcon:ZetaIconTypeCancel withSize:ZetaIconSizeTiny forState:UIControlStateNormal];
     [self.cancelButton setIconColor:UIColor.whiteColor forState:UIControlStateNormal];
     self.cancelButton.accessibilityIdentifier = @"cancelAddAccount";
-    self.cancelButton.hidden = self.shouldHideCancelButton || [[SessionManager shared] firstAuthenticatedAccount] == nil;
+    self.cancelButton.hidden = self.shouldHideCancelButton || [[SessionManager shared] firstAuthenticatedAccountExcludingCredentials:self.loginCredentials] == nil;
     self.cancelButton.accessibilityLabel = NSLocalizedString(@"registration.launch_back_button.label", @"");
 
     [self.cancelButton addTarget:self action:@selector(cancelAddAccount) forControlEvents:UIControlEventTouchUpInside];
@@ -220,9 +220,9 @@
 
 - (void)cancelAddAccount
 {
-    [SessionManager.shared select:[[SessionManager shared] firstAuthenticatedAccount]
-                       completion:nil
-               tearDownCompletion:nil];
+    if (self.loginCredentials) {
+        [SessionManager.shared removeAccountWithCredentials:self.loginCredentials];
+    }
 }
 
 - (void)executeErrorFeedbackAction:(AuthenticationErrorFeedbackAction)feedbackAction


### PR DESCRIPTION
## What's new in this PR?

### Issues

Following the login refactor, we identified two issues: 

1. When the user logs in with phone number but the account has an associated email, we didn't pre-fill the email.

2. When the user cancels giving the passcode, we actually selected the same account that needs the passcode, so we ended up on the skeleton list and the user was stuck.

### Causes / Solutions

1. In the event handler for the needs password to register client error, we didn't use the error user info key to extract the login credentials 

2. When the user tapped the cancel button, we selected the first authenticated account, which is was in fact the account that could not be registered (it is authenticated, because it has an access token). Now, we look for the first authenticated account that has different credentials and switch to it.