### PR TITLE
Fix force unwrap crash when loading older messages

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
@@ -323,15 +323,20 @@ final class ConversationTableViewDataSource: NSObject {
         
         // To avoid loosing scroll position:
         // 1. Remember the newest message now
-        let newestMessageBeforeReload = messages.first!
+        let newestMessageBeforeReload = messages.first
         // 2. Load more messages
         loadNewerMessages()
+        
         // 3. Get the index path of the message that should stay displayed
-        let indexPath = self.indexPath(for: newestMessageBeforeReload)!
-        // 4. Get the frame of that message
-        let indexPathRect = tableView.rectForRow(at: indexPath)
-        // 5. Update content offset so it stays visible. To reduce flickering compensate for empty space below the message
-        scrollView.contentOffset = CGPoint(x: 0, y: indexPathRect.minY - 16)        
+        if let newestMessageBeforeReload = newestMessageBeforeReload,
+           let indexPath = self.indexPath(for: newestMessageBeforeReload) {
+            
+            // 4. Get the frame of that message
+            let indexPathRect = tableView.rectForRow(at: indexPath)
+            
+            // 5. Update content offset so it stays visible. To reduce flickering compensate for empty space below the message
+            scrollView.contentOffset = CGPoint(x: 0, y: indexPathRect.minY - 16)
+        }
     }
     
     private func fetchRequest() -> NSFetchRequest<ZMMessage> {


### PR DESCRIPTION
## What's new in this PR?

### Issues

App would sometimes crash after scrolling.

### Causes

Stack trace show that we were force unwrapping an optional when attempting to load older messages.

### Solutions

Remove force unwraps.