### PR TITLE
Fix overlapping reuseIdentifiers if cell descriptors share the same view

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCellTableViewAdapter.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCellTableViewAdapter.swift
@@ -289,12 +289,12 @@ class ConversationMessageCellTableViewAdapter<C: ConversationMessageCellDescript
 extension UITableView {
 
     func register<C: ConversationMessageCellDescription>(cell: C.Type) {
-        let reuseIdentifier = String(describing: C.View.self)
+        let reuseIdentifier = String(describing: C.self)
         register(ConversationMessageCellTableViewAdapter<C>.self, forCellReuseIdentifier: reuseIdentifier)
     }
 
     func dequeueConversationCell<C: ConversationMessageCellDescription>(with description: C, for indexPath: IndexPath) -> ConversationMessageCellTableViewAdapter<C> {
-        let reuseIdentifier = String(describing: C.View.self)
+        let reuseIdentifier = String(describing: C.self)
 
         let cell = dequeueReusableCell(withIdentifier: reuseIdentifier, for: indexPath) as Any as! ConversationMessageCellTableViewAdapter<C>
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

We were crashing when re-using a `ConversationSystemMessageCell`.

### Causes

The crash happened due to a failed cast from `ConversationMessageCellDescription<ConversationMessageTimerCellDescription>` to  `ConversationMessageCellDescription<ConversationVerifiedSystemMessageSectionDescription>`.

This happens because both these cell description use the same view `ConversationSystemMessageCell` which is what's currently used as the reuse identifier.

### Solutions

Use the name of the cell description as the reuse identifier.