### PR TITLE
Remove type Either in favor of Result

### DIFF
--- a/Wire-iOS/Sources/Helpers/syncengine/UserClient+RemoveTask.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/UserClient+RemoveTask.swift
@@ -32,9 +32,9 @@ extension UIViewController {
     }
     
     func requestPassword(_ completion: @escaping (ZMEmailCredentials?)->()) {
-        let passwordRequest = RequestPasswordViewController.requestPasswordController() { (result: Either<String, NSError>) -> () in
+        let passwordRequest = RequestPasswordViewController.requestPasswordController() { (result: Result<String>) -> () in
             switch result {
-            case .left(let passwordString):
+            case .success(let passwordString):
                 if let email = ZMUser.selfUser()?.emailAddress {
                     let newCredentials = ZMEmailCredentials(email: email, password: passwordString)
                     completion(newCredentials)
@@ -44,7 +44,7 @@ extension UIViewController {
                     }
                     completion(nil)
                 }
-            case .right(let error):
+            case .failure(let error):
                 zmLog.error("Error: \(error)")
                 completion(nil)
             }

--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/RequestPasswordViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/RequestPasswordViewController.swift
@@ -19,18 +19,13 @@
 
 import Foundation
 
-enum Either<TLeft, TRight> {
-    case left(TLeft)
-    case right(TRight)
-}
-
 class RequestPasswordViewController: UIAlertController {
     
-    var callback: ((Either<String, NSError>) -> ())? = .none
+    var callback: ((Result<String>) -> ())? = .none
     
     var okAction: UIAlertAction? = .none
     
-    static func requestPasswordController(_ callback: @escaping (Either<String, NSError>) -> ()) -> RequestPasswordViewController {
+    static func requestPasswordController(_ callback: @escaping (Result<String>) -> ()) -> RequestPasswordViewController {
         
         let title = NSLocalizedString("self.settings.account_details.remove_device.title", comment: "")
         let message = NSLocalizedString("self.settings.account_details.remove_device.message", comment: "")
@@ -49,12 +44,12 @@ class RequestPasswordViewController: UIAlertController {
         let okAction = UIAlertAction(title: okTitle, style: .default) { [unowned controller] (action: UIAlertAction) -> Void in
             if let passwordField = controller.textFields?[0] {
                 let password = passwordField.text ?? ""
-                controller.callback?(Either.left(password))
+                controller.callback?(Result<String>.success(password))
             }
         }
         
         let cancelAction = UIAlertAction(title: cancelTitle, style: .cancel) { [unowned controller] (action: UIAlertAction) -> Void in
-            controller.callback?(Either.right(NSError(domain: "\(type(of: controller))", code: 0, userInfo: [NSLocalizedDescriptionKey: "User cancelled input"])))
+            controller.callback?(Result<String>.failure(NSError(domain: "\(type(of: controller))", code: 0, userInfo: [NSLocalizedDescriptionKey: "User cancelled input"])))
         }
         
         controller.okAction = okAction

--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/RequestPasswordViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/RequestPasswordViewController.swift
@@ -44,12 +44,12 @@ class RequestPasswordViewController: UIAlertController {
         let okAction = UIAlertAction(title: okTitle, style: .default) { [unowned controller] (action: UIAlertAction) -> Void in
             if let passwordField = controller.textFields?[0] {
                 let password = passwordField.text ?? ""
-                controller.callback?(Result<String>.success(password))
+                controller.callback?(.success(password))
             }
         }
         
         let cancelAction = UIAlertAction(title: cancelTitle, style: .cancel) { [unowned controller] (action: UIAlertAction) -> Void in
-            controller.callback?(Result<String>.failure(NSError(domain: "\(type(of: controller))", code: 0, userInfo: [NSLocalizedDescriptionKey: "User cancelled input"])))
+            controller.callback?(.failure(NSError(domain: "\(type(of: controller))", code: 0, userInfo: [NSLocalizedDescriptionKey: "User cancelled input"])))
         }
         
         controller.okAction = okAction


### PR DESCRIPTION
## What's new in this PR?

### Issues

The type `Result` is more specific to the given use case.