### PR TITLE
ZIOS-10940: fixed issue with ephemeral images

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationImageMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationImageMessageCell.swift
@@ -23,6 +23,7 @@ class ConversationImageMessageCell: UIView, ConversationMessageCell {
     struct Configuration {
         let image: ZMImageMessageData
         let isObfuscated: Bool
+        let message: ZMConversationMessage?
     }
     
     private var containerView = UIView()
@@ -115,6 +116,7 @@ class ConversationImageMessageCell: UIView, ConversationMessageCell {
 
         imageResourceView.setImageResource(imageResource) { [weak self] in
             self?.updateImageContainerAppearance()
+            _ = object.message?.startSelfDestructionIfNeeded()
         }
     }
     
@@ -151,7 +153,7 @@ class ConversationImageMessageCellDescription: ConversationMessageCellDescriptio
     
     init(message: ZMConversationMessage, image: ZMImageMessageData) {
         self.message = message
-        self.configuration = View.Configuration(image: image, isObfuscated: message.isObfuscated)
+        self.configuration = View.Configuration(image: image, isObfuscated: message.isObfuscated, message: message)
     }
     
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Ephemeral timer was not activated after receiving images from another user.

### Causes

This is because of the ephemeral timer that was fired before the complete download of the image inside `willDisplayCell()` and failing the condition on `startDestructionIfNeeded()` (`ZMAssetClientMessage+Ephemeral:64` from Data Model).

### Solutions

I've added a call to `startDestructionIfNeeded()` after downloading the image.
