### PR TITLE
Show unread count for new conversations

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ZMConversation+Status.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ZMConversation+Status.swift
@@ -634,6 +634,10 @@ final internal class StartConversationMatcher: TypedConversationStatusMatcher {
         return (resultString && type(of: self).regularStyle).addAttributes(type(of: self).emphasisStyle, toSubstring: senderString)
     }
     
+    func icon(with status: ConversationStatus, conversation: ZMConversation) -> ConversationStatusIcon? {
+        return ConversationStatusIcon.unreadMessages(count: 1)
+    }
+    
     var combinesWith: [ConversationStatusMatcher] = []
 }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

When team 1:1 conversations are created they generate an unread dot. This unread state was however only indicated by the subtitle "x started a conversation with you", which wasn't very obvious and many people missed it. This resulted in users complaining about unread badges which won't go away after reading all messages.

### Solutions

Show an unread count for this scenario so that it's obvious that this conversation is unread.