### PR TITLE
Fix crash after editing message

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
@@ -66,9 +66,6 @@ extension IndexSet {
     var context: ConversationMessageContext
     var layoutProperties: ConversationCellLayoutProperties
 
-    /// Wheater this section is selected
-    @objc var selected: Bool = false
-
     /// Whether we need to use inverted indices. This is `true` when the table view is upside down.
     @objc var useInvertedIndices = false
 
@@ -83,6 +80,9 @@ extension IndexSet {
 
     /// The object that receives informations from the section.
     @objc weak var sectionDelegate: ConversationMessageSectionControllerDelegate?
+    
+    /// Wheater this section is selected
+    private var selected: Bool
 
     private var changeObservers: [Any] = []
     
@@ -92,10 +92,11 @@ extension IndexSet {
         changeObservers.removeAll()
     }
 
-    init(message: ZMConversationMessage, context: ConversationMessageContext, layoutProperties: ConversationCellLayoutProperties) {
+    init(message: ZMConversationMessage, context: ConversationMessageContext, layoutProperties: ConversationCellLayoutProperties, selected: Bool = false) {
         self.message = message
         self.context = context
         self.layoutProperties = layoutProperties
+        self.selected = selected
         
         super.init()
         

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter+DataSource.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter+DataSource.swift
@@ -83,7 +83,7 @@ extension ConversationMessageWindowTableViewAdapter: ZMConversationMessageWindow
     func reconfigureVisibleSections() {
         tableView.beginUpdates()
         if let indexPathsForVisibleRows = tableView.indexPathsForVisibleRows {
-            let visibleSections = Set(indexPathsForVisibleRows.map({ $0.section }))
+            let visibleSections = Set(indexPathsForVisibleRows.map(\.section))
             for section in visibleSections {
                 reconfigureSectionController(at: section, tableView: tableView)
             }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter+DataSource.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter+DataSource.swift
@@ -83,7 +83,7 @@ extension ConversationMessageWindowTableViewAdapter: ZMConversationMessageWindow
     func reconfigureVisibleSections() {
         tableView.beginUpdates()
         if let indexPathsForVisibleRows = tableView.indexPathsForVisibleRows {
-            let visibleSections = indexPathsForVisibleRows.map({ $0.section })
+            let visibleSections = Set(indexPathsForVisibleRows.map({ $0.section }))
             for section in visibleSections {
                 reconfigureSectionController(at: section, tableView: tableView)
             }
@@ -107,12 +107,14 @@ extension ConversationMessageWindowTableViewAdapter: UITableViewDataSource {
         let context = messageWindow.context(for: message, firstUnreadMessage: firstUnreadMessage, searchQueries: self.searchQueries ?? [])
         let layoutProperties = messageWindow.layoutProperties(for: message, firstUnreadMessage: firstUnreadMessage)
         
-        let sectionController = ConversationMessageSectionController(message: message, context: context, layoutProperties: layoutProperties)
+        let sectionController = ConversationMessageSectionController(message: message,
+                                                                     context: context,
+                                                                     layoutProperties: layoutProperties,
+                                                                     selected: message.isEqual(selectedMessage))
         sectionController.useInvertedIndices = true
         sectionController.cellDelegate = conversationCellDelegate
         sectionController.sectionDelegate = self
         sectionController.actionController = actionController(for: message)
-        sectionController.selected = message.isEqual(selectedMessage)
         
         sectionControllers.setObject(sectionController, forKey: nonce as NSUUID)
         


### PR DESCRIPTION
## What's new in this PR?

### Issues

If a message was edited while showing the timestamp (message is selected) it would crash due to a tableview update exception.

### Causes

When editing a message we change the nonce which means we will re-create the section controller since they are cached by nonce. The newly created section controller would be missing the timestamp cell since the selection was configured afterwards and thus crash.

### Solutions

Add the selection state to the constructor of the section controller.