### PR TITLE
ZIOS-10978: Revert selection changes that cause implicit message animation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
@@ -23,6 +23,7 @@ struct ConversationMessageContext {
     let isTimeIntervalSinceLastMessageSignificant: Bool
     let isFirstMessageOfTheDay: Bool
     let isFirstUnreadMessage: Bool
+    let isLastMessage: Bool
     let searchQueries: [String]
 }
 
@@ -284,9 +285,8 @@ extension IndexSet {
         guard !message.isSystem else {
             return false
         }
-        
-        
-        return selected || message.deliveryState == .failedToSend || message.hasReactions()
+
+        return context.isLastMessage || selected || message.deliveryState == .failedToSend || message.hasReactions()
     }
     
     func isSenderVisible(in context: ConversationMessageContext) -> Bool {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter+DataSource.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter+DataSource.swift
@@ -107,33 +107,9 @@ extension ConversationMessageWindowTableViewAdapter: ZMConversationMessageWindow
                 self.tableView.lockContentOffset = false
             }
         }
-        
-        if changeInfo.insertedIndexes.count > 0 {
-            selectLastMessage()
-        }
     }
-    
-    @objc
-    func selectLastMessage() {
-        
-        if let lastMessage = self.messageWindow.conversation.messages.lastObject as? ZMConversationMessage,
-            let lastIndex = self.indexPath(for: lastMessage) {
-            
-            if let selectedMessage = selectedMessage,
-                let selectedIndex = self.indexPath(for: selectedMessage) {
-                self.selectedMessage = nil
-                deselect(indexPath: selectedIndex)
-                tableView.deselectRow(at: selectedIndex, animated: true)
-            }
-            
-            self.selectedMessage = lastMessage
-            select(indexPath: lastIndex)
-            tableView.selectRow(at: lastIndex, animated: true, scrollPosition: .none)
-        }
-    }
-    
-    @objc
-    func reconfigureVisibleSections() {
+
+    @objc func reconfigureVisibleSections() {
         tableView.beginUpdates()
         if let indexPathsForVisibleRows = tableView.indexPathsForVisibleRows {
             let visibleSections = Set(indexPathsForVisibleRows.map(\.section))

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ZMConversationMessageWindow+Formatting.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ZMConversationMessageWindow+Formatting.swift
@@ -48,6 +48,7 @@ extension ZMConversationMessageWindow {
             isTimeIntervalSinceLastMessageSignificant: isTimeIntervalSinceLastMessageSignificant,
             isFirstMessageOfTheDay: isFirstMessageOfTheDay(for: message),
             isFirstUnreadMessage: message.isEqual(firstUnreadMessage),
+            isLastMessage: self.messages.index(of: message) == 0,
             searchQueries: searchQueries
         )
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

When sending an image message, the message cell was implicitly animated.

### Causes

This was caused by manually selecting the last message.

### Solutions

We revert these changes and fallback to checking if the message is that last one to check if the toolbox needs to be selected. 

The consequence is that the message toolbox cannot be dismissed on the last message. We will revisit these changes later and find a better way to determine selection.