### PR TITLE
ZIOS-11368: Warn user about used email in team registration

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -1240,7 +1240,7 @@
 "registration.alert.account_exists.title" = "Account Exists";
 "registration.alert.account_exists.message_phone" = "The phone number you used to register is already linked to an account.\n\nUse another phone number, or try to log in if you own this account.";
 "registration.alert.account_exists.message_email" = "The email address you used to register is already linked to an account.\n\n Use another email address, or try to log in if you own this account.";
-"registration.alert.change_email_action" = "Change Email";
+"registration.alert.change_email_action" = "Register with Another Email";
 "registration.alert.change_phone_action" = "Register with Another Number";
 "registration.alert.change_signin_action" = "Log In";
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

Previously, when try to create a team with an email already tied to an account, there was no alert or warning, the spinner just disappeared.

### Causes

The event handler for activating the email during team registration was explicitly ignoring the error about used email, for some reason. 

### Solutions

- Update the aforementioned event handler to never ignore errors
- Update the "existing account policy" event handler to show the alert that allows the user to register with a different email or log in, as we do for personal accounts.
- Fix the copy for "register with another email" to match the one we use for phones.

This is what happens after the fix:

<img src="https://user-images.githubusercontent.com/16192914/56195053-780a0800-6034-11e9-97f0-f10e989cf989.png" height=600/>