### PR TITLE
Fix iPad action button frame setting and rotation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+ParticipantsPopover.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+ParticipantsPopover.swift
@@ -25,20 +25,9 @@ extension ConversationViewController: UIPopoverPresentationControllerDelegate {
                                                        from view: UIView,
                                                        contentViewController controller: UIViewController) {
 
-        controller.modalPresentationStyle = .popover
-        controller.preferredContentSize = CGSize.IPadPopover.preferredContentSize
-
-        guard let popover = controller.popoverPresentationController else { return }
-        guard let rootViewController = UIApplication.shared.keyWindow?.rootViewController as? PopoverPresenter & UIViewController else { return }
-
-        popover.delegate = self
-        popover.config(from: rootViewController,
-                       pointToView: view,
-                       sourceView: rootViewController.view)
-
-        popover.backgroundColor = .white
-
-        rootViewController.present(controller, animated: true)
+        endEditing()
+        controller.modalPresentationStyle = .formSheet
+        present(controller, animated: true)
     }
 
     @objc func didTap(onUserAvatar user: GenericUser, view: UIView?, frame: CGRect) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsContentViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsContentViewController.swift
@@ -303,7 +303,7 @@ extension MessageDetailsContentViewController {
     /// Presents a profile view controller as a popover or a modal depending on the context.
     fileprivate func presentDetailsViewController(_ controller: ProfileViewController, above cell: UserCell) {
         let presentedController = controller.wrapInNavigationController()
-        presentedController.modalPresentationStyle = .popover
+        presentedController.modalPresentationStyle = .formSheet
 
         if let popover = presentedController.popoverPresentationController {
             popover.sourceRect = cell.avatar.bounds

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/ProfilePresenter.m
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/ProfilePresenter.m
@@ -106,7 +106,7 @@
 
     UINavigationController *navigationController = profileViewController.wrapInNavigationController;
     navigationController.transitioningDelegate = self.transitionDelegate;
-    navigationController.modalPresentationStyle = UIModalPresentationPopover;
+    navigationController.modalPresentationStyle = UIModalPresentationFormSheet;
 
     [controller presentViewController:navigationController animated:YES completion:nil];
     

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController+Extension.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController+Extension.swift
@@ -93,14 +93,14 @@ extension ProfileViewController: ProfileFooterViewDelegate, IncomingRequestFoote
 
         for action in actions {
             let sheetAction = UIAlertAction(title: action.buttonText, style: .default) { _ in
-                self.performAction(action, targetView: footerView.rightButton)
+                self.performAction(action, targetView: footerView)
             }
 
             actionSheet.addAction(sheetAction)
         }
 
         actionSheet.addAction(.cancel())
-        presentAlert(actionSheet, targetView: footerView.rightButton)
+        presentAlert(actionSheet, targetView: footerView)
     }
 
     func performAction(_ action: ProfileAction, targetView: UIView) {
@@ -147,9 +147,9 @@ extension ProfileViewController: ProfileFooterViewDelegate, IncomingRequestFoote
     /// Presents an alert as a popover if needed.
     @objc(presentAlert:fromTargetView:)
     func presentAlert(_ alert: UIAlertController, targetView: UIView) {
-        let buttonFrame = view.convert(targetView.frame, from: targetView.superview).insetBy(dx: 8, dy: 8)
         alert.popoverPresentationController?.sourceView = targetView
-        alert.popoverPresentationController?.sourceRect = buttonFrame
+        alert.popoverPresentationController?.sourceRect = targetView.bounds.insetBy(dx: 8, dy: 8)
+        alert.popoverPresentationController?.permittedArrowDirections = .down
         present(alert, animated: true)
     }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

When opening the profile details on iPad, the action buttons popover was not visible, and had an unexpected behavior on rotation. (ZIOS-11259 and ZIOS-1160). 

### Causes

We were not setting the frame of the alert properly when setting up the popover. In addition to that, presenting the popover in a popover had some unintended effects.

### Solutions

- Assign the popover source rect to the bounds of the bottom bar, as we do in the group details.

- Always present the profile / group details in a form sheet. The conversation details button on top was the only place that presented this view as a popover (for ex: clicking on the device degraded message would open the details in a form sheet). This also reduces the number of corner cases we can encounter, such as handling split view changes (from regular to compact and vice versa).