### PR TITLE
Fix: "You started using *This device*" button doesn't work 

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationIconBasedCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationIconBasedCell.swift
@@ -169,7 +169,7 @@ class ConversationIconBasedCell: UIView {
 
 extension ConversationIconBasedCell: UITextViewDelegate {
     public func textView(_ textView: UITextView, shouldInteractWith url: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
-        //Fixes Swift 5.0 release build child class overrode method not called bug
+        // Fixes Swift 5.0 release build child class overridden method not called bug
         return false
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationIconBasedCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationIconBasedCell.swift
@@ -170,6 +170,6 @@ class ConversationIconBasedCell: UIView {
 extension ConversationIconBasedCell: UITextViewDelegate {
     public func textView(_ textView: UITextView, shouldInteractWith url: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
         //Fixes Swift 5.0 release build child class overrode method not called bug
-        fatal("Must be overridden")
+        return false
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationIconBasedCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationIconBasedCell.swift
@@ -18,7 +18,7 @@
 
 import UIKit
 
-class ConversationIconBasedCell: UIView, UITextViewDelegate {
+class ConversationIconBasedCell: UIView {
 
     let imageContainer = UIView()
     let imageView = UIImageView()
@@ -165,4 +165,11 @@ class ConversationIconBasedCell: UIView, UITextViewDelegate {
         topContentViewTrailingConstraint.constant = trailingTextMargin
     }
 
+}
+
+extension ConversationIconBasedCell: UITextViewDelegate {
+    public func textView(_ textView: UITextView, shouldInteractWith url: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
+        //Fixes Swift 5.0 release build child class overrode method not called bug
+        fatal("Must be overridden")
+    }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationLegalHoldCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationLegalHoldCell.swift
@@ -104,7 +104,7 @@ final class ConversationLegalHoldCellDescription: ConversationMessageCellDescrip
 
 extension ConversationLegalHoldSystemMessageCell {
     
-    public func textView(_ textView: UITextView, shouldInteractWith url: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
+    public override func textView(_ textView: UITextView, shouldInteractWith url: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
         
         if url == ConversationLegalHoldSystemMessageCell.legalHoldURL, let conversation = conversation {
             let legalHoldDetails = LegalHoldDetailsViewController(conversation: conversation)

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCell.swift
@@ -76,7 +76,7 @@ class ConversationStartedSystemMessageCell: ConversationIconBasedCell, Conversat
 // MARK: - UITextViewDelegate
 extension ConversationStartedSystemMessageCell {
 
-    public func textView(_ textView: UITextView, shouldInteractWith url: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
+    public override func textView(_ textView: UITextView, shouldInteractWith url: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
 
         delegate?.conversationMessageWantsToOpenParticipantsDetails(self, selectedUsers: selectedUsers, sourceView: self)
 
@@ -146,7 +146,7 @@ class LinkConversationSystemMessageCell: ConversationIconBasedCell, Conversation
 
 extension LinkConversationSystemMessageCell {
 
-    public func textView(_ textView: UITextView, shouldInteractWith url: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
+    public override func textView(_ textView: UITextView, shouldInteractWith url: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
 
         if let itemURL = lastConfiguration?.url {
             UIApplication.shared.open(itemURL)
@@ -203,17 +203,17 @@ class NewDeviceSystemMessageCell: ConversationIconBasedCell, ConversationMessage
 
 extension NewDeviceSystemMessageCell {
 
-    public func textView(_ textView: UITextView, shouldInteractWith url: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
+    public override func textView(_ textView: UITextView, shouldInteractWith url: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
 
-        guard let linkTarget = linkTarget  else { return false }
+        guard let linkTarget = linkTarget,
+              url == type(of: self).userClientURL,
+              let zClientViewController = ZClientViewController.shared() else { return false }
 
-        if url == type(of: self).userClientURL {
-            switch linkTarget {
-            case .user(let user):
-                ZClientViewController.shared()?.openClientListScreen(for: user)
-            case .conversation(let conversation):
-                ZClientViewController.shared()?.openDetailScreen(for: conversation)
-            }
+        switch linkTarget {
+        case .user(let user):
+            zClientViewController.openClientListScreen(for: user)
+        case .conversation(let conversation):
+            zClientViewController.openDetailScreen(for: conversation)
         }
 
         return false


### PR DESCRIPTION
## What's new in this PR?

### Issues

Link text in the system message is not tappable in release build. (It is tappable in debug build)

### Causes

Same as https://github.com/wireapp/wire-ios/pull/3403

### Solutions

Add an empty implementation of `textView(_ textView: UITextView, shouldInteractWith url: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool` in `ConversationIconBasedCell` and let the children of `ConversationIconBasedCell` overrides it.