### PR TITLE
Fix showing message toolbox for non-selected messages

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
@@ -317,11 +317,11 @@ extension ConversationTableViewDataSource: NSFetchedResultsControllerDelegate {
             }
             
             tableView.endUpdates()
-            
-            // Re-evalulate visible cells in all sections, this is necessary because if a message is inserted/moved the
-            // neighbouring messages may no longer want to display sender, toolbox or burst timestamp.
-            reconfigureVisibleSections()
         }
+        
+        // Re-evalulate visible cells in all sections, this is necessary because if a message is inserted/moved the
+        // neighbouring messages may no longer want to display sender, toolbox or burst timestamp.
+        reconfigureVisibleSections()
         
         if shouldJumpToTheConversationEnd {
             // The action has to be performed on the next run loop, since the current one already has the call to scroll


### PR DESCRIPTION
## What's new in this PR?

### Issues

If you send multiple messages in the same conversation they would all show the message toolbox and not only the last sent message as expected.

### Causes

To remove the toolbox we need to re-configure the section controller but this only happen when someone sends a message.

### Solutions

Always re-configure the visible section controllers.

### Notes

This causes to unwanted animation issues.
