### PR TITLE
Don't assert on violet color by fixing off by one

### DIFF
--- a/WireExtensionComponents/Utilities/ColorScheme.m
+++ b/WireExtensionComponents/Utilities/ColorScheme.m
@@ -104,7 +104,7 @@
     static const CGFloat accentColorNameColorBlendingCoefficientsDark[] = {0.0f, 0.8f, 0.72f, 1.0f, 0.8f, 0.8f, 0.8f, 0.64f};
     static const CGFloat accentColorNameColorBlendingCoefficientsLight[] = {0.0f, 0.8f, 0.72f, 1.0f, 0.8f, 0.8f, 0.64f, 1.0f};
  
-    assert(accentColor < ZMAccentColorMax);
+    assert(accentColor <= ZMAccentColorMax);
     
     const CGFloat *coefficientsArray = variant == ColorSchemeVariantDark ? accentColorNameColorBlendingCoefficientsDark : accentColorNameColorBlendingCoefficientsLight;
     const CGFloat coefficient = coefficientsArray[accentColor];


### PR DESCRIPTION
## What's new in this PR?

### Issues

App hit an assertion if you account were using violet accent color.

### Solutions

Replace `=` with `<=` to also include the max color in the valid range of colors.