### PR TITLE
Never show toolbox for system messages

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
@@ -293,6 +293,10 @@ extension IndexSet {
     }
     
     func isToolboxVisible(in context: ConversationMessageContext) -> Bool {
+        guard !message.isSystem else {
+            return false
+        }
+        
         return selected || context.isLastMessageSentBySelfUser || message.deliveryState == .failedToSend || message.hasReactions()
     }
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

Failed to decrypt message were having a toolbox

### Solutions

Never show the toolbox for system messages.


