### PR TITLE
Fix build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Wire logo](https://github.com/wireapp/wire/blob/master/assets/header-small.png?raw=true)](https://wire.com/jobs/)
 
-[![Build Status](https://dev.azure.com/wireswiss/wire-ios/_apis/build/status/wireapp.wire-ios)](https://dev.azure.com/wireswiss/wire-ios/_build/latest?definitionId=1)
+[![Build Status](https://dev.azure.com/wireswiss/Wire%20iOS/_apis/build/status/wire-ios)](https://dev.azure.com/wireswiss/Wire%20iOS/_build/latest?definitionId=32)
 
 This repository is part of the source code of Wire. You can find more information at [wire.com](https://wire.com) or by contacting opensource@wire.com.
 


### PR DESCRIPTION
Fix the build badge link since the current one isn't rendering. The current link points to a different project (which maybe is the correct definition, but not public?).