### PR TITLE
Avoid save when fetching profile picture

### DIFF
--- a/Wire-iOS/Sources/Helpers/syncengine/ZMUser+Images.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMUser+Images.swift
@@ -65,13 +65,9 @@ extension UserType {
         
         switch size {
         case .preview:
-            session.enqueueChanges {
-                self.requestPreviewProfileImage()
-            }
+            self.requestPreviewProfileImage()
         default:
-            session.enqueueChanges {
-                self.requestCompleteProfileImage()
-            }
+            self.requestCompleteProfileImage()
         }
         
         imageData(for: size, queue: cache.processingQueue) { (imageData) in


### PR DESCRIPTION
## What's new in this PR?

### Issues

When searching for people or scrolling a conversation we would make a save each time we fetch profile picture.

### Causes

We would wrap the method to request profile picture in `session.enqueueChanges`. This is not needed because the method simply sends a notification.
