### PR TITLE
ZIOS-11088: Added argument to localized string

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+SendButton.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+SendButton.swift
@@ -56,7 +56,7 @@ extension ConversationInputBarViewController {
     func showAlertIfTextIsTooLong(text: String) -> Bool {
         guard text.count > SharedConstants.maximumMessageLength else { return false }
         
-        self.showAlert(forMessage: "conversation.input_bar.message_too_long.message".localized,
+        self.showAlert(forMessage: "conversation.input_bar.message_too_long.message".localized(args: SharedConstants.maximumMessageLength),
                        title: "conversation.input_bar.message_too_long.title".localized,
                        handler: nil)
         


### PR DESCRIPTION
Added argument to the "Message too long" alert message.