### PR TITLE
Restore missing methods

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -756,3 +756,20 @@
 }
 
 @end
+
+@implementation ConversationContentViewController (EditMessages)
+
+- (void)editLastMessage
+{
+    ZMMessage *lastEditableMessage = self.conversation.lastEditableMessage;
+    if (lastEditableMessage != nil) {
+        [self wantsToPerformAction:MessageActionEdit forMessage:lastEditableMessage];
+    }
+}
+
+- (void)didFinishEditingMessage:(id<ZMConversationMessage>)message
+{
+    self.dataSource.editingMessage = nil;
+}
+
+@end


### PR DESCRIPTION
## What's new in this PR?

### Issues

App would crash when editing a message

### Causes

After an edit we attempt to call the method `didFinishEditingMessage:` which doesn't have an implementation.

### Solutions

Restore missing methods.