### PR TITLE
Remove unused method on Analytics and avoid retaining Team

### DIFF
--- a/Wire-iOS/Sources/Analytics/Analytics+OptOut.swift
+++ b/Wire-iOS/Sources/Analytics/Analytics+OptOut.swift
@@ -41,7 +41,7 @@ extension Analytics {
                 }
             } else {
                 provider = AnalyticsProviderFactory.shared.analyticsProvider()
-                team = ZMUser.selfUser()?.team
+                setTeam(ZMUser.selfUser()?.team)
                 tagEvent("settings.opted_in_tracking")
             }
         }

--- a/Wire-iOS/Sources/Analytics/Analytics.h
+++ b/Wire-iOS/Sources/Analytics/Analytics.h
@@ -31,17 +31,16 @@ FOUNDATION_EXPORT BOOL UseAnalytics;
 
 @property (nonatomic, readonly) AnalyticsSessionSummaryEvent *sessionSummary;
 
-@property (nonatomic, nullable) Team* team;
-
 + (void)loadSharedWithOptedOut:(BOOL)optedOut;
 + (instancetype)shared;
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithOptedOut:(BOOL)optedOut NS_DESIGNATED_INITIALIZER;
 
+- (void)setTeam:(nullable Team *)team;
+
 /// Record an event with no attributes
 - (void)tagEvent:(NSString *)event;
-- (void)tagEvent:(NSString *)event attributes:(NSDictionary *)attributes team:(nullable Team *)team;
 
 /// Record an event with optional attributes.
 - (void)tagEvent:(NSString *)event attributes:(NSDictionary *)attributes;

--- a/Wire-iOS/Sources/Analytics/Analytics.m
+++ b/Wire-iOS/Sources/Analytics/Analytics.m
@@ -48,8 +48,6 @@ static Analytics *sharedAnalytics = nil;
 
 @implementation Analytics
 
-@synthesize team = _team;
-
 + (instancetype)shared
 {
     return sharedAnalytics;
@@ -81,7 +79,6 @@ static Analytics *sharedAnalytics = nil;
 
 - (void)setTeam:(Team *)team
 {
-    _team = team;
     if (nil == team) {
         [self.provider setSuperProperty:@"team.size" value:@"0"];
         [self.provider setSuperProperty:@"team.in_team" value:@(NO)];
@@ -102,14 +99,6 @@ static Analytics *sharedAnalytics = nil;
 - (void)tagEvent:(NSString *)event
 {
     [self.provider tagEvent:event attributes:[NSDictionary dictionary]];
-}
-
-- (void)tagEvent:(NSString *)event attributes:(NSDictionary *)attributes team:(nullable Team *)team
-{
-    Team *currentTeam = self.team;
-    self.team = team;
-    [self.provider tagEvent:event attributes:attributes];
-    self.team = currentTeam;
 }
 
 - (void)tagEvent:(NSString *)event attributes:(NSDictionary *)attributes

--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -245,7 +245,7 @@ var defaultFontScheme: FontScheme = FontScheme(contentSizeCategory: UIApplicatio
                 clientViewController.needToShowDataUsagePermissionDialog = true
             }
 
-            Analytics.shared().team = ZMUser.selfUser().team
+            Analytics.shared().setTeam(ZMUser.selfUser().team)
 
             viewController = clientViewController
         case .headless:


### PR DESCRIPTION
## What's new in this PR?

### Issues

We were keeping too many conversations in memory 

### Causes

The analytics object was retaining the `Team` object which keeps a list of all team conversations.

### Solutions

Stop retaining the `Team` object.