### PR TITLE
Hide login hint if only one account is permitted

### DIFF
--- a/Wire-iOS/Sources/Authentication/Authentication/Landing/LandingViewController.swift
+++ b/Wire-iOS/Sources/Authentication/Authentication/Landing/LandingViewController.swift
@@ -151,6 +151,11 @@ final class LandingViewController: AuthenticationStepViewController {
         [headerContainerView, buttonStackView, loginHintsLabel, loginButton].forEach(view.addSubview)
         headerContainerView.addSubview(logoView)
         
+        #if MULTIPLE_ACCOUNTS_DISABLED
+            // no need to see this if you can only have one account
+            loginHintsLabel.isHidden = true
+        #endif
+        
         #if ALLOW_ONLY_EMAIL_LOGIN
             // Do not show buttons for account and team creation
         #else


### PR DESCRIPTION
## What's new in this PR?

If only one account is permitted, we don't want to show the label "Already have an account?" above the login button.