### PR TITLE
Fix crash when trying to restore draft quote which has been deleted

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -170,7 +170,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
     [self createConstraints];
     [self updateInputBarVisibility];
     
-    if (self.conversation.draftMessage.quote != nil) {
+    if (self.conversation.draftMessage.quote != nil && !self.conversation.draftMessage.quote.hasBeenDeleted) {
         [self.inputBarController addReplyComposingView:[self.contentViewController createReplyComposingViewForMessage:self.conversation.draftMessage.quote]];
     }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

We were crashing when trying restore a draft with quote which has been deleted.

### Causes

The `ReplyComposingView` is asserting if the quoted message can't be be presented.

### Solutions

Don't attempt to restore deleted quotes.
