### PR TITLE
ZIOS-11195: Fix logic for showing notifications popover

### DIFF
--- a/Wire-iOS/Sources/Authentication/Coordinator/Coordinator+Delegates/AuthenticationCoordinator+Backup.swift
+++ b/Wire-iOS/Sources/Authentication/Coordinator/Coordinator+Delegates/AuthenticationCoordinator+Backup.swift
@@ -21,7 +21,7 @@ import Foundation
 extension AuthenticationCoordinator: BackupRestoreControllerDelegate {
 
     func backupResoreControllerDidFinishRestoring(_ controller: BackupRestoreController) {
-        self.executeAction(.completeBackupStep)
+        self.executeActions([.configureNotifications, .completeBackupStep])
     }
 
 }

--- a/Wire-iOS/Sources/Authentication/Event Handlers/Input/AuthenticationButtonTapInputHandler.swift
+++ b/Wire-iOS/Sources/Authentication/Event Handlers/Input/AuthenticationButtonTapInputHandler.swift
@@ -35,7 +35,7 @@ class AuthenticationButtonTapInputHandler: AuthenticationEventHandler {
         // Only handle input during specified steps.
         switch currentStep {
         case .noHistory:
-            return [.showLoadingView, .completeBackupStep]
+            return [.showLoadingView, .configureNotifications, .completeBackupStep]
         case .clientManagement(let clients, let credentials):
             let nextStep = AuthenticationFlowStep.deleteClient(clients: clients, credentials: credentials)
             return [AuthenticationCoordinatorAction.transition(nextStep, mode: .normal)]

--- a/Wire-iOS/Sources/Authentication/Event Handlers/Post-Login/Backup/AuthenticationBackupReadyEventHandler.swift
+++ b/Wire-iOS/Sources/Authentication/Event Handlers/Post-Login/Backup/AuthenticationBackupReadyEventHandler.swift
@@ -31,7 +31,7 @@ class AuthenticationBackupReadyEventHandler: AuthenticationEventHandler {
 
         // Automatically complete the backup for @fastLogin automation
         guard AutomationHelper.sharedHelper.automationEmailCredentials == nil else {
-            return [.hideLoadingView, .completeBackupStep]
+            return [.showLoadingView, .configureNotifications, .completeBackupStep]
         }
 
         // Get the signed-in user credentials

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+PushPermissions.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+PushPermissions.swift
@@ -54,7 +54,7 @@ extension ConversationListViewController {
     @objc func showPushPermissionDeniedDialogIfNeeded() {
         // We only want to present the notification takeover when the user already has a handle
         // and is not coming from the registration flow (where we alreday ask for permissions).
-        if !isComingFromRegistration || nil == ZMUser.selfUser().handle {
+        if isComingFromRegistration || nil == ZMUser.selfUser().handle {
             return
         }
 


### PR DESCRIPTION
## What's new in this PR?

Fix the logic for asking for notifications and showing the popover after login. We were doing the check assuming the permissions were not asked for when logging in, which is not the case.

We also enforce asking for permissions before finishing the backup step.