### PR TITLE
Resign any first responder when presenting the call overlay

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/CallController/CallController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallController/CallController.swift
@@ -106,6 +106,10 @@ extension CallController: WireCallCenterCallStateObserver {
         viewController.dismisser = self
         activeCallViewController = viewController
         
+        // NOTE: We resign first reponder for the input bar since it will attempt to restore
+        // first responder when the call overlay is interactively dismissed but canceled.
+        UIResponder.wr_currentFirst()?.resignFirstResponder()
+        
         let modalVC = ModalPresentationViewController(viewController: viewController)
         targetViewController?.present(modalVC, animated: animated)
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

If the keyboard was up when answering a call, it would re-appear on top of the call overlay when doing a swipe gesture.

### Causes

Swiping down on the call overlay will start the interactive dismissal which calls `dismiss(animated:)`. Even though the dismissal might be canceled UIKit will still immediately attempt to restore the first responder which in this case is the input bar, if the interactive dismissal is cancelled we end up with the keyboard displayed on top of the call overlay.

### Solutions

Since I didn't find way to prevent UIKit from attempting to restore the first responder too early I'll instead make the input bar resign its first responder when presenting the call overlay.