### PR TITLE
ZIOS-10935: Fix dismissal of collection when revealing

### DIFF
--- a/Wire-iOS Tests/DismissalTests.swift
+++ b/Wire-iOS Tests/DismissalTests.swift
@@ -1,0 +1,122 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+import UIKit
+@testable import Wire
+
+class DismissalTests: ZMSnapshotTestCase {
+
+    var viewController: UIViewController!
+
+    // MARK: - Detection
+
+    func testThatItAllowsDismissalForViewController() {
+        // GIVEN
+        let viewController = UIViewController()
+
+        // WHEN
+        presentViewController(viewController)
+
+        // THEN
+        XCTAssertTrue(viewController.canBeDismissed)
+    }
+
+    func testThatItDoesNotAllowDismissalForUnpresentedViewController() {
+        // GIVEN
+        let viewController = UIViewController()
+
+        // THEN
+        XCTAssertFalse(viewController.canBeDismissed)
+    }
+
+    func testThatItDoesNotAllowDismissalForDismissedViewController() {
+        // GIVEN
+        let viewController = UIViewController()
+        presentViewController(viewController)
+
+        // WHEN
+        dismissViewController(viewController)
+
+        // THEN
+        XCTAssertFalse(viewController.canBeDismissed)
+    }
+
+    func testThatItAllowsDismissalForControllerInNavigationController() {
+        // GIVEN
+        let viewController = UIViewController()
+        let navigationController = UINavigationController(rootViewController: viewController)
+
+        // WHEN
+        presentViewController(navigationController)
+
+        // THEN
+        XCTAssertTrue(viewController.canBeDismissed)
+        XCTAssertTrue(navigationController.canBeDismissed)
+    }
+
+    func testThatItDoesAllowDismissalForNavigationControllerAfterChildDismissed() {
+        // GIVEN
+        let viewController = UIViewController()
+        let navigationController = UINavigationController(rootViewController: viewController)
+
+        // WHEN
+        presentViewController(navigationController)
+        dismissViewController(viewController)
+
+        // THEN
+        XCTAssertFalse(viewController.canBeDismissed)
+        XCTAssertFalse(navigationController.canBeDismissed)
+    }
+
+    // MARK: - Dismissal
+
+    func testThatItCallsHandlerAfterDismissing() {
+        // GIVEN
+        let viewController = UIViewController()
+        presentViewController(viewController)
+
+        // WHEN
+        let dismissalExpectation = expectation(description: "The handler is called.")
+
+        viewController.dismissIfNeeded(animated: false) {
+            dismissalExpectation.fulfill()
+        }
+
+        // THEN
+        waitForExpectations(timeout: 2, handler: nil)
+    }
+
+    func testThatItCallsHandlerForAlreadyDismissedViewController() {
+        // GIVEN
+        let viewController = UIViewController()
+        presentViewController(viewController)
+        dismissViewController(viewController)
+
+        // WHEN
+        let dismissalExpectation = expectation(description: "The handler is called.")
+
+        viewController.dismissIfNeeded(animated: false) {
+            dismissalExpectation.fulfill()
+        }
+
+        // THEN
+        waitForExpectations(timeout: 2, handler: nil)
+    }
+
+}

--- a/Wire-iOS Tests/Utils/ZMSnapshotTestCase+Swift.swift
+++ b/Wire-iOS Tests/Utils/ZMSnapshotTestCase+Swift.swift
@@ -208,7 +208,7 @@ extension ZMSnapshotTestCase {
 
 // MARK: - UIAlertController
 extension ZMSnapshotTestCase {
-    func verifyAlertController(_ controller: UIAlertController, file: StaticString = #file, line: UInt = #line) {
+    func presentViewController(_ controller: UIViewController, file: StaticString = #file, line: UInt = #line) {
         // Given
         let window = UIWindow(frame: .init(x: 0, y: 0, width: 375, height: 667))
         let container = UIViewController()
@@ -227,6 +227,19 @@ extension ZMSnapshotTestCase {
 
         // Then
         waitForExpectations(timeout: 2, handler: nil)
+    }
+
+    func dismissViewController(_ controller: UIViewController, file: StaticString = #file, line: UInt = #line) {
+        let dismissalExpectation = expectation(description: "It should be dismissed")
+        controller.dismiss(animated: false) {
+            dismissalExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 2, handler: nil)
+    }
+
+    func verifyAlertController(_ controller: UIAlertController, file: StaticString = #file, line: UInt = #line) {
+        presentViewController(controller, file: file, line: line)
         verify(view: controller.view, file: file, line: line)
     }
 }

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -282,6 +282,8 @@
 		5E766D9921144DFC005242B4 /* AuthenticationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E766D9821144DFC005242B4 /* AuthenticationCoordinator.swift */; };
 		5E766D9B211472C0005242B4 /* AuthenticationFlowStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E766D9A211472C0005242B4 /* AuthenticationFlowStep.swift */; };
 		5E766D9F21147697005242B4 /* AuthenticationCoordinatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E766D9E21147697005242B4 /* AuthenticationCoordinatorDelegate.swift */; };
+		5E769C5421AD89A900785EB7 /* UIViewController+Dismiss.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E769C5321AD89A900785EB7 /* UIViewController+Dismiss.swift */; };
+		5E769C5621AD8ABD00785EB7 /* DismissalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E769C5521AD8ABD00785EB7 /* DismissalTests.swift */; };
 		5E7E496A20F37DAA0005C602 /* Ziphy+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7E496920F37DAA0005C602 /* Ziphy+Convenience.swift */; };
 		5E8C38A8212D5AF7002AE12B /* RegistrationSessionAvailableEventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E8C38A7212D5AF7002AE12B /* RegistrationSessionAvailableEventHandler.swift */; };
 		5E8C38AA212D7003002AE12B /* VerificationCodeStepViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E8C38A9212D7003002AE12B /* VerificationCodeStepViewControllerTests.swift */; };
@@ -1788,6 +1790,8 @@
 		5E766D9821144DFC005242B4 /* AuthenticationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationCoordinator.swift; sourceTree = "<group>"; };
 		5E766D9A211472C0005242B4 /* AuthenticationFlowStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationFlowStep.swift; sourceTree = "<group>"; };
 		5E766D9E21147697005242B4 /* AuthenticationCoordinatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationCoordinatorDelegate.swift; sourceTree = "<group>"; };
+		5E769C5321AD89A900785EB7 /* UIViewController+Dismiss.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Dismiss.swift"; sourceTree = "<group>"; };
+		5E769C5521AD8ABD00785EB7 /* DismissalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DismissalTests.swift; sourceTree = "<group>"; };
 		5E7E496920F37DAA0005C602 /* Ziphy+Convenience.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Ziphy+Convenience.swift"; sourceTree = "<group>"; };
 		5E8C38A7212D5AF7002AE12B /* RegistrationSessionAvailableEventHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationSessionAvailableEventHandler.swift; sourceTree = "<group>"; };
 		5E8C38A9212D7003002AE12B /* VerificationCodeStepViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerificationCodeStepViewControllerTests.swift; sourceTree = "<group>"; };
@@ -5403,6 +5407,7 @@
 				5E35F77B2182124E00D3F4FE /* PerformanceDebugger.swift */,
 				5E4BC1CB218CA94D00A8682E /* ZMConversationMessage+Date.swift */,
 				5EFCB3BE21AAD46C00E892D9 /* Message+Pasteboard.swift */,
+				5E769C5321AD89A900785EB7 /* UIViewController+Dismiss.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -6024,6 +6029,7 @@
 				5E7315362191FCC400255A78 /* ConversationMessageActionControllerTests.swift */,
 				8758CDB82191A7D60031BE0F /* ReplyComposingViewTests.swift */,
 				EF13204121A6C58000E7EF21 /* ChangePhoneViewControllerSnapshotTests.swift */,
+				5E769C5521AD8ABD00785EB7 /* DismissalTests.swift */,
 			);
 			path = "Wire-iOS Tests";
 			sourceTree = "<group>";
@@ -7887,6 +7893,7 @@
 				EFDB3135217F5E0300D2A7CE /* ConversationListCell+Constraint.swift in Sources */,
 				EE1AFBFE2124330B003D1AE1 /* UNUserNotificationCenter+Permission.swift in Sources */,
 				7C25D755214911AC002E22BF /* UserSearchResultsViewController.swift in Sources */,
+				5E769C5421AD89A900785EB7 /* UIViewController+Dismiss.swift in Sources */,
 				5E35F733217F147A00D3F4FE /* ConversationMessageSectionController.swift in Sources */,
 				87797C0B1FF3C849009FC9A9 /* SearchServicesSectionController.swift in Sources */,
 				EF21271E1FB9DFE300625A9B /* AddEmailStepViewController.m in Sources */,
@@ -8452,6 +8459,7 @@
 				5E8C38AA212D7003002AE12B /* VerificationCodeStepViewControllerTests.swift in Sources */,
 				BF2A74751CEB595E002608BF /* AudioButtonOverlayTests.swift in Sources */,
 				EF01AF8520BED3F500E5E5B4 /* MockUserClient+RemoteIdentifier.swift in Sources */,
+				5E769C5621AD8ABD00785EB7 /* DismissalTests.swift in Sources */,
 				EF80466520D17130001A1C53 /* MessageDestructionTimeoutValueTests.swift in Sources */,
 				EF106E86204D8BDF00B9F0F6 /* MockDevice.swift in Sources */,
 				8732670E1D2D0C5C005A62C1 /* AudioRecordKeyboardViewControllerTests.swift in Sources */,

--- a/Wire-iOS/Sources/Helpers/UIViewController+Dismiss.swift
+++ b/Wire-iOS/Sources/Helpers/UIViewController+Dismiss.swift
@@ -1,0 +1,38 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import UIKit
+
+extension UIViewController {
+
+    /// Returns whether the view controller can be dismissed.
+    var canBeDismissed: Bool {
+        return self.presentingViewController?.presentedViewController == self
+            || (navigationController != nil && navigationController?.presentingViewController?.presentedViewController == navigationController)
+    }
+
+    /// Dismisses the view controller if needed before performing the specified actions.
+    func dismissIfNeeded(animated: Bool, completion: (() -> Void)? = nil) {
+        if canBeDismissed {
+            dismiss(animated: animated, completion: completion)
+        } else {
+            completion?()
+        }
+    }
+
+}

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.m
@@ -588,15 +588,15 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
     switch (action) {
         case MessageActionForward:
         {
-            [self dismissViewControllerAnimated:NO completion:^{
+            [self dismissViewControllerAnimated:YES completion:^{
                 [self.delegate wantsToPerformAction:MessageActionForward forMessage:message];
             }];
         }
             break;
 
-        case MessageActionPresent:
+        case MessageActionShowInConversation:
         {
-            [self dismissViewControllerAnimated:NO completion:^{
+            [self dismissViewControllerAnimated:YES completion:^{
                 [self.delegate wantsToPerformAction:MessageActionShowInConversation forMessage:message];
             }];
         }
@@ -604,7 +604,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
 
         case MessageActionReply:
         {
-            [self dismissViewControllerAnimated:NO completion:^{
+            [self dismissViewControllerAnimated:YES completion:^{
                 [self.delegate wantsToPerformAction:MessageActionReply forMessage:message];
             }];
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -787,7 +787,7 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
 
 - (void)wantsToPerformAction:(MessageAction)action forMessage:(id<ZMConversationMessage>)message
 {
-    ConversationCell *cell = [self cellForMessage:message];
+    UITableViewCell<SelectableView> *cell = [self cellForMessage:message];
     [self wantsToPerformAction:action forMessage:message cell:cell];
 }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
@@ -210,42 +210,24 @@ extension ConversationViewController: CollectionsViewControllerDelegate {
     public func collectionsViewController(_ viewController: CollectionsViewController, performAction action: MessageAction, onMessage message: ZMConversationMessage) {
         switch action {
         case .forward:
-            let actions: () -> Void = {
+            viewController.dismissIfNeeded(animated: true) {
                 self.contentViewController.scroll(to: message) { cell in
                     self.contentViewController.showForwardFor(message: message, fromCell: cell)
                 }
             }
 
-            if viewController.isBeingPresented {
-                viewController.dismiss(animated: true, completion: actions)
-            } else {
-                actions()
-            }
-
         case .showInConversation:
-            let actions: () -> Void = {
+            viewController.dismissIfNeeded(animated: true) {
                 self.contentViewController.scroll(to: message) { _ in
                     self.contentViewController.highlight(message)
                 }
             }
 
-            if viewController.isBeingPresented {
-                viewController.dismiss(animated: true, completion: actions)
-            } else {
-                actions()
-            }
-
         case .reply:
-            let actions = {
+            viewController.dismissIfNeeded(animated: true) {
                 self.contentViewController.scroll(to: message) { cell in
-                    self.contentViewController.wants(toPerform: action, for: message)
+                    self.contentViewController.wants(toPerform: .reply, for: message)
                 }
-            }
-            
-            if viewController.isBeingPresented {
-                viewController.dismiss(animated: true, completion: actions)
-            } else {
-                actions()
             }
 
         default:


### PR DESCRIPTION
## What's new in this PR?

### Issues

When the user tapped to reveal a message, or tapped on a search result, nothing happened and the collection wasn't dismissed as expected.

### Causes

In #2956, we introduced code that checks if the collection is already dismissed before running the reveal action, so we don't attempt to dismiss the collection view controller again.

This was necessary because the fullscreen image is responsible for dismissing itself – which means the action handler would be called on the collection controller after it was is dismissed.

However, it turns out the variable we checked to see if the view controller is presented (`isBeingPresented`) wasn't the right one, it only indicates if an animation is running. The view controller was never dismissed because of this mistake.

We were also checking the wrong action for revealing the image in the fullscreen controller (present instead of show in conversation).

### Solutions

We write and test our own logic for determining if a view controller can be dismissed.