### PR TITLE
ZIOS-11505: Numbers with prefix shared with multiple countries randomly select the country name

### DIFF
--- a/Wire-iOS/Sources/Authentication/Helpers/CountryCode/Country.m
+++ b/Wire-iOS/Sources/Authentication/Helpers/CountryCode/Country.m
@@ -118,10 +118,11 @@ NS_ASSUME_NONNULL_BEGIN
         return countryFromDevice;
     }
 
+    // List to prioritize main countries with shared prefixes (e.g., USA with "+1")
+    NSArray *priorityList = @[@"us", @"it", @"fi", @"tz", @"uk", @"no", @"ru"];
 
-    // Many countries have e164 == "1", but user with phone number "+1..." is most probably from USA
     for (Country *country in matches) {
-        if ([country.ISO isEqualToString:@"us"]) {
+        if([priorityList containsObject:country.ISO]) {
             return country;
         }
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Phone country codes shared with multiple countries (e.g. Italy and Vatican) are randomly selected every time a phone number is pasted or autocompleted.

### Solutions

I'm extending the filter already implemented with US to other countries in order to choose the main reference country for that prefix.
