### PR TITLE
ZIOS-11136: Removed setting of Audio Category for audio messages

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
@@ -481,17 +481,11 @@ private let zmLog = ZMSLog(tag: "UI")
     }
     
     private func setAudioOutput(earpiece: Bool) {
-        do {
             if earpiece {
-                try AVAudioSession.sharedInstance().setCategory(.playAndRecord, mode: .default)
                 AVSMediaManager.sharedInstance().playbackRoute = .builtIn
             } else {
-                try AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
                 AVSMediaManager.sharedInstance().playbackRoute = .speaker
             }
-        } catch {
-            zmLog.error("Cannot set AVAudioSession category: \(error)")
-        }
     }
     
     func proximityStateDidChange(_ raisedToEar: Bool) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
@@ -339,10 +339,11 @@ private let zmLog = ZMSLog(tag: "UI")
     }
     
     private func playTrack() {
+        let userSession = ZMUserSession.shared()
         guard let fileMessage = self.fileMessage,
               let fileMessageData = fileMessage.fileMessageData,
               let audioTrackPlayer = self.audioTrackPlayer,
-              ZMUserSession.shared()?.isCallOngoing == false else {
+              userSession == nil || userSession!.isCallOngoing == false else {
             return
         }
         

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
@@ -341,7 +341,8 @@ private let zmLog = ZMSLog(tag: "UI")
     private func playTrack() {
         guard let fileMessage = self.fileMessage,
               let fileMessageData = fileMessage.fileMessageData,
-              let audioTrackPlayer = self.audioTrackPlayer else {
+              let audioTrackPlayer = self.audioTrackPlayer,
+              ZMUserSession.shared()?.isCallOngoing == false else {
             return
         }
         
@@ -481,11 +482,17 @@ private let zmLog = ZMSLog(tag: "UI")
     }
     
     private func setAudioOutput(earpiece: Bool) {
+        do {
             if earpiece {
+                try AVAudioSession.sharedInstance().setCategory(.playAndRecord, mode: .default)
                 AVSMediaManager.sharedInstance().playbackRoute = .builtIn
             } else {
+                try AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
                 AVSMediaManager.sharedInstance().playbackRoute = .speaker
             }
+        } catch {
+            zmLog.error("Cannot set AVAudioSession category: \(error)")
+        }
     }
     
     func proximityStateDidChange(_ raisedToEar: Bool) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecorder.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecorder.swift
@@ -270,12 +270,6 @@ public final class AudioRecorder: NSObject, AudioRecorderType {
     public func playRecording() {
         guard let audioRecorder = self.audioRecorder else { return }
         
-        do {
-            try AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
-        } catch let error {
-            zmLog.error("Failed change audio category for playback: \(error)")
-        }
-        
         setupDisplayLink()
         audioPlayer = try? AVAudioPlayer(contentsOf: audioRecorder.url)
         audioPlayer?.isMeteringEnabled = true

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecorder.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecorder.swift
@@ -268,7 +268,14 @@ public final class AudioRecorder: NSObject, AudioRecorderType {
     // MARK: Playing
     
     public func playRecording() {
-        guard let audioRecorder = self.audioRecorder else { return }
+        guard let audioRecorder = self.audioRecorder,
+            ZMUserSession.shared()?.isCallOngoing == false else { return }
+        
+        do {
+            try AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
+        } catch let error {
+            zmLog.error("Failed change audio category for playback: \(error)")
+        }
         
         setupDisplayLink()
         audioPlayer = try? AVAudioPlayer(contentsOf: audioRecorder.url)


### PR DESCRIPTION
## What's new in this PR?

When we play an audio message we modify the audio session category, this confuses the media manager in AVS since it expects to be in control of the audio session.
I've removed the setting of audio category from `AudioMessageView` and `AudioRecorder` classes.