### PR TITLE
Fix: disabled notifications screen shows up even when they are enabled

### DIFF
--- a/Wire-iOS/Sources/Permissions/UNUserNotificationCenter+Permission.swift
+++ b/Wire-iOS/Sources/Permissions/UNUserNotificationCenter+Permission.swift
@@ -29,12 +29,9 @@ import Foundation
      * value is true iff the pushes are disabled.
      */
     func checkPushesDisabled(_ handler: @escaping (Bool) -> Void) {
-        let notRegistered = !UIApplication.shared.isRegisteredForRemoteNotifications
-
         getNotificationSettings { settings in
-            let notAuthorized = settings.authorizationStatus != .authorized
-            let pushedDisabled = notRegistered || notAuthorized
-            handler(pushedDisabled)
+            let pushesDisabled = settings.authorizationStatus == .denied
+            handler(pushesDisabled)
         }
     }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Sometimes when switching accounts or opening the app the takeover screen telling users to enable notifications is shown when notifications are enabled and working fine.

### Causes

We have a method that checks if pushes are disabled. It was relying on `UIApplication.shared.isRegisteredForRemoteNotifications` which returns `false` when using notifications through PushKit. In the old authentication flow we were probably registering for pushes on `UIApplication`, but this is not the case with new authentication flow.

### Solutions

Clean up the logic what we treat as pushes disabled - we now check only PushKit permissions. The old code was also treating `.notAuthorized` as `disabled`, but there is no realistic scenario when this could happen (i.e. we don't ask for permissions during registration/login). Even if this happens the user would not be able to do anything about it in this screen anyway.
