### PR TITLE
Fix: Unable to press "why verify conversations"

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1161,6 +1161,7 @@
 		EF44784F20906DDD00BD9827 /* FullscreenImageViewController+Zoom.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF44784E20906DDD00BD9827 /* FullscreenImageViewController+Zoom.swift */; };
 		EF4478522090BF8700BD9827 /* FullscreenImageViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF4478512090BF8700BD9827 /* FullscreenImageViewControllerTests.swift */; };
 		EF44C6A42215861F007C5CDC /* MockUserClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D553661C86F0450026573C /* MockUserClient.swift */; };
+		EF4686DD22A6AC3200E25764 /* ParticipantDeviceHeaderView+UITextViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF4686DC22A6AC3200E25764 /* ParticipantDeviceHeaderView+UITextViewDelegate.swift */; };
 		EF4795AD2077847E00334E32 /* ConversationInputBarViewController+UITextViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF4795AC2077847E00334E32 /* ConversationInputBarViewController+UITextViewDelegate.swift */; };
 		EF47971E211E398000EDFC15 /* MessagePresenter+OpenFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF47971D211E398000EDFC15 /* MessagePresenter+OpenFile.swift */; };
 		EF4FFB3522830BD200B69851 /* String+WholeRangeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF4FFB3422830BD200B69851 /* String+WholeRangeTests.swift */; };
@@ -2947,6 +2948,7 @@
 		EF44784E20906DDD00BD9827 /* FullscreenImageViewController+Zoom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FullscreenImageViewController+Zoom.swift"; sourceTree = "<group>"; };
 		EF4478502090BC1800BD9827 /* FullscreenImageViewController+internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "FullscreenImageViewController+internal.h"; sourceTree = "<group>"; };
 		EF4478512090BF8700BD9827 /* FullscreenImageViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullscreenImageViewControllerTests.swift; sourceTree = "<group>"; };
+		EF4686DC22A6AC3200E25764 /* ParticipantDeviceHeaderView+UITextViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ParticipantDeviceHeaderView+UITextViewDelegate.swift"; sourceTree = "<group>"; };
 		EF4795AC2077847E00334E32 /* ConversationInputBarViewController+UITextViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationInputBarViewController+UITextViewDelegate.swift"; sourceTree = "<group>"; };
 		EF47971D211E398000EDFC15 /* MessagePresenter+OpenFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MessagePresenter+OpenFile.swift"; sourceTree = "<group>"; };
 		EF4FFB3422830BD200B69851 /* String+WholeRangeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+WholeRangeTests.swift"; sourceTree = "<group>"; };
@@ -4607,6 +4609,7 @@
 				EF297DEB213340CF0002983A /* ParticipantDeviceHeaderView+Internal.h */,
 				BF5C37971C0E0D9C00EA11E3 /* ParticipantDeviceHeaderView.m */,
 				EF297DEA213340CF0002983A /* ParticipantDeviceHeaderView+Style.swift */,
+				EF4686DC22A6AC3200E25764 /* ParticipantDeviceHeaderView+UITextViewDelegate.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -7693,6 +7696,7 @@
 				5E35F733217F147A00D3F4FE /* ConversationMessageSectionController.swift in Sources */,
 				87797C0B1FF3C849009FC9A9 /* SearchServicesSectionController.swift in Sources */,
 				87BEB03E1D3E44DE00DE9575 /* CameraCell.swift in Sources */,
+				EF4686DD22A6AC3200E25764 /* ParticipantDeviceHeaderView+UITextViewDelegate.swift in Sources */,
 				5E8FFC1021EE0CA60052DF03 /* AuthenticationButtonTapInputHandler.swift in Sources */,
 				5E8DA74F211AEE3D00360979 /* AuthenticationCoordinatorAction.swift in Sources */,
 				EFA06E4721FB639700BF2E17 /* ConversationContentViewController+CanvasViewControllerDelegate.swift in Sources */,

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Devices/UserClientListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Devices/UserClientListViewController.swift
@@ -45,6 +45,8 @@ class UserClientListViewController: UIViewController, UICollectionViewDelegateFl
         if let userSession = ZMUserSession.shared() {
             tokens.append(UserChangeInfo.add(observer: self, for: user, userSession: userSession))
         }
+
+        self.headerView.delegate = self
         
         title = "profile.devices.title".localized
     }
@@ -146,4 +148,10 @@ extension UserClientListViewController: ZMUserObserver {
         collectionView.reloadData()
     }
     
+}
+
+extension UserClientListViewController: ParticipantDeviceHeaderViewDelegate {
+    func participantsDeviceHeaderViewDidTapLearnMore(_ headerView: ParticipantDeviceHeaderView!) {
+        URL.wr_fingerprintLearnMore.openInApp(above: self)
+    }
 }

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Views/ParticipantDeviceHeaderView+UITextViewDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Views/ParticipantDeviceHeaderView+UITextViewDelegate.swift
@@ -1,39 +1,28 @@
-// 
+
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
-// 
+// Copyright (C) 2019 Wire Swiss GmbH
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
+//
 
+import Foundation
 
-#import <UIKit/UIKit.h>
+extension ParticipantDeviceHeaderView: UITextViewDelegate {
 
-@protocol ParticipantDeviceHeaderViewDelegate;
+    public func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
+        delegate.participantsDeviceHeaderViewDidTapLearnMore(self)
 
-@interface ParticipantDeviceHeaderView : UIView
-
-- (instancetype)initWithUserName:(NSString *)userName;
-
-@property (weak, nonatomic) id <ParticipantDeviceHeaderViewDelegate> delegate;
-@property (nonatomic, readonly) NSString *userName;
-@property (nonatomic) BOOL showUnencryptedLabel;
-
-@end
-
-
-@protocol ParticipantDeviceHeaderViewDelegate <NSObject>
-
-- (void)participantsDeviceHeaderViewDidTapLearnMore:(ParticipantDeviceHeaderView *)headerView;
-
-@end
+        return false
+    }
+}

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Views/ParticipantDeviceHeaderView.m
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Views/ParticipantDeviceHeaderView.m
@@ -22,7 +22,7 @@
 #import "NSAttributedString+Wire.h"
 #import "Wire-Swift.h"
 
-@interface ParticipantDeviceHeaderView () <UITextViewDelegate>
+@interface ParticipantDeviceHeaderView ()
 @property (strong, nonatomic, readwrite) NSString *userName;
 @end
 
@@ -64,16 +64,6 @@
 - (void)setShowUnencryptedLabel:(BOOL)showUnencryptedLabel
 {
     self.textView.attributedText = [self attributedExplanationTextForUserName:self.userName showUnencryptedLabel:showUnencryptedLabel];
-}
-
-#pragma mark - UITextViewDelegate
-
-- (BOOL)textView:(UITextView *)textView shouldInteractWithURL:(NSURL *)URL inRange:(NSRange)characterRange interaction:(UITextItemInteraction)interaction
-{
-    if ([self.delegate respondsToSelector:@selector(participantsDeviceHeaderViewDidTapLearnMore:)]) {
-        [self.delegate participantsDeviceHeaderViewDidTapLearnMore:self];
-    }
-    return NO;
 }
 
 #pragma mark - Attributed Text


### PR DESCRIPTION
## What's new in this PR?

### Issues

In client devices screen, the link "why verify conversations" has no reaction after tapped.

### Causes

After https://github.com/wireapp/wire-ios/pull/3435,  no classes conform to `ParticipantDeviceHeaderViewDelegate` and `ParticipantDeviceHeaderView`'s delegate is not set

### Solutions

Make `UserClientListViewController` conforms `ParticipantDeviceHeaderViewDelegate` and set it as deleagate of `ParticipantDeviceHeaderView`.