### PR TITLE
Only show read receipts toggle if conversation was created within your own team

### DIFF
--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
@@ -123,7 +123,7 @@ import Cartography
             sections.append(optionsSectionController)            
         }
 
-        if let selfUser = ZMUser.selfUser(), selfUser.isTeamMember, conversation.team != nil {
+        if let selfUser = ZMUser.selfUser(), selfUser.isTeamMember, conversation.team == selfUser.team {
             let receiptOptionsSectionController = ReceiptOptionsSectionController(conversation: conversation,
                                                                                   syncCompleted: didCompleteInitialSync,
                                                                                   collectionView: self.collectionViewController.collectionView!,


### PR DESCRIPTION
## What's new in this PR?

### Issues

Read receipts toggle was visible for a team user being a guest in a conversation belonging to another team.

### Solutions

Check that the conversation was created within your own team.