### PR TITLE
Add methods to scroll to message from ZClientViewController

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationRootViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationRootViewController.swift
@@ -121,6 +121,11 @@ import Cartography
             return .lightContent
         }
     }
+    
+    @objc (scrollToMessage:)
+    func scroll(to message: ZMConversationMessage) {
+        conversationViewController?.scroll(to: message)
+    }
 }
 
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.h
@@ -33,6 +33,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, getter=isFocused) BOOL focused;
 @property (nonatomic, readonly) ConversationCallController *startCallController;
 
+- (void)scrollToMessage:(id<ZMConversationMessage>)message;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -337,6 +337,11 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
     [self updateLeftNavigationBarItems];
 }
 
+- (void)scrollToMessage:(id<ZMConversationMessage>)message
+{
+    [self.contentViewController scrollToMessage:message animated:YES];
+}
+
 #pragma mark - Device orientation
 
 - (BOOL)shouldAutorotate

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
@@ -379,6 +379,10 @@
     ConversationRootViewController *conversationRootController = nil;
     if ([conversation isEqual:self.currentConversation]) {
         conversationRootController = (ConversationRootViewController *)self.conversationRootViewController;
+        if (message) {
+            [conversationRootController scrollToMessage:message];            
+        }
+        
     } else {
         conversationRootController = [[ConversationRootViewController alloc] initWithConversation:conversation message:message clientViewController:self];
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Tapping on a mention notification for a conversation that is already loaded will not scroll to that mention.

### Causes

When a conversation is selected and loaded from the conversation list, `ZClientViewController` checks to see if the `ConversationRootViewController` for the given conversation exists. If it doesn't (because the conversation is not already loaded, it will create this root view controller and all of its sub view controllers, eventually scrolling to a particular message.

However, if the conversation already exists, then the root view controller already exists, and so nothing special happens.

### Solutions

In order to scroll to a particular message for an existing `ConversationRootViewController` object, we need to dive down into the hierarchy to find the view controller containing the `UITableView` used for displaying the messages. This is `ConversationContentViewController`.
