### PR TITLE
Don't disable IS_INTERNAL_BUILD on project level xcconfig

### DIFF
--- a/Wire-iOS/Resources/Configuration/Project-Release.xcconfig
+++ b/Wire-iOS/Resources/Configuration/Project-Release.xcconfig
@@ -38,7 +38,6 @@ ENABLE_NS_ASSERTIONS = NO
 //
 // ENABLE_DEVELOPER_MENU - Enabled developer menu from self profile -> settings
 // WIRESTAN - Enabled the fake country in the phone number selection
-IS_INTERNAL_BUILD = 0
 FEATURE_FLAGS = ENABLE_DEVELOPER_MENU=0 WIRESTAN=0
 
 // Use analytics / Hockey for Release builds:


### PR DESCRIPTION
## What's new in this PR?

### Issues

Developer settings are not available on dev and internal builds

### Causes

xcconfig files are applied in the following order for the release configuration:

1. Release.xcconfig
2. Project-Base.xcconfig
3. Project-Release.xcconfig
4. Wire-iOS-Release.xcconfig

`IS_INTERNAL_BUILD` is configured in the `Release.xcconfig` which is different for each build variant (develop, internal, appstore). This however got overriden in `Project-Release.xcconfig`, which set `IS_INTERNAL_BUILD` to `0`.

### Solutions

Don't set `IS_INTERNAL_BUILD` in `Project-Release.xcconfig`.