### PR TITLE
ZIOS-10831: Show menu when user long presses mention or link

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationMessageToolboxCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationMessageToolboxCell.swift
@@ -45,6 +45,7 @@ class ConversationMessageToolboxCell: UIView, ConversationMessageCell, MessageTo
     }
 
     private func configureSubviews() {
+        toolboxView.accessibilityIdentifier = "MessageToolbox"
         toolboxView.delegate = self
         addSubview(toolboxView)
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationTextMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationTextMessageCell.swift
@@ -29,6 +29,7 @@ class ConversationTextMessageCell: UIView, ConversationMessageCell, TextViewInte
 
     weak var message: ZMConversationMessage?
     weak var delegate: ConversationCellDelegate?
+    weak var menuPresenter: ConversationMessageCellMenuPresenter?
 
     var selectionView: UIView? {
         return messageTextView
@@ -101,7 +102,7 @@ class ConversationTextMessageCell: UIView, ConversationMessageCell, TextViewInte
     }
 
     func textViewDidLongPress(_ textView: LinkInteractionTextView) {
-        // no-op, handled by the container
+        self.menuPresenter?.showMenu()
     }
 
 }
@@ -129,6 +130,7 @@ class ConversationTextMessageCellDescription: ConversationMessageCellDescription
         let cell = tableView.dequeueConversationCell(with: self, for: indexPath)
         cell.cellView.delegate = self.delegate
         cell.cellView.message = self.message
+        cell.cellView.menuPresenter = cell
         return cell
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCellTableViewAdapter.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCellTableViewAdapter.swift
@@ -18,7 +18,11 @@
 
 import Foundation
 
-class ConversationMessageCellTableViewAdapter<C: ConversationMessageCellDescription>: UITableViewCell, SelectableView {
+protocol ConversationMessageCellMenuPresenter: class {
+    func showMenu()
+}
+
+class ConversationMessageCellTableViewAdapter<C: ConversationMessageCellDescription>: UITableViewCell, SelectableView, ConversationMessageCellMenuPresenter {
     
     var cellView: C.View
 
@@ -133,7 +137,7 @@ class ConversationMessageCellTableViewAdapter<C: ConversationMessageCellDescript
         return cellDescription?.actionController
     }
 
-    private func showMenu() {
+    func showMenu() {
         guard cellDescription?.supportsActions == true else {
             return
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

When the user long pressed a mention or a link, it was not triggering the menu with the message actions.

### Causes

The long press gesture recognizer of the text view was cancelling the long press gesture from the cell container; and we were not handling the delegate method to handle link press.

### Solutions

We manually request showing the menu to the parent cell when the text field reports that a link was long pressed.