### PR TITLE
Feature flag: possibility to disable editing account's email address

### DIFF
--- a/Wire-iOS/Sources/Components/Settings/SettingsPropertyFactory.swift
+++ b/Wire-iOS/Sources/Components/Settings/SettingsPropertyFactory.swift
@@ -122,7 +122,7 @@ class SettingsPropertyFactory {
                 switch(value) {
                 case .string(let stringValue):
                     guard let selfUser = self.selfUser else { requireInternal(false, "Attempt to modify a user property without a self user"); break }
-                    
+
                     var inOutString: NSString? = stringValue as NSString
                     try type(of: selfUser).validateName(&inOutString)
                     self.userSession?.enqueueChanges {
@@ -132,7 +132,16 @@ class SettingsPropertyFactory {
                     throw SettingsPropertyError.WrongValue("Incorrect type \(value) for key \(propertyName)")
                 }
             }
-            
+
+            return SettingsBlockProperty(propertyName: propertyName, getAction: getAction, setAction: setAction)
+        case .email:
+            // This is a read only item
+            let getAction: GetAction = { [unowned self] (property: SettingsBlockProperty) -> SettingsPropertyValue in
+                return SettingsPropertyValue.string(value: self.selfUser?.emailAddress ?? "")
+            }
+
+            let setAction: SetAction = { (property: SettingsBlockProperty, value: SettingsPropertyValue) throws -> () in }
+
             return SettingsBlockProperty(propertyName: propertyName, getAction: getAction, setAction: setAction)
 
         case .accentColor:

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptor.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptor.swift
@@ -209,7 +209,9 @@ func SettingsPropertyLabelText(_ name: SettingsPropertyName) -> String {
         // Profile
     case .profileName:
         return "self.settings.account_section.name.title".localized
-        
+    case .email:
+        return "self.settings.account_section.email.title".localized
+
         // AVS
     case .soundAlerts:
         return "self.settings.sound_menu.title".localized

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
@@ -56,19 +56,19 @@ extension SettingsCellDescriptorFactory {
 
     func infoSection() -> SettingsSectionDescriptorType {
         var cellDescriptors: [SettingsCellDescriptorType] = []
-        #if NAME_EDITING_DISABLED
-        let enabled = false
-        #else
-        let enabled = true
-        #endif
-        cellDescriptors = [nameElement(enabled: enabled), handleElement()]
+        cellDescriptors = [nameElement(), handleElement()]
         
         if let user = ZMUser.selfUser(), !user.usesCompanyLogin {
             if !ZMUser.selfUser().hasTeam || !(ZMUser.selfUser().phoneNumber?.isEmpty ?? true) {
                 cellDescriptors.append(phoneElement())
             }
             
-            cellDescriptors.append(emailElement())
+            #if EMAIL_EDITING_DISABLED
+            let enabled = false
+            #else
+            let enabled = true
+            #endif
+            cellDescriptors.append(emailElement(enabled: enabled))
         }
         return SettingsSectionDescriptor(
             cellDescriptors: cellDescriptors,
@@ -131,23 +131,30 @@ extension SettingsCellDescriptorFactory {
         return SettingsPropertyTextValueCellDescriptor(settingsProperty: settingsProperty)
     }
 
-    func emailElement() -> SettingsCellDescriptorType {
-        return SettingsExternalScreenCellDescriptor(
-            title: "self.settings.account_section.email.title".localized,
-            isDestructive: false,
-            presentationStyle: .navigation,
-            presentationAction: { () -> (UIViewController?) in
-                return ChangeEmailViewController()
-            },
-            previewGenerator: { _ in
-                if let email = ZMUser.selfUser().emailAddress, !email.isEmpty {
-                    return SettingsCellPreview.text(email)
-                } else {
-                    return SettingsCellPreview.text("self.add_email_password".localized)
-                }
-            },
-            accessoryViewMode: .alwaysHide
-        )
+    func emailElement(enabled: Bool = true) -> SettingsCellDescriptorType {
+
+        if enabled {
+            return SettingsExternalScreenCellDescriptor(
+                title: "self.settings.account_section.email.title".localized,
+                isDestructive: false,
+                presentationStyle: .navigation,
+                presentationAction: { () -> (UIViewController?) in
+                    return ChangeEmailViewController()
+                },
+                previewGenerator: { _ in
+                    if let email = ZMUser.selfUser().emailAddress, !email.isEmpty {
+                        return SettingsCellPreview.text(email)
+                    } else {
+                        return SettingsCellPreview.text("self.add_email_password".localized)
+                    }
+                },
+                accessoryViewMode: .alwaysHide
+            )
+        } else {
+            var settingsProperty = settingsPropertyFactory.property(.email)
+            settingsProperty.enabled = false
+            return SettingsPropertyTextValueCellDescriptor(settingsProperty: settingsProperty)
+        }
     }
 
     func phoneElement() -> SettingsCellDescriptorType {

--- a/WireCommonComponents/SettingsPropertyName.swift
+++ b/WireCommonComponents/SettingsPropertyName.swift
@@ -46,6 +46,7 @@ public enum SettingsPropertyName: String, CustomStringConvertible {
     
     // Profile
     case profileName = "ProfileName"
+    case email = "email"
     case accentColor = "AccentColor"
     
     // AVS


### PR DESCRIPTION
## What's new in this PR?

This PR is a rework of https://github.com/wireapp/wire-ios/pull/3138.

Support for feature flag EMAIL_EDITING_DISABLED. When this flag is enabled, the cell is read-only and have no actions for tap gesture (to open the detail screen for email editing).