### PR TITLE
Improve database statistics counting

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/DatabaseStatisticsController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DatabaseStatisticsController.swift
@@ -92,17 +92,21 @@ import WireDataModel
                     }
                 }
 
-                let conversations = ZMConversation.sortedFetchRequest()!
-                let conversationsCount = try syncMoc.count(for: conversations)
+                let allConversations = ZMConversation.fetchRequest()
+                
+                let conversationsCount = try syncMoc.count(for: allConversations)
                 self.addRow(title: "Number of conversations", contents: "\(conversationsCount)")
+                
+                allConversations.predicate = NSPredicate(format: "conversationType == %d", ZMConversationType.invalid.rawValue)
+                let invalidConversationsCount = try syncMoc.count(for: allConversations)
+                self.addRow(title: "   Invalid", contents: "\(invalidConversationsCount)")
 
-
-                let messages = ZMMessage.sortedFetchRequest()!
+                let messages = ZMMessage.fetchRequest()
                 let messagesCount = try syncMoc.count(for: messages)
                 self.addRow(title: "Number of messages", contents: "\(messagesCount)")
 
 
-                let assetMessages = ZMAssetClientMessage.sortedFetchRequest()!
+                let assetMessages = ZMAssetClientMessage.fetchRequest()
                 let allAssets = try syncMoc.fetch(assetMessages)
                     .compactMap {
                         $0 as? ZMAssetClientMessage

--- a/Wire-iOS/Sources/UserInterface/Settings/DatabaseStatisticsController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DatabaseStatisticsController.swift
@@ -101,6 +101,10 @@ import WireDataModel
                 let invalidConversationsCount = try syncMoc.count(for: allConversations)
                 self.addRow(title: "   Invalid", contents: "\(invalidConversationsCount)")
 
+                let users = ZMUser.fetchRequest()
+                let usersCount = try syncMoc.count(for: users)
+                self.addRow(title: "Number of users", contents: "\(usersCount)")
+                
                 let messages = ZMMessage.fetchRequest()
                 let messagesCount = try syncMoc.count(for: messages)
                 self.addRow(title: "Number of messages", contents: "\(messagesCount)")


### PR DESCRIPTION
## What's new in this PR?

### Issues

In developer settings we have a section that shows how big is your database by counting different kinds of objects. It was not showing the full picture because it used the wrong fetch requests.

### Causes

Our own `sortedFetchRequest` for some subclasses does validation, e.g. for conversation it ignores conversations with `conversationType = .ignored`.

### Solutions

Use plain CoreData fetch requests.

