### PR TITLE
Fix: User profile deep link does not show rich profile

### DIFF
--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -599,6 +599,9 @@ extension AppRootViewController: SessionManagerURLHandlerDelegate {
             case .invalidConversationLink:
                 presentAlert(title: "url_action.invalid_conversation.title".localized,
                              message: "url_action.invalid_conversation.message".localized)
+            case .notLoggedIn:
+                ///TODO: alert for this case
+                break
             }
         case .connectBot:
             guard let _ = ZMUser.selfUser().team else {

--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -599,9 +599,6 @@ extension AppRootViewController: SessionManagerURLHandlerDelegate {
             case .invalidConversationLink:
                 presentAlert(title: "url_action.invalid_conversation.title".localized,
                              message: "url_action.invalid_conversation.message".localized)
-            case .notLoggedIn:
-                ///TODO: alert for this case
-                break
             }
         case .connectBot:
             guard let _ = ZMUser.selfUser().team else {

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsContentController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsContentController.swift
@@ -115,7 +115,7 @@ final class ProfileDetailsContentController: NSObject, UITableViewDataSource, UI
     
     /// Updates the content for the current configuration.
     private func updateContent() {
-        switch (conversation?.conversationType, context) {
+        switch conversation?.conversationType ?? .oneOnOne {
         case (.group?, _),
              (_, .profileViewer):
             let richProfile = user.richProfile

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsContentController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsContentController.swift
@@ -33,7 +33,7 @@ protocol ProfileDetailsContentControllerDelegate: class {
  * An object that controls the content to display in the user details screen.
  */
 
-class ProfileDetailsContentController: NSObject, UITableViewDataSource, UITableViewDelegate, ZMUserObserver {
+final class ProfileDetailsContentController: NSObject, UITableViewDataSource, UITableViewDelegate, ZMUserObserver {
     
     /**
      * The type of content that can be displayed in the profile details.
@@ -55,7 +55,10 @@ class ProfileDetailsContentController: NSObject, UITableViewDataSource, UITableV
     
     /// The conversation where the profile details will be displayed.
     let conversation: ZMConversation?
-        
+
+    /// The context of this screen
+    let context: ProfileViewControllerContext
+
     // MARK: - Accessing the Content
     
     /// The contents to display for the current configuration.
@@ -79,10 +82,15 @@ class ProfileDetailsContentController: NSObject, UITableViewDataSource, UITableV
      * - parameter conversation: The conversation where the profile details will be displayed.
      */
     
-    init(user: GenericUser, viewer: GenericUser, conversation: ZMConversation?) {
+    init(user: GenericUser,
+         viewer: GenericUser,
+         conversation: ZMConversation?,
+         context: ProfileViewControllerContext) {
         self.user = user
         self.viewer = viewer
         self.conversation = conversation
+        self.context = context
+
         super.init()
         configureObservers()
         updateContent()
@@ -107,8 +115,8 @@ class ProfileDetailsContentController: NSObject, UITableViewDataSource, UITableV
     
     /// Updates the content for the current configuration.
     private func updateContent() {
-        switch conversation?.conversationType {
-        case .group?:
+        switch (conversation?.conversationType, context) {
+        case (.group?, _):
             let richProfile = user.richProfile
             if viewerCanAccessRichProfile, !richProfile.isEmpty {
                 // If there is rich profile data and the user is allowed to see it, display it.
@@ -118,7 +126,8 @@ class ProfileDetailsContentController: NSObject, UITableViewDataSource, UITableV
                 contents = []
             }
 
-        case .oneOnOne?:
+        case (.oneOnOne?, _),
+             (_, .profileViewer):
             let readReceiptsEnabled = viewer.readReceiptsEnabled
             let richProfile = user.richProfile
             if viewerCanAccessRichProfile, !richProfile.isEmpty {

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsContentController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsContentController.swift
@@ -115,9 +115,8 @@ final class ProfileDetailsContentController: NSObject, UITableViewDataSource, UI
     
     /// Updates the content for the current configuration.
     private func updateContent() {
-        switch conversation?.conversationType ?? .oneOnOne {
-        case (.group?, _),
-             (_, .profileViewer):
+        switch conversation?.conversationType ?? .group {
+        case .group:
             let richProfile = user.richProfile
             if viewerCanAccessRichProfile, !richProfile.isEmpty {
                 // If there is rich profile data and the user is allowed to see it, display it.
@@ -127,7 +126,7 @@ final class ProfileDetailsContentController: NSObject, UITableViewDataSource, UI
                 contents = []
             }
 
-        case (.oneOnOne?, _):
+        case .oneOnOne:
             let readReceiptsEnabled = viewer.readReceiptsEnabled
             let richProfile = user.richProfile
             if viewerCanAccessRichProfile, !richProfile.isEmpty {
@@ -137,6 +136,7 @@ final class ProfileDetailsContentController: NSObject, UITableViewDataSource, UI
                 // If there is no rich profile data, show the read receipts.
                 contents = [.readReceiptsStatus(enabled: readReceiptsEnabled)]
             }
+
         default:
             contents = []
         }

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsContentController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsContentController.swift
@@ -56,9 +56,6 @@ final class ProfileDetailsContentController: NSObject, UITableViewDataSource, UI
     /// The conversation where the profile details will be displayed.
     let conversation: ZMConversation?
 
-    /// The context of this screen
-    let context: ProfileViewControllerContext
-
     // MARK: - Accessing the Content
     
     /// The contents to display for the current configuration.
@@ -84,12 +81,10 @@ final class ProfileDetailsContentController: NSObject, UITableViewDataSource, UI
     
     init(user: GenericUser,
          viewer: GenericUser,
-         conversation: ZMConversation?,
-         context: ProfileViewControllerContext) {
+         conversation: ZMConversation?) {
         self.user = user
         self.viewer = viewer
         self.conversation = conversation
-        self.context = context
 
         super.init()
         configureObservers()

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsContentController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsContentController.swift
@@ -116,7 +116,8 @@ final class ProfileDetailsContentController: NSObject, UITableViewDataSource, UI
     /// Updates the content for the current configuration.
     private func updateContent() {
         switch (conversation?.conversationType, context) {
-        case (.group?, _):
+        case (.group?, _),
+             (_, .profileViewer):
             let richProfile = user.richProfile
             if viewerCanAccessRichProfile, !richProfile.isEmpty {
                 // If there is rich profile data and the user is allowed to see it, display it.
@@ -126,8 +127,7 @@ final class ProfileDetailsContentController: NSObject, UITableViewDataSource, UI
                 contents = []
             }
 
-        case (.oneOnOne?, _),
-             (_, .profileViewer):
+        case (.oneOnOne?, _):
             let readReceiptsEnabled = viewer.readReceiptsEnabled
             let richProfile = user.richProfile
             if viewerCanAccessRichProfile, !richProfile.isEmpty {
@@ -137,7 +137,6 @@ final class ProfileDetailsContentController: NSObject, UITableViewDataSource, UI
                 // If there is no rich profile data, show the read receipts.
                 contents = [.readReceiptsStatus(enabled: readReceiptsEnabled)]
             }
-
         default:
             contents = []
         }

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsViewController.swift
@@ -33,9 +33,6 @@ final class ProfileDetailsViewController: UIViewController, Themeable {
     /// The conversation where the profile is displayed.
     let conversation: ZMConversation?
 
-    /// The context of this screen
-    let context: ProfileViewControllerContext
-
     /**
      * The object that calculates and controls the content to display in the user
      * details screen. It is also responsible for reacting to user profile updates
@@ -69,17 +66,14 @@ final class ProfileDetailsViewController: UIViewController, Themeable {
     
     init(user: GenericUser,
          viewer: GenericUser,
-         conversation: ZMConversation?,
-         context: ProfileViewControllerContext) {
+         conversation: ZMConversation?) {
         self.user = user
         self.viewer = viewer
         self.conversation = conversation
-        self.context = context
         self.profileView = ProfileView(user: user, options: [.hideUsername, .hideHandle, .hideTeamName])
         self.contentController = ProfileDetailsContentController(user: user,
                                                                  viewer: viewer,
-                                                                 conversation: conversation,
-                                                                 context: context)
+                                                                 conversation: conversation)
         super.init(nibName: nil, bundle: nil)
         self.contentController.delegate = self
     }

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsViewController.swift
@@ -33,6 +33,9 @@ final class ProfileDetailsViewController: UIViewController, Themeable {
     /// The conversation where the profile is displayed.
     let conversation: ZMConversation?
 
+    /// The context of this screen
+    let context: ProfileViewControllerContext
+
     /**
      * The object that calculates and controls the content to display in the user
      * details screen. It is also responsible for reacting to user profile updates
@@ -64,12 +67,19 @@ final class ProfileDetailsViewController: UIViewController, Themeable {
      * - parameter conversation: The conversation where the profile is displayed.
      */
     
-    init(user: GenericUser, viewer: GenericUser, conversation: ZMConversation?) {
+    init(user: GenericUser,
+         viewer: GenericUser,
+         conversation: ZMConversation?,
+         context: ProfileViewControllerContext) {
         self.user = user
         self.viewer = viewer
         self.conversation = conversation
+        self.context = context
         self.profileView = ProfileView(user: user, options: [.hideUsername, .hideHandle, .hideTeamName])
-        self.contentController = ProfileDetailsContentController(user: user, viewer: viewer, conversation: conversation)
+        self.contentController = ProfileDetailsContentController(user: user,
+                                                                 viewer: viewer,
+                                                                 conversation: conversation,
+                                                                 context: context)
         super.init(nibName: nil, bundle: nil)
         self.contentController.delegate = self
     }

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController+Extension.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController+Extension.swift
@@ -43,8 +43,7 @@ extension ProfileViewController {
     func setupProfileDetailsViewController() -> ProfileDetailsViewController {
         let profileDetailsViewController = ProfileDetailsViewController(user: bareUser,
                                                                         viewer: viewer,
-                                                                        conversation: conversation,
-                                                                        context: context)
+                                                                        conversation: conversation)
         profileDetailsViewController.title = "profile.details.title".localized
 
         return profileDetailsViewController

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController+Extension.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController+Extension.swift
@@ -41,7 +41,10 @@ extension ProfileViewController {
     }
 
     func setupProfileDetailsViewController() -> ProfileDetailsViewController {
-        let profileDetailsViewController = ProfileDetailsViewController(user: bareUser, viewer: viewer, conversation: conversation)
+        let profileDetailsViewController = ProfileDetailsViewController(user: bareUser,
+                                                                        viewer: viewer,
+                                                                        conversation: conversation,
+                                                                        context: context)
         profileDetailsViewController.title = "profile.details.title".localized
 
         return profileDetailsViewController


### PR DESCRIPTION
## What's new in this PR?

### Issues

User profile deep link does not show rich profile.

### Causes

The rich profile section's visibility is despended on the `conversation` property, but it is nil in this case.

### Solutions

Add the `ProfileViewControllerContext` argument when creating `ProfileDetailsContentController`. Show the rich profile section when the `context` is `.ProfileViewer`.