### PR TITLE
Use section instead of row to look up message upon selection

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -780,7 +780,7 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    id<ZMConversationMessage>message = [self.messageWindow.messages objectAtIndex:indexPath.row];
+    id<ZMConversationMessage>message = [self.messageWindow.messages objectAtIndex:indexPath.section];
     BOOL isFile = [Message isFileTransferMessage:message] &&
                  ![Message isVideoMessage:message] &&
                  ![Message isAudioMessage:message];


### PR DESCRIPTION
## What's new in this PR?

### Issues

Opening files doesn't work 

### Causes

We were looking up the selected message by row instead of section, this usually resulted in trying to open the last message in the conversation.

### Solutions

Look up by section