### PR TITLE
Only allow updating the last read message if app is active

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -331,7 +331,7 @@
 - (void)updateVisibleMessagesWindow
 {
     if (UIApplication.sharedApplication.applicationState != UIApplicationStateActive) {
-        return; // We only update the last if the app is active
+        return; // We only update the last read if the app is active
     }
     
     BOOL isViewVisible = YES;

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -330,6 +330,10 @@
 
 - (void)updateVisibleMessagesWindow
 {
+    if (UIApplication.sharedApplication.applicationState != UIApplicationStateActive) {
+        return; // We only update the last if the app is active
+    }
+    
     BOOL isViewVisible = YES;
     if (self.view.window == nil) {
         isViewVisible = NO;


### PR DESCRIPTION
## What's new in this PR?

### Issues

Push notifications are removed without reading them

### Causes

Since we switched to using the fetched results controller we now do table view updates in the background, which caused us to update the last read for the currently displayed conversation.

### Solutions

Don't allow updating the last read unless the app is active.