### PR TITLE
ZIOS-11309: Fix regression with offset of message when tapping on search result

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageAction.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageAction.swift
@@ -109,8 +109,7 @@ extension ConversationContentViewController {
         case .like:
             // The new liked state, the value is flipped
             let updatedLikedState = !Message.isLikedMessage(message)
-
-            guard let indexPath = dataSource?.indexPath(for: message) else { return }
+            guard let indexPath = dataSource?.topIndexPath(for: message) else { return }
 
             let selectedMessage = dataSource?.selectedMessage
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

When tapping on a search result, the message would be positioned right under the viewport of the table view.

### Causes

We used the index 0 of the message in the message section to scroll. But the table is upside down, so the cell at the "visible" index 0 is actually the cell with the last index in the section.

### Solutions

Fix the calculation of the top message index and fix wrong usage of this function.