### PR TITLE
Don't attempt to scroll when table view is empty

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
@@ -266,6 +266,8 @@ final class ConversationTableViewDataSource: NSObject {
     }
     
     func scroll(toIndex indexToShow: Int, completion: ((UIView)->())? = .none) {
+        guard tableView.numberOfSections > 0 else { return }
+        
         let rowIndex = tableView.numberOfCells(inSection: indexToShow) - 1
         let cellIndexPath = IndexPath(row: rowIndex, section: indexToShow)
         


### PR DESCRIPTION
## What's new in this PR?

### Issues

We would crash if you tapped in the input bar in a conversation after deleting all the messages.

### Causes

App crashes when attempting to scroll to index 0 which doesn't exist because the table view is empty.

### Solutions

Guard against table view being empty.