### PR TITLE
Don't generate PDF previews in Share Ext

### DIFF
--- a/Wire-iOS Share Extension/UnsentSendable.swift
+++ b/Wire-iOS Share Extension/UnsentSendable.swift
@@ -247,7 +247,16 @@ class UnsentFileSendable: UnsentSendableBase, UnsentSendable {
                     error?.log(message: "Unable to prepare file attachment for sending")
                     return completion()
                 }
-
+                
+                // Generating PDF previews can be expensive. To avoid hitting the Share Extension's
+                // memory budget we should avoid to generate previews if the file is a PDF.
+                guard !UTTypeConformsTo(url.UTI() as CFString, kUTTypePDF) else {
+                    self?.metadata = ZMFileMetadata(fileURL: url)
+                    completion()
+                    return
+                }
+                
+                // Generate preview
                 FileMetaDataGenerator.metadataForFileAtURL(url, UTI: url.UTI(), name: name ?? url.lastPathComponent) { [weak self] metadata in
                     self?.metadata = metadata
                     completion()


### PR DESCRIPTION
## What's new in this PR?

### Issues
Sending large PDF files crashes the Share Extension.

### Causes
The Share Extension is being terminated by the OS due to excessive memory usage. On iOS12 it appears that memory budget for the Share Extension is 120MB. 

The reasons for high memory consumption vary, but the first main issue with PDF's is the generation of the preview. When I send a particular PDF (33MB) with an image embedded in the cover page, the preview generation allocated about ~350MB on the heap. These allocations are taking place in `CoreGraphics`.

A second cause for high memory consumption is when we encrypt the file data before sending. The problem is that we have the file loaded in memory while we create an encrypted copy. This effectively duplicates the amount memory being used.

### Solutions
I spent some time looking for ways to optimise PDF page drawing but did not find anything efficient enough for reliable use in the Share Extension. The solution I arrived at is to simply not render the preview for PDFs (within the Share Extension).

In regards to data encryption, a potential solution (not implemented here) would be to use a stream to encrypt the data. We're currently using Apple's `CommonCrypto`, I'm not sure if it supports streams, perhaps we would need to switch to `libsodium` for file encryption.

## Notes
While this PR doesn't fix _all_ PDF sending in the Share Extension, it should help in many cases that are currently failing.