### PR TITLE
Fix crash when liking a message

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -438,24 +438,24 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
             {
                 BOOL liked = ![Message isLikedMessage:message];
                 
-                NSIndexPath *indexPath = [self.tableView indexPathForCell:cell];
+                NSIndexPath *indexPath = [self.conversationMessageWindowTableViewAdapter indexPathForMessage:message];
                 
                 [[ZMUserSession sharedSession] enqueueChanges:^{
                     [Message setLikedMessage:message liked:liked];
-                    
-                    if (liked) {
-                        // Deselect if necessary to show list of likers
-                        if (self.conversationMessageWindowTableViewAdapter.selectedMessage == message) {
-                            [self tableView:self.tableView willSelectRowAtIndexPath:indexPath];
-                        }
-                    } else {
-                        // Select if necessary to prevent message from collapsing
-                        if (self.conversationMessageWindowTableViewAdapter.selectedMessage != message && ![Message hasReactions:message]) {
-                            [self tableView:self.tableView willSelectRowAtIndexPath:indexPath];
-                            [self.tableView selectRowAtIndexPath:indexPath animated:NO scrollPosition:UITableViewScrollPositionNone];
-                        }
-                    }
                 }];
+                
+                if (liked) {
+                    // Deselect if necessary to show list of likers
+                    if (self.conversationMessageWindowTableViewAdapter.selectedMessage == message) {
+                        [self tableView:self.tableView willSelectRowAtIndexPath:indexPath];
+                    }
+                } else {
+                    // Select if necessary to prevent message from collapsing
+                    if (self.conversationMessageWindowTableViewAdapter.selectedMessage != message && ![Message hasReactions:message]) {
+                        [self tableView:self.tableView willSelectRowAtIndexPath:indexPath];
+                        [self.tableView selectRowAtIndexPath:indexPath animated:NO scrollPosition:UITableViewScrollPositionNone];
+                    }
+                }
             }
                 break;
             case MessageActionForward:
@@ -626,12 +626,12 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
 
 - (ConversationCell *)cellForMessage:(id<ZMConversationMessage>)message
 {
-    NSUInteger messageIndex = [self.messageWindow.messages indexOfObject:message];
-    if (messageIndex == NSNotFound) {
+    NSIndexPath *indexPath = [self.conversationMessageWindowTableViewAdapter indexPathForMessage:message];
+    
+    if (indexPath == nil) {
         return nil;
     }
     
-    NSIndexPath *indexPath = [NSIndexPath indexPathForRow:0 inSection:messageIndex];
     ConversationCell *cell = (ConversationCell *)[self.tableView cellForRowAtIndexPath:indexPath];
     return cell;
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter+DataSource.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter+DataSource.swift
@@ -123,6 +123,17 @@ extension ConversationMessageWindowTableViewAdapter: UITableViewDataSource {
         return sectionController
     }
     
+    @objc(indexPathForMessage:)
+    public func indexPath(for message: ZMConversationMessage) -> IndexPath? {
+        let section = self.messageWindow.messages.index(of: message)
+        
+        guard section != NSNotFound else {
+            return nil
+        }
+        
+        return IndexPath(row: 0, section: section)
+    }
+    
     public func numberOfSections(in tableView: UITableView) -> Int {
         return self.messageWindow.messages.count
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

App would crash on liking a message

### Causes

If you like a message using the new section based cells the action would send the toolbox cell as the originating cell, the like action would them attempt find the index path of this cell which doesn't exists because it's wrapped in an adapter cell.

### Solutions

Look up the index path by the message instead.
