### PR TITLE
ZIOS-10733: Show correct error message for invalid activation code

### DIFF
--- a/Wire-iOS/Sources/Authentication/Authentication/Event Handlers/Team/TeamEmailVerificationErrorHandler.swift
+++ b/Wire-iOS/Sources/Authentication/Authentication/Event Handlers/Team/TeamEmailVerificationErrorHandler.swift
@@ -39,7 +39,7 @@ class TeamEmailVerificationErrorHandler: AuthenticationEventHandler {
         switch state {
         case .sendEmailCode:
             errorNeedsAlert = error.userSessionErrorCode != .emailIsAlreadyRegistered
-        case .verifyEmail:
+        case .verifyActivationCode:
             errorNeedsAlert = true
         default:
             return nil

--- a/Wire-iOS/Sources/UserInterface/Helpers/UIViewController+Errors.m
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UIViewController+Errors.m
@@ -79,6 +79,7 @@
                 break;
                 
             case ZMUserSessionInvalidPhoneNumberVerificationCode:
+            case ZMUserSessionInvalidActivationCode:
                 message = NSLocalizedString(@"error.user.phone_code_invalid", @"");
                 break;
                 


### PR DESCRIPTION
## What's new in this PR?

### Issues

When registering a team or a personal user with phone, if the user put the wrong code, we would show the "Please try again" error message. Instead, we need to show the "Please enter a valid code" prompt.

### Solutions

We check for the `ZMUserSessionInvalidActivationCode` error when creating the alert copy for the invalid code, and for the correct email verification step in the team event handler.