### PR TITLE
Wrap request to refresh message links in enqueue changes

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationTextMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationTextMessageCell.swift
@@ -178,7 +178,9 @@ extension ConversationTextMessageCellDescription {
 
         // Refetch the link attachments if needed
         if Settings.shared()?.disableLinkPreviews != true {
-            message.refetchLinkAttachmentsIfNeeded()
+            ZMUserSession.shared()?.performChanges {
+                message.refetchLinkAttachmentsIfNeeded()
+            }
         }
 
         // Text parsing


### PR DESCRIPTION
## What's new in this PR?

### Issues

We were not saving the YouTube links and for old messages when scrolling.

### Causes

We did not wrap the call to `message.refetchLinkAttachmentsIfNeeded()` in the session changes enqueuing, which means the data was not saved after the message was deallocated.

### Solutions

Wrap in `ZMUserSession.performChanges`.