### PR TITLE
Fix: [iPad] Always highlight best match in mention suggestions list 

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Mentions/UserSearchResultsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Mentions/UserSearchResultsViewController.swift
@@ -208,7 +208,7 @@ extension UserSearchResultsViewController: UICollectionViewDataSource {
         cell.avatarSpacing = UIView.conversationLayoutMargins.left
 
         // hightlight the lowest cell if keyboard is collapsed
-        if isKeyboardCollapsed {
+        if isKeyboardCollapsed || UIDevice.current.userInterfaceIdiom == .pad {
             if indexPath.item == searchResults.count - 1 {
                 cell.backgroundColor = .contentBackground
             } else {


### PR DESCRIPTION
## What's new in this PR?

Always highlight the best match in mention the suggestions list on iPad. The user can tap tab/enter to choose the best-matched mention suggestion.