### PR TITLE
Synthesize property declared in extension

### DIFF
--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.m
@@ -70,6 +70,7 @@
 
 @property (nonatomic) BOOL pendingInitialStateRestore;
 @property (nonatomic) SplitViewController *splitViewController;
+@property (nonatomic) id userObserverToken;
 
 @end
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

App crashes on launch

### Causes

Missing selector  `setUserObserverToken:`

### Solutions

Make sure property which is declared to exist in an extension is also synthesised.