### PR TITLE
Fix ephemeral pie chart animation not working

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/EphemeralCountdownView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/EphemeralCountdownView.swift
@@ -67,6 +67,7 @@ class EphemeralCountdownView: UIView {
     }
     
     func stopCountDown() {
+        destructionCountdownView.stopAnimating()
         timer?.invalidate()
         timer = nil
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Ephemeral pie chart timer wouldn't start sometimes

### Causes

The ephemeral pie chart animation only starts if it's not currently already animating. We didn't remove the animation before re-using the view so it only worked once per cell instance.

### Solutions

Clear all animations before attempting to start the pie chart timer.