### PR TITLE
Fix missing edited icon accessibility identifier

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -501,6 +501,7 @@
 "content.message.reply.original_timestamp.date" = "Original message from %@";
 "content.message.reply.original_timestamp.time" = "Original message from %@";
 "content.message.reply.broken_message" = "You cannot see this message.";
+"content.message.reply.edited_message" = "Edited";
 
 "content.message.open_link_alert.title" = "Visit Link";
 "content.message.open_link_alert.message" = "This will take you to\n%@";

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/CellComponents/SenderNameCellComponent.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/CellComponents/SenderNameCellComponent.swift
@@ -34,6 +34,16 @@ class SenderNameCellComponent: UIView {
         set { indicatorView.image = newValue }
     }
 
+    var indicatorLabel: String? {
+        get {
+            return indicatorView.accessibilityLabel
+        }
+        set {
+            indicatorView.accessibilityLabel = newValue
+            indicatorView.isAccessibilityElement = newValue != nil
+        }
+    }
+
     // MARK: - Initialization
 
     override init(frame: CGRect) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationQuoteCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationQuoteCell.swift
@@ -113,6 +113,7 @@ class ConversationReplyContentView: UIView {
 
         senderComponent.senderName = object.senderName
         senderComponent.indicatorIcon = object.isEdited ? UIImage(for: .pencil, iconSize: .messageStatus, color: .from(scheme: .iconNormal)) : nil
+        senderComponent.indicatorLabel = object.isEdited ? "content.message.reply.edited_message".localized : nil
         timestampLabel.text = object.timestamp
 
         switch object.content {


### PR DESCRIPTION
## What's new in this PR?

### Issues

The "Edited" icon was not visible to Voice Over and automation inside a quote displaying an edited message.

### Solutions

Add an accessibility label and make the element accessible when the label is set.