### PR TITLE
Fix crash on rendering empty sender name

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/CellComponents/SenderCellComponent.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/CellComponents/SenderCellComponent.swift
@@ -133,7 +133,7 @@ class SenderCellComponent: UIView {
     }
     
     private func attributedName(for kind: TextKind, string: String) -> NSAttributedString {
-        return string.attributedString.addAttributes([.foregroundColor : kind.color, .font : kind.font], toSubstring: string)
+        return NSAttributedString(string: string, attributes: [.foregroundColor : kind.color, .font : kind.font])
     }
     
 }

--- a/WireExtensionComponents/Utilities/AttributedStringOperators.swift
+++ b/WireExtensionComponents/Utilities/AttributedStringOperators.swift
@@ -227,8 +227,11 @@ public extension NSAttributedString {
     }
     
     @objc public func setAttributes(_ attributes: [NSAttributedString.Key: AnyObject], toSubstring substring: String) -> NSAttributedString {
+        let substringRange = (string as NSString).range(of: substring)
+        guard substringRange.location != NSNotFound else { return self }
+        
         let mutableSelf = NSMutableAttributedString(attributedString: self)
-        mutableSelf.setAttributes(attributes, range: (string as NSString).range(of: substring))
+        mutableSelf.setAttributes(attributes, range: substringRange)
         return NSAttributedString(attributedString: mutableSelf)
     }
 
@@ -265,7 +268,11 @@ extension Sequence where Iterator.Element == NSAttributedString {
 public extension NSMutableAttributedString {
 
     @objc public func addAttributes(_ attributes: [NSAttributedString.Key: AnyObject], to substring: String) {
-        addAttributes(attributes, range: (string as NSString).range(of: substring))
+        let substringRange = (string as NSString).range(of: substring)
+        
+        guard substringRange.location != NSNotFound else { return }
+        
+        addAttributes(attributes, range: substringRange)
     }
 
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

App would in some cases crash when constructing the sender name in a cell.

### Causes

We weren't handling the case of empty string in some of our attributed string operations, which would crash since we were sending invalid an `NSRange` to `NSMutableAttributedString.addAttributes(:range:)`.

### Solutions

This was already partially fixed in `ConversationCell+Sender.swift` by not using this method but not in the new `SenderCellComponent.swift`. We apply the same change there and guard against this scenario in attributed string operation methods.