### PR TITLE
Allow deleting cells partially off screen

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -698,6 +698,7 @@
 		87B8C3401DF9788B0015EC89 /* LinkOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B8C33C1DF9788B0015EC89 /* LinkOpener.swift */; };
 		87B8C3411DF9788B0015EC89 /* MapOpening.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B8C33D1DF9788B0015EC89 /* MapOpening.swift */; };
 		87B8C3421DF9788B0015EC89 /* TweetOpening.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B8C33E1DF9788B0015EC89 /* TweetOpening.swift */; };
+		87BC39BF21E78AC700C359A8 /* ConversationContentViewController+Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BC39BE21E78AC700C359A8 /* ConversationContentViewController+Message.swift */; };
 		87BEB0361D39018600DE9575 /* FormatterKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 87BEB0351D39018600DE9575 /* FormatterKit.framework */; };
 		87BEB03C1D3E44BA00DE9575 /* CameraKeyboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BEB03B1D3E44BA00DE9575 /* CameraKeyboardViewController.swift */; };
 		87BEB03E1D3E44DE00DE9575 /* CameraCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BEB03D1D3E44DE00DE9575 /* CameraCell.swift */; };
@@ -2297,6 +2298,7 @@
 		87B8C33C1DF9788B0015EC89 /* LinkOpener.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinkOpener.swift; sourceTree = "<group>"; };
 		87B8C33D1DF9788B0015EC89 /* MapOpening.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapOpening.swift; sourceTree = "<group>"; };
 		87B8C33E1DF9788B0015EC89 /* TweetOpening.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TweetOpening.swift; sourceTree = "<group>"; };
+		87BC39BE21E78AC700C359A8 /* ConversationContentViewController+Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationContentViewController+Message.swift"; sourceTree = "<group>"; };
 		87BEB0351D39018600DE9575 /* FormatterKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FormatterKit.framework; path = Carthage/Build/iOS/FormatterKit.framework; sourceTree = "<group>"; };
 		87BEB03B1D3E44BA00DE9575 /* CameraKeyboardViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CameraKeyboardViewController.swift; sourceTree = "<group>"; };
 		87BEB03D1D3E44DE00DE9575 /* CameraCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CameraCell.swift; sourceTree = "<group>"; };
@@ -5542,6 +5544,7 @@
 				878D7C8C1E65DB6500770E84 /* ConversationContentViewController+PinchZoom.h */,
 				878D7C8D1E65DB6500770E84 /* ConversationContentViewController+PinchZoom.m */,
 				87E8D0BC21821E6E00BD26AC /* ConversationContentViewController+Reply.swift */,
+				87BC39BE21E78AC700C359A8 /* ConversationContentViewController+Message.swift */,
 				BFE57B4A1D52335A00CB0806 /* ConversationPreviewViewController.swift */,
 				D567460F208F39D200DC7F26 /* TintColorCorrectedViewController.swift */,
 				EF80C0012097106D00E0040B /* ZMConversationMessageWindow+Formatting.swift */,
@@ -7586,6 +7589,7 @@
 				BADA35131B42FEC100396F2C /* NSURL+WireLocale.m in Sources */,
 				DBCBD19219F10A1F000510C1 /* ConnectRequestCell.m in Sources */,
 				EF3BA5D421075FC60093048F /* ConversationInputBarViewController+Language.swift in Sources */,
+				87BC39BF21E78AC700C359A8 /* ConversationContentViewController+Message.swift in Sources */,
 				87D679E61EBC8002005BEB4C /* String+Compatibility.swift in Sources */,
 				8719FD671C88802C005FBEC0 /* Delay.swift in Sources */,
 				871BC2841D34F8F800DF0793 /* UIApplication+StatusBar.swift in Sources */,

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
@@ -76,6 +76,9 @@ extension IndexSet {
     /// The message that is being presented.
     @objc var message: ZMConversationMessage
 
+    /// The index of the first cell that is displaying the message
+    var messageCellIndex: Int = 0
+    
     /// The delegate for cells injected by the list adapter.
     @objc weak var cellDelegate: ConversationMessageCellDelegate?
 
@@ -110,6 +113,8 @@ extension IndexSet {
     // MARK: - Content Types
     
     private func addContent(context: ConversationMessageContext, isSenderVisible: Bool) {
+        
+        messageCellIndex = cellDescriptions.count
         
         var contentCellDescriptions: [AnyConversationMessageCellDescription]
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Message.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Message.swift
@@ -1,0 +1,30 @@
+//
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension ConversationContentViewController {
+    @objc(cellForMessage:)
+    func cell(for message: ZMConversationMessage) -> UITableViewCell? {
+        guard let indexPath = self.conversationMessageWindowTableViewAdapter.indexPath(for: message) else {
+            return nil
+        }
+        
+        return self.tableView.cellForRow(at: indexPath)
+    }
+}

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Private.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Private.h
@@ -44,7 +44,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) CGPoint initialPinchLocation;
 
 - (void)removeHighlightsAndMenu;
-- (nullable UITableViewCell *)cellForMessage:(id<ZMConversationMessage>)message;
 
 @end
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -605,17 +605,6 @@ const static int ConversationContentViewControllerMessagePrefetchDepth = 10;
     [[UIMenuController sharedMenuController] setMenuVisible:NO animated:YES];
 }
 
-- (UITableViewCell *)cellForMessage:(id<ZMConversationMessage>)message
-{
-    NSIndexPath *indexPath = [self.conversationMessageWindowTableViewAdapter indexPathForMessage:message];
-    
-    if (indexPath == nil) {
-        return nil;
-    }
-    
-    return [self.tableView cellForRowAtIndexPath:indexPath];
-}
-
 - (BOOL)displaysMessage:(id<ZMConversationMessage>)message
 {
     NSInteger index = [self.messageWindow.messages indexOfObject:message];

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter+DataSource.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationMessageWindowTableViewAdapter+DataSource.swift
@@ -172,7 +172,11 @@ extension ConversationMessageWindowTableViewAdapter: UITableViewDataSource {
             return nil
         }
         
-        return IndexPath(row: 0, section: section)
+        guard let sectionController = sectionController(at: section, in: tableView) else {
+            return nil
+        }
+        
+        return IndexPath(row: sectionController.messageCellIndex, section: section)
     }
     
     public func numberOfSections(in tableView: UITableView) -> Int {


### PR DESCRIPTION
## What's new in this PR?

### Issues

It is impossible to delete the message, if it's bottom part is not in the viewport.

### Causes

The new conversation view system is separating the single message into several cells. So we can have cell for message sender name, for content and for the info footer.

The problem happens because we always presume the cell index 0 is the cell that displays the message content, so if we cannot fetch the 0 cell (it's the bottom most, since the table view is inverted), we cancel any action on the message.

### Solutions

We can calculate the index of the content cell and ask the table view for this cell. It must be visible.
