### PR TITLE
Fix: AdaptiveFormViewControllerTests flaky fails when running for iPad sizes

### DIFF
--- a/Wire-iOS Tests/Authentication/AdaptiveFormViewControllerTests.swift
+++ b/Wire-iOS Tests/Authentication/AdaptiveFormViewControllerTests.swift
@@ -21,26 +21,37 @@ import XCTest
 
 class AdaptiveFormViewControllerTests: ZMSnapshotTestCase {
 
-    var child: VerificationCodeStepViewController?
+    var child: VerificationCodeStepViewController!
+    var sut: AdaptiveFormViewController!
+
+    // wrap the SUT in a mock navigator VC to mock the traitcollection's horizontalSizeClass.
+    var mockParentViewControler: UINavigationController!
 
     override func setUp() {
         super.setUp()
         child = VerificationCodeStepViewController(credential: "user@example.com")
+        sut = AdaptiveFormViewController(childViewController: child)
+        mockParentViewControler = UINavigationController(rootViewController: sut)
     }
 
     override func tearDown() {
         child = nil
+        mockParentViewControler = nil
+        sut = nil
         super.tearDown()
     }
 
     func testThatItHasCorrectLayout() {
-        // GIVEN
-        let sut = AdaptiveFormViewController(childViewController: child!)
-
-        // THEN
         verifyInAllDeviceSizes(view: sut.view) { _, isPad in
-            sut.updateConstraints(usingRegularLayout: isPad)
+            let traitCollection: UITraitCollection
+            if isPad {
+                traitCollection = UITraitCollection(horizontalSizeClass: .regular)
+            } else {
+                traitCollection = UITraitCollection(horizontalSizeClass: .compact)
+            }
+
+            self.mockParentViewControler.setOverrideTraitCollection(traitCollection, forChild: self.sut)
+            self.sut.traitCollectionDidChange(nil)
         }
     }
-
 }

--- a/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
+++ b/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
@@ -39,11 +39,6 @@
                BlueprintName = "Wire-iOS-Tests"
                ReferencedContainer = "container:Wire-iOS.xcodeproj">
             </BuildableReference>
-            <SkippedTests>
-               <Test
-                  Identifier = "AdaptiveFormViewControllerTests/testThatItHasCorrectLayout()">
-               </Test>
-            </SkippedTests>
          </TestableReference>
       </Testables>
       <MacroExpansion>


### PR DESCRIPTION
## What's new in this PR?
This PR is part of the snapshot tests refactoring tasks.

### Issues

AdaptiveFormViewControllerTests produces flaky results and it was disabled.

### Causes

When running a set of snasphot tests for all device sizes, it was updated the constraints set only but may not update its child VCs. 

### Solutions

Wrap the AdaptiveFormViewController in a mock navigation VC as the real use case. Call setOverrideTraitCollection and traitCollectionDidChange to simulate size class update event.