### PR TITLE
fix: iPad - Camera is rotated in landscape

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Camera/CameraController.swift
+++ b/Wire-iOS/Sources/UserInterface/Camera/CameraController.swift
@@ -292,9 +292,16 @@ private extension AVCaptureVideoOrientation {
     static var current: AVCaptureVideoOrientation {
         let device = DeviceOrientationObserver.sharedInstance().deviceOrientation
         let ui = UIApplication.shared.statusBarOrientation
-        return self.init(deviceOrientation: device) ?? self.init(uiOrientation: ui) ?? .portrait
+
+        let deviceOrientation = self.init(deviceOrientation: device)
+        let uiOrientation = self.init(uiOrientation: ui)
+        return uiOrientation ?? deviceOrientation ?? .portrait
     }
 
+
+    /// convert UIDeviceOrientation to AVCaptureVideoOrientation except face up/down
+    ///
+    /// - Parameter deviceOrientation: a UIDeviceOrientation
     init?(deviceOrientation: UIDeviceOrientation) {
         switch deviceOrientation {
         case .landscapeLeft:        self = .landscapeRight


### PR DESCRIPTION
## What's new in this PR?

### Issues
Step to reproduce the issue:
1. enable screen lock under portrait mode
2. Launch the app in landscape orientation
3. Open camera keyboard

result: the preview image is rotated by 90 degree

### Causes

The video's orientation follows device orientation. In this case, device orientation is different from UI orientation.

### Solutions

The video's orientation follows UI orientation as the first priority