### PR TITLE
fix: duplicated @synthesize teamRole in MockUser

### DIFF
--- a/Wire-iOS Tests/Mocks/MockUser.m
+++ b/Wire-iOS Tests/Mocks/MockUser.m
@@ -148,6 +148,11 @@ static id<UserType> mockSelfUser = nil;
 @synthesize teamRole;
 @synthesize readReceiptsEnabled;
 
+#pragma mark - ZMBareUserConnection
+
+@synthesize isPendingApprovalByOtherUser = _isPendingApprovalByOtherUser;
+@synthesize isServiceUser;
+
 - (BOOL)conformsToProtocol:(Protocol *)aProtocol
 {
     if (aProtocol == @protocol(UserType)) {
@@ -286,12 +291,5 @@ static id<UserType> mockSelfUser = nil;
     return nil;
 }
 
-#pragma mark - ZMBareUserConnection
-
-@synthesize isPendingApprovalByOtherUser = _isPendingApprovalByOtherUser;
-
-@synthesize isServiceUser;
-
-@synthesize teamRole;
 
 @end


### PR DESCRIPTION
## What's new in this PR?

Fix the duplicate `@synthesize teamRole` caused by two merges at the same time.