### PR TITLE
ZIOS-11497: Update legal hold indicators on user change

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -752,7 +752,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
         [self updateGuestsBarVisibility];
     }
 
-    if (note.nameChanged || note.securityLevelChanged || note.connectionStateChanged) {
+    if (note.nameChanged || note.securityLevelChanged || note.connectionStateChanged || note.legalHoldStatusChanged) {
         [self setupNavigatiomItem];
     }
 }

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.m
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.m
@@ -198,6 +198,10 @@
     if (note.trustLevelChanged) {
         [self updateShowVerifiedShield];
     }
+
+    if (note.legalHoldStatusChanged) {
+        [self setupNavigationItems];
+    }
 }
 
 #pragma mark - Actions


### PR DESCRIPTION
## What's new in this PR?

### Issues

- When a participant's legal hold status changes in a group, the indicator in the conversation wasn't updated.
- When a participant's legal hold status changes when opening the devices list, the indicator in the profile details wasn't updated.  

### Solutions

Implement observing for the legal hold status and reload the navigation items upon change.