### PR TITLE
ZIOS-10871: Scroll to top of message when opening quote

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
@@ -233,7 +233,7 @@ extension ConversationContentViewController {
     @objc func scroll(toIndex indexToShow: Int, completion: ((UIView)->())? = .none) {
         let cellIndexPath = IndexPath(row: 0, section: indexToShow)
 
-        self.tableView.scrollToRow(at: cellIndexPath, at: .middle, animated: false)
+        self.tableView.scrollToRow(at: cellIndexPath, at: .top, animated: false)
         if let cell = self.tableView.cellForRow(at: cellIndexPath) {
             completion?(cell)
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

When the user was quoting a long message and they tapped the composer, we would scroll to the middle of the cell, which does not show the beginning of the original message.

### Solutions

Scroll to the top of the message.