### PR TITLE
ZIOS-10819: Dismiss keyboard when the conversation becomes read only

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -440,6 +440,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
 {
     if (self.conversation.isReadOnly) {
         [self.inputBarController.inputBar.textView resignFirstResponder];
+        [self.inputBarController dismissMentionsIfNeeded];
         [self.inputBarController removeReplyComposingView];
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -438,6 +438,11 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
 
 - (void)updateInputBarVisibility
 {
+    if (self.conversation.isReadOnly) {
+        [self.inputBarController.inputBar.textView resignFirstResponder];
+        [self.inputBarController removeReplyComposingView];
+    }
+
     self.inputBarZeroHeight.active = self.conversation.isReadOnly;
     [self.view setNeedsLayout];
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Mentions.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Mentions.swift
@@ -75,7 +75,7 @@ extension ConversationInputBarViewController: UserSearchResultsViewControllerDel
 
 extension ConversationInputBarViewController {
     
-    func dismissMentionsIfNeeded() {
+    @objc func dismissMentionsIfNeeded() {
         mentionsHandler = nil
         mentionsView?.dismiss()
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Reply.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Reply.swift
@@ -32,7 +32,7 @@ extension ConversationInputBarViewController: ReplyComposingViewDelegate {
         inputBar.textView.becomeFirstResponder()
     }
     
-    private func removeReplyComposingView() {
+    @objc func removeReplyComposingView() {
         self.quotedMessage = nil
         self.replyComposingView?.removeFromSuperview()
         self.replyComposingView = nil

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+UITextViewDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+UITextViewDelegate.swift
@@ -102,6 +102,7 @@ extension ConversationInputBarViewController: UITextViewDelegate {
         guard mode != .audioRecord else { return true }
         guard delegate?.responds(to:  #selector(ConversationInputBarViewControllerDelegate.conversationInputBarViewControllerShouldBeginEditing(_:))) == true else { return true }
 
+        triggerMentionsIfNeeded(from: textView)
         return delegate?.conversationInputBarViewControllerShouldBeginEditing?(self) ?? true
     }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

When replying to a message, and the user is removed from a conversation, the keyboard and the reply composer were still displayed.

### Solutions

When the conversation becomes read only, we resign first responder on the input bar and remove the composing view.