### PR TITLE
Disable option to delete legal hold device

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
@@ -383,7 +383,7 @@ final class ClientListViewController: UIViewController,
         case 0:
             return .none
         case 1:
-            return .delete
+            return sortedClients[indexPath.row].type == .legalHold ? .none : .delete
         default:
             return .none
         }

--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/SettingsClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/SettingsClientViewController.swift
@@ -184,11 +184,10 @@ class SettingsClientViewController: UIViewController,
     
     func numberOfSections(in tableView: UITableView) -> Int {
         
-        if let userClient = ZMUserSession.shared()?.selfUserClient(),
-            self.userClient == userClient {
+        if let userClient = ZMUserSession.shared()?.selfUserClient(), self.userClient == userClient {
             return 2
         } else {
-            return 4
+            return userClient.type == .legalHold ? 3 : 4
         }
     }
 


### PR DESCRIPTION
## What's new in this PR?

Disable option to delete legal hold device since backend won't allow it.
