### PR TITLE
Add file header template with automatic date

### DIFF
--- a/Wire-iOS.xcodeproj/xcshareddata/IDETemplateMacros.plist
+++ b/Wire-iOS.xcodeproj/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>FILEHEADER</key>
+	<string>
+// Wire
+// Copyright (C) ___YEAR___ Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//</string>
+</dict>
+</plist>


### PR DESCRIPTION
## What's new in this PR?

### Issues

When we create a file in Xcode, we need to make sure that the header format is correct, which means that we most of the times need to copy it from another file. It's happened before that we forget to fix the year after pasting it in the new file.

### Solutions

Add an Xcode file header template (https://oleb.net/blog/2017/07/xcode-9-text-macros/) to generate the template with the right format and year when creating a new file.