### PR TITLE
ZIOS-11501: Add identifiers for calling indicators

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallStatusView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallStatusView.swift
@@ -100,6 +100,7 @@ final class CallStatusView: UIView {
         bitrateLabel.text = "call.status.constant_bitrate".localized(uppercased: true)
         bitrateLabel.font = FontSpec(.small, .semibold).font
         bitrateLabel.alpha = 0.64
+        bitrateLabel.accessibilityIdentifier = "bitrate-indicator"
     }
     
     private func createConstraints() {

--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/NetworkConditionIndicatorView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/NetworkConditionIndicatorView.swift
@@ -32,6 +32,9 @@ final class NetworkConditionIndicatorView: UIView, RoundedViewProtocol {
 
     init() {
         super.init(frame: .zero)
+        isAccessibilityElement = true
+        shouldGroupAccessibilityChildren = true
+
         backgroundColor = UIColor.nameColor(for: .brightOrange, variant: .light)
         shape = .relative(multiplier: 1, dimension: .height)
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -51,6 +54,7 @@ final class NetworkConditionIndicatorView: UIView, RoundedViewProtocol {
     var networkQuality: NetworkQuality = .normal {
         didSet {
             label.attributedText = networkQuality.attributedString(color: .white)
+            accessibilityLabel = "conversation.status.poor_connection".localized
             layoutIfNeeded()
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridView.swift
@@ -139,6 +139,8 @@ final class VideoGridViewController: UIViewController {
 
         view.addSubview(muteIndicatorView)
         view.addSubview(networkConditionView)
+
+        networkConditionView.accessibilityIdentifier = "network-conditions-indicator"
     }
 
     func createConstraints() {


### PR DESCRIPTION
## What's new in this PR?

We add accessibility indicators for the CBR label (`bitrate-indicator`) and the network quality indicator (`network-conditions-indicator`).