### PR TITLE
Fix guest filtering on group creation

### DIFF
--- a/Wire-iOS/Sources/Components/TokenField/TokenField.m
+++ b/Wire-iOS/Sources/Components/TokenField/TokenField.m
@@ -584,6 +584,8 @@ CGFloat const accessoryButtonSize = 32.0f;
     
     if (anyTokenUpdated) {
         [self updateTokenAttachments];
+        NSRange wholeRange = NSMakeRange(0, self.textView.attributedText.length);
+        [self.textView.layoutManager invalidateLayoutForCharacterRange:wholeRange actualCharacterRange:NULL];
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
@@ -26,15 +26,24 @@ protocol ConversationCreationValuesConfigurable: class {
 }
 
 final public class ConversationCreationValues {
+    private var unfilteredParticipants: Set<ZMUser>
+    
     var allowGuests: Bool
     var enableReceipts: Bool
     var name: String
-    var participants: Set<ZMUser>
+    var participants: Set<ZMUser> {
+        get {
+            let selfUser = ZMUser.selfUser()
+            return allowGuests ? unfilteredParticipants : unfilteredParticipants.filter({ $0.team == selfUser?.team})
+        }
+        set {
+            unfilteredParticipants = newValue
+        }
+    }
     
     init (name: String = "", participants: Set<ZMUser> = [], allowGuests: Bool = true, enableReceipts: Bool = true) {
         self.name = name
-        let selfUser = ZMUser.selfUser()!
-        self.participants = allowGuests ? participants : Set(Array(participants).filter { $0.team == selfUser.team })
+        self.unfilteredParticipants = participants
         self.allowGuests = allowGuests
         self.enableReceipts = enableReceipts
     }

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+SearchResults.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+SearchResults.swift
@@ -40,11 +40,7 @@ extension StartUIViewController: SearchResultsViewControllerDelegate {
         guard let unboxedUser = BareUserToUser(user), unboxedUser.isConnected, !unboxedUser.isBlocked else {
             return
         }
-            
-        guard self.userSelection.users.count != 1 || self.userSelection.users.contains(unboxedUser) else {
-            return
-        }
-            
+        
         self.delegate.startUI(self, didSelect: [unboxedUser])
     }
     

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+internal.h
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+internal.h
@@ -20,8 +20,6 @@ static NSUInteger const StartUIInitiallyShowsKeyboardConversationThreshold = 10;
 
 @interface StartUIViewController ()
 
-@property (nonatomic) UserSelection *userSelection;
-
 - (void)presentProfileViewControllerForUser:(id<UserType>)bareUser atIndexPath:(NSIndexPath *)indexPath;
 
 @end


### PR DESCRIPTION
## What's new in this PR?

### Issues

Guests wouldn't be filtered out if the "allow guests" was changed after adding guests and then tapping the back button.

### Causes

Guests were only filtered in initializer.

### Solutions

Always filter guests depending on the current value of the guest toggle.

## Notes
- Remove some dead code in the `StartUIViewController`
-  fixed a rendering issue with the token field if it was pre-populated before appearing on the screen.