### PR TITLE
Fix link previews not responding to interaction

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationLinkPreviewArticleCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationLinkPreviewArticleCell.swift
@@ -49,6 +49,7 @@ class ConversationLinkPreviewArticleCell: UIView, ConversationMessageCell {
     }
 
     private func configureSubviews() {
+        articleView.delegate = self
         addSubview(articleView)
     }
 
@@ -76,6 +77,14 @@ class ConversationLinkPreviewArticleCell: UIView, ConversationMessageCell {
         updateImageLayout(isRegular: self.traitCollection.horizontalSizeClass == .regular)
     }
 
+}
+
+extension ConversationLinkPreviewArticleCell: ArticleViewDelegate {
+    
+    func articleViewWantsToOpenURL(_ articleView: ArticleView, url: URL) {
+        url.open()
+    }
+    
 }
 
 class ConversationLinkPreviewArticleCellDescription: ConversationMessageCellDescription {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ArticleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ArticleView.swift
@@ -25,7 +25,6 @@ import WireExtensionComponents
 
 @objc protocol ArticleViewDelegate: class {
     func articleViewWantsToOpenURL(_ articleView: ArticleView, url: URL)
-    func articleViewDidLongPressView(_ articleView: ArticleView)
 }
 
 @objcMembers class ArticleView: UIView {
@@ -94,7 +93,6 @@ import WireExtensionComponents
         let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(viewTapped))
         tapGestureRecognizer.delegate = self
         addGestureRecognizer(tapGestureRecognizer)
-        addGestureRecognizer(UILongPressGestureRecognizer(target: self, action: #selector(viewLongPressed)))
 
         updateLabels()
     }
@@ -211,11 +209,6 @@ import WireExtensionComponents
     @objc private func viewTapped(_ sender: UITapGestureRecognizer) {
         guard let url = linkPreview?.openableURL else { return }
         delegate?.articleViewWantsToOpenURL(self, url: url as URL)
-    }
-    
-    @objc private func viewLongPressed(_ sender: UILongPressGestureRecognizer) {
-        guard sender.state == .began else { return }
-        delegate?.articleViewDidLongPressView(self)
     }
     
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Link preview weren't responding to taps or long presses.

### Causes

ArticleView delegate wasn't set

### Solutions

- Set delegate 
- Remove long tap recognizer since that's handled by `ConversationMessageCellTableViewAdapter`