### PR TITLE
ZIOS-11178: Restart the flow from scratch if the user clicks the link again

### DIFF
--- a/Wire-iOS Tests/CompanyLoginLinkResponseActionTests.swift
+++ b/Wire-iOS Tests/CompanyLoginLinkResponseActionTests.swift
@@ -21,16 +21,15 @@ import XCTest
 
 struct MockCompanyLoginLinkResponseContext: CompanyLoginLinkResponseContext {
     var numberOfAccounts: Int
-    var userIsInIncompatibleState: Bool
 }
 
 class CompanyLoginLinkResponseActionTests: XCTestCase {
 
     // MARK: - Valid Link
 
-    func testThatItAllowsCompanyLogin_ValidLink_1AccountAndValidState() {
+    func testThatItAllowsCompanyLogin_ValidLink_1Account() {
         // GIVEN
-        let context = MockCompanyLoginLinkResponseContext(numberOfAccounts: 0, userIsInIncompatibleState: false)
+        let context = MockCompanyLoginLinkResponseContext(numberOfAccounts: 0)
 
         // WHEN
         let action = context.actionForValidLink()
@@ -39,20 +38,9 @@ class CompanyLoginLinkResponseActionTests: XCTestCase {
         XCTAssertEqual(action, .allowStartingFlow)
     }
 
-    func testThatItDoesNotAllowCompanyLogin_ValidLink_NoAccountdAndInvalidState() {
+    func testThatItDoesNotAllowCompanyLogin_ValidLink_3Accounts() {
         // GIVEN
-        let context = MockCompanyLoginLinkResponseContext(numberOfAccounts: 0, userIsInIncompatibleState: true)
-
-        // WHEN
-        let action = context.actionForValidLink()
-
-        // THEN
-        XCTAssertEqual(action, .preventStartingFlow)
-    }
-
-    func testThatItDoesNotAllowCompanyLogin_ValidLink_3AccountsAndValidState() {
-        // GIVEN
-        let context = MockCompanyLoginLinkResponseContext(numberOfAccounts: 3, userIsInIncompatibleState: false)
+        let context = MockCompanyLoginLinkResponseContext(numberOfAccounts: 3)
 
         // WHEN
         let action = context.actionForValidLink()
@@ -61,39 +49,17 @@ class CompanyLoginLinkResponseActionTests: XCTestCase {
         XCTAssertEqual(action, .showDismissableAlert(title: "self.settings.add_account.error.title".localized, message: "self.settings.add_account.error.message".localized, allowStartingFlow: false))
     }
 
-    func testThatItDoesNotAllowCompanyLogin_ValidLink_3AccountsAndInvalidState() {
-        // GIVEN
-        let context = MockCompanyLoginLinkResponseContext(numberOfAccounts: 3, userIsInIncompatibleState: true)
-
-        // WHEN
-        let action = context.actionForValidLink()
-
-        // THEN
-        XCTAssertEqual(action, .preventStartingFlow)
-    }
-
     // MARK: - Invalid Link
 
     func testThatItShowsAlert_InvalidLink() {
         // GIVEN
-        let context = MockCompanyLoginLinkResponseContext(numberOfAccounts: 3, userIsInIncompatibleState: false)
+        let context = MockCompanyLoginLinkResponseContext(numberOfAccounts: 3)
 
         // WHEN
         let action = context.actionForInvalidRequest(error: .invalidLink)
 
         // THEN
         XCTAssertEqual(action, .showDismissableAlert(title: "login.sso.start_error_title".localized, message: "login.sso.link_error_message".localized, allowStartingFlow: false))
-    }
-
-    func testThatItDoesntShowAlert_InvalidLink_InvalidState() {
-        // GIVEN
-        let context = MockCompanyLoginLinkResponseContext(numberOfAccounts: 3, userIsInIncompatibleState: true)
-
-        // WHEN
-        let action = context.actionForInvalidRequest(error: .invalidLink)
-
-        // THEN
-        XCTAssertEqual(action, .preventStartingFlow)
     }
 
 }

--- a/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
+++ b/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
@@ -704,12 +704,10 @@ extension AuthenticationCoordinator {
 
     /// Manually start the company login flow.
     private func startCompanyLoginFlowIfPossible(linkCode: UUID?) {
-        if canStartCompanyLogin {
-            if let linkCode = linkCode {
-                companyLoginController?.attemptLoginWithCode(linkCode)
-            } else {
-                companyLoginController?.displayLoginCodePrompt()
-            }
+        if let linkCode = linkCode {
+            companyLoginController?.attemptLoginWithCode(linkCode)
+        } else {
+            companyLoginController?.displayLoginCodePrompt()
         }
     }
 

--- a/Wire-iOS/Sources/UserInterface/Company Login/CompanyControllerLinkContext.swift
+++ b/Wire-iOS/Sources/UserInterface/Company Login/CompanyControllerLinkContext.swift
@@ -44,18 +44,13 @@ enum CompanyLoginLinkResponseAction: Equatable {
 protocol CompanyLoginLinkResponseContext {
     /// The number of accounts currently logged into the app.
     var numberOfAccounts: Int { get }
-
-    /// Whether the user is in an incompatible state, such as registration or SSO login.
-    var userIsInIncompatibleState: Bool { get }
 }
 
 extension CompanyLoginLinkResponseContext {
 
     /// The action to execute in case of a valid link.
     func actionForValidLink() -> CompanyLoginLinkResponseAction {
-        if userIsInIncompatibleState {
-            return .preventStartingFlow
-        } else if numberOfAccounts < SessionManager.maxNumberAccounts {
+        if numberOfAccounts < SessionManager.maxNumberAccounts {
             return .allowStartingFlow
         } else {
             return .showDismissableAlert(
@@ -68,10 +63,6 @@ extension CompanyLoginLinkResponseContext {
 
     /// The action to execute in case of an invalid link.
     func actionForInvalidRequest(error: ConmpanyLoginRequestError) -> CompanyLoginLinkResponseAction {
-        guard !userIsInIncompatibleState else {
-            return .preventStartingFlow
-        }
-
         switch error {
         case .invalidLink:
             return .showDismissableAlert(

--- a/Wire-iOS/Sources/UserInterface/Company Login/CompanyControllerLinkContext.swift
+++ b/Wire-iOS/Sources/UserInterface/Company Login/CompanyControllerLinkContext.swift
@@ -91,15 +91,6 @@ struct DefaultCompanyControllerLinkResponseContext: CompanyLoginLinkResponseCont
         return SessionManager.shared?.accountManager.accounts.count ?? 0
     }
 
-    var userIsInIncompatibleState: Bool {
-        if case .unauthenticated = appState {
-            // Do not start the login if the user is currently signing in with SSO or in a different flow
-            return authenticationCoordinator?.canStartCompanyLogin != true
-        } else {
-            return false
-        }
-    }
-
     init(sessionManager: SessionManager, appState: AppState, authenticationCoordinator: AuthenticationCoordinator?) {
         self.sessionManager = sessionManager
         self.appState = appState


### PR DESCRIPTION
## What's new in this PR?

### Issues

Previously, we had a restriction that disallowed starting the flow if the user wasn't in a list of predetermined states (not logging in or registering). However, it was decided to lift that limitation and allow them to start the flow again if they click the link again.

### Solutions

We remove the check for "incompatible state" when receiving the link. This means that a new authentication coordinator and UI will be created, and the UI will be reset.