### PR TITLE
Fix logic for when the sender and burst timestamp are displayed

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
@@ -289,7 +289,7 @@ extension IndexSet {
     }
     
     func isBurstTimestampVisible(in context: ConversationMessageContext) -> Bool {
-        return context.isTimeIntervalSinceLastMessageSignificant
+        return context.isTimeIntervalSinceLastMessageSignificant ||  context.isFirstUnreadMessage || context.isFirstMessageOfTheDay
     }
     
     func isToolboxVisible(in context: ConversationMessageContext) -> Bool {
@@ -301,7 +301,7 @@ extension IndexSet {
             return false
         }
         
-        return !context.isSameSenderAsPrevious || message.updatedAt != nil
+        return !context.isSameSenderAsPrevious || message.updatedAt != nil || isBurstTimestampVisible(in: context)
     }
     
     // MARK: - Data Source


### PR DESCRIPTION
## What's new in this PR?

- Unread dot was not always displayed for unread messages
- Burst timestamp was not always displayed for the first message of the day
- Sender should always be displayed if the burst timestamp is displayed.