### PR TITLE
fix: setDimensions return type

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordViewController.swift
@@ -226,7 +226,7 @@ final class AudioRecordViewController: UIViewController, AudioRecordBaseViewCont
         ]
 
         recordingDotViewVisible.append(contentsOf:
-            recordingDotView.setDimensions(length: 8, activate: false))
+            recordingDotView.setDimensions(length: 8, activate: false).array)
 
         NSLayoutConstraint.activate(recordingDotViewVisible)
 
@@ -244,7 +244,7 @@ final class AudioRecordViewController: UIViewController, AudioRecordBaseViewCont
                                         cancelButton.rightAnchor.constraint(equalTo: bottomContainerView.rightAnchor),
                                         buttonOverlay.rightAnchor.constraint(equalTo: cancelButton.leftAnchor, constant: -12)])
 
-        constraints.append(contentsOf: cancelButton.setDimensions(length: 56, activate: false))
+        constraints.append(contentsOf: cancelButton.setDimensions(length: 56, activate: false).array)
 
         NSLayoutConstraint.activate(constraints)
     }


### PR DESCRIPTION
## What's new in this PR?

Fix compiler error due to change of return type of `setDimensions` method.