### PR TITLE
Fix showing the menu controller for a video message

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ArticleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ArticleView.swift
@@ -207,6 +207,10 @@ import WireExtensionComponents
     }
 
     @objc private func viewTapped(_ sender: UITapGestureRecognizer) {
+        if UIMenuController.shared.isMenuVisible {
+            return UIMenuController.shared.setMenuVisible(false, animated: true)
+        }
+
         guard let url = linkPreview?.openableURL else { return }
         delegate?.articleViewWantsToOpenURL(self, url: url as URL)
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/VideoMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/VideoMessageCell.swift
@@ -119,6 +119,13 @@ public final class VideoMessageCell: ConversationCell {
     }
     
     // MARK: - Menu
+
+    public override func menuConfigurationProperties() -> MenuConfigurationProperties! {
+        let properties = MenuConfigurationProperties()
+        properties.targetRect = selectionRect
+        properties.targetView = selectionView
+        return properties
+    }
             
     @objc override func prepareLayoutForPreview(message: ZMConversationMessage?) -> CGFloat {
         super.prepareLayoutForPreview(message: message)

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -754,7 +754,13 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
 {
     ZMMessage *message = [self.messageWindow.messages objectAtIndex:indexPath.section];
     NSIndexPath *selectedIndexPath = nil;
-    
+
+    // If the menu is visible, hide it and do nothing
+    if (UIMenuController.sharedMenuController.isMenuVisible) {
+        [UIMenuController.sharedMenuController setMenuVisible:NO animated:YES];
+        return nil;
+    }
+
     if ([message isEqual:self.conversationMessageWindowTableViewAdapter.selectedMessage]) {
         
         // If this cell is already selected, deselect it.


### PR DESCRIPTION
## What's new in this PR?

### Issues

We accidentally removed the method override for `menuConfigurationProperties` in the video message cell. Which caused the long press handler to return without trying to present the menu, because there was no configuration.

### Solutions

We restored the missing method, and added checks in other tap gesture recognizers to prevent tap handling (for example, to prevent the link to be opened when the user taps to dismiss the menu).