### PR TITLE
Improve image messages scrolling performance

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageActionController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageActionController.swift
@@ -24,6 +24,8 @@ import UIKit
     enum Context: Int {
         case content, collection
     }
+    
+    private var actions = [Selector : Bool]()
 
     @objc let message: ZMConversationMessage
     @objc let context: Context
@@ -55,8 +57,8 @@ import UIKit
         UIMenuItem(title: "content.message.resend".localized, action: #selector(ConversationMessageActionController.resendMessage)),
         UIMenuItem(title: "content.message.go_to_conversation".localized, action: #selector(ConversationMessageActionController.revealMessage))
     ]
-
-    @objc func canPerformAction(_ selector: Selector) -> Bool {
+    
+    private func message(_ message: ZMConversationMessage, canPerformAction selector: Selector) -> Bool {
         switch selector {
         case #selector(ConversationMessageActionController.copyMessage):
             return message.canBeCopied
@@ -87,6 +89,16 @@ import UIKit
         default:
             return false
         }
+    }
+
+    @objc func canPerformAction(_ selector: Selector) -> Bool {
+        if let result = actions[selector] {
+            return result
+        }
+        
+        let result = message(self.message, canPerformAction: selector)
+        actions[selector] = result
+        return result
     }
 
     @objc func makeAccessibilityActions() -> [UIAccessibilityCustomAction] {


### PR DESCRIPTION
## What's new in this PR?

### Issues

When profiling the app some performance issues were isolated in conversation view while scrolling image messages.

### Causes

When cell was dequeued we were re-calculating `accessibilityCustomActions` unnecessary. Most of the work was done in `ZMConversationMessage.isImage`.

### Solutions

Cache possible actions for the message to avoid recalculating it.

