### PR TITLE
ZIOS-10871: Searching for a message in the collection scrolls to the message toolbox

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
@@ -231,7 +231,8 @@ extension ConversationContentViewController {
     }
     
     @objc func scroll(toIndex indexToShow: Int, completion: ((UIView)->())? = .none) {
-        let cellIndexPath = IndexPath(row: 0, section: indexToShow)
+        let rowIndex = tableView.numberOfCells(inSection: indexToShow) - 1
+        let cellIndexPath = IndexPath(row: rowIndex, section: indexToShow)
 
         self.tableView.scrollToRow(at: cellIndexPath, at: .top, animated: false)
         if let cell = self.tableView.cellForRow(at: cellIndexPath) {


### PR DESCRIPTION
## What's new in this PR?

### Issues

When the user opens a search result that isn't at the bottom of the viewport, it would scroll the last cell of the message section in view. While this works in some scenarios, it was only scrolling the message toolbox into view if the toolbox was open.

### Solutions

Like we did for scrolling to the latest unread message in #2918, we always scroll to the first cell in the section, which corresponds to the cell with the last index in the section in the context of upside down table view.