### PR TITLE
Prevent link action if menu controller is visible

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Views/LinkInteractionTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/LinkInteractionTextView.swift
@@ -18,7 +18,7 @@
 
 
 import UIKit
-
+ 
 @objc public protocol TextViewInteractionDelegate: NSObjectProtocol {
     func textView(_ textView: LinkInteractionTextView, open url: URL) -> Bool
     func textViewDidLongPress(_ textView: LinkInteractionTextView)
@@ -103,6 +103,10 @@ extension LinkInteractionTextView: UITextViewDelegate {
     public func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
         switch interaction {
         case .invokeDefaultAction:
+            guard !UIMenuController.shared.isMenuVisible else {
+                return false // Don't open link/show alert if menu controller is visible
+            }
+            
             // if alert shown, link opening is handled in alert actions
             if showAlertIfNeeded(for: URL, in: characterRange) { return false }
             // data detector links should be handle by the system


### PR DESCRIPTION
## What's new in this PR?

### Issues

For a message containing only a markdown link, it's very hard to open the action menu since it's interrupted by the open link alert.

### Solutions

Don't perform the link action if the menu controller is visible.