### PR TITLE
Feature flag: possibility to disable editing account's email address

### DIFF
--- a/Wire-iOS Tests/SettingsTextCellSnapshotTests.swift
+++ b/Wire-iOS Tests/SettingsTextCellSnapshotTests.swift
@@ -22,6 +22,7 @@ import XCTest
 final class SettingsTextCellSnapshotTests: CoreDataSnapshotTestCase {
     
     var sut: SettingsTextCell!
+    var settingsCellDescriptorFactory: SettingsCellDescriptorFactory!
     
     override func setUp() {
         super.setUp()
@@ -31,14 +32,8 @@ final class SettingsTextCellSnapshotTests: CoreDataSnapshotTestCase {
 
         let settingsPropertyFactory = SettingsPropertyFactory(userSession: SessionManager.shared?.activeUserSession, selfUser: ZMUser.selfUser())
 
-        let settingsCellDescriptorFactory = SettingsCellDescriptorFactory(settingsPropertyFactory: settingsPropertyFactory)
+        settingsCellDescriptorFactory = SettingsCellDescriptorFactory(settingsPropertyFactory: settingsPropertyFactory)
 
-        let cellDescriptor = settingsCellDescriptorFactory.nameElement()
-
-        sut.descriptor = cellDescriptor
-        cellDescriptor.featureCell(sut)
-
-        sut.backgroundColor = .black
     }
     
     override func tearDown() {
@@ -47,8 +42,27 @@ final class SettingsTextCellSnapshotTests: CoreDataSnapshotTestCase {
     }
 
     func testForNameElementWithALongName(){
+        let cellDescriptor = settingsCellDescriptorFactory.nameElement()
+        sut.descriptor = cellDescriptor
+        cellDescriptor.featureCell(sut)
+        sut.backgroundColor = .black
+
         let mockTableView = sut.wrapInTableView()
         mockTableView.backgroundColor = .black
+
+        XCTAssert(sut.textInput.isUserInteractionEnabled)
+
         verify(view: mockTableView)
+    }
+
+    func testThatTextFieldIsDisabledWhenEnabledFlagIsFalse(){
+        // GIVEN
+        let cellDescriptor = settingsCellDescriptorFactory.nameElement(enabled: false)
+
+        // WHEN
+        cellDescriptor.featureCell(sut)
+
+        //THEN
+        XCTAssertFalse(sut.textInput.isUserInteractionEnabled)
     }
 }

--- a/Wire-iOS/Sources/Components/Settings/SettingsProperty.swift
+++ b/Wire-iOS/Sources/Components/Settings/SettingsProperty.swift
@@ -78,6 +78,7 @@ protocol SettingsProperty {
     var propertyName : SettingsPropertyName { get }
     func value() -> SettingsPropertyValue
     func set(newValue: SettingsPropertyValue) throws
+    var enabled: Bool { get set }
 }
 
 extension SettingsProperty {
@@ -122,6 +123,8 @@ func << (value: inout Any?, property: SettingsProperty) {
 
 /// Generic user defaults property
 class SettingsUserDefaultsProperty : SettingsProperty {
+    var enabled: Bool = true
+
     internal func set(newValue: SettingsPropertyValue) throws {
         self.userDefaults.set(newValue.value(), forKey: self.userDefaultsKey)
         NotificationCenter.default.post(name: Notification.Name(rawValue: self.propertyName.changeNotificationName), object: self)
@@ -160,6 +163,8 @@ typealias SetAction = (SettingsBlockProperty, SettingsPropertyValue) throws -> (
 
 /// Genetic block property
 open class SettingsBlockProperty : SettingsProperty {
+    var enabled: Bool = true
+
     let propertyName : SettingsPropertyName
     func value() -> SettingsPropertyValue {
         return self.getAction(self)

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
@@ -55,7 +55,13 @@ extension SettingsCellDescriptorFactory {
     // MARK: - Sections
 
     func infoSection() -> SettingsSectionDescriptorType {
-        var cellDescriptors = [nameElement(), handleElement()]
+        var cellDescriptors: [SettingsCellDescriptorType] = []
+        #if NAME_EDITING_DISABLED
+        let enabled = false
+        #else
+        let enabled = true
+        #endif
+        cellDescriptors = [nameElement(enabled: enabled), handleElement()]
         
         if let user = ZMUser.selfUser(), !user.usesCompanyLogin {
             if !ZMUser.selfUser().hasTeam || !(ZMUser.selfUser().phoneNumber?.isEmpty ?? true) {
@@ -119,8 +125,10 @@ extension SettingsCellDescriptorFactory {
 
     // MARK: - Elements
 
-    func nameElement() -> SettingsCellDescriptorType {
-        return SettingsPropertyTextValueCellDescriptor(settingsProperty: settingsPropertyFactory.property(.profileName))
+    func nameElement(enabled: Bool = true) -> SettingsPropertyTextValueCellDescriptor {
+        var settingsProperty = settingsPropertyFactory.property(.profileName)
+        settingsProperty.enabled = enabled
+        return SettingsPropertyTextValueCellDescriptor(settingsProperty: settingsProperty)
     }
 
     func emailElement() -> SettingsCellDescriptorType {

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsPropertyTextValueCellDescriptor.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsPropertyTextValueCellDescriptor.swift
@@ -39,12 +39,15 @@ class SettingsPropertyTextValueCellDescriptor: SettingsPropertyCellDescriptorTyp
         self.identifier = identifier
     }
     
-    func featureCell(_ cell: SettingsCellType) {
-        cell.titleText = self.title
-        if let textCell = cell as? SettingsTextCell,
-            let stringValue = self.settingsProperty.rawValue() as? String {
+    func featureCell(_ cell: SettingsCellType) { ///TODO: unit test disable property
+        cell.titleText = title
+        guard let textCell = cell as? SettingsTextCell else { return }
+
+        if let stringValue = settingsProperty.rawValue() as? String {
             textCell.textInput.text = stringValue
         }
+
+        textCell.textInput.isUserInteractionEnabled = settingsProperty.enabled
     }
     
     func select(_ value: SettingsPropertyValue?) {

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsPropertyTextValueCellDescriptor.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsPropertyTextValueCellDescriptor.swift
@@ -39,7 +39,7 @@ class SettingsPropertyTextValueCellDescriptor: SettingsPropertyCellDescriptorTyp
         self.identifier = identifier
     }
     
-    func featureCell(_ cell: SettingsCellType) { ///TODO: unit test disable property
+    func featureCell(_ cell: SettingsCellType) {
         cell.titleText = title
         guard let textCell = cell as? SettingsTextCell else { return }
 


### PR DESCRIPTION
## What's new in this PR?

Support for feature flag NAME_EDITING_DISABLED. A new property enabled is added to Protocol SettingsProperty and it will be checked in SettingsPropertyTextValueCellDescriptor's featureCell() method.