### PR TITLE
Declare default init implementation for ObjC

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Views/UserImageView/BadgeUserImageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/UserImageView/BadgeUserImageView.swift
@@ -50,7 +50,7 @@ import WireExtensionComponents
 
     // MARK: - Initialization
 
-    @objc convenience init() {
+    @objc override convenience init(frame: CGRect) {
         self.init(size: .small)
     }
     

--- a/Wire-iOS/Sources/UserInterface/Components/Views/UserImageView/BadgeUserImageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/UserImageView/BadgeUserImageView.swift
@@ -50,6 +50,10 @@ import WireExtensionComponents
 
     // MARK: - Initialization
 
+    @objc convenience init() {
+        self.init(size: .small)
+    }
+    
     override init(size: UserImageView.Size = .small) {
         super.init(size: size)
         configureSubviews()


### PR DESCRIPTION
## What's new in this PR?

### Issues

Start UI was crashing when trying to show the top people line.

### Causes

In `TopPeopleCell.createUserImageView` we have the following code:

```c
    self.badgeUserImageView = [[BadgeUserImageView alloc] init];
```

Seems like the `BadgeUserImageView` cannot be alloc-init'ed from Objective-C.

### Solutions

I was really surprised by that, since me and Obj-C compiler knew that any object inherited from NSObject has init method.

The solution is to declare the init method in swift.
