### PR TITLE
Message Toolbox: fix update

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxDataSource.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxDataSource.swift
@@ -24,10 +24,10 @@ enum MessageToolboxContent: Equatable {
     case sendFailure(NSAttributedString)
 
     /// Display the list of reactions.
-    case reactions(NSAttributedString)
+    case reactions(NSAttributedString, likers: [ZMUser])
 
     /// Display the message details (timestamp and/or status).
-    case details(timestamp: NSAttributedString?, status: NSAttributedString?)
+    case details(timestamp: NSAttributedString?, status: NSAttributedString?, likers: [ZMUser])
 }
 
 extension MessageToolboxContent: Comparable {
@@ -77,7 +77,7 @@ class MessageToolboxDataSource {
     /// Creates a toolbox data source for the given message.
     init(message: ZMConversationMessage) {
         self.message = message
-        self.content = .details(timestamp: nil, status: nil)
+        self.content = .details(timestamp: nil, status: nil, likers: [])
     }
 
     // MARK: - Content
@@ -107,12 +107,12 @@ class MessageToolboxDataSource {
         // 2) Likers
         else if !showTimestamp {
             let text = makeReactionsLabel(with: likers, widthConstraint: widthConstraint)
-            content = .reactions(text)
+            content = .reactions(text, likers: likers)
         }
         // 3) Timestamp
         else {
             let (timestamp, status) = makeDetailsString()
-            content = .details(timestamp: timestamp, status: status)
+            content = .details(timestamp: timestamp, status: status, likers: likers)
         }
 
         // Only perform the changes if the content did change.
@@ -130,7 +130,7 @@ class MessageToolboxDataSource {
         let likers = message.likers()
         let conversation = message.conversation
 
-        // If there is only one liker, always display the name, even if the width doesn't fir
+        // If there is only one liker, always display the name, even if the width doesn't fit
         if likers.count == 1 {
             return likers[0].displayName(in: conversation) && attributes
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
@@ -228,7 +228,7 @@ import WireSyncEngine
         }
 
         switch dataSource.content {
-        case .reactions(let reactionsString):
+        case .reactions(let reactionsString, _):
             updateContentStack(to: newPosition, animated: animated) {
                 self.detailsLabel.attributedText = reactionsString
                 self.detailsLabel.isHidden = false
@@ -248,7 +248,7 @@ import WireSyncEngine
                 self.resendButton.isHidden = false
             }
 
-        case .details(let timestamp, let status):
+        case .details(let timestamp, let status, _):
             updateContentStack(to: newPosition, animated: animated) {
                 self.detailsLabel.attributedText = timestamp
                 self.detailsLabel.isHidden = timestamp == nil


### PR DESCRIPTION
## What's new in this PR?

### Issues

The message would not reflect the liked state change when selected.

### Causes

When the message toolbox state is calculated, we check if it's different from the old one, and update the view only if it is. In case of selected message, we are always showing the timestamp, so the previous state (show timestamp) equals to the new state (show timestamp).

The problem is happening because we also have the heart view that reflects the liked state, and it is not reflected in the enum state.

### Solutions

I added the list of likers to the state, so when it is changing the status is considered different from the previous one.
