### PR TITLE
Fix keyboard not appearing after tapping input bar 

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -319,7 +319,7 @@
 
 - (BOOL)isScrolledToBottom
 {
-    return self.dataSource.hasNewerMessagesToLoad && self.tableView.contentOffset.y + self.tableView.correctedContentInset.bottom <= 0;
+    return !self.dataSource.hasNewerMessagesToLoad && self.tableView.contentOffset.y + self.tableView.correctedContentInset.bottom <= 0;
 }
 #pragma mark - Actions
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

Keyboard doesn't appear when tapping the input bar after long pressing an image.

### Causes

`isScrolledToBottom` was returning `false` even though we are scrolled to the bottom. This meant that we were trying to scroll the tableview which blocked the input bar from getting the focus.

### Solutions

`hasNewerMessagesToLoad` should be `false` when we are scrolled to the bottom.