### PR TITLE
ZIOS-11112: Improve backup restoring flow

### DIFF
--- a/Wire-iOS/Sources/Authentication/Backup/BackupRestoreController.swift
+++ b/Wire-iOS/Sources/Authentication/Backup/BackupRestoreController.swift
@@ -73,8 +73,6 @@ class BackupRestoreController: NSObject {
 
     fileprivate func performRestore(using password: String, from url: URL) {
         guard let sessionManager = SessionManager.shared else { return }
-
-        target.spinnerView?.subtitle = "registration.no_history.restore_backup.restoring".localized.uppercased()
         target.showLoadingView = true
 
         sessionManager.restoreFromBackup(at: url, password: password) { [weak self] result in
@@ -85,16 +83,15 @@ class BackupRestoreController: NSObject {
                 self.showWrongPasswordAlert {
                     self.restore(with: url)
                 }
+
             case .failure(let error):
                 BackupEvent.importFailed.track()
                 self.showRestoreError(error)
                 self.target.showLoadingView = false
+
             case .success:
                 BackupEvent.importSucceeded.track()
-                self.target.spinnerView?.subtitle = "registration.no_history.restore_backup.completed".localized.uppercased()
-                self.target.indicateLoadingSuccessRemovingCheckmark(false) {
-                    self.delegate?.backupResoreControllerDidFinishRestoring(self)
-                }
+                self.delegate?.backupResoreControllerDidFinishRestoring(self)
             }
         }
     }

--- a/Wire-iOS/Sources/Authentication/Event Handlers/Input/AuthenticationButtonTapInputHandler.swift
+++ b/Wire-iOS/Sources/Authentication/Event Handlers/Input/AuthenticationButtonTapInputHandler.swift
@@ -35,7 +35,7 @@ class AuthenticationButtonTapInputHandler: AuthenticationEventHandler {
         // Only handle input during specified steps.
         switch currentStep {
         case .noHistory:
-            return [.completeBackupStep]
+            return [.showLoadingView, .completeBackupStep]
         case .clientManagement(let clients, let credentials):
             let nextStep = AuthenticationFlowStep.deleteClient(clients: clients, credentials: credentials)
             return [AuthenticationCoordinatorAction.transition(nextStep, mode: .normal)]

--- a/Wire-iOS/Sources/Authentication/Event Handlers/Post-Login/Registration Error/ClientRegistrationErrorEventHandler.swift
+++ b/Wire-iOS/Sources/Authentication/Event Handlers/Post-Login/Registration Error/ClientRegistrationErrorEventHandler.swift
@@ -29,6 +29,17 @@ class ClientRegistrationErrorEventHandler: AuthenticationEventHandler {
     func handleEvent(currentStep: AuthenticationFlowStep, context: (NSError, UUID)) -> [AuthenticationCoordinatorAction]? {
         let (error, _) = context
 
+        // Only handle needsToRegisterEmailToRegisterClient errors
+        if error.userSessionErrorCode == .needsToRegisterEmailToRegisterClient {
+            // If we are already registering the credentials, do not handle the error
+            switch currentStep {
+            case .addEmailAndPassword, .registerEmailCredentials, .pendingEmailLinkVerification:
+                return nil
+            default:
+                break
+            }
+        }
+
         let alert = AuthenticationCoordinatorErrorAlert(error: error, completionActions: [.unwindState(withInterface: false)])
         return [.hideLoadingView, .presentErrorAlert(alert)]
     }

--- a/Wire-iOS/Sources/Authentication/Event Handlers/Post-Login/Success/AuthenticationSuccessEventHandler.swift
+++ b/Wire-iOS/Sources/Authentication/Event Handlers/Post-Login/Success/AuthenticationSuccessEventHandler.swift
@@ -27,7 +27,7 @@ class AuthenticationClientRegistrationSuccessHandler: AuthenticationEventHandler
     weak var statusProvider: AuthenticationStatusProvider?
 
     func handleEvent(currentStep: AuthenticationFlowStep, context: Void) -> [AuthenticationCoordinatorAction]? {
-        return [.hideLoadingView, .transition(.pendingInitialSync(next: nil), mode: .normal)]
+        return [.transition(.pendingInitialSync(next: nil), mode: .normal)]
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/Components/Loading/UIViewController+LoadingView.h
+++ b/Wire-iOS/Sources/UserInterface/Components/Loading/UIViewController+LoadingView.h
@@ -29,6 +29,4 @@
 @property (strong, nonatomic) SpinnerSubtitleView *spinnerView;
 @property (assign, nonatomic) BOOL showLoadingView;
 
-- (void)indicateLoadingSuccessRemovingCheckmark:(BOOL)removingCheckmark completion:(dispatch_block_t)completion;
-
 @end

--- a/Wire-iOS/Sources/UserInterface/Components/Loading/UIViewController+LoadingView.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Loading/UIViewController+LoadingView.m
@@ -93,37 +93,4 @@ const NSString *LoadingViewKey = @"loadingView";
     objc_setAssociatedObject(self, (__bridge void *) LoadingViewKey, loadingView, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
-- (void)indicateLoadingSuccessRemovingCheckmark:(BOOL)removingCheckmark completion:(dispatch_block_t)completion
-{
-    CheckAnimationView __block *checkView = nil;
-    
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.25 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        checkView = [[CheckAnimationView alloc] init];
-        checkView.center = self.loadingView.center;
-        [self.loadingView addSubview:checkView];
-        checkView.alpha = 0;
-        
-        [UIView animateWithDuration:0.5f animations:^{
-            checkView.alpha = 1;
-        } completion:nil];
-    });
-    
-    [UIView animateWithDuration:0.75f animations:^{
-        self.spinnerView.spinner.alpha = 0;
-        self.spinnerView.spinner.transform = CGAffineTransformMakeScale(0.01, 0.01);
-    } completion:^(BOOL completed){
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-            if (completion != nil) {
-                completion();
-            }
-            if (removingCheckmark) {
-                self.spinnerView.spinner.alpha = 1;
-                self.spinnerView.spinner.transform = CGAffineTransformIdentity;
-                [self setShowLoadingView:NO];
-                [checkView removeFromSuperview];
-            }
-        });
-    }];
-}
-
 @end


### PR DESCRIPTION
## What's new in this PR?

### Issues

- Some users were not able to restore a backup with phone number
- It was possible to dismiss the checkmark and restore again

### Solutions

- Do not hide the restore spinner until the initial sync finishes
- Remove the checkmark, as it was misleading: the operation wasn't actually completed until the sync finishes (discussed with @vytis and @typfel this morning)
- Show the spinner even if you ignore restoring, until the initial sync finishes
- Do not show the "add email/password" alert if the user is adding it already