### PR TITLE
Stash changes in configuration folder before pulling

### DIFF
--- a/Scripts/download-assets.sh
+++ b/Scripts/download-assets.sh
@@ -62,6 +62,7 @@ done
 if [ -e "${CONFIGURATION_LOCATION}" ]; then
     pushd ${CONFIGURATION_LOCATION} &> /dev/null
     echo "Pulling configuration..."
+    git stash # Stash in case there are some changes here
     git pull
     popd &> /dev/null
 else


### PR DESCRIPTION
## What's new in this PR?

### Issues

The CI would fail pulling updated configuration repository because there are uncommitted changes.

### Causes

When we build custom app versions we copy files over to the configuration folder. Because we don't wipe workspace before each build there might be some leftover files from previous run that would prevent `git pull` from working.

### Solutions

Stash changes before pulling. We could simply delete the folder or `git reset`, but when running on local machine we might want to retrieve the changes we made in configuration.
