### PR TITLE
Save preference for log tags

### DIFF
--- a/Wire-iOS/Sources/Components/Settings+Logging.swift
+++ b/Wire-iOS/Sources/Components/Settings+Logging.swift
@@ -48,7 +48,7 @@ extension Settings {
         let avsTag = "AVS"
         if isInternal {
             var tagsToEnable = Set(arrayLiteral: avsTag)
-            if let savedTags = UserDefaults.shared().object(forKey: "WireEnabledZMLogTags") as? Array<String> {
+            if let savedTags = UserDefaults.shared().object(forKey: enabledLogsKey) as? Array<String> {
                 tagsToEnable.formUnion(savedTags)
             } else {
                 tagsToEnable.formUnion(["Network", "SessionManager", "Conversations", "calling", "link previews", "ephemeral", "event-processing", "SyncStatus", "OperationStatus", "Push"])

--- a/Wire-iOS/Sources/Components/Settings+Logging.swift
+++ b/Wire-iOS/Sources/Components/Settings+Logging.swift
@@ -47,8 +47,12 @@ extension Settings {
     @objc public func loadEnabledLogs() {
         let avsTag = "AVS"
         if isInternal {
-            var tagsToEnable = UserDefaults.shared().value(forKey: enabledLogsKey) as? Set<String> ?? ["Network", "SessionManager", "Conversations", avsTag, "calling", "link previews", "ephemeral", "event-processing", "SyncStatus", "OperationStatus", "Push"]
-            tagsToEnable.insert(avsTag)
+            var tagsToEnable = Set(arrayLiteral: avsTag)
+            if let savedTags = UserDefaults.shared().object(forKey: "WireEnabledZMLogTags") as? Array<String> {
+                tagsToEnable.formUnion(savedTags)
+            } else {
+                tagsToEnable.formUnion(["Network", "SessionManager", "Conversations", "calling", "link previews", "ephemeral", "event-processing", "SyncStatus", "OperationStatus", "Push"])
+            }
             enableLogs(tagsToEnable)
         } else {
             enableLogs([avsTag])


### PR DESCRIPTION
## What's new in this PR?

### Issues

On internal builds we can turn on logging from various subsystems. The preferences would not get saved and on next launch it would fallback to default set of logs again.

### Causes

It was caused by two issues:
1. We used `value(forKey:)` which is a KVC method, instead of `object(forKey:)`. This call crashes on simulator but I assume gets optimised out (or returns nil) on release builds 🤷‍♂️.
2. We were casting the result to `Set<String>` when user defaults always return `Array<String>` in these cases, so it was falling back to default values.

### Solutions

Fix issues outlined above.