### PR TITLE
ZIOS-11188: Fix keyboard jumping and unresponsive button

### DIFF
--- a/Wire-iOS Tests/Authentication/AuthenticationInterfaceBuilderTests.swift
+++ b/Wire-iOS Tests/Authentication/AuthenticationInterfaceBuilderTests.swift
@@ -112,16 +112,16 @@ class AuthenticationInterfaceBuilderTests: ZMSnapshotTestCase {
     // MARK: - Login
 
     func testLoginScreen_Phone() {
-        runSnapshotTest(for: .provideCredentials(.phone))
+        runSnapshotTest(for: .provideCredentials(.phone, nil))
     }
 
     func testLoginScreen_Email() {
-        runSnapshotTest(for: .provideCredentials(.email))
+        runSnapshotTest(for: .provideCredentials(.email, nil))
     }
 
     func testLoginScreen_Email_PhoneDisabled() {
         featureProvider.allowOnlyEmailLogin = true
-        runSnapshotTest(for: .provideCredentials(.email))
+        runSnapshotTest(for: .provideCredentials(.email, nil))
     }
 
     func testLoginScreen_PhoneNumberVerification() {

--- a/Wire-iOS Tests/Authentication/AuthenticationStateControllerTests.swift
+++ b/Wire-iOS Tests/Authentication/AuthenticationStateControllerTests.swift
@@ -109,12 +109,12 @@ class AuthenticationStateControllerTests: XCTestCase {
         let phoneNumber = "+4912345678900"
 
         stateController.transition(to: .landingScreen, mode: .reset)
-        stateController.transition(to: .provideCredentials(.email))
+        stateController.transition(to: .provideCredentials(.email, nil))
         stateController.transition(to: .sendLoginCode(phoneNumber: phoneNumber, isResend: false))
 
         XCTAssertEqual(stateController.stack, [
             .landingScreen,
-            .provideCredentials(.email),
+            .provideCredentials(.email, nil),
             .sendLoginCode(phoneNumber: phoneNumber, isResend: false)
         ])
 
@@ -122,8 +122,8 @@ class AuthenticationStateControllerTests: XCTestCase {
         stateController.unwindState()
 
         // THEN
-        XCTAssertEqual(stateController.currentStep, .provideCredentials(.email)) // we should rewind to n-1 step
-        XCTAssertEqual(stateController.stack, [.landingScreen, .provideCredentials(.email)])
+        XCTAssertEqual(stateController.currentStep, .provideCredentials(.email, nil)) // we should rewind to n-1 step
+        XCTAssertEqual(stateController.stack, [.landingScreen, .provideCredentials(.email, nil)])
     }
 
     func testThatItUnwindsFromNonUIToUIState() {
@@ -131,13 +131,13 @@ class AuthenticationStateControllerTests: XCTestCase {
         let phoneNumber = "+4912345678900"
 
         stateController.transition(to: .landingScreen, mode: .reset)
-        stateController.transition(to: .provideCredentials(.phone)) // user logs in with phone number
+        stateController.transition(to: .provideCredentials(.phone, nil)) // user logs in with phone number
         stateController.transition(to: .sendLoginCode(phoneNumber: phoneNumber, isResend: false))
         stateController.transition(to: .enterLoginCode(phoneNumber: phoneNumber))
 
         XCTAssertEqual(stateController.stack, [
             .landingScreen,
-            .provideCredentials(.phone),
+            .provideCredentials(.phone, nil),
             .sendLoginCode(phoneNumber: phoneNumber, isResend: false), // non-ui
             .enterLoginCode(phoneNumber: phoneNumber)
         ])
@@ -146,8 +146,8 @@ class AuthenticationStateControllerTests: XCTestCase {
         stateController.unwindState() // user taps back button on enter code screen
 
         // THEN
-        XCTAssertEqual(stateController.currentStep, .provideCredentials(.phone)) // we should rewind to n-2, because n-1 is non-ui
-        XCTAssertEqual(stateController.stack, [.landingScreen, .provideCredentials(.phone)])
+        XCTAssertEqual(stateController.currentStep, .provideCredentials(.phone, nil)) // we should rewind to n-2, because n-1 is non-ui
+        XCTAssertEqual(stateController.stack, [.landingScreen, .provideCredentials(.phone, nil)])
     }
 
 }

--- a/Wire-iOS/Sources/Authentication/AuthenticationFlowStep.swift
+++ b/Wire-iOS/Sources/Authentication/AuthenticationFlowStep.swift
@@ -55,7 +55,7 @@ indirect enum AuthenticationFlowStep: Equatable {
     case reauthenticate(credentials: LoginCredentials?, numberOfAccounts: Int)
 
     // Sign-In
-    case provideCredentials(AuthenticationCredentialsType)
+    case provideCredentials(AuthenticationCredentialsType, AuthenticationPrefilledCredentials?)
     case sendLoginCode(phoneNumber: String, isResend: Bool)
     case enterLoginCode(phoneNumber: String)
     case authenticateEmailCredentials(ZMEmailCredentials)

--- a/Wire-iOS/Sources/Authentication/AuthenticationInterfaceBuilder.swift
+++ b/Wire-iOS/Sources/Authentication/AuthenticationInterfaceBuilder.swift
@@ -89,8 +89,8 @@ class AuthenticationInterfaceBuilder {
             viewController.setRightItem("registration.signin.too_many_devices.sign_out_button.title".localized, withAction: .signOut(warn: true), accessibilityID: "signOutButton")
             return viewController
 
-        case .provideCredentials(let credentialsFlowType):
-            let viewController = makeCredentialsViewController(for: .login(credentialsFlowType))
+        case .provideCredentials(let credentialsFlowType, let prefill):
+            let viewController = makeCredentialsViewController(for: .login(credentialsFlowType, prefill))
 
             // Add the item to start company login if needed.
             if featureProvider.allowCompanyLogin {

--- a/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
+++ b/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
@@ -374,11 +374,11 @@ extension AuthenticationCoordinator {
     /// Signs the current user out with a warning.
     private func signOut(warn: Bool) {
         if warn {
-            let signOutAction = AuthenticationCoordinatorAlertAction(title: "general.ok".localized, coordinatorActions: [.showLoadingView, .signOut(warn: false)])
+            let signOutAction = AuthenticationCoordinatorAlertAction(title: "general.ok".localized, coordinatorActions: [.showLoadingView, .signOut(warn: false)], style: .destructive)
 
             let alertModel = AuthenticationCoordinatorAlert(title: "self.settings.account_details.log_out.alert.title".localized,
                                                             message: "self.settings.account_details.log_out.alert.message".localized,
-                                                            actions: [signOutAction, .cancelDestructiveAction])
+                                                            actions: [.cancel, signOutAction])
 
             presentAlert(for: alertModel)
         } else {

--- a/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
+++ b/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
@@ -453,7 +453,7 @@ extension AuthenticationCoordinator {
             let newStep = AuthenticationFlowStep.createCredentials(unregisteredUser, newType)
             stateController.transition(to: newStep, mode: .replace)
         case .provideCredentials:
-            let newStep = AuthenticationFlowStep.provideCredentials(newType)
+            let newStep = AuthenticationFlowStep.provideCredentials(newType, nil)
             stateController.transition(to: newStep, mode: .replace)
         default:
             log.warn("The current step does not support credential type switching")

--- a/Wire-iOS/Sources/Authentication/Coordinator/Coordinator+Delegates/AuthenticationCoordinator+LandingScreen.swift
+++ b/Wire-iOS/Sources/Authentication/Coordinator/Coordinator+Delegates/AuthenticationCoordinator+LandingScreen.swift
@@ -25,7 +25,7 @@ extension AuthenticationCoordinator: LandingViewControllerDelegate {
             let loginRequest = AuthenticationLoginRequest.email(address: fastloginCredentials.email, password: fastloginCredentials.password)
             executeActions([.showLoadingView, .startLoginFlow(loginRequest)])
         } else {
-            stateController.transition(to: .provideCredentials(.email))
+            stateController.transition(to: .provideCredentials(.email, nil))
         }
     }
 

--- a/Wire-iOS/Sources/Authentication/Event Handlers/AuthenticationCoordinatorAction.swift
+++ b/Wire-iOS/Sources/Authentication/Event Handlers/AuthenticationCoordinatorAction.swift
@@ -96,7 +96,6 @@ struct AuthenticationCoordinatorAlertAction {
 extension AuthenticationCoordinatorAlertAction {
     static let ok: AuthenticationCoordinatorAlertAction = AuthenticationCoordinatorAlertAction(title: "general.ok".localized, coordinatorActions: [])
     static let cancel: AuthenticationCoordinatorAlertAction = AuthenticationCoordinatorAlertAction(title: "general.cancel".localized, coordinatorActions: [], style: .cancel)
-    static let cancelDestructiveAction: AuthenticationCoordinatorAlertAction = AuthenticationCoordinatorAlertAction(title: "general.cancel".localized, coordinatorActions: [], style: .destructive)
 }
 
 /**

--- a/Wire-iOS/Sources/Authentication/Event Handlers/Flow Start/AuthenticationStartAddAccountEventHandler.swift
+++ b/Wire-iOS/Sources/Authentication/Event Handlers/Flow Start/AuthenticationStartAddAccountEventHandler.swift
@@ -34,7 +34,7 @@ class AuthenticationStartAddAccountEventHandler: AuthenticationEventHandler {
     func handleEvent(currentStep: AuthenticationFlowStep, context: (NSError?, Int)) -> [AuthenticationCoordinatorAction]? {
         if featureProvider.allowOnlyEmailLogin {
             // Hide the landing screen if account creation is disabled.
-            return [.transition(.provideCredentials(.email), mode: .reset)]
+            return [.transition(.provideCredentials(.email, nil), mode: .reset)]
         } else {
             return [.transition(.landingScreen, mode: .reset)]
         }

--- a/Wire-iOS/Sources/Authentication/Event Handlers/Registration/RegistrationActivationExistingAccountPolicyHandler.swift
+++ b/Wire-iOS/Sources/Authentication/Event Handlers/Registration/RegistrationActivationExistingAccountPolicyHandler.swift
@@ -46,9 +46,14 @@ class RegistrationActivationExistingAccountPolicyHandler: AuthenticationEventHan
         var actions: [AuthenticationCoordinatorAction] = [.hideLoadingView]
 
         switch user.credentials! {
-        case .email:
+        case .email(let email):
+            let prefilledCredentials = AuthenticationPrefilledCredentials(
+                primaryCredentialsType: .email, credentials:
+                LoginCredentials(emailAddress: email, phoneNumber: nil, hasPassword: true, usesCompanyLogin: false)
+            )
+
             let changeEmailAction = AuthenticationCoordinatorAlertAction(title: "registration.alert.change_email_action".localized, coordinatorActions: [.unwindState(withInterface: false), .executeFeedbackAction(.clearInputFields)])
-            let loginAction = AuthenticationCoordinatorAlertAction(title: "registration.alert.change_signin_action".localized, coordinatorActions: [])
+            let loginAction = AuthenticationCoordinatorAlertAction(title: "registration.alert.change_signin_action".localized, coordinatorActions: [.transition(.provideCredentials(.email, prefilledCredentials), mode: .replace)])
 
             let alert = AuthenticationCoordinatorAlert(title: "registration.alert.account_exists.title".localized,
                                                        message: "registration.alert.account_exists.message_email".localized,

--- a/Wire-iOS/Sources/Authentication/Interface/Descriptions/ScreenDescriptions/Login/LogInStepDescription.swift
+++ b/Wire-iOS/Sources/Authentication/Interface/Descriptions/ScreenDescriptions/Login/LogInStepDescription.swift
@@ -22,7 +22,7 @@ import Foundation
  * An object holding the configuration of the login prefill.
  */
 
-struct AuthenticationPrefilledCredentials {
+struct AuthenticationPrefilledCredentials: Equatable {
     /// The primary type of credentials held in the value.
     let primaryCredentialsType: AuthenticationCredentialsType
 

--- a/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationStepController.swift
+++ b/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationStepController.swift
@@ -88,12 +88,6 @@ class AuthenticationStepController: AuthenticationStepViewController {
 
     // MARK: - View Lifecycle
 
-    override var showLoadingView: Bool {
-        didSet {
-            stepDescription.mainView.acceptsInput = !showLoadingView
-        }
-    }
-
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = UIColor.Team.background
@@ -103,15 +97,10 @@ class AuthenticationStepController: AuthenticationStepViewController {
         updateBackButton()
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        configureObservers()
-    }
-
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        configureObservers()
         showKeyboard()
-        updateKeyboard(with: KeyboardFrameObserver.shared.keyboardFrame)
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -278,7 +267,6 @@ class AuthenticationStepController: AuthenticationStepViewController {
         authenticationCoordinator?.executeAction(rightItemAction)
     }
 
-
     // MARK: - Back Button
 
     private func updateBackButton() {
@@ -329,7 +317,7 @@ class AuthenticationStepController: AuthenticationStepViewController {
 
         // Calculate the height of the content under the keyboard
         let contentRect = CGRect(x: contentStack.frame.origin.x,
-                                 y: contentStack.frame.origin.y + currentOffset - minimumKeyboardSpacing / 2,
+                                 y: contentStack.frame.origin.y + currentOffset,
                                  width: contentStack.frame.width,
                                  height: contentStack.frame.height + minimumKeyboardSpacing)
 
@@ -343,7 +331,7 @@ class AuthenticationStepController: AuthenticationStepViewController {
 
     func clearInputFields() {
         (mainView as? TextContainer)?.text = nil
-        mainView.becomeFirstResponderIfPossible()
+        showKeyboard()
     }
 
     func showKeyboard() {


### PR DESCRIPTION
## What's new in this PR?

### Issues

- When pushing or popping a view controller in the login UI, the bottom buttons could be under the keyboard
- When popping a view controller in the login UI, the content was moved to the center and not adapted to the keyboard frame
- When submitting and email or phone number on the registration screen, the keyboard would appear again after accepting the TOS
- When registering with an existing email, the "log in" button would do nothing
- The wrong button was set as destructive in the logout popup

### Solutions

- Start observing keyboard changes after the view was presented but before we show the keyboard
- Remove multiple calls to the action handling method from email and phone fields
- Fix bottom padding calculation
- Add missing actions to handle logging in from registration