### PR TITLE
Revert configuration name back to Debug

### DIFF
--- a/Scripts/remove-bitcode.sh
+++ b/Scripts/remove-bitcode.sh
@@ -30,7 +30,7 @@ if [ "$PLATFORM_NAME" == "iphonesimulator" ] ; then
 	exit 0
 fi
 
-if [ "$CONFIGURATION" == "Development" ] ; then
+if [ "$CONFIGURATION" == "Debug" ] ; then
 	echo 'Not necessary to strip for debug.'
 	exit 0
 fi

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -8585,12 +8585,12 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
-		168A16B51D9597C2005CFA6C /* Development */ = {
+		168A16B51D9597C2005CFA6C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = F1B24239219B2C9B00F7035C /* Share-Extension-Development.xcconfig */;
 			buildSettings = {
 			};
-			name = Development;
+			name = Debug;
 		};
 		168A16B61D9597C2005CFA6C /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -8599,12 +8599,12 @@
 			};
 			name = Release;
 		};
-		1EE85C6A1B5F96FC008E084B /* Development */ = {
+		1EE85C6A1B5F96FC008E084B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = F114466521A2D8CC00B5FEBA /* ExtensionComponents-Development.xcconfig */;
 			buildSettings = {
 			};
-			name = Development;
+			name = Debug;
 		};
 		1EE85C6B1B5F96FC008E084B /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -8613,11 +8613,11 @@
 			};
 			name = Release;
 		};
-		8F42C556199244A700288E4D /* Development */ = {
+		8F42C556199244A700288E4D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 			};
-			name = Development;
+			name = Debug;
 		};
 		8F42C557199244A700288E4D /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -8625,12 +8625,12 @@
 			};
 			name = Release;
 		};
-		8F42C559199244A700288E4D /* Development */ = {
+		8F42C559199244A700288E4D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = F1B24232219B2C9B00F7035C /* Wire-iOS-Development.xcconfig */;
 			buildSettings = {
 			};
-			name = Development;
+			name = Debug;
 		};
 		8F42C55A199244A700288E4D /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -8639,12 +8639,12 @@
 			};
 			name = Release;
 		};
-		BACB885A1AF7C48900DDCDB0 /* Development */ = {
+		BACB885A1AF7C48900DDCDB0 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = F114466821A2F8BC00B5FEBA /* Tests-Development.xcconfig */;
 			buildSettings = {
 			};
-			name = Development;
+			name = Debug;
 		};
 		BACB885B1AF7C48900DDCDB0 /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -8659,7 +8659,7 @@
 		168A16B41D9597C2005CFA6C /* Build configuration list for PBXNativeTarget "Wire Share Extension" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				168A16B51D9597C2005CFA6C /* Development */,
+				168A16B51D9597C2005CFA6C /* Debug */,
 				168A16B61D9597C2005CFA6C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -8668,7 +8668,7 @@
 		1EE85C701B5F96FC008E084B /* Build configuration list for PBXNativeTarget "WireExtensionComponents" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				1EE85C6A1B5F96FC008E084B /* Development */,
+				1EE85C6A1B5F96FC008E084B /* Debug */,
 				1EE85C6B1B5F96FC008E084B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -8677,7 +8677,7 @@
 		8F42C533199244A700288E4D /* Build configuration list for PBXProject "Wire-iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				8F42C556199244A700288E4D /* Development */,
+				8F42C556199244A700288E4D /* Debug */,
 				8F42C557199244A700288E4D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -8686,7 +8686,7 @@
 		8F42C558199244A700288E4D /* Build configuration list for PBXNativeTarget "Wire-iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				8F42C559199244A700288E4D /* Development */,
+				8F42C559199244A700288E4D /* Debug */,
 				8F42C55A199244A700288E4D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -8695,7 +8695,7 @@
 		BACB88591AF7C48900DDCDB0 /* Build configuration list for PBXNativeTarget "Wire-iOS-Tests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BACB885A1AF7C48900DDCDB0 /* Development */,
+				BACB885A1AF7C48900DDCDB0 /* Debug */,
 				BACB885B1AF7C48900DDCDB0 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -3163,8 +3163,8 @@
 		F1141C961F5EB2DC005340B3 /* WireApplication.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WireApplication.swift; sourceTree = "<group>"; };
 		F114466321A2D8CC00B5FEBA /* ExtensionComponents-Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "ExtensionComponents-Base.xcconfig"; sourceTree = "<group>"; };
 		F114466421A2D8CC00B5FEBA /* ExtensionComponents-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "ExtensionComponents-Release.xcconfig"; sourceTree = "<group>"; };
-		F114466521A2D8CC00B5FEBA /* ExtensionComponents-Development.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "ExtensionComponents-Development.xcconfig"; sourceTree = "<group>"; };
-		F114466821A2F8BC00B5FEBA /* Tests-Development.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Tests-Development.xcconfig"; sourceTree = "<group>"; };
+		F114466521A2D8CC00B5FEBA /* ExtensionComponents-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "ExtensionComponents-Debug.xcconfig"; sourceTree = "<group>"; };
+		F114466821A2F8BC00B5FEBA /* Tests-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Tests-Debug.xcconfig"; sourceTree = "<group>"; };
 		F114466921A56F3200B5FEBA /* Version.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Version.xcconfig; sourceTree = "<group>"; };
 		F1199D2F1FC8490A0070FAC3 /* TeamCreationState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TeamCreationState.swift; sourceTree = "<group>"; };
 		F1199D301FC8490A0070FAC3 /* TeamCreationStepController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TeamCreationStepController.swift; sourceTree = "<group>"; };
@@ -3174,7 +3174,7 @@
 		F1199D3E1FC849440070FAC3 /* VerificationCodeFieldDescription.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerificationCodeFieldDescription.swift; sourceTree = "<group>"; };
 		F127BD561E262E9F0093B2F1 /* CollectionsViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionsViewControllerTests.swift; sourceTree = "<group>"; };
 		F127BD581E265FB40093B2F1 /* MockCollection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockCollection.swift; sourceTree = "<group>"; };
-		F12C48EF2199D2C200F49548 /* Development.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Development.xcconfig; sourceTree = "<group>"; };
+		F12C48EF2199D2C200F49548 /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		F12C48F02199D2C200F49548 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		F12C48F12199D2C200F49548 /* Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
 		F12CDADA1E43868200CEFCEB /* ChangeEmailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChangeEmailViewController.swift; sourceTree = "<group>"; };
@@ -3213,14 +3213,14 @@
 		F19C3A8E20513532004387E4 /* DatabaseStatisticsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseStatisticsController.swift; sourceTree = "<group>"; };
 		F1A989CF1FD1630300B8A82E /* SecondaryViewDescription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondaryViewDescription.swift; sourceTree = "<group>"; };
 		F1B2422F219B2C9B00F7035C /* Project-Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Project-Base.xcconfig"; sourceTree = "<group>"; };
-		F1B24230219B2C9B00F7035C /* Project-Development.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Project-Development.xcconfig"; sourceTree = "<group>"; };
-		F1B24232219B2C9B00F7035C /* Wire-iOS-Development.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Wire-iOS-Development.xcconfig"; sourceTree = "<group>"; };
+		F1B24230219B2C9B00F7035C /* Project-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Project-Debug.xcconfig"; sourceTree = "<group>"; };
+		F1B24232219B2C9B00F7035C /* Wire-iOS-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Wire-iOS-Debug.xcconfig"; sourceTree = "<group>"; };
 		F1B24233219B2C9B00F7035C /* Wire-iOS-Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Wire-iOS-Base.xcconfig"; sourceTree = "<group>"; };
 		F1B24234219B2C9B00F7035C /* Wire-iOS-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Wire-iOS-Release.xcconfig"; sourceTree = "<group>"; };
 		F1B24235219B2C9B00F7035C /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		F1B24236219B2C9B00F7035C /* Project-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Project-Release.xcconfig"; sourceTree = "<group>"; };
 		F1B24238219B2C9B00F7035C /* Share-Extension-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Share-Extension-Release.xcconfig"; sourceTree = "<group>"; };
-		F1B24239219B2C9B00F7035C /* Share-Extension-Development.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Share-Extension-Development.xcconfig"; sourceTree = "<group>"; };
+		F1B24239219B2C9B00F7035C /* Share-Extension-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Share-Extension-Debug.xcconfig"; sourceTree = "<group>"; };
 		F1B2423A219B2C9B00F7035C /* Share-Extension-Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Share-Extension-Base.xcconfig"; sourceTree = "<group>"; };
 		F1B5D54C2182096B00986911 /* NetworkConditionIndicatorView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkConditionIndicatorView.swift; sourceTree = "<group>"; };
 		F1B5EAC62029AB9A0081D402 /* SimpleTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleTextField.swift; sourceTree = "<group>"; };
@@ -6544,7 +6544,7 @@
 			isa = PBXGroup;
 			children = (
 				F114466321A2D8CC00B5FEBA /* ExtensionComponents-Base.xcconfig */,
-				F114466521A2D8CC00B5FEBA /* ExtensionComponents-Development.xcconfig */,
+				F114466521A2D8CC00B5FEBA /* ExtensionComponents-Debug.xcconfig */,
 				F114466421A2D8CC00B5FEBA /* ExtensionComponents-Release.xcconfig */,
 			);
 			path = ExtensionComponents;
@@ -6553,7 +6553,7 @@
 		F114466721A2F89D00B5FEBA /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				F114466821A2F8BC00B5FEBA /* Tests-Development.xcconfig */,
+				F114466821A2F8BC00B5FEBA /* Tests-Debug.xcconfig */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -6584,7 +6584,7 @@
 			isa = PBXGroup;
 			children = (
 				F12C48F12199D2C200F49548 /* Base.xcconfig */,
-				F12C48EF2199D2C200F49548 /* Development.xcconfig */,
+				F12C48EF2199D2C200F49548 /* Debug.xcconfig */,
 				F12C48F02199D2C200F49548 /* Release.xcconfig */,
 			);
 			path = Configuration;
@@ -6639,7 +6639,7 @@
 				F1B24235219B2C9B00F7035C /* Warnings.xcconfig */,
 				F114466921A56F3200B5FEBA /* Version.xcconfig */,
 				F1B2422F219B2C9B00F7035C /* Project-Base.xcconfig */,
-				F1B24230219B2C9B00F7035C /* Project-Development.xcconfig */,
+				F1B24230219B2C9B00F7035C /* Project-Debug.xcconfig */,
 				F1B24236219B2C9B00F7035C /* Project-Release.xcconfig */,
 				F1B24231219B2C9B00F7035C /* Wire-iOS */,
 				F114466221A2D8B500B5FEBA /* ExtensionComponents */,
@@ -6653,7 +6653,7 @@
 			isa = PBXGroup;
 			children = (
 				F1B24233219B2C9B00F7035C /* Wire-iOS-Base.xcconfig */,
-				F1B24232219B2C9B00F7035C /* Wire-iOS-Development.xcconfig */,
+				F1B24232219B2C9B00F7035C /* Wire-iOS-Debug.xcconfig */,
 				F1B24234219B2C9B00F7035C /* Wire-iOS-Release.xcconfig */,
 			);
 			path = "Wire-iOS";
@@ -6663,7 +6663,7 @@
 			isa = PBXGroup;
 			children = (
 				F1B2423A219B2C9B00F7035C /* Share-Extension-Base.xcconfig */,
-				F1B24239219B2C9B00F7035C /* Share-Extension-Development.xcconfig */,
+				F1B24239219B2C9B00F7035C /* Share-Extension-Debug.xcconfig */,
 				F1B24238219B2C9B00F7035C /* Share-Extension-Release.xcconfig */,
 			);
 			path = "Share Extension";
@@ -8587,7 +8587,7 @@
 /* Begin XCBuildConfiguration section */
 		168A16B51D9597C2005CFA6C /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F1B24239219B2C9B00F7035C /* Share-Extension-Development.xcconfig */;
+			baseConfigurationReference = F1B24239219B2C9B00F7035C /* Share-Extension-Debug.xcconfig */;
 			buildSettings = {
 			};
 			name = Debug;
@@ -8601,7 +8601,7 @@
 		};
 		1EE85C6A1B5F96FC008E084B /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F114466521A2D8CC00B5FEBA /* ExtensionComponents-Development.xcconfig */;
+			baseConfigurationReference = F114466521A2D8CC00B5FEBA /* ExtensionComponents-Debug.xcconfig */;
 			buildSettings = {
 			};
 			name = Debug;
@@ -8627,7 +8627,7 @@
 		};
 		8F42C559199244A700288E4D /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F1B24232219B2C9B00F7035C /* Wire-iOS-Development.xcconfig */;
+			baseConfigurationReference = F1B24232219B2C9B00F7035C /* Wire-iOS-Debug.xcconfig */;
 			buildSettings = {
 			};
 			name = Debug;
@@ -8641,14 +8641,14 @@
 		};
 		BACB885A1AF7C48900DDCDB0 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F114466821A2F8BC00B5FEBA /* Tests-Development.xcconfig */;
+			baseConfigurationReference = F114466821A2F8BC00B5FEBA /* Tests-Debug.xcconfig */;
 			buildSettings = {
 			};
 			name = Debug;
 		};
 		BACB885B1AF7C48900DDCDB0 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F114466821A2F8BC00B5FEBA /* Tests-Development.xcconfig */;
+			baseConfigurationReference = F114466821A2F8BC00B5FEBA /* Tests-Debug.xcconfig */;
 			buildSettings = {
 			};
 			name = Release;

--- a/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire Share Extension.xcscheme
+++ b/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire Share Extension.xcscheme
@@ -38,7 +38,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Development"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
@@ -57,7 +57,7 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Development"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = ""
       selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       launchStyle = "0"
@@ -110,7 +110,7 @@
       </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
-      buildConfiguration = "Development">
+      buildConfiguration = "Debug">
    </AnalyzeAction>
    <ArchiveAction
       buildConfiguration = "Release"

--- a/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
+++ b/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
@@ -23,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Development"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       disableMainThreadChecker = "YES"
@@ -59,7 +59,7 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Development"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -180,7 +180,7 @@
       </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
-      buildConfiguration = "Development">
+      buildConfiguration = "Debug">
    </AnalyzeAction>
    <ArchiveAction
       buildConfiguration = "Release"

--- a/Wire-iOS.xcodeproj/xcshareddata/xcschemes/WireExtensionComponents.xcscheme
+++ b/Wire-iOS.xcodeproj/xcshareddata/xcschemes/WireExtensionComponents.xcscheme
@@ -23,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Development"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
@@ -33,7 +33,7 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Development"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -71,7 +71,7 @@
       </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
-      buildConfiguration = "Development">
+      buildConfiguration = "Debug">
    </AnalyzeAction>
    <ArchiveAction
       buildConfiguration = "Release"

--- a/Wire-iOS/Resources/Configuration/ExtensionComponents/ExtensionComponents-Debug.xcconfig
+++ b/Wire-iOS/Resources/Configuration/ExtensionComponents/ExtensionComponents-Debug.xcconfig
@@ -16,18 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-#include "../Project-Development.xcconfig"
+#include "../Project-Debug.xcconfig"
+#include "ExtensionComponents-Base.xcconfig"
 
-// Linking
-BUNDLE_LOADER = $(TEST_HOST)
-
-// Packaging
-INFOPLIST_FILE = Wire-iOS Tests/Info.plist
-PRODUCT_NAME = $(TARGET_NAME)
-PRODUCT_BUNDLE_IDENTIFIER = $(WIRE_BUNDLE_ID).$(PRODUCT_NAME:rfc1034identifier)
-
-// Swift Compiler - General
-SWIFT_OBJC_BRIDGING_HEADER = Wire-iOS Tests/Wire-iOS-Tests-Bridging-Header.h
-
-// Testing
-TEST_HOST = $(BUILT_PRODUCTS_DIR)/Wire.app/Wire

--- a/Wire-iOS/Resources/Configuration/Project-Debug.xcconfig
+++ b/Wire-iOS/Resources/Configuration/Project-Debug.xcconfig
@@ -16,7 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-#include "../../../Configuration/Development.xcconfig"
+#include "../../../Configuration/Debug.xcconfig"
 #include "Project-Base.xcconfig"
 
 // Architectures

--- a/Wire-iOS/Resources/Configuration/Share Extension/Share-Extension-Debug.xcconfig
+++ b/Wire-iOS/Resources/Configuration/Share Extension/Share-Extension-Debug.xcconfig
@@ -16,6 +16,5 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-#include "../Project-Development.xcconfig"
-#include "ExtensionComponents-Base.xcconfig"
-
+#include "../Project-Debug.xcconfig"
+#include "Share-Extension-Base.xcconfig"

--- a/Wire-iOS/Resources/Configuration/Tests/Tests-Debug.xcconfig
+++ b/Wire-iOS/Resources/Configuration/Tests/Tests-Debug.xcconfig
@@ -14,9 +14,20 @@
 // 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-//
+// 
 
-#include "Wire-iOS-Base.xcconfig"
-#include "../Project-Development.xcconfig"
+#include "../Project-Debug.xcconfig"
 
-GCC_SYMBOLS_PRIVATE_EXTERN = NO
+// Linking
+BUNDLE_LOADER = $(TEST_HOST)
+
+// Packaging
+INFOPLIST_FILE = Wire-iOS Tests/Info.plist
+PRODUCT_NAME = $(TARGET_NAME)
+PRODUCT_BUNDLE_IDENTIFIER = $(WIRE_BUNDLE_ID).$(PRODUCT_NAME:rfc1034identifier)
+
+// Swift Compiler - General
+SWIFT_OBJC_BRIDGING_HEADER = Wire-iOS Tests/Wire-iOS-Tests-Bridging-Header.h
+
+// Testing
+TEST_HOST = $(BUILT_PRODUCTS_DIR)/Wire.app/Wire

--- a/Wire-iOS/Resources/Configuration/Warnings.xcconfig
+++ b/Wire-iOS/Resources/Configuration/Warnings.xcconfig
@@ -16,7 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-GCC_TREAT_WARNINGS_AS_ERRORS[config=Development] = YES
+GCC_TREAT_WARNINGS_AS_ERRORS[config=Debug] = YES
 GCC_WARN_ABOUT_RETURN_TYPE = YES
 GCC_WARN_SIGN_COMPARE = YES
 GCC_WARN_UNINITIALIZED_AUTOS = YES

--- a/Wire-iOS/Resources/Configuration/Wire-iOS/Wire-iOS-Debug.xcconfig
+++ b/Wire-iOS/Resources/Configuration/Wire-iOS/Wire-iOS-Debug.xcconfig
@@ -14,7 +14,9 @@
 // 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
+//
 
-#include "../Project-Development.xcconfig"
-#include "Share-Extension-Base.xcconfig"
+#include "Wire-iOS-Base.xcconfig"
+#include "../Project-Debug.xcconfig"
+
+GCC_SYMBOLS_PRIVATE_EXTERN = NO

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -13,7 +13,7 @@ platform :ios do
     lane :build do
         scan(
             scheme: "Wire-iOS",
-            configuration: "Development",
+            configuration: "Debug",
             build_for_testing: true,
             devices: ["iPhone 7"],
             code_coverage: true,
@@ -28,7 +28,7 @@ platform :ios do
     lane :test do
         scan(
             scheme: "Wire-iOS",
-            configuration: "Development",
+            configuration: "Debug",
             test_without_building: true,
             devices: ["iPhone 7"],
             code_coverage: true,


### PR DESCRIPTION
## What's new in this PR?

### Issues

We were having some issues after #2941 because configuration was renamed to Development. When building with other frameworks dragged in it would not be found because they are in "Debug" folder inside build products, but the app is being built in "Development"

