### PR TITLE
ZIOS-11219: Update accessibility traits for disabled settings text field

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsPropertyTextValueCellDescriptor.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsPropertyTextValueCellDescriptor.swift
@@ -46,8 +46,17 @@ class SettingsPropertyTextValueCellDescriptor: SettingsPropertyCellDescriptorTyp
         if let stringValue = settingsProperty.rawValue() as? String {
             textCell.textInput.text = stringValue
         }
-
-        textCell.textInput.isUserInteractionEnabled = settingsProperty.enabled
+        
+        if settingsProperty.enabled {
+            textCell.textInput.isUserInteractionEnabled = true
+            textCell.textInput.accessibilityTraits.remove(.staticText)
+        } else {
+            textCell.textInput.isUserInteractionEnabled = false
+            textCell.textInput.accessibilityTraits.insert(.staticText)
+        }
+        
+        textCell.textInput.accessibilityIdentifier = title + "Field"
+        textCell.textInput.isAccessibilityElement = true
     }
     
     func select(_ value: SettingsPropertyValue?) {

--- a/Wire-iOS/Sources/UserInterface/Settings/SettingsCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/SettingsCell.swift
@@ -372,7 +372,8 @@ protocol SettingsCellType: class {
         textInput.textAlignment = .right
         textInput.textColor = UIColor.lightGray
         textInput.setContentCompressionResistancePriority(UILayoutPriority.defaultLow, for: .horizontal)
-
+        textInput.isAccessibilityElement = true
+        
         contentView.addSubview(textInput)
 
         createConstraints()
@@ -401,7 +402,7 @@ protocol SettingsCellType: class {
         super.setupAccessibiltyElements()
         
         var currentElements = accessibilityElements ?? []
-        currentElements.append(contentsOf: [textInput!])
+        currentElements.append(textInput)
         accessibilityElements = currentElements
     }
     

--- a/Wire-iOS/Sources/UserInterface/Settings/UserRight.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/UserRight.swift
@@ -34,16 +34,18 @@ final class UserRight: UserRightInterface {
     }
 
     static func selfUserIsPermitted(to permission: UserRight.Permission) -> Bool {
+        let selfUser = ZMUser.selfUser()
+        let usesCompanyLogin = selfUser?.usesCompanyLogin == true
+        
         switch permission {
         case .editEmail:
         #if EMAIL_EDITING_DISABLED
             return false
         #else
-            return isProfileEditable
+            return isProfileEditable && !usesCompanyLogin
         #endif
         case .resetPassword:
-        	///TODO: For SSO user we don't allow setting or resetting the password
-            break
+            return isProfileEditable && !usesCompanyLogin
         case .editName,
              .editHandle,
              .editPhone,
@@ -51,8 +53,6 @@ final class UserRight: UserRightInterface {
              .editAccentColor:
 			return isProfileEditable
         }
-
-        return false
     }
 	
 	private static var isProfileEditable: Bool {

--- a/Wire-iOS/Sources/UserInterface/Settings/UserRight.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/UserRight.swift
@@ -42,10 +42,10 @@ final class UserRight: UserRightInterface {
         #if EMAIL_EDITING_DISABLED
             return false
         #else
-            return isProfileEditable && !usesCompanyLogin
+            return !usesCompanyLogin
         #endif
         case .resetPassword:
-            return isProfileEditable && !usesCompanyLogin
+            return !usesCompanyLogin
         case .editName,
              .editHandle,
              .editPhone,

--- a/Wire-iOS/Sources/UserInterface/Settings/UserRight.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/UserRight.swift
@@ -42,10 +42,10 @@ final class UserRight: UserRightInterface {
         #if EMAIL_EDITING_DISABLED
             return false
         #else
-            return !usesCompanyLogin
+            return isProfileEditable || !usesCompanyLogin
         #endif
         case .resetPassword:
-            return !usesCompanyLogin
+            return isProfileEditable || !usesCompanyLogin
         case .editName,
              .editHandle,
              .editPhone,


### PR DESCRIPTION
## What's new in this PR?

### Issues

The automation suite needs a way to check if a text field is disabled in the settings Account screen.

### Solutions

We change the accessibility properties of the text field cells used in the Accounts screen:

- The accessibility ID of the field will be `(property name)Field` (ex: `UsernameField`) where property name is the text of the label visible next to the field
- If the user can change the value, the element type is "text field" and it can be edited
- If the user cannot change the value, the element type is "static text" and it cannot be edited

### Note

We also add the missing logic to check if a user can reset their password (was TODO previously).