### PR TITLE
Fix optional unwrapping crash

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/ProfileSelfPictureViewController+SetupViews.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/ProfileSelfPictureViewController+SetupViews.swift
@@ -27,7 +27,6 @@ extension ProfileSelfPictureViewController {
 
         setupBottomOverlay()
         setupTopView()
-        setupGestureRecognizers()
     }
 
     override open var supportedInterfaceOrientations: UIInterfaceOrientationMask {
@@ -160,24 +159,11 @@ extension ProfileSelfPictureViewController {
 
         bottomOverlayView.fitInSuperview(exclude: [.top])
         bottomOverlayView.heightAnchor.constraint(equalToConstant: height + UIScreen.safeArea.bottom).isActive = true
-
         bottomOverlayView.backgroundColor = UIColor.black.withAlphaComponent(0.8)
 
         addCameraButton()
         addLibraryButton()
         addCloseButton()
-    }
-
-
-// MARK: - Gesture
-
-    func setupGestureRecognizers() {
-        tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(self.didTap(_:)))
-        topView.addGestureRecognizer(tapGestureRecognizer)
-    }
-
-    @objc func didTap(_ gestureRecognizer: UITapGestureRecognizer?) {
-        delegate.bottomOverlayViewControllerBackgroundTapped(self)
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/Settings/ProfileSelfPictureViewController.h
+++ b/Wire-iOS/Sources/UserInterface/Settings/ProfileSelfPictureViewController.h
@@ -20,24 +20,13 @@
 
 #import <Foundation/Foundation.h>
 
-@protocol BottomOverlayViewControllerDelegate <NSObject>
-
-- (void)bottomOverlayViewControllerBackgroundTapped:(id)controller;
-
-@end
-
-
 @class ZMUser;
 
 @interface ProfileSelfPictureViewController : UIViewController
 
 @property (nonatomic) ZMUser *user;
 @property (nonatomic, readonly) UIImageView *selfUserImageView;
-
-@property (nonatomic, strong) UITapGestureRecognizer *tapGestureRecognizer;
 @property (nonatomic, strong) UIView *bottomOverlayView;
 @property (nonatomic, strong) UIView *topView;
-
-@property (weak, nonatomic) id <BottomOverlayViewControllerDelegate> delegate;
 
 @end

--- a/Wire-iOS/Sources/UserInterface/Settings/ProfileSelfPictureViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Settings/ProfileSelfPictureViewController.m
@@ -76,7 +76,6 @@
     
     [[ZMUserSession sharedSession] enqueueChanges:^{
         [[ZMUserSession sharedSession].profileUpdate updateImageWithImageData:jpegData];
-        [self.delegate bottomOverlayViewControllerBackgroundTapped:self];
     }];
 }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

App would crash when tapping the picture while choosing a new profile picture.

### Causes

We would force unwrap the the optional `delegate` property which was not set.

### Solutions

Remove delegate since it's not used for anything.