### PR TITLE
Fix: add accessibilityIdentifier to ConversationListCell and ConnectRequestsCell

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1160,6 +1160,8 @@
 		EF334B98229D789500099D80 /* StartUIViewController+ContactsViewControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF334B97229D789500099D80 /* StartUIViewController+ContactsViewControllerDelegate.swift */; };
 		EF3371C22216D9D9005ED048 /* ZMUser+Self.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3371C12216D9D9005ED048 /* ZMUser+Self.swift */; };
 		EF3371C52216F067005ED048 /* MockUser+SelfUserFromSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3371C32216EEE2005ED048 /* MockUser+SelfUserFromSession.swift */; };
+		EF3510FD22CA3C4500115B97 /* ConversationListCell+Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3510FC22CA3C4500115B97 /* ConversationListCell+Accessibility.swift */; };
+		EF3510FF22CA42A000115B97 /* UICollectionViewCell+Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3510FE22CA42A000115B97 /* UICollectionViewCell+Accessibility.swift */; };
 		EF36168A21E753310041F0CC /* SettingsTableViewControllerSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF36168921E753300041F0CC /* SettingsTableViewControllerSnapshotTests.swift */; };
 		EF37C3892256614300EA0C32 /* ConnectRequestsCellSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF37C3882256614300EA0C32 /* ConnectRequestsCellSnapshotTests.swift */; };
 		EF3976CE2114506E0030BE68 /* KeyboardAvoidingViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3976CD2114506E0030BE68 /* KeyboardAvoidingViewController+Extension.swift */; };
@@ -2962,6 +2964,8 @@
 		EF334B97229D789500099D80 /* StartUIViewController+ContactsViewControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StartUIViewController+ContactsViewControllerDelegate.swift"; sourceTree = "<group>"; };
 		EF3371C12216D9D9005ED048 /* ZMUser+Self.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUser+Self.swift"; sourceTree = "<group>"; };
 		EF3371C32216EEE2005ED048 /* MockUser+SelfUserFromSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MockUser+SelfUserFromSession.swift"; sourceTree = "<group>"; };
+		EF3510FC22CA3C4500115B97 /* ConversationListCell+Accessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationListCell+Accessibility.swift"; sourceTree = "<group>"; };
+		EF3510FE22CA42A000115B97 /* UICollectionViewCell+Accessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionViewCell+Accessibility.swift"; sourceTree = "<group>"; };
 		EF36168921E753300041F0CC /* SettingsTableViewControllerSnapshotTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsTableViewControllerSnapshotTests.swift; sourceTree = "<group>"; };
 		EF37C3882256614300EA0C32 /* ConnectRequestsCellSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectRequestsCellSnapshotTests.swift; sourceTree = "<group>"; };
 		EF3976CD2114506E0030BE68 /* KeyboardAvoidingViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyboardAvoidingViewController+Extension.swift"; sourceTree = "<group>"; };
@@ -5142,6 +5146,7 @@
 				8F8913F11A9F287E0056AB0C /* ConversationListCell.h */,
 				8F8913F21A9F287E0056AB0C /* ConversationListCell.m */,
 				EFDB3133217F5E0300D2A7CE /* ConversationListCell+Constraint.swift */,
+				EF3510FC22CA3C4500115B97 /* ConversationListCell+Accessibility.swift */,
 				8F8913F51A9F287E0056AB0C /* ConversationListItemView.h */,
 				EF6251D1213844D400943708 /* ConversationListItemView+Internal.h */,
 				8F8913F61A9F287E0056AB0C /* ConversationListItemView.m */,
@@ -5167,6 +5172,7 @@
 				875F15C91ED5BDFC008E9A6D /* ConversationListViewModel+Private.h */,
 				8F89140C1A9F287E0056AB0C /* ConversationListViewModel.m */,
 				870C926E1E8D1C7300A10995 /* ConversationListViewModel+Teams.swift */,
+				EF3510FE22CA42A000115B97 /* UICollectionViewCell+Accessibility.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -7240,6 +7246,7 @@
 				D503538C207B5DB900CE34A5 /* UIAlertController+RestorePassword.swift in Sources */,
 				871BC35E1D34F94200DF0793 /* NetworkConditionHelper.m in Sources */,
 				879489E51E54500A0071B2C1 /* TextSearchResultsView.swift in Sources */,
+				EF3510FF22CA42A000115B97 /* UICollectionViewCell+Accessibility.swift in Sources */,
 				F15650D621DD0FC600210504 /* VerticalColumnCollectionViewLayout.swift in Sources */,
 				5E4BC1CA218C9F6600A8682E /* ConversationQuoteCell.swift in Sources */,
 				54FF9E281E813BA500323D2E /* DebugAlert.swift in Sources */,
@@ -7629,6 +7636,7 @@
 				EFC8E21D212D777A00BE7BBE /* UIColor+TeamCreation.swift in Sources */,
 				8F41CFC8199297C600E3B032 /* ZMConversation+Additions.m in Sources */,
 				F15650E021DD119D00210504 /* OverflowSeparatorView.swift in Sources */,
+				EF3510FD22CA3C4500115B97 /* ConversationListCell+Accessibility.swift in Sources */,
 				EFF3DA452097587F007A3358 /* UIPasteboard+MediaAsset.swift in Sources */,
 				BAEF10FA1B8C8849005BFA48 /* AnimatedListMenuView.m in Sources */,
 				1682AEB620480C80003A052A /* UIViewController+Navigation.swift in Sources */,

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConnectRequestsCell.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConnectRequestsCell.swift
@@ -43,6 +43,7 @@ final class ConnectRequestsCell : UICollectionViewCell {
         }
 
         setNeedsUpdateConstraints()
+        setupAccessbility(accessibilityIdentifier: "conversation_name")
     }
 
     override func updateConstraints() {
@@ -111,3 +112,25 @@ extension ConnectRequestsCell: ZMConversationListObserver {
     }
 }
 
+////MARK: - accessibility
+extension ConnectRequestsCell {
+    override var accessibilityValue: String? {
+        get {
+            return itemView.rightAccessory.accessibilityValue
+        }
+
+        set {
+            itemView.rightAccessory.accessibilityValue = newValue;
+        }
+    }
+
+    override var accessibilityLabel: String? {
+        get {
+            return itemView.titleField.accessibilityLabel
+        }
+
+        set {
+            itemView.titleField.accessibilityLabel = newValue;
+        }
+    }
+}

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListCell+Accessibility.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListCell+Accessibility.swift
@@ -1,0 +1,41 @@
+
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension ConversationListCell {
+    override open var accessibilityValue: String? {
+        get {
+            return itemView.accessibilityValue
+        }
+
+        set {
+            itemView.accessibilityValue = newValue;
+        }
+    }
+
+    override open var accessibilityLabel: String? {
+        get {
+            return itemView.accessibilityLabel
+        }
+
+        set {
+            itemView.accessibilityLabel = newValue;
+        }
+    }
+}

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListCell.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListCell.m
@@ -93,6 +93,8 @@ static const NSTimeInterval OverscrollRatio = 2.5;
     [self setNeedsUpdateConstraints];
      
     [AVSMediaManagerClientChangeNotification addObserver:self];
+
+    [self setupAccessbilityWithAccessibilityIdentifier: @"conversation_name"];
 }
 
 - (void)setVisualDrawerOffset:(CGFloat)visualDrawerOffset updateUI:(BOOL)doUpdate

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListItemView.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListItemView.m
@@ -101,10 +101,6 @@ NSString * const ConversationListItemDidScrollNotification = @"ConversationListI
                                              selector:@selector(otherConversationListItemDidScroll:)
                                                  name:ConversationListItemDidScrollNotification
                                                object:nil];
-    
-    self.isAccessibilityElement = YES;
-    self.shouldGroupAccessibilityChildren = YES;
-    self.accessibilityIdentifier = @"conversation_name";
 }
 
 - (void)createLabelsStack

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/Model/UICollectionViewCell+Accessibility.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/Model/UICollectionViewCell+Accessibility.swift
@@ -1,0 +1,28 @@
+
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension UICollectionViewCell {
+    @objc
+    func setupAccessbility(accessibilityIdentifier: String) {
+        isAccessibilityElement = true
+        shouldGroupAccessibilityChildren = true
+        self.accessibilityIdentifier = accessibilityIdentifier
+    }
+}


### PR DESCRIPTION
## What's new in this PR?

Move `accessibilityIdentifier` from `ConversationListItemView` to `ConversationListCell` and `ConnectRequestsCell`.
Customize `ConnectRequestsCell`'s  `accessibilityLabel` & `accessibilityValue`.