### PR TITLE
ZIOS-11249: Searching for a contact and sending a contact request crashes the app

### DIFF
--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileDetailsViewController+Extension.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileDetailsViewController+Extension.swift
@@ -59,7 +59,7 @@ extension ProfileDetailsViewController {
         view.addSubview(stackViewContainer)
 
         teamsGuestIndicator.isHidden = !showGuestLabel
-        availabilityView.isHidden = !ZMUser.selfUser().isTeamMember || fullUser()?.availability == .none
+        availabilityView.isHidden = !ZMUser.selfUser().isTeamMember || fullUser()?.availability == Availability.none
 
         let remainingTimeString = fullUser()?.expirationDisplayString
         remainingTimeLabel = UILabel()

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileDetailsViewController+Extension.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileDetailsViewController+Extension.swift
@@ -59,9 +59,9 @@ extension ProfileDetailsViewController {
         view.addSubview(stackViewContainer)
 
         teamsGuestIndicator.isHidden = !showGuestLabel
-        availabilityView.isHidden = !ZMUser.selfUser().isTeamMember || fullUser().availability == .none
+        availabilityView.isHidden = !ZMUser.selfUser().isTeamMember || fullUser()?.availability == .none
 
-        let remainingTimeString = fullUser().expirationDisplayString
+        let remainingTimeString = fullUser()?.expirationDisplayString
         remainingTimeLabel = UILabel()
         remainingTimeLabel.setContentCompressionResistancePriority(.required, for: .vertical)
         remainingTimeLabel.text = remainingTimeString
@@ -153,8 +153,9 @@ extension ProfileDetailsViewController {
     }
 
     @objc func presentRemoveUserMenuSheetController() {
+        guard let user = fullUser() else { return }
         actionsController = RemoveUserActionController(conversation: conversation,
-                                                       participant: fullUser(),
+                                                       participant: user,
                                                        dismisser: viewControllerDismisser,
                                                        target: self)
 

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.m
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.m
@@ -233,7 +233,7 @@ typedef NS_ENUM(NSUInteger, ProfileViewControllerTabBarIndex) {
 
 #pragma mark - Utilities
 
-- (ZMUser * _Nullable)fullUser
+- (ZMUser *)fullUser
 {
     if ([self.bareUser isKindOfClass:[ZMUser class]]) {
         return (ZMUser *)self.bareUser;

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.m
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.m
@@ -233,7 +233,7 @@ typedef NS_ENUM(NSUInteger, ProfileViewControllerTabBarIndex) {
 
 #pragma mark - Utilities
 
-- (ZMUser *)fullUser
+- (ZMUser * _Nullable)fullUser
 {
     if ([self.bareUser isKindOfClass:[ZMUser class]]) {
         return (ZMUser *)self.bareUser;


### PR DESCRIPTION
## What's new in this PR?

### Issues

App was crashing when sending a contact request.

### Causes

This is because `fullUser()` in `ProfileViewController` could be `nil` but it was not considered `Nullable` from the Swift extension.

### Solutions

I've added `_Nullable` to the return type of `fullUser()` and adapted the code.