### PR TITLE
Revert AVS version to 4.9.9

### DIFF
--- a/Wire-iOS/Sources/Helpers/sound/AVSMediaManager+Additions.m
+++ b/Wire-iOS/Sources/Helpers/sound/AVSMediaManager+Additions.m
@@ -67,12 +67,12 @@ static NSDictionary *MediaManagerSoundConfig = nil;
     AVSMediaManager *mediaManager = AVSMediaManager.sharedInstance;
     
     // Unregister all previous custom sounds
-    [mediaManager unregisterMediaByName:MediaManagerSoundFirstMessageReceivedSound];
-    [mediaManager unregisterMediaByName:MediaManagerSoundMessageReceivedSound];
-    [mediaManager unregisterMediaByName:MediaManagerSoundRingingFromThemInCallSound];
-    [mediaManager unregisterMediaByName:MediaManagerSoundRingingFromThemSound];
-    [mediaManager unregisterMediaByName:MediaManagerSoundOutgoingKnockSound];
-    [mediaManager unregisterMediaByName:MediaManagerSoundIncomingKnockSound];
+    [mediaManager registerUrl:nil forMedia:MediaManagerSoundFirstMessageReceivedSound];
+    [mediaManager registerUrl:nil forMedia:MediaManagerSoundMessageReceivedSound];
+    [mediaManager registerUrl:nil forMedia:MediaManagerSoundRingingFromThemInCallSound];
+    [mediaManager registerUrl:nil forMedia:MediaManagerSoundRingingFromThemSound];
+    [mediaManager registerUrl:nil forMedia:MediaManagerSoundOutgoingKnockSound];
+    [mediaManager registerUrl:nil forMedia:MediaManagerSoundIncomingKnockSound];
     
     [mediaManager registerMediaFromConfiguration:MediaManagerSoundConfig
                                      inDirectory:audioDir];

--- a/avs-versions
+++ b/avs-versions
@@ -17,4 +17,4 @@
 # along with this program. If not, see http://www.gnu.org/licenses/.
 #
 
-export APPSTORE_AVS_VERSION=4.9.12
+export APPSTORE_AVS_VERSION=4.9.9


### PR DESCRIPTION
## What's new in this PR?

We don't want to upgrade to AVS 4.9.12 just yet so we need to downgrade.
