### PR TITLE
ZIOS-10967: username/avatar is not shown when a user sends a message immediately after sending a ping

### DIFF
--- a/Wire-iOS Tests/ConversationMessageCell/ConversationCellSnapshotTestCase.swift
+++ b/Wire-iOS Tests/ConversationMessageCell/ConversationCellSnapshotTestCase.swift
@@ -39,7 +39,8 @@ class ConversationCellSnapshotTestCase: CoreDataSnapshotTestCase {
                                                     isFirstMessageOfTheDay: false,
                                                     isFirstUnreadMessage: false,
                                                     isLastMessage: false,
-                                                    searchQueries: [])
+                                                    searchQueries: [],
+                                                    previousMessageIsKnock: false)
         
         resetDayFormatter()
         

--- a/Wire-iOS Tests/ConversationMessageCell/ConversationMessageSectionControllerTests.swift
+++ b/Wire-iOS Tests/ConversationMessageCell/ConversationMessageSectionControllerTests.swift
@@ -29,7 +29,7 @@ class ConversationMessageSectionControllerTests: XCTestCase {
     override func setUp() {
         super.setUp()
         
-        context = ConversationMessageContext(isSameSenderAsPrevious: false, isTimeIntervalSinceLastMessageSignificant: false, isFirstMessageOfTheDay: false, isFirstUnreadMessage: false, isLastMessage: false, searchQueries: [])
+        context = ConversationMessageContext(isSameSenderAsPrevious: false, isTimeIntervalSinceLastMessageSignificant: false, isFirstMessageOfTheDay: false, isFirstUnreadMessage: false, isLastMessage: false, searchQueries: [], previousMessageIsKnock: false)
         layoutProperties = ConversationCellLayoutProperties()
     }
     

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
@@ -25,6 +25,7 @@ struct ConversationMessageContext {
     let isFirstUnreadMessage: Bool
     let isLastMessage: Bool
     let searchQueries: [String]
+    let previousMessageIsKnock: Bool
 }
 
 extension IndexSet {
@@ -294,7 +295,7 @@ extension IndexSet {
             return false
         }
         
-        return !context.isSameSenderAsPrevious || message.updatedAt != nil || isBurstTimestampVisible(in: context)
+        return !context.isSameSenderAsPrevious || context.previousMessageIsKnock || message.updatedAt != nil || isBurstTimestampVisible(in: context)
     }
     
     // MARK: - Data Source

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ZMConversationMessageWindow+Formatting.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ZMConversationMessageWindow+Formatting.swift
@@ -49,7 +49,8 @@ extension ZMConversationMessageWindow {
             isFirstMessageOfTheDay: isFirstMessageOfTheDay(for: message),
             isFirstUnreadMessage: message.isEqual(firstUnreadMessage),
             isLastMessage: self.messages.index(of: message) == 0,
-            searchQueries: searchQueries
+            searchQueries: searchQueries,
+            previousMessageIsKnock: messagePrevious(to: message)?.isKnock == true
         )
     }
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

Sender is not shown when sending a message in a conversation after pinging.

### Solutions

I've added the `context.previousMessageIsKnock` condition inside of `isSenderVisible` method of `ConversationMessageSectionController`.