### PR TITLE
ZIOS-11170: Do not show the consent alert if the user logs in again

### DIFF
--- a/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
+++ b/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
@@ -96,6 +96,9 @@ class AuthenticationCoordinator: NSObject, AuthenticationEventResponderChainDele
     private var initialSyncObserver: Any?
     private var pendingAlert: AuthenticationCoordinatorAlert?
 
+    /// Whether an account was added.
+    var addedAccount: Bool = false
+
     // MARK: - Initialization
 
     /// Creates a new authentication coordinator with the required supporting objects.
@@ -231,10 +234,10 @@ extension AuthenticationCoordinator: AuthenticationActioner, SessionManagerCreat
                 presentErrorAlert(for: alertModel)
 
             case .completeLoginFlow:
-                delegate?.userAuthenticationDidComplete(registered: false)
+                delegate?.userAuthenticationDidComplete(addedAccount: addedAccount)
 
             case .completeRegistrationFlow:
-                delegate?.userAuthenticationDidComplete(registered: true)
+                delegate?.userAuthenticationDidComplete(addedAccount: true)
 
             case .startPostLoginFlow:
                 registerPostLoginObserversIfNeeded()

--- a/Wire-iOS/Sources/Authentication/Coordinator/Coordinator+Delegates/AuthenticationCoordinator+PreLogin.swift
+++ b/Wire-iOS/Sources/Authentication/Coordinator/Coordinator+Delegates/AuthenticationCoordinator+PreLogin.swift
@@ -33,6 +33,7 @@ extension AuthenticationCoordinator: PreLoginAuthenticationObserver {
 
     /// Called when the backup is ready to be imported.
     func authenticationReadyToImportBackup(existingAccount: Bool) {
+        addedAccount = !existingAccount
         eventResponderChain.handleEvent(ofType: .backupReady(existingAccount))
     }
 

--- a/Wire-iOS/Sources/Authentication/Coordinator/Coordinator+Delegates/AuthenticationCoordinator+Teams.swift
+++ b/Wire-iOS/Sources/Authentication/Coordinator/Coordinator+Delegates/AuthenticationCoordinator+Teams.swift
@@ -21,7 +21,7 @@ import UIKit
 extension AuthenticationCoordinator: TeamMemberInviteViewControllerDelegate {
 
     func teamInviteViewControllerDidFinish(_ controller: TeamMemberInviteViewController) {
-        delegate?.userAuthenticationDidComplete(registered: true)
+        delegate?.userAuthenticationDidComplete(addedAccount: true)
     }
 
 }

--- a/Wire-iOS/Sources/Authentication/Delegates/AuthenticationCoordinatorDelegate.swift
+++ b/Wire-iOS/Sources/Authentication/Delegates/AuthenticationCoordinatorDelegate.swift
@@ -26,11 +26,10 @@ protocol AuthenticationCoordinatorDelegate: AuthenticationStatusProvider {
 
     /**
      * The coordinator finished authenticating the user.
-     *
-     * - parameter registered: Whether the current user was registered (`true`),
-     * or simply logged in (`false`).
+     * - parameter addedAccount: Whether the authentication action added a new account
+     * to this device.
      */
 
-    func userAuthenticationDidComplete(registered: Bool)
+    func userAuthenticationDidComplete(addedAccount: Bool)
 
 }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+DataUsagePermissions.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+DataUsagePermissions.swift
@@ -32,10 +32,7 @@ extension ConversationListViewController {
         guard needToShowDataUsagePermissionDialog else { return }
 
         // If the user registers, show the alert.
-        // If the user logs in and hasn't accepted analytics yet, show the alert.
-        guard isComingFromRegistration ||
-              (isComingFromSetUsername && ZMUser.selfUser().isTeamMember) ||
-              !userAcceptedAnalytics else { return }
+        guard isComingFromRegistration else { return }
 
         let alertController = UIAlertController(title: "conversation_list.data_usage_permission_alert.title".localized, message: "conversation_list.data_usage_permission_alert.message".localized, preferredStyle: .alert)
 
@@ -60,7 +57,4 @@ extension ConversationListViewController {
         #endif
     }
 
-    private var userAcceptedAnalytics: Bool {
-        return TrackingManager.shared.disableCrashAndAnalyticsSharing == false
-    }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Previously, we'd show the "Help us make Wire better" alert when the user logs in a second time with the same account on the same device. It was decided to not do this anymore.

### Solutions

We update the logic of checking if the alert needs to be shown. We only show it if you "add a new account" (login / registration).