### PR TITLE
Fix: share extension fails to launch

### DIFF
--- a/Scripts/remove-bitcode.sh
+++ b/Scripts/remove-bitcode.sh
@@ -30,7 +30,7 @@ if [ "$PLATFORM_NAME" == "iphonesimulator" ] ; then
 	exit 0
 fi
 
-if [ "$CONFIGURATION" == "Debug" ] ; then
+if [ "$CONFIGURATION" == "Development" ] ; then
 	echo 'Not necessary to strip for debug.'
 	exit 0
 fi

--- a/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire Share Extension.xcscheme
+++ b/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire Share Extension.xcscheme
@@ -38,21 +38,11 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Development"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "BFAD54021E6972CD0015C677"
-               BuildableName = "NotificationFetchComponentsTests.xctest"
-               BlueprintName = "NotificationFetchComponentsTests"
-               ReferencedContainer = "container:Wire-iOS.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference
@@ -67,7 +57,7 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Development"
       selectedDebuggerIdentifier = ""
       selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       launchStyle = "0"
@@ -120,7 +110,7 @@
       </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
-      buildConfiguration = "Debug">
+      buildConfiguration = "Development">
    </AnalyzeAction>
    <ArchiveAction
       buildConfiguration = "Release"

--- a/Wire-iOS.xcodeproj/xcshareddata/xcschemes/WireExtensionComponents.xcscheme
+++ b/Wire-iOS.xcodeproj/xcshareddata/xcschemes/WireExtensionComponents.xcscheme
@@ -23,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Development"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
@@ -33,7 +33,7 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Development"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -71,7 +71,7 @@
       </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
-      buildConfiguration = "Debug">
+      buildConfiguration = "Development">
    </AnalyzeAction>
    <ArchiveAction
       buildConfiguration = "Release"

--- a/Wire-iOS/Resources/Configuration/Share Extension/Share-Extension-Base.xcconfig
+++ b/Wire-iOS/Resources/Configuration/Share Extension/Share-Extension-Base.xcconfig
@@ -25,6 +25,9 @@ APPLICATION_EXTENSION_API_ONLY = YES
 // Deployment
 SKIP_INSTALL = YES
 
+// Linking
+LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks @executable_path/../../Frameworks @loader_path/Frameworks $(PROJECT_DIR)/Carthage/Build/iOS ;
+
 // Packaging
 DEFINES_MODULE = NO
 INFOPLIST_FILE = Wire-iOS Share Extension/Info.plist

--- a/Wire-iOS/Resources/Configuration/Warnings.xcconfig
+++ b/Wire-iOS/Resources/Configuration/Warnings.xcconfig
@@ -16,7 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-GCC_TREAT_WARNINGS_AS_ERRORS[config=Debug] = YES
+GCC_TREAT_WARNINGS_AS_ERRORS[config=Development] = YES
 GCC_WARN_ABOUT_RETURN_TYPE = YES
 GCC_WARN_SIGN_COMPARE = YES
 GCC_WARN_UNINITIALIZED_AUTOS = YES


### PR DESCRIPTION
## What's new in this PR?

### Issues

After #2941 was merged the share extension would not launch.

### Causes

The extension could not launch with error:
```
dyld: Library not loaded: @rpath/WireExtensionComponents.framework/WireExtensionComponents
```

This means that it could not locate `WireExtensionComponents.framework`. 

### Solutions

After comparing the configuration before the changes it seems we missed adding one entry to `LD_RUNPATH_SEARCH_PATHS`. 
The framework is located in `Wire.app/Frameworks/WireExtensionComponents.framework` and the share extension lives in `Wire.app/Plugins/Wire Share Extension.appex`. 
When it is launched it would only try to look inside its own `Frameworks` folder and could not find `WireExtensionComponents.framework` because it's located inside main app . Adding `@executable_path/../../Frameworks` fixed the issue.

## Notes

Also removed traces of `Debug` configuration which was still present in the project.
