### PR TITLE
Fix: branch was not present in changelog when making playground build

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -115,7 +115,7 @@ platform :ios do
         changelog = ""
 
         if build.playground_build
-            changelog = "Playground build for #{@git_branch}"
+            changelog = "Playground build for #{build.git_branch}"
         elsif build.last_commit.nil? || build.last_commit.empty? 
             changelog = "No changelog available"
         else


### PR DESCRIPTION
## What's new in this PR?

### Issues

Playground build in hockey does not contain a real changelog, but should have the branch name it was built from. It was missing.

### Causes

Wrong variable was used to get the branch name from. 
