### PR TITLE
ZIOS-11306: Fix regression crash when tapping on an unconnected user

### DIFF
--- a/Wire-iOS/Sources/Helpers/syncengine/ZMUser+Permissions.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMUser+Permissions.swift
@@ -51,6 +51,15 @@ extension UserType {
     
 }
 
+extension UserType {
+
+    /// Returns whether the current user (viewer) can see the devices list of another user.
+    func canSeeDevices(of otherUser: UserType) -> Bool {
+        return otherUser.isConnected || self.canAccessCompanyInformation(of: otherUser) || otherUser.isWirelessUser
+    }
+
+}
+
 /// Conform to this protocol to mark an object as being restricted. This
 /// indicates that the self user permissions need to be checked in order
 /// to use the object. By defining `requiredPermissions`, the rest of the

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Devices/ProfileDevicesViewController.h
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Devices/ProfileDevicesViewController.h
@@ -23,6 +23,7 @@
 @class ZMUser;
 @protocol ProfileDevicesViewControllerDelegate;
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface ProfileDevicesViewController : UITableViewController
 
@@ -39,3 +40,5 @@
 - (void)profileDevicesViewController:(ProfileDevicesViewController *)profileDevicesViewController didTapDetailForClient:(id)client;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Devices/ProfileDevicesViewController.m
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Devices/ProfileDevicesViewController.m
@@ -42,14 +42,13 @@
 
 - (instancetype)initWithUser:(ZMUser *)user
 {
-    if (!(self = [super init])) {
-        return nil;
+    if (self = [super initWithStyle:UITableViewStylePlain]) {
+        self.user = user;
+        if ([ZMUserSession sharedSession] != nil) {
+            self.userObserverToken = [UserChangeInfo addObserver:self forUser:self.user userSession:[ZMUserSession sharedSession]];
+        }
+        [self refreshSortedClientsWithSet:user.clients];
     }
-    self.user = user;
-    if ([ZMUserSession sharedSession] != nil) {
-        self.userObserverToken = [UserChangeInfo addObserver:self forUser:self.user userSession:[ZMUserSession sharedSession]];
-    }
-    [self refreshSortedClientsWithSet:user.clients];
     return self;
 }
 

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController+internal.h
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController+internal.h
@@ -29,19 +29,20 @@
 #import "AccentColorProvider.h"
 #import "ProfileDevicesViewController.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface ProfileViewController () <ZMUserObserver>
 
 @property (nonatomic, readonly) ProfileViewControllerContext context;
-@property (nonatomic, readonly) ZMConversation *conversation;
-@property (nonatomic) id<ActionController> actionsController;
+@property (nonatomic, readonly, nullable) ZMConversation *conversation;
+
 @property (nonatomic) ProfileFooterView *profileFooterView;
 @property (nonatomic) IncomingRequestFooterView *incomingRequestFooter;
-
 @property (nonatomic) UserNameDetailView *usernameDetailsView;
 @property (nonatomic) ProfileTitleView *profileTitleView;
 @property (nonatomic) TabBarController *tabsController;
 
-- (ZMUser *)fullUser;
+- (ZMUser * _Nullable)fullUser;
 - (void)updateShowVerifiedShield;
 
 @end
@@ -49,4 +50,4 @@
 @interface ProfileViewController (DevicesListDelegate) <ProfileDevicesViewControllerDelegate>
 @end
 
-
+NS_ASSUME_NONNULL_END

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.h
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.h
@@ -50,8 +50,6 @@ typedef NS_ENUM(NSInteger, ProfileViewControllerContext) {
 
 @end
 
-
-
 @interface ProfileViewController : UIViewController
 
 - (instancetype)initWithUser:(id<UserType, AccentColorProvider>)user viewer:(id<UserType, AccentColorProvider>)viewer context:(ProfileViewControllerContext)context;


### PR DESCRIPTION
## What's new in this PR?

### Issues

Tapping on an unconnected user crashed the app.

### Causes

We force-unwrapped the `fullUser()` property when determining whether the

### Solutions

- Move the checks to `UserType` so that we don't need to get the full user when making the tabs.
- Annotate the view controller header with nullability to avoid crashes in the future.

We also fix an issue where we'd try to show the devices for a guest from another team (wouldn't show any because ).