### PR TITLE
Always show the message just sent

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Views/UITableView+Scrolling.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/UITableView+Scrolling.swift
@@ -25,6 +25,6 @@ extension UITableView {
         self.setContentOffset(self.contentOffset, animated: false)
         
         // scroll to bottom
-        self.scrollRectToVisible(CGRect(x: 0, y: 0, width: 1, height: 1), animated:animated)
+        self.setContentOffset(CGPoint(x: 0, y: self.contentInset.bottom), animated:animated)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Components/Views/UpsideDownTableView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/UpsideDownTableView.swift
@@ -63,13 +63,18 @@ class UpsideDownTableView: UITableView {
         }
     }
 
+    var lockContentOffset: Bool = false
+    
     override var contentOffset: CGPoint {
         get {
             return super.contentOffset
         }
 
         set {
-
+            // Blindly ignoring the SOLID principles, we are modifying the functionality of the parent class.
+            if lockContentOffset {
+                return
+            }
             /// do not set contentOffset if the user is panning on the bottom edge of pannableView (with 10 pt threshold)
             if let pannableView = pannableView,
                self.panGestureRecognizer.location(in: self.superview).y >= pannableView.frame.maxY - 10 {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -604,16 +604,17 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
 
 - (void)canvasViewController:(CanvasViewController *)canvasViewController didExportImage:(UIImage *)image
 {
-    [self.parentViewController dismissViewControllerAnimated:YES completion:nil];
-    if (image) {
-        NSData *imageData = UIImagePNGRepresentation(image);
-        
-        [[ZMUserSession sharedSession] enqueueChanges:^{
-            [self.conversation appendMessageWithImageData:imageData];
-        } completionHandler:^{
-            [[Analytics shared] tagMediaActionCompleted:ConversationMediaActionPhoto inConversation:self.conversation];
-        }];
-    }
+    [self.parentViewController dismissViewControllerAnimated:YES completion:^{
+        if (image) {
+            NSData *imageData = UIImagePNGRepresentation(image);
+            
+            [[ZMUserSession sharedSession] enqueueChanges:^{
+                [self.conversation appendMessageWithImageData:imageData];
+            } completionHandler:^{
+                [[Analytics shared] tagMediaActionCompleted:ConversationMediaActionPhoto inConversation:self.conversation];
+            }];
+        }
+    }];
 }
 
 #pragma mark - Custom UI, utilities

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter+DataSource.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter+DataSource.swift
@@ -61,7 +61,7 @@ extension ConversationMessageWindowTableViewAdapter: ZMConversationMessageWindow
         
         let isLoadingInitialContent = messageWindow.messages.count == changeInfo.insertedIndexes.count && changeInfo.deletedIndexes.count == 0
         let isExpandingMessageWindow = changeInfo.insertedIndexes.count > 0 && changeInfo.insertedIndexes.last == messageWindow.messages.count - 1
-        let shouldJumpToTheConversationEnd = changeInfo.insertedMessages.any({ $0.isSentFromThisDevice })
+        let shouldJumpToTheConversationEnd = changeInfo.insertedMessages.any(\.isSentFromThisDevice)
         
         stopAudioPlayer(forDeletedMessages: changeInfo.deletedObjects)
         

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter+DataSource.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter+DataSource.swift
@@ -33,6 +33,21 @@ extension ConversationMessageWindowTableViewAdapter: ConversationMessageSectionC
     
 }
 
+extension MessageWindowChangeInfo {
+    var insertedMessages: [ZMConversationMessage] {
+        return self.insertedIndexes.compactMap { conversationMessageWindow.messages[$0] as? ZMConversationMessage }
+    }
+}
+
+extension ZMConversationMessage {
+    var isSentFromThisDevice: Bool {
+        guard let sender = sender else {
+            return false
+        }
+        return sender.isSelfUser && deliveryState.isOne(of: [.pending])
+    }
+}
+
 extension ConversationMessageWindowTableViewAdapter: ZMConversationMessageWindowObserver {
     
     func reconfigureSectionController(at index: Int, tableView: UITableView) {
@@ -46,11 +61,15 @@ extension ConversationMessageWindowTableViewAdapter: ZMConversationMessageWindow
         
         let isLoadingInitialContent = messageWindow.messages.count == changeInfo.insertedIndexes.count && changeInfo.deletedIndexes.count == 0
         let isExpandingMessageWindow = changeInfo.insertedIndexes.count > 0 && changeInfo.insertedIndexes.last == messageWindow.messages.count - 1
+        let shouldJumpToTheConversationEnd = changeInfo.insertedMessages.any({ $0.isSentFromThisDevice })
+        
         stopAudioPlayer(forDeletedMessages: changeInfo.deletedObjects)
         
         if isLoadingInitialContent ||
             (isExpandingMessageWindow && changeInfo.deletedIndexes.count == 0) ||
-            changeInfo.needsReload {
+            changeInfo.needsReload ||
+            shouldJumpToTheConversationEnd {
+
             tableView.reloadData()
         } else {
             tableView.beginUpdates()
@@ -77,6 +96,16 @@ extension ConversationMessageWindowTableViewAdapter: ZMConversationMessageWindow
             // Re-evalulate visible cells in all sections, this is necessary because if a message is inserted/moved the
             // neighbouring messages may no longer want to display sender, toolbox or burst timestamp.
             reconfigureVisibleSections()
+        }
+        
+        if shouldJumpToTheConversationEnd {
+            // The action has to be performed on the next run loop, since the current one already has the call to scroll
+            // the table view back to the previous position.
+            self.tableView.scrollToBottom(animated: false)
+            self.tableView.lockContentOffset = true
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                self.tableView.lockContentOffset = false
+            }
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter+Private.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter+Private.h
@@ -39,13 +39,14 @@ static NSString *const ConversationUnknownMessageCellId     = @"conversationUnkn
 static NSString *const ConversationMessageTimerUpdateCellId = @"ConversationMessageTimerUpdateCellId";
 
 @class ConversationCell;
+@class UpsideDownTableView;
 @class ConversationCellActionController;
 
 @interface ConversationMessageWindowTableViewAdapter ()
 
 - (void)configureConversationCell:(ConversationCell *)conversationCell withMessage:(nullable id<ZMConversationMessage>)message;
 
-@property (nonatomic) UITableView * _Nonnull tableView;
+@property (nonatomic) UpsideDownTableView * _Nonnull tableView;
 @property (nonatomic) ZMConversationMessageWindow * _Nonnull messageWindow;
 @property (nonatomic) id _Nonnull messageWindowObserverToken;
 @property (nonatomic) BOOL expandingWindow;

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter.h
@@ -26,6 +26,7 @@
 @class ConversationMessageSectionController;
 @class AnyConversationMessageCellDescription;
 @class ConversationCellActionController;
+@class UpsideDownTableView;
 
 @interface ConversationMessageWindowTableViewAdapter : NSObject
 
@@ -37,7 +38,7 @@
 
 @property (nonatomic) NSArray<NSString *> *searchQueries;
 
-- (instancetype)initWithTableView:(UITableView *)tableView messageWindow:(ZMConversationMessageWindow *)messageWindow;
+- (instancetype)initWithTableView:(UpsideDownTableView *)tableView messageWindow:(ZMConversationMessageWindow *)messageWindow;
 - (void)expandMessageWindow;
 
 - (void)stopAudioPlayerForDeletedMessages:(NSSet *)deletedMessages;

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter.m
@@ -33,7 +33,7 @@
 
 @implementation ConversationMessageWindowTableViewAdapter
 
-- (instancetype)initWithTableView:(UITableView *)tableView messageWindow:(ZMConversationMessageWindow *)messageWindow
+- (instancetype)initWithTableView:(UpsideDownTableView *)tableView messageWindow:(ZMConversationMessageWindow *)messageWindow
 {
     self = [super init];
     

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarSendController.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarSendController.h
@@ -22,19 +22,10 @@
 @class Mention;
 @class ZMConversation;
 @protocol ZMConversationMessage;
-@class ConversationInputBarSendController;
-
-@protocol ConversationInputBarSendControllerDelegate <NSObject>
-
-@optional
-- (void)conversationInputBarSendController:(ConversationInputBarSendController *)controller didSendMessage:(id<ZMConversationMessage>)message;
-
-@end
 
 @interface ConversationInputBarSendController : NSObject
 
 @property (nonatomic, readonly) ZMConversation *conversation;
-@property (nonatomic, weak) id<ConversationInputBarSendControllerDelegate> delegate;
 
 - (instancetype)initWithConversation:(ZMConversation *)conversation;
 - (void)sendMessageWithImageData:(NSData *)imageData completion:(dispatch_block_t)completionHandler;

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarSendController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarSendController.m
@@ -49,20 +49,21 @@
     return self;
 }
 
--(void)sendMessageWithImageData:(NSData *)imageData completion:(dispatch_block_t)completionHandler
+- (void)sendMessageWithImageData:(NSData *)imageData completion:(dispatch_block_t)completionHandler
 {
-    if (imageData != nil) {
-        [self.feedbackGenerator prepare];
-        [[ZMUserSession sharedSession] enqueueChanges:^{
-            [self.conversation appendMessageWithImageData:imageData];
-            [self.feedbackGenerator impactOccurred];
-        } completionHandler:^{
-            if (completionHandler){
-                completionHandler();
-            }
-            [[Analytics shared] tagMediaActionCompleted:ConversationMediaActionPhoto inConversation:self.conversation];
-        }];
+    if (imageData == nil) {
+        return;
     }
+    [self.feedbackGenerator prepare];
+    [[ZMUserSession sharedSession] enqueueChanges:^{
+        [self.conversation appendMessageWithImageData:imageData];
+        [self.feedbackGenerator impactOccurred];
+    } completionHandler:^{
+        if (completionHandler){
+            completionHandler();
+        }
+        [[Analytics shared] tagMediaActionCompleted:ConversationMediaActionPhoto inConversation:self.conversation];
+    }];
 }
 
 - (void)sendTextMessage:(NSString *)text

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
@@ -165,17 +165,17 @@ extension ConversationInputBarViewController: CameraKeyboardViewControllerDelega
         confirmImageViewController.image = image
         confirmImageViewController.previewTitle = self.conversation.displayName.uppercased()
         confirmImageViewController.onConfirm = { [unowned self] (editedImage: UIImage?) in
-            self.dismiss(animated: true, completion: .none)
-            
-            if isFromCamera {
-                let selector = #selector(ConversationInputBarViewController.image(_:didFinishSavingWithError:contextInfo:))
-                UIImageWriteToSavedPhotosAlbum(UIImage(data: imageData as Data)!, self, selector, nil)
-            }
-            
-            if let editedImage = editedImage, let editedImageData = editedImage.pngData() {
-                self.sendController.sendMessage(withImageData: editedImageData, completion: .none)
-            } else {
-                self.sendController.sendMessage(withImageData: imageData as Data, completion: .none)
+            self.dismiss(animated: true) {
+                if isFromCamera {
+                    let selector = #selector(ConversationInputBarViewController.image(_:didFinishSavingWithError:contextInfo:))
+                    UIImageWriteToSavedPhotosAlbum(UIImage(data: imageData as Data)!, self, selector, nil)
+                }
+                
+                if let editedImage = editedImage, let editedImageData = editedImage.pngData() {
+                    self.sendController.sendMessage(withImageData: editedImageData, completion: .none)
+                } else {
+                    self.sendController.sendMessage(withImageData: imageData as Data, completion: .none)
+                }
             }
         }
         

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -821,9 +821,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
 
 - (void)postImage:(id<MediaAsset>)image
 {
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
-        [self.sendController sendMessageWithImageData:image.data completion:^() {}];
-    });
+    [self.sendController sendMessageWithImageData:image.data completion:^() {}];
 }
 
 @end
@@ -1048,17 +1046,17 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
 - (void)giphySearchViewController:(GiphySearchViewController *)giphySearchViewController didSelectImageData:(NSData *)imageData searchTerm:(NSString *)searchTerm
 {
     [self clearInputBar];
-    [self dismissViewControllerAnimated:YES completion:nil];
-    
-    NSString *messageText = nil;
-    
-    if ([searchTerm isEqualToString:@""]) {
-        messageText = [NSString stringWithFormat:NSLocalizedString(@"giphy.conversation.random_message", nil), searchTerm];
-    } else {
-        messageText = [NSString stringWithFormat:NSLocalizedString(@"giphy.conversation.message", nil), searchTerm];
-    }
-    
-    [self.sendController sendTextMessage:messageText mentions:@[] withImageData:imageData];
+    [self dismissViewControllerAnimated:YES completion:^{
+        NSString *messageText = nil;
+        
+        if ([searchTerm isEqualToString:@""]) {
+            messageText = [NSString stringWithFormat:NSLocalizedString(@"giphy.conversation.random_message", nil), searchTerm];
+        } else {
+            messageText = [NSString stringWithFormat:NSLocalizedString(@"giphy.conversation.message", nil), searchTerm];
+        }
+        
+        [self.sendController sendTextMessage:messageText mentions:@[] withImageData:imageData];
+    }];
 }
 
 @end


### PR DESCRIPTION
## What's new in this PR?

### Issues

We want to always show the message that was just sent from this device, even if user was looking on the older messages in the conversation history.

### Solutions

Message window observer is going to tell us if the new message is coming into the window, so we can check if this is the message that was just inserted.

Unfortunately the table view is showing the really weird behaviour w.r.t. scrolling position. Even if the position was set from the code, when some other part of the code is trying to enumerate the cells visible the table view layout is kicking in and moving the viewport back to the initial position.

The original fix is to blindly block the table view to accept any scroll position for the period of time.