### PR TITLE
Fix: Cannot see self profile via deeplink

### DIFF
--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -580,7 +580,13 @@ extension AppRootViewController: SessionManagerURLHandlerDelegate {
     func sessionManagerShouldExecuteURLAction(_ action: URLAction, callback: @escaping (Bool) -> Void) {
         switch action {
         case .openUserProfile(let id):
-            sessionManager?.showConnectionRequest(userId: id)
+            /// For self user, open the profile viewer without searching
+            if let selfUser = ZMUser.selfUser(),
+                id == selfUser.remoteIdentifier {
+                sessionManager?.showUserProfile(user: selfUser)
+            } else {
+                sessionManager?.showConnectionRequest(userId: id)
+            }
         case .openConversation(_, let conversation):
             if let conversation = conversation,
                let userSession = ZMUserSession.shared() {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Cannot see self-profile via deeplink.

### Causes

After https://github.com/wireapp/wire-ios/pull/3324, we always start searching for the userID fro user profile deep link, but self-user does not exist in search result.

### Solutions

directly open profile screen if the user id is self-user's id