### PR TITLE
ZIOS-10812: Remove reply option for unsent message

### DIFF
--- a/Wire-iOS Tests/ConversationCellActionControllerTests.swift
+++ b/Wire-iOS Tests/ConversationCellActionControllerTests.swift
@@ -1,0 +1,42 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+@testable import Wire
+
+class ConversationCellActionControllerTests: CoreDataSnapshotTestCase {
+
+    // MARK: - Reply
+
+    func testThatItDoesNotShowReplyItemForUnsentTextMessage() {
+        // GIVEN
+        let message = MockMessageFactory.textMessage(withText: "Text")!
+        message.sender = otherUser
+        message.conversation = otherUserConversation
+        message.deliveryState = .failedToSend
+
+        // WHEN
+        let actionController = ConversationCellActionController(responder: nil, message: message)
+        let supportsReply = actionController.canPerformAction(#selector(ConversationCellActionController.quoteMessage))
+
+        // THEN
+        XCTAssertFalse(supportsReply)
+
+    }
+
+}

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -268,6 +268,7 @@
 		5E672C942179D41100522E61 /* UserType+ZMUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E672C932179D41100522E61 /* UserType+ZMUser.swift */; };
 		5E678061204E8BEB002F63FB /* CallQualityPresentationTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E678060204E8BEB002F63FB /* CallQualityPresentationTransition.swift */; };
 		5E7315352191EADF00255A78 /* Message+Formatters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7315342191EADF00255A78 /* Message+Formatters.swift */; };
+		5E7315382191FCCB00255A78 /* ConversationCellActionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7315362191FCC400255A78 /* ConversationCellActionControllerTests.swift */; };
 		5E766D9921144DFC005242B4 /* AuthenticationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E766D9821144DFC005242B4 /* AuthenticationCoordinator.swift */; };
 		5E766D9B211472C0005242B4 /* AuthenticationFlowStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E766D9A211472C0005242B4 /* AuthenticationFlowStep.swift */; };
 		5E766D9F21147697005242B4 /* AuthenticationCoordinatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E766D9E21147697005242B4 /* AuthenticationCoordinatorDelegate.swift */; };
@@ -1782,6 +1783,7 @@
 		5E672C932179D41100522E61 /* UserType+ZMUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserType+ZMUser.swift"; sourceTree = "<group>"; };
 		5E678060204E8BEB002F63FB /* CallQualityPresentationTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallQualityPresentationTransition.swift; sourceTree = "<group>"; };
 		5E7315342191EADF00255A78 /* Message+Formatters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Message+Formatters.swift"; sourceTree = "<group>"; };
+		5E7315362191FCC400255A78 /* ConversationCellActionControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationCellActionControllerTests.swift; sourceTree = "<group>"; };
 		5E766D9821144DFC005242B4 /* AuthenticationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationCoordinator.swift; sourceTree = "<group>"; };
 		5E766D9A211472C0005242B4 /* AuthenticationFlowStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationFlowStep.swift; sourceTree = "<group>"; };
 		5E766D9E21147697005242B4 /* AuthenticationCoordinatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationCoordinatorDelegate.swift; sourceTree = "<group>"; };
@@ -6048,6 +6050,7 @@
 				873F91942189BB3C00E1DBB9 /* MessageReplyPreviewViewTests.swift */,
 				5EC7C87B21907D94004662AC /* ConversationReplyCellDescriptionTests.swift */,
 				5E294596219087CA0045ACFA /* ConversationReplyCellTests.swift */,
+				5E7315362191FCC400255A78 /* ConversationCellActionControllerTests.swift */,
 				8758CDB82191A7D60031BE0F /* ReplyComposingViewTests.swift */,
 			);
 			path = "Wire-iOS Tests";
@@ -8299,6 +8302,7 @@
 				BFF655741E81235900D48337 /* ConversationAvatarViewTests.swift in Sources */,
 				16D4932C203DD480008DDFFA /* UserCellTests.swift in Sources */,
 				7CD0747620D94BC500BC0A26 /* MessageTimerSystemMessageTests.swift in Sources */,
+				5E7315382191FCCB00255A78 /* ConversationCellActionControllerTests.swift in Sources */,
 				EF98987420C5A589005680C5 /* ZMSnapshotTestCase+MockUserClient.swift in Sources */,
 				1E98C81B1BD1719500C7A7A2 /* ContactsDataSourceTests.m in Sources */,
 				162E8C631CF5D68A004B4F45 /* AudioProcessingTests.swift in Sources */,

--- a/Wire-iOS/Sources/Helpers/syncengine/ZMMessage+Actions.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMMessage+Actions.swift
@@ -43,7 +43,9 @@ extension ZMConversationMessage {
         guard let conversation = self.conversation else {
             return false
         }
-        return !isEphemeral && conversation.isSelfAnActiveMember && (isText || isImage || isLocation || isFile)
+
+        let isSent = self.deliveryState == .delivered || self.deliveryState == .sent
+        return !isEphemeral && conversation.isSelfAnActiveMember && isSent && (isText || isImage || isLocation || isFile)
     }
 
     /// Wether it is possible to download the message content.


### PR DESCRIPTION
## What's new in this PR?

### Issues

Before, it was possible to reply to a message that failed to deliver.

### Solutions

We check for the delivery status in the `canReply` method.