### PR TITLE
Avoid changing fetchLimit inside performBatchUpdate()

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
@@ -257,7 +257,11 @@ final class ConversationTableViewDataSource: NSObject {
         let scrolledToTop = (tableView.contentOffset.y + tableView.bounds.height) - tableView.contentSize.height > 0
         
         if scrolledToTop, !hasFetchedAllMessages {
-            fetchLimit = fetchLimit + ConversationTableViewDataSource.defaultBatchSize
+            // NOTE: we dispatch async because `didScroll(tableView:` can be called inside a `performBatchUpdate()`,
+            // which would cause data source inconsistency if change the fetchLimit.
+            DispatchQueue.main.async {
+                self.fetchLimit = self.fetchLimit + ConversationTableViewDataSource.defaultBatchSize
+            }
         }
     }
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

Conversation table view would get corrupted and show empty messages

### Causes

If you are scrolled close to the message window when a message gets deleted it could trigger a `didScroll(tableView:` event, which in turn would cause the `fetchLimit` to be extended. Changing `fetchLimit`will cause more messages to be inserted so we would be calling `performBatchUpdates()` inside a  performBatchUpdates() which corrupts the table view.

### Solutions

Delay changing the `fetchLimit` to next runloop.