### PR TITLE
Fix: iPad - update orientation when cell will diaplay

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraCell.swift
@@ -123,7 +123,7 @@ open class CameraCell: UICollectionViewCell {
         self.updateVideoOrientation()
     }
 
-    fileprivate func updateVideoOrientation() {
+    func updateVideoOrientation() {
         guard UIDevice.current.userInterfaceIdiom == .pad else { return }
         cameraController?.updatePreviewOrientation()
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
@@ -496,6 +496,8 @@ extension CameraKeyboardViewController: UICollectionViewDelegateFlowLayout, UICo
     public func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
         if cell is CameraCell || cell is CameraKeyboardPermissionsCell  {
             self.goBackButtonRevealed = false
+
+            (cell as? CameraCell)?.updateVideoOrientation()
         }
     }
 }


### PR DESCRIPTION
## What's new in this PR?

Follow up of https://github.com/wireapp/wire-ios/pull/3482. Fix the issue that after switching keyboards(audio recording/normal) camera preview is rotated.