### PR TITLE
Fix: framework CFBundleVersion is not set

### DIFF
--- a/WireExtensionComponents/Info.plist
+++ b/WireExtensionComponents/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<string>1</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>


### PR DESCRIPTION
## What's new in this PR?

### Issues

After merging #2941 we have changed many configuration options and overlooked that CFBundleVersion for WireExtensionComponents is not set in Info.plist.

### Causes

In the old configurations we had CURRENT_PROJECT_VERSION build parameter set which is not present in new configs. It was always set to 1.

### Solutions

Internal framework version number is not important, setting it to 1 to make it similar to original implementation.

