### PR TITLE
Correctly pass the player to the soundcloud controllers

### DIFF
--- a/Wire-iOS/Sources/Components/AudioPlayer/AudioPlaylistViewController.m
+++ b/Wire-iOS/Sources/Components/AudioPlayer/AudioPlaylistViewController.m
@@ -92,6 +92,12 @@ static const CGFloat SeparatorLineOverflow = 4;
     return self;
 }
 
+- (instancetype)init
+{
+    self = [self initWithAudioTrackPlayer:[AppDelegate sharedAppDelegate].mediaPlaybackManager.audioTrackPlayer];
+    return self;
+}
+
 - (void)viewDidLoad
 {
     [super viewDidLoad];

--- a/Wire-iOS/Sources/Components/AudioPlayer/AudioTrackViewController.m
+++ b/Wire-iOS/Sources/Components/AudioPlayer/AudioTrackViewController.m
@@ -73,6 +73,12 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
     return self;
 }
 
+- (instancetype)init
+{
+    self = [self initWithAudioTrackPlayer:[AppDelegate sharedAppDelegate].mediaPlaybackManager.audioTrackPlayer];
+    return self;
+}
+
 - (void)viewDidLoad
 {
     [super viewDidLoad];

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationSoundCloudAttachmentCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationSoundCloudAttachmentCell.swift
@@ -19,7 +19,6 @@
 import Foundation
 
 protocol PlayerViewControllerProtocol: class, LinkAttachmentPresenter {
-    init(audioTrackPlayer: AudioTrackPlayer!)
     var providerImage: UIImage! { get set }
     var sourceMessage: ZMConversationMessage! { get set }
 }
@@ -32,11 +31,6 @@ class ConversationSoundCloudAttachmentCell<Player: UIViewController & PlayerView
     struct Configuration {
         let attachment: LinkAttachment
         let message: ZMConversationMessage
-    }
-
-    convenience init() {
-        let player = Player(audioTrackPlayer: AppDelegate.shared().mediaPlaybackManager?.audioTrackPlayer)
-        self.init(viewController: player)
     }
 
     func configure(with object: Configuration, animated: Bool) {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Soundcloud cells where unable to play the tracks.

### Causes

The view controllers backing the cells where missing the reference to the player.

It turned out that the `ConversationSoundCloudAttachmentCell.init` was not called, since the `ConversationSoundCloudAttachmentCell.init(frame:)` was called instead, where we just create the backing controller with alloc-init.

### Solutions

Changed the default implementation of player controllers to grab the default player, if they are created with alloc-init.