### PR TITLE
Improve initial position when a loading conversation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Views/UpsideDownTableView+Scrolling.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/UpsideDownTableView+Scrolling.swift
@@ -29,7 +29,7 @@ extension UpsideDownTableView {
     func scroll(toIndex indexToShow: Int, completion: ((UIView)->())? = .none) {
         guard numberOfSections > 0 else { return }
         
-        let rowIndex = numberOfCells(inSection: indexToShow) - 1
+        guard let rowIndex = numberOfCells(inSection: indexToShow) - 1,  rowIndex >= 0 else { return }
         let cellIndexPath = IndexPath(row: rowIndex, section: indexToShow)
         
         scrollToRow(at: cellIndexPath, at: .top, animated: false)

--- a/Wire-iOS/Sources/UserInterface/Components/Views/UpsideDownTableView+Scrolling.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/UpsideDownTableView+Scrolling.swift
@@ -31,7 +31,7 @@ private extension UITableView {
         // kill existing scrolling animation
         self.setContentOffset(self.contentOffset, animated: false)
         
-        // sroll completely to top
+        // scroll completely to top
         self.setContentOffset(CGPoint(x: 0, y: -self.contentInset.top), animated:animated)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Components/Views/UpsideDownTableView+Scrolling.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/UpsideDownTableView+Scrolling.swift
@@ -29,7 +29,8 @@ extension UpsideDownTableView {
     func scroll(toIndex indexToShow: Int, completion: ((UIView)->())? = .none) {
         guard numberOfSections > 0 else { return }
         
-        guard let rowIndex = numberOfCells(inSection: indexToShow) - 1,  rowIndex >= 0 else { return }
+        let rowIndex = numberOfCells(inSection: indexToShow) - 1
+        guard rowIndex >= 0 else { return }
         let cellIndexPath = IndexPath(row: rowIndex, section: indexToShow)
         
         scrollToRow(at: cellIndexPath, at: .top, animated: false)

--- a/Wire-iOS/Sources/UserInterface/Components/Views/UpsideDownTableView+Scrolling.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/UpsideDownTableView+Scrolling.swift
@@ -19,11 +19,25 @@
 import Foundation
 
 extension UpsideDownTableView {
+    
     @objc(scrollToBottomAnimated:)
     func scrollToBottom(animated: Bool) {
         // upside-down tableview's bottom is rightside-up tableview's top
         super.scrollToTop(animated: animated)
     }
+    
+    func scroll(toIndex indexToShow: Int, completion: ((UIView)->())? = .none) {
+        guard numberOfSections > 0 else { return }
+        
+        let rowIndex = numberOfCells(inSection: indexToShow) - 1
+        let cellIndexPath = IndexPath(row: rowIndex, section: indexToShow)
+        
+        scrollToRow(at: cellIndexPath, at: .top, animated: false)
+        if let cell = cellForRow(at: cellIndexPath) {
+            completion?(cell)
+        }
+    }
+    
 }
 
 private extension UITableView {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Scrolling.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Scrolling.swift
@@ -23,9 +23,9 @@ extension ConversationContentViewController {
     @objc(scrollToMessage:completion:)
     public func scroll(to message: ZMConversationMessage?, completion: ((UIView)->())? = .none) {
         if let message = message {
-            dataSource.find(message) { index in
+            dataSource.loadMessages(near: message) { index in
                 
-                guard messageToShow.conversation == self.conversation else {
+                guard message.conversation == self.conversation else {
                     fatal("Message from the wrong conversation")
                 }
                 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Scrolling.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Scrolling.swift
@@ -21,29 +21,37 @@ import Foundation
 extension ConversationContentViewController {
     
     @objc(scrollToMessage:completion:)
-    public func scroll(to messageToShow: ZMConversationMessage, completion: ((UIView)->())? = .none) {
-        guard messageToShow.conversation == self.conversation else {
-            fatal("Message from the wrong conversation")
+    public func scroll(to message: ZMConversationMessage?, completion: ((UIView)->())? = .none) {
+        if let message = message {
+            dataSource.find(message) { index in
+                
+                guard messageToShow.conversation == self.conversation else {
+                    fatal("Message from the wrong conversation")
+                }
+                
+                guard let indexToShow = index else {
+                    return
+                }
+                
+                self.tableView.scrollToRow(at: indexToShow, at: .top, animated: false)
+                
+                if let cell = self.tableView.cellForRow(at: indexToShow) {
+                    completion?(cell)
+                }
+            }
+        } else {
+            dataSource.loadMessages()
         }
         
-        showLoadingView = true
-        
-        dataSource.find(messageToShow) { index in
-            self.showLoadingView = false
-            
-            guard let indexToShow = index else {
-                return
-            }
-            
-            self.tableView.scrollToRow(at: indexToShow, at: .top, animated: false)
-            if let cell = self.tableView.cellForRow(at: indexToShow) {
-                completion?(cell)
-            }
-        }
+        updateTableViewHeaderView()
     }
     
     @objc public func scrollToBottom() {
         guard !isScrolledToBottom else { return }
-        self.dataSource.scrollToBottom()
+        
+        dataSource.loadMessages()
+        dataSource.scroll(toIndex: 0)
+        
+        updateTableViewHeaderView()
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Scrolling.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Scrolling.swift
@@ -50,7 +50,7 @@ extension ConversationContentViewController {
         guard !isScrolledToBottom else { return }
         
         dataSource.loadMessages()
-        dataSource.scroll(toIndex: 0)
+        tableView.scroll(toIndex: 0)
         
         updateTableViewHeaderView()
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -215,7 +215,6 @@
         [self registerForPreviewingWithDelegate:self sourceView:self.view];
     }
 
-    [self scrollToFirstUnreadMessageIfNeeded];
     UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, nil);
 }
 
@@ -229,6 +228,7 @@
 - (void)viewDidLayoutSubviews {
     [super viewDidLayoutSubviews];
 
+    [self scrollToFirstUnreadMessageIfNeeded];
     [self updatePopover];
 }
 
@@ -236,11 +236,7 @@
 {
     if (! self.hasDoneInitialLayout) {
         self.hasDoneInitialLayout = YES;
-        [self updateTableViewHeaderView];
-
-        if (self.messageVisibleOnLoad != nil) {
-            [self scrollToMessage:self.messageVisibleOnLoad completion:nil];
-        }
+        [self scrollToMessage:self.messageVisibleOnLoad completion:nil];
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
@@ -273,19 +273,6 @@ final class ConversationTableViewDataSource: NSObject {
         loadMessages(offset: newOffset, limit: currentLimit)
     }
     
-    func scroll(toIndex indexToShow: Int, completion: ((UIView)->())? = .none) {
-        guard tableView.numberOfSections > 0 else { return }
-        
-        let rowIndex = tableView.numberOfCells(inSection: indexToShow) - 1
-        let cellIndexPath = IndexPath(row: rowIndex, section: indexToShow)
-        
-        self.tableView.scrollToRow(at: cellIndexPath, at: .top, animated: false)
-        if let cell = self.tableView.cellForRow(at: cellIndexPath) {
-            completion?(cell)
-        }
-    }
-
-    
     @objc func indexOfMessage(_ message: ZMConversationMessage) -> Int {
         guard let index = index(of: message) else {
             return NSNotFound
@@ -522,11 +509,4 @@ extension ConversationTableViewDataSource {
         return !Calendar.current.isDate(current, inSameDayAs: previous)
     }
     
-}
-
-extension ConversationTableViewDataSource {
-    func scrollToBottom() {
-        loadMessages(offset: 0, limit: ConversationTableViewDataSource.defaultBatchSize)
-        scroll(toIndex: 0, completion: nil)
-    }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
@@ -209,7 +209,7 @@ final class ConversationTableViewDataSource: NSObject {
         return cellDescription.supportsActions ? message : nil
     }
     
-    public func find(_ message: ZMConversationMessage, completion: ((IndexPath?)->())? = nil) {
+    public func loadMessages(near message: ZMConversationMessage, completion: ((IndexPath?)->())? = nil) {
         guard let moc = conversation.managedObjectContext, let serverTimestamp = message.serverTimestamp else {
             fatal("conversation.managedObjectContext == nil or serverTimestamp == nil")
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
@@ -146,8 +146,6 @@ final class ConversationTableViewDataSource: NSObject {
         super.init()
         
         tableView.dataSource = self
-        
-        loadMessages()
     }
 
     func section(for message: ZMConversationMessage) -> Int? {
@@ -236,7 +234,7 @@ final class ConversationTableViewDataSource: NSObject {
         completion?(indexPath)
     }
     
-    private func loadMessages(offset: Int = 0, limit: Int = ConversationTableViewDataSource.defaultBatchSize) {
+    public func loadMessages(offset: Int = 0, limit: Int = ConversationTableViewDataSource.defaultBatchSize) {
         let fetchRequest = self.fetchRequest()
         fetchRequest.fetchLimit = limit + 5 // We need to fetch a bit more than requested so that there is overlap between messages in different fetches
         fetchRequest.fetchOffset = offset


### PR DESCRIPTION
## What's new in this PR?

### Issues

When loading a conversation with unread messages we would first load and display the last messages and then reload the messages again around first unread message. This is both unnecessary performance wise and looks bad.

### Causes

We didn't used to reload message when scrolling to the first unread message but after some re-factoring that's now the case.

### Solutions

Before displaying the table view load either the last messages or messages near the first unread message.

NOTE: this needs to be done in `viewDidLayoutSubviews` because only then is bounds set which makes it possible to scroll the table view.