### PR TITLE
Fix VoiceOver copy for profile picture

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -821,8 +821,8 @@
 "self.add_phone_number" = "Add phone number";
 "self.add_email_password" = "Add email address and password";
 
-"self.accessibility.profile_photo_image" = "Profile Photo";
-"self.accessibility.profile_photo_edit_button" = "Change Profile Photo";
+"self.accessibility.profile_photo_image" = "Profile picture";
+"self.accessibility.profile_photo_edit_button" = "Change profile picture";
 
 // About screen
 "about.tos.title"="Terms of Use";


### PR DESCRIPTION
Change "profile photo" to "profile picture" in the accessibility label for the profile picture view (requested by Astrid).