### PR TITLE
Fix crash when starting ping animation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationPingCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationPingCell.swift
@@ -114,14 +114,12 @@ class ConversationPingCell: ConversationIconBasedCell, ConversationMessageCell {
     func willDisplay() {
         
         if let conversation = self.configuration?.message?.conversation,
-            let lastMessage = conversation.conversationWindow(withSize: 30).messages.firstObject as? ZMConversationMessage,
-            let message = self.configuration?.message {
+           let lastMessage = conversation.messages.lastObject as? ZMConversationMessage,
+           let message = self.configuration?.message {
             
             let isLastMessage = lastMessage.isEqual(message)
-            let result = message.serverTimestamp?.compare(conversation.lastServerTimeStamp ?? Date())
-            let isMessageOlder = result != .orderedAscending
             
-            if isLastMessage && message.isKnock && isMessageOlder {
+            if isLastMessage && message.isKnock {
                 startAnimation()
             }
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

App would sometimes crash when determining if it should start the ping animation

### Causes

App was crashing when initialising a message window.

### Solutions

We don't need create a message window in order to calculate if the ping cell is the last message. Simplify logic for determining if we should start the ping animation.