### PR TITLE
Fix size of Wire logo in share extension

### DIFF
--- a/Wire-iOS Share Extension/ShareExtensionViewController.swift
+++ b/Wire-iOS Share Extension/ShareExtensionViewController.swift
@@ -132,10 +132,11 @@ class ShareExtensionViewController: SLComposeServiceViewController {
     }
 
     private func setupNavigationBar() {
+        let iconSize = CGSize(width: 32, height: 26.3)
         guard let item = navigationController?.navigationBar.items?.first else { return }
         item.rightBarButtonItem?.action = #selector(appendPostTapped)
         item.rightBarButtonItem?.title = "share_extension.send_button.title".localized
-        item.titleView = UIImageView(image: WireStyleKit.imageOfLogo(color: .black))
+        item.titleView = UIImageView(image: WireStyleKit.imageOfLogo(color: .black).downscaling(to: iconSize))
     }
 
     private var authenticatedAccounts: [Account] {

--- a/WireCommonComponents/Icons/UIImage+StyleKit.swift
+++ b/WireCommonComponents/Icons/UIImage+StyleKit.swift
@@ -56,6 +56,27 @@ extension UIImage {
         return icon.makeImage(size: .custom(size), color: color)
     }
 
+    /**
+     * Resizes the image to the desired size.
+     * - parameter targetSize: The size you want to give to the image.
+     * - returns: The resized image.
+     * - warning: Passing a target size bigger than the size of the receiver is a
+     * programmer error and will cause an assertion failure.
+     */
+
+    @objc(imageByDownscalingToSize:)
+    public func downscaling(to targetSize: CGSize) -> UIImage {
+        assert(targetSize.width < size.width)
+        assert(targetSize.height < size.height)
+
+        let renderer = UIGraphicsImageRenderer(size: targetSize)
+
+        return renderer.image { context in
+            context.cgContext.scaleBy(x: targetSize.width / size.width, y: targetSize.height / size.height)
+            self.draw(at: .zero)
+        }
+    }
+
 }
 
 extension UIImageView {


### PR DESCRIPTION
## What's new in this PR?

### Issues

After the icons refactor, the size of the Wire logo on top of the share extension was broken.

### Solutions

Fix the size by downscaling the image.