### PR TITLE
Fix: enter password alert not showing after entered a wrong password

### DIFF
--- a/Wire-iOS Tests/DeviceManagement/ClientListViewControllerTests.swift
+++ b/Wire-iOS Tests/DeviceManagement/ClientListViewControllerTests.swift
@@ -19,6 +19,10 @@
 import XCTest
 @testable import Wire
 
+final class ClientListViewControllerRetainTests: XCTestCase {
+    var sut: ClientListViewController!
+}
+
 final class ClientListViewControllerTests: ZMSnapshotTestCase {
 
     var sut: ClientListViewController!
@@ -69,6 +73,10 @@ final class ClientListViewControllerTests: ZMSnapshotTestCase {
                                        variant: variant)
 
         sut.showLoadingView = false
+    }
+
+    func testThatObserverIsNonRetained(){
+        prepareSut(variant: nil)
     }
 
     func testForTransparentBackground(){

--- a/Wire-iOS Tests/DeviceManagement/ClientListViewControllerTests.swift
+++ b/Wire-iOS Tests/DeviceManagement/ClientListViewControllerTests.swift
@@ -19,16 +19,14 @@
 import XCTest
 @testable import Wire
 
-final class ClientListViewControllerRetainTests: XCTestCase {
-    var sut: ClientListViewController!
-}
-
 final class ClientListViewControllerTests: ZMSnapshotTestCase {
 
     var sut: ClientListViewController!
     var mockUser: MockUser!
     var client: UserClient!
     var selfClient: UserClient!
+
+    weak var clientRemovalObserver: ClientRemovalObserver!
 
     override func setUp() {
         super.setUp()
@@ -77,6 +75,15 @@ final class ClientListViewControllerTests: ZMSnapshotTestCase {
 
     func testThatObserverIsNonRetained(){
         prepareSut(variant: nil)
+
+        let emailCredentials = ZMEmailCredentials(email: "foo@bar.com", password: "12345678")
+        sut.deleteUserClient(client, credentials: emailCredentials)
+
+        clientRemovalObserver = sut.removalObserver
+        XCTAssertNotNil(clientRemovalObserver)
+
+        sut.viewDidDisappear(false)
+        XCTAssertNil(clientRemovalObserver)
     }
 
     func testForTransparentBackground(){

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -656,7 +656,7 @@
 		87AAE4251E4347F000E1D13A /* ConversationContentViewController+PeekPop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87AAE4241E4347F000E1D13A /* ConversationContentViewController+PeekPop.swift */; };
 		87AAE4291E43682E00E1D13A /* LocalAuthentication.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 87AAE4281E43682E00E1D13A /* LocalAuthentication.framework */; };
 		87AB6DB61D9AB47400ADAD38 /* SettingsStyleNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87AB6DB51D9AB47400ADAD38 /* SettingsStyleNavigationController.swift */; };
-		87AC33CB2181C6FB00069C79 /* UserClient+RemoveTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87AC33CA2181C6FB00069C79 /* UserClient+RemoveTask.swift */; };
+		87AC33CB2181C6FB00069C79 /* ClientRemovalObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87AC33CA2181C6FB00069C79 /* ClientRemovalObserver.swift */; };
 		87AC33CD2182064F00069C79 /* ReplyComposingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87AC33CC2182064F00069C79 /* ReplyComposingView.swift */; };
 		87AC77DB1DE48C01009F6D56 /* Copyable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87AC77DA1DE48C01009F6D56 /* Copyable.swift */; };
 		87AC9F561C0749FB00E1ED6F /* TailEditingTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87AC9F551C0749FB00E1ED6F /* TailEditingTextField.swift */; };
@@ -2294,7 +2294,7 @@
 		87AAE4281E43682E00E1D13A /* LocalAuthentication.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = LocalAuthentication.framework; path = System/Library/Frameworks/LocalAuthentication.framework; sourceTree = SDKROOT; };
 		87AB6DB51D9AB47400ADAD38 /* SettingsStyleNavigationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsStyleNavigationController.swift; sourceTree = "<group>"; };
 		87AC33AD217F4FE400069C79 /* BackendEnvironment+Shared.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "BackendEnvironment+Shared.swift"; sourceTree = "<group>"; };
-		87AC33CA2181C6FB00069C79 /* UserClient+RemoveTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserClient+RemoveTask.swift"; sourceTree = "<group>"; };
+		87AC33CA2181C6FB00069C79 /* ClientRemovalObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientRemovalObserver.swift; sourceTree = "<group>"; };
 		87AC33CC2182064F00069C79 /* ReplyComposingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplyComposingView.swift; sourceTree = "<group>"; };
 		87AC77DA1DE48C01009F6D56 /* Copyable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Copyable.swift; sourceTree = "<group>"; };
 		87AC9F551C0749FB00E1ED6F /* TailEditingTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TailEditingTextField.swift; sourceTree = "<group>"; };
@@ -5353,7 +5353,7 @@
 				8787D1831EA74F5B00254D02 /* ZMUser+Additions.swift */,
 				D50892FA2056BD51004D3AE2 /* ZMUser+ExpirationTimeFormatting.swift */,
 				871DD79C2080C4F6006B1C56 /* Conversation+Participants.swift */,
-				87AC33CA2181C6FB00069C79 /* UserClient+RemoveTask.swift */,
+				87AC33CA2181C6FB00069C79 /* ClientRemovalObserver.swift */,
 				1661674F223A81CB00779AE3 /* MessageKeyPathObserver.swift */,
 			);
 			path = syncengine;
@@ -7579,7 +7579,7 @@
 				D550F56E204444EE009E09DD /* ConversationActionController+Leave.swift in Sources */,
 				F15650E621DD14B300210504 /* TransformLabel.swift in Sources */,
 				87F61D1A1CD36F0900670794 /* GradientView.swift in Sources */,
-				87AC33CB2181C6FB00069C79 /* UserClient+RemoveTask.swift in Sources */,
+				87AC33CB2181C6FB00069C79 /* ClientRemovalObserver.swift in Sources */,
 				5E4B1387204FE7DA00ED5DF1 /* SystemAnimationCurves.swift in Sources */,
 				D550F5772044532D009E09DD /* ConversationAction.swift in Sources */,
 				D5F8BFF42007AC84008F8C3D /* UIView+TableViewHeaderFooterSizing.swift in Sources */,

--- a/Wire-iOS/Sources/Helpers/syncengine/ClientRemovalObserver.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ClientRemovalObserver.swift
@@ -100,15 +100,14 @@ final class ClientRemovalObserver: NSObject, ZMClientUpdateObserver {
         if !passwordIsNecessaryForDelete {
             controller.requestPassword { [weak self] newCredentials in
                 guard let emailCredentials = newCredentials,
-                    emailCredentials.password?.isEmpty == false,
-                    let weakSelf = self else {
+                    emailCredentials.password?.isEmpty == false else {
                     self?.endRemoval(result: ClientRemovalUIError.noPasswordProvided)
                     return
                 }
-                weakSelf.credentials = emailCredentials
-                weakSelf.startRemoval()
+                self?.credentials = emailCredentials
+                self?.startRemoval()
 
-                weakSelf.passwordIsNecessaryForDelete = true
+                self?.passwordIsNecessaryForDelete = true
             }
         } else {
             controller.presentAlertWithOKButton(message: "self.settings.account_details.remove_device.password.error".localized)

--- a/Wire-iOS/Sources/Helpers/syncengine/ClientRemovalObserver.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ClientRemovalObserver.swift
@@ -72,10 +72,6 @@ final class ClientRemovalObserver: NSObject, ZMClientUpdateObserver {
         observerToken = ZMUserSession.shared()?.add(self)
     }
 
-    deinit {
-        observerToken = nil
-    }
-    
     func startRemoval() {
         controller.showLoadingView = true
         ZMUserSession.shared()?.delete(userClientToDelete, with: credentials)
@@ -113,12 +109,14 @@ final class ClientRemovalObserver: NSObject, ZMClientUpdateObserver {
                 ZMUserSession.shared()?.delete(weakSelf.userClientToDelete,
                                                with: weakSelf.credentials)
                 weakSelf.controller.showLoadingView = true
+
+                weakSelf.passwordIsNecessaryForDelete = true
             }
-            passwordIsNecessaryForDelete = true
-        } else {
+        } else {///TODO: not showing if self is not top VC?
             controller.presentAlertWithOKButton(message: "self.settings.account_details.remove_device.password.error".localized)
             endRemoval(result: error)
-            
+
+            /// allow password input alert can be show next time
             passwordIsNecessaryForDelete = false
         }
     }

--- a/Wire-iOS/Sources/Helpers/syncengine/ClientRemovalObserver.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ClientRemovalObserver.swift
@@ -106,9 +106,7 @@ final class ClientRemovalObserver: NSObject, ZMClientUpdateObserver {
                     return
                 }
                 weakSelf.credentials = emailCredentials
-                ZMUserSession.shared()?.delete(weakSelf.userClientToDelete,
-                                               with: weakSelf.credentials)
-                weakSelf.controller.showLoadingView = true
+                weakSelf.startRemoval()
 
                 weakSelf.passwordIsNecessaryForDelete = true
             }

--- a/Wire-iOS/Sources/Helpers/syncengine/ClientRemovalObserver.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ClientRemovalObserver.swift
@@ -112,7 +112,7 @@ final class ClientRemovalObserver: NSObject, ZMClientUpdateObserver {
 
                 weakSelf.passwordIsNecessaryForDelete = true
             }
-        } else {///TODO: not showing if self is not top VC?
+        } else {
             controller.presentAlertWithOKButton(message: "self.settings.account_details.remove_device.password.error".localized)
             endRemoval(result: error)
 

--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
@@ -249,13 +249,14 @@ final class ClientListViewController: UIViewController,
     }
 
     func deleteUserClient(_ userClient: UserClient, credentials: ZMEmailCredentials?) {
-        if removalObserver == nil {
-            removalObserver = ClientRemovalObserver(userClientToDelete: userClient,
+        removalObserver = nil
+
+        removalObserver = ClientRemovalObserver(userClientToDelete: userClient,
                                                     controller: self,
                                                     credentials: credentials)
 
-        }
         removalObserver?.userClientToDelete = userClient
+        removalObserver?.credentials = credentials
         removalObserver?.startRemoval()
 
         delegate?.finishedDeleting(self)

--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/SettingsClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/SettingsClientViewController.swift
@@ -289,20 +289,19 @@ class SettingsClientViewController: UIViewController,
             break
             
         case .removeDevice:
-            if removalObserver == nil {
-            
-                let completion: ((Error?)->()) = { error in
-                    if error == nil {
-                        self.navigationController?.popViewController(animated: true)
-                    }
+            removalObserver = nil
+
+            let completion: ((Error?)->()) = { error in
+                if error == nil {
+                    self.navigationController?.popViewController(animated: true)
                 }
-                
-                removalObserver = ClientRemovalObserver(userClientToDelete: userClient,
-                                                            controller: self,
-                                                            credentials: credentials, completion: completion)
+            }
+
+            removalObserver = ClientRemovalObserver(userClientToDelete: userClient,
+                                                        controller: self,
+                                                        credentials: credentials, completion: completion)
                 
 
-            }
             removalObserver?.startRemoval()
 
         default:


### PR DESCRIPTION
## What's new in this PR?

### Issues

In setting screen, enter password alert not showing after entered a wrong password. (Wrong password alert appears after `remove device` cell is tapped)

### Causes

Multiple instance of `ClientRemovalObserver` exists due to they are not released after created when `remove device` is button is tapped everytime. And they are not release since self-retained and captured in closures.


### Solutions

Refactor and make ViewControllers retain `ClientRemovalObserver`. Refactor closures not to retain `ClientRemovalObserver`.