### PR TITLE
ZIOS-10833: Add accessibility identifiers for quote

### DIFF
--- a/Wire-iOS Tests/ConversationReplyCellTests.swift
+++ b/Wire-iOS Tests/ConversationReplyCellTests.swift
@@ -44,6 +44,7 @@ class ConversationReplyCellTests: CoreDataSnapshotTestCase {
 
         // THEN
         verifyInAllPhoneWidths(view: cell)
+        verifyAccessibilityIdentifiers(cell, message)
     }
 
     func testThatItRendersShortMessageWithOtherMention_31() {
@@ -58,6 +59,7 @@ class ConversationReplyCellTests: CoreDataSnapshotTestCase {
 
         // THEN
         verifyInAllPhoneWidths(view: cell)
+        verifyAccessibilityIdentifiers(cell, message)
     }
 
     func testThatItRendersShortMessageWithSelfMention_31() {
@@ -72,6 +74,7 @@ class ConversationReplyCellTests: CoreDataSnapshotTestCase {
 
         // THEN
         verifyInAllPhoneWidths(view: cell)
+        verifyAccessibilityIdentifiers(cell, message)
     }
 
     func testThatItTruncatesTextAfterFourLines_31() {
@@ -86,6 +89,7 @@ class ConversationReplyCellTests: CoreDataSnapshotTestCase {
 
         // THEN
         verifyInAllPhoneWidths(view: cell)
+        verifyAccessibilityIdentifiers(cell, message)
     }
 
     func testThatItRendersMarkdownWithoutFontChanges_32() {
@@ -106,6 +110,7 @@ class ConversationReplyCellTests: CoreDataSnapshotTestCase {
 
         // THEN
         verifyInAllPhoneWidths(view: cell)
+        verifyAccessibilityIdentifiers(cell, message)
     }
 
     func testThatItRendersMarkdownWithoutFontChanges_NoHeaders_32() {
@@ -124,6 +129,7 @@ class ConversationReplyCellTests: CoreDataSnapshotTestCase {
 
         // THEN
         verifyInAllPhoneWidths(view: cell)
+        verifyAccessibilityIdentifiers(cell, message)
     }
 
 
@@ -138,6 +144,7 @@ class ConversationReplyCellTests: CoreDataSnapshotTestCase {
 
         // THEN
         verifyInAllPhoneWidths(view: cell)
+        verifyAccessibilityIdentifiers(cell, message)
     }
 
     func testThatItShowsEditBadgeWhenMessageIsEdited_34() {
@@ -153,6 +160,7 @@ class ConversationReplyCellTests: CoreDataSnapshotTestCase {
 
         // THEN
         verifyInAllPhoneWidths(view: cell)
+        verifyAccessibilityIdentifiers(cell, message)
     }
 
     // MARK: - Rich content
@@ -170,6 +178,7 @@ class ConversationReplyCellTests: CoreDataSnapshotTestCase {
 
         // THEN
         verifyInAllPhoneWidths(view: cell)
+        verifyAccessibilityIdentifiers(cell, message)
     }
 
     func testThatItDisplaysLinkPreviewAsText_WithText_51() {
@@ -185,6 +194,7 @@ class ConversationReplyCellTests: CoreDataSnapshotTestCase {
 
         // THEN
         verifyInAllPhoneWidths(view: cell)
+        verifyAccessibilityIdentifiers(cell, message)
     }
 
     func testThatItDisplaysPortraitImage_52() {
@@ -199,6 +209,7 @@ class ConversationReplyCellTests: CoreDataSnapshotTestCase {
 
         // THEN
         verifyInAllPhoneWidths(view: cell)
+        verifyAccessibilityIdentifiers(cell, message)
     }
 
     func testThatItDisplaysSquareImage_52() {
@@ -213,6 +224,7 @@ class ConversationReplyCellTests: CoreDataSnapshotTestCase {
 
         // THEN
         verifyInAllPhoneWidths(view: cell)
+        verifyAccessibilityIdentifiers(cell, message)
     }
 
     func testThatItDisplaysPanoImage_52() {
@@ -227,6 +239,7 @@ class ConversationReplyCellTests: CoreDataSnapshotTestCase {
 
         // THEN
         verifyInAllPhoneWidths(view: cell)
+        verifyAccessibilityIdentifiers(cell, message)
     }
 
     func testThatItDisplaysVideoMessage_53() {
@@ -244,6 +257,7 @@ class ConversationReplyCellTests: CoreDataSnapshotTestCase {
 
         // THEN
         verifyInAllPhoneWidths(view: cell)
+        verifyAccessibilityIdentifiers(cell, message)
     }
 
     func testThatItDisplaysFileMessage_54() {
@@ -259,6 +273,7 @@ class ConversationReplyCellTests: CoreDataSnapshotTestCase {
 
         // THEN
         verifyInAllPhoneWidths(view: cell)
+        verifyAccessibilityIdentifiers(cell, message)
     }
 
     func testThatItDisplaysAudioMessage_55() {
@@ -274,6 +289,7 @@ class ConversationReplyCellTests: CoreDataSnapshotTestCase {
 
         // THEN
         verifyInAllPhoneWidths(view: cell)
+        verifyAccessibilityIdentifiers(cell, message)
     }
 
     func testThatItDisplaysLocationMessage_56() {
@@ -288,6 +304,7 @@ class ConversationReplyCellTests: CoreDataSnapshotTestCase {
 
         // THEN
         verifyInAllPhoneWidths(view: cell)
+        verifyAccessibilityIdentifiers(cell, message)
     }
 
     func testThatItDoesNotTruncateLongLocationMessage_56() {
@@ -302,6 +319,7 @@ class ConversationReplyCellTests: CoreDataSnapshotTestCase {
 
         // THEN
         verifyInAllPhoneWidths(view: cell)
+        verifyAccessibilityIdentifiers(cell, message)
     }
 
     func testThatItDisplaysErrorForUnsupportedMessageType_57() {
@@ -315,6 +333,7 @@ class ConversationReplyCellTests: CoreDataSnapshotTestCase {
 
         // THEN
         verifyInAllPhoneWidths(view: cell)
+        verifyAccessibilityIdentifiers(cell, message)
     }
 
     func testThatItDisplaysErrorForDeletedMessage_57() {
@@ -326,6 +345,7 @@ class ConversationReplyCellTests: CoreDataSnapshotTestCase {
 
         // THEN
         verifyInAllPhoneWidths(view: cell)
+        verifyAccessibilityIdentifiers(cell, message)
     }
 
     // MARK: - Highlighting
@@ -342,6 +362,7 @@ class ConversationReplyCellTests: CoreDataSnapshotTestCase {
 
         // THEN
         verifyInAllPhoneWidths(view: cell)
+        verifyAccessibilityIdentifiers(cell, message)
     }
 
     // MARK: - Helpers
@@ -352,6 +373,47 @@ class ConversationReplyCellTests: CoreDataSnapshotTestCase {
         cell.configure(with: cellDescription.configuration, animated: false)
         XCTAssertTrue(waitForGroupsToBeEmpty([defaultImageCache.dispatchGroup]))
         return cell
+    }
+
+    private func verifyAccessibilityIdentifiers(_ cell: ConversationReplyCell, _ message: ZMConversationMessage?, file: StaticString = #file, line: UInt = #line) {
+        let contentView = cell.contentView
+
+        // Structure
+        XCTAssertEqual(contentView.accessibilityIdentifier, "ReplyCell", file: file, line: line)
+        XCTAssertEqual(contentView.senderComponent.label.accessibilityIdentifier, "original.sender", file: file, line: line)
+        XCTAssertEqual(contentView.senderComponent.indicatorView.accessibilityIdentifier, "original.edit_icon", file: file, line: line)
+        XCTAssertEqual(contentView.timestampLabel.accessibilityIdentifier, "original.timestamp", file: file, line: line)
+
+        // Content
+        switch message {
+        case let message? where message.isText:
+            XCTAssertEqual(contentView.contentTextView.accessibilityIdentifier, "quote.type.text", file: file, line: line)
+            XCTAssertNil(contentView.assetThumbnail.accessibilityIdentifier, file: file, line: line)
+
+        case let message? where message.isLocation:
+            XCTAssertEqual(contentView.contentTextView.accessibilityIdentifier, "quote.type.location", file: file, line: line)
+            XCTAssertNil(contentView.assetThumbnail.accessibilityIdentifier, file: file, line: line)
+
+        case let message? where message.isAudio:
+            XCTAssertEqual(contentView.contentTextView.accessibilityIdentifier, "quote.type.audio", file: file, line: line)
+            XCTAssertNil(contentView.assetThumbnail.accessibilityIdentifier, file: file, line: line)
+
+        case let message? where message.isImage:
+            XCTAssertEqual(contentView.assetThumbnail.accessibilityIdentifier, "quote.type.image", file: file, line: line)
+            XCTAssertNil(contentView.contentTextView.accessibilityIdentifier, file: file, line: line)
+
+        case let message? where message.isVideo:
+            XCTAssertEqual(contentView.assetThumbnail.accessibilityIdentifier, "quote.type.video", file: file, line: line)
+            XCTAssertNil(contentView.contentTextView.accessibilityIdentifier, file: file, line: line)
+
+        case let message? where message.isFile:
+            XCTAssertEqual(contentView.contentTextView.accessibilityIdentifier, "quote.type.file", file: file, line: line)
+            XCTAssertNil(contentView.assetThumbnail.accessibilityIdentifier, file: file, line: line)
+
+        default:
+            XCTAssertEqual(contentView.contentTextView.accessibilityIdentifier, "quote.type.unavailable", file: file, line: line)
+            XCTAssertNil(contentView.assetThumbnail.accessibilityIdentifier, file: file, line: line)
+        }
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationQuoteCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationQuoteCell.swift
@@ -36,6 +36,7 @@ class ConversationReplyContentView: UIView {
         let timestamp: String?
 
         let content: Content
+        let contentType: String
     }
 
     let senderComponent = SenderNameCellComponent()
@@ -60,11 +61,15 @@ class ConversationReplyContentView: UIView {
     }
 
     private func configureSubviews() {
+        accessibilityIdentifier = "ReplyCell"
+        isAccessibilityElement = true
+
         stackView.axis = .vertical
         stackView.alignment = .leading
         stackView.spacing = 6
         addSubview(stackView)
 
+        senderComponent.label.accessibilityIdentifier = "original.sender"
         senderComponent.label.font = .mediumSemiboldFont
         senderComponent.label.textColor = .from(scheme: .textForeground)
         stackView.addArrangedSubview(senderComponent)
@@ -86,6 +91,7 @@ class ConversationReplyContentView: UIView {
         assetThumbnail.setContentCompressionResistancePriority(.required, for: .vertical)
         stackView.addArrangedSubview(assetThumbnail)
 
+        timestampLabel.accessibilityIdentifier = "original.timestamp"
         timestampLabel.font = .mediumFont
         timestampLabel.textColor = .from(scheme: .textDimmed)
         timestampLabel.numberOfLines = 1
@@ -117,11 +123,17 @@ class ConversationReplyContentView: UIView {
         case .text(let attributedContent):
             contentTextView.attributedText = attributedContent
             contentTextView.isHidden = false
+            contentTextView.accessibilityIdentifier = object.contentType
+            contentTextView.isAccessibilityElement = true
             assetThumbnail.isHidden = true
+            assetThumbnail.isAccessibilityElement = false
         case .imagePreview(let resource, let isVideo):
             assetThumbnail.setResource(resource, isVideoPreview: isVideo)
             assetThumbnail.isHidden = false
+            assetThumbnail.accessibilityIdentifier = object.contentType
+            assetThumbnail.isAccessibilityElement = true
             contentTextView.isHidden = true
+            contentTextView.isAccessibilityElement = false
         }
     }
 
@@ -216,6 +228,7 @@ class ConversationReplyCellDescription: ConversationMessageCellDescription {
 
         var isUnavailable = false
         let content: View.Configuration.Content
+        let contentType: String
         let attributes: [NSAttributedString.Key: Any] = [.font: UIFont.smallSemiboldFont,
                                                          .foregroundColor: UIColor.from(scheme: .textForeground)]
 
@@ -223,37 +236,44 @@ class ConversationReplyCellDescription: ConversationMessageCellDescription {
         case let message? where message.isText:
             let data = message.textMessageData!
             content = .text(NSAttributedString.formatForPreview(message: data, inputMode: false))
+            contentType = "quote.type.text"
 
         case let message? where message.isLocation:
             let location = message.locationMessageData!
             let imageIcon = NSTextAttachment.textAttachment(for: .location, with: .from(scheme: .textForeground))!
             let initialString = NSAttributedString(attachment: imageIcon) + "  " + (location.name ?? "conversation.input_bar.message_preview.location".localized).localizedUppercase
             content = .text(initialString && attributes)
+            contentType = "quote.type.location"
 
         case let message? where message.isAudio:
             let imageIcon = NSTextAttachment.textAttachment(for: .microphone, with: .from(scheme: .textForeground))!
             let initialString = NSAttributedString(attachment: imageIcon) + "  " + "conversation.input_bar.message_preview.audio".localized.localizedUppercase
             content = .text(initialString && attributes)
+            contentType = "quote.type.audio"
 
         case let message? where message.isImage:
             content = .imagePreview(thumbnail: message.imageMessageData!.image, isVideo: false)
+            contentType = "quote.type.image"
 
         case let message? where message.isVideo:
             content = .imagePreview(thumbnail: message.fileMessageData!.thumbnailImage, isVideo: true)
+            contentType = "quote.type.video"
 
         case let message? where message.isFile:
             let fileData = message.fileMessageData!
             let imageIcon = NSTextAttachment.textAttachment(for: .document, with: .from(scheme: .textForeground))!
             let initialString = NSAttributedString(attachment: imageIcon) + "  " + (fileData.filename ?? "conversation.input_bar.message_preview.file".localized).localizedUppercase
             content = .text(initialString && attributes)
+            contentType = "quote.type.file"
 
         default:
             isUnavailable = true
             let attributes: [NSAttributedString.Key: AnyObject] = [.font: UIFont.mediumFont.italic, .foregroundColor: UIColor.from(scheme: .textDimmed)]
             content = .text(NSAttributedString(string: "content.message.reply.broken_message".localized, attributes: attributes))
+            contentType = "quote.type.unavailable"
         }
 
-        configuration = View.Configuration(showDetails: !isUnavailable, isEdited: isEdited, senderName: senderName, timestamp: timestamp, content: content)
+        configuration = View.Configuration(showDetails: !isUnavailable, isEdited: isEdited, senderName: senderName, timestamp: timestamp, content: content, contentType: contentType)
     }
 
     func makeCell(for tableView: UITableView, at indexPath: IndexPath) -> UITableViewCell {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationQuoteCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationQuoteCell.swift
@@ -70,6 +70,7 @@ class ConversationReplyContentView: UIView {
         addSubview(stackView)
 
         senderComponent.label.accessibilityIdentifier = "original.sender"
+        senderComponent.indicatorView.accessibilityIdentifier = "original.edit_icon"
         senderComponent.label.font = .mediumSemiboldFont
         senderComponent.label.textColor = .from(scheme: .textForeground)
         stackView.addArrangedSubview(senderComponent)


### PR DESCRIPTION
## What's new in this PR?

Accessibility identifiers are needed for automation on the quote cell. This is the map of the identifiers we added:

### Structure

- Container = `ReplyCell`
- Sender name = `original.sender`
- Message edited icon = `original.edit_icon`
- Timestamp = `original.timestamp`

### Quoted Content

- Text = `quote.type.text`
- Location = `quote.type.location`
- Audio = `quote.type.audio`
- Image = `quote.type.image`
- Video = `quote.type.video`
- File = `quote.type.file`
- Invalid quote = `quote.type.unavailable`
