### PR TITLE
fix: update mock user for usersCompanyLogin property

### DIFF
--- a/Wire-iOS Tests/Mocks/MockUser.h
+++ b/Wire-iOS Tests/Mocks/MockUser.h
@@ -55,6 +55,7 @@
 @property (nonatomic, readwrite) BOOL hasTeam;
 @property (nonatomic, readwrite) NSString *expirationDisplayString;
 @property (nonatomic, readwrite) BOOL isWirelessUser;
+@property (nonatomic, readwrite) BOOL usesCompanyLogin;
 @property (nonatomic) ZMUser * user;
 
 @property (nonatomic) NSSet <id<UserClientType>> * clients;

--- a/Wire-iOS Tests/Mocks/MockUser.m
+++ b/Wire-iOS Tests/Mocks/MockUser.m
@@ -240,6 +240,11 @@ static id<UserType> mockSelfUser = nil;
     return false;
 }
 
+- (BOOL)usesCompanyLogin
+{
+    return false;
+}
+
 - (BOOL)isKindOfClass:(Class)aClass
 {
     if ([aClass isSubclassOfClass:[ZMUser class]]) {

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
@@ -50,7 +50,7 @@ extension SettingsCellDescriptorFactory {
     func infoSection() -> SettingsSectionDescriptorType {
         var cellDescriptors = [nameElement(), handleElement()]
         
-        if !ZMUser.selfUser()!.usesCompanyLogin {
+        if let user = ZMUser.selfUser(), !user.usesCompanyLogin {
             if !ZMUser.selfUser().hasTeam || !(ZMUser.selfUser().phoneNumber?.isEmpty ?? true) {
                 cellDescriptors.append(phoneElement())
             }


### PR DESCRIPTION
## What's new in this PR?

Test crash when running SelfProfileViewControllerTests' setup() due to MockUser missing new usersCompanyLogin property.