### PR TITLE
Fix crash when calling showLoadingScreen before view is loaded

### DIFF
--- a/Wire-iOS/Sources/UserInterface/LaunchImage/LaunchImageViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/LaunchImage/LaunchImageViewController.swift
@@ -24,8 +24,8 @@ class LaunchImageViewController: UIViewController {
     private var shouldShowLoadingScreenOnViewDidLoad = false
 
     private var contentView: UIView!
-    private var loadingScreenLabel: UILabel!
-    private var activityIndicator: ProgressSpinner!
+    private let loadingScreenLabel = UILabel()
+    private let activityIndicator = ProgressSpinner()
 
     /// Convenience method for showing the @c activityIndicator and @c loadingScreenLabel and start the spinning animation
     func showLoadingScreen() {
@@ -54,11 +54,9 @@ class LaunchImageViewController: UIViewController {
             contentView = nibView
         }
 
-        activityIndicator = ProgressSpinner()
         activityIndicator.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(activityIndicator)
 
-        loadingScreenLabel = UILabel()
         loadingScreenLabel.font = .systemFont(ofSize: 12)
         loadingScreenLabel.textColor = .white
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

App would would crash when switching account 

### Causes

If the account need migration we will show the launch screen with a spinner

```
case .migrating:
let launchImageViewController = LaunchImageViewController()
launchImageViewController.showLoadingScreen()
```

This will trigger a force unwrap since the views are not created yet.

### Solutions

Make views non optional by creating them on init.
