### PR TITLE
ZIOS-11370: Call cell doesn't refresh after multiple calls

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCell.swift
@@ -22,7 +22,7 @@ import UIKit
 
 class ConversationSystemMessageCell: ConversationIconBasedCell, ConversationMessageCell {
 
-    struct Configuration {
+    struct Configuration: Equatable {
         let icon: UIImage?
         let attributedText: NSAttributedString?
         let showLine: Bool
@@ -466,6 +466,14 @@ class ConversationCallSystemMessageCellDescription: ConversationMessageCellDescr
 
         configuration = View.Configuration(icon: viewModel.image(), attributedText: viewModel.attributedTitle(), showLine: false)
         actionController = nil
+    }
+
+    func isConfigurationEqual(with other: Any) -> Bool {
+        guard let otherDescription = other as? ConversationCallSystemMessageCellDescription else {
+            return false
+        }
+
+        return self.configuration == otherDescription.configuration
     }
 }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

When the user makes multiple calls, the cell with the message wasn't updated.

### Solutions

This is mostly a hot fix for this specific case and we'll probably need to look into refreshing cells more in detail. But for now, we just update the comparison method used by DifferenceKit to force refreshing the call system message cell when the description text becomes different.