### PR TITLE
ZIOS-11017: Fix tab bar deallocation crash on iOS 10

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/TabBar/TabBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/TabBar/TabBar.swift
@@ -55,7 +55,11 @@ class TabBar: UIView {
         return self.tabs[selectedIndex]
     }
 
-    private var titleObservers: [Any] = []
+    private var titleObservers: [NSKeyValueObservation] = []
+
+    deinit {
+        titleObservers.forEach { $0.invalidate() }
+    }
 
     // MARK: - Initialization
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

When signing in on iOS 10, the app would crash.

### Causes

In the `TabBar` view, we are observing the title of a view controller through its tab bar item. When it is deallocated, the observer token is not automatically unregistered on iOS 10 (on iOS 11+, it is unregistered automatically).

### Solutions

Invalidate the observation tokens manually.