### PR TITLE
Don't become first reponder when restoring quote from draft

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -194,16 +194,6 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
     [self.view addGestureRecognizer:pinchImageGestureRecognizer];
     
     [self createMentionsResultsView];
-    
-}
-
-- (void)loadQuotedMessageIfNeeded {
-    
-    ZMMessage *quote = self.conversation.draftMessage.quote;
-    
-    if (quote != nil && quote.conversation != nil) {
-        [self.delegate conversationContentViewController:self didTriggerReplyingToMessage:quote];
-    }
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -243,7 +233,6 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
     }
 
     [self scrollToFirstUnreadMessageIfNeeded];
-    [self loadQuotedMessageIfNeeded];
     UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, nil);
 }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -169,6 +169,10 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
 
     [self createConstraints];
     [self updateInputBarVisibility];
+    
+    if (self.conversation.draftMessage.quote != nil) {
+        [self.inputBarController addReplyComposingView:[self.contentViewController createReplyComposingViewForMessage:self.conversation.draftMessage.quote]];
+    }
 }
 
 - (void)createInputBarController

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Reply.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Reply.swift
@@ -26,10 +26,13 @@ extension ConversationInputBarViewController: ReplyComposingViewDelegate {
             removeReplyComposingView()
         }
         
-        self.quotedMessage = message
+        addReplyComposingView(composingView)
+    }
+    
+    @objc func addReplyComposingView(_ composingView: ReplyComposingView) {
+        self.quotedMessage = composingView.message
         self.replyComposingView = composingView
         composingView.delegate = self
-        inputBar.textView.becomeFirstResponder()
     }
     
     @objc func removeReplyComposingView() {


### PR DESCRIPTION
## What's new in this PR?

### Issues

If conversation had a draft with a quote it was impossible to dismiss the keyboard.

### Causes

We would call restore the reply composer form the draft in `viewWillAppear` and make the input bar first responder. This is trigger when the user dismisses the keyboard.

### Solutions

Restore the reply composer in `viewDidLoad` and don't make it first responder.
