### PR TITLE
Add missing options parameter

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -83,7 +83,7 @@ platform :ios do
     end
 
     desc "Upload to AppStore"
-    lane :upload_app_store do
+    lane :upload_app_store do |options|
         build = Build.new(options: options)
 
         sh "cp ../Configuration/Appfile ."


### PR DESCRIPTION
## What's new in this PR?

### Issues

App Store upload fails

### Causes

`Could not find action, lane or variable 'options'. Check out the documentation for more details: https://docs.fastlane.tools/actions`

### Solutions

Add missing options parameter