### PR TITLE
Conversation: Reload when coming to the foreground

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -186,7 +186,8 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
     self.tableView.keyboardDismissMode = UIScrollViewKeyboardDismissModeInteractive;
     
     [UIView performWithoutAnimation:^{
-    self.tableView.backgroundColor = self.view.backgroundColor = [UIColor wr_colorFromColorScheme:ColorSchemeColorContentBackground];
+        self.tableView.backgroundColor = [UIColor wr_colorFromColorScheme:ColorSchemeColorContentBackground];
+        self.view.backgroundColor = [UIColor wr_colorFromColorScheme:ColorSchemeColorContentBackground];
     }];
     
     UIPinchGestureRecognizer *pinchImageGestureRecognizer = [[UIPinchGestureRecognizer alloc] initWithTarget:self action:@selector(onPinchZoom:)];
@@ -194,6 +195,18 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
     [self.view addGestureRecognizer:pinchImageGestureRecognizer];
     
     [self createMentionsResultsView];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(applicationDidBecomeActive:)
+                                                 name:UIApplicationDidBecomeActiveNotification
+                                               object:nil];
+
+}
+
+- (void)applicationDidBecomeActive:(NSNotification *)notification
+{
+    self.conversationMessageWindowTableViewAdapter.sectionControllers = [[NSMutableDictionary alloc] init];
+    [self.tableView reloadData];
 }
 
 - (void)viewWillAppear:(BOOL)animated

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter+Private.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter+Private.h
@@ -41,6 +41,7 @@ static NSString *const ConversationMessageTimerUpdateCellId = @"ConversationMess
 @class ConversationCell;
 @class UpsideDownTableView;
 @class ConversationCellActionController;
+@class ConversationMessageSectionController;
 
 @interface ConversationMessageWindowTableViewAdapter ()
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter.h
@@ -23,7 +23,6 @@
 #import "MessageAction.h"
 
 @protocol ConversationCellDelegate;
-@class ConversationMessageSectionController;
 @class AnyConversationMessageCellDescription;
 @class ConversationCellActionController;
 @class UpsideDownTableView;


### PR DESCRIPTION
## What's new in this PR?

### Issues

App is frequently crashing or is in the inconsistent state after sharing the content with the share extension.

### Investigation

Earlier today we discovered with @johnxnguyen that the CoreData does not really know what change happens from the other process (share extension) on the database, so it is failing to build the change set for the observers.

This is dangerous for the conversation view, since we usually only doing the delta updates, considering the inserted and deleted sections/rows.

### Solution

Temporary solution is to always reload the conversation view when app is activated. John is working on IPC solution where we would send the change set as darwin notification.