### PR TITLE
Fix: Cannot like the last message

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageAction.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageAction.swift
@@ -91,11 +91,12 @@ extension ConversationContentViewController {
             // The new liked state, the value is flipped
             let updatedLikedState = !Message.isLikedMessage(message)
 
-            guard let indexPath = dataSource?.indexPath(for: message),
-                let selectedMessage = dataSource?.selectedMessage else { break }
+            guard let indexPath = dataSource?.indexPath(for: message) else { return }
+
+            let selectedMessage = dataSource?.selectedMessage
 
             session.performChanges({
-            Message.setLikedMessage(message, liked: updatedLikedState)
+                Message.setLikedMessage(message, liked: updatedLikedState)
             })
 
             if updatedLikedState {
@@ -145,7 +146,8 @@ extension ConversationContentViewController {
 
         let shouldDismissModal: Bool = actionId != .delete && actionId != .copy
 
-        if messagePresenter.modalTargetController?.presentedViewController != nil && shouldDismissModal {
+        if messagePresenter.modalTargetController?.presentedViewController != nil &&
+            shouldDismissModal {
             messagePresenter.modalTargetController?.dismiss(animated: true) {
                 self.messageAction(actionId: actionId,
                                    for: message,


### PR DESCRIPTION
## What's new in this PR?

### Issues

The user can not like the messages.

### Causes

After https://github.com/wireapp/wire-ios/pull/3139, a guard for optional unwrapping is added and prevents the like action.

### Solutions

Do not guard for optional unwrapping for variable selectedMessage.