### PR TITLE
Fix: Accessibility for Seen icon in message delivery status

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxDataSource.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxDataSource.swift
@@ -249,6 +249,12 @@ class MessageToolboxDataSource {
         return NSAttributedString(string: deliveryStateString) && attributes
     }
 
+    private func seenTextAttachment() -> NSTextAttachment {
+        let imageIcon = NSTextAttachment.textAttachment(for: .eye, with: statusTextColor, verticalCorrection: -1)
+        imageIcon.accessibilityLabel = "seen"
+        return imageIcon
+    }
+
     /// Creates the status for the read receipts.
     fileprivate func selfStatusForReadDeliveryState(for message: ZMConversationMessage) -> NSAttributedString? {
         guard let conversationType = message.conversation?.conversationType else {return nil}
@@ -260,16 +266,23 @@ class MessageToolboxDataSource {
                 .foregroundColor: statusTextColor
             ]
 
-            let imageIcon = NSTextAttachment.textAttachment(for: .eye, with: statusTextColor, verticalCorrection: -1)
-            return NSAttributedString(attachment: imageIcon) + " \(message.readReceipts.count)" && attributes
+            let imageIcon = seenTextAttachment()
+            let attributedString = NSAttributedString(attachment: imageIcon) + " \(message.readReceipts.count)" && attributes
+            attributedString.accessibilityLabel = (imageIcon.accessibilityLabel ?? "") + " \(message.readReceipts.count)"
+            return attributedString
 
         case .oneOnOne:
             guard let timestamp = message.readReceipts.first?.serverTimestamp else {
                 return nil
             }
 
-            let imageIcon = NSTextAttachment.textAttachment(for: .eye, with: statusTextColor, verticalCorrection: -1)
-            return NSAttributedString(attachment: imageIcon) + " " + message.formattedDate(timestamp) && attributes
+            let imageIcon = seenTextAttachment()
+
+            let timestampString = message.formattedDate(timestamp)
+            let attributedString = NSAttributedString(attachment: imageIcon) + " " + timestampString && attributes
+            attributedString.accessibilityLabel = (imageIcon.accessibilityLabel ?? "") + " " + timestampString
+            return attributedString
+
 
         default:
             return nil

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
@@ -70,6 +70,7 @@ final class MessageToolboxView: UIView {
         label.lineBreakMode = .byTruncatingMiddle
         label.numberOfLines = 1
         label.accessibilityIdentifier = "Details"
+        label.isAccessibilityElement = true
         label.setContentHuggingPriority(.required, for: .horizontal)
         label.setContentCompressionResistancePriority(.required, for: .horizontal)
         return label
@@ -111,6 +112,7 @@ final class MessageToolboxView: UIView {
         label.lineBreakMode = .byTruncatingMiddle
         label.numberOfLines = 1
         label.accessibilityIdentifier = "DeliveryStatus"
+        label.isAccessibilityElement = true
         label.setContentHuggingPriority(.required, for: .horizontal)
         label.setContentCompressionResistancePriority(.required, for: .horizontal)
         return label
@@ -299,6 +301,10 @@ final class MessageToolboxView: UIView {
                 self.detailsLabel.isHidden = timestamp == nil
                 self.detailsLabel.numberOfLines = 1
                 self.statusLabel.attributedText = status
+                //override accessibilityLabel if the attributed string has customized accessibilityLabel
+                if let accessibilityLabel = status?.accessibilityLabel {
+                    self.statusLabel.accessibilityLabel = accessibilityLabel
+                }
                 self.statusLabel.isHidden = status == nil
                 self.timestampSeparatorLabel.isHidden = timestamp == nil || status == nil
                 self.deleteButton.isHidden = true


### PR DESCRIPTION
## What's new in this PR?

### Issues

The "eye" icon has no text representation in the accessibility label.

### Causes

`NSTextAttachment` in the attributed text does not generate text in the accessibility label.

### Solutions

Manually create an accessibility label for the "eye" `NSTextAttachment` and set it to the Label.

