### PR TITLE
Don’t destroy recording when trying to present open audio keyboard

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Audio.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Audio.swift
@@ -69,17 +69,21 @@ extension ConversationInputBarViewController {
         if displayAudioMessageAlertIfNeeded() {
             return
         }
-
-        if self.mode != .audioRecord {
+        
+        switch self.mode {
+        case .audioRecord:
+            if self.inputBar.textView.isFirstResponder {
+                hideInKeyboardAudioRecordViewController()
+            } else {
+                self.inputBar.textView.becomeFirstResponder()
+            }
+        default:
             UIApplication.wr_requestOrWarnAboutMicrophoneAccess({ accepted in
                 if accepted {
                     self.mode = .audioRecord
                     self.inputBar.textView.becomeFirstResponder()
                 }
             })
-        }
-        else {
-            hideInKeyboardAudioRecordViewController()
         }
     }
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

After opening the audio keyboard and starting a recording, if the user scrolls up into the conversation such that the keyboard is dismissed, it is impossible to reopen the audio keyboard without destroying an active recording.

### Causes

The only way to reopen the audio keyboard is to tap on the audio icon. However, if a recording is active, tapping the icon will try to hide the keyboard, which will stop the recording.

### Solutions

When opening the audio keyboard, check if a recording is in process. If so, show the keyboard.

