### PR TITLE
Localization fixes: use correct uppercasing method

### DIFF
--- a/Wire-iOS Tests/Mocks/MockUserClient+RemoteIdentifier.swift
+++ b/Wire-iOS Tests/Mocks/MockUserClient+RemoteIdentifier.swift
@@ -25,7 +25,7 @@ extension MockUserClient {
 
         let identifierPrefixString = NSLocalizedString("registration.devices.id", comment: "") + " "
         let identifierString = NSMutableAttributedString(string: identifierPrefixString, attributes: attributes)
-        let identifier = uppercase ? displayIdentifier.uppercased() : displayIdentifier
+        let identifier = uppercase ? displayIdentifier.localizedUppercase : displayIdentifier
         let attributedRemoteIdentifier = identifier.fingerprintStringWithSpaces().fingerprintString(attributes: attributes,
                                                                                                     boldAttributes:boldAttributes)
         identifierString.append(attributedRemoteIdentifier!)

--- a/Wire-iOS/Sources/Authentication/Interface/Descriptions/ViewDescriptions/ButtonDescription.swift
+++ b/Wire-iOS/Sources/Authentication/Interface/Descriptions/ViewDescriptions/ButtonDescription.swift
@@ -40,7 +40,7 @@ extension ButtonDescription: ViewDescriptor {
         button.contentEdgeInsets = UIEdgeInsets(top: 4, left: 12, bottom: 4, right: 12)
         button.setContentCompressionResistancePriority(UILayoutPriority.required, for: .horizontal)
         button.translatesAutoresizingMaskIntoConstraints = false
-        button.setTitle(title.uppercased(), for: .normal)
+        button.setTitle(title.localizedUppercase, for: .normal)
         button.accessibilityIdentifier = self.accessibilityIdentifier
         button.addTarget(self, action: #selector(ButtonDescription.buttonTapped(_:)), for: .touchUpInside)
         return button

--- a/Wire-iOS/Sources/Authentication/Interface/Team Invites/TeamInviteTextFieldFooterView.swift
+++ b/Wire-iOS/Sources/Authentication/Interface/Team Invites/TeamInviteTextFieldFooterView.swift
@@ -41,7 +41,7 @@ final class TeamInviteTextFieldFooterView: UIView {
     var shouldConfirm: ((String) -> Bool)? {
         didSet {
             textField.textFieldValidator.customValidator = { [weak self] email in
-                (self?.shouldConfirm?(email) ?? true) ? nil : .custom("team.invite.error.already_invited".localized.uppercased())
+                (self?.shouldConfirm?(email) ?? true) ? nil : .custom("team.invite.error.already_invited".localized(uppercased: true))
             }
         }
     }
@@ -82,13 +82,13 @@ final class TeamInviteTextFieldFooterView: UIView {
         errorLabel.textColor = UIColor.Team.errorMessageColor
         textField.overrideButtonIcon = .send
         textFieldDescriptor.valueValidated = { [weak self] error in
-            self?.errorMessage = error.errorDescription?.uppercased()
+            self?.errorMessage = error.errorDescription?.localizedUppercase
             if error == .none {
                 self?.errorButton.isHidden = true
             }
         }
 
-        errorButton.setTitle("team.invite.learn_more.title".localized.uppercased(), for: .normal)
+        errorButton.setTitle("team.invite.learn_more.title".localized(uppercased: true), for: .normal)
         errorButton.titleLabel?.font = FontSpec(.medium, .semibold).font!
         errorButton.setTitleColor(.black, for: .normal)
         errorButton.setTitleColor(.darkGray, for: .highlighted)

--- a/Wire-iOS/Sources/Authentication/Interface/Team Invites/TeamMemberInviteViewController.swift
+++ b/Wire-iOS/Sources/Authentication/Interface/Team Invites/TeamMemberInviteViewController.swift
@@ -29,8 +29,8 @@ final class TeamMemberInviteViewController: AuthenticationStepViewController {
 
         var title: String {
             switch self {
-            case .skip: return "team.invite.top_bar.skip".localized.uppercased()
-            case .done: return "team.invite.top_bar.done".localized.uppercased()
+            case .skip: return "team.invite.top_bar.skip".localized(uppercased: true)
+            case .done: return "team.invite.top_bar.done".localized(uppercased: true)
             }
         }
     }
@@ -128,7 +128,7 @@ final class TeamMemberInviteViewController: AuthenticationStepViewController {
         }
 
         if case .unreachable = NetworkStatus.shared().reachability() {
-            return footerTextFieldView.errorMessage = "team.invite.error.no_internet".localized.uppercased()
+            return footerTextFieldView.errorMessage = "team.invite.error.no_internet".localized(uppercased: true)
         }
         
         guard let userSession = ZMUserSession.shared() else { return }
@@ -157,7 +157,7 @@ final class TeamMemberInviteViewController: AuthenticationStepViewController {
             dataSource.append(result)
             footerTextFieldView.clearInput()
         case let .failure(_, error: error):
-            footerTextFieldView.errorMessage = error.errorDescription.uppercased()
+            footerTextFieldView.errorMessage = error.errorDescription.localizedUppercase
             footerTextFieldView.errorButton.isHidden = error != .alreadyRegistered
         }
     }

--- a/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationStepController.swift
+++ b/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationStepController.swift
@@ -376,7 +376,7 @@ extension AuthenticationStepController {
     }
 
     func displayError(_ error: Error) {
-        errorLabel.text = error.localizedDescription.uppercased()
+        errorLabel.text = error.localizedDescription.localizedUppercase
         showSecondaryView(for: error)
     }
 

--- a/Wire-iOS/Sources/Components/ShareViewController/ShareViewController+Views.swift
+++ b/Wire-iOS/Sources/Components/ShareViewController/ShareViewController+Views.swift
@@ -53,7 +53,7 @@ extension ShareViewController {
         self.tokenField.tokenTitleVerticalAdjustment = 1
         self.tokenField.textView.placeholderTextAlignment = .natural
         self.tokenField.textView.accessibilityIdentifier = "textViewSearch"
-        self.tokenField.textView.placeholder = "content.message.forward.to".localized.uppercased()
+        self.tokenField.textView.placeholder = "content.message.forward.to".localized(uppercased: true)
         self.tokenField.textView.keyboardAppearance = .dark
         self.tokenField.textView.returnKeyType = .done
         self.tokenField.textView.autocorrectionType = .no

--- a/Wire-iOS/Sources/Helpers/UserClient+Fingerprint.swift
+++ b/Wire-iOS/Sources/Helpers/UserClient+Fingerprint.swift
@@ -24,7 +24,7 @@ extension UserClient {
     @objc public func attributedRemoteIdentifier(_ attributes: [NSAttributedString.Key : AnyObject], boldAttributes: [NSAttributedString.Key : AnyObject], uppercase: Bool = false) -> NSAttributedString {
         let identifierPrefixString = NSLocalizedString("registration.devices.id", comment: "") + " "
         let identifierString = NSMutableAttributedString(string: identifierPrefixString, attributes: attributes)
-        let identifier = uppercase ? displayIdentifier.uppercased() : displayIdentifier
+        let identifier = uppercase ? displayIdentifier.localizedUppercase : displayIdentifier
         let attributedRemoteIdentifier = identifier.fingerprintStringWithSpaces().fingerprintString(attributes: attributes,
             boldAttributes:boldAttributes)
         identifierString.append(attributedRemoteIdentifier!)

--- a/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewModel.swift
@@ -45,8 +45,8 @@ struct AddParticipantsViewModel {
     
     func title(with users: Set<ZMUser>) -> String {
         return users.isEmpty
-            ? "peoplepicker.group.title.singular".localized.uppercased()
-            : "peoplepicker.group.title.plural".localized(args: users.count).uppercased()
+            ? "peoplepicker.group.title.singular".localized(uppercased: true)
+            : "peoplepicker.group.title.plural".localized(uppercased: true, args: users.count)
     }
     
     var filterConversation: ZMConversation? {
@@ -68,9 +68,9 @@ struct AddParticipantsViewModel {
         case .create: return nil
         case .add(let conversation):
             if conversation.conversationType == .oneOnOne {
-                return "peoplepicker.button.create_conversation".localized.uppercased()
+                return "peoplepicker.button.create_conversation".localized(uppercased: true)
             } else {
-                return "peoplepicker.button.add_to_conversation".localized.uppercased()
+                return "peoplepicker.button.add_to_conversation".localized(uppercased: true)
             }
         }
     }
@@ -83,7 +83,7 @@ struct AddParticipantsViewModel {
             return item
         case .create(let values):
             let key = values.participants.isEmpty ? "peoplepicker.group.skip" : "peoplepicker.group.done"
-            let item = UIBarButtonItem(title: key.localized.uppercased(), style: .plain, target: target, action: action)
+            let item = UIBarButtonItem(title: key.localized(uppercased: true), style: .plain, target: target, action: action)
             item.tintColor = UIColor.accent()
             item.accessibilityIdentifier = values.participants.isEmpty ? "button.addpeople.skip" : "button.addpeople.create"
             return item

--- a/Wire-iOS/Sources/UserInterface/Availability/AvailabilityStringBuilder.swift
+++ b/Wire-iOS/Sources/UserInterface/Availability/AvailabilityStringBuilder.swift
@@ -37,12 +37,12 @@
                 }
             }
             case .participants: do {
-                title = user.displayName.uppercased()
+                title = user.displayName.localizedUppercase
                 color = UIColor.from(scheme: .textForeground)
             }
             case .placeholder: do {
                 if availability != .none { //Should use the default placeholder string
-                    title = "availability.\(availability.canonicalName).placeholder".localized(args: user.displayName).uppercased()
+                    title = "availability.\(availability.canonicalName).placeholder".localized(args: user.displayName).localizedUppercase
                 }
             }
         }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallStatusView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallStatusView.swift
@@ -97,7 +97,7 @@ final class CallStatusView: UIView {
         subtitleLabel.font = FontSpec(.normal, .semibold).font
         subtitleLabel.alpha = 0.64
 
-        bitrateLabel.text = "call.status.constant_bitrate".localized.uppercased()
+        bitrateLabel.text = "call.status.constant_bitrate".localized(uppercased: true)
         bitrateLabel.font = FontSpec(.small, .semibold).font
         bitrateLabel.alpha = 0.64
     }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallParticipantsView/CallParticipantsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallParticipantsView/CallParticipantsViewController.swift
@@ -76,7 +76,7 @@ class CallParticipantsViewController: UIViewController, UICollectionViewDelegate
     }
     
     private func setupViews() {
-        title = "call.participants.list.title".localized.uppercased()
+        title = "call.participants.list.title".localized(uppercased: true)
         let collectionViewLayout = UICollectionViewFlowLayout()
         collectionViewLayout.scrollDirection = .vertical
         collectionViewLayout.minimumInteritemSpacing = 12

--- a/Wire-iOS/Sources/UserInterface/Calling/Helper/NetworkCondition+Helper.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/Helper/NetworkCondition+Helper.swift
@@ -26,7 +26,7 @@ extension NetworkQuality {
             let attachment = NSTextAttachment()
             attachment.image = UIImage(for: .networkCondition, iconSize: .tiny, color: color)
             attachment.bounds = CGRect(x: 0.0, y: -4, width: attachment.image!.size.width, height: attachment.image!.size.height)
-            let text = "conversation.status.poor_connection".localized.uppercased()
+            let text = "conversation.status.poor_connection".localized(uppercased: true)
             let attributedText = text.attributedString.adding(font: FontSpec(.small, .semibold).font!, to: text).adding(color: color, to: text)
             return NSAttributedString(attachment: attachment) + " " + attributedText
         }

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionHeaderView.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionHeaderView.swift
@@ -27,16 +27,16 @@ import Cartography
             
             switch(section) {
             case CollectionsSectionSet.images:
-                self.titleLabel.text = "collections.section.images.title".localized.uppercased()
+                self.titleLabel.text = "collections.section.images.title".localized(uppercased: true)
                 icon = .photo
             case CollectionsSectionSet.filesAndAudio:
-                self.titleLabel.text = "collections.section.files.title".localized.uppercased()
+                self.titleLabel.text = "collections.section.files.title".localized(uppercased: true)
                 icon = .document
             case CollectionsSectionSet.videos:
-                self.titleLabel.text = "collections.section.videos.title".localized.uppercased()
+                self.titleLabel.text = "collections.section.videos.title".localized(uppercased: true)
                 icon = .movie
             case CollectionsSectionSet.links:
-                self.titleLabel.text = "collections.section.links.title".localized.uppercased()
+                self.titleLabel.text = "collections.section.links.title".localized(uppercased: true)
                 icon = .link
             default: fatal("Unknown section")
             }

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionsView.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionsView.swift
@@ -57,7 +57,7 @@ public final class CollectionsView: UIView {
         self.addSubview(self.collectionView)
    
         self.noResultsView.label.accessibilityLabel = "no items"
-        self.noResultsView.label.text = "collections.section.no_items".localized.uppercased()
+        self.noResultsView.label.text = "collections.section.no_items".localized(uppercased: true)
         self.noResultsView.icon = .library
         self.noResultsView.isHidden = true
         self.addSubview(self.noResultsView)

--- a/Wire-iOS/Sources/UserInterface/Collections/ConversationImagesViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/ConversationImagesViewController.swift
@@ -325,7 +325,7 @@ final class ConversationImagesViewController: TintColorCorrectedViewController {
         guard let sender = currentMessage.sender, let serverTimestamp = currentMessage.serverTimestamp else {
             return
         }
-        self.navigationItem.titleView = TwoLineTitleView(first: sender.displayName.uppercased(), second: serverTimestamp.formattedDate)
+        self.navigationItem.titleView = TwoLineTitleView(first: sender.displayName.localizedUppercase, second: serverTimestamp.formattedDate)
     }
     
     private func updateButtonsForMessage() {
@@ -351,7 +351,7 @@ final class ConversationImagesViewController: TintColorCorrectedViewController {
     }
 
     @objc public func copyCurrent(_ sender: AnyObject!) {
-        let text = "collections.image_viewer.copied.title".localized.uppercased()
+        let text = "collections.image_viewer.copied.title".localized(uppercased: true)
         overlay.show(text: text)
         perform(action: .copy)
     }

--- a/Wire-iOS/Sources/UserInterface/Collections/TextSearch/TextSearchResultsView.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/TextSearch/TextSearchResultsView.swift
@@ -40,7 +40,7 @@ import Cartography
         self.addSubview(self.tableView)
 
         self.noResultsView.label.accessibilityLabel = "no text messages"
-        self.noResultsView.label.text = "collections.search.no_items".localized.uppercased()
+        self.noResultsView.label.text = "collections.search.no_items".localized(uppercased: true)
         self.noResultsView.icon = .search
         self.addSubview(self.noResultsView)
     }

--- a/Wire-iOS/Sources/UserInterface/Collections/TextSearch/TextSearchViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/TextSearch/TextSearchViewController.swift
@@ -58,7 +58,7 @@ import Cartography
         
         self.searchBar = TextSearchInputView()
         self.searchBar.delegate = self
-        self.searchBar.placeholderString = "collections.search.field.placeholder".localized.uppercased()
+        self.searchBar.placeholderString = "collections.search.field.placeholder".localized(uppercased: true)
     }
 
     public func teardown() {

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/CallQualityController/CallQualityViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/CallQualityController/CallQualityViewController.swift
@@ -98,8 +98,8 @@ class CallQualityViewController : UIViewController, UIGestureRecognizerDelegate 
         dimmingView.alpha = 0
 
         let graphite = UIColor.from(scheme: .textForeground)
-        let closeButtonTitle = "calling.quality_survey.skip_button_title".localized
-        closeButton.setTitle(closeButtonTitle.uppercased(), for: .normal)
+        let closeButtonTitle = "calling.quality_survey.skip_button_title".localized(uppercased: true)
+        closeButton.setTitle(closeButtonTitle, for: .normal)
         closeButton.accessibilityIdentifier = "score_close"
         closeButton.accessibilityLabel = closeButtonTitle
         closeButton.titleLabel?.font = FontSpec(.small, .semibold).font!

--- a/Wire-iOS/Sources/UserInterface/Components/Giphy/GiphyConfirmationViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Giphy/GiphyConfirmationViewController.swift
@@ -72,7 +72,7 @@ class GiphyConfirmationViewController: UIViewController {
         let titleLabel = UILabel()
         titleLabel.font = FontSpec(.small, .semibold).font!
         titleLabel.textColor = UIColor.from(scheme: .textForeground)
-        titleLabel.text = title?.uppercased()
+        titleLabel.text = title?.localizedUppercase
         titleLabel.sizeToFit()
         navigationItem.titleView = titleLabel
         

--- a/Wire-iOS/Sources/UserInterface/Components/Giphy/GiphySearchViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Giphy/GiphySearchViewController.swift
@@ -85,7 +85,7 @@ import Ziphy
 
         extendedLayoutIncludesOpaqueBars = true
 
-        noResultsLabel.text = "giphy.error.no_result".localized.uppercased()
+        noResultsLabel.text = "giphy.error.no_result".localized(uppercased: true)
         noResultsLabel.isHidden = true
         view.addSubview(noResultsLabel)
 
@@ -289,7 +289,7 @@ extension GiphySearchViewController {
     @discardableResult
     func pushConfirmationViewController(ziph: Ziph?, previewImage: FLAnimatedImage?, animated: Bool = true) -> GiphyConfirmationViewController {
         let confirmationController = GiphyConfirmationViewController(withZiph: ziph, previewImage: previewImage, searchResultController: searchResultsController)
-        confirmationController.title = conversation.displayName.uppercased()
+        confirmationController.title = conversation.displayName.localizedUppercase
         confirmationController.delegate = self
         navigationController?.pushViewController(confirmationController, animated: animated)
 

--- a/Wire-iOS/Sources/UserInterface/Components/NetworkStatus/OfflineBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/NetworkStatus/OfflineBar.swift
@@ -47,7 +47,7 @@ class OfflineBar: UIView {
 
         offlineLabel.font = FontSpec(FontSize.small, .medium).font
         offlineLabel.textColor = UIColor.white
-        offlineLabel.text = "system_status_bar.no_internet.title".localized.uppercased()
+        offlineLabel.text = "system_status_bar.no_internet.title".localized(uppercased: true)
 
         addSubview(offlineLabel)
 

--- a/Wire-iOS/Sources/UserInterface/ConnectRequests/IncomingConnectionView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConnectRequests/IncomingConnectionView.swift
@@ -64,11 +64,11 @@ public final class IncomingConnectionView: UIView {
 
     private func setup() {
         self.acceptButton.accessibilityLabel = "accept"
-        self.acceptButton.setTitle("inbox.connection_request.connect_button_title".localized.uppercased(), for: .normal)
+        self.acceptButton.setTitle("inbox.connection_request.connect_button_title".localized(uppercased: true), for: .normal)
         self.acceptButton.addTarget(self, action: #selector(onAcceptButton), for: .touchUpInside)
 
         self.ignoreButton.accessibilityLabel = "ignore"
-        self.ignoreButton.setTitle("inbox.connection_request.ignore_button_title".localized.uppercased(), for: .normal)
+        self.ignoreButton.setTitle("inbox.connection_request.ignore_button_title".localized(uppercased: true), for: .normal)
         self.ignoreButton.addTarget(self, action: #selector(onIgnoreButton), for: .touchUpInside)
 
         self.userImageView.accessibilityLabel = "user image"

--- a/Wire-iOS/Sources/UserInterface/ConnectRequests/OutgoingConnectionBottomBar.swift
+++ b/Wire-iOS/Sources/UserInterface/ConnectRequests/OutgoingConnectionBottomBar.swift
@@ -52,7 +52,7 @@ import Cartography
     private func setupCancelButton() {
         cancelButton.accessibilityLabel = "cancel connection"
         cancelButton.setIcon(.undo, with: .tiny, for: .normal)
-        cancelButton.setTitle("profile.cancel_connection_button_title".localized.uppercased(), for: .normal)
+        cancelButton.setTitle("profile.cancel_connection_button_title".localized(uppercased: true), for: .normal)
         cancelButton.titleLabel?.font = FontSpec(.small, .light).font!
         cancelButton.setTitleColor(UIColor.from(scheme: .textForeground), for: .normal)
         cancelButton.titleImageSpacing = 24

--- a/Wire-iOS/Sources/UserInterface/Conversation Options/Conversation+OptionsConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/Conversation+OptionsConfiguration.swift
@@ -35,7 +35,7 @@ extension ZMConversation {
         }
         
         var title: String {
-            return conversation.displayName.uppercased()
+            return conversation.displayName.localizedUppercase
         }
         
         var allowGuests: Bool {

--- a/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationNotificationOptionsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationNotificationOptionsViewController.swift
@@ -52,7 +52,7 @@ class ConversationNotificationOptionsViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        title = "group_details.notification_options_cell.title".localized.uppercased()
+        title = "group_details.notification_options_cell.title".localized(uppercased: true)
         navigationItem.rightBarButtonItem = navigationController?.closeItem()
         
         configureSubviews()

--- a/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationTimeoutOptionsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationTimeoutOptionsViewController.swift
@@ -76,7 +76,7 @@ class ConversationTimeoutOptionsViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        title = "group_details.timeout_options_cell.title".localized.uppercased()
+        title = "group_details.timeout_options_cell.title".localized(uppercased: true)
         navigationItem.rightBarButtonItem = navigationController?.closeItem()
 
         configureSubviews()

--- a/Wire-iOS/Sources/UserInterface/Conversation Options/LinkHeaderCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/LinkHeaderCell.swift
@@ -45,7 +45,7 @@ final class LinkHeaderCell: UITableViewCell, CellConfigurationConfigurable {
     private func setupViews() {
         [topSeparator, titleLabel, subtitleLabel].forEach(contentView.addSubview)
         titleLabel.font = FontSpec(.small, .semibold).font
-        titleLabel.text = "guest_room.link.header.title".localized.uppercased()
+        titleLabel.text = "guest_room.link.header.title".localized(uppercased: true)
         subtitleLabel.numberOfLines = 0
         subtitleLabel.font = FontSpec(.medium, .regular).font
         subtitleLabel.text = "guest_room.link.header.subtitle".localized

--- a/Wire-iOS/Sources/UserInterface/Conversation/ArchivedListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ArchivedListViewController.swift
@@ -34,7 +34,7 @@ import Cartography
     override var preferredStatusBarStyle: UIStatusBarStyle { return .lightContent }
     
     fileprivate var collectionView: UICollectionView!
-    fileprivate let archivedNavigationBar = ArchivedNavigationBar(title: "archived_list.title".localized.uppercased())
+    fileprivate let archivedNavigationBar = ArchivedNavigationBar(title: "archived_list.title".localized(uppercased: true))
     fileprivate let cellReuseIdentifier = "ConversationListCellArchivedIdentifier"
     fileprivate let swipeIdentifier = "ArchivedList"
     fileprivate let viewModel = ArchivedListViewModel()

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCellBurstTimestampView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCellBurstTimestampView.swift
@@ -139,12 +139,12 @@ import Cartography
             isSeparatorExpanded = true
             isSeparatorHidden = false
             label.font = burstBoldFont
-            label.text = timestamp.olderThanOneWeekdateFormatter.string(from: timestamp).uppercased()
+            label.text = timestamp.olderThanOneWeekdateFormatter.string(from: timestamp).localizedUppercase
         } else {
             isSeparatorExpanded = false
             isSeparatorHidden = false
             label.font = burstNormalFont
-            label.text = timestamp.formattedDate.uppercased()
+            label.text = timestamp.formattedDate.localizedUppercase
         }
         
         isShowingUnreadDot = showUnreadDot

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/FileTransferView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/FileTransferView.swift
@@ -166,7 +166,7 @@ final public class FileTransferView: UIView, TransferView {
         switch fileMessageData.transferState {
             
         case .uploading:
-            let statusText = "content.file.uploading".localized.uppercased() && labelFont && labelTextBlendedColor
+            let statusText = "content.file.uploading".localized(uppercased: true) && labelFont && labelTextBlendedColor
             let firstLine = fileNameAttributed
             let secondLine = fileSizeAttributed + dot + statusText
             self.topLabel.attributedText = firstLine
@@ -179,7 +179,7 @@ final public class FileTransferView: UIView, TransferView {
                 self.topLabel.attributedText = firstLine
                 self.bottomLabel.attributedText = secondLine
             case .downloading:
-                let statusText = "content.file.downloading".localized.uppercased() && labelFont && labelTextBlendedColor
+                let statusText = "content.file.downloading".localized(uppercased: true) && labelFont && labelTextBlendedColor
                 let firstLine = fileNameAttributed
                 let secondLine = fileSizeAttributed + dot + statusText
                 self.topLabel.attributedText = firstLine
@@ -187,7 +187,7 @@ final public class FileTransferView: UIView, TransferView {
             }
         case .uploadingFailed, .uploadingCancelled:
             let statusText = fileMessageData.transferState == .uploadingFailed ? "content.file.upload_failed".localized : "content.file.upload_cancelled".localized
-            let attributedStatusText = statusText.uppercased() && labelFont && UIColor.vividRed
+            let attributedStatusText = statusText.localizedUppercase && labelFont && UIColor.vividRed
             
             let firstLine = fileNameAttributed
             let secondLine = fileSizeAttributed + dot + attributedStatusText

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageAction.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageAction.swift
@@ -45,7 +45,7 @@ extension ConversationContentViewController {
             canvasViewController.sketchImage = UIImage(data: imageData)
         }
         canvasViewController.delegate = self
-        canvasViewController.title = message.conversation?.displayName.uppercased()
+        canvasViewController.title = message.conversation?.displayName.localizedUppercase
         canvasViewController.select(editMode: editMode, animated: false)
 
         present(canvasViewController.wrapInNavigationController(), animated: true)

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationTitleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationTitleView.swift
@@ -46,15 +46,15 @@ class ConversationTitleView: TitleView {
             attachment = .verifiedShield()
         }
         super.configure(icon: attachment,
-                        title: conversation.displayName.uppercased(),
+                        title: conversation.displayName.localizedUppercase,
                         interactive: self.interactive && conversation.relatedConnectionState != .sent)
     }
 
     override func updateAccessibilityLabel() {
         if conversation.securityLevel == .secure {
-            self.accessibilityLabel = conversation.displayName.uppercased() + ", " + "conversation.voiceover.verified".localized
+            self.accessibilityLabel = conversation.displayName.localizedUppercase + ", " + "conversation.voiceover.verified".localized
         } else {
-            self.accessibilityLabel = conversation.displayName.uppercased()
+            self.accessibilityLabel = conversation.displayName.localizedUppercase
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
@@ -56,7 +56,7 @@ public extension ConversationViewController {
         let button = IconButton()
         button.adjustsTitleWhenHighlighted = true
         button.adjustBackgroundImageWhenHighlighted = true
-        button.setTitle("conversation_list.right_accessory.join_button.title".localized.uppercased(), for: .normal)
+        button.setTitle("conversation_list.right_accessory.join_button.title".localized(uppercased: true), for: .normal)
         button.accessibilityLabel = "conversation.join_call.voiceover".localized
         button.accessibilityTraits.insert(.startsMediaSession)
         button.titleLabel?.font = FontSpec(.small, .semibold).font

--- a/Wire-iOS/Sources/UserInterface/Conversation/Create/Cells/ConversationCreateNameCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Create/Cells/ConversationCreateNameCell.swift
@@ -43,7 +43,7 @@ class ConversationCreateNameCell: UICollectionViewCell {
         textField.translatesAutoresizingMaskIntoConstraints = false
         textField.isAccessibilityElement = true
         textField.accessibilityIdentifier = "textfield.newgroup.name"
-        textField.placeholder = "conversation.create.group_name.placeholder".localized.uppercased()
+        textField.placeholder = "conversation.create.group_name.placeholder".localized(uppercased: true)
                 
         contentView.addSubview(textField)
         textField.fitInSuperview()

--- a/Wire-iOS/Sources/UserInterface/Conversation/Create/Cells/ConversationCreateOptionsCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Create/Cells/ConversationCreateOptionsCell.swift
@@ -16,7 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
+import WireCommonComponents
 
 class ConversationCreateOptionsCell: RightIconDetailsCell {
     
@@ -51,8 +51,8 @@ class ConversationCreateOptionsCell: RightIconDetailsCell {
 
 extension ConversationCreateOptionsCell: ConversationCreationValuesConfigurable {
     func configure(with values: ConversationCreationValues) {
-        let guests = values.allowGuests.localized(uppercased: true)
-        let receipts = values.enableReceipts.localized(uppercased: true)
+        let guests = values.allowGuests.localized.localizedUppercase
+        let receipts = values.enableReceipts.localized.localizedUppercase
         status = "conversation.create.options.subtitle".localized(args: guests, receipts)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Create/Cells/ConversationCreateOptionsCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Create/Cells/ConversationCreateOptionsCell.swift
@@ -51,8 +51,8 @@ class ConversationCreateOptionsCell: RightIconDetailsCell {
 
 extension ConversationCreateOptionsCell: ConversationCreationValuesConfigurable {
     func configure(with values: ConversationCreationValues) {
-        let guests = values.allowGuests.localized.uppercased()
-        let receipts = values.enableReceipts.localized.uppercased()
+        let guests = values.allowGuests.localized(uppercased: true)
+        let receipts = values.enableReceipts.localized(uppercased: true)
         status = "conversation.create.options.subtitle".localized(args: guests, receipts)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
@@ -144,7 +144,7 @@ final public class ConversationCreationValues {
         Analytics.shared().tagLinearGroupOpened(with: self.source)
 
         view.backgroundColor = UIColor.from(scheme: .contentBackground, variant: colorSchemeVariant)
-        title = "conversation.create.group_name.title".localized.uppercased()
+        title = "conversation.create.group_name.title".localized(uppercased: true)
         
         setupNavigationBar()
         setupViews()
@@ -213,7 +213,7 @@ final public class ConversationCreationValues {
             navigationItem.leftBarButtonItem = navigationController?.closeItem()
         }
         
-        let nextButtonItem = UIBarButtonItem(title: "general.next".localized.uppercased(), style: .plain, target: self, action: #selector(tryToProceed))
+        let nextButtonItem = UIBarButtonItem(title: "general.next".localized(uppercased: true), style: .plain, target: self, action: #selector(tryToProceed))
         nextButtonItem.accessibilityIdentifier = "button.newgroup.next"
         nextButtonItem.tintColor = UIColor.accent()
         nextButtonItem.isEnabled = false

--- a/Wire-iOS/Sources/UserInterface/Conversation/Create/Sections/ConversationCreateErrorSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Create/Sections/ConversationCreateErrorSectionController.swift
@@ -37,7 +37,7 @@ class ConversationCreateErrorSectionController: NSObject, CollectionViewSectionC
     }
     
     func displayError(_ error: Error) {
-        errorCell?.label.text = error.localizedDescription.uppercased()
+        errorCell?.label.text = error.localizedDescription.localizedUppercase
 
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/GuestBar/GuestBarState.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/GuestBar/GuestBarState.swift
@@ -25,7 +25,7 @@
 
 extension GuestBarState {
     var displayString: String {
-        return localizationKey.localized.uppercased()
+        return localizationKey.localized(uppercased: true)
     }
     
     private var localizationKey: String {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioEffectsPickerViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioEffectsPickerViewController.swift
@@ -229,7 +229,7 @@ import WireCommonComponents
         
         switch self.state {
         case .tip:
-            self.subtitleLabel.text = "conversation.input_bar.audio_message.keyboard.filter_tip".localized.uppercased()
+            self.subtitleLabel.text = "conversation.input_bar.audio_message.keyboard.filter_tip".localized(uppercased: true)
             self.subtitleLabel.textColor = colorScheme.color(named: .textForeground)
         case .time:
             let duration: Int

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
@@ -140,7 +140,7 @@ private let zmLog = ZMSLog(tag: "UI")
     
     private func createTipLabel() {
         let color = UIColor.from(scheme: .textDimmed, variant: .light)
-        let text = "conversation.input_bar.audio_message.keyboard.record_tip".localized.uppercased()
+        let text = "conversation.input_bar.audio_message.keyboard.record_tip".localized(uppercased: true)
         let attrText = NSMutableAttributedString(string: text)
         let atRange = (text as NSString).range(of: "%@")
         

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordViewController.swift
@@ -154,7 +154,7 @@ private let zmLog = ZMSLog(tag: "UI")
         timeLabel.font = FontSpec(.small, .none).font!
         timeLabel.textColor = UIColor.from(scheme: .textForeground)
         
-        topTooltipLabel.text = "conversation.input_bar.audio_message.tooltip.pull_send".localized.uppercased()
+        topTooltipLabel.text = "conversation.input_bar.audio_message.tooltip.pull_send".localized(uppercased: true)
         topTooltipLabel.accessibilityLabel = "audioRecorderTopTooltipLabel"
         topTooltipLabel.font = FontSpec(.small, .none).font!
         topTooltipLabel.textColor = UIColor.from(scheme: .textDimmed)
@@ -308,7 +308,7 @@ private let zmLog = ZMSLog(tag: "UI")
         self.recordingDotView.animating = !finished
         
         let pathComponent = finished ? "tooltip.tap_send" : "tooltip.pull_send"
-        topTooltipLabel.text = "\(localizationBasePath).\(pathComponent)".localized.uppercased()
+        topTooltipLabel.text = "\(localizationBasePath).\(pathComponent)".localized(uppercased: true)
         
         if self.recordingState == .recording {
             self.recordingDotViewHidden?.active = false

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
@@ -100,7 +100,7 @@ extension ConversationInputBarViewController: CameraKeyboardViewControllerDelega
             let confirmVideoViewController = ConfirmAssetViewController()
             confirmVideoViewController.transitioningDelegate = FastTransitioningDelegate.sharedDelegate
             confirmVideoViewController.videoURL = videoURL as URL
-            confirmVideoViewController.previewTitle = self.conversation.displayName.uppercased()
+            confirmVideoViewController.previewTitle = self.conversation.displayName.localizedUppercase
             confirmVideoViewController.onConfirm = { [unowned self] (editedImage: UIImage?)in
                 self.dismiss(animated: true, completion: .none)
                 self.uploadFile(at: videoURL as URL)
@@ -163,7 +163,7 @@ extension ConversationInputBarViewController: CameraKeyboardViewControllerDelega
         let confirmImageViewController = ConfirmAssetViewController()
         confirmImageViewController.transitioningDelegate = FastTransitioningDelegate.sharedDelegate
         confirmImageViewController.image = image
-        confirmImageViewController.previewTitle = self.conversation.displayName.uppercased()
+        confirmImageViewController.previewTitle = self.conversation.displayName.localizedUppercase
         confirmImageViewController.onConfirm = { [unowned self] (editedImage: UIImage?) in
             self.dismiss(animated: true) {
                 if isFromCamera {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/EphemeralKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/EphemeralKeyboardViewController.swift
@@ -164,7 +164,7 @@ extension UIAlertController {
         titleLabel.textColor = UIColor.from(scheme: .textForeground, variant: .dark)
         titleLabel.font = .smallSemiboldFont
 
-        titleLabel.text = "input.ephemeral.title".localized.uppercased()
+        titleLabel.text = "input.ephemeral.title".localized(uppercased: true)
         titleLabel.numberOfLines = 0
         [titleLabel, picker].forEach(view.addSubview)
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsContentViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsContentViewController.swift
@@ -177,17 +177,17 @@ class MessageDetailsContentViewController: UIViewController {
         switch contentType {
         case .reactions:
             noResultsView.label.accessibilityIdentifier = "placeholder.no_likes"
-            noResultsView.placeholderText = "message_details.empty_likes".localized.uppercased()
+            noResultsView.placeholderText = "message_details.empty_likes".localized(uppercased: true)
             noResultsView.icon = .like
 
         case .receipts(enabled: true):
             noResultsView.label.accessibilityIdentifier = "placeholder.no_read_receipts"
-            noResultsView.placeholderText = "message_details.empty_read_receipts".localized.uppercased()
+            noResultsView.placeholderText = "message_details.empty_read_receipts".localized(uppercased: true)
             noResultsView.icon = .eye
 
         case .receipts(enabled: false):
             noResultsView.label.accessibilityIdentifier = "placeholder.read_receipts_disabled"
-            noResultsView.placeholderText = "message_details.read_receipts_disabled".localized.uppercased()
+            noResultsView.placeholderText = "message_details.read_receipts_disabled".localized(uppercased: true)
             noResultsView.icon = .eye
         }
     }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListAccessoryView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListAccessoryView.swift
@@ -117,7 +117,7 @@ import UIKit
             accessibilityValue = "conversation_list.voiceover.status.active_call".localized
             return .none
         case .activeCall(true):
-            textLabel.text = "conversation_list.right_accessory.join_button.title".localized.uppercased()
+            textLabel.text = "conversation_list.right_accessory.join_button.title".localized(uppercased: true)
             accessibilityValue = textLabel.text
             return textLabel
         case .missedCall:

--- a/Wire-iOS/Sources/UserInterface/DraftListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/DraftListViewController.swift
@@ -65,8 +65,8 @@ final class DraftListViewController: CoreDataTableViewController<MessageDraft, D
         paragraphStyle.paragraphSpacing = 4
         let paragraphAttributes = [NSAttributedString.Key.paragraphStyle: paragraphStyle]
         let color = UIColor.from(scheme: .textDimmed)
-        let title = "compose.drafts.empty.title".localized.uppercased() && FontSpec(.small, .semibold).font!
-        let subtitle = "compose.drafts.empty.subtitle".localized.uppercased() && FontSpec(.small, .light).font!
+        let title = "compose.drafts.empty.title".localized(uppercased: true) && FontSpec(.small, .semibold).font!
+        let subtitle = "compose.drafts.empty.subtitle".localized(uppercased: true) && FontSpec(.small, .light).font!
         emptyLabel.attributedText = (title + "\n" + subtitle) && color && paragraphAttributes
         emptyLabel.numberOfLines = 0
         view.addSubview(emptyLabel)
@@ -87,7 +87,7 @@ final class DraftListViewController: CoreDataTableViewController<MessageDraft, D
     }
 
     private func setupViews() {
-        title = "compose.drafts.title".localized.uppercased()
+        title = "compose.drafts.title".localized(uppercased: true)
         tableView.backgroundColor = UIColor.from(scheme: .background)
         navigationItem.rightBarButtonItem = UIBarButtonItem(icon: .X, style: .done, target: self, action: #selector(closeTapped))
         navigationItem.rightBarButtonItem?.accessibilityLabel = "closeButton"

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsFooterView.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsFooterView.swift
@@ -54,7 +54,7 @@ final class GroupDetailsFooterView: ConversationDetailFooterView {
     
     override func setupButtons() {
         leftIcon = .plus
-        leftButton.setTitle("participants.footer.add_title".localized.uppercased(), for: .normal)
+        leftButton.setTitle("participants.footer.add_title".localized(uppercased: true), for: .normal)
         leftButton.accessibilityIdentifier = "OtherUserMetaControllerLeftButton"
         rightIcon = .ellipsis
         rightButton.accessibilityIdentifier = "OtherUserMetaControllerRightButton"

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
@@ -90,7 +90,7 @@ import Cartography
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = "participants.title".localized.uppercased()
+        title = "participants.title".localized(uppercased: true)
         view.backgroundColor = UIColor.from(scheme: .contentBackground)
     }
     

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupParticipantsDetail/GroupParticipantsDetailViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupParticipantsDetail/GroupParticipantsDetailViewController.swift
@@ -83,7 +83,7 @@ final class GroupParticipantsDetailViewController: UIViewController, UICollectio
         collectionView.delegate = self
         collectionView.dataSource = self
         collectionView.register(SelectedUserCell.self, forCellWithReuseIdentifier: SelectedUserCell.reuseIdentifier)
-        title = "participants.all.title".localized.uppercased()
+        title = "participants.all.title".localized(uppercased: true)
         view.backgroundColor = UIColor.from(scheme: .contentBackground)
         navigationItem.rightBarButtonItem = navigationController?.closeItem()
     }

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/GroupOptionsSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/GroupOptionsSectionController.swift
@@ -93,7 +93,7 @@ class GroupOptionsSectionController: GroupDetailsSectionController {
     // MARK: - Collection View
     
     override var sectionTitle: String {
-        return "participants.section.settings".localized.uppercased()
+        return "participants.section.settings".localized(uppercased: true)
     }
 
     override func prepareForUse(in collectionView: UICollectionView?) {

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/ParticipantsSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/ParticipantsSectionController.swift
@@ -46,7 +46,7 @@ private struct ParticipantsSectionViewModel {
     var sectionAccesibilityIdentifier = "label.groupdetails.participants"
     
     var sectionTitle: String {
-        return "participants.section.participants".localized(args: participants.count).uppercased()
+        return "participants.section.participants".localized(uppercased: true, args: participants.count)
     }
 
     init(participants: [UserType]) {

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/ServicesSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/ServicesSectionController.swift
@@ -37,7 +37,7 @@ class ServicesSectionController: GroupDetailsSectionController {
     }
     
     override var sectionTitle: String {
-        return "participants.section.services".localized(args: serviceUsers.count).uppercased()
+        return "participants.section.services".localized(uppercased: true, args: serviceUsers.count)
     }
     
     override var sectionAccessibilityIdentifier: String {

--- a/Wire-iOS/Sources/UserInterface/Location/LocationSendViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Location/LocationSendViewController.swift
@@ -56,7 +56,7 @@ import Cartography
     }
     
     fileprivate func configureViews() {
-        sendButton.setTitle("location.send_button.title".localized.uppercased(), for: [])
+        sendButton.setTitle("location.send_button.title".localized(uppercased: true), for: [])
         sendButton.addTarget(self, action: #selector(sendButtonTapped), for: .touchUpInside)
         sendButton.accessibilityIdentifier = "sendLocation"
         addressLabel.accessibilityIdentifier = "selectedAddress"

--- a/Wire-iOS/Sources/UserInterface/Location/ModalTopBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Location/ModalTopBar.swift
@@ -66,7 +66,7 @@ import Cartography
     
     private var title: String? {
         didSet {
-            titleLabel.text = title?.uppercased()
+            titleLabel.text = title?.localizedUppercase
             titleLabel.isHidden = title == nil
             titleLabel.accessibilityLabel = title
             titleLabel.accessibilityTraits.insert(.header)
@@ -75,7 +75,7 @@ import Cartography
 
     private var subtitle: String? {
         didSet {
-            subtitleLabel.text = subtitle?.uppercased()
+            subtitleLabel.text = subtitle?.localizedUppercase
             subtitleLabel.isHidden = subtitle == nil
             subtitleLabel.accessibilityLabel = subtitle
         }

--- a/Wire-iOS/Sources/UserInterface/MessageComposeViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/MessageComposeViewController.swift
@@ -119,7 +119,7 @@ final class MessageComposeViewController: UIViewController {
         subjectTextField.tintColor = .accent()
         subjectTextField.textAlignment = .center
         subjectTextField.font = FontSpec(.medium, .semibold).font!
-        let placeholder = "compose.drafts.compose.subject.placeholder".localized.uppercased()
+        let placeholder = "compose.drafts.compose.subject.placeholder".localized(uppercased: true)
         subjectTextField.attributedPlaceholder = placeholder && UIColor.from(scheme: .separator) && FontSpec(.medium, .semibold).font!
         subjectTextField.bounds = CGRect(x: 0, y: 0, width: 200, height: 44)
         subjectTextField.accessibilityLabel = "subjectTextField"

--- a/Wire-iOS/Sources/UserInterface/Overlay/CallTopOverlayController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/CallTopOverlayController.swift
@@ -203,7 +203,7 @@ final class CallTopOverlayController: UIViewController {
     }
     
     private func updateLabel() {
-        durationLabel.text = statusString.uppercased()
+        durationLabel.text = statusString.localizedUppercase
         view.accessibilityValue = durationLabel.text
     }
     

--- a/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
@@ -156,7 +156,7 @@ final class SelfProfileViewController: UIViewController {
         if SessionManager.shared?.accountManager.accounts.count > 1 {
             navigationItem.titleView = accountSelectorController.view
         } else {
-            title = "self.account".localized.uppercased()
+            title = "self.account".localized(uppercased: true)
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/Settings/AccentColorPickerController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/AccentColorPickerController.swift
@@ -211,7 +211,7 @@ final class AccentColorPickerController: ColorPickerController {
         self.allAccentColors = AccentColor.allSelectable()
         
         super.init(colors: self.allAccentColors.map { UIColor(for: $0) })
-        self.title = "self.settings.account_picture_group.color".localized.uppercased()
+        self.title = "self.settings.account_picture_group.color".localized(uppercased: true)
         
         if let accentColor = AccentColor(ZMAccentColor: ZMUser.selfUser().accentColorValue), let currentColorIndex = self.allAccentColors.index(of: accentColor) {
             self.currentColor = self.colors[currentColorIndex]

--- a/Wire-iOS/Sources/UserInterface/Settings/BackupPasswordViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/BackupPasswordViewController.swift
@@ -125,15 +125,15 @@ final class BackupPasswordViewController: UIViewController {
         navigationController?.navigationBar.barTintColor = UIColor.from(scheme: .textForeground, variant: .light)
         navigationController?.navigationBar.titleTextAttributes = DefaultNavigationBar.titleTextAttributes(for: .light)
         
-        title = "self.settings.history_backup.password.title".localized.uppercased()
+        title = "self.settings.history_backup.password.title".localized(uppercased: true)
         navigationItem.leftBarButtonItem = UIBarButtonItem(
-            title: "self.settings.history_backup.password.cancel".localized.uppercased(),
+            title: "self.settings.history_backup.password.cancel".localized(uppercased: true),
             style: .plain,
             target: self,
             action: #selector(cancel)
         )
         navigationItem.rightBarButtonItem = UIBarButtonItem(
-            title: "self.settings.history_backup.password.next".localized.uppercased(),
+            title: "self.settings.history_backup.password.next".localized(uppercased: true),
             style: .done,
             target: self,
             action: #selector(completeWithCurrentResult)

--- a/Wire-iOS/Sources/UserInterface/Settings/BackupViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/BackupViewController.swift
@@ -116,7 +116,7 @@ final class BackupViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = "self.settings.history_backup.title".localized.uppercased()
+        title = "self.settings.history_backup.title".localized(uppercased: true)
         setupViews()
         setupLayout()
     }

--- a/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ChangeHandleViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ChangeHandleViewController.swift
@@ -228,7 +228,7 @@ struct HandleChangeState {
     }
 
     private func setupViews() {
-        title = "self.settings.account_section.handle.change.title".localized.uppercased()
+        title = "self.settings.account_section.handle.change.title".localized(uppercased: true)
         view.backgroundColor = .clear
         ChangeHandleTableViewCell.register(in: tableView)
         tableView.allowsSelection = false

--- a/Wire-iOS/Sources/UserInterface/Settings/DatabaseStatisticsController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DatabaseStatisticsController.swift
@@ -39,7 +39,7 @@ import WireDataModel
 
         edgesForExtendedLayout = []
 
-        self.title = "Database Statistics".uppercased()
+        self.title = "Database Statistics".localizedUppercase
 
         view.addSubview(stackView)
 

--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
@@ -133,7 +133,7 @@ final class ClientListViewController: UIViewController,
         }
 
         super.init(nibName: nil, bundle: nil)
-        title = "registration.devices.title".localized.uppercased()
+        title = "registration.devices.title".localized(uppercased: true)
 
         self.initalizeProperties(clientsList ?? Array(ZMUser.selfUser().clients.filter { !$0.isSelfClient() } ))
         self.clientsObserverToken = ZMUserSession.shared()?.add(self)

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchGroupSelector.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchGroupSelector.swift
@@ -42,7 +42,7 @@ import Foundation
         self.style = style
 
         let groupItems: [UITabBarItem] = groups.enumerated().map { index, group in
-            UITabBarItem(title: group.name.uppercased(), image: nil, tag: index)
+            UITabBarItem(title: group.name.localizedUppercase, image: nil, tag: index)
         }
 
         tabBar = TabBar(items: groupItems, style: style, selectedIndex: 0)

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchHeaderViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchHeaderViewController.swift
@@ -78,7 +78,7 @@ public protocol SearchHeaderViewControllerDelegate : class {
         tokenField.textView.placeholderTextColor = UIColor.from(scheme: .tokenFieldTextPlaceHolder, variant: colorSchemeVariant)
         tokenField.textView.backgroundColor = UIColor.from(scheme: .tokenFieldBackground, variant: colorSchemeVariant)
         tokenField.textView.accessibilityIdentifier = "textViewSearch"
-        tokenField.textView.placeholder = "peoplepicker.search_placeholder".localized.uppercased()
+        tokenField.textView.placeholder = "peoplepicker.search_placeholder".localized(uppercased: true)
         tokenField.textView.keyboardAppearance = ColorScheme.keyboardAppearance(for: colorSchemeVariant)
         tokenField.textView.returnKeyType = .done
         tokenField.textView.autocorrectionType = .no

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Devices/ProfileClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Devices/ProfileClientViewController.swift
@@ -129,7 +129,7 @@ import Cartography
     
     private func setupShowMyDeviceButton() {
         showMyDeviceButton.accessibilityIdentifier = "show my device"
-        showMyDeviceButton.setTitle(NSLocalizedString("profile.devices.detail.show_my_device.title", comment: "").uppercased(), for: [])
+        showMyDeviceButton.setTitle("profile.devices.detail.show_my_device.title".localized(uppercased: true), for: [])
         showMyDeviceButton.addTarget(self, action: #selector(ProfileClientViewController.onShowMyDeviceTapped(_:)), for: .touchUpInside)
         showMyDeviceButton.setTitleColor(UIColor.accent(), for: .normal)
         showMyDeviceButton.titleLabel?.font = FontSpec(.small, .light).font!
@@ -163,7 +163,7 @@ import Cartography
     }
     
     private func setupTypeLabel() {
-        typeLabel.text = self.userClient.deviceClass?.uppercased()
+        typeLabel.text = self.userClient.deviceClass?.localizedUppercase
         typeLabel.numberOfLines = 1
         typeLabel.font = FontSpec(.small, .semibold).font!
         typeLabel.textColor = UIColor.from(scheme: .textForeground)
@@ -228,7 +228,7 @@ import Cartography
     private func setupVerifiedToggleLabel() {
         verifiedToggleLabel.font = FontSpec(.small, .light).font!
         verifiedToggleLabel.textColor = UIColor.from(scheme: .textForeground)
-        verifiedToggleLabel.text = NSLocalizedString("device.verified", comment: "").uppercased()
+        verifiedToggleLabel.text = "device.verified".localized(uppercased: true)
         verifiedToggleLabel.numberOfLines = 0
         self.contentView.addSubview(verifiedToggleLabel)
     }
@@ -236,7 +236,7 @@ import Cartography
     private func setupResetButton() {
         resetButton.setTitleColor(UIColor.accent(), for: .normal)
         resetButton.titleLabel?.font = FontSpec(.small, .light).font!
-        resetButton.setTitle(NSLocalizedString("profile.devices.detail.reset_session.title", comment: "").uppercased(), for: [])
+        resetButton.setTitle("profile.devices.detail.reset_session.title".localized(uppercased: true), for: [])
         resetButton.addTarget(self, action: #selector(ProfileClientViewController.onResetTapped(_:)), for: .touchUpInside)
         resetButton.accessibilityIdentifier = "reset session"
         self.contentView.addSubview(resetButton)

--- a/WireCommonComponents/AttributedStringOperators.swift
+++ b/WireCommonComponents/AttributedStringOperators.swift
@@ -198,9 +198,10 @@ public extension String {
     }
    
     /// Used to generate localized strings with plural rules from the stringdict
-    public func localized(pov pointOfView: PointOfView = .none, args: CVarArg...) -> String {
+    public func localized(uppercased: Bool = false, pov pointOfView: PointOfView = .none, args: CVarArg...) -> String {
         return withVaList(args) {
-            return NSString(format: self.localized(pov: pointOfView), arguments: $0) as String
+            let text = NSString(format: self.localized(pov: pointOfView), arguments: $0) as String
+            return uppercased ? text.localizedUppercase : text
         }
     }
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

When uppercasing strings for display, we were using the non-localized version, meaning that in some languages, the wrong uppercased letter would be picked.

According to [objc.io](https://www.objc.io/issues/9-strings/string-localization/):

> Whenever you need to uppercase or lowercase a string that should be presented to the user, you should use the localized versions of those `NSString` methods: `lowercaseStringWithLocale:` and `uppercaseStringWithLocale:`.

### Solutions

Replace use of `String.uppercased()` by `String.localizedUppercase` where appropriate.