### PR TITLE
Image message cell fixes

### DIFF
--- a/Wire-iOS/Sources/Components/ImageResourceView.swift
+++ b/Wire-iOS/Sources/Components/ImageResourceView.swift
@@ -41,14 +41,14 @@ class ImageResourceView: FLAnimatedImageView {
     
     public func setImageResource(_ imageResource: ImageResource?, completion: (() -> Void)? = nil) {
         let token = UUID()
-        
+        setMediaAsset(nil)
+
         imageResourceInternal = imageResource
         reuseToken = token
         loadingView.isHidden = loadingView.isHidden || imageResource == nil
-        
+
         guard let imageResource = imageResource, imageResource.cacheIdentifier != nil else {
             loadingView.isHidden = true
-            setMediaAsset(nil)
             completion?()
             return
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationImageMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationImageMessageCell.swift
@@ -110,8 +110,10 @@ class ConversationImageMessageCell: UIView, ConversationMessageCell {
         
         containerView.backgroundColor = UIColor.from(scheme: .placeholderBackground)
         imageResourceView.layer.borderWidth = 0
-        
-        imageResourceView.setImageResource(object.image.image) { [weak self] in
+
+        let imageResource = object.isObfuscated ? nil : object.image.image
+
+        imageResourceView.setImageResource(imageResource) { [weak self] in
             self?.updateImageContainerAppearance()
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+SaveImage.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+SaveImage.swift
@@ -20,14 +20,14 @@ import Foundation
 
 extension ConversationContentViewController {
     @objc(saveImageFromMessage:cell:)
-    func saveImage(from message: ZMConversationMessage, cell: ImageMessageCell?) {
+    func saveImage(from message: ZMConversationMessage, cell: SelectableView?) {
         guard let imageMessageData = message.imageMessageData, let imageData = imageMessageData.imageData else { return }
         
         let savableImage = SavableImage(data: imageData, isGIF: imageMessageData.isAnimatedGIF)
         
         if let cell = cell {
-            let snapshot = cell.fullImageView.snapshotView(afterScreenUpdates: true)
-            let sourceRect = self.view.convert(cell.fullImageView.frame, from: cell.fullImageView.superview)
+            let snapshot = cell.selectionView.snapshotView(afterScreenUpdates: true)
+            let sourceRect = self.view.convert(cell.selectionView.frame, from: cell.selectionView.superview)
             savableImage.saveToLibrary { success in
                 guard nil != self.view.window, success else { return }
                 snapshot?.translatesAutoresizingMaskIntoConstraints = true

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -366,7 +366,7 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
     [self.conversationMessageWindowTableViewAdapter highlightMessage:message];
 }
 
-- (void)wantsToPerformAction:(MessageAction)actionId forMessage:(id<ZMConversationMessage>)message cell:(ConversationCell *)cell
+- (void)wantsToPerformAction:(MessageAction)actionId forMessage:(id<ZMConversationMessage>)message cell:(UIView<SelectableView> *)cell
 {
     dispatch_block_t action = ^{
         switch (actionId) {
@@ -411,23 +411,10 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
             case MessageActionSave:
             {
                 if ([Message isImageMessage:message]) {
-                    [self saveImageFromMessage:message cell:(ImageMessageCell *)cell];
+                    [self saveImageFromMessage:message cell:cell];
                 } else {
                     self.conversationMessageWindowTableViewAdapter.selectedMessage = message;
-                    
-                    UIView *targetView = nil;
-                    
-                    if ([cell isKindOfClass:[FileTransferCell class]]) {
-                        FileTransferCell *fileCell = (FileTransferCell *)cell;
-                        targetView = fileCell.actionButton;
-                    }
-                    else if ([cell isKindOfClass:[AudioMessageCell class]]) {
-                        AudioMessageCell *audioCell = (AudioMessageCell *)cell;
-                        targetView = audioCell.contentView;
-                    }
-                    else {
-                        targetView = cell;
-                    }
+                    UIView *targetView = cell.selectionView;
 
                     UIActivityViewController *saveController = [[UIActivityViewController alloc] initWithMessage:message from:targetView];
                     [self presentViewController:saveController animated:YES completion:nil];


### PR DESCRIPTION
## What's new in this PR?

### Issues

1. The image is not removed after the message expires (ZIOS-10912)
2. The app crashes when saving an image (ZIOS-10911)
3. The old image was displayed for a short time when reusing the cell in scrolling (ZIOS-10913)

### Causes

1. We were not removing the image when the message expires.
2. We were casting the cell to the old `ImageMessageCell` type while saving.
3. When setting the image resource, we were not removing the outdated one.

### Solutions

1. When the message expires, set the image message resource to `nil`.
2. Pass `UIView<SelectableView>` to the action handler, as both new and legacy cells conform to this protocol. Use the selection view to perform the image save animation.
3. Set the image resource to `nil` before we start fetching the new one.