### PR TITLE
ZIOS-10732: Fix random profile picture assignation for team users

### DIFF
--- a/Wire-iOS/Sources/Authentication/Authentication/Event Handlers/Initial Sync/AuthenticationInitialSyncEventHandler.swift
+++ b/Wire-iOS/Sources/Authentication/Authentication/Event Handlers/Initial Sync/AuthenticationInitialSyncEventHandler.swift
@@ -40,21 +40,20 @@ class AuthenticationInitialSyncEventHandler: NSObject, AuthenticationEventHandle
         // Check the registration status
         let isRegistered = statusProvider?.authenticatedUserWasRegisteredOnThisDevice == true
 
-        switch isRegistered {
-        case true:
-            if let nextStep = nextRegistrationStep {
-                return [.hideLoadingView, .assignRandomProfileImage, .transition(nextStep, resetStack: true)]
-            } else {
-                return [.hideLoadingView, .assignRandomProfileImage, .completeRegistrationFlow]
-            }
+        // Build the list of actions
+        var actions: [AuthenticationCoordinatorAction] = [.hideLoadingView]
 
-        case false:
-            if let nextStep = nextRegistrationStep {
-                return [.hideLoadingView, .transition(nextStep, resetStack: true)]
-            } else {
-                return [.hideLoadingView, .completeLoginFlow]
-            }
+        if isRegistered {
+            actions.append(.assignRandomProfileImage)
         }
+
+        if let nextStep = nextRegistrationStep {
+            actions.append(.transition(nextStep, resetStack: true))
+        } else {
+            actions.append(isRegistered ? .completeRegistrationFlow : .completeLoginFlow)
+        }
+
+        return actions
     }
 
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Upon registration, team users were not assigned a random profile picture, but it was working for personal accounts.

### Causes

The initial sync event handler was not performing the `assignRandomProfileImage` action if there was a next step to transition to, which is the case for team registration only (the next step is the invite flow).

We make sure that it always is performed if `isRegistered` is true. We also remove the code for handling email, because it's handled in `AuthenticationNoCredentialsErrorHandler`.