### PR TITLE
ZIOS-11447: iOS call failure pop-up in multiple devices

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/CallQualityController/CallQualityController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallQualityController/CallQualityController.swift
@@ -93,6 +93,7 @@ class CallQualityController: NSObject {
         switch reason {
         case .normal, .stillOngoing:
             handleCallSuccess(callStartDate: callStartDate, callEndDate: eventDate)
+        case .anweredElsewhere: break;
         default:
             handleCallFailure()
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Call logs popup was shown when answering from another device.

### Causes

This because the `handleCallCompletion` method is called with `reason = .answeredElsewhere`, that should not be taken in account for the call logs popup.

### Solutions

I've added the case inside the switch that handles possible reasons.
