### PR TITLE
Fix: Keyboard appears over contact permission screen and UIActivityViewController not show

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1102,9 +1102,9 @@
 		EF297DDD213209220002983A /* ContactsViewController+Style.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF297DDB213209220002983A /* ContactsViewController+Style.swift */; };
 		EF297DE321320AC20002983A /* InviteContactsViewController+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF297DE121320AC20002983A /* InviteContactsViewController+Swift.swift */; };
 		EF297DEC213340CF0002983A /* ParticipantDeviceHeaderView+Style.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF297DEA213340CF0002983A /* ParticipantDeviceHeaderView+Style.swift */; };
+		EF298BD1228D942A0078BE68 /* ImageManagerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF298BD0228D942A0078BE68 /* ImageManagerProtocol.swift */; };
 		EF298BD3228D9BB20078BE68 /* StartUIViewController+AddressBook.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF298BD2228D9BB20078BE68 /* StartUIViewController+AddressBook.swift */; };
 		EF298BD5228D9E830078BE68 /* ConversationListViewController+StartUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF298BD4228D9E830078BE68 /* ConversationListViewController+StartUI.swift */; };
-		EF298BD1228D942A0078BE68 /* ImageManagerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF298BD0228D942A0078BE68 /* ImageManagerProtocol.swift */; };
 		EF29E89C212302CD0023B80C /* AudioMessageViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF29E89B212302CD0023B80C /* AudioMessageViewTests.swift */; };
 		EF29F1BB21271A9A00BE94E6 /* GroupDetailsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF29F1BA21271A9A00BE94E6 /* GroupDetailsViewControllerTests.swift */; };
 		EF2A8DE7214A816D002C9058 /* StartUIViewControllerSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2A8DE6214A816D002C9058 /* StartUIViewControllerSnapshotTests.swift */; };
@@ -1138,6 +1138,7 @@
 		EF32AB0121C13C09002E4777 /* UIViewController+Present.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF32AB0021C13C09002E4777 /* UIViewController+Present.swift */; };
 		EF32AB0321C15B0E002E4777 /* String+MessageToolBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF32AB0221C15B0E002E4777 /* String+MessageToolBox.swift */; };
 		EF33204C21496A0D0079E832 /* AVPlayerViewController+StatusBarAndNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF33204B21496A0D0079E832 /* AVPlayerViewController+StatusBarAndNotification.swift */; };
+		EF334B98229D789500099D80 /* StartUIViewController+ContactsViewControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF334B97229D789500099D80 /* StartUIViewController+ContactsViewControllerDelegate.swift */; };
 		EF3371C22216D9D9005ED048 /* ZMUser+Self.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3371C12216D9D9005ED048 /* ZMUser+Self.swift */; };
 		EF3371C52216F067005ED048 /* MockUser+SelfUserFromSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3371C32216EEE2005ED048 /* MockUser+SelfUserFromSession.swift */; };
 		EF36168A21E753310041F0CC /* SettingsTableViewControllerSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF36168921E753300041F0CC /* SettingsTableViewControllerSnapshotTests.swift */; };
@@ -2886,9 +2887,9 @@
 		EF297DE221320AC20002983A /* InviteContactsViewController+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "InviteContactsViewController+Internal.h"; sourceTree = "<group>"; };
 		EF297DEA213340CF0002983A /* ParticipantDeviceHeaderView+Style.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ParticipantDeviceHeaderView+Style.swift"; sourceTree = "<group>"; };
 		EF297DEB213340CF0002983A /* ParticipantDeviceHeaderView+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ParticipantDeviceHeaderView+Internal.h"; sourceTree = "<group>"; };
+		EF298BD0228D942A0078BE68 /* ImageManagerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageManagerProtocol.swift; sourceTree = "<group>"; };
 		EF298BD2228D9BB20078BE68 /* StartUIViewController+AddressBook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StartUIViewController+AddressBook.swift"; sourceTree = "<group>"; };
 		EF298BD4228D9E830078BE68 /* ConversationListViewController+StartUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationListViewController+StartUI.swift"; sourceTree = "<group>"; };
-		EF298BD0228D942A0078BE68 /* ImageManagerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageManagerProtocol.swift; sourceTree = "<group>"; };
 		EF29E89B212302CD0023B80C /* AudioMessageViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioMessageViewTests.swift; sourceTree = "<group>"; };
 		EF29F1BA21271A9A00BE94E6 /* GroupDetailsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupDetailsViewControllerTests.swift; sourceTree = "<group>"; };
 		EF2A8DE6214A816D002C9058 /* StartUIViewControllerSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartUIViewControllerSnapshotTests.swift; sourceTree = "<group>"; };
@@ -2919,6 +2920,7 @@
 		EF32AB0021C13C09002E4777 /* UIViewController+Present.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Present.swift"; sourceTree = "<group>"; };
 		EF32AB0221C15B0E002E4777 /* String+MessageToolBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+MessageToolBox.swift"; sourceTree = "<group>"; };
 		EF33204B21496A0D0079E832 /* AVPlayerViewController+StatusBarAndNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVPlayerViewController+StatusBarAndNotification.swift"; sourceTree = "<group>"; };
+		EF334B97229D789500099D80 /* StartUIViewController+ContactsViewControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StartUIViewController+ContactsViewControllerDelegate.swift"; sourceTree = "<group>"; };
 		EF3371C12216D9D9005ED048 /* ZMUser+Self.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUser+Self.swift"; sourceTree = "<group>"; };
 		EF3371C32216EEE2005ED048 /* MockUser+SelfUserFromSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MockUser+SelfUserFromSession.swift"; sourceTree = "<group>"; };
 		EF36168921E753300041F0CC /* SettingsTableViewControllerSnapshotTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsTableViewControllerSnapshotTests.swift; sourceTree = "<group>"; };
@@ -5009,6 +5011,7 @@
 				16325E641EE03CC4000E72EB /* SearchResultsView.swift */,
 				164C29AA1ED33A5F0026562A /* SearchResultsViewController.swift */,
 				8775BF1B2007C6B900A8AD93 /* SearchGroupSelector.swift */,
+				EF334B97229D789500099D80 /* StartUIViewController+ContactsViewControllerDelegate.swift */,
 			);
 			path = StartUI;
 			sourceTree = "<group>";
@@ -7709,6 +7712,7 @@
 				EE0DE1CD21B172BF00CF3C4E /* ConversationCreateGuestsSectionController.swift in Sources */,
 				5E7315352191EADF00255A78 /* Message+Formatters.swift in Sources */,
 				5E8FFC1821EF61A90052DF03 /* ClientUnregisterInvitationStepDescription.swift in Sources */,
+				EF334B98229D789500099D80 /* StartUIViewController+ContactsViewControllerDelegate.swift in Sources */,
 				8F8914111A9F287E0056AB0C /* ConversationListCell.m in Sources */,
 				5E21344621CCEF1700273D0D /* EmptyViewDescription.swift in Sources */,
 				F16427061FCC5BE400D2ABFC /* SetFullNameStepDescription.swift in Sources */,

--- a/Wire-iOS/Sources/Permissions/ShareContactsViewController+Extension.swift
+++ b/Wire-iOS/Sources/Permissions/ShareContactsViewController+Extension.swift
@@ -20,6 +20,7 @@ import Foundation
 
 extension ShareContactsViewController {
 
+    // MARK: - Constraints
     @objc
     func createConstraints() {
         [backgroundBlurView,
@@ -55,6 +56,25 @@ extension ShareContactsViewController {
         ]
 
         NSLayoutConstraint.activate(constraints)
+    }
+
+    // MARK: - AddressBook Access Denied ViewController
+
+    @objc(displayContactsAccessDeniedMessageAnimated:)
+    func displayContactsAccessDeniedMessage(animated: Bool) {
+        endEditing()
+
+        showingAddressBookAccessDeniedViewController = true
+
+        if animated {
+            UIView.transition(from: shareContactsContainerView,
+                              to: addressBookAccessDeniedViewController.view,
+                              duration: 0.35,
+                              options: [.showHideTransitionViews, .transitionCrossDissolve])
+        } else {
+            shareContactsContainerView.isHidden = true
+            addressBookAccessDeniedViewController.view.isHidden = false
+        }
     }
 }
 

--- a/Wire-iOS/Sources/Permissions/ShareContactsViewController+Internal.h
+++ b/Wire-iOS/Sources/Permissions/ShareContactsViewController+Internal.h
@@ -19,6 +19,8 @@
 @class Button;
 @class PermissionDeniedViewController;
 
+@protocol PermissionDeniedViewControllerDelegate;
+
 @interface ShareContactsViewController ()
 
 @property (nonatomic) UIButton *notNowButton;
@@ -27,5 +29,11 @@
 @property (nonatomic) UIView *shareContactsContainerView;
 @property (nonatomic) PermissionDeniedViewController *addressBookAccessDeniedViewController;
 @property (nonatomic) UIVisualEffectView *backgroundBlurView;
+
+@end
+
+@interface ShareContactsViewController () <PermissionDeniedViewControllerDelegate>
+
+@property (nonatomic) BOOL showingAddressBookAccessDeniedViewController;
 
 @end

--- a/Wire-iOS/Sources/Permissions/ShareContactsViewController.m
+++ b/Wire-iOS/Sources/Permissions/ShareContactsViewController.m
@@ -26,12 +26,6 @@
 #import "Wire-Swift.h"
 
 
-@interface ShareContactsViewController () <PermissionDeniedViewControllerDelegate>
-
-@property (nonatomic) BOOL showingAddressBookAccessDeniedViewController;
-
-@end
-
 @implementation ShareContactsViewController
 
 - (void)viewDidLoad
@@ -119,22 +113,6 @@
     [self.view addSubview:self.addressBookAccessDeniedViewController.view];
     [self.addressBookAccessDeniedViewController didMoveToParentViewController:self];
     self.addressBookAccessDeniedViewController.view.hidden = YES;
-}
-
-- (void)displayContactsAccessDeniedMessageAnimated:(BOOL)animated
-{
-    self.showingAddressBookAccessDeniedViewController = YES;
-
-    if (animated) {
-        [UIView transitionFromView:self.shareContactsContainerView
-                            toView:self.addressBookAccessDeniedViewController.view
-                          duration:0.35
-                           options:UIViewAnimationOptionShowHideTransitionViews | UIViewAnimationOptionTransitionCrossDissolve
-                        completion:nil];
-    } else {
-        self.shareContactsContainerView.hidden = YES;
-        self.addressBookAccessDeniedViewController.view.hidden = NO;
-    }
 }
 
 - (void)setBackgroundBlurDisabled:(BOOL)backgroundBlurDisabled

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+ContactsViewControllerDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+ContactsViewControllerDelegate.swift
@@ -25,8 +25,9 @@ extension StartUIViewController: ContactsViewControllerDelegate {
     }
 
     public func contactsViewControllerDidNotShareContacts(_ controller: ContactsViewController) {
-        dismiss(animated: true) { ///TODO: top VC
-            UIApplication.shared.wr_topmostController()?.wr_presentInviteActivityViewController(withSourceView: self.quickActionsBar, logicalContext: GenericInviteContext.startUIBanner)
+        dismiss(animated: true) {
+            UIApplication.shared.wr_topmostController()?.wr_presentInviteActivityViewController(withSourceView: self.quickActionsBar,
+                                                                                                logicalContext: GenericInviteContext.startUIBanner)
         }
     }
 

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+ContactsViewControllerDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+ContactsViewControllerDelegate.swift
@@ -1,0 +1,33 @@
+
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension StartUIViewController: ContactsViewControllerDelegate {
+
+    public func contactsViewControllerDidCancel(_ controller: ContactsViewController) {
+        dismiss(animated: true)
+    }
+
+    public func contactsViewControllerDidNotShareContacts(_ controller: ContactsViewController) {
+        dismiss(animated: true) { ///TODO: top VC
+            UIApplication.shared.wr_topmostController()?.wr_presentInviteActivityViewController(withSourceView: self.quickActionsBar, logicalContext: GenericInviteContext.startUIBanner)
+        }
+    }
+
+}

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+internal.h
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+internal.h
@@ -21,6 +21,8 @@ static NSUInteger const StartUIInitiallyShowsKeyboardConversationThreshold = 10;
 @class SearchHeaderViewController;
 @class SearchGroupSelector;
 @class SearchResultsViewController;
+@class StartUIInviteActionBar;
+
 @protocol UserType;
 @protocol AddressBookHelperProtocol;
 
@@ -34,6 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) SearchResultsViewController *searchResultsViewController;
 @property (nonatomic) BOOL addressBookUploadLogicHandled;
 @property (nonatomic, null_unspecified) id<AddressBookHelperProtocol> addressBookHelper;
+@property (nonatomic) StartUIInviteActionBar *quickActionsBar;
 
 -(instancetype) init;
 

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.m
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.m
@@ -40,10 +40,9 @@
 static NSString* ZMLogTag ZM_UNUSED = @"UI";
 
 
-@interface StartUIViewController () <ContactsViewControllerDelegate, SearchHeaderViewControllerDelegate>
+@interface StartUIViewController () <SearchHeaderViewControllerDelegate>
 
 @property (nonatomic) ProfilePresenter *profilePresenter;
-@property (nonatomic) StartUIInviteActionBar *quickActionsBar;
 @property (nonatomic) EmptySearchResultsView *emptyResultView;
 
 @end
@@ -252,20 +251,6 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
     [self.searchResultsViewController cancelPreviousSearch];
     [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(performSearch) object:nil];
     [self performSelector:@selector(performSearch) withObject:nil afterDelay:0.2f];
-}
-
-#pragma mark - ContactsViewControllerDelegate
-
-- (void)contactsViewControllerDidCancel:(ContactsViewController *)controller
-{
-    [self dismissViewControllerAnimated:YES completion:nil];
-}
-
-- (void)contactsViewControllerDidNotShareContacts:(ContactsViewController *)controller
-{
-    [self dismissViewControllerAnimated:YES completion:^{
-        [self wr_presentInviteActivityViewControllerWithSourceView:self.quickActionsBar logicalContext:GenericInviteContextStartUIBanner];
-    }];
 }
 
 @end


### PR DESCRIPTION
## What's new in this PR?

### Issues
- the keyboard is shown above `AddressBookAccessDeniedViewController` but it has no text field
- `UIActivityViewController` for sharing via other method is not shown.

### Causes

- `AddressBookAccessDeniedViewController` is added above `ShareContactsViewController` and the text field on it is focused.
- `UIActivityViewController` is presented from `StartUIViewController`, which is not visible.

### Solutions

- call `endediting` before `AddressBookAccessDeniedViewController` is shown
- presented `UIActivityViewController` form top view controller.