### PR TITLE
Fix add participants button not appearing on release builds

### DIFF
--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/Contacts/ContactsSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/Contacts/ContactsSectionController.swift
@@ -80,18 +80,18 @@ class ContactsSectionController : SearchSectionController {
         return cell
     }
     
-    func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
+    override func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
         return !(selection?.hasReachedLimit ?? false)
     }
     
-    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let user = contacts[indexPath.row]
         selection?.add(user)
         
         delegate?.searchSectionController(self, didSelectUser: user, at: indexPath)
     }
     
-    func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
+    override func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
         let user = contacts[indexPath.row]
         selection?.remove(user)
     }

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/GroupConversations/GroupConversationSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/GroupConversations/GroupConversationSectionController.swift
@@ -54,7 +54,7 @@ class GroupConversationsSectionController: SearchSectionController {
         return cell
     }
     
-    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let conversation = groupConversations[indexPath.row]
         
         delegate?.searchSectionController(self, didSelectConversation: conversation, at: indexPath)

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/SearchSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/SearchSectionController.swift
@@ -83,5 +83,21 @@ class SearchSectionController: NSObject, CollectionViewSectionController {
         fatal("Must be overridden")
     }
     
+    func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
+        return true
+        // NOTE: workaround for regression in Swift 5
+        // https://bugs.swift.org/browse/SR-2919
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        // NOTE: workaround for regression in Swift 5
+        // https://bugs.swift.org/browse/SR-2919
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
+        // NOTE: workaround for regression in Swift 5
+        // https://bugs.swift.org/browse/SR-2919
+    }
+    
 }
 

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/Services/SearchServicesSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/Services/SearchServicesSectionController.swift
@@ -87,7 +87,7 @@ class SearchServicesSectionController: SearchSectionController {
         }
     }
     
-    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if canSelfUserManageTeam && indexPath.row == 0 {
             delegate?.addServicesSectionDidRequestOpenServicesAdmin()
         }

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/Suggestions/DirectorySectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/Suggestions/DirectorySectionController.swift
@@ -74,7 +74,7 @@ class DirectorySectionController: SearchSectionController {
         }
     }
     
-    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let user = suggestions[indexPath.row]
         delegate?.searchSectionController(self, didSelectUser: user, at: indexPath)
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Add-participant button didn't appear on release builds when selecting participants.

### Causes

Swift 5 had a regression where it would not call optional methods only implemented a child class.
https://bugs.swift.org/browse/SR-2919

### Solutions

Add empty base class implementations.