### PR TITLE
Appstore and RC builds

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -83,12 +83,12 @@ platform :ios do
     end
 
     desc "Upload to AppStore"
-    lane :upload_app_store do
+    lane :upload_app_store do |options|
         build = Build.new(options: options)
 
         sh "cp ../Configuration/Appfile ."
         deliver(
-            ipa: build.filename,
+            ipa: "#{build.artifact_path(with_filename: true)}.ipa",
             submit_for_review: false,
             automatic_release: false,
             force: true, # Skip HTML report verification

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -239,6 +239,10 @@ class Build
         @build_type == "AVS"
     end
 
+    def rc_build
+        @build_type == "RC"
+    end
+
     def debug_build
         @configuration == "Debug"
     end
@@ -344,6 +348,11 @@ class Build
         if !@avs_version.nil?
             prefix = "AVS:#{@avs_version}-"
         end
+        if rc_build
+            version = IO.foreach('../Wire-iOS/Resources/Configuration/Version.xcconfig').grep(/WIRE_SHORT_VERSION/).first.split(" = ")[1].chomp
+            prefix = "#{version}-"
+        end
+
         prefix + @build_number
     end
 
@@ -354,6 +363,8 @@ class Build
     def iconset_name
         if playground_build || avs_build
             "Development"
+        elsif rc_build
+            "Release"
         else
             @build_type
         end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -138,6 +138,23 @@ platform :ios do
         )
     end
 
+    desc "Upload dSYMs for AppStore crash tracking"
+    lane :upload_hockey_appstore do |options|
+        build = Build.new(options: options)
+
+        if !build.appstore_build
+            UI.user_error! "This step is only relevant for AppStore builds"
+        end
+
+        hockey(
+          api_token: ENV["HOCKEY_APP_TOKEN"],
+          public_identifier: build.hockey_app_id,
+          dsym: "#{build.artifact_path(with_filename: true)}.app.dSYM.zip",
+          upload_dsym_only: true,
+          release_type: "1",
+          notify: "0"
+        )
+    end
 
     desc "Run post-test tasks"
     lane :post_test do


### PR DESCRIPTION
## What's new in this PR?

### Issues

The last piece was missing in migrating build scripts - uploading app to AppStore. This PR adds the functionality missing to finish this.

### Solutions

Added extra information to RC build icon - app version. Also added a separate Hockey step that uploads only dSYMs for crash tracking.

