### PR TITLE
[Temp] Remove legal hold disabled alert

### DIFF
--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController+ZMUserObserver.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController+ZMUserObserver.swift
@@ -21,7 +21,7 @@ extension ZClientViewController: ZMUserObserver {
     public func userDidChange(_ changeInfo: UserChangeInfo) {
         if changeInfo.legalHoldStatusChanged,
             !ZMUser.selfUser().isUnderLegalHold {
-            presentLegalHoldDeactivatedAlert()
+            // presentLegalHoldDeactivatedAlert()
         }
 
         if changeInfo.accentColorValueChanged {


### PR DESCRIPTION
## What's new in this PR?

### Issues

QA reported that this alert was shown mistakenly every time the user logs in, and it caused their nightly test passing rate to drop to 24%. We need to disable this alert until we have a proper mechanism for displaying it.