### PR TITLE
Fix: GIF image moves outside the frame after double tapped

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController+Zoom.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController+Zoom.swift
@@ -84,6 +84,12 @@ extension FullscreenImageViewController {
         guard let image = imageView?.image else { return }
 
         UIMenuController.shared.isMenuVisible = false
+
+        /// Notice: fix the case the the image is just fit on the screen and call scrollView.zoom causes images move outside the frame issue
+        guard scrollView.minimumZoomScale != scrollView.maximumZoomScale else {
+            return
+        }
+
         let scaleDiff: CGFloat = scrollView.zoomScale - scrollView.minimumZoomScale
 
         // image view in minimum zoom scale, zoom in to a 50 x 50 rect


### PR DESCRIPTION
## What's new in this PR?

### Issues

When double tap on an image with has the same width as the screen, it moves outside the frame.

### Causes

Unknown, seems like a bug of `UIScrollView` when try to zoom the view which is not able to zoom.

### Solutions

Do not zoom in this case.