### PR TITLE
fix: UI freezes when creating a cell for message

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationTextMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationTextMessageCell.swift
@@ -178,7 +178,7 @@ extension ConversationTextMessageCellDescription {
 
         // Refetch the link attachments if needed
         if Settings.shared()?.disableLinkPreviews != true {
-            ZMUserSession.shared()?.performChanges {
+            ZMUserSession.shared()?.enqueueChanges {
                 message.refetchLinkAttachmentsIfNeeded()
             }
         }


### PR DESCRIPTION
## What's new in this PR?

Fixed the issue caused by `performChanges` blocking UI thread when creating a message cell.