### PR TITLE
ZIOS-11262: Fix keyboard adjustment on iPad landscape in registration

### DIFF
--- a/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
+++ b/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
@@ -158,16 +158,12 @@ extension AuthenticationCoordinator: AuthenticationStateControllerDelegate {
             presenter.pushViewController(stepViewController, animated: true)
 
         case .reset:
-            UIView.transition(with: presenter.view, duration: 0.25, options: .transitionCrossDissolve, animations: {
-                presenter.viewControllers = [stepViewController]
-            }, completion: nil)
+            presenter.setViewControllers([stepViewController], animated: true)
 
         case .replace:
-            UIView.transition(with: presenter.view, duration: 0.25, options: .transitionCrossDissolve, animations: {
-                var viewControllers = presenter.viewControllers
-                viewControllers[viewControllers.count - 1] = stepViewController
-                presenter.viewControllers = viewControllers
-            }, completion: nil)
+            var viewControllers = presenter.viewControllers
+            viewControllers[viewControllers.count - 1] = stepViewController
+            presenter.setViewControllers(viewControllers, animated: true)
         }
     }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

When registering an account on iPad, the keyboard was showing above the text field to show the name step.

### Causes

We were not using the correct animation method to replace the displayed view controller in the authentication coordinator. We were performing the transition manually, which caused `viewDidAppear` and hence `showKeyboard` to be called before the view was actually displayed.

### Solutions

Use `UINavigationController.setViewControllers(_:animated:)` directly.