### PR TITLE
Only add a text message cell if the message has text content to display

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationTextMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationTextMessageCell.swift
@@ -176,8 +176,10 @@ extension ConversationTextMessageCellDescription {
         }
 
         // Text
-        let textCell = ConversationTextMessageCellDescription(attributedString: messageText)
-        cells.append(AnyConversationMessageCellDescription(textCell))
+        if messageText.length > 0 {
+            let textCell = ConversationTextMessageCellDescription(attributedString: messageText)
+            cells.append(AnyConversationMessageCellDescription(textCell))
+        }
 
         guard !message.isObfuscated else {
             return cells


### PR DESCRIPTION
## What's new in this PR?

### Issues

Text messages containing only a link would display a link preview and an empty gap above it.

### Causes

We we always create a text message cell even if there's not text content to display.

### Solutions

Conditionally create text message cell.