### PR TITLE
ZIOS-11147: Ephemeral message gets deleted before reading if active account is running at the foreground

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
@@ -202,7 +202,9 @@ extension ConversationMessageCellDescription {
         
         adapterCell.cellView.configure(with: self.configuration, animated: animated)
         
-        _ = message?.startSelfDestructionIfNeeded()
+        if cell.isVisible {
+            _ = message?.startSelfDestructionIfNeeded()
+        }
     }
     
     func isConfigurationEqual(with other: Any) -> Bool {

--- a/Wire-iOS/Sources/UserInterface/Helpers/UIViewController+IsVisible.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UIViewController+IsVisible.swift
@@ -24,9 +24,15 @@ extension UIViewController {
     @objc var isVisible: Bool {
         let isInWindow = view.window != nil
         let notCoveredModally = presentedViewController == nil
-        let viewIsVisible = view.convert(view.bounds, to: nil).intersects(UIScreen.main.bounds)
+        let viewIsVisible = view.isVisible
 
         return isInWindow && notCoveredModally && viewIsVisible
     }
 
+}
+
+extension UIView {
+    @objc var isVisible: Bool {
+        return convert(bounds, to: nil).intersects(UIScreen.main.bounds)
+    }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

On the conversation list, the destruction timer was starting right after receiving a message in the last opened conversation.

### Causes

After https://github.com/wireapp/wire-ios/pull/3043, the ephemeral timer is started when calling `configureCell` of `ConversationMessageCell`. But, since the conversation view is instantiated even if not visible from the conversation list, the timer starts anyway.

### Solutions

Since we need to avoid improper calls to `configureCell`, I'm checking if the cell is visible on screen in order to start the timer. I've also added a new `isVisible` extension to `UIView`.
