### PR TITLE
Don't scroll to bottom if already at the bottom

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Scrolling.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Scrolling.swift
@@ -43,6 +43,7 @@ extension ConversationContentViewController {
     }
     
     @objc public func scrollToBottom() {
+        guard !isScrolledToBottom else { return }
         self.dataSource.scrollToBottom()
     }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

On older phones the scroll position would be lost after sending a link preview

### Causes

Before sending message we always scroll to the bottom. This method recently changed implementation so that it now reload the messages, this disrupts the scroll position.

### Solutions

Don't call method which reload the messages if we are already scrolled to the bottom.