### PR TITLE
Added feature flag for account creation

### DIFF
--- a/Wire-iOS/Sources/Authentication/Authentication/Landing/LandingViewController.swift
+++ b/Wire-iOS/Sources/Authentication/Authentication/Landing/LandingViewController.swift
@@ -151,9 +151,13 @@ final class LandingViewController: AuthenticationStepViewController {
         [headerContainerView, buttonStackView, loginHintsLabel, loginButton].forEach(view.addSubview)
         headerContainerView.addSubview(logoView)
         
-        [createAccountButton, createTeamButton].forEach { button in
-            buttonStackView.addArrangedSubview(button)
-        }
+        #if ACCOUNT_CREATION_DISABLED
+            // Do not show buttons for account and team creation
+        #else
+            [createAccountButton, createTeamButton].forEach { button in
+                buttonStackView.addArrangedSubview(button)
+            }
+        #endif
 
         self.view.backgroundColor = UIColor.Team.background
         navigationBar.pushItem(navigationItem, animated: false)


### PR DESCRIPTION
## What's new in this PR?

When building we need to have a possibility to disable team creation and registration. This PR adds a feature flag `ACCOUNT_CREATION_DISABLED` that controls this.
