### PR TITLE
Added feature flag for add service to a conversation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
@@ -25,8 +25,13 @@ import WireSyncEngine
 }
 
 extension SearchGroup {
+#if ADD_SERVICE_DISABLED
+    // remove service from the tab
+    static let all: [SearchGroup] = [.people]
+#else
     static let all: [SearchGroup] = [.people, .services]
-    
+#endif
+
     var name: String {
         switch self {
         case .people:


### PR DESCRIPTION
## What's new in this PR?

When building we need to have a possibility to add services to a conversation.  This PR adds a feature flag ADD_SERVICE_DISABLED that controls this.