### PR TITLE
Fix: Nothing happens when tapping OPEN PROFILE on deeplink self user profile popup

### DIFF
--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController+Extension.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController+Extension.swift
@@ -165,8 +165,10 @@ extension ProfileViewController: ProfileFooterViewDelegate, IncomingRequestFoote
             leftViewControllerRevealed = true
         }
 
-        transitionToListAndEnqueue(leftViewControllerRevealed: leftViewControllerRevealed) {
-            ZClientViewController.shared()?.conversationListViewController.presentSettings()
+        dismiss(animated: true){ [weak self] in
+            self?.transitionToListAndEnqueue(leftViewControllerRevealed: leftViewControllerRevealed) {
+                ZClientViewController.shared()?.conversationListViewController.presentSettings()
+            }
         }
     }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

The self-profile screen is not shown after the open self profile button is tapped. (The app is launched with the self profile deep link)

### Causes

`ProfileViewController` is not dismissed before transited to setting screen.

### Solutions

Dismiss `ProfileViewController` itself before the transition.