### PR TITLE
Re-factor timers in cell

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/BurstTimestampTableViewCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/BurstTimestampTableViewCell.swift
@@ -54,11 +54,7 @@ class BurstTimestampSenderMessageCellDescription: ConversationMessageCellDescrip
 class BurstTimestampSenderMessageCell: UIView, ConversationMessageCell {
 
     private let timestampView = ConversationCellBurstTimestampView()
-    private var configuration: BurstTimestampSenderMessageCellConfiguration? = nil {
-        didSet {
-            updateTimer()
-        }
-    }
+    private var configuration: BurstTimestampSenderMessageCellConfiguration? = nil
     private var timer: Timer? = nil
     
     override init(frame: CGRect) {
@@ -91,9 +87,17 @@ class BurstTimestampSenderMessageCell: UIView, ConversationMessageCell {
     override open func willMove(toWindow newWindow: UIWindow?) {
         super.willMove(toWindow: newWindow)
         
-        if self.window != newWindow {
-            updateTimer(window: newWindow)
+        if self.window == nil {
+            stopTimer()
         }
+    }
+    
+    func willDisplay() {
+        startTimer()
+    }
+    
+    func didEndDisplaying() {
+        stopTimer()
     }
     
     private func reconfigure() {
@@ -103,18 +107,16 @@ class BurstTimestampSenderMessageCell: UIView, ConversationMessageCell {
         configure(with: configuration, animated: false)
     }
     
-    private func updateTimer(window: UIWindow? = nil) {
-        let currentWindow: UIWindow? = window ?? self.window
-
-        if currentWindow != nil && timer == nil {
-            timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true, block: { [weak self] _ in
-                self?.reconfigure()
-            })
-        }
-        
-        if currentWindow == nil && timer != nil {
-            timer = nil
-        }
+    private func startTimer() {
+        stopTimer()
+        timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true, block: { [weak self] _ in
+            self?.reconfigure()
+        })
+    }
+    
+    private func stopTimer() {
+        timer?.invalidate()
+        timer = nil
     }
     
     // MARK: - Cell
@@ -124,7 +126,6 @@ class BurstTimestampSenderMessageCell: UIView, ConversationMessageCell {
     func configure(with object: BurstTimestampSenderMessageCellConfiguration, animated: Bool) {
         configuration = object
         timestampView.configure(with: object.date, includeDayOfWeek: object.includeDayOfWeek, showUnreadDot: object.showUnreadDot)
-        updateTimer()
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationMessageToolboxCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationMessageToolboxCell.swift
@@ -54,6 +54,14 @@ class ConversationMessageToolboxCell: UIView, ConversationMessageCell, MessageTo
         toolboxView.translatesAutoresizingMaskIntoConstraints = false
         toolboxView.fitInSuperview()
     }
+    
+    func willDisplay() {
+        toolboxView.startCountdownTimer()
+    }
+    
+    func didEndDisplaying() {
+        toolboxView.stopCountdownTimer()
+    }
 
     func configure(with object: Configuration, animated: Bool) {
         toolboxView.configureForMessage(object.message, forceShowTimestamp: object.selected, animated: animated)

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/EphemeralCountdownView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/EphemeralCountdownView.swift
@@ -57,11 +57,9 @@ class EphemeralCountdownView: UIView {
     func startCountDown() {
         stopCountDown()
         
-        guard let message = message, message.shouldShowDestructionCountdown else {
+        guard !isHidden else {
             return
         }
-        
-        _ = message.startSelfDestructionIfNeeded()
         
         timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
             self?.updateCountdown()

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationPingCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationPingCell.swift
@@ -41,9 +41,12 @@ class ConversationPingCellDescription: ConversationMessageCellDescription {
     weak var delegate: ConversationCellDelegate? 
     weak var actionController: ConversationCellActionController?
     
-    var showEphemeralTimer: Bool = false
-    var topMargin: Float = 0
+    var showEphemeralTimer: Bool {
+        get { return false }
+        set { /* pings doesn't support the ephemeral timer */ }
+    }
 
+    var topMargin: Float = 0
     let isFullWidth: Bool = true
     let supportsActions: Bool = false
     let containsHighlightableContent: Bool = false

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
@@ -46,6 +46,12 @@ protocol ConversationMessageCell {
      */
 
     func configure(with object: Configuration, animated: Bool)
+    
+    /// Called before the cell will be displayed on the screen.
+    func willDisplay()
+    
+    /// Called after the cell as been moved off screen.
+    func didEndDisplaying()
 }
 
 extension ConversationMessageCell {
@@ -60,6 +66,14 @@ extension ConversationMessageCell {
     
     var ephemeralTimerTopInset: CGFloat {
         return 8
+    }
+    
+    func willDisplay() {
+        // to be overriden
+    }
+    
+    func didEndDisplaying() {
+        // to be overriden
     }
 
 }
@@ -107,11 +121,21 @@ protocol ConversationMessageCellDescription: class {
 
     func register(in tableView: UITableView)
     func makeCell(for tableView: UITableView, at indexPath: IndexPath) -> UITableViewCell
+    func willDisplayCell()
+    func didEndDisplayingCell()
 }
 
 // MARK: - Table View Dequeuing
 
 extension ConversationMessageCellDescription {
+    
+    func willDisplayCell() {
+        _ = message?.startSelfDestructionIfNeeded()
+    }
+    
+    func didEndDisplayingCell() {
+        
+    }
 
     func register(in tableView: UITableView) {
         tableView.register(cell: type(of: self))

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCellTableViewAdapter.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCellTableViewAdapter.swift
@@ -249,15 +249,15 @@ class ConversationMessageCellTableViewAdapter<C: ConversationMessageCellDescript
     }
     
     override func willDisplayCell() {
-        if cellDescription?.showEphemeralTimer == true {
-            ephemeralCountdownView.startCountDown()
-        }
+        cellDescription?.willDisplayCell()
+        cellView.willDisplay()
+        ephemeralCountdownView.startCountDown()
     }
     
     override func didEndDisplayingCell() {
-        if cellDescription?.showEphemeralTimer == true {
-            ephemeralCountdownView.stopCountDown()
-        }
+        cellDescription?.didEndDisplayingCell()
+        cellView.didEndDisplaying()
+        ephemeralCountdownView.stopCountDown()
     }
     
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell+BurstTimestamp.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell+BurstTimestamp.swift
@@ -38,6 +38,7 @@ public extension ConversationCell {
 
     @objc func willDisplayInTableView() {
         scheduledTimerForUpdateBurstTimestamp()
+        toolboxView.startCountdownTimer()
 
         if delegate != nil &&
             delegate.responds(to: #selector(ConversationCellDelegate.conversationCellShouldStartDestructionTimer)) &&

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
@@ -212,6 +212,7 @@ static const CGFloat BurstContainerExpandedHeight = 40;
 {
     [self.burstTimestampTimer invalidate];
     self.burstTimestampTimer = nil;
+    [self.toolboxView stopCountdownTimer];
     [self tearDownCountdown];
     [self cellDidEndBeingVisible];
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
@@ -170,26 +170,25 @@ import TTTAttributedLabel
             self.configureTimestamp(message, animated: animated)
             self.tapGestureRecogniser.isEnabled = false
         }
-        
-        updateTimestampTimer()
     }
     
-    private func updateTimestampTimer(window: UIWindow? = nil) {
-        let currentWindow: UIWindow? = window ?? self.window
-        let shouldShowDestructionCountdown = (message?.shouldShowDestructionCountdown ?? false) && currentWindow != nil
+    @objc
+    func startCountdownTimer() {
+        guard let message = message, message.isEphemeral, !message.hasBeenDeleted else { return }
         
-        if shouldShowDestructionCountdown && timestampTimer == nil {
-            timestampTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] _ in
-                guard let `self` = self, let message = self.message else {
-                    return
-                }
-                self.configureTimestamp(message, animated: false)
+        stopCountdownTimer()
+        timestampTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] _ in
+            guard let `self` = self, let message = self.message else {
+                return
             }
+            self.configureTimestamp(message, animated: false)
         }
-        
-        if !shouldShowDestructionCountdown && timestampTimer != nil {
-            timestampTimer = nil
-        }
+    }
+    
+    @objc
+    func stopCountdownTimer() {
+        timestampTimer?.invalidate()
+        timestampTimer = nil
     }
     
     func setHidden(_ isHidden: Bool, animated: Bool) {
@@ -224,8 +223,8 @@ import TTTAttributedLabel
     override open func willMove(toWindow newWindow: UIWindow?) {
         super.willMove(toWindow: newWindow)
         
-        if newWindow != self.window {
-            updateTimestampTimer(window: newWindow)
+        if newWindow == nil {
+            stopCountdownTimer()
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
@@ -174,9 +174,10 @@ import TTTAttributedLabel
     
     @objc
     func startCountdownTimer() {
-        guard let message = message, message.isEphemeral, !message.hasBeenDeleted else { return }
-        
         stopCountdownTimer()
+        
+        guard let message = message, message.isEphemeral, !message.hasBeenDeleted, !message.isObfuscated else { return }
+        
         timestampTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] _ in
             guard let `self` = self, let message = self.message else {
                 return


### PR DESCRIPTION
## What's new in this PR?

- Introduce `willDisplay`/`didEndDisplaying` on the `ConversationMessageCell` which the cells can use to start/stop timers/animations.
- Hide ephemeral timer for pings
- Refactor burst timestamp and ephemeral countdown to use the above mentioned method to start and stop the timers.