### PR TITLE
ZIOS-10877: Fix position of scroll when opening a conversation with unread messages

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Scrolling.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Scrolling.m
@@ -65,7 +65,8 @@
 {
     NSUInteger index = [self.messageWindow.messages indexOfObject:message];
     if (index != NSNotFound) {
-        [self.tableView scrollToRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:index]
+        NSInteger rowIndex = [self.tableView numberOfRowsInSection:index] - 1;
+        [self.tableView scrollToRowAtIndexPath:[NSIndexPath indexPathForRow:rowIndex inSection:index]
                               atScrollPosition:UITableViewScrollPositionTop
                                       animated:animated];
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

When the user opened a conversation with unread messages, we'd scroll them to the top of the last cell in the first unread message section (ex: the link preview) instead of the top of the first cell in the section (ex: the burst timestamp). 

### Solutions

Fix the index of the cell we scroll to in the section to be the last cell's index, because the table view is upside down.