### PR TITLE
Fix: destruction pie timer starts before the file message is sent 

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ZMConversationMessage+CountDown.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ZMConversationMessage+CountDown.swift
@@ -20,10 +20,11 @@ import Foundation
 
 extension ZMConversationMessage {
 
-
-    /// Return the percentage (range: 0 to 1) to destruct of a ephemeral message. Return if self is not a ephemeral message or invalid deletionTimeout
+    /// Return the percentage (range: 0 to 1) to destruct of a ephemeral message.
+    /// Return nil if self is not a ephemeral message or invalid deletionTimeout or deliveryState is pending
     var countdownProgress: Double? {
-        guard let destructionDate = destructionDate, deletionTimeout > 0 else { return nil }
+        guard deliveryState != .pending,
+              let destructionDate = destructionDate, deletionTimeout > 0 else { return nil }
 
         return 1 - destructionDate.timeIntervalSinceNow / deletionTimeout
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

The pie count down timer starts before the message is sent successfully.

### Causes

missing a checking for the message's deliveryState.

### Solutions

Start count down only if deliveryState != .pending 