### PR TITLE
Fix: Obfuscated view not shown after an image is expired

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationAudioMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationAudioMessageCell.swift
@@ -22,7 +22,9 @@ class ConversationAudioMessageCell: RoundedView, ConversationMessageCell {
     
     struct Configuration {
         let message: ZMConversationMessage
-        let isObfuscated: Bool
+        var isObfuscated: Bool {
+            return message.isObfuscated
+        }
     }
     
     private let transferView = AudioMessageView(frame: .zero)
@@ -127,7 +129,7 @@ class ConversationAudioMessageCellDescription: ConversationMessageCellDescriptio
     let accessibilityLabel: String? = nil
     
     init(message: ZMConversationMessage) {
-        self.configuration = View.Configuration(message: message, isObfuscated: message.isObfuscated)
+        self.configuration = View.Configuration(message: message)
     }
     
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationImageMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationImageMessageCell.swift
@@ -23,6 +23,9 @@ class ConversationImageMessageCell: UIView, ConversationMessageCell {
     struct Configuration {
         let image: ZMImageMessageData
         let message: ZMConversationMessage
+        var isObfuscated: Bool {
+            return message.isObfuscated
+        }
     }
     
     private var containerView = UIView()
@@ -97,7 +100,7 @@ class ConversationImageMessageCell: UIView, ConversationMessageCell {
     }
     
     func configure(with object: Configuration, animated: Bool) {
-        let showObfuscationView = object.message.isObfuscated
+        let showObfuscationView = object.isObfuscated
 
         obfuscationView.isHidden = !showObfuscationView
         let imageResource = showObfuscationView ? nil : object.image.image

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationImageMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationImageMessageCell.swift
@@ -22,8 +22,7 @@ class ConversationImageMessageCell: UIView, ConversationMessageCell {
     
     struct Configuration {
         let image: ZMImageMessageData
-        let isObfuscated: Bool
-        let message: ZMConversationMessage?
+        let message: ZMConversationMessage
     }
     
     private var containerView = UIView()
@@ -98,13 +97,7 @@ class ConversationImageMessageCell: UIView, ConversationMessageCell {
     }
     
     func configure(with object: Configuration, animated: Bool) {
-        let showObfuscationView: Bool
-
-        if let isObfuscated = message?.isObfuscated {
-            showObfuscationView = isObfuscated
-        } else {
-            showObfuscationView = object.isObfuscated
-        }
+        let showObfuscationView = object.message.isObfuscated
 
         obfuscationView.isHidden = !showObfuscationView
         let imageResource = showObfuscationView ? nil : object.image.image
@@ -123,7 +116,7 @@ class ConversationImageMessageCell: UIView, ConversationMessageCell {
 
         imageResourceView.setImageResource(imageResource) { [weak self] in
             self?.updateImageContainerAppearance()
-            _ = object.message?.startSelfDestructionIfNeeded()
+            _ = object.message.startSelfDestructionIfNeeded()
         }
     }
     
@@ -160,7 +153,7 @@ class ConversationImageMessageCellDescription: ConversationMessageCellDescriptio
     
     init(message: ZMConversationMessage, image: ZMImageMessageData) {
         self.message = message
-        self.configuration = View.Configuration(image: image, isObfuscated: message.isObfuscated, message: message)
+        self.configuration = View.Configuration(image: image, message: message)
     }
     
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationImageMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationImageMessageCell.swift
@@ -100,10 +100,7 @@ class ConversationImageMessageCell: UIView, ConversationMessageCell {
     }
     
     func configure(with object: Configuration, animated: Bool) {
-        let showObfuscationView = object.isObfuscated
-
-        obfuscationView.isHidden = !showObfuscationView
-        let imageResource = showObfuscationView ? nil : object.image.image
+        obfuscationView.isHidden = !object.isObfuscated
 
         let scaleFactor: CGFloat = object.image.isAnimatedGIF ? 1 : 0.5
         let imageSize = object.image.originalSize.applying(CGAffineTransform.init(scaleX: scaleFactor, y: scaleFactor))
@@ -116,6 +113,8 @@ class ConversationImageMessageCell: UIView, ConversationMessageCell {
         
         containerView.backgroundColor = UIColor.from(scheme: .placeholderBackground)
         imageResourceView.layer.borderWidth = 0
+
+        let imageResource = object.isObfuscated ? nil : object.image.image
 
         imageResourceView.setImageResource(imageResource) { [weak self] in
             self?.updateImageContainerAppearance()

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationImageMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationImageMessageCell.swift
@@ -98,8 +98,17 @@ class ConversationImageMessageCell: UIView, ConversationMessageCell {
     }
     
     func configure(with object: Configuration, animated: Bool) {
-        obfuscationView.isHidden = !object.isObfuscated
-        
+        let showObfuscationView: Bool
+
+        if let isObfuscated = message?.isObfuscated {
+            showObfuscationView = isObfuscated
+        } else {
+            showObfuscationView = object.isObfuscated
+        }
+
+        obfuscationView.isHidden = !showObfuscationView
+        let imageResource = showObfuscationView ? nil : object.image.image
+
         let scaleFactor: CGFloat = object.image.isAnimatedGIF ? 1 : 0.5
         let imageSize = object.image.originalSize.applying(CGAffineTransform.init(scaleX: scaleFactor, y: scaleFactor))
         
@@ -111,8 +120,6 @@ class ConversationImageMessageCell: UIView, ConversationMessageCell {
         
         containerView.backgroundColor = UIColor.from(scheme: .placeholderBackground)
         imageResourceView.layer.borderWidth = 0
-
-        let imageResource = object.isObfuscated ? nil : object.image.image
 
         imageResourceView.setImageResource(imageResource) { [weak self] in
             self?.updateImageContainerAppearance()

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationLocationMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationLocationMessageCell.swift
@@ -23,7 +23,10 @@ class ConversationLocationMessageCell: UIView, ConversationMessageCell {
 
     struct Configuration {
         let location: LocationMessageData
-        let isObfuscated: Bool
+        let message: ZMConversationMessage
+        var isObfuscated: Bool {
+            return message.isObfuscated
+        }
     }
 
     private var lastConfiguration: Configuration?
@@ -189,6 +192,6 @@ class ConversationLocationMessageCellDescription: ConversationMessageCellDescrip
     let accessibilityLabel: String? = nil
 
     init(message: ZMConversationMessage, location: LocationMessageData) {
-        configuration = View.Configuration(location: location, isObfuscated: message.isObfuscated)
+        configuration = View.Configuration(location: location, message: message)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationLocationMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationLocationMessageCell.swift
@@ -130,6 +130,7 @@ class ConversationLocationMessageCell: UIView, ConversationMessageCell {
         lastConfiguration = object
         recognizer?.isEnabled = !object.isObfuscated
         obfuscationView.isHidden = !object.isObfuscated
+        mapView.isHidden = object.isObfuscated
 
         if let address = object.location.name {
             addressContainerView.isHidden = false

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationVideoMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationVideoMessageCell.swift
@@ -22,7 +22,9 @@ class ConversationVideoMessageCell: RoundedView, ConversationMessageCell {
     
     struct Configuration {
         let message: ZMConversationMessage
-        let isObfuscated: Bool
+        var isObfuscated: Bool {
+            return message.isObfuscated
+        }
     }
     
     private let transferView = VideoMessageView(frame: .zero)
@@ -127,7 +129,7 @@ class ConversationVideoMessageCellDescription: ConversationMessageCellDescriptio
     let accessibilityLabel: String? = nil
     
     init(message: ZMConversationMessage) {
-        self.configuration = View.Configuration(message: message, isObfuscated: message.isObfuscated)
+        self.configuration = View.Configuration(message: message)
     }
     
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationFileMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationFileMessageCell.swift
@@ -22,7 +22,9 @@ class ConversationFileMessageCell: RoundedView, ConversationMessageCell {
 
     struct Configuration {
         let message: ZMConversationMessage
-        let isObfuscated: Bool
+        var isObfuscated: Bool {
+            return message.isObfuscated
+        }
     }
 
     private let fileTransferView = FileTransferView(frame: .zero)
@@ -127,7 +129,7 @@ class ConversationFileMessageCellDescription: ConversationMessageCellDescription
     let accessibilityLabel: String? = nil
 
     init(message: ZMConversationMessage) {
-        self.configuration = View.Configuration(message: message, isObfuscated: message.isObfuscated)
+        self.configuration = View.Configuration(message: message)
     }
         
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationLinkPreviewArticleCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationLinkPreviewArticleCell.swift
@@ -22,8 +22,11 @@ class ConversationLinkPreviewArticleCell: UIView, ConversationMessageCell {
 
     struct Configuration {
         let textMessageData: ZMTextMessageData
-        let isObfuscated: Bool
         let showImage: Bool
+        let message: ZMConversationMessage
+        var isObfuscated: Bool {
+            return message.isObfuscated
+        }
     }
 
     private let articleView = ArticleView(withImagePlaceholder: true)
@@ -110,6 +113,6 @@ class ConversationLinkPreviewArticleCellDescription: ConversationMessageCellDesc
 
     init(message: ZMConversationMessage, data: ZMTextMessageData) {
         let showImage = data.linkPreviewHasImage
-        configuration = View.Configuration(textMessageData: data, isObfuscated: message.isObfuscated, showImage: showImage)
+        configuration = View.Configuration(textMessageData: data, showImage: showImage, message: message)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationTextMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationTextMessageCell.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 
-class ConversationTextMessageCell: UIView, ConversationMessageCell, TextViewInteractionDelegate {
+final class ConversationTextMessageCell: UIView, ConversationMessageCell, TextViewInteractionDelegate {
 
     struct Configuration: Equatable {
         let attributedText: NSAttributedString

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationTextMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationTextMessageCell.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 
-final class ConversationTextMessageCell: UIView, ConversationMessageCell, TextViewInteractionDelegate {
+class ConversationTextMessageCell: UIView, ConversationMessageCell, TextViewInteractionDelegate {
 
     struct Configuration: Equatable {
         let attributedText: NSAttributedString


### PR DESCRIPTION
## What's new in this PR?

### Issues

Obfuscated view not shown after an image is expired.

### Causes

isObfuscated is got from local struct Configuration, it is not updated after message object is updated.

### Solutions

Get the isObfuscated from the message.isObfuscated.

