### PR TITLE
Restore missing cancel request button

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+Constraints.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+Constraints.swift
@@ -30,21 +30,23 @@ extension ConversationViewController {
         contentViewController.tableView.isScrollEnabled = !outgoingConnection
 
 
-        guard let outgoingConnectionViewController = outgoingConnectionViewController else {
-            return
-        }
-
         if outgoingConnection {
+            if outgoingConnectionViewController != nil {
+                return
+            }
+            
             createOutgoingConnectionViewController()
-
-            addToSelf(outgoingConnectionViewController)
-
-            outgoingConnectionViewController.view.translatesAutoresizingMaskIntoConstraints = false
-            outgoingConnectionViewController.view.fitInSuperview(exclude: [.top])
+            
+            if let outgoingConnectionViewController = outgoingConnectionViewController {
+                outgoingConnectionViewController.willMove(toParent: self)
+                view.addSubview(outgoingConnectionViewController.view)
+                addChild(outgoingConnectionViewController)
+                outgoingConnectionViewController.view.fitInSuperview(exclude: [.top])
+            }
         } else {
-            outgoingConnectionViewController.willMove(toParent: nil)
-            outgoingConnectionViewController.view.removeFromSuperview()
-            outgoingConnectionViewController.removeFromParent()
+            outgoingConnectionViewController?.willMove(toParent: nil)
+            outgoingConnectionViewController?.view.removeFromSuperview()
+            outgoingConnectionViewController?.removeFromParent()
             self.outgoingConnectionViewController = nil
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -195,6 +195,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
 - (void)createOutgoingConnectionViewController
 {
     self.outgoingConnectionViewController = [[OutgoingConnectionViewController alloc] init];
+    self.outgoingConnectionViewController.view.translatesAutoresizingMaskIntoConstraints = NO;
     ZM_WEAK(self);
     self.outgoingConnectionViewController.buttonCallback = ^(OutgoingConnectionBottomBarAction action) {
         ZM_STRONG(self);
@@ -211,8 +212,6 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
 
         [self openConversationList];
     };
-
-    self.outgoingConnectionViewController.view.translatesAutoresizingMaskIntoConstraints = NO;
 }
 
 - (void)createConversationBarController


### PR DESCRIPTION
## What's new in this PR?

### Issues

Cancel request button was missing for outgoing connection request conversations.

### Causes

In correct guard statement prevented the `OutgoingConnectionViewController` from being created.

### Solutions

Revert code to previous logic.