### PR TITLE
Fix: Contacts permission reminder UI overlaps

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsViewController+Internal.h
+++ b/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsViewController+Internal.h
@@ -21,6 +21,8 @@
 @class TransformLabel;
 @class ContactsEmptyResultView;
 
+@protocol ShareContactsViewControllerDelegate;
+
 NS_ASSUME_NONNULL_BEGIN
 
 static NSString * const ContactsViewControllerCellID = @"ContactsCell";
@@ -71,3 +73,7 @@ static NSString * const ContactsViewControllerSectionHeaderID = @"ContactsSectio
 @end
 
 NS_ASSUME_NONNULL_END
+
+@interface ContactsViewController (ShareContactsDelegate)  <ShareContactsViewControllerDelegate>
+
+@end

--- a/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsViewController+ShareContacts.h
+++ b/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsViewController+ShareContacts.h
@@ -21,6 +21,4 @@
 
 @interface ContactsViewController (ShareContacts)
 
-- (void)presentShareContactsViewController;
-
 @end

--- a/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsViewController+ShareContacts.m
+++ b/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsViewController+ShareContacts.m
@@ -22,26 +22,8 @@
 #import "ContactsDataSource.h"
 #import "Wire-Swift.h"
 
-@interface ContactsViewController (ShareContactsDelegate)  <ShareContactsViewControllerDelegate>
-
-@end
-
 @implementation ContactsViewController (ShareContacts)
 
-- (void)presentShareContactsViewController
-{
-    ShareContactsViewController *shareContactsViewController = [[ShareContactsViewController alloc] init];
-    shareContactsViewController.delegate = self;
-
-    [self presentChildViewcontroller:shareContactsViewController];
-}
-
-- (void)presentChildViewcontroller:(UIViewController *)viewController
-{
-    [self addChildViewController:viewController];
-    [self.view addSubview:viewController.view];
-    [viewController didMoveToParentViewController:self];
-}
 
 - (void)dismissChildViewController:(UIViewController *)viewController
 {

--- a/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsViewController+ViewLifeCycle.swift
+++ b/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsViewController+ViewLifeCycle.swift
@@ -26,6 +26,23 @@ extension ContactsViewController {
         showKeyboardIfNeeded()
     }
 
+    open override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        presentShareContactsViewControllerIfNeeded()
+    }
+
+    private func presentShareContactsViewControllerIfNeeded() {
+        let shouldSkip: Bool = AutomationHelper.sharedHelper.skipFirstLoginAlerts || ZMUser.selfUser().hasTeam
+        if sharingContactsRequired &&
+            !AddressBookHelper.sharedHelper.isAddressBookAccessGranted &&
+            !shouldSkip &&
+            shouldShowShareContactsViewController {
+            presentShareContactsViewController()
+        }
+    }
+    
+
     open override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         searchHeaderViewController.tokenField.resignFirstResponder()

--- a/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsViewController+ViewLifeCycle.swift
+++ b/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsViewController+ViewLifeCycle.swift
@@ -61,7 +61,7 @@ extension ContactsViewController {
         }, completion: nil)
     }
 
-    func presentShareContactsViewController() {
+    private func presentShareContactsViewController() {
         let shareContactsViewController = ShareContactsViewController()
         shareContactsViewController.delegate = self
 

--- a/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsViewController+ViewLifeCycle.swift
+++ b/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsViewController+ViewLifeCycle.swift
@@ -60,5 +60,13 @@ extension ContactsViewController {
             self.view.layoutIfNeeded()
         }, completion: nil)
     }
+
+    func presentShareContactsViewController() {
+        let shareContactsViewController = ShareContactsViewController()
+        shareContactsViewController.delegate = self
+
+        addToSelf(shareContactsViewController)
+    }
+
 }
 

--- a/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsViewController.m
+++ b/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsViewController.m
@@ -66,18 +66,6 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
 
 #pragma mark - UIViewController overrides
 
-- (void)viewDidLoad
-{
-    [super viewDidLoad];
-    
-
-    BOOL shouldSkip = AutomationHelper.sharedHelper.skipFirstLoginAlerts || ZMUser.selfUser.hasTeam;
-    if (self.sharingContactsRequired && ! [[AddressBookHelper sharedHelper] isAddressBookAccessGranted] && !shouldSkip && self.shouldShowShareContactsViewController) {
-        [self presentShareContactsViewController];
-    }
-
-}
-
 - (BOOL)prefersStatusBarHidden
 {
     return NO;


### PR DESCRIPTION
## What's new in this PR?

### Issues

`ShareContactsViewController` is coverd by the `tableView`.

### Causes

After https://github.com/wireapp/wire-ios/pull/3339, the `tableView` is created in `init` instead of `viewDidLoad`, after `ShareContactsViewController` is presented.

### Solutions

present `ShareContactsViewController` when `viewWillAppear`.