### PR TITLE
Improve VoiceOver support in Message Details

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -1506,3 +1506,4 @@
 "message_details.tabs.likes" = "Likes (%d)";
 "message_details.subtitle_send_date" = "Sent: %@";
 "message_details.subtitle_edit_date" = "Edited: %@";
+"message_details.subtitle_label_voiceOver" = "Message Details";

--- a/Wire-iOS/Sources/Helpers/ZMConversationMessage+Date.swift
+++ b/Wire-iOS/Sources/Helpers/ZMConversationMessage+Date.swift
@@ -51,6 +51,25 @@ extension ZMConversationMessage {
             return Message.shortDateTimeFormatter.string(from: date)
         }
     }
+
+    func formattedAccessibleMessageDetails() -> String? {
+        guard let serverTimestamp = self.serverTimestamp else {
+            return nil
+        }
+
+        let formattedTimestamp = Message.spellOutDateTimeFormatter.string(from: serverTimestamp)
+        let sendDate = "message_details.subtitle_send_date".localized(args: formattedTimestamp)
+
+        var accessibleMessageDetails = sendDate
+
+        if let editTimestamp = self.updatedAt {
+            let formattedEditTimestamp = Message.spellOutDateTimeFormatter.string(from: editTimestamp)
+            let editDate = "message_details.subtitle_edit_date".localized(args: formattedEditTimestamp)
+            accessibleMessageDetails += ("\n" + editDate)
+        }
+
+        return accessibleMessageDetails
+    }
 }
 
 extension ZMSystemMessageData {

--- a/Wire-iOS/Sources/Helpers/syncengine/Message+UI.h
+++ b/Wire-iOS/Sources/Helpers/syncengine/Message+UI.h
@@ -36,6 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (class, nonatomic, strong, readonly) NSDateFormatter *shortTimeFormatter;
 @property (class, nonatomic, strong, readonly) NSDateFormatter *shortDateFormatter;
 @property (class, nonatomic, strong, readonly) NSDateFormatter *shortDateTimeFormatter;
+@property (class, nonatomic, strong, readonly) NSDateFormatter *spellOutDateTimeFormatter;
 
 @end
 

--- a/Wire-iOS/Sources/Helpers/syncengine/Message+UI.m
+++ b/Wire-iOS/Sources/Helpers/syncengine/Message+UI.m
@@ -97,6 +97,20 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
     return longDateFormatter;
 }
 
++ (NSDateFormatter *)spellOutDateTimeFormatter
+{
+    static NSDateFormatter *longDateFormatter = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        longDateFormatter = [[NSDateFormatter alloc] init];
+        [longDateFormatter setDateStyle:NSDateFormatterLongStyle];
+        [longDateFormatter setTimeStyle:NSDateFormatterShortStyle];
+        longDateFormatter.doesRelativeDateFormatting = YES;
+    });
+
+    return longDateFormatter;
+}
+
 + (NSString *)nonNilImageDataIdentifier:(id<ZMConversationMessage>)message
 {
     NSString *identifier = message.imageMessageData.imageDataIdentifier;

--- a/Wire-iOS/Sources/UserInterface/Collections/NoResultsView.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/NoResultsView.swift
@@ -22,6 +22,16 @@ import Cartography
 @objcMembers final public class NoResultsView: UIView {
     public let label = UILabel()
     private let iconView = UIImageView()
+
+    public var placeholderText: String? {
+        get {
+            return label.text
+        }
+        set {
+            label.text = newValue
+            label.accessibilityLabel = newValue
+        }
+    }
     
     public var icon: ZetaIconType = .none {
         didSet {

--- a/Wire-iOS/Sources/UserInterface/Components/TabBar/Tab.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/TabBar/Tab.swift
@@ -23,6 +23,7 @@ class Tab: Button {
 
     var title: String = "" {
         didSet {
+            accessibilityLabel = title
             setTitle(title.localizedUppercase, for: .normal)
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Components/TabBar/TabBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/TabBar/TabBar.swift
@@ -80,7 +80,7 @@ class TabBar: UIView {
     }
     
     fileprivate func setupViews() {
-        tabs = items.map(makeButtonForItem)
+        tabs = items.enumerated().map(makeButtonForItem)
         tabs.forEach(stackView.addArrangedSubview)
 
         stackView.distribution = .fillEqually
@@ -145,10 +145,11 @@ class TabBar: UIView {
         }
     }
 
-    fileprivate func makeButtonForItem(_ item: UITabBarItem) -> Tab {
+    fileprivate func makeButtonForItem(_ index: Int, _ item: UITabBarItem) -> Tab {
         let tab = Tab(variant: style)
         tab.textTransform = .upper
         tab.setTitle(item.title, for: .normal)
+        tab.accessibilityIdentifier = "Tab\(index)"
 
         let changeObserver = item.observe(\.title) { [unowned tab, unowned item] _, _ in
             tab.setTitle(item.title, for: .normal)

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageActionController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageActionController.swift
@@ -86,6 +86,14 @@ import UIKit
         }
     }
 
+    @objc func makeAccessibilityActions() -> [UIAccessibilityCustomAction] {
+        return ConversationMessageActionController.allMessageActions
+            .filter { self.canPerformAction($0.action) }
+            .map { menuItem in
+                UIAccessibilityCustomAction(name: menuItem.title, target: self, selector: menuItem.action)
+            }
+    }
+
     @objc func makePreviewActions() -> [UIPreviewAction] {
         return ConversationMessageActionController.allMessageActions
             .filter { self.canPerformAction($0.action) }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
@@ -271,6 +271,7 @@ extension IndexSet {
         
         for (index, description) in tableViewCellDescriptions.enumerated() {
             if let cell = tableView.cellForRow(at: IndexPath(row: index, section: sectionIndex)) {
+                cell.accessibilityCustomActions = self.actionController?.makeAccessibilityActions()
                 description.configure(cell: cell, animated: true)
             }
         }
@@ -319,6 +320,7 @@ extension IndexSet {
         description.actionController = self.actionController
 
         let cell = description.makeCell(for: tableView, at: indexPath)
+        cell.accessibilityCustomActions = actionController?.makeAccessibilityActions()
         return cell
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsContentViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsContentViewController.swift
@@ -52,6 +52,16 @@ class MessageDetailsContentViewController: UIViewController {
         }
     }
 
+    /// The subtitle displaying message details in Voice Over.
+    var accessibleSubtitle: String? {
+        get {
+            return subtitleLabel.accessibilityValue
+        }
+        set {
+            subtitleLabel.accessibilityValue = newValue
+        }
+    }
+
     /// The displayed cells.
     fileprivate(set) var cells: [MessageDetailsCellDescription] = []
 
@@ -107,7 +117,8 @@ class MessageDetailsContentViewController: UIViewController {
         subtitleLabel.textAlignment = .center
         subtitleLabel.font = .mediumFont
         subtitleLabel.textColor = UIColor.from(scheme: .sectionText)
-        subtitleLabel.accessibilityLabel = "DeliveryStatus"
+        subtitleLabel.accessibilityIdentifier = "DeliveryStatus"
+        subtitleLabel.accessibilityLabel = "message_details.subtitle_label_voiceOver".localized
         view.addSubview(subtitleLabel)
 
         noResultsView.isHidden = true
@@ -159,18 +170,18 @@ class MessageDetailsContentViewController: UIViewController {
     private func configureForContentType() {
         switch contentType {
         case .reactions:
-            noResultsView.label.accessibilityLabel = "no likes"
-            noResultsView.label.text = "message_details.empty_likes".localized.uppercased()
+            noResultsView.label.accessibilityIdentifier = "placeholder.no_likes"
+            noResultsView.placeholderText = "message_details.empty_likes".localized.uppercased()
             noResultsView.icon = .like
 
         case .receipts(enabled: true):
-            noResultsView.label.accessibilityLabel = "no read receipts"
-            noResultsView.label.text = "message_details.empty_read_receipts".localized.uppercased()
+            noResultsView.label.accessibilityIdentifier = "placeholder.no_read_receipts"
+            noResultsView.placeholderText = "message_details.empty_read_receipts".localized.uppercased()
             noResultsView.icon = .eye
 
         case .receipts(enabled: false):
-            noResultsView.label.accessibilityLabel = "read receipts disabled"
-            noResultsView.label.text = "message_details.read_receipts_disabled".localized.uppercased()
+            noResultsView.label.accessibilityIdentifier = "placeholder.read_receipts_disabled"
+            noResultsView.placeholderText = "message_details.read_receipts_disabled".localized.uppercased()
             noResultsView.icon = .eye
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsDataSource.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsDataSource.swift
@@ -59,6 +59,9 @@ class MessageDetailsDataSource: NSObject, ZMMessageObserver, ZMConversationObser
     /// The subtitle of the message details.
     private(set) var subtitle: String!
 
+    /// The subtitle of the message details for accessibility purposes.
+    private(set) var accessibilitySubtitle: String!
+
     /// The list of likes.
     private(set) var reactions: [MessageDetailsCellDescription]
 
@@ -133,6 +136,7 @@ class MessageDetailsDataSource: NSObject, ZMMessageObserver, ZMConversationObser
         }
 
         self.subtitle = subtitle
+        self.accessibilitySubtitle = message.formattedAccessibleMessageDetails()
         self.observer?.detailsFooterDidChange(self)
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsViewController.swift
@@ -144,14 +144,17 @@ import WireExtensionComponents
         case .combined:
             reactionsViewController.subtitle = dataSource.subtitle
             reactionsViewController.accessibleSubtitle = dataSource.accessibilitySubtitle
+            
             readReceiptsViewController.subtitle = dataSource.subtitle
-            reactionsViewController.accessibleSubtitle = dataSource.accessibilitySubtitle
+            readReceiptsViewController.accessibleSubtitle = dataSource.accessibilitySubtitle
+
         case .reactions:
             reactionsViewController.subtitle = dataSource.subtitle
             reactionsViewController.accessibleSubtitle = dataSource.accessibilitySubtitle
+
         case .receipts:
             readReceiptsViewController.subtitle = dataSource.subtitle
-            reactionsViewController.accessibleSubtitle = dataSource.accessibilitySubtitle
+            readReceiptsViewController.accessibleSubtitle = dataSource.accessibilitySubtitle
         }
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsViewController.swift
@@ -101,6 +101,11 @@ import WireExtensionComponents
         reloadPlaceholders()
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        UIAccessibility.post(notification: .layoutChanged, argument: topBar)
+    }
+
     private func configureConstraints() {
         topBar.translatesAutoresizingMaskIntoConstraints = false
         container.view.translatesAutoresizingMaskIntoConstraints = false
@@ -138,11 +143,15 @@ import WireExtensionComponents
         switch dataSource.displayMode {
         case .combined:
             reactionsViewController.subtitle = dataSource.subtitle
+            reactionsViewController.accessibleSubtitle = dataSource.accessibilitySubtitle
             readReceiptsViewController.subtitle = dataSource.subtitle
+            reactionsViewController.accessibleSubtitle = dataSource.accessibilitySubtitle
         case .reactions:
             reactionsViewController.subtitle = dataSource.subtitle
+            reactionsViewController.accessibleSubtitle = dataSource.accessibilitySubtitle
         case .receipts:
             readReceiptsViewController.subtitle = dataSource.subtitle
+            reactionsViewController.accessibleSubtitle = dataSource.accessibilitySubtitle
         }
     }
 
@@ -155,6 +164,11 @@ import WireExtensionComponents
     }
 
     // MARK: - Top Bar
+
+    override func accessibilityPerformEscape() -> Bool {
+        dismiss(animated: true, completion: nil)
+        return true
+    }
 
     func modelTopBarWantsToBeDismissed(_ topBar: ModalTopBar) {
         dismiss(animated: true, completion: nil)

--- a/Wire-iOS/Sources/UserInterface/Location/ModalTopBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Location/ModalTopBar.swift
@@ -31,6 +31,7 @@ import Cartography
         let label = UILabel()
         label.textColor = .from(scheme: .textForeground)
         label.textAlignment = .center
+        label.accessibilityIdentifier = "Title"
 
         return label
     }()
@@ -40,6 +41,7 @@ import Cartography
         label.textColor = .from(scheme: .textForeground)
         label.font = UIFont.systemFont(ofSize: 11)
         label.textAlignment = .center
+        label.accessibilityIdentifier = "Subtitle"
 
         return label
     }()
@@ -66,6 +68,8 @@ import Cartography
         didSet {
             titleLabel.text = title?.uppercased()
             titleLabel.isHidden = title == nil
+            titleLabel.accessibilityLabel = title
+            titleLabel.accessibilityTraits.insert(.header)
         }
     }
 
@@ -73,6 +77,7 @@ import Cartography
         didSet {
             subtitleLabel.text = subtitle?.uppercased()
             subtitleLabel.isHidden = subtitle == nil
+            subtitleLabel.accessibilityLabel = subtitle
         }
     }
 
@@ -113,6 +118,10 @@ import Cartography
         subtitleLabel.isHidden = true
         [titleLabel, subtitleLabel].forEach(contentStackView.addArrangedSubview)
         [contentStackView, dismissButton, separatorView].forEach(addSubview)
+
+        dismissButton.accessibilityIdentifier = "Close"
+        dismissButton.accessibilityLabel = "general.close".localized
+
         dismissButton.setIcon(.cancel, with: .tiny, for: [])
         dismissButton.setIconColor(.from(scheme: .iconNormal), for: .normal)
         dismissButton.addTarget(self, action: #selector(dismissButtonTapped), for: .touchUpInside)


### PR DESCRIPTION
## What's new in this PR?

### Issues

The message details screen was not accessible for QA or screenreader users.

### Solutions

We add support for accessibility actions in message cells: now, VoiceOver users can select a cell and swipe up and down and double tap to trigger an action, instead of using the menu controller – which was not accessible at all.

In addition, we:
- Add correct accessibility IDs for QA
- Improve accessibility labels and values (ex: spell out the date in the timestamp in the message details screen, instead of saying "slash")
- Improve general experience (dismiss gesture, close buttons and default selection)