### PR TITLE
Fix: Microphone permissions alert appear behind keyboard

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
@@ -158,10 +158,12 @@ public extension ConversationViewController {
     }
 
     @objc func voiceCallItemTapped(_ sender: UIBarButtonItem) {
+        endEditing()
         startCallController.startAudioCall(started: ConversationInputBarViewController.endEditingMessage)
     }
 
     @objc func videoCallItemTapped(_ sender: UIBarButtonItem) {
+        endEditing()
         startCallController.startVideoCall(started: ConversationInputBarViewController.endEditingMessage)
     }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

The microphone permissions alert appear behind the keyboard. This alert is shown the first time you attempt to make a call. 

### Causes

Keyboard is not dismissed.

### Solutions

End editing after the one of the call button is tapped.