### PR TITLE
Fix scrolling to the wrong message when tapping a reply

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
@@ -148,8 +148,8 @@ final class ConversationTableViewDataSource: NSObject {
         
         let fetchRequest = NSFetchRequest<ZMMessage>(entityName: ZMMessage.entityName())
         let validMessage = conversation.visibleMessagesPredicate!
-        let beforeGivenMessage = NSPredicate(format: "%K < %@", ZMMessageServerTimestampKey, serverTimestamp as NSDate)
-    
+        let beforeGivenMessage = NSPredicate(format: "%K > %@", ZMMessageServerTimestampKey, serverTimestamp as NSDate)
+            
         fetchRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [validMessage, beforeGivenMessage])
         fetchRequest.sortDescriptors = [NSSortDescriptor(key: #keyPath(ZMMessage.serverTimestamp), ascending: false)]
         


### PR DESCRIPTION
## What's new in this PR?

### Issues

When tapping a reply we would scroll to the wrong message

### Causes

After the unordered relation change we now need to do a fetch request to find the location of a reply message. The predicate was wrong and was counting all messages sent before the reply message.

### Solutions

Flip the `<` operator.