### PR TITLE
Fix: Invite contacts does not work

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsViewController.m
+++ b/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsViewController.m
@@ -426,7 +426,8 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
                                                                  [unableToSendController dismissViewControllerAnimated:YES completion:nil];
                                                              }];
             [unableToSendController addAction:okAction];
-            [self presentViewController:unableToSendController animated:YES completion:nil];
+
+            [[AppDelegate sharedAppDelegate].notificationsWindow.rootViewController presentViewController:unableToSendController animated:YES completion:nil];
             return;
         }
         


### PR DESCRIPTION
## What's new in this PR?

### Issues

When the user has no email client installed, the screen jumps back to contacts overview and no one is invited/contacted. 

### Causes

The "Please configure your email..." dialog is not shown in this case for the warning "Warning: Attempt to present <UIAlertController: 0x7f9d0aa37800> on <InviteContactsViewController: 0x7f9d0c16dc00> whose view is not in the window hierarchy!
"

### Solutions

Present the dialog in NotificationsWindow.