### PR TITLE
ZIOS-11286: Add properties to disable "For Companies" login button

### DIFF
--- a/Wire-iOS Tests/Authentication/MockAuthenticationFeatureProvider.swift
+++ b/Wire-iOS Tests/Authentication/MockAuthenticationFeatureProvider.swift
@@ -21,4 +21,5 @@
 class MockAuthenticationFeatureProvider: AuthenticationFeatureProvider {
     var allowOnlyEmailLogin: Bool = false
     var allowCompanyLogin: Bool = true
+    var allowDirectCompanyLogin: Bool = true
 }

--- a/Wire-iOS/Sources/Authentication/AuthenticationFeatureProvider.swift
+++ b/Wire-iOS/Sources/Authentication/AuthenticationFeatureProvider.swift
@@ -30,6 +30,9 @@ protocol AuthenticationFeatureProvider {
     /// Whether we allow company login.
     var allowCompanyLogin: Bool { get }
 
+    /// Whether we allow the users to log in with their company manually, or only enable SSO links.
+    var allowDirectCompanyLogin: Bool { get }
+
 }
 
 /**
@@ -48,6 +51,10 @@ class BuildSettingAuthenticationFeatureProvider: AuthenticationFeatureProvider {
 
     var allowCompanyLogin: Bool {
         return CompanyLoginController.isCompanyLoginEnabled
+    }
+
+    var allowDirectCompanyLogin: Bool {
+        return allowCompanyLogin && !allowOnlyEmailLogin
     }
 
 }

--- a/Wire-iOS/Sources/Authentication/AuthenticationInterfaceBuilder.swift
+++ b/Wire-iOS/Sources/Authentication/AuthenticationInterfaceBuilder.swift
@@ -93,7 +93,7 @@ class AuthenticationInterfaceBuilder {
             let viewController = makeCredentialsViewController(for: .login(credentialsFlowType, prefill))
 
             // Add the item to start company login if needed.
-            if featureProvider.allowCompanyLogin {
+            if featureProvider.allowDirectCompanyLogin {
                 viewController.setRightItem("signin.company_idp.button.title".localized, withAction: .startCompanyLogin(code: nil), accessibilityID: "companyLoginButton")
             }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

We want to hide the "For Companies" button on the login screen for clients that allow only email login. At the same time, we need to keep supporting SSO links and clipboard auto-detect for future proofing.

### Solutions

Add the `allowDirectCompanyLogin` property to the authentication feature provider protocol. It checks whether we allow company login and don't disallow email-only login.