### PR TITLE
Separate localization string "Original message from %@" for German

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -497,7 +497,8 @@
 
 // Reply
 "content.message.reply" = "Reply";
-"content.message.reply.original_timestamp" = "Original message from %@";
+"content.message.reply.original_timestamp.date" = "Original message from %@";
+"content.message.reply.original_timestamp.time" = "Original message from %@";
 "content.message.reply.broken_message" = "You cannot see this message.";
 
 "content.message.open_link_alert.title" = "Visit Link";

--- a/Wire-iOS/Resources/de.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/de.lproj/Localizable.strings
@@ -479,6 +479,11 @@
 "content.reactions_list.likers" = "Gefällt";
 
 "content.file.too_big" = "Du kannst Dateien bis zu %@ senden";
+
+// Reply
+"content.message.reply.original_timestamp.date" = "Ursprüngliche Nachricht vom %@";
+"content.message.reply.original_timestamp.time" = "Ursprüngliche Nachricht von %@";
+
 // Someone pinged
 "content.ping.text" = "%@ hat gepingt";
 "content.ping.text-you" = "%@ hast gepingt";

--- a/Wire-iOS/Sources/Helpers/ZMConversationMessage+Date.swift
+++ b/Wire-iOS/Sources/Helpers/ZMConversationMessage+Date.swift
@@ -29,11 +29,11 @@ extension ZMConversationMessage {
 
         if Calendar.current.isDateInToday(timestamp) {
             formattedDate = Message.shortTimeFormatter.string(from: timestamp)
+            return "content.message.reply.original_timestamp.time".localized(args: formattedDate)
         } else {
             formattedDate = Message.shortDateFormatter.string(from: timestamp)
+            return "content.message.reply.original_timestamp.date".localized(args: formattedDate)
         }
-
-        return "content.message.reply.original_timestamp".localized(args: formattedDate)
     }
 
     func formattedReceivedDate() -> String? {


### PR DESCRIPTION
## What's new in this PR?

Separate localization string "Original message from %@" for German for the cases the timestamp is a date or a time in today.