### PR TITLE
Missing call overlay after first login

### DIFF
--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -321,10 +321,8 @@ var defaultFontScheme: FontScheme = FontScheme(contentSizeCategory: UIApplicatio
 
     func applicationWillTransition(to appState: AppState) {
 
-        if appState == .authenticated(completedRegistration: false) {
+        if case .authenticated = appState {
             callWindow.callController.transitionToLoggedInSession()
-        } else {
-            overlayWindow.rootViewController = NotificationWindowRootViewController()
         }
 
         let colorScheme = ColorScheme.default
@@ -333,7 +331,7 @@ var defaultFontScheme: FontScheme = FontScheme(contentSizeCategory: UIApplicatio
     }
     
     func applicationDidTransition(to appState: AppState) {
-        if appState == .authenticated(completedRegistration: false) {
+        if case .authenticated = appState {
             callWindow.callController.presentCallCurrentlyInProgress()
         }
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Call overlay is missing when making a call directly after logging in.

### Causes

`transitionToLoggedInSession()` is no longer called when transitioning to the authenticated state after logging in. The reason for this is that associated value `completedRegistration` has changed meaning to "added new account".

### Solutions

I don't see a reason why we should not always call `transitionToLoggedInSession()` when transitioning to the authenticated state, so I'll just ignore the value of `completedRegistration`.

## Notes

- Seems like good idea to rename `completedRegistration` to `addedAccount`