### PR TITLE
Fixed double instance of footer view in notification options

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationNotificationOptionsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationNotificationOptionsViewController.swift
@@ -27,8 +27,6 @@ class ConversationNotificationOptionsViewController: UIViewController {
     private var observerToken: Any! = nil
     
     public weak var dismisser: ViewControllerDismisser?
-
-    private var footerView = SectionFooter(frame: .zero)
     
     private let collectionViewLayout = UICollectionViewFlowLayout()
     
@@ -71,6 +69,7 @@ class ConversationNotificationOptionsViewController: UIViewController {
         collectionViewLayout.minimumLineSpacing = 0
         
         CheckmarkCell.register(in: collectionView)
+        collectionView.register(SectionHeader.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: "SectionHeader")
         collectionView.register(SectionFooter.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionFooter, withReuseIdentifier: "SectionFooter")
     }
     
@@ -109,17 +108,22 @@ extension ConversationNotificationOptionsViewController: UICollectionViewDelegat
     }
     
     func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
-        
-        let view = collectionView.dequeueReusableSupplementaryView(ofKind: UICollectionView.elementKindSectionFooter, withReuseIdentifier: "SectionFooter", for: indexPath)
-        (view as? SectionFooter)?.titleLabel.text = "group_details.notification_options_cell.description".localized
-        return view
+        if kind == UICollectionView.elementKindSectionHeader {
+            let view = collectionView.dequeueReusableSupplementaryView(ofKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: "SectionHeader", for: indexPath)
+            return view
+        } else {
+            guard let view = collectionView.dequeueReusableSupplementaryView(ofKind: UICollectionView.elementKindSectionFooter, withReuseIdentifier: "SectionFooter", for: indexPath) as? SectionFooter else { return UICollectionReusableView(frame: .zero) }
+            view.titleLabel.text = "group_details.notification_options_cell.description".localized
+            return view
+        }
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForFooterInSection section: Int) -> CGSize {
         
-        footerView.titleLabel.text = "group_details.notification_options_cell.description".localized
-        footerView.size(fittingWidth: collectionView.bounds.width)
-        return footerView.bounds.size
+        guard let view = collectionView.dequeueReusableSupplementaryView(ofKind: UICollectionView.elementKindSectionFooter, withReuseIdentifier: "SectionFooter", for: IndexPath(item: 0, section: section)) as? SectionFooter else { return .zero }
+        view.titleLabel.text = "group_details.notification_options_cell.description".localized
+        view.size(fittingWidth: collectionView.bounds.width)
+        return view.bounds.size
     }
     
     // MARK: Saving Changes


### PR DESCRIPTION
## What's new in this PR?

### Issues

`SectionFooter` was shown twice (two instances at the same origin in the view) in the footer of `ConversationNotificationOptionsViewController`.
![screenshot 2019-01-02 at 11 27 27](https://user-images.githubusercontent.com/2906234/50631947-9301b200-0f46-11e9-86b3-46708d14afee.png)

### Causes

That's because the collection view has both header and footer, and we were returning only the footer view inside `viewForSupplementaryElementOfKind:`, without distinguishing between header and footer.

### Solutions

I'm now returning `SectionHeader` for the header and `SectionFooter` for the footer.
