### PR TITLE
Fix: Set accessibilityLabel for team member conversation case

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListCell+Accessibility.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListCell+Accessibility.swift
@@ -25,7 +25,7 @@ extension ConversationListCell {
         }
 
         set {
-            itemView.accessibilityValue = newValue;
+            // no op
         }
     }
 
@@ -35,7 +35,7 @@ extension ConversationListCell {
         }
 
         set {
-            itemView.accessibilityLabel = newValue;
+            // no op
         }
     }
 }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListItemView+Update.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListItemView+Update.swift
@@ -72,6 +72,7 @@ extension ConversationListItemView {
             if connectedUser.availability != .none {
                 statusComponents.append(connectedUser.availability.localizedName)
             }
+            accessibilityLabel = title?.string
         } else {
             title = conversation.displayName.attributedString
             accessibilityLabel = conversation.displayName


### PR DESCRIPTION
## What's new in this PR?

### Issues

When the conversation is a 1-to-1 type with a team member, the `accessibilityLabel` is missing.

### Causes

Missing `accessibilityLabel` setting for that case

### Solutions

Set `accessibilityLabel` for that case.