### PR TITLE
Fix: ProfileViewController is not dismissed after the user is removed

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1226,7 +1226,7 @@
 		EF3BA5D421075FC60093048F /* ConversationInputBarViewController+Language.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3BA5D321075FC60093048F /* ConversationInputBarViewController+Language.swift */; };
 		EF3BA5D72107688D0093048F /* InputLanguageSettable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3BA5D62107688D0093048F /* InputLanguageSettable.swift */; };
 		EF3CB75321DD0F0C0030C3E8 /* ConversationViewController+ParticipantsPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3CB75221DD0F0B0030C3E8 /* ConversationViewController+ParticipantsPopover.swift */; };
-		EF3CB75521DD157B0030C3E8 /* ProfileViewController+KeyboardFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3CB75421DD157B0030C3E8 /* ProfileViewController+KeyboardFrame.swift */; };
+		EF3CB75521DD157B0030C3E8 /* ProfileViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3CB75421DD157B0030C3E8 /* ProfileViewController+Extension.swift */; };
 		EF3CBC0A2147D81800566295 /* ConversationListViewController+PushPermissions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3CBC092147D81700566295 /* ConversationListViewController+PushPermissions.swift */; };
 		EF40005720568C4400E03347 /* NetworkStatusBarConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF40005620568C4400E03347 /* NetworkStatusBarConstants.swift */; };
 		EF4018BE205975C100CFBCB0 /* ApplicationProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF4018BD205975C100CFBCB0 /* ApplicationProtocol.swift */; };
@@ -3009,7 +3009,7 @@
 		EF3BA5D321075FC60093048F /* ConversationInputBarViewController+Language.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationInputBarViewController+Language.swift"; sourceTree = "<group>"; };
 		EF3BA5D62107688D0093048F /* InputLanguageSettable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputLanguageSettable.swift; sourceTree = "<group>"; };
 		EF3CB75221DD0F0B0030C3E8 /* ConversationViewController+ParticipantsPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationViewController+ParticipantsPopover.swift"; sourceTree = "<group>"; };
-		EF3CB75421DD157B0030C3E8 /* ProfileViewController+KeyboardFrame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProfileViewController+KeyboardFrame.swift"; sourceTree = "<group>"; };
+		EF3CB75421DD157B0030C3E8 /* ProfileViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProfileViewController+Extension.swift"; sourceTree = "<group>"; };
 		EF3CBC092147D81700566295 /* ConversationListViewController+PushPermissions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ConversationListViewController+PushPermissions.swift"; sourceTree = "<group>"; };
 		EF40005620568C4400E03347 /* NetworkStatusBarConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkStatusBarConstants.swift; sourceTree = "<group>"; };
 		EF4018BD205975C100CFBCB0 /* ApplicationProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationProtocol.swift; sourceTree = "<group>"; };
@@ -5763,7 +5763,7 @@
 				8FC852BE199245760008B66B /* ProfileViewController.h */,
 				EF538FE02028AB6600EA4048 /* ProfileViewController+internal.h */,
 				8FC852BF199245760008B66B /* ProfileViewController.m */,
-				EF3CB75421DD157B0030C3E8 /* ProfileViewController+KeyboardFrame.swift */,
+				EF3CB75421DD157B0030C3E8 /* ProfileViewController+Extension.swift */,
 				1613C76C1C3D2E7400B1FB8A /* ProfileDetailsViewController.h */,
 				EF297DE5213213A60002983A /* ProfileDetailsViewController+Internal.h */,
 				1613C76D1C3D2E7400B1FB8A /* ProfileDetailsViewController.m */,
@@ -7947,7 +7947,7 @@
 				EEAC0A1221AD875900BE5F5D /* ConversationCreateNameSectionController.swift in Sources */,
 				870815881BF4EAD100D321BC /* SettingsTableViewController.swift in Sources */,
 				EF2127261FB9DFE300625A9B /* RegistrationRootViewController.m in Sources */,
-				EF3CB75521DD157B0030C3E8 /* ProfileViewController+KeyboardFrame.swift in Sources */,
+				EF3CB75521DD157B0030C3E8 /* ProfileViewController+Extension.swift in Sources */,
 				F16426FE1FCC5A2C00D2ABFC /* TeamCreationStepDescription.swift in Sources */,
 				871BC2241D34F8F800DF0793 /* BottomOverlayViewController.m in Sources */,
 				87D56DFA1E0046FE00DFF722 /* CollectionImageCell.swift in Sources */,

--- a/Wire-iOS/Sources/Helpers/syncengine/Conversation+Participants.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/Conversation+Participants.swift
@@ -69,7 +69,8 @@ extension ZMConversation {
             self.showAlertForRemoval(for: NetworkError.offline)
             return
         }
-        
+
+        /// if the user is not in this conversation, result = .success
         self.removeParticipant(user,
                                userSession: ZMUserSession.shared()!) { result in
                                 switch result {

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+ParticipantsPopover.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+ParticipantsPopover.swift
@@ -47,7 +47,9 @@ extension ConversationViewController: UIPopoverPresentationControllerDelegate {
             return
         }
 
-        let profileViewController = ProfileViewController(user: user as! UserType & AccentColorProvider, conversation: conversation)
+        let profileViewController = ProfileViewController(user: user as! UserType & AccentColorProvider,
+                                                          conversation: conversation,
+                                                          viewControllerDismisser: self)
         profileViewController.preferredContentSize = CGSize.IPadPopover.preferredContentSize
 
         profileViewController.delegate = self
@@ -59,3 +61,8 @@ extension ConversationViewController: UIPopoverPresentationControllerDelegate {
 
 }
 
+extension ConversationViewController: ViewControllerDismisser {
+    func dismiss(viewController: UIViewController, completion: (() -> ())?) {
+        dismiss(animated: true, completion: completion)
+    }
+}

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -74,9 +74,6 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
 @interface ConversationViewController (Content) <ConversationContentViewControllerDelegate>
 @end
 
-@interface ConversationViewController (ViewControllerDismisser) <ViewControllerDismisser>
-@end
-
 @interface ConversationViewController (ZMConversationObserver) <ZMConversationObserver>
 @end
 
@@ -774,15 +771,6 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
 - (void)conversationInputBarViewControllerEditLastMessage
 {
     [self.contentViewController editLastMessage];
-}
-
-@end
-
-@implementation ConversationViewController (ViewControllerDismisser)
-
-- (void)dismissViewController:(UIViewController *)profileViewController completion:(dispatch_block_t)completion
-{
-    [self dismissViewControllerAnimated:YES completion:completion];
 }
 
 @end

--- a/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
@@ -61,7 +61,7 @@ final public class ConversationCreationValues {
     
 }
 
-@objcMembers final class ConversationCreationController: UIViewController {
+@objcMembers public final class ConversationCreationController: UIViewController {
 
     static let mainViewHeight: CGFloat = 56
     fileprivate let colorSchemeVariant = ColorScheme.default.variant
@@ -135,11 +135,11 @@ final public class ConversationCreationValues {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override var prefersStatusBarHidden: Bool {
+    override public var prefersStatusBarHidden: Bool {
         return false
     }
 
-    override func viewDidLoad() {
+    override public func viewDidLoad() {
         super.viewDidLoad()
         Analytics.shared().tagLinearGroupOpened(with: self.source)
 
@@ -155,16 +155,16 @@ final public class ConversationCreationValues {
         }
     }
 
-    override var preferredStatusBarStyle: UIStatusBarStyle {
+    override public var preferredStatusBarStyle: UIStatusBarStyle {
         return colorSchemeVariant == .light ? .default : .lightContent
     }
 
-    override func viewWillAppear(_ animated: Bool) {
+    override public func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         UIApplication.shared.wr_updateStatusBarForCurrentControllerAnimated(animated)
     }
     
-    override func viewDidAppear(_ animated: Bool) {
+    override public func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         nameSection.becomeFirstResponder()
     }
@@ -258,7 +258,7 @@ final public class ConversationCreationValues {
 
 extension ConversationCreationController: AddParticipantsConversationCreationDelegate {
     
-    func addParticipantsViewController(_ addParticipantsViewController: AddParticipantsViewController, didPerform action: AddParticipantsViewController.CreateAction) {
+    public func addParticipantsViewController(_ addParticipantsViewController: AddParticipantsViewController, didPerform action: AddParticipantsViewController.CreateAction) {
         switch action {
         case .updatedUsers(let users):
             values.participants = users

--- a/Wire-iOS/Sources/UserInterface/Helpers/UIViewController+removeUserConfirmationUI.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UIViewController+removeUserConfirmationUI.swift
@@ -21,6 +21,7 @@ import Foundation
 extension UIViewController {
 
     /// Present an action sheet for user removal confirmation
+    /// Notice: if the participant is not in the conversation, the action sheet still shows.
     ///
     /// - Parameters:
     ///   - participant: user to remove

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -164,7 +164,7 @@ extension ZClientViewController {
             if let conversationViewController = (conversationRootViewController as? ConversationRootViewController)?.conversationViewController {
                 profileViewController.delegate = conversationViewController
 
-                profileViewController.viewControllerDismisser = conversationViewController as? ViewControllerDismisser
+                profileViewController.viewControllerDismisser = conversationViewController
             }
             viewController = profileViewController
         }

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController+Extension.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController+Extension.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 
+// MARK: - Keyboard frame observer
 extension ProfileViewController {
     @objc func setupKeyboardFrameNotification() {
         NotificationCenter.default.addObserver(self,
@@ -39,9 +40,7 @@ extension ProfileViewController {
 
         self.viewControllerDismisser = viewControllerDismisser
     }
-}
 
-extension ProfileViewController {
     @objc
     func setupProfileDetailsViewController() -> ProfileDetailsViewController? {
         guard let profileDetailsViewController = ProfileDetailsViewController(user: bareUser, conversation: conversation, context: context) else { return nil }

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController+KeyboardFrame.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController+KeyboardFrame.swift
@@ -31,3 +31,49 @@ extension ProfileViewController {
         updatePopoverFrame()
     }
 }
+
+// MARK: - init
+extension ProfileViewController {
+    convenience init(user: (UserType & AccentColorProvider), conversation: ZMConversation?, viewControllerDismisser: ViewControllerDismisser) {
+        self.init(user: user, conversation: conversation)
+
+        self.viewControllerDismisser = viewControllerDismisser
+    }
+}
+
+extension ProfileViewController {
+    @objc
+    func setupProfileDetailsViewController() -> ProfileDetailsViewController? {
+        guard let profileDetailsViewController = ProfileDetailsViewController(user: bareUser, conversation: conversation, context: context) else { return nil }
+        profileDetailsViewController.delegate = self
+        profileDetailsViewController.viewControllerDismisser = viewControllerDismisser ?? self
+        profileDetailsViewController.title = "profile.details.title".localized
+
+        return profileDetailsViewController
+    }
+}
+
+extension ProfileViewController: ViewControllerDismisser {
+    func dismiss(viewController: UIViewController, completion: (() -> ())?) {
+        navigationController?.popViewController(animated: true)
+    }
+}
+
+extension ProfileViewController: ProfileDetailsViewControllerDelegate {
+    public func profileDetailsViewController(_ profileDetailsViewController: ProfileDetailsViewController!, didSelect conversation: ZMConversation!) {
+        
+        delegate?.profileViewController?(self, wantsToNavigateTo: conversation)
+    }
+
+    public func profileDetailsViewController(_ profileDetailsViewController: ProfileDetailsViewController!, didPresent conversationCreationController: ConversationCreationController!) {
+        conversationCreationController.delegate = self as? ConversationCreationControllerDelegate
+    }
+
+    public func profileDetailsViewController(_ profileDetailsViewController: ProfileDetailsViewController!, wantsToBeDismissedWithCompletion completion: (() -> Void)!) {
+        if let viewControllerDismisser = viewControllerDismisser {
+            viewControllerDismisser.dismiss(viewController: self, completion: completion)
+        } else {
+            completion()
+        }
+    }
+}

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController+internal.h
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController+internal.h
@@ -19,5 +19,6 @@
 @interface ProfileViewController () <ZMUserObserver>
 
 @property (nonatomic, readonly) ProfileViewControllerContext context;
+@property (nonatomic, readonly) ZMConversation *conversation;
 
 @end

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.m
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.m
@@ -47,12 +47,6 @@ typedef NS_ENUM(NSUInteger, ProfileViewControllerTabBarIndex) {
 @interface ProfileViewController (ProfileViewControllerDelegate) <ProfileViewControllerDelegate>
 @end
 
-@interface ProfileViewController (ViewControllerDismisser) <ViewControllerDismisser>
-@end
-
-@interface ProfileViewController (ProfileDetailsViewControllerDelegate) <ProfileDetailsViewControllerDelegate>
-@end
-
 @interface ProfileViewController (DevicesListDelegate) <ProfileDevicesViewControllerDelegate>
 @end
 
@@ -66,7 +60,6 @@ typedef NS_ENUM(NSUInteger, ProfileViewControllerTabBarIndex) {
 
 @interface ProfileViewController () <ZMUserObserver>
 
-@property (nonatomic, readonly) ZMConversation *conversation;
 @property (nonatomic) id observerToken;
 @property (nonatomic) UserNameDetailView *usernameDetailsView;
 @property (nonatomic) ProfileTitleView *profileTitleView;
@@ -157,10 +150,7 @@ typedef NS_ENUM(NSUInteger, ProfileViewControllerTabBarIndex) {
     NSMutableArray *viewControllers = [NSMutableArray array];
     
     if (self.context != ProfileViewControllerContextDeviceList) {
-        ProfileDetailsViewController *profileDetailsViewController = [[ProfileDetailsViewController alloc] initWithUser:self.bareUser conversation:self.conversation context:self.context];
-        profileDetailsViewController.delegate = self;
-        profileDetailsViewController.viewControllerDismisser = self;
-        profileDetailsViewController.title = NSLocalizedString(@"profile.details.title", nil);
+        ProfileDetailsViewController *profileDetailsViewController = [self setupProfileDetailsViewController];
         [viewControllers addObject:profileDetailsViewController];
     }
     
@@ -258,16 +248,6 @@ typedef NS_ENUM(NSUInteger, ProfileViewControllerTabBarIndex) {
 
 @end
 
-
-@implementation ProfileViewController (ViewControllerDismisser)
-
-- (void)dismissViewController:(UIViewController *)controller completion:(dispatch_block_t)completion
-{
-    [self.navigationController popViewControllerAnimated:YES];
-}
-
-@end
-
 @implementation ProfileViewController (ProfileViewControllerDelegate)
 
 - (void)profileViewController:(ProfileViewController *)controller wantsToNavigateToConversation:(ZMConversation *)conversation
@@ -280,32 +260,6 @@ typedef NS_ENUM(NSUInteger, ProfileViewControllerTabBarIndex) {
 - (NSString *)suggestedBackButtonTitleForProfileViewController:(id)controller
 {
     return [self.bareUser.displayName uppercasedWithCurrentLocale];
-}
-
-@end
-
-
-@implementation ProfileViewController (ProfileDetailsViewControllerDelegate)
-
-- (void)profileDetailsViewController:(ProfileDetailsViewController *)profileDetailsViewController didSelectConversation:(ZMConversation *)conversation
-{
-    if ([self.delegate respondsToSelector:@selector(profileViewController:wantsToNavigateToConversation:)]) {
-        [self.delegate profileViewController:self wantsToNavigateToConversation:conversation];
-    }
-}
-
-- (void)profileDetailsViewController:(ProfileDetailsViewController *)profileDetailsViewController didPresentConversationCreationController:(ConversationCreationController *)conversationCreationController
-{
-    conversationCreationController.delegate = self;
-}
-
-- (void)profileDetailsViewController:(ProfileDetailsViewController *)profileDetailsViewController wantsToBeDismissedWithCompletion:(dispatch_block_t)completion
-{
-    if ([self.delegate respondsToSelector:@selector(dismissViewController:completion:)]) {
-        [self.viewControllerDismisser dismissViewController:self completion:completion];
-    } else if (completion != nil) {
-        completion();
-    }
 }
 
 @end


### PR DESCRIPTION
## What's new in this PR?

### Issues

After a user is removed from a group conversation, ProfileViewController is not dismissed.

### Causes

When ProfileDetailsViewController is created in ProfileViewController, profileDetailsViewController.viewControllerDismisser is set to ProfileViewController, it can not dismiss itself by popViewController call.

### Solutions

inject the correct ViewControllerDismisser(ConversationViewController) when creating ProfileViewController. When the remove button of ProfileDetailsViewController is tapped, the ProfileViewController will be dismissed by ConversationViewController.
