### PR TITLE
Fix when message gets deleted while composing reply

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/MessagePreviewView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/MessagePreviewView.swift
@@ -193,6 +193,10 @@ final class MessageThumbnailPreviewView: UIView {
 
 extension MessageThumbnailPreviewView: ZMMessageObserver {
     func messageDidChange(_ changeInfo: MessageChangeInfo) {
+        guard !message.hasBeenDeleted else {
+            return // Deleted message won't have any content
+        }
+        
         updateForMessage()
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
@@ -373,6 +373,10 @@ extension IndexSet {
     }
 
     func messageDidChange(_ changeInfo: MessageChangeInfo) {
+        guard !changeInfo.message.hasBeenDeleted else {
+            return // Deletions are handled by the window observer
+        }
+        
         sectionDelegate?.messageSectionController(self, didRequestRefreshForMessage: self.message)
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ReplyComposingView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ReplyComposingView.swift
@@ -149,7 +149,7 @@ final class ReplyComposingView: UIView {
 
 extension ReplyComposingView: ZMMessageObserver {
     func messageDidChange(_ changeInfo: MessageChangeInfo) {
-        if changeInfo.message.hiddenInConversation != nil {
+        if changeInfo.message.hasBeenDeleted {
             self.delegate?.composingViewDidCancel(composingView: self)
         }
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

We would hit an assertion if a video message got deleted while we were composing reply to it.

### Causes

The `MessagePreviewView` is observing the quoted message for changes but if the message gets deleted it will run into an assertion since it can't determine the message type anymore.

### Solutions

Don't update the `MessagePreviewView` when a message gets deleted.

## Notes

- Also fixed a similar issue when a message gets deleted in the conversation, where we were briefly showing the "unknown message" cell.