### PR TITLE
Fix search for unread conversations not iterating over all conversations

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
@@ -456,9 +456,11 @@ class SettingsCellDescriptorFactory {
         guard let controller = UIApplication.shared.wr_topmostController(onlyFullScreen: false) else { return }
         let alert = UIAlertController(title: nil, message: "", preferredStyle: .alert)
 
-        if let convo = (ZMConversationList.conversations(inUserSession: userSession) as! [ZMConversation])
-            .first(where: { predicate.evaluate(with: $0) })
-        {
+        let uiMOC = userSession.managedObjectContext
+        let fetchRequest = NSFetchRequest<ZMConversation>(entityName: ZMConversation.entityName())
+        let allConversations = uiMOC?.fetchOrAssert(request: fetchRequest)
+        
+        if let convo = allConversations?.first(where: { predicate.evaluate(with: $0) }) {
             alert.message = ["Found an unread conversation:",
                        "\(convo.displayName)",
                         "<\(convo.remoteIdentifier?.uuidString ?? "n/a")>"


### PR DESCRIPTION
## What's new in this PR?

### Issues

Debug tool for finding unread conversation was sometimes reporting "no unread conversations" when the badge count was > 0.

### Causes

`ZMConversationList.conversations(inUserSession:)` is not returning all converations.

### Solutions

Do a fetch request for all conversations.
