### PR TITLE
ZIOS-11343: Do not validate the format of the password used to log in

### DIFF
--- a/Wire-iOS Tests/AccessoryTextField/AccessoryTextFieldValidationTests.swift
+++ b/Wire-iOS Tests/AccessoryTextField/AccessoryTextFieldValidationTests.swift
@@ -84,8 +84,14 @@ final class AccessoryTextFieldValidateionTests: XCTestCase {
         sut.confirmButton.sendActions(for: .touchUpInside)
 
         // THEN
-        XCTAssertEqual(mockViewController.errorCounter, 1, "Should have an error", file: file, line: line)
-        XCTAssertEqual(mockViewController.successCounter, 0, "Should not have been success", file: file, line: line)
+        if case .none = expectedError {
+            XCTAssertEqual(mockViewController.errorCounter, 0, "Should have not have an error", file: file, line: line)
+            XCTAssertEqual(mockViewController.successCounter, 1, "Should have been a success", file: file, line: line)
+        } else {
+            XCTAssertEqual(mockViewController.errorCounter, 1, "Should have an error", file: file, line: line)
+            XCTAssertEqual(mockViewController.successCounter, 0, "Should not have been success", file: file, line: line)
+        }
+
         XCTAssertEqual(expectedError, mockViewController.lastError, "Error should be \(expectedError), was \(mockViewController.lastError)", file: file, line: line)
     }
 
@@ -184,18 +190,36 @@ final class AccessoryTextFieldValidateionTests: XCTestCase {
         checkError(textFieldType: type, text: text, expectedError: .tooLong(kind: type))
     }
 
-    func testThat7CharacterPasswordIsInvalid() {
+    func testThat7CharacterPasswordIsValid_Existing() {
         // GIVEN
         let type: AccessoryTextField.Kind = .password(isNew: false)
+        let text = String(repeating: "a", count: 7)
+
+        // WHEN & THEN
+        checkError(textFieldType: type, text: text, expectedError: .none)
+    }
+
+    func testThat129CharacterPasswordIsValid_Existing() {
+        // GIVEN
+        let type: AccessoryTextField.Kind = .password(isNew: false)
+        let text = String(repeating: "a", count: 129)
+
+        // WHEN & THEN
+        checkError(textFieldType: type, text: text, expectedError: .none)
+    }
+
+    func testThat7CharacterPasswordIsInvalid_New() {
+        // GIVEN
+        let type: AccessoryTextField.Kind = .password(isNew: true)
         let text = String(repeating: "a", count: 7)
 
         // WHEN & THEN
         checkError(textFieldType: type, text: text, expectedError: .tooShort(kind: type))
     }
 
-    func testThat129CharacterPasswordIsInvalid() {
+    func testThat129CharacterPasswordIsInvalid_New() {
         // GIVEN
-        let type: AccessoryTextField.Kind = .password(isNew: false)
+        let type: AccessoryTextField.Kind = .password(isNew: true)
         let text = String(repeating: "a", count: 129)
 
         // WHEN & THEN

--- a/Wire-iOS/Sources/Authentication/Interface/Helpers/TextFieldValidator.swift
+++ b/Wire-iOS/Sources/Authentication/Interface/Helpers/TextFieldValidator.swift
@@ -47,12 +47,18 @@ class TextFieldValidator {
             } else if !text.isEmail {
                 return .invalidEmail
             }
-        case .password:
-            if text.count > maxPasswordLength {
-                return .tooLong(kind: kind)
-            } else if text.count < minPasswordLength {
-                return .tooShort(kind: kind)
+        case .password(let isNew):
+            if isNew {
+                if text.count > maxPasswordLength {
+                    return .tooLong(kind: kind)
+                } else if text.count < minPasswordLength {
+                    return .tooShort(kind: kind)
+                }
+            } else {
+                // If the user is signing in, we do not require any format
+                return text.isEmpty ? .tooShort(kind: kind) : .none
             }
+
         case .name:
             /// We should ignore leading/trailing whitespace when counting the number of characters in the string
             let stringToValidate = text.trimmingCharacters(in: .whitespacesAndNewlines)


### PR DESCRIPTION
## What's new in this PR?

### Issues

We previously required the users to enter a valid password in order to log in. But with the upcoming changes, we cannot guarantee that a password valid on a version will be valid on another version of the app.

### Solutions

Align with the behavior of web and require the user to enter a non-empty string on log in.