### PR TITLE
ZIOS-10815: Fix actions not performed for message toolbox cell

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationMessageToolboxCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationMessageToolboxCell.swift
@@ -18,13 +18,15 @@
 
 import UIKit
 
-class ConversationMessageToolboxCell: UIView, ConversationMessageCell {
+class ConversationMessageToolboxCell: UIView, ConversationMessageCell, MessageToolboxViewDelegate {
 
     struct Configuration {
         let message: ZMConversationMessage
     }
 
     let toolboxView = MessageToolboxView()
+    weak var delegate: ConversationCellDelegate?
+    weak var message: ZMConversationMessage?
 
     var isSelected: Bool = false
 
@@ -41,6 +43,7 @@ class ConversationMessageToolboxCell: UIView, ConversationMessageCell {
     }
 
     private func configureSubviews() {
+        toolboxView.delegate = self
         addSubview(toolboxView)
     }
 
@@ -51,6 +54,22 @@ class ConversationMessageToolboxCell: UIView, ConversationMessageCell {
 
     func configure(with object: Configuration) {
         toolboxView.configureForMessage(object.message, forceShowTimestamp: false, animated: false)
+    }
+
+    func messageToolboxViewDidRequestLike(_ messageToolboxView: MessageToolboxView) {
+        delegate?.conversationCell?(self, didSelect: .like, for: message)
+    }
+
+    func messageToolboxViewDidSelectDelete(_ messageToolboxView: MessageToolboxView) {
+        delegate?.conversationCell?(self, didSelect: .delete, for: message)
+    }
+
+    func messageToolboxViewDidSelectResend(_ messageToolboxView: MessageToolboxView) {
+        delegate?.conversationCell?(self, didSelect: .resend, for: message)
+    }
+
+    func messageToolboxViewDidSelectLikers(_ messageToolboxView: MessageToolboxView) {
+        delegate?.conversationCellDidTapOpenLikers?(self, for: message)
     }
 
 }
@@ -68,6 +87,13 @@ class ConversationMessageToolboxCellDescription: ConversationMessageCellDescript
 
     init(message: ZMConversationMessage) {
         configuration = View.Configuration(message: message)
+    }
+
+    func makeCell(for tableView: UITableView, at indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueConversationCell(with: self, for: indexPath)
+        cell.cellView.delegate = self.delegate
+        cell.cellView.message = self.message
+        return cell
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.h
@@ -58,7 +58,7 @@ typedef void (^SelectedMenuBlock)(BOOL selected, BOOL animated);
 - (void)conversationCell:(ConversationCell *)cell didSelectURL:(NSURL *)url;
 - (BOOL)conversationCell:(ConversationCell *)cell shouldBecomeFirstResponderWhenShowMenuWithCellType:(MessageType)messageType;
 - (void)conversationCell:(ConversationCell *)cell didOpenMenuForCellType:(MessageType)messageType;
-- (void)conversationCellDidTapOpenLikers:(ConversationCell *)cell;
+- (void)conversationCellDidTapOpenLikers:(UIView *)cell forMessage:(id<ZMConversationMessage>)message;
 - (BOOL)conversationCellShouldStartDestructionTimer:(ConversationCell *)cell;
 - (void)conversationCell:(UIView *)cell openGuestOptionsFromView:(UIView *)sourceView;
 - (void)conversationCell:(UIView *)cell openParticipantsDetailsWithSelectedUsers:(NSArray <ZMUser *>*)selectedUsers fromView:(UIView *)sourceView;

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
@@ -600,7 +600,7 @@ static const CGFloat BurstContainerExpandedHeight = 40;
 
 - (void)messageToolboxViewDidSelectLikers:(MessageToolboxView *)messageToolboxView
 {
-    [self.delegate conversationCellDidTapOpenLikers:self];
+    [self.delegate conversationCellDidTapOpenLikers:self forMessage:self.message];
 }
 
 - (void)messageToolboxViewDidSelectResend:(MessageToolboxView *)messageToolboxView

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -847,10 +847,10 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
     // no op
 }
 
-- (void)conversationCellDidTapOpenLikers:(ConversationCell *)cell
+- (void)conversationCellDidTapOpenLikers:(UIView *)cell forMessage:(id<ZMConversationMessage>)message
 {
-    if ([Message hasLikers:cell.message]) {
-        ReactionsListViewController *reactionsListController = [[ReactionsListViewController alloc] initWithMessage:cell.message showsStatusBar:!IS_IPAD_FULLSCREEN];
+    if ([Message hasLikers:message]) {
+        ReactionsListViewController *reactionsListController = [[ReactionsListViewController alloc] initWithMessage:message showsStatusBar:!IS_IPAD_FULLSCREEN];
         [self.parentViewController presentViewController:reactionsListController animated:YES completion:nil];
     }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

When tapping the like, resend, delete or likers button on the new message toolbox cell, nothing was happening.

### Solutions

The `ConversationMessageToolboxCell` was not a delegate of the message toolbox. We now inject the appropriate cell delegate and perform the actions when the toolbox requests them.