### PR TITLE
Fix/message toolbox

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
@@ -81,7 +81,7 @@ extension IndexSet {
     /// The object that receives informations from the section.
     @objc weak var sectionDelegate: ConversationMessageSectionControllerDelegate?
     
-    /// Wheater this section is selected
+    /// Whether this section is selected
     private var selected: Bool
 
     private var changeObservers: [Any] = []

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -449,7 +449,7 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
                 
                 NSIndexPath *indexPath = [self.conversationMessageWindowTableViewAdapter indexPathForMessage:message];
                 
-                [[ZMUserSession sharedSession] enqueueChanges:^{
+                [[ZMUserSession sharedSession] performChanges:^{
                     [Message setLikedMessage:message liked:liked];
                 }];
                 


### PR DESCRIPTION
## What's new in this PR?

### Issues

Unliking a message collapses the toolbar, it should not.

### Causes

When unliking a message we remove the self user from the list of reactions on the message. Then check if the message is not selected and if it has no reactions, in which case we reselect the message so it doesn't collapse. 

The problem is that we were enqueueing the change to remove the self user from the reactions. Then when we check if the message has no reactions, it fails, because the change hasn't been saved yet.

### Solutions

Perform the change immediately.