### PR TITLE
Bump to AVS 4.9.

### DIFF
--- a/avs-versions
+++ b/avs-versions
@@ -17,4 +17,4 @@
 # along with this program. If not, see http://www.gnu.org/licenses/.
 #
 
-export APPSTORE_AVS_VERSION=4.8.14
+export APPSTORE_AVS_VERSION=4.9.5


### PR DESCRIPTION
New AVS release 4.9.

Change log can be found here: https://github.com/wearezeta/avs/blob/release-4.9/ChangeLog.txt