### PR TITLE
Restore switching between timestamp and list of likers

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/BurstTimestampTableViewCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/BurstTimestampTableViewCell.swift
@@ -87,7 +87,7 @@ class BurstTimestampSenderMessageCell: UIView, ConversationMessageCell {
 
     var isSelected: Bool = false
 
-    func configure(with object: BurstTimestampSenderMessageCellConfiguration) {
+    func configure(with object: BurstTimestampSenderMessageCellConfiguration, animated: Bool) {
         timestampView.configure(with: object.date, includeDayOfWeek: object.includeDayOfWeek, showUnreadDot: object.showUnreadDot)
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationLegacyCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationLegacyCell.swift
@@ -25,7 +25,7 @@ extension ConversationCell: ConversationMessageCell {
         let layoutProperties: ConversationCellLayoutProperties
     }
 
-    func configure(with object: Configuration) {
+    func configure(with object: Configuration, animated: Bool = false) {
         self.configure(for: object.message, layoutProperties: object.layoutProperties)
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationMessageToolboxCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationMessageToolboxCell.swift
@@ -22,6 +22,7 @@ class ConversationMessageToolboxCell: UIView, ConversationMessageCell, MessageTo
 
     struct Configuration {
         let message: ZMConversationMessage
+        let selected: Bool
     }
 
     let toolboxView = MessageToolboxView()
@@ -53,8 +54,8 @@ class ConversationMessageToolboxCell: UIView, ConversationMessageCell, MessageTo
         toolboxView.fitInSuperview()
     }
 
-    func configure(with object: Configuration) {
-        toolboxView.configureForMessage(object.message, forceShowTimestamp: false, animated: false)
+    func configure(with object: Configuration, animated: Bool) {
+        toolboxView.configureForMessage(object.message, forceShowTimestamp: object.selected, animated: animated)
     }
 
     func messageToolboxViewDidRequestLike(_ messageToolboxView: MessageToolboxView) {
@@ -86,9 +87,9 @@ class ConversationMessageToolboxCellDescription: ConversationMessageCellDescript
     let isFullWidth: Bool = true
     let supportsActions: Bool = false
         
-    init(message: ZMConversationMessage) {
+    init(message: ZMConversationMessage, selected: Bool) {
         self.message = message
-        self.configuration = View.Configuration(message: message)
+        self.configuration = View.Configuration(message: message, selected: selected)
     }
 
     func makeCell(for tableView: UITableView, at indexPath: IndexPath) -> UITableViewCell {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSenderMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSenderMessageCell.swift
@@ -43,7 +43,7 @@ class ConversationSenderMessageCell: UIView, ConversationMessageCell {
         configureConstraints()
     }
 
-    func configure(with object: Configuration) {
+    func configure(with object: Configuration, animated: Bool) {
         senderView.configure(with: object.user)
         indicatorImageView.isHidden = object.indicatorIcon == nil
         indicatorImageView.image = object.indicatorIcon

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCell.swift
@@ -31,7 +31,7 @@ class ConversationSystemMessageCell: ConversationIconBasedCell, ConversationMess
 
     // MARK: - Configuration
 
-    func configure(with object: Configuration) {
+    func configure(with object: Configuration, animated: Bool) {
         lineView.isHidden = !object.showLine
         imageView.image = object.icon
         attributedText = object.attributedText
@@ -52,7 +52,7 @@ class LinkConversationSystemMessageCell: ConversationIconBasedCell, Conversation
 
     // MARK: - Configuration
 
-    func configure(with object: Configuration) {
+    func configure(with object: Configuration, animated: Bool) {
         lastConfiguration = object
         lineView.isHidden = !object.showLine
         imageView.image = object.icon
@@ -92,7 +92,7 @@ class ConversationRenamedSystemMessageCell: ConversationIconBasedCell, Conversat
 
     // MARK: - Configuration
 
-    func configure(with object: Configuration) {
+    func configure(with object: Configuration, animated: Bool) {
         lineView.isHidden = false
         attributedText = object.attributedText
         nameLabel.attributedText = object.newConversationName

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/UnknownMessageCellDescription.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/UnknownMessageCellDescription.swift
@@ -24,7 +24,7 @@ extension CustomMessageView: ConversationMessageCell {
         return messageLabel
     }
 
-    func configure(with object: String) {
+    func configure(with object: String, animated: Bool) {
         messageText = object
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationLocationMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationLocationMessageCell.swift
@@ -114,7 +114,7 @@ class ConversationLocationMessageCell: UIView, ConversationMessageCell {
         ])
     }
 
-    func configure(with object: Configuration) {
+    func configure(with object: Configuration, animated: Bool) {
         lastConfiguration = object
         recognizer?.isEnabled = !object.isObfuscated
         obfuscationView.isHidden = !object.isObfuscated

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationPingCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationPingCell.swift
@@ -25,7 +25,7 @@ class ConversationPingCell: ConversationIconBasedCell, ConversationMessageCell {
         let pingText: NSAttributedString
     }
 
-    func configure(with object: Configuration) {
+    func configure(with object: Configuration, animated: Bool) {
         attributedText = object.pingText
         imageView.image = UIImage(for: .ping, fontSize: 20, color: object.pingColor)
         lineView.isHidden = true

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationLinkPreviewArticleCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationLinkPreviewArticleCell.swift
@@ -57,7 +57,7 @@ class ConversationLinkPreviewArticleCell: UIView, ConversationMessageCell {
         articleView.fitInSuperview()
     }
 
-    func configure(with object: Configuration) {
+    func configure(with object: Configuration, animated: Bool) {
         configuration = object
         articleView.configure(withTextMessageData: object.textMessageData, obfuscated: object.isObfuscated)
         updateImageLayout(isRegular: self.traitCollection.horizontalSizeClass == .regular)

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationQuoteCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationQuoteCell.swift
@@ -188,7 +188,7 @@ class ConversationReplyCell: UIView, ConversationMessageCell, ConversationReplyC
         ])
     }
 
-    func configure(with object: Configuration) {
+    func configure(with object: Configuration, animated: Bool) {
         contentView.configure(with: object)
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationSoundCloudAttachmentCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationSoundCloudAttachmentCell.swift
@@ -39,7 +39,7 @@ class ConversationSoundCloudAttachmentCell<Player: UIViewController & PlayerView
         self.init(viewController: player)
     }
 
-    func configure(with object: Configuration) {
+    func configure(with object: Configuration, animated: Bool) {
         viewController.linkAttachment = object.attachment
         viewController.sourceMessage = object.message
         viewController.providerImage = UIImage(named: "soundcloud")

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationTextMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationTextMessageCell.swift
@@ -79,7 +79,7 @@ class ConversationTextMessageCell: UIView, ConversationMessageCell {
         ])
     }
 
-    func configure(with object: Configuration) {
+    func configure(with object: Configuration, animated: Bool) {
         messageTextView.attributedText = object.attributedText
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationYouTubeAttachmentCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationYouTubeAttachmentCell.swift
@@ -30,7 +30,7 @@ class ConversationYouTubeAttachmentCell: ViewControllerBasedCell<MediaPreviewVie
         self.init(viewController: MediaPreviewViewController())
     }
 
-    func configure(with object: Configuration) {
+    func configure(with object: Configuration, animated: Bool) {
         viewController.linkAttachment = object.attachment
         viewController.fetchAttachment()
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
@@ -39,9 +39,10 @@ protocol ConversationMessageCell {
     /**
      * Configures the cell with the specified configuration object.
      * - parameter object: The view model for the cell.
+     * - parameter animated: True if the view should animate the changes
      */
 
-    func configure(with object: Configuration)
+    func configure(with object: Configuration, animated: Bool)
 }
 
 extension ConversationMessageCell {
@@ -102,10 +103,10 @@ extension ConversationMessageCellDescription {
         return tableView.dequeueConversationCell(with: self, for: indexPath)
     }
     
-    func configureCell(_ cell: UITableViewCell) {
+    func configureCell(_ cell: UITableViewCell, animated: Bool = false) {
         guard let adapterCell = cell as? ConversationMessageCellTableViewAdapter<Self> else { return }
         
-        adapterCell.cellView.configure(with: self.configuration)
+        adapterCell.cellView.configure(with: self.configuration, animated: animated)
     }
     
 }
@@ -117,7 +118,7 @@ extension ConversationMessageCellDescription {
 @objc class AnyConversationMessageCellDescription: NSObject {
     private let cellGenerator: (UITableView, IndexPath) -> UITableViewCell
     private let registrationBlock: (UITableView) -> Void
-    private let configureBlock: (UITableViewCell) -> Void
+    private let configureBlock: (UITableViewCell, Bool) -> Void
     private let baseTypeGetter: () -> AnyClass
 
     private let _delegate: AnyMutableProperty<ConversationCellDelegate?>
@@ -129,8 +130,8 @@ extension ConversationMessageCellDescription {
             description.register(in: tableView)
         }
         
-        configureBlock = { cell in
-            description.configureCell(cell)
+        configureBlock = { cell, animated in
+            description.configureCell(cell, animated: animated)
         }
 
         cellGenerator = { tableView, indexPath in
@@ -165,8 +166,8 @@ extension ConversationMessageCellDescription {
         set { _actionController.setter(newValue) }
     }
         
-    func configure(cell: UITableViewCell) {
-        configureBlock(cell)
+    func configure(cell: UITableViewCell, animated: Bool = false) {
+        configureBlock(cell, animated)
     }
 
     @objc(registerInTableView:)

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCellTableViewAdapter.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCellTableViewAdapter.swift
@@ -79,7 +79,7 @@ class ConversationMessageCellTableViewAdapter<C: ConversationMessageCellDescript
     }
     
     func configure(with object: C.View.Configuration, fullWidth: Bool) {
-        cellView.configure(with: object)
+        cellView.configure(with: object, animated: false)
         self.isFullWidth = fullWidth
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
@@ -84,6 +84,8 @@ extension IndexSet {
     @objc weak var sectionDelegate: ConversationMessageSectionControllerDelegate?
 
     private var changeObservers: [Any] = []
+    
+    private var hasLegacyContent: Bool = false
 
     deinit {
         changeObservers.removeAll()
@@ -97,6 +99,7 @@ extension IndexSet {
         super.init()
         
         if addLegacyContentIfNeeded(layoutProperties: layoutProperties) {
+            hasLegacyContent = true
             return
         }
         
@@ -215,11 +218,15 @@ extension IndexSet {
     }
     
     func didSelect(indexPath: IndexPath, tableView: UITableView) {
+        guard !hasLegacyContent else { return }
+        
         selected = true
         configure(at: indexPath.section, in: tableView)
     }
     
     func didDeselect(indexPath: IndexPath, tableView: UITableView) {
+        guard !hasLegacyContent else { return }
+        
         selected = false
         configure(at: indexPath.section, in: tableView)
     }
@@ -237,7 +244,7 @@ extension IndexSet {
         addContent(context: context, layoutProperties: layoutProperties)
         
         if isToolboxVisible(in: context) {
-            add(description: ConversationMessageToolboxCellDescription(message: message))
+            add(description: ConversationMessageToolboxCellDescription(message: message, selected: selected))
         }
     }
     
@@ -246,6 +253,8 @@ extension IndexSet {
     }
     
     func configure(in context: ConversationMessageContext, at sectionIndex: Int, in tableView: UITableView) {
+        guard !hasLegacyContent else { return }
+        
         self.context = context
         tableView.beginUpdates()
         
@@ -266,7 +275,7 @@ extension IndexSet {
         
         for (index, description) in tableViewCellDescriptions.enumerated() {
             if let cell = tableView.cellForRow(at: IndexPath(row: index, section: sectionIndex)) {
-                description.configure(cell: cell)
+                description.configure(cell: cell, animated: true)
             }
         }
     }


### PR DESCRIPTION
## What's new in this PR?

- Add support for doing animated updates of cells (used for animating the toolbox)
- Guard against doing certain operation on the message section controller when it contains legacy content
