### PR TITLE
Fix: avoid force-cast

### DIFF
--- a/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsContentController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsContentController.swift
@@ -87,7 +87,7 @@ class ProfileDetailsContentController: NSObject, UITableViewDataSource, UITableV
         configureObservers()
         updateContent()
         ZMUserSession.shared()?.performChanges {
-            (user as! ZMUser).needsRichProfileUpdate = true
+            user.needsRichProfileUpdate = true
         }
     }
     


### PR DESCRIPTION
## What's new in this PR?

Some test code was left and merged with #3215 - no need to force-cast to `ZMUser` because `GenericUser` already provides access to this method.

