### PR TITLE
Fix: set accessibilityIdentifier of ConversationListItemView

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListItemView.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListItemView.m
@@ -104,6 +104,7 @@ NSString * const ConversationListItemDidScrollNotification = @"ConversationListI
     
     self.isAccessibilityElement = YES;
     self.shouldGroupAccessibilityChildren = YES;
+    self.accessibilityIdentifier = @"conversation_name";
 }
 
 - (void)createLabelsStack


### PR DESCRIPTION
## What's new in this PR?

Set `ConversationListItemView`'s `accessibilityIdentifier` to "conversation_name" for automation.