### PR TITLE
Remove configuration before building

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -6,6 +6,8 @@ platform :ios do
     desc "Fetch dependencies"
     lane :prepare do |options|
         build_type = options[:build_type]
+        # Delete configurations in case we switch ti different branch or repo
+        sh "rm -rf ../Configuration"
         if build_type.nil? 
             sh "cd .. && ./setup.sh"
         else


### PR DESCRIPTION
## What's new in this PR?

### Issues

Sometimes we want to use a custom branch/repo for configuration and it causes problems on build machine.

### Causes

When configuration is already there the build scripts only does `git pull`. If a previous build used custom branch of configuration then the regular build would end up using it as well.

### Solutions

Remove configuration when preparing for the build job.

