### PR TITLE
10658: Hide markdown and timeout buttons when editing

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarButtonState.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarButtonState.swift
@@ -44,7 +44,7 @@ extension ZMConversation {
     }
 
     public var ephemeralIndicatorButtonHidden: Bool {
-        return (conversationType != .oneOnOne && disableEphemeralSendingInGroups) || !ephemeral || disableEphemeralSending
+        return (conversationType != .oneOnOne && disableEphemeralSendingInGroups) || editing || !ephemeral || disableEphemeralSending
     }
 
     public var ephemeralIndicatorButtonEnabled: Bool {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Markdown.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Markdown.swift
@@ -29,9 +29,9 @@ extension ConversationInputBarViewController {
     }
     
     @objc public func updateMarkdownButton() {
-    
         let color: UIColor
-        
+        markdownButton.isHidden = inputBar.isEditing
+
         if inputBar.isMarkingDown {
             color = .accent()
         } else {


### PR DESCRIPTION
## What's new in this PR?

### Issues

When editing a message, the markdown and edit buttons were not hidden.