### PR TITLE
Fix: The top bar in device settings should not have transparent background

### DIFF
--- a/Wire-iOS Tests/DeviceManagement/ClientListViewControllerTests.swift
+++ b/Wire-iOS Tests/DeviceManagement/ClientListViewControllerTests.swift
@@ -90,15 +90,12 @@ final class ClientListViewControllerTests: ZMSnapshotTestCase {
         self.verify(view: sut.view)
     }
 
-    func testForLightThemeWrappedInNavigationControllerAndScrollToBottom(){
-        prepareSut(variant: .light, numberOfClients: 7)
+    func testForLightThemeWrappedInNavigationController(){
+        prepareSut(variant: .light)
         let navWrapperController = sut.wrapInNavigationController()
         navWrapperController.navigationBar.tintColor = UIColor.accent()
 
-        verify(view: navWrapperController.view,
-               configuration:{ _ in
-                self.sut.clientsTableView?.scrollToRow(at: IndexPath(row:6, section: 1), at: .bottom, animated: false)
-        })
+        self.verify(view: navWrapperController.view)
     }
 
     func testForOneDeviceWithNoEditButton(){

--- a/Wire-iOS Tests/DeviceManagement/ClientListViewControllerTests.swift
+++ b/Wire-iOS Tests/DeviceManagement/ClientListViewControllerTests.swift
@@ -20,7 +20,7 @@ import XCTest
 @testable import Wire
 
 final class ClientListViewControllerTests: ZMSnapshotTestCase {
-    
+
     var sut: ClientListViewController!
     var mockUser: MockUser!
     var client: UserClient!
@@ -35,7 +35,7 @@ final class ClientListViewControllerTests: ZMSnapshotTestCase {
         selfClient = mockUserClient()
         client = mockUserClient()
     }
-    
+
     override func tearDown() {
         sut = nil
         mockUser = nil
@@ -90,12 +90,15 @@ final class ClientListViewControllerTests: ZMSnapshotTestCase {
         self.verify(view: sut.view)
     }
 
-    func testForLightThemeWrappedInNavigationController(){
-        prepareSut(variant: .light)
+    func testForLightThemeWrappedInNavigationControllerAndScrollToBottom(){
+        prepareSut(variant: .light, numberOfClients: 7)
         let navWrapperController = sut.wrapInNavigationController()
         navWrapperController.navigationBar.tintColor = UIColor.accent()
 
-        self.verify(view: navWrapperController.view)
+        verify(view: navWrapperController.view,
+               configuration:{ _ in
+                self.sut.clientsTableView?.scrollToRow(at: IndexPath(row:6, section: 1), at: .bottom, animated: false)
+        })
     }
 
     func testForOneDeviceWithNoEditButton(){

--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
@@ -19,7 +19,6 @@
 
 import UIKit
 import WireSyncEngine
-import Cartography
 import WireExtensionComponents
 
 private let zmLog = ZMSLog(tag: "UI")
@@ -134,7 +133,7 @@ private let zmLog = ZMSLog(tag: "UI")
         }
 
         super.init(nibName: nil, bundle: nil)
-        self.title = "registration.devices.title".localized.uppercased()
+        title = "registration.devices.title".localized.uppercased()
 
         self.initalizeProperties(clientsList ?? Array(ZMUser.selfUser().clients.filter { !$0.isSelfClient() } ))
         self.clientsObserverToken = ZMUserSession.shared()?.add(self)
@@ -217,14 +216,7 @@ private let zmLog = ZMSLog(tag: "UI")
 
         clientsTableView.translatesAutoresizingMaskIntoConstraints = false
 
-        let constraints: [NSLayoutConstraint] = [
-            clientsTableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            clientsTableView.topAnchor.constraint(equalTo: view.topAnchor),
-            clientsTableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            clientsTableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ]
-
-        NSLayoutConstraint.activate(constraints)
+        clientsTableView.fitInSuperview(safely: true)
     }
     
     fileprivate func convertSection(_ section: Int) -> Int {

--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
@@ -23,7 +23,7 @@ import WireExtensionComponents
 
 private let zmLog = ZMSLog(tag: "UI")
 
-@objcMembers class ClientListViewController: UIViewController,
+final class ClientListViewController: UIViewController,
                                 UITableViewDelegate,
                                 UITableViewDataSource,
                                 ZMClientUpdateObserver,
@@ -38,7 +38,7 @@ private let zmLog = ZMSLog(tag: "UI")
         }
     }
 
-    override open var showLoadingView: Bool {
+    override public var showLoadingView: Bool {
         set {
             if let navigationController = self.navigationController {
                 navigationController.showLoadingView = newValue


### PR DESCRIPTION
## What's new in this PR?

In ClientListViewController, fix the issue that the navigation bar overlaps the tableview when scrolling.