### PR TITLE
[WIP] ZIOS-10761: Fix actions in ephemeral collection items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,4 @@ Scripts/**/.build
 /fastlane/report.xml
 /test
 /fastlane/README.md
-Configuration/**
+Configuration

--- a/Wire-iOS Tests/ConversationCellActionControllerTests.swift
+++ b/Wire-iOS Tests/ConversationCellActionControllerTests.swift
@@ -19,7 +19,7 @@
 import XCTest
 @testable import Wire
 
-class ConversationCellActionControllerTests: CoreDataSnapshotTestCase {
+class ConversationMessageActionControllerTests: CoreDataSnapshotTestCase {
     
     // MARK: - Single Tap Action
     
@@ -30,7 +30,7 @@ class ConversationCellActionControllerTests: CoreDataSnapshotTestCase {
         message.conversation = otherUserConversation
         
         // WHEN
-        let actionController = ConversationCellActionController(responder: nil, message: message)
+        let actionController = ConversationMessageActionController(responder: nil, message: message)
         let singleTapAction = actionController.singleTapAction
         
         // THEN
@@ -44,7 +44,7 @@ class ConversationCellActionControllerTests: CoreDataSnapshotTestCase {
         message.conversation = otherUserConversation
         
         // WHEN
-        let actionController = ConversationCellActionController(responder: nil, message: message)
+        let actionController = ConversationMessageActionController(responder: nil, message: message)
         let singleTapAction = actionController.singleTapAction
         
         // THEN
@@ -61,8 +61,8 @@ class ConversationCellActionControllerTests: CoreDataSnapshotTestCase {
         message.deliveryState = .failedToSend
 
         // WHEN
-        let actionController = ConversationCellActionController(responder: nil, message: message)
-        let supportsReply = actionController.canPerformAction(#selector(ConversationCellActionController.quoteMessage))
+        let actionController = ConversationMessageActionController(responder: nil, message: message)
+        let supportsReply = actionController.canPerformAction(#selector(ConversationMessageActionController.quoteMessage))
 
         // THEN
         XCTAssertFalse(supportsReply)

--- a/Wire-iOS Tests/ConversationMessageCell/MockCell.swift
+++ b/Wire-iOS Tests/ConversationMessageCell/MockCell.swift
@@ -45,7 +45,7 @@ class MockCellDescription<T>: ConversationMessageCellDescription {
 
     weak var message: ZMConversationMessage?
     weak var delegate: ConversationCellDelegate?
-    weak var actionController: ConversationCellActionController?
+    weak var actionController: ConversationMessageActionController?
 
     var accessibilityIdentifier: String?
     var accessibilityLabel: String?

--- a/Wire-iOS Tests/DeleteMessageTests.swift
+++ b/Wire-iOS Tests/DeleteMessageTests.swift
@@ -67,13 +67,13 @@ final class DeleteMessageTests: XCTestCase {
         return message as Any as? ZMConversationMessage
     }
 
-    func actionController(for conversationType: ConversationCellType) -> ConversationCellActionController {
+    func actionController(for conversationType: ConversationCellType) -> ConversationMessageActionController {
         let message = self.message(for: conversationType)!
-        return ConversationCellActionController(responder: nil, message: message)
+        return ConversationMessageActionController(responder: nil, message: message)
     }
 
     func testThatTheExpectedCellsCanBeDeleted() {
-        let deleteAction = #selector(ConversationCellActionController.deleteMessage)
+        let deleteAction = #selector(ConversationMessageActionController.deleteMessage)
 
         // can perform action decides if the action will be present in menu, therefore be deletable
         let textMessageCell = actionController(for: .text)

--- a/Wire-iOS Tests/LocationPreviewControllerTests.swift
+++ b/Wire-iOS Tests/LocationPreviewControllerTests.swift
@@ -20,16 +20,11 @@ import XCTest
 @testable import Wire
 
 class MockActionResponder: NSObject, MessageActionResponder {
-    func canPerform(_ action: MessageAction, for message: ZMConversationMessage!) -> Bool {
-        // no-op
-        return false
-    }
-    
+
     func wants(toPerform action: MessageAction, for message: ZMConversationMessage!) {
         // no-op
     }
-    
-    
+        
 }
 
 final class LocationPreviewControllerTests: ZMSnapshotTestCase {

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -334,7 +334,7 @@
 		5EB45761204EA75300BA217A /* CallQualityDismissalTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EB45760204EA75300BA217A /* CallQualityDismissalTransition.swift */; };
 		5EBBE96B21872060008BC1B7 /* MockCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EBBE96721871F70008BC1B7 /* MockCell.swift */; };
 		5EBBE96D218751D0008BC1B7 /* ConversationLegacyCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EBBE96C218751D0008BC1B7 /* ConversationLegacyCell.swift */; };
-		5EBBE96F218783A2008BC1B7 /* ConversationCellActionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EBBE96E218783A2008BC1B7 /* ConversationCellActionController.swift */; };
+		5EBBE96F218783A2008BC1B7 /* ConversationMessageActionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EBBE96E218783A2008BC1B7 /* ConversationMessageActionController.swift */; };
 		5EBBE97121878D09008BC1B7 /* ConversationMessageToolboxCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EBBE97021878D09008BC1B7 /* ConversationMessageToolboxCell.swift */; };
 		5EBBE9732187A844008BC1B7 /* MessageToolboxViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EBBE9722187A844008BC1B7 /* MessageToolboxViewTests.swift */; };
 		5EBBE9782188B85B008BC1B7 /* ZMMessage+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EBBE9772188B85A008BC1B7 /* ZMMessage+Actions.swift */; };
@@ -1839,7 +1839,7 @@
 		5EB45760204EA75300BA217A /* CallQualityDismissalTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallQualityDismissalTransition.swift; sourceTree = "<group>"; };
 		5EBBE96721871F70008BC1B7 /* MockCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCell.swift; sourceTree = "<group>"; };
 		5EBBE96C218751D0008BC1B7 /* ConversationLegacyCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationLegacyCell.swift; sourceTree = "<group>"; };
-		5EBBE96E218783A2008BC1B7 /* ConversationCellActionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationCellActionController.swift; sourceTree = "<group>"; };
+		5EBBE96E218783A2008BC1B7 /* ConversationMessageActionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationMessageActionController.swift; sourceTree = "<group>"; };
 		5EBBE97021878D09008BC1B7 /* ConversationMessageToolboxCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationMessageToolboxCell.swift; sourceTree = "<group>"; };
 		5EBBE9722187A844008BC1B7 /* MessageToolboxViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageToolboxViewTests.swift; sourceTree = "<group>"; };
 		5EBBE9772188B85A008BC1B7 /* ZMMessage+Actions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMMessage+Actions.swift"; sourceTree = "<group>"; };
@@ -2437,7 +2437,7 @@
 		8F41CFC5199297C600E3B032 /* ZMConversation+Additions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ZMConversation+Additions.m"; sourceTree = "<group>"; };
 		8F41CFC6199297C600E3B032 /* Message+UI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Message+UI.h"; sourceTree = "<group>"; };
 		8F41CFC7199297C600E3B032 /* Message+UI.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "Message+UI.m"; sourceTree = "<group>"; };
-		8F42C538199244A700288E4D /* Wire.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Wire.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		8F42C538199244A700288E4D /* Wire.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = Wire.app; path = .app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8F5A3E9A19AE2C9E00D0E9DA /* avs+iOS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "avs+iOS.h"; sourceTree = "<group>"; };
 		8F5A3E9B19AE2C9E00D0E9DA /* AVSMediaManager+Additions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "AVSMediaManager+Additions.h"; sourceTree = "<group>"; };
 		8F5A3E9C19AE2C9E00D0E9DA /* AVSMediaManager+Additions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "AVSMediaManager+Additions.m"; sourceTree = "<group>"; };
@@ -3801,7 +3801,7 @@
 				166264FF217DAC4F00300F45 /* ConversationMessageCell.swift */,
 				5E35F732217F147A00D3F4FE /* ConversationMessageSectionController.swift */,
 				16626501217DACBE00300F45 /* ConversationMessageCellTableViewAdapter.swift */,
-				5EBBE96E218783A2008BC1B7 /* ConversationCellActionController.swift */,
+				5EBBE96E218783A2008BC1B7 /* ConversationMessageActionController.swift */,
 				5E35F7462180A25100D3F4FE /* Content */,
 				5E35F734217F415700D3F4FE /* Components */,
 			);
@@ -6610,7 +6610,7 @@
 				F12C48F02199D2C200F49548 /* Release.xcconfig */,
 			);
 			path = Configuration;
-			sourceTree = "<group>";
+			sourceTree = SOURCE_ROOT;
 		};
 		F12CDAD91E43868200CEFCEB /* ChangingDetails */ = {
 			isa = PBXGroup;
@@ -8035,7 +8035,7 @@
 				F1199D3F1FC849450070FAC3 /* BackButtonDescription.swift in Sources */,
 				54F7C2851D746F3F004D8087 /* AddressBookHelper+Automation.swift in Sources */,
 				BF4D99BF1E78555700A7B08F /* ZMConversationMessageWindow+DaySeparator.swift in Sources */,
-				5EBBE96F218783A2008BC1B7 /* ConversationCellActionController.swift in Sources */,
+				5EBBE96F218783A2008BC1B7 /* ConversationMessageActionController.swift in Sources */,
 				BFAAB2391DEC6B2800CBC096 /* ConversationListViewController+Handles.swift in Sources */,
 				EF2127051FB9DFE300625A9B /* RegistrationTextField.m in Sources */,
 				BF0BDF801DAB8923003C61DE /* EphemeralKeyboardViewController.swift in Sources */,

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -387,6 +387,7 @@
 		5EF5C54C209B33E600676405 /* CGSize+AspectRatio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF5C54B209B33E600676405 /* CGSize+AspectRatio.swift */; };
 		5EF5CDA520EF739200CC98B0 /* DataTaskSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF5CDA420EF739200CC98B0 /* DataTaskSession.swift */; };
 		5EF5CDAA20EF925000CC98B0 /* MockDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF5CDA620EF903A00CC98B0 /* MockDataTask.swift */; };
+		5EFCB3BF21AAD46C00E892D9 /* Message+Pasteboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EFCB3BE21AAD46C00E892D9 /* Message+Pasteboard.swift */; };
 		5EFD4526215A78E800BEE703 /* IndexedListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EFD4525215A78E800BEE703 /* IndexedListView.swift */; };
 		5EFE9BFF21246483007932A6 /* RegistrationFinalErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EFE9BFE21246483007932A6 /* RegistrationFinalErrorHandler.swift */; };
 		5EFE9C01212468E8007932A6 /* RegistrationSuccessEventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EFE9C00212468E8007932A6 /* RegistrationSuccessEventHandler.swift */; };
@@ -1893,6 +1894,7 @@
 		5EF5C54B209B33E600676405 /* CGSize+AspectRatio.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGSize+AspectRatio.swift"; sourceTree = "<group>"; };
 		5EF5CDA420EF739200CC98B0 /* DataTaskSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataTaskSession.swift; sourceTree = "<group>"; };
 		5EF5CDA620EF903A00CC98B0 /* MockDataTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDataTask.swift; sourceTree = "<group>"; };
+		5EFCB3BE21AAD46C00E892D9 /* Message+Pasteboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Message+Pasteboard.swift"; sourceTree = "<group>"; };
 		5EFD4525215A78E800BEE703 /* IndexedListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexedListView.swift; sourceTree = "<group>"; };
 		5EFE9BFE21246483007932A6 /* RegistrationFinalErrorHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationFinalErrorHandler.swift; sourceTree = "<group>"; };
 		5EFE9C00212468E8007932A6 /* RegistrationSuccessEventHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationSuccessEventHandler.swift; sourceTree = "<group>"; };
@@ -5400,6 +5402,7 @@
 				5E936E8E20B590530060E6AA /* UIDevice+Platform.swift */,
 				5E35F77B2182124E00D3F4FE /* PerformanceDebugger.swift */,
 				5E4BC1CB218CA94D00A8682E /* ZMConversationMessage+Date.swift */,
+				5EFCB3BE21AAD46C00E892D9 /* Message+Pasteboard.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -7991,6 +7994,7 @@
 				875E7D1B2188C25A00E571B7 /* ReplyRoundCornersView.swift in Sources */,
 				D53D390E20596ED300B87DAD /* ConversationActionController+Block.swift in Sources */,
 				5EE73BF1212319BB0032986D /* RegistrationIncrementalUserDataChangeHandler.swift in Sources */,
+				5EFCB3BF21AAD46C00E892D9 /* Message+Pasteboard.swift in Sources */,
 				BFC47D86211DAA9D0021B3F2 /* ZMConversation+GuestBarState.swift in Sources */,
 				BF52C1571CAEB9E10037331F /* ArchivedListViewController.swift in Sources */,
 				87CB36BC1D7480F6007AB4E5 /* ConversationCell+Like.swift in Sources */,

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -2437,7 +2437,7 @@
 		8F41CFC5199297C600E3B032 /* ZMConversation+Additions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ZMConversation+Additions.m"; sourceTree = "<group>"; };
 		8F41CFC6199297C600E3B032 /* Message+UI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Message+UI.h"; sourceTree = "<group>"; };
 		8F41CFC7199297C600E3B032 /* Message+UI.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "Message+UI.m"; sourceTree = "<group>"; };
-		8F42C538199244A700288E4D /* Wire.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = Wire.app; path = .app; sourceTree = BUILT_PRODUCTS_DIR; };
+		8F42C538199244A700288E4D /* Wire.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Wire.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8F5A3E9A19AE2C9E00D0E9DA /* avs+iOS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "avs+iOS.h"; sourceTree = "<group>"; };
 		8F5A3E9B19AE2C9E00D0E9DA /* AVSMediaManager+Additions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "AVSMediaManager+Additions.h"; sourceTree = "<group>"; };
 		8F5A3E9C19AE2C9E00D0E9DA /* AVSMediaManager+Additions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "AVSMediaManager+Additions.m"; sourceTree = "<group>"; };

--- a/Wire-iOS/Sources/Helpers/Message+Pasteboard.swift
+++ b/Wire-iOS/Sources/Helpers/Message+Pasteboard.swift
@@ -1,0 +1,49 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension Message {
+
+    @objc static func copy(_ message: ZMConversationMessage, in pasteboard: UIPasteboard) {
+        message.copy(in: pasteboard)
+    }
+
+}
+
+extension ZMConversationMessage {
+
+    func copy(in pasteboard: UIPasteboard) {
+        if self.isText {
+            if let text = textMessageData?.messageText, !text.isEmpty {
+                pasteboard.string = text
+            }
+        } else if self.isImage {
+            if let imageData = imageMessageData?.imageData {
+                UIPasteboard.general.setMediaAsset(UIImage(data: imageData))
+            }
+        } else if self.isLocation {
+            if let locationName = locationMessageData?.name {
+                pasteboard.string = locationName
+            }
+        } else {
+            return
+        }
+    }
+
+}

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionAudioCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionAudioCell.swift
@@ -19,7 +19,7 @@
 import Foundation
 import Cartography
 
-final public class CollectionAudioCell: CollectionForwardableSaveableFileCell {
+final public class CollectionAudioCell: CollectionCell {
     private let audioMessageView = AudioMessageView()
     private let headerView = CollectionCellHeader()
 

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionCell.swift
@@ -29,6 +29,7 @@ protocol CollectionCellMessageChangeDelegate: class {
 
 open class CollectionCell: UICollectionViewCell {
 
+    var actionController: ConversationMessageActionController?
     var messageObserverToken: NSObjectProtocol? = .none
     weak var delegate: CollectionCellDelegate?
     // Cell forwards the message changes to the delegate
@@ -40,6 +41,11 @@ open class CollectionCell: UICollectionViewCell {
             if let userSession = ZMUserSession.shared(), let newMessage = message {
                 self.messageObserverToken = MessageChangeInfo.add(observer: self, for: newMessage, userSession: userSession)
             }
+
+            actionController = message.map {
+                ConversationMessageActionController(responder: self, message: $0, context: .collection)
+            }
+
             self.updateForMessage(changeInfo: .none)
         }
     }
@@ -166,11 +172,6 @@ open class CollectionCell: UICollectionViewCell {
         let properties = MenuConfigurationProperties()
         properties.targetRect = self.contentView.bounds
         properties.targetView = self.contentView
-        if message?.canBeLiked == true {
-            properties.additionalItems = [.forbiddenInEphemeral(.like(for: message, with: #selector(like)))]
-        } else {
-            properties.additionalItems = []
-        }
 
         return properties
     }
@@ -191,17 +192,7 @@ open class CollectionCell: UICollectionViewCell {
         self.becomeFirstResponder()
         
         let menuController = UIMenuController.shared
-        let menuItems: [UIMenuItem] = [
-            .forward(with: #selector(forward)),
-            .delete(with: #selector(deleteMessage)),
-            .reveal(with: #selector(showInConversation)),
-        ]
-        
-        let existingItems = menuConfigurationProperties.additionalItems?
-            .filter { $0.isAvailableInEphemeralConversations }
-            .map { $0.item }
-
-        menuController.menuItems = (existingItems ?? []) + menuItems
+        menuController.menuItems = ConversationMessageActionController.allMessageActions
         menuController.setTargetRect(menuConfigurationProperties.targetRect, in: menuConfigurationProperties.targetView)
         menuController.setMenuVisible(true, animated: true)
     }
@@ -211,16 +202,11 @@ open class CollectionCell: UICollectionViewCell {
     }
     
     override open func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
-        switch action {
-        case #selector(forward), #selector(showInConversation):
-            return true
-        case #selector(like):
-            return message?.canBeLiked == true
-        case #selector(deleteMessage):
-            return message?.canBeDeleted == true
-        default:
-            return false
-        }
+        return actionController?.canPerformAction(action) == true
+    }
+
+    open override func forwardingTarget(for aSelector: Selector!) -> Any? {
+        return actionController
     }
     
     /// To be implemented in the subclass
@@ -228,24 +214,7 @@ open class CollectionCell: UICollectionViewCell {
         self.updateMessageVisibility()
         // no-op
     }
-
-    @objc func deleteMessage(_ sender: AnyObject!) {
-        guard message?.canBeDeleted == true else { return }
-        delegate?.collectionCell(self, performAction: .delete)
-    }
-
-    @objc func like(_ sender: AnyObject!) {
-        guard let message = message else { return }
-        Message.setLikedMessage(message, liked: !message.liked)
-    }
-
-    @objc func forward(_ sender: AnyObject!) {
-        self.delegate?.collectionCell(self, performAction: .forward)
-    }
     
-    @objc func showInConversation(_ sender: AnyObject!) {
-        self.delegate?.collectionCell(self, performAction: .showInConversation)
-    }
 }
 
 extension CollectionCell: ZMMessageObserver {
@@ -253,4 +222,16 @@ extension CollectionCell: ZMMessageObserver {
         self.updateForMessage(changeInfo: changeInfo)
         self.messageChangeDelegate?.messageDidChange(self, changeInfo: changeInfo)
     }
+}
+
+extension CollectionCell: MessageActionResponder {
+
+    public func canPerform(_ action: MessageAction, for message: ZMConversationMessage!) -> Bool {
+        return true
+    }
+
+    public func wants(toPerform action: MessageAction, for message: ZMConversationMessage!) {
+        delegate?.collectionCell(self, performAction: action)
+    }
+
 }

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionCell.swift
@@ -214,6 +214,11 @@ open class CollectionCell: UICollectionViewCell {
         self.updateMessageVisibility()
         // no-op
     }
+
+    /// To be implemented in the subclass
+    func copyDisplayedContent(in pasteboard: UIPasteboard) {
+        // no-op
+    }
     
 }
 
@@ -225,10 +230,6 @@ extension CollectionCell: ZMMessageObserver {
 }
 
 extension CollectionCell: MessageActionResponder {
-
-    public func canPerform(_ action: MessageAction, for message: ZMConversationMessage!) -> Bool {
-        return true
-    }
 
     public func wants(toPerform action: MessageAction, for message: ZMConversationMessage!) {
         delegate?.collectionCell(self, performAction: action)

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionFileCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionFileCell.swift
@@ -21,36 +21,7 @@ import Foundation
 import Cartography
 import WireExtensionComponents
 
-open class CollectionForwardableSaveableFileCell: CollectionCell {
-
-    override func menuConfigurationProperties() -> MenuConfigurationProperties? {
-        guard let properties = super.menuConfigurationProperties() else { return nil }
-        if message?.isFileDownloaded() == true {
-            var mutableItems = properties.additionalItems ?? []
-            mutableItems.append(.forbiddenInEphemeral(.save(with: #selector(save))))
-            properties.additionalItems = mutableItems
-        }
-        return properties
-    }
-
-    override open func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
-        switch action {
-        case #selector(forward), #selector(save):
-            return self.message?.isFileDownloaded() ?? false
-        default:
-            return super.canPerformAction(action, withSender: sender)
-        }
-    }
-
-    @objc func save(_ sender: AnyObject) {
-        guard message?.isFileDownloaded() == true else { return }
-        delegate?.collectionCell(self, performAction: .save)
-    }
-
-}
-
-
-final public class CollectionFileCell: CollectionForwardableSaveableFileCell {
+final public class CollectionFileCell: CollectionCell {
     private let fileTransferView = FileTransferView()
     private let headerView = CollectionCellHeader()
     

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionImageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionImageCell.swift
@@ -83,31 +83,8 @@ final public class CollectionImageCell: CollectionCell {
         
         loadImage()
     }
-    
-    override func menuConfigurationProperties() -> MenuConfigurationProperties? {
-        guard let properties = super.menuConfigurationProperties() else {
-            return .none
-        }
-        
-        var mutableItems = properties.additionalItems ?? []
-        
-        let saveItem = UIMenuItem(title: "content.image.save_image".localized, action: #selector(CollectionImageCell.save(_:)))
-        mutableItems.append(.forbiddenInEphemeral(saveItem))
-        
-        properties.additionalItems = mutableItems
-        return properties
-    }
-    
-    override public func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
-        switch action {
-        case #selector(CollectionImageCell.save(_:)): fallthrough
-        case #selector(copy(_:)):
-            return true
-        default:
-            return super.canPerformAction(action, withSender: sender)
-        }
-    }
-    
+
+
     override public func copy(_ sender: Any?) {
         guard let imageData = self.message?.imageMessageData?.imageData else {
             return

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionImageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionImageCell.swift
@@ -84,15 +84,6 @@ final public class CollectionImageCell: CollectionCell {
         loadImage()
     }
 
-
-    override public func copy(_ sender: Any?) {
-        guard let imageData = self.message?.imageMessageData?.imageData else {
-            return
-        }
-        
-        UIPasteboard.general.setMediaAsset(UIImage(data: imageData))
-    }
-    
     var saveableImage : SavableImage?
     
     @objc func save(_ sender: AnyObject!) {

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionLinkCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionLinkCell.swift
@@ -82,14 +82,7 @@ final public class CollectionLinkCell: CollectionCell {
         }
     }
 
-    public override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
-        switch action{
-        case #selector(copy(_:)): return true
-        default: return super.canPerformAction(action, withSender: sender)
-        }
-    }
-
-    public override func copy(_ sender: Any?) {
+    override func copyDisplayedContent(in pasteboard: UIPasteboard) {
         guard let link = message?.textMessageData?.linkPreview else { return }
         UIPasteboard.general.url = link.openableURL as URL?
     }

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionVideoCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionVideoCell.swift
@@ -19,7 +19,7 @@
 import Foundation
 import Cartography
 
-final public class CollectionVideoCell: CollectionForwardableSaveableFileCell {
+final public class CollectionVideoCell: CollectionCell {
     private let videoMessageView = VideoMessageView()
 
     public required init?(coder aDecoder: NSCoder) {

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
@@ -299,45 +299,7 @@ public protocol CollectionsViewControllerDelegate: class {
             self.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: backButton)
         }
     }
-    
-    public func perform(_ action: MessageAction, for message: ZMConversationMessage, from view: UIView) {
-        switch (action) {
-        case .cancel:
-            self.selectedMessage = .none
-            ZMUserSession.shared()?.enqueueChanges {
-                message.fileMessageData?.cancelTransfer()
-            }
-        case .present:
-            self.selectedMessage = message
-                        
-            if message.isImage {
-                let imagesController = ConversationImagesViewController(collection: self.collection, initialMessage: message)
-            
-                let backButton = CollectionsView.backButton()
-                backButton.addTarget(self, action: #selector(CollectionsViewController.backButtonPressed(_:)), for: .touchUpInside)
 
-                let closeButton = CollectionsView.closeButton()
-                closeButton.addTarget(self, action: #selector(CollectionsViewController.closeButtonPressed(_:)), for: .touchUpInside)
-
-                imagesController.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: backButton)
-                imagesController.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: closeButton)
-                imagesController.swipeToDismiss = false
-                imagesController.messageActionDelegate = self
-                self.navigationController?.pushViewController(imagesController, animated: true)
-            }
-            else {
-                self.messagePresenter.open(message, targetView: view, actionResponder: self)
-            }
-
-        case .save:
-            guard let saveController = UIActivityViewController(message: message, from: view) else { return }
-            present(saveController, animated: true, completion: nil)
-            
-        default:
-            break
-        }
-    }
-    
     @objc func closeButtonPressed(_ button: UIButton) {
         self.onDismiss?(self)
     }
@@ -517,6 +479,8 @@ extension CollectionsViewController: UICollectionViewDelegate, UICollectionViewD
         
         return self.elements(for: section).count > 0 ? UIEdgeInsets(top: 0, left: 16, bottom: 8, right: 16) : .zero
     }
+
+    // MARK: - Data Source
     
     public func numberOfSections(in collectionView: UICollectionView) -> Int {
         return CollectionsSectionSet.visible.count
@@ -583,22 +547,7 @@ extension CollectionsViewController: UICollectionViewDelegate, UICollectionViewD
         
         return resultCell
     }
-    
-    public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
-        guard let section = CollectionsSectionSet(index: UInt(section)) else {
-            fatal("Unknown section")
-        }
-        
-        if section == CollectionsSectionSet.loading {
-            return .zero
-        }
-        return self.elements(for: section).count > 0 ? CGSize(width: collectionView.bounds.size.width, height: 48) : .zero
-    }
-    
-    public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForFooterInSection section: Int) -> CGSize {
-        return .zero
-    }
-    
+
     public func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
         guard let section = CollectionsSectionSet(index: UInt(indexPath.section)) else {
             fatal("Unknown section")
@@ -626,9 +575,38 @@ extension CollectionsViewController: UICollectionViewDelegate, UICollectionViewD
             fatal("No supplementary view for \(kind)")
         }
     }
+
+    // MARK: - Layout
+
+    public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
+        guard let section = CollectionsSectionSet(index: UInt(section)) else {
+            fatal("Unknown section")
+        }
+
+        if section == CollectionsSectionSet.loading {
+            return .zero
+        }
+        return self.elements(for: section).count > 0 ? CGSize(width: collectionView.bounds.size.width, height: 48) : .zero
+    }
+
+    public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForFooterInSection section: Int) -> CGSize {
+        return .zero
+    }
+
+    public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+        guard let section = CollectionsSectionSet(index: UInt(section)) else {
+            fatal("Unknown section")
+        }
+        return self.sectionInsets(in: section)
+    }
+
+    // MARK: - Delegate
     
     public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        guard let section = CollectionsSectionSet(index: UInt(indexPath.section)) else {
+        guard
+            let section = CollectionsSectionSet(index: UInt(indexPath.section)),
+            let cell = collectionView.cellForItem(at: indexPath) as? CollectionCell
+        else {
             fatal("Unknown section")
         }
         
@@ -637,15 +615,9 @@ extension CollectionsViewController: UICollectionViewDelegate, UICollectionViewD
         }
         
         let message = self.message(for: indexPath)
-        self.perform(.present, for: message, from: collectionView.cellForItem(at: indexPath)!)
+        self.perform(.present, for: message, source: cell)
     }
     
-    public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
-        guard let section = CollectionsSectionSet(index: UInt(section)) else {
-            fatal("Unknown section")
-        }
-        return self.sectionInsets(in: section)
-    }
 }
 
 extension CollectionsViewController: UICollectionViewDataSourcePrefetching {
@@ -662,34 +634,11 @@ extension CollectionsViewController: UICollectionViewDataSourcePrefetching {
     }
 }
 
-extension CollectionsViewController: CollectionCellDelegate {
-    func collectionCell(_ cell: CollectionCell, performAction action: MessageAction) {
-        guard let message = cell.message else {
-            fatal("Cell does not have a message: \(cell)")
-        }
-        
-        switch action {
-        case .forward, .showInConversation:
-            self.delegate?.collectionsViewController(self, performAction: action, onMessage: message)
-        case .delete:
-            deletionDialogPresenter?.presentDeletionAlertController(forMessage: message, source: cell) { [weak self] deleted in
-                guard deleted else { return }
-                self?.refetchCollection()
-            }
-        default:
-            if message.isFile {
-                self.perform(action, for: message, from: cell)
-            }
-            else if let linkPreview = message.textMessageData?.linkPreview {
-                linkPreview.openableURL?.open()
-            }
-        }
-    }
-}
+// MARK: - Message Change
 
 extension CollectionsViewController: CollectionCellMessageChangeDelegate {
     public func messageDidChange(_ cell: CollectionCell, changeInfo: MessageChangeInfo) {
-        
+        // Open the file when it is downloaded
         guard let message = self.selectedMessage as? ZMMessage,
               changeInfo.message == message,
               let fileMessageData = message.fileMessageData,
@@ -700,39 +649,10 @@ extension CollectionsViewController: CollectionCellMessageChangeDelegate {
         }
         
         self.messagePresenter.openFileMessage(message, targetView: cell)
-        
     }
 }
 
-extension CollectionsViewController: MessageActionResponder {
-    public func canPerform(_ action: MessageAction, for message: ZMConversationMessage!) -> Bool {
-        if message.isImage {
-            switch action {
-            case .like, .forward, .copy, .save, .showInConversation:
-                return true
-            
-            default:
-                return false
-            }
-        }
-        
-        return false
-    }
-    
-    public func wants(toPerform action: MessageAction, for message: ZMConversationMessage!) {
-        switch action {
-        case .forward, .copy, .save, .showInConversation:
-            self.delegate?.collectionsViewController(self, performAction: action, onMessage: message)
-        case .delete:
-            deletionDialogPresenter?.presentDeletionAlertController(forMessage: message, source: nil) { [weak self] deleted in
-                guard deleted else { return }
-                _ = self?.navigationController?.popViewController(animated: true)
-                self?.refetchCollection()
-            }
-        default: break
-        }
-    }
-}
+// MARK: - Gestures
 
 extension CollectionsViewController: UIGestureRecognizerDelegate {
     public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
@@ -743,4 +663,84 @@ extension CollectionsViewController: UIGestureRecognizerDelegate {
             return true
         }
     }
+}
+
+// MARK: - Actions
+
+extension CollectionsViewController: CollectionCellDelegate, MessageActionResponder {
+
+    func collectionCell(_ cell: CollectionCell, performAction action: MessageAction) {
+        guard let message = cell.message else {
+            fatal("Cell does not have a message: \(cell)")
+        }
+
+        self.perform(action, for: message, source: cell)
+    }
+    
+    public func wants(toPerform action: MessageAction, for message: ZMConversationMessage!) {
+        self.perform(action, for: message, source: nil)
+    }
+
+    func perform(_ action: MessageAction, for message: ZMConversationMessage, source: CollectionCell?) {
+        switch action {
+        case .copy:
+            if let cell = source {
+                cell.copyDisplayedContent(in: .general)
+            } else {
+                message.copy(in: .general)
+            }
+
+        case .forward, .showInConversation, .reply:
+            self.delegate?.collectionsViewController(self, performAction: action, onMessage: message)
+
+        case .delete:
+            deletionDialogPresenter?.presentDeletionAlertController(forMessage: message, source: source) { [weak self] deleted in
+                guard deleted else { return }
+                _ = self?.navigationController?.popViewController(animated: true)
+                self?.refetchCollection()
+            }
+
+        case .cancel:
+            self.selectedMessage = .none
+            ZMUserSession.shared()?.enqueueChanges {
+                message.fileMessageData?.cancelTransfer()
+            }
+        case .present:
+            self.selectedMessage = message
+
+            if message.isImage {
+                let imagesController = ConversationImagesViewController(collection: self.collection, initialMessage: message)
+
+                let backButton = CollectionsView.backButton()
+                backButton.addTarget(self, action: #selector(CollectionsViewController.backButtonPressed(_:)), for: .touchUpInside)
+
+                let closeButton = CollectionsView.closeButton()
+                closeButton.addTarget(self, action: #selector(CollectionsViewController.closeButtonPressed(_:)), for: .touchUpInside)
+
+                imagesController.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: backButton)
+                imagesController.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: closeButton)
+                imagesController.swipeToDismiss = false
+                imagesController.messageActionDelegate = self
+                self.navigationController?.pushViewController(imagesController, animated: true)
+            } else {
+                self.messagePresenter.open(message, targetView: view, actionResponder: self)
+            }
+
+        case .save:
+            if message.isImage {
+                guard let imageMessageData = message.imageMessageData, let imageData = imageMessageData.imageData else { return }
+
+                let saveableImage = SavableImage(data: imageData, isGIF: imageMessageData.isAnimatedGIF)
+                saveableImage.saveToLibrary()
+
+            } else {
+                guard let saveController = UIActivityViewController(message: message, from: view) else { return }
+                present(saveController, animated: true, completion: nil)
+            }
+
+        default:
+            break
+        }
+    }
+
 }

--- a/Wire-iOS/Sources/UserInterface/Collections/ConversationImagesViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/ConversationImagesViewController.swift
@@ -395,9 +395,6 @@ final class ConversationImagesViewController: TintColorCorrectedViewController {
 }
 
 extension ConversationImagesViewController: MessageActionResponder {
-    public func canPerform(_ action: MessageAction, for message: ZMConversationMessage!) -> Bool {
-        return self.messageActionDelegate?.canPerform(action, for: message) ?? false
-    }
 
     func wants(toPerform action: MessageAction, for message: ZMConversationMessage!) {
         switch action {
@@ -405,6 +402,7 @@ extension ConversationImagesViewController: MessageActionResponder {
         default: self.messageActionDelegate?.wants(toPerform: action, for: message)
         }
     }
+
 }
 
 extension ConversationImagesViewController: ScreenshotProvider {

--- a/Wire-iOS/Sources/UserInterface/Collections/ConversationImagesViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/ConversationImagesViewController.swift
@@ -58,7 +58,7 @@ final class ConversationImagesViewController: TintColorCorrectedViewController {
     
     internal let inverse: Bool
 
-    public var currentActionController: ConversationCellActionController?
+    public var currentActionController: ConversationMessageActionController?
 
     public weak var messageActionDelegate: MessageActionResponder? = .none {
         didSet {
@@ -339,7 +339,7 @@ final class ConversationImagesViewController: TintColorCorrectedViewController {
     }
 
     private func updateActionControllerForMessage() {
-        currentActionController = ConversationCellActionController(responder: messageActionDelegate, message: currentMessage)
+        currentActionController = ConversationMessageActionController(responder: messageActionDelegate, message: currentMessage, context: .collection)
     }
     
     var currentController: FullscreenImageViewController? {

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.m
@@ -583,11 +583,6 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
 
 @implementation FullscreenImageViewController (ActionResponder)
 
-- (BOOL)canPerformAction:(MessageAction)action forMessage:(id<ZMConversationMessage>)message
-{
-    return [self.delegate canPerformAction:action forMessage:message];
-}
-
 - (void)wantsToPerformAction:(MessageAction)action forMessage:(id<ZMConversationMessage>)message
 {
     switch (action) {

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.m
@@ -602,7 +602,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
         case MessageActionPresent:
         {
             [self dismissWithCompletion:^{
-                [self.delegate wantsToPerformAction:MessageActionPresent forMessage:message];
+                [self.delegate wantsToPerformAction:MessageActionShowInConversation forMessage:message];
             }];
         }
             break;

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.m
@@ -35,6 +35,7 @@
 
 // helpers
 #import "NSDate+Format.h"
+#import "MessageAction.h"
 
 #import "Constants.h"
 #import "UIImage+ZetaIconsNeue.h"
@@ -71,10 +72,15 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
 
 @end
 
+@interface FullscreenImageViewController (ActionResponder) <MessageActionResponder>
+
+@end
+
 
 @interface FullscreenImageViewController () <UIScrollViewDelegate>
 
 @property (nonatomic, readwrite) UIScrollView *scrollView;
+@property (nonatomic, strong) ConversationMessageActionController *actionController;
 
 @property (nonatomic) CALayer *highlightLayer;
 @property (nonatomic, strong) ObfuscationView *obfuscationView;
@@ -107,6 +113,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
         _forcePortraitMode = NO;
         _swipeToDismiss = YES;
         _showCloseButton = YES;
+        self.actionController = [[ConversationMessageActionController alloc] initWithResponder:nil message:message context:ConversationMessageActionControllerContextContent];
         if (nil != [ZMUserSession sharedSession]) {
             self.messageObserverToken = [MessageChangeInfo addObserver:self forMessage:message userSession:[ZMUserSession sharedSession]];
         }
@@ -461,13 +468,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
         [self.view becomeFirstResponder];
         
         UIMenuController *menuController = UIMenuController.sharedMenuController;
-        menuController.menuItems = @[
-                                     [UIMenuItem likeItemForMessage:self.message action:@selector(likeImage)],
-                                     [UIMenuItem saveItemWithAction:@selector(saveImage)],
-                                     [UIMenuItem forwardItemWithAction:@selector(forward)],
-                                     [UIMenuItem deleteItemWithAction:@selector(deleteImage)],
-                                     [UIMenuItem revealItemWithAction:@selector(revealInConversation)]
-                                     ];
+        menuController.menuItems = ConversationMessageActionController.allMessageActions;
         
         [menuController setTargetRect:self.imageView.bounds inView:self.imageView];
         [menuController setMenuVisible:YES animated:YES];
@@ -476,59 +477,16 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
 }
 
 
-#pragma mark - Copy/Paste
+#pragma mark - Actions
 
-- (BOOL)canPerformAction:(SEL)action
-              withSender:(id)sender
+- (id)forwardingTargetForSelector:(SEL)aSelector
 {
-    if (action == @selector(cut:)) {
-        return NO;
-    }
-    else if (action == @selector(copy:)) {
-        return !self.message.isEphemeral && [self.delegate canPerformAction:MessageActionCopy forMessage:self.message];
-    }
-    else if (action == @selector(saveImage)) {
-        return !self.message.isEphemeral && [self.delegate canPerformAction:MessageActionSave forMessage:self.message];
-    }
-    else if (action == @selector(forward)) {
-        return !self.message.isEphemeral && [self.delegate canPerformAction:MessageActionForward forMessage:self.message];
-    }
-    else if (action == @selector(revealInConversation)) {
-        return !self.message.isEphemeral && [self.delegate canPerformAction:MessageActionShowInConversation forMessage:self.message];
-    }
-    else if (action == @selector(likeImage)) {
-        return [Message messageCanBeLiked:self.message];
-    }
-    else if (action == @selector(deleteImage)) {
-        return self.message.canBeDeleted;
-    }
-    else if (action == @selector(paste:)) {
-        return NO;
-    }
-    else if (action == @selector(select:) || action == @selector(selectAll:)) {
-        return NO;
-    }
-
-    return [super canPerformAction:action withSender:sender];
+    return self.actionController;
 }
 
-- (void)copy:(id)sender
+- (BOOL)canPerformAction:(SEL)action withSender:(id)sender
 {
-    [self.delegate wantsToPerformAction:MessageActionCopy forMessage:self.message];
-}
-
-- (void)forward
-{
-    [self dismissWithCompletion:^{
-        [self.delegate wantsToPerformAction:MessageActionForward forMessage:self.message];
-    }];
-}
-
-- (void)revealInConversation
-{
-    [self dismissWithCompletion:^{
-        [self.delegate wantsToPerformAction:MessageActionShowInConversation forMessage:self.message];
-    }];
+    return [self.actionController canPerformAction:action];
 }
 
 - (void)saveImage
@@ -618,6 +576,41 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
         changeInfo.isObfuscatedChanged) {
         
         [self updateForMessage];
+    }
+}
+
+@end
+
+@implementation FullscreenImageViewController (ActionResponder)
+
+- (BOOL)canPerformAction:(MessageAction)action forMessage:(id<ZMConversationMessage>)message
+{
+    return [self.delegate canPerformAction:action forMessage:message];
+}
+
+- (void)wantsToPerformAction:(MessageAction)action forMessage:(id<ZMConversationMessage>)message
+{
+    switch (action) {
+        case MessageActionForward:
+        {
+            [self dismissWithCompletion:^{
+                [self.delegate wantsToPerformAction:MessageActionForward forMessage:message];
+            }];
+        }
+            break;
+
+        case MessageActionPresent:
+        {
+            [self dismissWithCompletion:^{
+                [self.delegate wantsToPerformAction:MessageActionPresent forMessage:message];
+            }];
+        }
+            break;
+        default:
+        {
+            [self.delegate wantsToPerformAction:action forMessage:message];
+        }
+            break;
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/BurstTimestampTableViewCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/BurstTimestampTableViewCell.swift
@@ -31,7 +31,7 @@ class BurstTimestampSenderMessageCellDescription: ConversationMessageCellDescrip
 
     weak var message: ZMConversationMessage?
     weak var delegate: ConversationCellDelegate?
-    weak var actionController: ConversationCellActionController?
+    weak var actionController: ConversationMessageActionController?
     
     var showEphemeralTimer: Bool = false
     var topMargin: Float = 0

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationLegacyCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationLegacyCell.swift
@@ -37,7 +37,7 @@ class ConversationLegacyCellDescription<T: ConversationCell>: ConversationMessag
 
     var message: ZMConversationMessage?
     weak var delegate: ConversationCellDelegate? 
-    weak var actionController: ConversationCellActionController?
+    weak var actionController: ConversationMessageActionController?
     
     var showEphemeralTimer: Bool = false
     var topMargin: Float = 0

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationMessageToolboxCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationMessageToolboxCell.swift
@@ -90,7 +90,7 @@ class ConversationMessageToolboxCellDescription: ConversationMessageCellDescript
 
     var message: ZMConversationMessage?
     weak var delegate: ConversationCellDelegate? 
-    weak var actionController: ConversationCellActionController?
+    weak var actionController: ConversationMessageActionController?
 
     var showEphemeralTimer: Bool = false
     var topMargin: Float = 2

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSenderMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSenderMessageCell.swift
@@ -86,7 +86,7 @@ class ConversationSenderMessageCellDescription: ConversationMessageCellDescripti
 
     var message: ZMConversationMessage?
     weak var delegate: ConversationCellDelegate?
-    weak var actionController: ConversationCellActionController?
+    weak var actionController: ConversationMessageActionController?
     
     var showEphemeralTimer: Bool = false
     var topMargin: Float = 16

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCell.swift
@@ -253,7 +253,7 @@ class ConversationParticipantsChangedSystemMessageCellDescription: ConversationM
     
     var message: ZMConversationMessage?
     weak var delegate: ConversationCellDelegate?
-    weak var actionController: ConversationCellActionController?
+    weak var actionController: ConversationMessageActionController?
     
     var showEphemeralTimer: Bool = false
     var topMargin: Float = 0
@@ -279,7 +279,7 @@ class ConversationRenamedSystemMessageCellDescription: ConversationMessageCellDe
 
     var message: ZMConversationMessage?
     weak var delegate: ConversationCellDelegate? 
-    weak var actionController: ConversationCellActionController?
+    weak var actionController: ConversationMessageActionController?
     
     var showEphemeralTimer: Bool = false
     var topMargin: Float = 0
@@ -311,7 +311,7 @@ class ConversationCallSystemMessageCellDescription: ConversationMessageCellDescr
 
     var message: ZMConversationMessage?
     weak var delegate: ConversationCellDelegate? 
-    weak var actionController: ConversationCellActionController?
+    weak var actionController: ConversationMessageActionController?
     
     var showEphemeralTimer: Bool = false
     var topMargin: Float = 0
@@ -345,7 +345,7 @@ class ConversationMessageTimerCellDescription: ConversationMessageCellDescriptio
 
     var message: ZMConversationMessage?
     weak var delegate: ConversationCellDelegate? 
-    weak var actionController: ConversationCellActionController?
+    weak var actionController: ConversationMessageActionController?
     
     var showEphemeralTimer: Bool = false
     var topMargin: Float = 0
@@ -388,7 +388,7 @@ class ConversationVerifiedSystemMessageSectionDescription: ConversationMessageCe
 
     var message: ZMConversationMessage?
     weak var delegate: ConversationCellDelegate? 
-    weak var actionController: ConversationCellActionController?
+    weak var actionController: ConversationMessageActionController?
     
     var showEphemeralTimer: Bool = false
     var topMargin: Float = 0
@@ -420,7 +420,7 @@ class ConversationCannotDecryptSystemMessageCellDescription: ConversationMessage
 
     var message: ZMConversationMessage?
     weak var delegate: ConversationCellDelegate?
-    weak var actionController: ConversationCellActionController?
+    weak var actionController: ConversationMessageActionController?
     
     var showEphemeralTimer: Bool = false
     var topMargin: Float = 0
@@ -508,7 +508,7 @@ class ConversationNewDeviceSystemMessageCellDescription: ConversationMessageCell
     
     var message: ZMConversationMessage?
     weak var delegate: ConversationCellDelegate?
-    weak var actionController: ConversationCellActionController?
+    weak var actionController: ConversationMessageActionController?
     
     var showEphemeralTimer: Bool = false
     var topMargin: Float = 0

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/UnknownMessageCellDescription.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/UnknownMessageCellDescription.swift
@@ -39,7 +39,7 @@ class UnknownMessageCellDescription: ConversationMessageCellDescription {
 
     weak var message: ZMConversationMessage?
     weak var delegate: ConversationCellDelegate?
-    weak var actionController: ConversationCellActionController?
+    weak var actionController: ConversationMessageActionController?
     
     var showEphemeralTimer: Bool = false
     var topMargin: Float = 0

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationAudioMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationAudioMessageCell.swift
@@ -122,7 +122,7 @@ class ConversationAudioMessageCellDescription: ConversationMessageCellDescriptio
     
     weak var message: ZMConversationMessage?
     weak var delegate: ConversationCellDelegate?
-    weak var actionController: ConversationCellActionController?
+    weak var actionController: ConversationMessageActionController?
     
     let accessibilityIdentifier: String? = nil
     let accessibilityLabel: String? = nil

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationImageMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationImageMessageCell.swift
@@ -135,7 +135,7 @@ class ConversationImageMessageCellDescription: ConversationMessageCellDescriptio
     
     var message: ZMConversationMessage?
     weak var delegate: ConversationCellDelegate?
-    weak var actionController: ConversationCellActionController?
+    weak var actionController: ConversationMessageActionController?
     
     var showEphemeralTimer: Bool = false
     var topMargin: Float = 8

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationLocationMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationLocationMessageCell.swift
@@ -167,7 +167,7 @@ class ConversationLocationMessageCellDescription: ConversationMessageCellDescrip
 
     var message: ZMConversationMessage?
     weak var delegate: ConversationCellDelegate?     
-    weak var actionController: ConversationCellActionController?
+    weak var actionController: ConversationMessageActionController?
     
     var showEphemeralTimer: Bool = false
     var topMargin: Float = 0

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationPingCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationPingCell.swift
@@ -134,7 +134,7 @@ class ConversationPingCellDescription: ConversationMessageCellDescription {
 
     weak var message: ZMConversationMessage?
     weak var delegate: ConversationCellDelegate? 
-    weak var actionController: ConversationCellActionController?
+    weak var actionController: ConversationMessageActionController?
     
     var showEphemeralTimer: Bool {
         get { return false }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationVideoMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationVideoMessageCell.swift
@@ -122,7 +122,7 @@ class ConversationVideoMessageCellDescription: ConversationMessageCellDescriptio
     
     weak var message: ZMConversationMessage?
     weak var delegate: ConversationCellDelegate?
-    weak var actionController: ConversationCellActionController?
+    weak var actionController: ConversationMessageActionController?
     
     let accessibilityIdentifier: String? = nil
     let accessibilityLabel: String? = nil

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationFileMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationFileMessageCell.swift
@@ -122,7 +122,7 @@ class ConversationFileMessageCellDescription: ConversationMessageCellDescription
 
     weak var message: ZMConversationMessage?
     weak var delegate: ConversationCellDelegate?
-    weak var actionController: ConversationCellActionController?
+    weak var actionController: ConversationMessageActionController?
 
     let accessibilityIdentifier: String? = nil
     let accessibilityLabel: String? = nil

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationLinkPreviewArticleCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationLinkPreviewArticleCell.swift
@@ -93,7 +93,7 @@ class ConversationLinkPreviewArticleCellDescription: ConversationMessageCellDesc
 
     weak var message: ZMConversationMessage?
     weak var delegate: ConversationCellDelegate? 
-    weak var actionController: ConversationCellActionController?
+    weak var actionController: ConversationMessageActionController?
     
     var showEphemeralTimer: Bool = false
     var topMargin: Float = 8

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationQuoteCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationQuoteCell.swift
@@ -197,7 +197,7 @@ class ConversationReplyCellDescription: ConversationMessageCellDescription {
 
     weak var message: ZMConversationMessage?
     weak var delegate: ConversationCellDelegate?
-    weak var actionController: ConversationCellActionController?
+    weak var actionController: ConversationMessageActionController?
 
     let accessibilityLabel: String? = "content.message.original_label".localized
     let accessibilityIdentifier: String? = "ReplyCell"

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationSoundCloudAttachmentCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationSoundCloudAttachmentCell.swift
@@ -48,7 +48,7 @@ class ConversationSoundCloudCellDescription<Player: PlayerViewControllerProtocol
 
     weak var message: ZMConversationMessage?
     weak var delegate: ConversationCellDelegate?
-    weak var actionController: ConversationCellActionController?
+    weak var actionController: ConversationMessageActionController?
     
     var showEphemeralTimer: Bool = false
     var topMargin: Float = 8

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationTextMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationTextMessageCell.swift
@@ -125,7 +125,7 @@ class ConversationTextMessageCellDescription: ConversationMessageCellDescription
 
     weak var message: ZMConversationMessage?
     weak var delegate: ConversationCellDelegate?
-    weak var actionController: ConversationCellActionController?
+    weak var actionController: ConversationMessageActionController?
     
     var showEphemeralTimer: Bool = false
     var topMargin: Float = 8

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationYouTubeAttachmentCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationYouTubeAttachmentCell.swift
@@ -43,7 +43,7 @@ class ConversationYouTubeAttachmentCellDescription: ConversationMessageCellDescr
 
     weak var message: ZMConversationMessage?
     weak var delegate: ConversationCellDelegate?
-    weak var actionController: ConversationCellActionController?
+    weak var actionController: ConversationMessageActionController?
     
     var showEphemeralTimer: Bool = false
     var topMargin: Float = 8

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageActionController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageActionController.swift
@@ -18,60 +18,70 @@
 
 import UIKit
 
-@objc class ConversationCellActionController: NSObject {
+@objc class ConversationMessageActionController: NSObject {
 
-    let message: ZMConversationMessage
-    weak var responder: MessageActionResponder?
+    @objc(ConversationMessageActionControllerContext)
+    enum Context: Int {
+        case content, collection
+    }
 
-    @objc init(responder: MessageActionResponder?, message: ZMConversationMessage) {
+    @objc let message: ZMConversationMessage
+    @objc let context: Context
+    @objc weak var responder: MessageActionResponder?
+
+    @objc init(responder: MessageActionResponder?, message: ZMConversationMessage, context: Context) {
         self.responder = responder
         self.message = message
+        self.context = context
     }
 
     // MARK: - List of Actions
 
     @objc static let allMessageActions: [UIMenuItem] = [
-        UIMenuItem(title: "content.message.copy".localized, action: #selector(ConversationCellActionController.copyMessage)),
-        UIMenuItem(title: "content.message.reply".localized, action: #selector(ConversationCellActionController.quoteMessage)),
-        UIMenuItem(title: "message.menu.edit.title".localized, action: #selector(ConversationCellActionController.editMessage)),
-        UIMenuItem(title: "content.message.delete".localized, action: #selector(ConversationCellActionController.deleteMessage)),
-        UIMenuItem(title: "content.message.save".localized, action: #selector(ConversationCellActionController.saveMessage)),
-        UIMenuItem(title: "content.message.download".localized, action: #selector(ConversationCellActionController.downloadMessage)),
-        UIMenuItem(title: "content.message.forward".localized, action: #selector(ConversationCellActionController.forwardMessage)),
-        UIMenuItem(title: "content.message.like".localized, action: #selector(ConversationCellActionController.likeMessage)),
-        UIMenuItem(title: "content.message.unlike".localized, action: #selector(ConversationCellActionController.unlikeMessage)),
-        UIMenuItem(title: "content.message.resend".localized, action: #selector(ConversationCellActionController.resendMessage))
+        UIMenuItem(title: "content.message.copy".localized, action: #selector(ConversationMessageActionController.copyMessage)),
+        UIMenuItem(title: "content.message.reply".localized, action: #selector(ConversationMessageActionController.quoteMessage)),
+        UIMenuItem(title: "message.menu.edit.title".localized, action: #selector(ConversationMessageActionController.editMessage)),
+        UIMenuItem(title: "content.message.delete".localized, action: #selector(ConversationMessageActionController.deleteMessage)),
+        UIMenuItem(title: "content.message.save".localized, action: #selector(ConversationMessageActionController.saveMessage)),
+        UIMenuItem(title: "content.message.download".localized, action: #selector(ConversationMessageActionController.downloadMessage)),
+        UIMenuItem(title: "content.message.forward".localized, action: #selector(ConversationMessageActionController.forwardMessage)),
+        UIMenuItem(title: "content.message.like".localized, action: #selector(ConversationMessageActionController.likeMessage)),
+        UIMenuItem(title: "content.message.unlike".localized, action: #selector(ConversationMessageActionController.unlikeMessage)),
+        UIMenuItem(title: "content.message.resend".localized, action: #selector(ConversationMessageActionController.resendMessage)),
+        UIMenuItem(title: "content.message.go_to_conversation".localized, action: #selector(ConversationMessageActionController.revealMessage))
     ]
 
     @objc func canPerformAction(_ selector: Selector) -> Bool {
         switch selector {
-        case #selector(ConversationCellActionController.copyMessage):
+        case #selector(ConversationMessageActionController.copyMessage):
             return message.canBeCopied
-        case #selector(ConversationCellActionController.editMessage):
+        case #selector(ConversationMessageActionController.editMessage):
             return message.canBeEdited
-        case #selector(ConversationCellActionController.quoteMessage):
+        case #selector(ConversationMessageActionController.quoteMessage):
             return message.canBeQuoted
-        case #selector(ConversationCellActionController.downloadMessage):
+        case #selector(ConversationMessageActionController.downloadMessage):
             return message.canBeDownloaded
-        case #selector(ConversationCellActionController.saveMessage):
+        case #selector(ConversationMessageActionController.saveMessage):
             return message.canBeSaved
-        case #selector(ConversationCellActionController.forwardMessage):
+        case #selector(ConversationMessageActionController.forwardMessage):
             return message.canBeForwarded
-        case #selector(ConversationCellActionController.likeMessage):
+        case #selector(ConversationMessageActionController.likeMessage):
             return message.canBeLiked && !message.liked
-        case #selector(ConversationCellActionController.unlikeMessage):
+        case #selector(ConversationMessageActionController.unlikeMessage):
             return message.canBeLiked && message.liked
-        case #selector(ConversationCellActionController.deleteMessage):
+        case #selector(ConversationMessageActionController.deleteMessage):
             return message.canBeDeleted
-        case #selector(ConversationCellActionController.resendMessage):
+        case #selector(ConversationMessageActionController.resendMessage):
             return message.canBeResent
+        case #selector(ConversationMessageActionController.revealMessage):
+            return context == .collection
         default:
             return false
         }
     }
 
     @objc func makePreviewActions() -> [UIPreviewAction] {
-        return ConversationCellActionController.allMessageActions
+        return ConversationMessageActionController.allMessageActions
             .filter { self.canPerformAction($0.action) }
             .map { menuItem in
                 UIPreviewAction(title: menuItem.title, style: .default) { [weak self] _, _ in
@@ -143,6 +153,10 @@ import UIKit
     
     @objc func resendMessage() {
         responder?.wants(toPerform: .resend, for: message)
+    }
+
+    @objc func revealMessage() {
+        responder?.wants(toPerform: .present, for: message)
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageActionController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageActionController.swift
@@ -156,7 +156,7 @@ import UIKit
     }
 
     @objc func revealMessage() {
-        responder?.wants(toPerform: .present, for: message)
+        responder?.wants(toPerform: .showInConversation, for: message)
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
@@ -114,7 +114,7 @@ protocol ConversationMessageCellDescription: class {
     var delegate: ConversationCellDelegate? { get set }
 
     /// The action controller that handles the menu item.
-    var actionController: ConversationCellActionController? { get set }
+    var actionController: ConversationMessageActionController? { get set }
 
     /// The configuration object that will be used to populate the cell.
     var configuration: View.Configuration { get }
@@ -196,7 +196,7 @@ extension ConversationMessageCellDescription {
 
     private let _delegate: AnyMutableProperty<ConversationCellDelegate?>
     private let _message: AnyMutableProperty<ZMConversationMessage?>
-    private let _actionController: AnyMutableProperty<ConversationCellActionController?>
+    private let _actionController: AnyMutableProperty<ConversationMessageActionController?>
     private let _topMargin: AnyMutableProperty<Float>
     private let _containsHighlightableContent: AnyConstantProperty<Bool>
     private let _showEphemeralTimer: AnyMutableProperty<Bool>
@@ -248,7 +248,7 @@ extension ConversationMessageCellDescription {
         set { _message.setter(newValue) }
     }
 
-    @objc var actionController: ConversationCellActionController? {
+    @objc var actionController: ConversationMessageActionController? {
         get { return _actionController.getter() }
         set { _actionController.setter(newValue) }
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCellTableViewAdapter.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCellTableViewAdapter.swift
@@ -183,7 +183,7 @@ class ConversationMessageCellTableViewAdapter<C: ConversationMessageCellDescript
         registerMenuObservers()
 
         let menu = UIMenuController.shared
-        menu.menuItems = ConversationCellActionController.allMessageActions
+        menu.menuItems = ConversationMessageActionController.allMessageActions
 
         if needsFirstResponder != false {
             self.becomeFirstResponder()

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
@@ -70,7 +70,7 @@ extension IndexSet {
     @objc var useInvertedIndices = false
 
     /// The object that controls actions for the cell.
-    @objc var actionController: ConversationCellActionController?
+    @objc var actionController: ConversationMessageActionController?
 
     /// The message that is being presented.
     @objc var message: ZMConversationMessage

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell+Menu.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell+Menu.swift
@@ -35,7 +35,7 @@ public extension ConversationCell {
             becomeFirstResponder()
         }
         
-        UIMenuController.shared.menuItems = ConversationCellActionController.allMessageActions
+        UIMenuController.shared.menuItems = ConversationMessageActionController.allMessageActions
         UIMenuController.shared.setTargetRect(selectionRect, in: selectionView)
         UIMenuController.shared.setMenuVisible(true, animated: true)
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.h
@@ -31,7 +31,7 @@
 @class AdditionalMenuItem;
 @class MenuConfigurationProperties;
 @class UserImageView;
-@class ConversationCellActionController;
+@class ConversationMessageActionController;
 
 extern const CGFloat ConversationCellSelectedOpacity;
 extern const NSTimeInterval ConversationCellSelectionAnimationDuration;
@@ -95,7 +95,7 @@ typedef void (^SelectedMenuBlock)(BOOL selected, BOOL animated);
 @property (nonatomic) UIFont *burstNormalFont;
 @property (nonatomic) UIFont *burstBoldFont;
 
-@property (nonatomic) ConversationCellActionController *actionController;
+@property (nonatomic) ConversationMessageActionController *actionController;
 
 - (void)configureForMessage:(id<ZMConversationMessage>)message layoutProperties:(ConversationCellLayoutProperties *)layoutProperties;
 /// Update cell due since the message content has changed. Return True if the change requires the cell to be re-sized.

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCell.m
@@ -322,7 +322,7 @@ static const CGFloat BurstContainerExpandedHeight = 40;
         [self updateBurstTimestamp];
     }
 
-    self.actionController = [[ConversationCellActionController alloc] initWithResponder:self.delegate message:message];
+    self.actionController = [[ConversationMessageActionController alloc] initWithResponder:self.delegate message:message context:ConversationMessageActionControllerContextContent];
 
     [self updateConstraintConstants];
     [self updateToolboxVisibilityAnimated:NO];

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/MenuConfigurationProperties.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/MenuConfigurationProperties.swift
@@ -22,6 +22,4 @@ import Foundation
     var targetRect = CGRect.zero
     var targetView: UIView!
     var selectedMenuBlock: SelectedMenuBlock?
-    var additionalItems: [AdditionalMenuItem]?
-    var likeItemIndex: Int = 0
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/MessageAction.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/MessageAction.h
@@ -40,6 +40,5 @@ typedef NS_ENUM(NSUInteger, MessageAction) {
 
 @protocol MessageActionResponder <NSObject>
 @required
-- (BOOL)canPerformAction:(MessageAction)action forMessage:(id<ZMConversationMessage>)message;
 - (void)wantsToPerformAction:(MessageAction)action forMessage:(id<ZMConversationMessage>)message;
 @end

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -389,7 +389,7 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
             case MessageActionDelete:
             {
                 assert([message canBeDeleted]);
-                
+
                 self.deletionDialogPresenter = [[DeletionDialogPresenter alloc] initWithSourceViewController:self.presentedViewController ?: self];
                 [self.deletionDialogPresenter presentDeletionAlertControllerForMessage:message source:cell completion:^(BOOL deleted) {
                     if (self.presentedViewController && deleted) {
@@ -493,16 +493,7 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
                 break;
             case MessageActionCopy:
             {
-                if ([Message isTextMessage:message]) {
-                    [[UIPasteboard generalPasteboard] setString:message.textMessageData.messageText];
-                } else if ([Message isImageMessage:message]) {
-                    NSData *imageData = message.imageMessageData.imageData;
-                    [[UIPasteboard generalPasteboard] setMediaAsset:[[UIImage alloc] initWithData:imageData]];
-                } else if ([Message isLocationMessage:message]) {
-                    if (message.locationMessageData.name) {
-                        [[UIPasteboard generalPasteboard] setString:message.locationMessageData.name];
-                    }
-                }
+                [Message copy:message in:UIPasteboard.generalPasteboard];
             }
                 break;
             
@@ -806,26 +797,6 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
 
 
 @implementation ConversationContentViewController (ConversationCellDelegate)
-
-- (BOOL)canPerformAction:(MessageAction)action forMessage:(id<ZMConversationMessage>)message
-{
-    if ([Message isImageMessage:message]) {
-
-        switch (action) {
-            case MessageActionForward:
-            case MessageActionSave:
-            case MessageActionCopy:
-
-                return YES;
-                break;
-
-            default:
-                break;
-        }
-    }
-
-    return NO;
-}
 
 - (void)wantsToPerformAction:(MessageAction)action forMessage:(id<ZMConversationMessage>)message
 {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter+Private.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter+Private.h
@@ -40,7 +40,7 @@ static NSString *const ConversationMessageTimerUpdateCellId = @"ConversationMess
 
 @class ConversationCell;
 @class UpsideDownTableView;
-@class ConversationCellActionController;
+@class ConversationMessageActionController;
 @class ConversationMessageSectionController;
 
 @interface ConversationMessageWindowTableViewAdapter ()
@@ -54,7 +54,7 @@ static NSString *const ConversationMessageTimerUpdateCellId = @"ConversationMess
 
 @property (nonatomic, strong) NSMutableArray<Class> *registeredCells;
 @property (nonatomic, strong) NSMutableDictionary<NSString *, ConversationMessageSectionController *> *sectionControllers;
-@property (nonatomic, strong) NSMutableDictionary<NSString *, ConversationCellActionController *> *actionControllers;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, ConversationMessageActionController *> *actionControllers;
 
 NS_ASSUME_NONNULL_END
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter.h
@@ -24,7 +24,7 @@
 
 @protocol ConversationCellDelegate;
 @class AnyConversationMessageCellDescription;
-@class ConversationCellActionController;
+@class ConversationMessageActionController;
 @class UpsideDownTableView;
 
 @interface ConversationMessageWindowTableViewAdapter : NSObject
@@ -41,7 +41,7 @@
 - (void)expandMessageWindow;
 
 - (void)stopAudioPlayerForDeletedMessages:(NSSet *)deletedMessages;
-- (ConversationCellActionController *)actionControllerForMessage:(id<ZMConversationMessage>)message;
+- (ConversationMessageActionController *)actionControllerForMessage:(id<ZMConversationMessage>)message;
 - (void)registerCellIfNeeded:(AnyConversationMessageCellDescription *)cellDescription inTableView:(UITableView *)tableView;
 
 @end

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter.m
@@ -59,16 +59,16 @@
     }
 }
 
-- (ConversationCellActionController *)actionControllerForMessage:(id<ZMConversationMessage>)message
+- (ConversationMessageActionController *)actionControllerForMessage:(id<ZMConversationMessage>)message
 {
     NSString *identifier = message.objectIdentifier;
-    ConversationCellActionController *cachedEntry = [self.actionControllers objectForKey:identifier];
+    ConversationMessageActionController *cachedEntry = [self.actionControllers objectForKey:identifier];
 
     if (cachedEntry) {
         return cachedEntry;
     }
 
-    ConversationCellActionController *actionController = [[ConversationCellActionController alloc] initWithResponder:self.messageActionResponder message:message];
+    ConversationMessageActionController *actionController = [[ConversationMessageActionController alloc] initWithResponder:self.messageActionResponder message:message context: ConversationMessageActionControllerContextContent];
     [self.actionControllers setObject:actionController forKey:identifier];
 
     return actionController;

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Previews/LocationPreviewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Previews/LocationPreviewController.swift
@@ -24,7 +24,7 @@ import Cartography
 class LocationPreviewController: TintColorCorrectedViewController {
 
     let message: ZMConversationMessage
-    let actionController: ConversationCellActionController
+    let actionController: ConversationMessageActionController
 
     private var mapView = MKMapView()
     private let containerView = UIView()
@@ -39,7 +39,7 @@ class LocationPreviewController: TintColorCorrectedViewController {
 
     init(message: ZMConversationMessage, actionResponder: MessageActionResponder) {
         self.message = message
-        self.actionController = ConversationCellActionController(responder: actionResponder, message: message)
+        self.actionController = ConversationMessageActionController(responder: actionResponder, message: message, context: .content)
         super.init(nibName: nil, bundle: nil)
         containerView.translatesAutoresizingMaskIntoConstraints = false
         containerView.backgroundColor = .from(scheme: .placeholderBackground)

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
@@ -228,6 +228,17 @@ extension ConversationViewController: CollectionsViewControllerDelegate {
                     self.contentViewController.highlight(message)
                 }
             }
+
+        case .reply:
+            viewController.dismiss(animated: true) {
+                self.contentViewController.scroll(to: message) { [weak self] cell in
+                    guard let `self` = self else {
+                        return
+                    }
+                    self.contentViewController.wants(toPerform: action, for: message)
+                }
+            }
+
         default:
             self.contentViewController.wants(toPerform: action, for: message)
             break


### PR DESCRIPTION
## What's new in this PR?

### Issues

We were displaying forbidden ephemeral actions in the collection (copy, like, etc).

### Solutions

To reduce code duplication and make sure we enforce the same behavior everywhere we use a menu controller, we use the new conversation message action controller (introduced with the cell refactor) in the collection and in the full-screen image controller.

We also refactor the collection view controller to simplify the handling of actions. Previously, there were 3 different entry points for actions, and they were always handled the same way.

Finally, we add a utility method for copying the message, so that all contents are copied the same way in different areas of the code.