### PR TITLE
ZIOS-10939: Fix username not shown for added guest

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
@@ -244,7 +244,7 @@ extension IndexSet {
         }
     }
     
-    func configure(at sectionIndex: Int, in tableView: UITableView) {
+    @objc func configure(at sectionIndex: Int, in tableView: UITableView) {
         configure(in: context, at: sectionIndex, in: tableView)
     }
     

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ParticipantsCell/ParticipantsCellViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ParticipantsCell/ParticipantsCellViewModel.swift
@@ -158,7 +158,7 @@ class ParticipantsCellViewModel {
         if user.isSelfUser {
             return "content.system.you_\(grammaticalCase(for: user))".localized
         }
-        return user.displayName
+        return user.nameAsSender(in: message.conversation!)
     }
     
     private var nameList: NameList {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ParticipantsCell/ParticipantsCellViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ParticipantsCell/ParticipantsCellViewModel.swift
@@ -158,7 +158,9 @@ class ParticipantsCellViewModel {
         if user.isSelfUser {
             return "content.system.you_\(grammaticalCase(for: user))".localized
         }
-        return user.nameAsSender(in: message.conversation!)
+
+        let username = user.nameAsSender(in: message.conversation!)
+        return username.isEmpty ? "conversation.status.someone".localized : username
     }
     
     private var nameList: NameList {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter.m
@@ -30,6 +30,12 @@
 
 #import "Wire-Swift.h"
 
+@interface ConversationMessageWindowTableViewAdapter () <ZMConversationObserver>
+
+@property (nonatomic, nullable) id conversationChangeObserver;
+
+@end
+
 @implementation ConversationMessageWindowTableViewAdapter
 
 - (instancetype)initWithTableView:(UpsideDownTableView *)tableView messageWindow:(ZMConversationMessageWindow *)messageWindow
@@ -43,9 +49,15 @@
         self.firstUnreadMessage = self.messageWindow.conversation.firstUnreadMessage;
         self.sectionControllers = [[NSMutableDictionary alloc] init];
         self.actionControllers = [[NSMutableDictionary alloc] init];
+        self.conversationChangeObserver = [ConversationChangeInfo addObserver:self forConversation:messageWindow.conversation];
     }
     
     return self;
+}
+
+- (void)dealloc
+{
+    self.conversationChangeObserver = nil;
 }
 
 - (void)stopAudioPlayerForDeletedMessages:(NSSet *)deletedMessages
@@ -136,6 +148,11 @@
             self.expandingWindow = NO;
         });
     }
+}
+
+- (void)conversationDidChange:(ConversationChangeInfo *)changeInfo
+{
+    [self reconfigureVisibleSections];
 }
 
 @end

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter.m
@@ -55,11 +55,6 @@
     return self;
 }
 
-- (void)dealloc
-{
-    self.conversationChangeObserver = nil;
-}
-
 - (void)stopAudioPlayerForDeletedMessages:(NSSet *)deletedMessages
 {
     AudioTrackPlayer *audioTrackerPlayer = [AppDelegate sharedAppDelegate].mediaPlaybackManager.audioTrackPlayer;
@@ -152,7 +147,9 @@
 
 - (void)conversationDidChange:(ConversationChangeInfo *)changeInfo
 {
-    [self reconfigureVisibleSections];
+    if (changeInfo.participantsChanged) {
+        [self reconfigureVisibleSections];
+    }
 }
 
 @end


### PR DESCRIPTION
## What's new in this PR?

### Issues

When a wireless guest joined a conversation through a link, their name was not displayed in the system message cell on iOS clients.

### Causes

When the system message is inserted, it seems that the name is not fetched yet, which means that the generated cell won’t display a name either.

### Solutions

Prior to the cell refactoring, the update was performed in the message window change observer callback in the message window adapter. However, this part of the code was not updated to include the new section system, which means cells were not reloaded appropriately.

We fix this by using the new section controller logic in the message window observer.