### PR TITLE
Fix: build script failed to upload to Hockey

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -53,7 +53,7 @@ platform :ios do
         if build.for_simulator
             Dir.chdir("..") do
                 # Build the app for simulator
-                sh "xcodebuild -scheme 'Wire-iOS' -configuration 'Debug' -sdk 'iphonesimulator' -derivedDataPath DerivedData -quiet build BUILD_NUMBER=#{build.build_number}"
+                sh "xcodebuild -scheme 'Wire-iOS' -configuration 'Debug' -sdk 'iphonesimulator' -derivedDataPath DerivedData -quiet clean build BUILD_NUMBER=#{build.build_number}"
 
                 # make a "fake" .ipa package that QA will use for installing to simulator
                 sh "mkdir -p debug/Payload"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -112,11 +112,23 @@ platform :ios do
     desc "Upload for internal use"
     lane :upload_hockey do |options|
         build = Build.new(options: options, branch: git_branch)
+        changelog = ""
+
+        if build.playground_build
+            changelog = "Playground build for #{@git_branch}"
+        elsif build.last_commit.nil? || build.last_commit.empty? 
+            changelog = "No changelog available"
+        else
+            changelog = "Changes Since Last Build:\n" + changelog_from_git_commits(
+                between: [build.last_commit, "HEAD"],
+                pretty: "* [%an] %s",
+            )
+        end
         hockey(
           api_token: ENV["HOCKEY_APP_TOKEN"],
           public_identifier: build.hockey_app_id,
           ipa: "#{build.artifact_path(with_filename: true)}.ipa",
-          notes: build.changelog,
+          notes: changelog,
           notify: "0"
         )
     end
@@ -186,6 +198,10 @@ class Build
     end
 
     # Helpers
+
+    def playground_build
+        @build_type == "Playground"
+    end
 
     def appstore_build
         @build_type == "AppStore"
@@ -296,20 +312,6 @@ class Build
     end
 
     # Hockey
-
-    def changelog
-        if @build_type == "Playground"
-            "Playground build for #{@git_branch}"
-        elsif @last_commit.nil? || @last_commit.empty?
-            "No changelog available"
-        else
-            "Changes Since Last Build:\n" + changelog_from_git_commits(
-                between: [last_commit, "HEAD"],
-                pretty: "* [%an] %s",
-            )
-        end
-
-    end
 
     def hockey_app_id
         case @build_type

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -174,7 +174,7 @@ class Build
         end
         build_type = options[:build_type]
         if build_type.nil? 
-            UI.user_error! "Pass buid_type parameter, e.g. fastlane build build_type:Development"
+            UI.user_error! "Pass build_type parameter, e.g. fastlane build build_type:Development"
         end
 
         @last_commit = options[:last_commit]


### PR DESCRIPTION
## What's new in this PR?

### Issues

The pipeline failed because of a missing method

### Causes

`changelog_from_git_commits` method is not available when called from a different class.

### Solutions

Move logic to create changelog outside of `Build` class.

### Notes

Also fixed a small issue that simulator builds were larger than needed. It contained some data left over from running tests. We now clean before building simulator build.
