### PR TITLE
Fix: Tweets list shows "Safari/Twitter" even if Firefox is chosen for the browser

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -1003,7 +1003,7 @@
 "self.settings.link_options.maps.title" = "Locations";
 "self.settings.link_options.browser.title" = "Browser";
 
-"open_link.twitter.option.default" = "Safari / Twitter";
+"open_link.twitter.option.default" = "Browser / Twitter";
 "open_link.twitter.option.tweetbot" = "Tweetbot";
 "open_link.twitter.option.twitterrific" = "Twitterrific";
 


### PR DESCRIPTION
## What's new in this PR?

Fix the wording to prevent an incorrect combination for the open link target.