### PR TITLE
Fix environment variable for recording snapshots 

### DIFF
--- a/Wire-iOS Tests/Utils/ZMSnapshotTestCase.swift
+++ b/Wire-iOS Tests/Utils/ZMSnapshotTestCase.swift
@@ -109,9 +109,7 @@ open class ZMSnapshotTestCase: FBSnapshotTestCase {
         snapshotBackgroundColor = UIColor.clear
 
         // Enable when the design of the view has changed in order to update the reference snapshots
-        #if RECORDING_SNAPSHOTS
-        recordMode = true
-        #endif
+        recordMode = strcmp(getenv("RECORDING_SNAPSHOTS"), "YES") == 0
 
         usesDrawViewHierarchyInRect = true
         let contextExpectation: XCTestExpectation = expectation(description: "It should create a context")

--- a/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
+++ b/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
@@ -142,6 +142,11 @@
             isEnabled = "NO">
          </EnvironmentVariable>
          <EnvironmentVariable
+            key = "RECORDING_SNAPSHOTS"
+            value = "NO"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
             key = "IMAGE_DIFF_DIR"
             value = "$(SOURCE_ROOT)/SnapshotResults"
             isEnabled = "YES">


### PR DESCRIPTION
## What's new in this PR?

### Issues

There was a flag in `ZMSnapshotTestCase` to enable recording, but it was not available in Swift.

### Solutions

Change the flag from a conditional build flag to an environment variable that you can set to `YES` to force recording snapshots.