### PR TITLE
Crash on markdown links

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/NSAttributedString+MessageFormatting.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/NSAttributedString+MessageFormatting.swift
@@ -208,10 +208,9 @@ extension NSMutableAttributedString {
     
     func removeTrailingLink(for linkPreview: LinkMetadata) {
         let text = self.string
-        let linkPreviewStartIndex = text.index(text.startIndex, offsetBy: linkPreview.characterOffsetInText)
-
+        
         guard
-            let linkPreviewRange = text.range(of: linkPreview.originalURLString, range: linkPreviewStartIndex ..< text.endIndex),
+            let linkPreviewRange = text.range(of: linkPreview.originalURLString, options: .backwards, range: nil, locale: nil),
             linkPreviewRange.upperBound == text.endIndex
         else {
             return


### PR DESCRIPTION
## What's new in this PR?

### Issues

App crashes when on message with markdown link & link preview

### Causes

`linkPreview.characterOffsetInText` is referring to the offset before the text has been formatted for markdown, which results in an index of out of bounds crash.

### Solutions

Re-write method not to rely on `linkPreview.characterOffsetInText`