### PR TITLE
Always scroll to the bottom before sending a message

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -716,6 +716,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
 
 - (void)conversationInputBarViewControllerDidComposeText:(NSString *)text mentions:(NSArray<Mention *> *)mentions replyingToMessage:(nullable id<ZMConversationMessage>)message
 {
+    [self.contentViewController scrollToBottomAnimated:NO];
     [self.inputBarController.sendController sendTextMessage:text mentions:mentions replyingToMessage:message];
 }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

We no longer scroll to the bottom when replying

### Causes

This behaviour broke during the conversation view re-factoring

### Solutions

Always scroll to bottom before appending a message