### PR TITLE
Fix missing call accessibility identifiers

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/CallActionsView/CallStatusViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallActionsView/CallStatusViewController.swift
@@ -56,7 +56,6 @@ final class CallStatusViewController: UIViewController {
     }
     
     private func setupViews() {
-        statusView.isAccessibilityElement = true
         statusView.accessibilityTraits = .header
         statusView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(statusView)

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallStatusView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallStatusView.swift
@@ -123,8 +123,6 @@ final class CallStatusView: UIView {
         [titleLabel, subtitleLabel, bitrateLabel].forEach {
             $0.textColor = UIColor.from(scheme: .textForeground, variant: configuration.effectiveColorVariant)
         }
-
-        accessibilityLabel = stackView.arrangedSubviews.compactMap { $0.accessibilityLabel }.joined(separator: "\n")
     }
     
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

The accessibility identifiers for the CBR and network status are not visible.

### Causes

They are hidden since the entire `CallStatusView` is exposed as a single accessibility item.

### Solutions

Expose each status label individually.