### PR TITLE
Missing unread dot in the account switcher

### DIFF
--- a/Wire-iOS/Sources/UserInterface/SelfProfile/DotView.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/DotView.swift
@@ -75,11 +75,9 @@ class DotView: UIView {
     }
     
     internal func updateIndicator() {
-        guard let user = user else { return }
-
         showIndicator = hasUnreadMessages ||
-                        user.clientsRequiringUserAttention.count > 0 ||
-                        user.readReceiptsEnabledChangedRemotely
+                        user?.clientsRequiringUserAttention.count > 0 ||
+                        user?.readReceiptsEnabledChangedRemotely == true
     }
 }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

If you were using Wire with multiple accounts the account switcher wouldn't indicate which accounts have unread messages.

### Causes

The `AccountView` used in the account switcher weren't initialised with a user since it can't observe the self user of a background account. The unread dot was only updated if a user was associated with the `AccountView`.

### Solutions

Re-write the update method to not require a user to be present.