### PR TITLE
Using correct icon for AVS build

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -335,8 +335,7 @@ class Build
     end
 
     def iconset_name
-        case @build_type
-        when "Playground"
+        if playground_build || avs_build
             "Development"
         else
             @build_type


### PR DESCRIPTION
## What's new in this PR?

### Issues

AVS build did not have the extra information on the icon.

### Causes

We don't have a separate icon for AVS and it could not find one.

### Solutions

Use develop build icon instead.

