### PR TITLE
Support disabling newsletter and sharing data usage in settings

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
@@ -33,12 +33,15 @@ extension ZMUser {
 extension SettingsCellDescriptorFactory {
 
     func accountGroup() -> SettingsCellDescriptorType {
-        var sections: [SettingsSectionDescriptorType] = [
-            infoSection(),
-            appearanceSection(),
-            privacySection(),
-            personalInformationSection(),
-            conversationsSection()]
+        var sections: [SettingsSectionDescriptorType] = [infoSection(),
+                                                         appearanceSection(),
+                                                         privacySection()]
+        
+        #if !SEND_ANONYMOUS_DATA_DISABLED || !NEWSLETTER_DISABLED
+            sections.append(personalInformationSection())
+        #endif
+        
+        sections.append(conversationsSection())
         
         if let user = ZMUser.selfUser(), !user.usesCompanyLogin {
             sections.append(actionsSection())

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
@@ -37,7 +37,7 @@ extension SettingsCellDescriptorFactory {
                                                          appearanceSection(),
                                                          privacySection()]
         
-        #if !SEND_ANONYMOUS_DATA_DISABLED || !NEWSLETTER_DISABLED
+        #if !DATA_COLLECTION_DISABLED
             sections.append(personalInformationSection())
         #endif
         

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+DataUsagePermissions.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+DataUsagePermissions.swift
@@ -27,9 +27,15 @@ extension SettingsCellDescriptorFactory {
 
         let receiveNewsAndOffersData = SettingsPropertyToggleCellDescriptor(settingsProperty: self.settingsPropertyFactory.property(.receiveNewsAndOffers))
         let receiveNewsAndOffersSection = SettingsSectionDescriptor(cellDescriptors: [receiveNewsAndOffersData], footer: "self.settings.receiveNews_and_offers.description.title".localized)
-
-        items.append(contentsOf: [sendAnonymousDataSection, receiveNewsAndOffersSection])
-
+        
+        #if !SEND_ANONYMOUS_DATA_DISABLED
+            items.append(sendAnonymousDataSection)
+        #endif
+        
+        #if !NEWSLETTER_DISABLED
+            items.append(receiveNewsAndOffersSection)
+        #endif
+        
         return SettingsGroupCellDescriptor(
             items: items,
             title: "self.settings.account.data_usage_permissions.title".localized

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+DataUsagePermissions.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+DataUsagePermissions.swift
@@ -27,15 +27,9 @@ extension SettingsCellDescriptorFactory {
 
         let receiveNewsAndOffersData = SettingsPropertyToggleCellDescriptor(settingsProperty: self.settingsPropertyFactory.property(.receiveNewsAndOffers))
         let receiveNewsAndOffersSection = SettingsSectionDescriptor(cellDescriptors: [receiveNewsAndOffersData], footer: "self.settings.receiveNews_and_offers.description.title".localized)
-        
-        #if !SEND_ANONYMOUS_DATA_DISABLED
-            items.append(sendAnonymousDataSection)
-        #endif
-        
-        #if !NEWSLETTER_DISABLED
-            items.append(receiveNewsAndOffersSection)
-        #endif
-        
+
+        items.append(contentsOf: [sendAnonymousDataSection, receiveNewsAndOffersSection])
+
         return SettingsGroupCellDescriptor(
             items: items,
             title: "self.settings.account.data_usage_permissions.title".localized


### PR DESCRIPTION
## What's new in this PR?

Support `SEND_ANONYMOUS_DATA_DISABLED` and `NEWSLETTER_DISABLED` in settings by hiding the corresponding sections if these flags are present.