### PR TITLE
ZIOS-10764: Removed dismissing of options view controller for conversation details

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationNotificationOptionsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationNotificationOptionsViewController.swift
@@ -137,8 +137,6 @@ extension ConversationNotificationOptionsViewController: UICollectionViewDelegat
         userSession.performChanges {
             self.conversation.mutedMessageTypes = types
         }
-        
-        self.dismisser?.dismiss(viewController: self, completion: nil)
     }
     
     // MARK: Layout

--- a/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationTimeoutOptionsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationTimeoutOptionsViewController.swift
@@ -173,10 +173,8 @@ extension ConversationTimeoutOptionsViewController: UICollectionViewDelegateFlow
             item.cancel()
             self.showLoadingView = false
 
-            switch result {
-            case .success:
-                self.dismisser?.dismiss(viewController: self, completion: nil)
-            case .failure(let error): self.handle(error: error)
+            if case .failure(let error) = result {
+                self.handle(error: error)
             }
         }
     }


### PR DESCRIPTION
## What's new in this PR?

Removed calls to the dismisser when updating options inside the conversation details (see ticket).