### PR TITLE
Conversation screen - open profile when tapped on the avatar

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/CellComponents/SenderCellComponent.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/CellComponents/SenderCellComponent.swift
@@ -150,7 +150,7 @@ class SenderCellComponent: UIView {
         return NSAttributedString(string: string, attributes: [.foregroundColor : kind.color, .font : kind.font])
     }
 
-    //MARK: - tap on gesture
+    //MARK: - tap gesture of avatar
 
     @objc func tappedOnAvatar() {
         guard let user = avatar.user else { return }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/CellComponents/SenderCellComponent.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/CellComponents/SenderCellComponent.swift
@@ -76,6 +76,8 @@ class SenderCellComponent: UIView {
         avatar.initialsFont = .avatarInitial
         avatar.size = .badge
         avatar.translatesAutoresizingMaskIntoConstraints = false
+        avatar.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(tappedOnAvatar)))
+
         
         avatarSpacer.addSubview(avatar)
         avatarSpacer.translatesAutoresizingMaskIntoConstraints = false
@@ -147,6 +149,15 @@ class SenderCellComponent: UIView {
     private func attributedName(for kind: TextKind, string: String) -> NSAttributedString {
         return NSAttributedString(string: string, attributes: [.foregroundColor : kind.color, .font : kind.font])
     }
+
+    //MARK: - tap on gesture
+
+    @objc func tappedOnAvatar() {
+        guard let user = avatar.user else { return }
+
+        SessionManager.shared?.showUserProfile(user: user)
+    }
+
     
 }
 


### PR DESCRIPTION
## What's new in this PR?

Allow user to tap on an avatar in the conversation to see the profile of a user.