### PR TITLE
Fix: prevent showing photo permission dialog when testing

### DIFF
--- a/Wire-iOS Tests/CameraKeyboardViewControllerTests.swift
+++ b/Wire-iOS Tests/CameraKeyboardViewControllerTests.swift
@@ -91,6 +91,7 @@ final class CameraKeyboardViewControllerTests: CoreDataSnapshotTestCase {
 
     override func setUp() {
         super.setUp()
+
         mockAssetLibrary = MockAssetLibrary(photoLibrary: MockPhotoLibrary())
         mockImageManager = MockImageManager()
         splitView = SplitLayoutObservableMock()
@@ -99,9 +100,12 @@ final class CameraKeyboardViewControllerTests: CoreDataSnapshotTestCase {
 
     override func tearDown() {
         sut = nil
+
         splitView = nil
         delegateMock = nil
         mockAssetLibrary = nil
+        mockImageManager = nil
+
         super.tearDown()
     }
     

--- a/Wire-iOS Tests/CameraKeyboardViewControllerTests.swift
+++ b/Wire-iOS Tests/CameraKeyboardViewControllerTests.swift
@@ -72,9 +72,9 @@ final class CameraKeyboardViewControllerTests: CoreDataSnapshotTestCase {
     
     override func setUp() {
         super.setUp()
-        self.assetLibrary = MockAssetLibrary(photoLibrary: MockPhotoLibrary())
-        self.splitView = SplitLayoutObservableMock()
-        self.delegateMock = CameraKeyboardViewControllerDelegateMock()
+        assetLibrary = MockAssetLibrary(photoLibrary: MockPhotoLibrary())
+        splitView = SplitLayoutObservableMock()
+        delegateMock = CameraKeyboardViewControllerDelegateMock()
     }
 
     override func tearDown() {

--- a/Wire-iOS Tests/CameraKeyboardViewControllerTests.swift
+++ b/Wire-iOS Tests/CameraKeyboardViewControllerTests.swift
@@ -72,7 +72,7 @@ final class CameraKeyboardViewControllerTests: CoreDataSnapshotTestCase {
     
     override func setUp() {
         super.setUp()
-        self.assetLibrary = MockAssetLibrary()
+        self.assetLibrary = MockAssetLibrary(photoLibrary: MockPhotoLibrary())
         self.splitView = SplitLayoutObservableMock()
         self.delegateMock = CameraKeyboardViewControllerDelegateMock()
     }
@@ -102,23 +102,33 @@ final class CameraKeyboardViewControllerTests: CoreDataSnapshotTestCase {
             sut.view.bottomAnchor.constraint(equalTo: container.bottomAnchor),
             sut.view.leadingAnchor.constraint(equalTo: container.leadingAnchor),
             sut.view.trailingAnchor.constraint(equalTo: container.trailingAnchor)
-        ])
+            ])
         
         container.setNeedsLayout()
         container.layoutIfNeeded()
         return container
     }
-    
+
+    private func setupSut(permissions: PhotoPermissionsController) {
+        sut = CameraKeyboardViewController(splitLayoutObservable: splitView,
+                                           assetLibrary: assetLibrary,
+//                                           photoLibrary: MockPhotoLibrary(),
+                                           permissions: permissions)
+    }
+
     func testWithCallingOverlay() {
         let permissions = MockPhotoPermissionsController(camera: true, library: true)
+//        setupSut(permissions: permissions)///TODO
         self.sut = CallingMockCameraKeyboardViewController(splitLayoutObservable: self.splitView, assetLibrary: assetLibrary, permissions: permissions)
+
         self.verify(view: self.prepareForSnapshot())
     }
     
     func testThatFirstSectionContainsCameraCellOnly() {
         // given
         let permissions = MockPhotoPermissionsController(camera: true, library: true)
-        self.sut = CameraKeyboardViewController(splitLayoutObservable: self.splitView, assetLibrary: assetLibrary, permissions: permissions)
+        setupSut(permissions: permissions)
+
         self.sut.delegate = self.delegateMock
         self.prepareForSnapshot()
         
@@ -133,7 +143,7 @@ final class CameraKeyboardViewControllerTests: CoreDataSnapshotTestCase {
     
     func testThatTableViewContainsPermissionsCellOnly_CameraAndLibraryAccessNotGranted() {
         let permissions = MockPhotoPermissionsController(camera: false, library: false)
-        self.sut = CameraKeyboardViewController(splitLayoutObservable: self.splitView, assetLibrary: assetLibrary, permissions: permissions)
+        setupSut(permissions: permissions)
         self.sut.delegate = self.delegateMock
         self.prepareForSnapshot()
         
@@ -149,7 +159,7 @@ final class CameraKeyboardViewControllerTests: CoreDataSnapshotTestCase {
     func testThatSecondSectionContainsCameraRollElements() {
         // given
         let permissions = MockPhotoPermissionsController(camera: true, library: true)
-        self.sut = CameraKeyboardViewController(splitLayoutObservable: self.splitView, assetLibrary: assetLibrary, permissions: permissions)
+        setupSut(permissions: permissions)
         self.sut.delegate = self.delegateMock
         self.prepareForSnapshot()
         
@@ -165,7 +175,7 @@ final class CameraKeyboardViewControllerTests: CoreDataSnapshotTestCase {
         // given
         self.splitView?.layoutSize = .compact
         // when
-        self.sut = CameraKeyboardViewController(splitLayoutObservable: self.splitView, assetLibrary: assetLibrary, permissions: permissions)
+        setupSut(permissions: permissions)
         // then
         self.verify(view: self.prepareForSnapshot())
     }
@@ -195,7 +205,7 @@ final class CameraKeyboardViewControllerTests: CoreDataSnapshotTestCase {
         self.splitView?.layoutSize = .regularPortrait
         self.splitView?.leftViewControllerWidth = 216
         // when
-        self.sut = CameraKeyboardViewController(splitLayoutObservable: self.splitView, assetLibrary: assetLibrary, permissions: permissions)
+        setupSut(permissions: permissions)
         // then
         self.verify(view: self.prepareForSnapshot(CGSize(width: 768, height: 264)))
     }
@@ -225,7 +235,7 @@ final class CameraKeyboardViewControllerTests: CoreDataSnapshotTestCase {
         self.splitView?.layoutSize = .regularLandscape
         self.splitView?.leftViewControllerWidth = 216
         // when
-        self.sut = CameraKeyboardViewController(splitLayoutObservable: self.splitView, assetLibrary: assetLibrary, permissions: permissions)
+        setupSut(permissions: permissions)
         // then
         self.verify(view: self.prepareForSnapshot(CGSize(width: 1024, height: 352)))
     }
@@ -253,7 +263,7 @@ final class CameraKeyboardViewControllerTests: CoreDataSnapshotTestCase {
     func cameraScrolledHorizontallySomePercent(with permissions: PhotoPermissionsController) {
         // given
         self.splitView?.layoutSize = .compact
-        self.sut = CameraKeyboardViewController(splitLayoutObservable: self.splitView, assetLibrary: assetLibrary, permissions: permissions)
+        setupSut(permissions: permissions)
         self.prepareForSnapshot()
         // when
         self.sut.collectionView.scrollRectToVisible(CGRect(x: 300, y: 0, width: 160, height: 10), animated: false)
@@ -283,7 +293,7 @@ final class CameraKeyboardViewControllerTests: CoreDataSnapshotTestCase {
     func cameraScrolledHorizontallyAwayPercent(with permissions: PhotoPermissionsController) {
         // given
         self.splitView?.layoutSize = .compact
-        self.sut = CameraKeyboardViewController(splitLayoutObservable: self.splitView, assetLibrary: assetLibrary, permissions: permissions)
+        setupSut(permissions: permissions)
         self.prepareForSnapshot()
         // when
         self.sut.collectionView.scrollRectToVisible(CGRect(x: 320, y: 0, width: 160, height: 10), animated: false)
@@ -314,7 +324,7 @@ final class CameraKeyboardViewControllerTests: CoreDataSnapshotTestCase {
     func testThatItCallsDelegateCameraRollWhenCameraRollButtonPressed() {
         // given
         let permissions = MockPhotoPermissionsController(camera: true, library: true)
-        self.sut = CameraKeyboardViewController(splitLayoutObservable: self.splitView, assetLibrary: assetLibrary, permissions: permissions)
+        setupSut(permissions: permissions)
         self.sut.delegate = self.delegateMock
         self.prepareForSnapshot()
         
@@ -331,7 +341,7 @@ final class CameraKeyboardViewControllerTests: CoreDataSnapshotTestCase {
     func testThatItCallsDelegateWhenWantsToOpenFullScreenCamera() {
         // given
         let permissions = MockPhotoPermissionsController(camera: true, library: true)
-        self.sut = CameraKeyboardViewController(splitLayoutObservable: self.splitView, assetLibrary: assetLibrary, permissions: permissions)
+        setupSut(permissions: permissions)
         self.sut.delegate = self.delegateMock
         self.prepareForSnapshot()
         

--- a/Wire-iOS Tests/CameraKeyboardViewControllerTests.swift
+++ b/Wire-iOS Tests/CameraKeyboardViewControllerTests.swift
@@ -17,7 +17,6 @@
 //
 
 import XCTest
-import Photos
 import AVFoundation
 @testable import Wire
 
@@ -112,16 +111,17 @@ final class CameraKeyboardViewControllerTests: CoreDataSnapshotTestCase {
     private func setupSut(permissions: PhotoPermissionsController) {
         sut = CameraKeyboardViewController(splitLayoutObservable: splitView,
                                            assetLibrary: assetLibrary,
-//                                           photoLibrary: MockPhotoLibrary(),
                                            permissions: permissions)
     }
 
     func testWithCallingOverlay() {
         let permissions = MockPhotoPermissionsController(camera: true, library: true)
-//        setupSut(permissions: permissions)///TODO
-        self.sut = CallingMockCameraKeyboardViewController(splitLayoutObservable: self.splitView, assetLibrary: assetLibrary, permissions: permissions)
+        setupSut(permissions: permissions)
+        sut = CallingMockCameraKeyboardViewController(splitLayoutObservable: self.splitView, assetLibrary: assetLibrary, permissions: permissions)
 
-        self.verify(view: self.prepareForSnapshot())
+        prepareForSnapshot()
+
+        verify(view: prepareForSnapshot())
     }
     
     func testThatFirstSectionContainsCameraCellOnly() {

--- a/Wire-iOS Tests/CameraKeyboardViewControllerTests.swift
+++ b/Wire-iOS Tests/CameraKeyboardViewControllerTests.swift
@@ -68,7 +68,7 @@ final class CameraKeyboardViewControllerTests: CoreDataSnapshotTestCase {
     var sut: CameraKeyboardViewController!
     var splitView: SplitLayoutObservableMock!
     var delegateMock: CameraKeyboardViewControllerDelegateMock!
-    var assetLibrary: AssetLibrary!
+    fileprivate var assetLibrary: MockAssetLibrary!
     
     override func setUp() {
         super.setUp()

--- a/Wire-iOS Tests/CameraKeyboardViewControllerTests.swift
+++ b/Wire-iOS Tests/CameraKeyboardViewControllerTests.swift
@@ -86,12 +86,12 @@ final class CameraKeyboardViewControllerTests: CoreDataSnapshotTestCase {
     var sut: CameraKeyboardViewController!
     var splitView: SplitLayoutObservableMock!
     var delegateMock: CameraKeyboardViewControllerDelegateMock!
-    fileprivate var assetLibrary: MockAssetLibrary!
+    fileprivate var mockAssetLibrary: MockAssetLibrary!
     fileprivate var mockImageManager: MockImageManager!
 
     override func setUp() {
         super.setUp()
-        assetLibrary = MockAssetLibrary(photoLibrary: MockPhotoLibrary())
+        mockAssetLibrary = MockAssetLibrary(photoLibrary: MockPhotoLibrary())
         mockImageManager = MockImageManager()
         splitView = SplitLayoutObservableMock()
         delegateMock = CameraKeyboardViewControllerDelegateMock()
@@ -101,7 +101,7 @@ final class CameraKeyboardViewControllerTests: CoreDataSnapshotTestCase {
         sut = nil
         splitView = nil
         delegateMock = nil
-        assetLibrary = nil
+        mockAssetLibrary = nil
         super.tearDown()
     }
     
@@ -124,22 +124,21 @@ final class CameraKeyboardViewControllerTests: CoreDataSnapshotTestCase {
             sut.view.trailingAnchor.constraint(equalTo: container.trailingAnchor)
             ])
         
-        container.setNeedsLayout()
         container.layoutIfNeeded()
         return container
     }
 
     private func setupSut(permissions: PhotoPermissionsController) {
         sut = CameraKeyboardViewController(splitLayoutObservable: splitView,
-                                           assetLibrary: assetLibrary,
+                                           assetLibrary: mockAssetLibrary,
+                                           imageManager: mockImageManager,
                                            permissions: permissions)
     }
 
     func testWithCallingOverlay() {
         let permissions = MockPhotoPermissionsController(camera: true, library: true)
-        setupSut(permissions: permissions)
         sut = CallingMockCameraKeyboardViewController(splitLayoutObservable: splitView,
-                                                      assetLibrary: assetLibrary,
+                                                      assetLibrary: mockAssetLibrary,
                                                       imageManager: mockImageManager,
                                                       permissions: permissions)
 

--- a/Wire-iOS Tests/CameraKeyboardViewControllerTests.swift
+++ b/Wire-iOS Tests/CameraKeyboardViewControllerTests.swift
@@ -18,6 +18,7 @@
 
 import XCTest
 import AVFoundation
+import Photos
 @testable import Wire
 
 class CameraKeyboardViewControllerDelegateMock: CameraKeyboardViewControllerDelegate {
@@ -57,6 +58,24 @@ private final class MockAssetLibrary: AssetLibrary {
     }
 }
 
+private final class MockImageManager: ImageManagerProtocol {
+    func cancelImageRequest(_ requestID: PHImageRequestID) {
+        // no op
+    }
+
+    func requestImage(for asset: PHAsset, targetSize: CGSize, contentMode: PHImageContentMode, options: PHImageRequestOptions?, resultHandler: @escaping (UIImage?, [AnyHashable : Any]?) -> Void) -> PHImageRequestID {
+        return 0
+    }
+
+    func requestImageData(for asset: PHAsset, options: PHImageRequestOptions?, resultHandler: @escaping (Data?, String?, UIImage.Orientation, [AnyHashable : Any]?) -> Void) -> PHImageRequestID {
+        return 0
+    }
+
+    func requestExportSession(forVideo asset: PHAsset, options: PHVideoRequestOptions?, exportPreset: String, resultHandler: @escaping (AVAssetExportSession?, [AnyHashable : Any]?) -> Void) -> PHImageRequestID {
+        return 0
+    }
+}
+
 fileprivate final class CallingMockCameraKeyboardViewController: CameraKeyboardViewController {
     @objc override var shouldBlockCallingRelatedActions: Bool {
         return true
@@ -68,10 +87,12 @@ final class CameraKeyboardViewControllerTests: CoreDataSnapshotTestCase {
     var splitView: SplitLayoutObservableMock!
     var delegateMock: CameraKeyboardViewControllerDelegateMock!
     fileprivate var assetLibrary: MockAssetLibrary!
-    
+    fileprivate var mockImageManager: MockImageManager!
+
     override func setUp() {
         super.setUp()
         assetLibrary = MockAssetLibrary(photoLibrary: MockPhotoLibrary())
+        mockImageManager = MockImageManager()
         splitView = SplitLayoutObservableMock()
         delegateMock = CameraKeyboardViewControllerDelegateMock()
     }
@@ -117,9 +138,10 @@ final class CameraKeyboardViewControllerTests: CoreDataSnapshotTestCase {
     func testWithCallingOverlay() {
         let permissions = MockPhotoPermissionsController(camera: true, library: true)
         setupSut(permissions: permissions)
-        sut = CallingMockCameraKeyboardViewController(splitLayoutObservable: self.splitView, assetLibrary: assetLibrary, permissions: permissions)
-
-        prepareForSnapshot()
+        sut = CallingMockCameraKeyboardViewController(splitLayoutObservable: splitView,
+                                                      assetLibrary: assetLibrary,
+                                                      imageManager: mockImageManager,
+                                                      permissions: permissions)
 
         verify(view: prepareForSnapshot())
     }

--- a/Wire-iOS Tests/Mocks/MockPhotoLibrary.swift
+++ b/Wire-iOS Tests/Mocks/MockPhotoLibrary.swift
@@ -1,0 +1,36 @@
+//
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import Photos
+@testable import Wire
+
+final class MockPhotoLibrary: PhotoLibraryProtocol {
+    func register(_ observer: PHPhotoLibraryChangeObserver) {
+        // no-ops
+    }
+
+    func unregisterChangeObserver(_ observer: PHPhotoLibraryChangeObserver) {
+        // no-ops
+    }
+
+    func performChanges(_ changeBlock: @escaping () -> Void, completionHandler: ((Bool, Error?) -> Void)?) {
+        changeBlock()
+        completionHandler?(true, nil)
+    }
+}

--- a/Wire-iOS Tests/SavableImageTests.swift
+++ b/Wire-iOS Tests/SavableImageTests.swift
@@ -20,13 +20,6 @@ import XCTest
 @testable import Wire
 import Photos
 
-final class MockPhotoLibrary: PhotoLibraryProtocol {
-    func performChanges(_ changeBlock: @escaping () -> Void, completionHandler: ((Bool, Error?) -> Void)?) {
-        changeBlock()
-        completionHandler?(true, nil)
-    }
-}
-
 final class MockAssetChangeRequest: AssetChangeRequestProtocol {
     static var url: URL?
     static var image: UIImage?

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1096,6 +1096,7 @@
 		EF297DE321320AC20002983A /* InviteContactsViewController+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF297DE121320AC20002983A /* InviteContactsViewController+Swift.swift */; };
 		EF297DE9213215210002983A /* ProfileDevicesViewController+Style.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF297DE7213215210002983A /* ProfileDevicesViewController+Style.swift */; };
 		EF297DEC213340CF0002983A /* ParticipantDeviceHeaderView+Style.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF297DEA213340CF0002983A /* ParticipantDeviceHeaderView+Style.swift */; };
+		EF298BD1228D942A0078BE68 /* ImageManagerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF298BD0228D942A0078BE68 /* ImageManagerProtocol.swift */; };
 		EF29E89C212302CD0023B80C /* AudioMessageViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF29E89B212302CD0023B80C /* AudioMessageViewTests.swift */; };
 		EF29F1BB21271A9A00BE94E6 /* GroupDetailsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF29F1BA21271A9A00BE94E6 /* GroupDetailsViewControllerTests.swift */; };
 		EF2A8DE7214A816D002C9058 /* StartUIViewControllerSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2A8DE6214A816D002C9058 /* StartUIViewControllerSnapshotTests.swift */; };
@@ -2869,6 +2870,7 @@
 		EF297DE8213215210002983A /* ProfileDevicesViewController+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ProfileDevicesViewController+Internal.h"; sourceTree = "<group>"; };
 		EF297DEA213340CF0002983A /* ParticipantDeviceHeaderView+Style.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ParticipantDeviceHeaderView+Style.swift"; sourceTree = "<group>"; };
 		EF297DEB213340CF0002983A /* ParticipantDeviceHeaderView+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ParticipantDeviceHeaderView+Internal.h"; sourceTree = "<group>"; };
+		EF298BD0228D942A0078BE68 /* ImageManagerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageManagerProtocol.swift; sourceTree = "<group>"; };
 		EF29E89B212302CD0023B80C /* AudioMessageViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioMessageViewTests.swift; sourceTree = "<group>"; };
 		EF29F1BA21271A9A00BE94E6 /* GroupDetailsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupDetailsViewControllerTests.swift; sourceTree = "<group>"; };
 		EF2A8DE6214A816D002C9058 /* StartUIViewControllerSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartUIViewControllerSnapshotTests.swift; sourceTree = "<group>"; };
@@ -4595,6 +4597,7 @@
 				16D68E9A1CEF99C7003AB9E0 /* WaveformProgressView.swift */,
 				BF02CDC21D79A98000C87D38 /* SavableImage.swift */,
 				875F89111D6DCD2C00D8748E /* MessageToolboxView.swift */,
+				EF298BD0228D942A0078BE68 /* ImageManagerProtocol.swift */,
 				5EBF4A2A21B958F30021CFFC /* MessageToolboxDataSource.swift */,
 				EF32AB0221C15B0E002E4777 /* String+MessageToolBox.swift */,
 				BF69C6C21F0CEBC500649C55 /* EphemeralTimeoutFormatter.swift */,
@@ -7161,6 +7164,7 @@
 				5E65A7AF213450D2008BFCC0 /* TeamEmailVerificationErrorHandler.swift in Sources */,
 				BA8DC27C1B5FF5CF00103262 /* SketchColorPickerController.m in Sources */,
 				871BC2871D34F8F800DF0793 /* UIFont+MonoSpaced.swift in Sources */,
+				EF298BD1228D942A0078BE68 /* ImageManagerProtocol.swift in Sources */,
 				EF71BFD820EBD0DC00894A7C /* UIPopoverPresentationController+config.swift in Sources */,
 				5E8FFC1A21EF6EB10052DF03 /* RemoveClientStepViewController.swift in Sources */,
 				D5490A1D20050AAA0057EAA8 /* TeamMemberInviteViewController.swift in Sources */,

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1111,6 +1111,7 @@
 		EF2C9545214983BB000E4960 /* video.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = EF2C9544214983BB000E4960 /* video.mp4 */; };
 		EF2CF3202243C9D9003E16BC /* ProfileViewController+TabBarControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2CF31F2243C9D9003E16BC /* ProfileViewController+TabBarControllerDelegate.swift */; };
 		EF2CF3262243EBAC003E16BC /* AppDelegate+URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2CF3252243EBAA003E16BC /* AppDelegate+URL.swift */; };
+		EF2D6D38228C1FB300D8DBF4 /* MockPhotoLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2D6D37228C1FB300D8DBF4 /* MockPhotoLibrary.swift */; };
 		EF2E2F6E223BAF410038D7D9 /* MediaBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FC8524A199245760008B66B /* MediaBar.swift */; };
 		EF2E2F6F223BB6560038D7D9 /* NotificationWindowRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FC85255199245760008B66B /* NotificationWindowRootViewController.swift */; };
 		EF2E2F71223BC4A60038D7D9 /* VersionInfoViewControllerSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2E2F70223BC4A60038D7D9 /* VersionInfoViewControllerSnapshotTests.swift */; };
@@ -2882,6 +2883,7 @@
 		EF2C9544214983BB000E4960 /* video.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = video.mp4; sourceTree = "<group>"; };
 		EF2CF31F2243C9D9003E16BC /* ProfileViewController+TabBarControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProfileViewController+TabBarControllerDelegate.swift"; sourceTree = "<group>"; };
 		EF2CF3252243EBAA003E16BC /* AppDelegate+URL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AppDelegate+URL.swift"; sourceTree = "<group>"; };
+		EF2D6D37228C1FB300D8DBF4 /* MockPhotoLibrary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPhotoLibrary.swift; sourceTree = "<group>"; };
 		EF2E2F70223BC4A60038D7D9 /* VersionInfoViewControllerSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionInfoViewControllerSnapshotTests.swift; sourceTree = "<group>"; };
 		EF2EA63021F8AB31000E12CA /* RestrictedButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestrictedButton.swift; sourceTree = "<group>"; };
 		EF2EA63221F8AFB2000E12CA /* ServiceDetailViewControllerSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceDetailViewControllerSnapshotTests.swift; sourceTree = "<group>"; };
@@ -4759,6 +4761,7 @@
 				EF6251D321392FFE00943708 /* MockTapGestureRecognizer.swift */,
 				EF207B3A2208438700738E84 /* MockZMUserSession.swift */,
 				A97192B2221302DD00E72AD1 /* MockUserRight.swift */,
+				EF2D6D37228C1FB300D8DBF4 /* MockPhotoLibrary.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -8179,6 +8182,7 @@
 				5EBBE9732187A844008BC1B7 /* MessageToolboxViewTests.swift in Sources */,
 				162AE748219B26AF00581D98 /* ConversationSystemMessageTests.swift in Sources */,
 				EF91A0561FF3A05A00FE2F53 /* GiphySearchViewControllerTests.swift in Sources */,
+				EF2D6D38228C1FB300D8DBF4 /* MockPhotoLibrary.swift in Sources */,
 				EF15A7B620BC34F700A045C7 /* XCTestCase+ImageFromBundle.swift in Sources */,
 				EF84DF442130332200033702 /* ParticipantDeviceCellTests.swift in Sources */,
 				874941CD1DE458DF006CF32B /* CombinationTest.swift in Sources */,

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1112,6 +1112,7 @@
 		EF2CF3202243C9D9003E16BC /* ProfileViewController+TabBarControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2CF31F2243C9D9003E16BC /* ProfileViewController+TabBarControllerDelegate.swift */; };
 		EF2CF3262243EBAC003E16BC /* AppDelegate+URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2CF3252243EBAA003E16BC /* AppDelegate+URL.swift */; };
 		EF2D6D38228C1FB300D8DBF4 /* MockPhotoLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2D6D37228C1FB300D8DBF4 /* MockPhotoLibrary.swift */; };
+		EF2D6D43228C741500D8DBF4 /* PhotoPermissionsControllerStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2D6D42228C741500D8DBF4 /* PhotoPermissionsControllerStrategy.swift */; };
 		EF2E2F6E223BAF410038D7D9 /* MediaBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FC8524A199245760008B66B /* MediaBar.swift */; };
 		EF2E2F6F223BB6560038D7D9 /* NotificationWindowRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FC85255199245760008B66B /* NotificationWindowRootViewController.swift */; };
 		EF2E2F71223BC4A60038D7D9 /* VersionInfoViewControllerSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2E2F70223BC4A60038D7D9 /* VersionInfoViewControllerSnapshotTests.swift */; };
@@ -2884,6 +2885,7 @@
 		EF2CF31F2243C9D9003E16BC /* ProfileViewController+TabBarControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProfileViewController+TabBarControllerDelegate.swift"; sourceTree = "<group>"; };
 		EF2CF3252243EBAA003E16BC /* AppDelegate+URL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AppDelegate+URL.swift"; sourceTree = "<group>"; };
 		EF2D6D37228C1FB300D8DBF4 /* MockPhotoLibrary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPhotoLibrary.swift; sourceTree = "<group>"; };
+		EF2D6D42228C741500D8DBF4 /* PhotoPermissionsControllerStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPermissionsControllerStrategy.swift; sourceTree = "<group>"; };
 		EF2E2F70223BC4A60038D7D9 /* VersionInfoViewControllerSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionInfoViewControllerSnapshotTests.swift; sourceTree = "<group>"; };
 		EF2EA63021F8AB31000E12CA /* RestrictedButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestrictedButton.swift; sourceTree = "<group>"; };
 		EF2EA63221F8AFB2000E12CA /* ServiceDetailViewControllerSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceDetailViewControllerSnapshotTests.swift; sourceTree = "<group>"; };
@@ -4723,6 +4725,7 @@
 				87BEB0431D3E478500DE9575 /* AssetLibrary.swift */,
 				7C52F722200CBE61009F85FB /* CameraKeyboardPermissionsCell.swift */,
 				7C72F03C200E0D03001231D3 /* PhotoPermissionsController.swift */,
+				EF2D6D42228C741500D8DBF4 /* PhotoPermissionsControllerStrategy.swift */,
 			);
 			path = CameraKeyboard;
 			sourceTree = "<group>";
@@ -7902,6 +7905,7 @@
 				BFE57B4B1D52335A00CB0806 /* ConversationPreviewViewController.swift in Sources */,
 				5E628021221ED0A60039A8AB /* ProfileActionsFactory.swift in Sources */,
 				D5677158202B496700308448 /* CreateGroupSection.swift in Sources */,
+				EF2D6D43228C741500D8DBF4 /* PhotoPermissionsControllerStrategy.swift in Sources */,
 				5EBF4A2B21B958F30021CFFC /* MessageToolboxDataSource.swift in Sources */,
 				F15650FA21DD20D900210504 /* NSDate+Format.swift in Sources */,
 				EF32AB0321C15B0E002E4777 /* String+MessageToolBox.swift in Sources */,

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ImageManagerProtocol.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ImageManagerProtocol.swift
@@ -1,0 +1,34 @@
+//
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Photos
+
+protocol ImageManagerProtocol {
+    func cancelImageRequest(_ requestID: PHImageRequestID)
+
+    @discardableResult
+    func requestImage(for asset: PHAsset, targetSize: CGSize, contentMode: PHImageContentMode, options: PHImageRequestOptions?, resultHandler: @escaping (UIImage?, [AnyHashable : Any]?) -> Void) -> PHImageRequestID
+
+    @discardableResult
+    func requestImageData(for asset: PHAsset, options: PHImageRequestOptions?, resultHandler: @escaping (Data?, String?, UIImage.Orientation, [AnyHashable : Any]?) -> Void) -> PHImageRequestID
+
+    @discardableResult
+    func requestExportSession(forVideo asset: PHAsset, options: PHVideoRequestOptions?, exportPreset: String, resultHandler: @escaping (AVAssetExportSession?, [AnyHashable : Any]?) -> Void) -> PHImageRequestID
+}
+
+extension PHImageManager: ImageManagerProtocol {}

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/SavableImage.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/SavableImage.swift
@@ -21,6 +21,9 @@ import Photos
 
 protocol PhotoLibraryProtocol {
     func performChanges(_ changeBlock: @escaping () -> Swift.Void, completionHandler: ((Bool, Error?) -> Swift.Void)?)
+
+    func register(_ observer: PHPhotoLibraryChangeObserver)
+    func unregisterChangeObserver(_ observer: PHPhotoLibraryChangeObserver)
 }
 
 extension PHPhotoLibrary: PhotoLibraryProtocol {}

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/SavableImage.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/SavableImage.swift
@@ -19,6 +19,21 @@
 
 import Photos
 
+protocol ImageManagerProtocol {
+    func cancelImageRequest(_ requestID: PHImageRequestID)
+
+    @discardableResult
+    func requestImage(for asset: PHAsset, targetSize: CGSize, contentMode: PHImageContentMode, options: PHImageRequestOptions?, resultHandler: @escaping (UIImage?, [AnyHashable : Any]?) -> Void) -> PHImageRequestID
+
+    @discardableResult
+    func requestImageData(for asset: PHAsset, options: PHImageRequestOptions?, resultHandler: @escaping (Data?, String?, UIImage.Orientation, [AnyHashable : Any]?) -> Void) -> PHImageRequestID
+
+    @discardableResult
+    func requestExportSession(forVideo asset: PHAsset, options: PHVideoRequestOptions?, exportPreset: String, resultHandler: @escaping (AVAssetExportSession?, [AnyHashable : Any]?) -> Void) -> PHImageRequestID
+}
+
+extension PHImageManager: ImageManagerProtocol {}
+
 protocol PhotoLibraryProtocol {
     func performChanges(_ changeBlock: @escaping () -> Swift.Void, completionHandler: ((Bool, Error?) -> Swift.Void)?)
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/SavableImage.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/SavableImage.swift
@@ -19,21 +19,6 @@
 
 import Photos
 
-protocol ImageManagerProtocol {
-    func cancelImageRequest(_ requestID: PHImageRequestID)
-
-    @discardableResult
-    func requestImage(for asset: PHAsset, targetSize: CGSize, contentMode: PHImageContentMode, options: PHImageRequestOptions?, resultHandler: @escaping (UIImage?, [AnyHashable : Any]?) -> Void) -> PHImageRequestID
-
-    @discardableResult
-    func requestImageData(for asset: PHAsset, options: PHImageRequestOptions?, resultHandler: @escaping (Data?, String?, UIImage.Orientation, [AnyHashable : Any]?) -> Void) -> PHImageRequestID
-
-    @discardableResult
-    func requestExportSession(forVideo asset: PHAsset, options: PHVideoRequestOptions?, exportPreset: String, resultHandler: @escaping (AVAssetExportSession?, [AnyHashable : Any]?) -> Void) -> PHImageRequestID
-}
-
-extension PHImageManager: ImageManagerProtocol {}
-
 protocol PhotoLibraryProtocol {
     func performChanges(_ changeBlock: @escaping () -> Swift.Void, completionHandler: ((Bool, Error?) -> Swift.Void)?)
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/AssetCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/AssetCell.swift
@@ -65,48 +65,48 @@ open class AssetCell: UICollectionViewCell {
         return options
     }()
     
-    var asset: PHAsset? {
+    var asset: PHAsset? {///TODO mock
         didSet {
-            self.imageView.image = nil
-
-            let manager = PHImageManager.default()
-            
-            if self.imageRequestTag != PHInvalidImageRequestID {
-                manager.cancelImageRequest(self.imageRequestTag)
-                self.imageRequestTag = PHInvalidImageRequestID
-            }
-            
-            guard let asset = self.asset else {
-                self.durationView.text = ""
-                self.durationView.isHidden = true
-                return
-            }
-            
-            let maxDimensionRetina = max(self.bounds.size.width, self.bounds.size.height) * (self.window ?? UIApplication.shared.keyWindow!).screen.scale
-
-            representedAssetIdentifier = asset.localIdentifier
-            imageRequestTag = manager.requestImage(for: asset,
-                                                   targetSize: CGSize(width: maxDimensionRetina, height: maxDimensionRetina),
-                                                   contentMode: .aspectFill,
-                                                   options: type(of: self).imageFetchOptions,
-                                                   resultHandler: { [weak self] result, info -> Void in
-                                                    guard let `self` = self,
-                                                        self.representedAssetIdentifier == asset.localIdentifier
-                                                        else { return }
-                                                    self.imageView.image = result
-            })
-            
-            if asset.mediaType == .video {
-                let duration = Int(ceil(asset.duration))
-                
-                let (seconds, minutes) = (duration % 60, duration / 60)
-                self.durationView.text = String(format: "%d:%02d", minutes, seconds)
-                self.durationView.isHidden = false
-            }
-            else {
-                self.durationView.text = ""
-                self.durationView.isHidden = true
-            }
+//            self.imageView.image = nil
+//
+//            let manager = PHImageManager.default()///TODO mock
+//
+//            if self.imageRequestTag != PHInvalidImageRequestID {
+//                manager.cancelImageRequest(self.imageRequestTag)
+//                self.imageRequestTag = PHInvalidImageRequestID
+//            }
+//
+//            guard let asset = self.asset else {
+//                self.durationView.text = ""
+//                self.durationView.isHidden = true
+//                return
+//            }
+//
+//            let maxDimensionRetina = max(self.bounds.size.width, self.bounds.size.height) * (self.window ?? UIApplication.shared.keyWindow!).screen.scale
+//
+//            representedAssetIdentifier = asset.localIdentifier
+////            imageRequestTag = manager.requestImage(for: asset,
+////                                                   targetSize: CGSize(width: maxDimensionRetina, height: maxDimensionRetina),
+////                                                   contentMode: .aspectFill,
+////                                                   options: type(of: self).imageFetchOptions,
+////                                                   resultHandler: { [weak self] result, info -> Void in
+////                                                    guard let `self` = self,
+////                                                        self.representedAssetIdentifier == asset.localIdentifier
+////                                                        else { return }
+////                                                    self.imageView.image = result
+////            })
+//
+//            if asset.mediaType == .video {
+//                let duration = Int(ceil(asset.duration))
+//
+//                let (seconds, minutes) = (duration % 60, duration / 60)
+//                self.durationView.text = String(format: "%d:%02d", minutes, seconds)
+//                self.durationView.isHidden = false
+//            }
+//            else {
+//                self.durationView.text = ""
+//                self.durationView.isHidden = true
+//            }
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/AssetCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/AssetCell.swift
@@ -28,7 +28,7 @@ open class AssetCell: UICollectionViewCell {
     
     var imageRequestTag: PHImageRequestID = PHInvalidImageRequestID
     var representedAssetIdentifier: String!
-    var manager: ImageManagerProtocol = PHImageManager.default()
+    var manager: ImageManagerProtocol!
 
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/AssetCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/AssetCell.swift
@@ -28,6 +28,7 @@ open class AssetCell: UICollectionViewCell {
     
     var imageRequestTag: PHImageRequestID = PHInvalidImageRequestID
     var representedAssetIdentifier: String!
+    var manager: ImageManagerProtocol = PHImageManager.default()
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -65,48 +66,46 @@ open class AssetCell: UICollectionViewCell {
         return options
     }()
     
-    var asset: PHAsset? {///TODO mock
+    var asset: PHAsset? {
         didSet {
-//            self.imageView.image = nil
-//
-//            let manager = PHImageManager.default()///TODO mock
-//
-//            if self.imageRequestTag != PHInvalidImageRequestID {
-//                manager.cancelImageRequest(self.imageRequestTag)
-//                self.imageRequestTag = PHInvalidImageRequestID
-//            }
-//
-//            guard let asset = self.asset else {
-//                self.durationView.text = ""
-//                self.durationView.isHidden = true
-//                return
-//            }
-//
-//            let maxDimensionRetina = max(self.bounds.size.width, self.bounds.size.height) * (self.window ?? UIApplication.shared.keyWindow!).screen.scale
-//
-//            representedAssetIdentifier = asset.localIdentifier
-////            imageRequestTag = manager.requestImage(for: asset,
-////                                                   targetSize: CGSize(width: maxDimensionRetina, height: maxDimensionRetina),
-////                                                   contentMode: .aspectFill,
-////                                                   options: type(of: self).imageFetchOptions,
-////                                                   resultHandler: { [weak self] result, info -> Void in
-////                                                    guard let `self` = self,
-////                                                        self.representedAssetIdentifier == asset.localIdentifier
-////                                                        else { return }
-////                                                    self.imageView.image = result
-////            })
-//
-//            if asset.mediaType == .video {
-//                let duration = Int(ceil(asset.duration))
-//
-//                let (seconds, minutes) = (duration % 60, duration / 60)
-//                self.durationView.text = String(format: "%d:%02d", minutes, seconds)
-//                self.durationView.isHidden = false
-//            }
-//            else {
-//                self.durationView.text = ""
-//                self.durationView.isHidden = true
-//            }
+            self.imageView.image = nil
+
+            if self.imageRequestTag != PHInvalidImageRequestID {
+                manager.cancelImageRequest(self.imageRequestTag)
+                self.imageRequestTag = PHInvalidImageRequestID
+            }
+
+            guard let asset = self.asset else {
+                self.durationView.text = ""
+                self.durationView.isHidden = true
+                return
+            }
+
+            let maxDimensionRetina = max(self.bounds.size.width, self.bounds.size.height) * (self.window ?? UIApplication.shared.keyWindow!).screen.scale
+
+            representedAssetIdentifier = asset.localIdentifier
+            imageRequestTag = manager.requestImage(for: asset,
+                                                   targetSize: CGSize(width: maxDimensionRetina, height: maxDimensionRetina),
+                                                   contentMode: .aspectFill,
+                                                   options: type(of: self).imageFetchOptions,
+                                                   resultHandler: { [weak self] result, info -> Void in
+                                                    guard let `self` = self,
+                                                        self.representedAssetIdentifier == asset.localIdentifier
+                                                        else { return }
+                                                    self.imageView.image = result
+            })
+
+            if asset.mediaType == .video {
+                let duration = Int(ceil(asset.duration))
+
+                let (seconds, minutes) = (duration % 60, duration / 60)
+                self.durationView.text = String(format: "%d:%02d", minutes, seconds)
+                self.durationView.isHidden = false
+            }
+            else {
+                self.durationView.text = ""
+                self.durationView.isHidden = true
+            }
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/AssetLibrary.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/AssetLibrary.swift
@@ -28,7 +28,8 @@ open class AssetLibrary: NSObject, PHPhotoLibraryChangeObserver {
     open weak var delegate: AssetLibraryDelegate?
     fileprivate var fetchingAssets = false
     public let synchronous: Bool
-    
+    let photoLibrary: PhotoLibraryProtocol
+
     open var count: UInt {
         guard let fetch = self.fetch else {
             return 0
@@ -61,7 +62,7 @@ open class AssetLibrary: NSObject, PHPhotoLibraryChangeObserver {
         let syncOperation = {
             let options = PHFetchOptions()
             options.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
-            self.fetch = PHAsset.fetchAssets(with: options)
+            self.fetch = PHAsset.fetchAssets(with: options) ///TODO: mock
             self.notifyChangeToDelegate()
         }
         
@@ -105,14 +106,17 @@ open class AssetLibrary: NSObject, PHPhotoLibraryChangeObserver {
 
     }
 
-    init(synchronous: Bool = false) {
+    init(synchronous: Bool = false, photoLibrary: PhotoLibraryProtocol = PHPhotoLibrary.shared()) {
         self.synchronous = synchronous
+        self.photoLibrary = photoLibrary
+
         super.init()
-        PHPhotoLibrary.shared().register(self)
+
+        self.photoLibrary.register(self)
         self.refetchAssets(synchronous: synchronous)
     }
 
     deinit {
-        PHPhotoLibrary.shared().unregisterChangeObserver(self)
+        photoLibrary.unregisterChangeObserver(self)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/AssetLibrary.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/AssetLibrary.swift
@@ -62,7 +62,7 @@ open class AssetLibrary: NSObject, PHPhotoLibraryChangeObserver {
         let syncOperation = {
             let options = PHFetchOptions()
             options.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
-            self.fetch = PHAsset.fetchAssets(with: options) ///TODO: mock
+            self.fetch = PHAsset.fetchAssets(with: options)
             self.notifyChangeToDelegate()
         }
         

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
@@ -35,7 +35,7 @@ public protocol CameraKeyboardViewControllerDelegate: class {
 
 open class CameraKeyboardViewController: UIViewController {
     
-    fileprivate var permissions: PhotoPermissionsController!
+    fileprivate var permissions: PhotoPermissionsController! ///TODO mock
     fileprivate var lastLayoutSize = CGSize.zero
     fileprivate let collectionViewLayout = UICollectionViewFlowLayout()
     fileprivate let sideMargin: CGFloat = 14
@@ -209,7 +209,7 @@ open class CameraKeyboardViewController: UIViewController {
     }
 
     fileprivate func forwardSelectedPhotoAsset(_ asset: PHAsset) {
-        let manager = PHImageManager.default()
+        let manager = PHImageManager.default()///TODO: mock?
 
         let completeBlock = { (data: Data?, uti: String?) in
             guard let data = data else { return }
@@ -415,7 +415,7 @@ extension CameraKeyboardViewController: UICollectionViewDelegateFlowLayout, UICo
             
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: AssetCell.reuseIdentifier, for: indexPath) as! AssetCell
             if let asset = try? assetLibrary.asset(atIndex: UInt((indexPath as NSIndexPath).row)) {
-                cell.asset = asset
+                cell.asset = asset //TODO: inject mock PHImageManager
             }
             return cell
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
@@ -69,7 +69,9 @@ open class CameraKeyboardViewController: UIViewController {
         NotificationCenter.default.removeObserver(self)
     }
     
-    init(splitLayoutObservable: SplitLayoutObservable, assetLibrary: AssetLibrary = AssetLibrary(), permissions: PhotoPermissionsController = PhotoPermissionsControllerStrategy()) {
+    init(splitLayoutObservable: SplitLayoutObservable,
+         assetLibrary: AssetLibrary = AssetLibrary(),
+         permissions: PhotoPermissionsController = PhotoPermissionsControllerStrategy()) {
         self.splitLayoutObservable = splitLayoutObservable
         self.assetLibrary = assetLibrary
         self.permissions = permissions

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
@@ -414,11 +414,13 @@ extension CameraKeyboardViewController: UICollectionViewDelegateFlowLayout, UICo
             }
             
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: AssetCell.reuseIdentifier, for: indexPath) as! AssetCell
+
+            cell.manager = imageManager
+
             if let asset = try? assetLibrary.asset(atIndex: UInt((indexPath as NSIndexPath).row)) {
                 cell.asset = asset
             }
 
-            cell.manager = imageManager
 
             return cell
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/PhotoPermissionsController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/PhotoPermissionsController.swift
@@ -17,7 +17,6 @@
 //
 
 import Foundation
-import Photos
 
 // This protocol is used for UI (& testing) purposes only.
 // In case you'll create a class compliant with this protocol, that returns `true`
@@ -30,32 +29,4 @@ public protocol PhotoPermissionsController {
     var isPhotoLibraryAuthorized: Bool { get }
     var areCameraOrPhotoLibraryAuthorized: Bool { get }
     var areCameraAndPhotoLibraryAuthorized: Bool { get }
-}
-
-final class PhotoPermissionsControllerStrategy: PhotoPermissionsController {
-    
-    // `unauthorized` state happens the first time before opening the keyboard,
-    // so we don't need to check it for our purposes.
-    
-    var isCameraAuthorized: Bool {
-        switch AVCaptureDevice.authorizationStatus(for: AVMediaType.video) {
-        case .authorized: return true
-        default: return false
-        }
-    }
-    
-    var isPhotoLibraryAuthorized: Bool {
-        switch PHPhotoLibrary.authorizationStatus() {
-        case .authorized: return true
-        default: return false
-        }
-    }
-    
-    var areCameraOrPhotoLibraryAuthorized: Bool {
-        return isCameraAuthorized || isPhotoLibraryAuthorized
-    }
-    
-    var areCameraAndPhotoLibraryAuthorized: Bool {
-        return isCameraAuthorized && isPhotoLibraryAuthorized
-    }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/PhotoPermissionsControllerStrategy.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/PhotoPermissionsControllerStrategy.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2018 Wire Swiss GmbH
+// Copyright (C) 2019 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -16,35 +16,34 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import UIKit
 import Foundation
-import XCTest
-@testable import Wire
+import Photos
 
-final class MockPhotoPermissionsController: PhotoPermissionsController {
-    
-    private var camera = false
-    private var library = false
-    
-    init(camera: Bool, library: Bool) {
-        self.camera = camera
-        self.library = library
-    }
-    
+
+final class PhotoPermissionsControllerStrategy: PhotoPermissionsController {
+
+    // `unauthorized` state happens the first time before opening the keyboard,
+    // so we don't need to check it for our purposes.
+
     var isCameraAuthorized: Bool {
-        return camera
-    }
-    
-    var isPhotoLibraryAuthorized: Bool {
-        return library
-    }
-    
-    var areCameraOrPhotoLibraryAuthorized: Bool {
-        return camera || library
-    }
-    
-    var areCameraAndPhotoLibraryAuthorized: Bool {
-        return camera && library
+        switch AVCaptureDevice.authorizationStatus(for: AVMediaType.video) {
+        case .authorized: return true
+        default: return false
+        }
     }
 
+    var isPhotoLibraryAuthorized: Bool {
+        switch PHPhotoLibrary.authorizationStatus() {
+        case .authorized: return true
+        default: return false
+        }
+    }
+
+    var areCameraOrPhotoLibraryAuthorized: Bool {
+        return isCameraAuthorized || isPhotoLibraryAuthorized
+    }
+
+    var areCameraAndPhotoLibraryAuthorized: Bool {
+        return isCameraAuthorized && isPhotoLibraryAuthorized
+    }
 }

--- a/Wire-iOS/Sources/UserInterface/Settings/ProfileSelfPictureViewController+SetupViews.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/ProfileSelfPictureViewController+SetupViews.swift
@@ -108,7 +108,7 @@ extension ProfileSelfPictureViewController {
         libraryButton.setIconColor(.white, for: .normal)
         libraryButton.setIcon(.photo, size: .small, for: .normal)
 
-        if PHPhotoLibrary.authorizationStatus() == .authorized {
+        if PHPhotoLibrary.authorizationStatus() == .authorized {//TODO: ProfileSelfPictureViewControllerSnapshotTests
             let options = PHFetchOptions()
             options.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
             options.fetchLimit = 1

--- a/Wire-iOS/Sources/UserInterface/Settings/ProfileSelfPictureViewController+SetupViews.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/ProfileSelfPictureViewController+SetupViews.swift
@@ -108,7 +108,7 @@ extension ProfileSelfPictureViewController {
         libraryButton.setIconColor(.white, for: .normal)
         libraryButton.setIcon(.photo, size: .small, for: .normal)
 
-        if PHPhotoLibrary.authorizationStatus() == .authorized {//TODO: ProfileSelfPictureViewControllerSnapshotTests
+        if PHPhotoLibrary.authorizationStatus() == .authorized {
             let options = PHFetchOptions()
             options.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
             options.fetchLimit = 1


### PR DESCRIPTION
## What's new in this PR?

### Issues

For PR https://github.com/wireapp/wire-ios/pull/3408 and https://github.com/wireapp/wire-ios/pull/3407 I want to create snapshot tests for UIAlertController but they are always fail whening running on CI server.

### Causes

There are some system dialogs for Photo and Contacts permissions and causes nil snapshot images of the UIAlertControllers

### Solutions

Prevent interaction with Photo API when running tests. Inject mocks of `PHImageManager` and `PHPhotoLibrary` to `CameraKeyboardViewController` and its subviews.

### TODO

- [ ] fix for the Contacts permission dialog

