### PR TITLE
Remove Cartography from tests

### DIFF
--- a/Wire-iOS Tests/AudioEffectsPickerViewControllerTests.swift
+++ b/Wire-iOS Tests/AudioEffectsPickerViewControllerTests.swift
@@ -16,9 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
-import Foundation
-import Cartography
+import XCTest
 @testable import Wire
 
 class AudioEffectsPickerViewControllerTests: ZMSnapshotTestCase {
@@ -46,15 +44,18 @@ class AudioEffectsPickerViewControllerTests: ZMSnapshotTestCase {
         let container = UIView()
         container.addSubview(self.sut.view)
         container.backgroundColor = UIColor.from(scheme: .textForeground, variant: .light)
-
-        constrain(self.sut.view, container) { view, container in
-            container.height == 216
-            container.width == 320
-            view.top == container.top
-            view.bottom == container.bottom
-            view.left == container.left
-            view.right == container.right
-        }
+        container.translatesAutoresizingMaskIntoConstraints = false
+        sut.view.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            container.heightAnchor.constraint(equalToConstant: 216),
+            container.widthAnchor.constraint(equalToConstant: 320),
+            sut.view.topAnchor.constraint(equalTo: container.topAnchor),
+            sut.view.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+            sut.view.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            sut.view.trailingAnchor.constraint(equalTo: container.trailingAnchor)
+        ])
+        
         container.setNeedsLayout()
         container.layoutIfNeeded()
         return container

--- a/Wire-iOS Tests/AudioRecordViewControllerTests.swift
+++ b/Wire-iOS Tests/AudioRecordViewControllerTests.swift
@@ -16,9 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import XCTest
-import Cartography
 @testable import Wire
 
 @objc private class MockAudioRecordViewControllerDelegate: NSObject, AudioRecordViewControllerDelegate {
@@ -133,14 +131,16 @@ private extension UIViewController {
 
         let container = UIView()
         container.addSubview(view)
-
-        constrain(view, container) { view, container in
-            view.height == 112
-            container.height == 130
-            view.bottom == container.bottom
-            view.left == container.left
-            view.right == container.right
-        }
+        container.translatesAutoresizingMaskIntoConstraints = false
+        view.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            view.heightAnchor.constraint(equalToConstant: 112),
+            container.heightAnchor.constraint(equalToConstant: 130),
+            view.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+            view.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: container.trailingAnchor)
+        ])
 
         return container
     }

--- a/Wire-iOS Tests/AvailabilityLabelTests.swift
+++ b/Wire-iOS Tests/AvailabilityLabelTests.swift
@@ -17,7 +17,6 @@
 //
 
 import XCTest
-import Cartography
 @testable import Wire
 
 class AvailabilityLabelTests: ZMSnapshotTestCase {

--- a/Wire-iOS Tests/AvailabilityTitleViewTests.swift
+++ b/Wire-iOS Tests/AvailabilityTitleViewTests.swift
@@ -18,7 +18,6 @@
 
 import XCTest
 @testable import Wire
-import Cartography
 
 class AvailabilityTitleViewTests: ZMSnapshotTestCase {
 

--- a/Wire-iOS Tests/CameraKeyboardViewControllerTests.swift
+++ b/Wire-iOS Tests/CameraKeyboardViewControllerTests.swift
@@ -16,13 +16,10 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
 import XCTest
 import Photos
-import Cartography
 import AVFoundation
 @testable import Wire
-
 
 class CameraKeyboardViewControllerDelegateMock: CameraKeyboardViewControllerDelegate {
     
@@ -95,15 +92,18 @@ final class CameraKeyboardViewControllerTests: CoreDataSnapshotTestCase {
         let container = UIView()
         container.addSubview(self.sut.view)
         container.backgroundColor = UIColor.from(scheme: .textForeground, variant: .light)
+        container.translatesAutoresizingMaskIntoConstraints = false
+        sut.view.translatesAutoresizingMaskIntoConstraints = false
         
-        constrain(self.sut.view, container) { view, container in
-            container.height == size.height
-            container.width == size.width
-            view.top == container.top
-            view.bottom == container.bottom
-            view.left == container.left
-            view.right == container.right
-        }
+        NSLayoutConstraint.activate([
+            container.heightAnchor.constraint(equalToConstant: size.height),
+            container.widthAnchor.constraint(equalToConstant: size.width),
+            sut.view.topAnchor.constraint(equalTo: container.topAnchor),
+            sut.view.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+            sut.view.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            sut.view.trailingAnchor.constraint(equalTo: container.trailingAnchor)
+        ])
+        
         container.setNeedsLayout()
         container.layoutIfNeeded()
         return container

--- a/Wire-iOS Tests/ChangeHandleViewControllerTests.swift
+++ b/Wire-iOS Tests/ChangeHandleViewControllerTests.swift
@@ -16,11 +16,8 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import XCTest
-import Cartography
 @testable import Wire
-
 
 class ChangeHandleViewControllerTests: ZMSnapshotTestCase {
 

--- a/Wire-iOS Tests/CharacterInputFieldTests.swift
+++ b/Wire-iOS Tests/CharacterInputFieldTests.swift
@@ -16,9 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
 import XCTest
-import Cartography
 @testable import Wire
 
 class TestCharacterInputFieldDelegate: NSObject, CharacterInputFieldDelegate {
@@ -265,16 +263,18 @@ final class CharacterInputFieldScreenshotTests: ZMSnapshotTestCase {
 fileprivate extension UIView {
     func snapshotView() -> UIView {
         let topView = UIApplication.shared.keyWindow!.rootViewController!.view!
-            
         topView.addSubview(self)
-
-        constrain(self, topView) { selfView, topView in
-            selfView.center == topView.center
-        }
+        translatesAutoresizingMaskIntoConstraints = false
+        topView.translatesAutoresizingMaskIntoConstraints = false
         
-        self.layer.speed = 0
-        self.setNeedsLayout()
-        self.layoutIfNeeded()
+        NSLayoutConstraint.activate([
+            topView.centerXAnchor.constraint(equalTo: centerXAnchor),
+            topView.centerYAnchor.constraint(equalTo: centerYAnchor)
+        ])
+        
+        layer.speed = 0
+        setNeedsLayout()
+        layoutIfNeeded()
         return self
     }
 }

--- a/Wire-iOS Tests/CollectionsViewControllerTests.swift
+++ b/Wire-iOS Tests/CollectionsViewControllerTests.swift
@@ -17,9 +17,8 @@
 //
 
 import XCTest
-import Cartography
-@testable import Wire
 import WireDataModel
+@testable import Wire
 
 extension MockMessage {
     var message: ZMConversationMessage {

--- a/Wire-iOS Tests/ConversationAvatarViewTests.swift
+++ b/Wire-iOS Tests/ConversationAvatarViewTests.swift
@@ -16,9 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import XCTest
-import Cartography
 @testable import Wire
 
 private let accentColors: [ZMAccentColor] = [.vividRed, .softPink, .brightYellow, .strongBlue, .strongLimeGreen]
@@ -169,12 +167,17 @@ fileprivate extension UIView {
     func prepareForSnapshots() -> UIView {
         let container = UIView()
         container.addSubview(self)
-
-        constrain(container, self) { container, view in
-            container.height == 24
-            container.width == 24
-            view.edges == container.edges
-        }
+        translatesAutoresizingMaskIntoConstraints = false
+        container.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            container.heightAnchor.constraint(equalToConstant: 24),
+            container.widthAnchor.constraint(equalToConstant: 24),
+            container.topAnchor.constraint(equalTo: topAnchor),
+            container.bottomAnchor.constraint(equalTo: bottomAnchor),
+            container.leadingAnchor.constraint(equalTo: leadingAnchor),
+            container.trailingAnchor.constraint(equalTo: trailingAnchor)
+        ])
 
         container.setNeedsLayout()
         container.layoutIfNeeded()

--- a/Wire-iOS Tests/DestructionCountdownViewTests.swift
+++ b/Wire-iOS Tests/DestructionCountdownViewTests.swift
@@ -16,11 +16,8 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import XCTest
-import Cartography
 @testable import Wire
-
 
 class DestructionCountdownViewTests: ZMSnapshotTestCase {
 

--- a/Wire-iOS Tests/EphemeralKeyboardViewControllerTests.swift
+++ b/Wire-iOS Tests/EphemeralKeyboardViewControllerTests.swift
@@ -16,11 +16,8 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import XCTest
-import Cartography
 @testable import Wire
-
 
 class EphemeralKeyboardViewControllerTests: CoreDataSnapshotTestCase {
 
@@ -56,10 +53,12 @@ class EphemeralKeyboardViewControllerTests: CoreDataSnapshotTestCase {
 fileprivate extension UIViewController {
 
     func prepareForSnapshots() -> UIView {
-        constrain(view) { view in
-            view.height == 290
-            view.width == 375
-        }
+        view.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            view.heightAnchor.constraint(equalToConstant: 290),
+            view.widthAnchor.constraint(equalToConstant: 375)
+        ])
 
         beginAppearanceTransition(true, animated: false)
         endAppearanceTransition()

--- a/Wire-iOS Tests/ImageMessageViewTests.swift
+++ b/Wire-iOS Tests/ImageMessageViewTests.swift
@@ -16,9 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
 import XCTest
-import Cartography
 @testable import Wire
 
 class ImageMessageViewTests: ZMSnapshotTestCase {
@@ -68,12 +66,10 @@ class ImageMessageViewTests: ZMSnapshotTestCase {
 
 fileprivate extension ImageMessageView {
     func snapshotView() -> UIView {
-        constrain(self) { cell in
-            cell.width == 320
-        }
-        self.layer.speed = 0
-        self.setNeedsLayout()
-        self.layoutIfNeeded()
+        widthAnchor.constraint(equalToConstant: 320).isActive = true
+        layer.speed = 0
+        setNeedsLayout()
+        layoutIfNeeded()
         return self
     }
 }

--- a/Wire-iOS Tests/InputBar/InputBarEditViewTests.swift
+++ b/Wire-iOS Tests/InputBar/InputBarEditViewTests.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Cartography
 @testable import Wire
 
 class InputBarEditViewTests: ZMSnapshotTestCase {
@@ -27,7 +26,8 @@ class InputBarEditViewTests: ZMSnapshotTestCase {
         super.setUp()
         snapshotBackgroundColor = UIColor.white
         sut = InputBarEditView()
-        constrain(sut) { $0.height == 56 }
+        sut.translatesAutoresizingMaskIntoConstraints = false
+        sut.heightAnchor.constraint(equalToConstant: 56).isActive = true
     }
 
     override func tearDown() {

--- a/Wire-iOS Tests/LocationSendViewControllerTests.swift
+++ b/Wire-iOS Tests/LocationSendViewControllerTests.swift
@@ -16,8 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
-import Cartography
+import XCTest
 @testable import Wire
 
 class LocationSendViewControllerTests: ZMSnapshotTestCase {
@@ -53,7 +52,7 @@ class LocationSendViewControllerTests: ZMSnapshotTestCase {
 
 private extension UIViewController {
     func prepareForSnapshot() -> UIView {
-        constrain(self.view) { $0.height == 56 }
-        return self.view
+        view.heightAnchor.constraint(equalToConstant: 56).isActive = true
+        return view
     }
 }

--- a/Wire-iOS Tests/NetworkStatusView/NetworkStatusViewControllerSnapshotTests.swift
+++ b/Wire-iOS Tests/NetworkStatusView/NetworkStatusViewControllerSnapshotTests.swift
@@ -16,8 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
-import Cartography
+import XCTest
 @testable import Wire
 
 class MockContainerViewController: UIViewController, NetworkStatusBarDelegate {
@@ -55,13 +54,14 @@ final class NetworkStatusViewControllerSnapshotTests: ZMSnapshotTestCase {
         mockContainerViewController.view.addSubview(mockContentView)
 
         sut.createConstraintsInParentController(bottomView: mockContentView, controller: mockContainerViewController)
-
-        constrain(mockContentView, mockContainerViewController.view) { mockContentView, view in
-            mockContentView.left == view.left
-            mockContentView.right == view.right
-
-            mockContentView.bottom == view.bottom - UIScreen.safeArea.bottom
-        }
+        
+        mockContentView.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            mockContentView.leadingAnchor.constraint(equalTo: mockContainerViewController.view.leadingAnchor),
+            mockContentView.trailingAnchor.constraint(equalTo: mockContainerViewController.view.trailingAnchor),
+            mockContentView.bottomAnchor.constraint(equalTo: mockContainerViewController.safeBottomAnchor)
+        ])
     }
 
     override func tearDown() {

--- a/Wire-iOS Tests/SearchResultLabelTests.swift
+++ b/Wire-iOS Tests/SearchResultLabelTests.swift
@@ -16,9 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
 import XCTest
-import Cartography
 @testable import Wire
 
 class SearchResultLabelTests: ZMSnapshotTestCase {
@@ -63,13 +61,11 @@ class SearchResultLabelTests: ZMSnapshotTestCase {
             print("Testing combination " + identifier)
 
             $0.result.configure(with: $0.result.resultText!, queries: $0.result.queries)
-
-            constrain($0.result) { label in
-                label.width <= 320
-            }
             $0.result.numberOfLines = 1
+            $0.result.translatesAutoresizingMaskIntoConstraints = false
             $0.result.setContentCompressionResistancePriority(.required, for: .vertical)
             $0.result.setContentHuggingPriority(.required, for: .vertical)
+            $0.result.widthAnchor.constraint(lessThanOrEqualToConstant: 320).isActive = true
 
             $0.result.layoutForTest()
             let mockBackgroundView = UIView(frame: $0.result.frame)

--- a/Wire-iOS Tests/ShareViewControllerTests.swift
+++ b/Wire-iOS Tests/ShareViewControllerTests.swift
@@ -17,7 +17,6 @@
 //
 
 import XCTest
-import Cartography
 import WireLinkPreview
 @testable import Wire
 

--- a/Wire-iOS Tests/TypingIndicatorViewTests.swift
+++ b/Wire-iOS Tests/TypingIndicatorViewTests.swift
@@ -17,9 +17,7 @@
 //
 
 import XCTest
-
 @testable import Wire
-import Cartography
 
 class TypingIndicatorViewTests: ZMSnapshotTestCase {
 
@@ -51,9 +49,8 @@ class TypingIndicatorViewTests: ZMSnapshotTestCase {
     
     func testManyTypingUsers() {
         // limit width to test overflow behaviour
-        constrain(sut) { typingIndicator in
-            typingIndicator.width == 320
-        }
+        sut.translatesAutoresizingMaskIntoConstraints = false
+        sut.widthAnchor.constraint(equalToConstant: 320).isActive = true
         
         sut.typingUsers = Array(MockUser.mockUsers().prefix(5))
         sut.layoutIfNeeded()


### PR DESCRIPTION
## What's new in this PR?

### Issues

We want to remove the dependency on Cartography. It was used in some test cases.

### Solutions

Replace Cartography by plain constraint creation in tests.