### PR TITLE
Fix: Partner can edit the Group name after navigate from other views(Notification/People/... button)

### DIFF
--- a/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/RenameGroupSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/RenameGroupSectionController.swift
@@ -54,8 +54,6 @@ class RenameGroupSectionController: NSObject, CollectionViewSectionController {
         let cell = collectionView.dequeueReusableCell(ofType: GroupDetailsRenameCell.self, for: indexPath)
         cell.configure(for: conversation)
         cell.titleTextField.textFieldDelegate = self
-        renameCell?.titleTextField.isUserInteractionEnabled = conversation.isSelfAnActiveMember
-        renameCell?.accessoryIconView.isHidden = !conversation.isSelfAnActiveMember
         renameCell = cell
         return cell
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Rename conversation cell is editable after the screen is reloaded.

### Causes

The textField's isUserInteractionEnabled property is set again after cell.configure() method is called.

### Solutions

Remove the unnecessary property settings. 