### PR TITLE
Fix sending status

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
@@ -479,7 +479,7 @@ extension ConversationTableViewDataSource {
             isTimeIntervalSinceLastMessageSignificant = false
         }
         
-        let isLastMessage = (index == 0) && !hasOlderMessagesToLoad
+        let isLastMessage = (index == 0) && !hasNewerMessagesToLoad
         return ConversationMessageContext(
             isSameSenderAsPrevious: isPreviousSenderSame(forMessage: message, at: index),
             isTimeIntervalSinceLastMessageSignificant: isTimeIntervalSinceLastMessageSignificant,


### PR DESCRIPTION
## What's new in this PR?

### Issues

The sending status wasn't displayed for the last message

### Causes

`isLastMessage` was evaluated to `false`, which was due to a mix up between `hasOlderMessagesToLoad ` and `hasNewerMessagesToLoad .

### Solutions

Replace `hasOlderMessagesToLoad` with `hasNewerMessagesToLoad`
