### PR TITLE
Allow automation suite to save backend type in Settings when starting

### DIFF
--- a/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
+++ b/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
@@ -123,6 +123,10 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
+            argument = "--persist-backend-type"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "-UseAnalytics 1"
             isEnabled = "NO">
          </CommandLineArgument>

--- a/Wire-iOS/Sources/AppDelegate.m
+++ b/Wire-iOS/Sources/AppDelegate.m
@@ -69,6 +69,10 @@ static AppDelegate *sharedAppDelegate = nil;
     NSString *BackendEnvironmentTypeKey = @"ZMBackendEnvironmentType";
     NSString *backendEnvironment = [[NSUserDefaults standardUserDefaults] stringForKey:BackendEnvironmentTypeKey];
     [[NSUserDefaults sharedUserDefaults] setObject:backendEnvironment forKey:BackendEnvironmentTypeKey];
+
+    if (AutomationHelper.sharedHelper.shouldPersistBackendType) {
+        [[NSUserDefaults standardUserDefaults] setObject:backendEnvironment forKey:BackendEnvironmentTypeKey];
+    }
     
     if (backendEnvironment.length == 0 || [backendEnvironment isEqualToString:@"default"]) {
         NSString *defaultBackend = @STRINGIZE(DEFAULT_BACKEND);

--- a/WireCommonComponents/AutomationHelper.swift
+++ b/WireCommonComponents/AutomationHelper.swift
@@ -78,6 +78,9 @@ import WireSystem
     /// The name of the arguments file in the /tmp directory
     private let fileArgumentsName = "wire_arguments.txt"
 
+    /// Whether the backend environment type should be persisted as a setting.
+    @objc public let shouldPersistBackendType: Bool
+
     override init() {
         let url = URL(string: NSTemporaryDirectory())?.appendingPathComponent(fileArgumentsName)
         let arguments: ArgumentsType = url.flatMap(FileArguments.init) ?? CommandLineArguments()
@@ -86,6 +89,7 @@ import WireSystem
         self.disableAutocorrection = arguments.hasFlag(AutomationKey.disableAutocorrection)
         self.uploadAddressbookOnSimulator = arguments.hasFlag(AutomationKey.enableAddressBookOnSimulator)
         self.disableCallQualitySurvey = arguments.hasFlag(AutomationKey.disableCallQualitySurvey)
+        self.shouldPersistBackendType = arguments.hasFlag(AutomationKey.persistBackendType)
 
         self.automationEmailCredentials = AutomationHelper.credentials(arguments)
         if arguments.hasFlag(AutomationKey.logNetwork) {
@@ -119,6 +123,7 @@ import WireSystem
         case addressBookRemoteSearchDelay = "addressbook-search-delay"
         case debugDataToInstall = "debug-data-to-install"
         case disableCallQualitySurvey = "disable-call-quality-survey"
+        case persistBackendType = "persist-backend-type"
     }
     
     /// Returns the login email and password credentials if set in the given arguments


### PR DESCRIPTION
## What's new in this PR?

### Issues

When launching the app from Appium, the automation suite passes the `-ZMBackendEnvironmentType` flag and sets it to staging.

But we cannot persist this setting, which means that for some tests where we kill the app and launch it from the URL scheme, Safari will not set the environment type back to staging and all further tests will fail.

### Solutions

We introduce a `--persist-backend-type` launch flag which acts as a shortcut to change the backend type in the Settings app.

If this flag is passed, we will set the value from `-ZMBackendEnvironmentType` in the standard user defaults to persist it to the next run.