### PR TITLE
ZIOS-10914: Removed isAccessibilityElement from video, file and audio cells container

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationAudioMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationAudioMessageCell.swift
@@ -51,7 +51,6 @@ class ConversationAudioMessageCell: RoundedView, ConversationMessageCell {
         clipsToBounds = true
         
         transferView.delegate = self
-        transferView.isAccessibilityElement = true
         obfuscationView.isHidden = true
         
         addSubview(self.transferView)

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationVideoMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationVideoMessageCell.swift
@@ -51,7 +51,6 @@ class ConversationVideoMessageCell: RoundedView, ConversationMessageCell {
         clipsToBounds = true
         
         transferView.delegate = self
-        transferView.isAccessibilityElement = true
         obfuscationView.isHidden = true
         
         addSubview(self.transferView)

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationFileMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationFileMessageCell.swift
@@ -51,7 +51,6 @@ class ConversationFileMessageCell: RoundedView, ConversationMessageCell {
         clipsToBounds = true
 
         fileTransferView.delegate = self
-        fileTransferView.isAccessibilityElement = true
         obfuscationView.isHidden = true
 
         addSubview(self.fileTransferView)


### PR DESCRIPTION
## What's new in this PR?

The `isAccessibilityElement` setting on video, file and audio cell containers were causing the subviews not being accessible from the inspector, even if they had proper IDs setted. I've removed those assignments.