### PR TITLE
Show unconnected users as desaturated

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConnectRequests/UserConnectionView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConnectRequests/UserConnectionView.swift
@@ -65,7 +65,6 @@ public final class UserConnectionView: UIView, Copyable {
         }
 
         self.userImageView.accessibilityLabel = "user image"
-        self.userImageView.shouldDesaturate = false
         self.userImageView.size = .big
         self.userImageView.user = self.user
         


### PR DESCRIPTION
## What's new in this PR?

### Issues

Pending connection conversations were displaying the big user image at the start of the conversation in color.

### Causes

De-saturation of the user image was turned of for this view.

### Solutions

Allow default de-saturation logic.