### PR TITLE
Register cells right before requesting them if needed

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter+DataSource.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter+DataSource.swift
@@ -100,8 +100,8 @@ extension ConversationMessageWindowTableViewAdapter: UITableViewDataSource {
     func sectionController(at sectionIndex: Int, in tableView: UITableView) -> ConversationMessageSectionController? {
         guard let message = messageWindow.messages.object(at: sectionIndex) as? ZMConversationMessage, let nonce = message.nonce else { return nil }
         
-        if let cachedEntry = sectionControllers.object(forKey: nonce) {
-            return cachedEntry as? ConversationMessageSectionController
+        if let cachedEntry = sectionControllers.object(forKey: nonce) as? ConversationMessageSectionController {
+            return cachedEntry
         }
         
         let context = messageWindow.context(for: message, firstUnreadMessage: firstUnreadMessage)
@@ -115,10 +115,6 @@ extension ConversationMessageWindowTableViewAdapter: UITableViewDataSource {
         sectionController.selected = message.isEqual(selectedMessage)
         
         sectionControllers.setObject(sectionController, forKey: nonce as NSUUID)
-        
-        for description in sectionController.cellDescriptions {
-            registerCellIfNeeded(description, in: tableView)
-        }
         
         return sectionController
     }
@@ -144,6 +140,11 @@ extension ConversationMessageWindowTableViewAdapter: UITableViewDataSource {
     
     public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let sectionController = self.sectionController(at: indexPath.section, in: tableView)!
+        
+        for description in sectionController.cellDescriptions {
+            registerCellIfNeeded(description, in: tableView)
+        }
+        
         return sectionController.makeCell(for: tableView, at: indexPath)
     }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

App would sometimes crash due requesting cell with unknown identifier.

### Causes

We used to register the necessary cells when creating the section controller but it can now happen that a section controller changes which cells it needs after it's been created (it's gets selected for example). 

### Solutions

Register cells right before we use them.

## Notes

Is this a performance issue? I think not since it will in practice on loop through a small list and do a dictionary check. It should be negligible compared to the time it takes to render the cell but I'm open for other suggestions.
