### PR TITLE
Fix scroll position when opening conversation with many unread messages

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
@@ -85,7 +85,10 @@ final class ConversationTableViewDataSource: NSObject {
     }
     
     @objc public var messages: [ZMConversationMessage] {
-        return fetchController.fetchedObjects ?? []
+        // NOTE: We limit the number of messages to the fetchLimit since it's a known bug that the
+        // NSFetchResultsController doesn't always respect the fetchLimit.
+        // http://www.openradar.appspot.com/30381905
+        return Array(fetchController.fetchedObjects?.suffix(fetchController.fetchRequest.fetchLimit) ?? [])
     }
     
     var previousSections: [ArraySection<String, AnyConversationMessageCellDescription>] = []

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
@@ -85,10 +85,16 @@ final class ConversationTableViewDataSource: NSObject {
     }
     
     @objc public var messages: [ZMConversationMessage] {
-        // NOTE: We limit the number of messages to the fetchLimit since it's a known bug that the
-        // NSFetchResultsController doesn't always respect the fetchLimit.
+        // NOTE: We limit the number of messages to the fetchLimit since it's a known issue that the
+        // NSFetchResultsController doesn't always respect the fetchLimit, which becomes a problem if
+        // the fetchOffset > 0 since we will get unwanted table view updates.
         // http://www.openradar.appspot.com/30381905
-        return Array(fetchController.fetchedObjects?.suffix(fetchController.fetchRequest.fetchLimit) ?? [])
+        
+        if fetchController.fetchRequest.fetchOffset > 0 {
+            return Array(fetchController.fetchedObjects?.suffix(fetchController.fetchRequest.fetchLimit) ?? [])
+        } else {
+            return fetchController.fetchedObjects ?? []
+        }
     }
     
     var previousSections: [ArraySection<String, AnyConversationMessageCellDescription>] = []


### PR DESCRIPTION
## What's new in this PR?

### Issues

When opening a conversation with more unread messages than the size of the message window we would lose the scroll position.

### Causes

When opening a conversation with unread message the following things were happening:

1. Load initial message window of size 30
2. Load message window which includes the first unread message
3. Scroll to the first unread message
4. We change properties of some messages when they appear on screen and save (link attachments)
5. The fetch results controller monitors the save notifications and updates its `fetchObjects` property
6. We discover that there's new messages in the message window and perform a table view update

The problem is caused by the the last table view update which is happening because the `NSFetchResultsController` is not very strict about the `fetchLimit` and might include more messages if they are modified after the initial fetch.

### Solutions

Only work on the `fetchObjects` within the `fetchLimit` if the message window is detached from the bottom.

### Todo
- [x] Handle new incoming messages