### PR TITLE
Try starting ephemeral timer after configuring message

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
@@ -179,6 +179,8 @@ extension ConversationMessageCellDescription {
         guard let adapterCell = cell as? ConversationMessageCellTableViewAdapter<Self> else { return }
         
         adapterCell.cellView.configure(with: self.configuration, animated: animated)
+        
+        _ = message?.startSelfDestructionIfNeeded()
     }
     
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

The ephemeral timer would not start for files if the conversation was already open when receiving the file.

### Causes

We don't start the timer while we show the file placeholder but we also didn't try to start the timer after the file has been uploaded.

### Solutions

Try to start the timer after configuring a cell.
