### PR TITLE
Allow editing of profile picture also for users not managed by wire

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/UserRight.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/UserRight.swift
@@ -46,10 +46,11 @@ final class UserRight: UserRightInterface {
         #endif
         case .resetPassword:
             return isProfileEditable || !usesCompanyLogin
+        case .editProfilePicture:
+            return true // NOTE we always allow editing for now since settting profile picture is not yet supported by SCIM
         case .editName,
              .editHandle,
              .editPhone,
-             .editProfilePicture,
              .editAccentColor:
 			return isProfileEditable
         }


### PR DESCRIPTION
## What's new in this PR?

Managing profile picture is not yet supported for SCIM users, until that's the case we enable setting it manually.