### PR TITLE
fix: Typing indicator is stretched

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+CreateViews.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+CreateViews.swift
@@ -167,7 +167,7 @@ extension ConversationInputBarViewController {
             typingIndicatorView.centerYAnchor.constraint(equalTo: inputBar.topAnchor),
             typingIndicatorView.centerXAnchor.constraint(equalTo: typingIndicatorView.superview!.centerXAnchor),
             typingIndicatorView.leftAnchor.constraint(greaterThanOrEqualTo: typingIndicatorView.superview!.leftAnchor, constant: 48),
-            typingIndicatorView.rightAnchor.constraint(greaterThanOrEqualTo: typingIndicatorView.superview!.rightAnchor, constant: 48)
+            typingIndicatorView.rightAnchor.constraint(lessThanOrEqualTo: typingIndicatorView.superview!.rightAnchor, constant: 48)
             ])
     }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Typing indicator is stretched

### Causes

caused by https://github.com/wireapp/wire-ios/pull/3304. `PureLayourt`'s `NSLayoutRelationGreaterThanOrEqual` has different defination with `NSLayoutConstraint`.

### Solutions

user `lessThanOrEqualTo` instead

### Note
I will add a snapshot case for typing indicator in another PR.