### PR TITLE
ZIOS-10985: Typing indicator won't dismiss after unsuccessful edit

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Editing.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Editing.swift
@@ -50,6 +50,7 @@ extension ConversationInputBarViewController {
             self.conversation.draftMessage = nil
         }
         updateWritingState(animated: true)
+        conversation.setIsTyping(false)
 
         NotificationCenter.default.removeObserver(
             self,


### PR DESCRIPTION
## What's new in this PR?

Typing indicator wasn't dismissed after closing the editing input bar in a conversation; this is because `conversation.setIsTyping(false)` was not called after the end of the editing.