### PR TITLE
Grooming: Fix memory errors detected by analyzer

### DIFF
--- a/Wire-iOS Tests/InviteContactsViewControllerSnapshotTests.swift
+++ b/Wire-iOS Tests/InviteContactsViewControllerSnapshotTests.swift
@@ -73,7 +73,9 @@ final class InviteContactsViewControllerSnapshotTests: ZMSnapshotTestCase {
     func DISABLE_testForNoEmailClientAlert() {
         let contact = ZMAddressBookContact()
 
-        let alert = sut.invite(contact, from: UIView())
+        guard let alert = sut.invite(contact, from: UIView()) else {
+            return XCTFail("No alert generated for the contact.")
+        }
 
         verifyAlertController(alert)
     }

--- a/Wire-iOS/Sources/Helpers/UIImage+ImageUtilities.m
+++ b/Wire-iOS/Sources/Helpers/UIImage+ImageUtilities.m
@@ -231,7 +231,7 @@
     }
     
     CFDictionaryRef options = (__bridge CFDictionaryRef)@{ (id)kCGImageSourceShouldCache: (id)kCFBooleanTrue };
-    NSDictionary *properties = (__bridge NSDictionary *)CGImageSourceCopyPropertiesAtIndex(source, 0, options);
+    NSDictionary *properties = CFBridgingRelease(CGImageSourceCopyPropertiesAtIndex(source, 0, options));
     
     if (!properties) {
         return size;

--- a/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsDataSource.m
+++ b/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsDataSource.m
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ContactsDataSource ()
 
 // Search
-@property (nonatomic) SearchDirectory *searchDirectory;
+@property (nonatomic, readwrite, nullable) SearchDirectory *searchDirectory;
 
 // Group
 @property (nonatomic, readonly) UILocalizedIndexedCollation *indexedCollation;

--- a/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsViewController.h
+++ b/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsViewController.h
@@ -65,7 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) Button *__nullable bottomButton;
 @property (nonatomic) BOOL shouldShowShareContactsViewController;
 
-- (UIAlertController *)inviteContact:(ZMAddressBookContact *)contact fromView:(UIView *)view;
+- (UIAlertController * _Nullable)inviteContact:(ZMAddressBookContact *)contact fromView:(UIView *)view;
 
 @end
 

--- a/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsViewController.m
+++ b/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsViewController.m
@@ -476,7 +476,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
 
         return chooseContactDetailController;
     }
-    
+
     return nil;
 }
 

--- a/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsViewController.m
+++ b/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsViewController.m
@@ -386,14 +386,14 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
  */
 - (UIAlertController *)inviteContact:(ZMAddressBookContact *)contact fromView:(UIView *)view
 {
-    UIAlertController * alertController;
-
     if (contact.contactDetails.count == 1) {
         if (contact.emailAddresses.count == 1 && [ZMAddressBookContact canInviteLocallyWithEmail]) {
             [contact inviteLocallyWithEmail:contact.emailAddresses[0]];
+            return nil;
         }
         else if (contact.rawPhoneNumbers.count == 1 && [ZMAddressBookContact canInviteLocallyWithPhoneNumber]) {
             [contact inviteLocallyWithPhoneNumber:contact.rawPhoneNumbers[0]];
+            return nil;
         }
         else {
             // Cannot invite
@@ -423,7 +423,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
                                                                  }];
                 [unableToSendController addAction:okAction];
 
-                alertController = unableToSendController;
+                return unableToSendController;
             }
         }
     }
@@ -474,10 +474,10 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
             [chooseContactDetailController dismissViewControllerAnimated:YES completion:nil];
         }]];
 
-        alertController = chooseContactDetailController;
+        return chooseContactDetailController;
     }
-
-    return alertController;
+    
+    return nil;
 }
 
 @end

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Private.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Private.h
@@ -53,7 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable) id<ZMUserSessionInterface> session;
 
 - (void)removeHighlightsAndMenu;
-- (NSIndexPath *) willSelectRowAtIndexPath:(NSIndexPath *)indexPath tableView:(UITableView *)tableView;
+- (NSIndexPath * _Nullable)willSelectRowAtIndexPath:(NSIndexPath *)indexPath tableView:(UITableView *)tableView;
 
 @end
 

--- a/Wire-iOS/Sources/UserInterface/InviteContacts/InviteContactsViewController.m
+++ b/Wire-iOS/Sources/UserInterface/InviteContacts/InviteContactsViewController.m
@@ -84,7 +84,9 @@
     } else {
         UIAlertController * alertController = [self inviteContact:user.contact fromView:view];
 
-        [alertController presentInNotificationsWindow];
+        if (alertController) {
+            [alertController presentInNotificationsWindow];
+        }
     }
 }
 

--- a/Wire-iOS/Sources/Vendor/SCSiriWaveformView.m
+++ b/Wire-iOS/Sources/Vendor/SCSiriWaveformView.m
@@ -135,20 +135,23 @@ static const CGFloat kDefaultSecondaryLineWidth = 1.0f;
 		
 		CGFloat multiplier = MIN(1.0, (progress / 3.0f * 2.0f) + (1.0f / 3.0f));
 		[[self.waveColor colorWithAlphaComponent:multiplier * CGColorGetAlpha(self.waveColor.CGColor)] set];
-		
-		for (CGFloat x = 0; x<width + self.density; x += self.density) {
-			// We use a parable to scale the sinus wave, that has its peak in the middle of the view.
-			CGFloat scaling = -pow(1 / mid * (x - mid), 2) + 1;
-			
-			CGFloat y = scaling * maxAmplitude * normedAmplitude * sinf(2 * M_PI *(x / width) * self.frequency + self.phase) + halfHeight;
-			
-			if (x == 0) {
-				CGContextMoveToPoint(context, x, y);
-			} else {
-				CGContextAddLineToPoint(context, x, y);
-			}
-		}
-		
+
+        CGFloat x = 0;
+        while (x < width + self.density) {
+            // We use a parable to scale the sinus wave, that has its peak in the middle of the view.
+            CGFloat scaling = -pow(1 / mid * (x - mid), 2) + 1;
+            
+            CGFloat y = scaling * maxAmplitude * normedAmplitude * sinf(2 * M_PI *(x / width) * self.frequency + self.phase) + halfHeight;
+            
+            if (x == 0) {
+                CGContextMoveToPoint(context, x, y);
+            } else {
+                CGContextAddLineToPoint(context, x, y);
+            }
+            
+            x += self.density;
+        }
+        
 		CGContextStrokePath(context);
 	}
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

When analyzing the app, some memory management issues were found:

- We were not releasing the dictionary of properties of an image, which caused a leak
- Some nullability annotations were not respected
- The third-party Siri waveform used CGFloat at the index of a for-loop, which is disallowed