### PR TITLE
Do not scroll conversation to the bottom when replying

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Scrolling.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Scrolling.m
@@ -69,7 +69,7 @@
 {
     NSUInteger index = [self.messageWindow.messages indexOfObject:message];
     if (index != NSNotFound) {
-        [self.tableView scrollToRowAtIndexPath:[NSIndexPath indexPathForRow:index inSection:0]
+        [self.tableView scrollToRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:index]
                               atScrollPosition:UITableViewScrollPositionTop
                                       animated:animated];
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -737,9 +737,9 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
     [self.inputBarController.sendController sendTextMessage:text mentions:mentions replyingToMessage:message];
 }
 
-- (BOOL)conversationInputBarViewControllerShouldBeginEditing:(ConversationInputBarViewController *)controller isEditingMessage:(BOOL)isEditing
+- (BOOL)conversationInputBarViewControllerShouldBeginEditing:(ConversationInputBarViewController *)controller
 {
-    if (! self.contentViewController.isScrolledToBottom && !isEditing) {
+    if (! self.contentViewController.isScrolledToBottom && !controller.isEditingMessage && !controller.isReplyingToMessage) {
         [self.contentViewController scrollToBottomAnimated:YES];
     }
     

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Reply.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Reply.swift
@@ -37,4 +37,12 @@ extension ConversationInputBarViewController: ReplyComposingViewDelegate {
     func composingViewWantsToShowMessage(composingView: ReplyComposingView, message: ZMConversationMessage) {
         self.delegate?.conversationInputBarViewControllerWants?(toShow: message)
     }
+    
+    @objc var isReplyingToMessage: Bool {
+        return replyingToMessage != nil
+    }
+    
+    @objc var isEditingMessage: Bool {
+        return editingMessage != nil
+    }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+UITextViewDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+UITextViewDelegate.swift
@@ -99,9 +99,9 @@ extension ConversationInputBarViewController: UITextViewDelegate {
 
     public func textViewShouldBeginEditing(_ textView: UITextView) -> Bool {
         guard mode != .audioRecord else { return true }
-        guard delegate?.responds(to:  #selector(ConversationInputBarViewControllerDelegate.conversationInputBarViewControllerShouldBeginEditing(_:isEditingMessage:))) == true else { return true }
+        guard delegate?.responds(to:  #selector(ConversationInputBarViewControllerDelegate.conversationInputBarViewControllerShouldBeginEditing(_:))) == true else { return true }
 
-        return delegate?.conversationInputBarViewControllerShouldBeginEditing?(self, isEditingMessage: (nil != editingMessage)) ?? true
+        return delegate?.conversationInputBarViewControllerShouldBeginEditing?(self) ?? true
     }
 
     public func textViewDidBeginEditing(_ textView: UITextView) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.h
@@ -50,7 +50,7 @@ typedef NS_ENUM(NSUInteger, ConversationInputBarViewControllerMode) {
                                        replyingToMessage:(nullable id <ZMConversationMessage>)message;
 
 @optional
-- (BOOL)conversationInputBarViewControllerShouldBeginEditing:(ConversationInputBarViewController *)controller isEditingMessage:(BOOL)isEditing;
+- (BOOL)conversationInputBarViewControllerShouldBeginEditing:(ConversationInputBarViewController *)controller;
 - (BOOL)conversationInputBarViewControllerShouldEndEditing:(ConversationInputBarViewController *)controller;
 - (void)conversationInputBarViewControllerDidNotSendMessageConversationDegraded:(ConversationInputBarViewController *)controller;
 - (void)conversationInputBarViewControllerDidFinishEditingMessage:(id <ZMConversationMessage>)message withText:(NSString *)newText mentions:(NSArray <Mention *> *)mentions;


### PR DESCRIPTION
## What's new in this PR?

### Issues

- The conversation used to have the logic to scroll the content to the bottom when user is focusing on the input field. This should not happen when user is editing the message or is replying to the message.
- ~~Fixed delegate call `delegate?.conversationCell?(self, didSelect: .save, for: self.message)` -> `delegate?.conversationCell?(self, didSelect: .save)` (message is inferred from the cell now).~~
- Fixed jumping to the cell (row index vs section index).