### PR TITLE
Added build type parameter to prepare step

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -4,8 +4,13 @@ default_platform(:ios)
 platform :ios do
 
     desc "Fetch dependencies"
-    lane :prepare do
-        sh "cd .. && ./setup.sh"
+    lane :prepare do |options|
+        build_type = options[:build_type]
+        if build_type.nil? 
+            sh "cd .. && ./setup.sh"
+        else
+            sh "cd .. && ./setup.sh --override_with wire-ios-build-assets/CI\ configuration/#{build_type}"
+        end
     end
 
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

For internal builds we need to override app configuration by passing a parameter to `setup.sh`.

### Solutions

Added a build type parameter to Fastlane `prepare` stage that copies configuration from predefined folder. https://github.com/wireapp/wire-ios-build-assets should be checked out to project directory before running this step.