### PR TITLE
Use build parameter for URL scheme

### DIFF
--- a/Wire-iOS/Wire-Info.plist
+++ b/Wire-iOS/Wire-Info.plist
@@ -58,7 +58,7 @@
 			<string>Editor</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>wire</string>
+				<string>${WIRE_URL_SCHEME}</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
## What's new in this PR?

### Issues

We want to have URL scheme be dynamic to be able to set it on build time.

### Solutions

Added build parameter `WIRE_URL_SCHEME` which can be overridden.

### Dependencies

- [ ] https://github.com/wireapp/wire-ios-build-configuration/pull/4
