### PR TITLE
ZIOS-11361: Unable to finish login to existing account after the user removed the device

### DIFF
--- a/Wire-iOS/Sources/Authentication/Event Handlers/Post-Login/Success/AuthenticationSuccessEventHandler.swift
+++ b/Wire-iOS/Sources/Authentication/Event Handlers/Post-Login/Success/AuthenticationSuccessEventHandler.swift
@@ -27,7 +27,11 @@ class AuthenticationClientRegistrationSuccessHandler: AuthenticationEventHandler
     weak var statusProvider: AuthenticationStatusProvider?
 
     func handleEvent(currentStep: AuthenticationFlowStep, context: Void) -> [AuthenticationCoordinatorAction]? {
-        return [.transition(.pendingInitialSync(next: nil), mode: .normal)]
+        if ZMUserSession.shared()?.hasCompletedInitialSync == true {
+            return [.hideLoadingView, .completeLoginFlow]
+        } else {
+            return [.transition(.pendingInitialSync(next: nil), mode: .normal)]
+        }
     }
 
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

After being logged out for device removal, the user gets stuck in the login flow and can't do anything until he restarts the app, while the user was correctly logged in.

### Causes

That's because we usually wait for the slow sync to be completed, but in this case, the history is already on the device and we don't need to do slow sync, so the app gets stuck waiting for a sync that never happens.

### Solutions

I'm checking if the client has made a slow sync before inside `AuthenticationClientRegistrationSuccessHandler` If true, it returns `hideLoadingView` and `completeLoginFlow`, which causes the login flow to disappear.