### PR TITLE
Fix grouped call system messages not showing all timestamps

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxDataSource.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxDataSource.swift
@@ -109,17 +109,17 @@ class MessageToolboxDataSource {
            message.systemMessageData?.systemMessageType == .missedCall {
             content = .callList(makeCallList())
         }
-        // 1) Failed to send
+        // 2) Failed to send
         else if failedToSend && isSentBySelfUser {
             let detailsString = "content.system.failedtosend_message_timestamp".localized && attributes
             content = .sendFailure(detailsString)
         }
-        // 2) Likers
+        // 3) Likers
         else if !showTimestamp {
             let text = makeReactionsLabel(with: likers, widthConstraint: widthConstraint)
             content = .reactions(text, likers: likers)
         }
-        // 3) Timestamp
+        // 4) Timestamp
         else {
             let (timestamp, status, countdown) = makeDetailsString()
             content = .details(timestamp: timestamp, status: status, countdown: countdown, likers: likers)

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
@@ -254,10 +254,24 @@ final class MessageToolboxView: UIView {
         }
 
         switch dataSource.content {
+            
+        case .callList(let callListString):
+            updateContentStack(to: newPosition, animated: animated) {
+                self.detailsLabel.attributedText = callListString
+                self.detailsLabel.isHidden = false
+                self.detailsLabel.numberOfLines = 0
+                self.statusLabel.isHidden = true
+                self.timestampSeparatorLabel.isHidden = true
+                self.deleteButton.isHidden = true
+                self.resendButton.isHidden = true
+                self.statusSeparatorLabel.isHidden = true
+                self.countdownLabel.isHidden = true
+            }
         case .reactions(let reactionsString, _):
             updateContentStack(to: newPosition, animated: animated) {
                 self.detailsLabel.attributedText = reactionsString
                 self.detailsLabel.isHidden = false
+                self.detailsLabel.numberOfLines = 1
                 self.statusLabel.isHidden = true
                 self.timestampSeparatorLabel.isHidden = true
                 self.deleteButton.isHidden = true
@@ -270,6 +284,7 @@ final class MessageToolboxView: UIView {
             updateContentStack(to: newPosition, animated: animated) {
                 self.detailsLabel.attributedText = detailsString
                 self.detailsLabel.isHidden = false
+                self.detailsLabel.numberOfLines = 1
                 self.statusLabel.isHidden = true
                 self.timestampSeparatorLabel.isHidden = false
                 self.deleteButton.isHidden = false
@@ -282,6 +297,7 @@ final class MessageToolboxView: UIView {
             updateContentStack(to: newPosition, animated: animated) {
                 self.detailsLabel.attributedText = timestamp
                 self.detailsLabel.isHidden = timestamp == nil
+                self.detailsLabel.numberOfLines = 1
                 self.statusLabel.attributedText = status
                 self.statusLabel.isHidden = status == nil
                 self.timestampSeparatorLabel.isHidden = timestamp == nil || status == nil


### PR DESCRIPTION
## What's new in this PR?

### Issues

When multiple calls are made we group them together into one system message. When tapping on such a system message we should expand and show a timestamp for when each call was made but we only showed the first timestamp.

### Causes

Label was configured with `.numberOfLines = 1`

### Solutions

Configure label with `.numberOfLines = 0` when displaying the call list.