### PR TITLE
Show legal hold alert again after entering the wrong password

### DIFF
--- a/Wire-iOS Tests/LegalHoldAlertFactoryTests.swift
+++ b/Wire-iOS Tests/LegalHoldAlertFactoryTests.swift
@@ -46,8 +46,7 @@ final class LegalHoldAlertFactoryTests: ZMSnapshotTestCase {
     func testThatItCanCreateLegalHoldPendingAlert() {
         let prekey = LegalHoldRequest.Prekey(id: 65535, key: Data(base64Encoded: "pQABARn//wKhAFggHsa0CszLXYLFcOzg8AA//E1+Dl1rDHQ5iuk44X0/PNYDoQChAFgg309rkhG6SglemG6kWae81P1HtQPx9lyb6wExTovhU4cE9g==")!)
         let request = LegalHoldRequest(clientIdentifier: "eca3c87cfe28be49", lastPrekey: prekey)
-
-        let alert = LegalHoldAlertFactory.makeLegalHoldActivationAlert(for: request, user: user, presenter: ignorePresentation, suggestedStateChangeHandler: nil)
+        let alert = LegalHoldAlertFactory.makeLegalHoldActivationAlert(for: request, user: user, suggestedStateChangeHandler: nil)
         verifyAlertController(alert)
     }
 

--- a/Wire-iOS/Sources/Managers/LegalHoldDisclosureController.swift
+++ b/Wire-iOS/Sources/Managers/LegalHoldDisclosureController.swift
@@ -175,10 +175,8 @@ import UIKit
     /// Dismisses the alert if it's presented, and calls the dismissal handler.
     private func dismissAlertIfNeeded(_ alert: UIAlertController?, dismissalHandler: @escaping () -> Void) {
         if let currentAlert = alert, currentAlert.presentingViewController != nil {
-            presentedAlertController = nil
             currentAlert.dismiss(animated: true, completion: dismissalHandler)
         } else {
-            presentedAlertController = nil
             dismissalHandler()
         }
     }
@@ -208,6 +206,8 @@ import UIKit
             if let alertController = alertController {
                 self.presentedAlertController = alertController
                 self.presenter(alertController, true, nil)
+            } else {
+                self.presentedAlertController = nil
             }
         }
     }

--- a/Wire-iOS/Sources/Managers/LegalHoldDisclosureController.swift
+++ b/Wire-iOS/Sources/Managers/LegalHoldDisclosureController.swift
@@ -29,7 +29,7 @@ import UIKit
         case none
 
         /// The user is being warned about a pending legal hold alert.
-        case warningAboutPendingRequest(UIAlertController)
+        case warningAboutPendingRequest(LegalHoldRequest)
 
         /// The user is waiting for the response on the legal hold acceptation.
         case acceptingRequest
@@ -38,20 +38,10 @@ import UIKit
         case warningAboutAcceptationResult(UIAlertController)
 
         /// The user is being warned about the deactivation of legal hold.
-        case warningAboutDisabled(UIAlertController)
+        case warningAboutDisabled
 
         /// The user is being warned about the activation of legal hold.
-        case warningAboutEnabled(UIAlertController)
-
-        /// The alert associated with the state, if any.
-        var alert: UIAlertController? {
-            switch self {
-            case .warningAboutEnabled(let alert), .warningAboutDisabled(let alert), .warningAboutPendingRequest(let alert), .warningAboutAcceptationResult(let alert):
-                return alert
-            case .acceptingRequest, .none:
-                return nil
-            }
-        }
+        case warningAboutEnabled
     }
 
     enum DisclosureCause {
@@ -75,9 +65,16 @@ import UIKit
 
     /// The block that presents view controllers when requested.
     let presenter: ViewControllerPresenter
+    
+    /// UIAlertController currently presented
+    var presentedAlertController: UIAlertController? = nil
 
     /// The current state of legal hold disclosure. Defaults to none.
-    var currentState: DisclosureState = .none
+    var currentState: DisclosureState = .none {
+        didSet {
+            presentAlertController(for: currentState)
+        }
+    }
 
     private var userObserverToken: Any?
 
@@ -134,16 +131,6 @@ import UIKit
 
     /// Present an alert about legal hold being enabled.
     private func discloseEnabledStateIfPossible() {
-        func presentEnabledAlert() {
-            let alert = LegalHoldAlertFactory.makeLegalHoldActivatedAlert(
-                for: selfUser,
-                suggestedStateChangeHandler: assignState
-            )
-
-            currentState = .warningAboutEnabled(alert)
-            presenter(alert, true, nil)
-        }
-
         switch currentState {
         case .acceptingRequest, .warningAboutEnabled:
             // If we are already accepting the request or it's already accepted, do not show a popup
@@ -151,51 +138,24 @@ import UIKit
         default:
             // If there is a current alert, replace it with the latest disclosure
             if selfUser.needsToAcknowledgeLegalHoldStatus {
-                dismissAlertIfNeeded(currentState.alert, dismissalHandler: presentEnabledAlert)
+                currentState = .warningAboutEnabled
             }
         }
     }
 
     /// Present an alert about a pending legal hold request.
     private func disclosePendingRequestIfPossible(_ request: LegalHoldRequest) {
-        func presentPendingRequestAlert() {
-            let alert = LegalHoldAlertFactory.makeLegalHoldActivationAlert(
-                for: request,
-                user: selfUser,
-                presenter: presenter,
-                suggestedStateChangeHandler: assignState
-            )
-
-            currentState = .warningAboutPendingRequest(alert)
-            presenter(alert, true, nil)
-        }
-        
         // Do not present alert if we already in process of accepting the request
         if case .acceptingRequest = currentState { return }
         
         // If there is a current alert, replace it with the latest disclosure
-        dismissAlertIfNeeded(currentState.alert, dismissalHandler: presentPendingRequestAlert)
+        currentState = .warningAboutPendingRequest(request)
     }
 
     private func discloseDisabledStateIfPossible() {
-        func presentDisabledAlert() {
-            let alert = LegalHoldAlertFactory.makeLegalHoldDeactivatedAlert(
-                for: selfUser,
-                suggestedStateChangeHandler: assignState
-            )
-
-            currentState = .warningAboutDisabled(alert)
-            presenter(alert, true, nil)
-        }
-        
         switch currentState {
-        case .warningAboutPendingRequest(let alert):
-            // If we are warning about the pending request, dismiss it
-            dismissAlertIfNeeded(alert, dismissalHandler: {})
-            return
-        case .warningAboutAcceptationResult(let alert):
-            // If we are warning about the pending request result (error alert), dismiss it
-            dismissAlertIfNeeded(alert, dismissalHandler: {})
+        case .warningAboutPendingRequest, .warningAboutAcceptationResult:
+            currentState = .none
             return
         case .warningAboutDisabled:
             // If we are already warning about disabled, do nothing
@@ -206,8 +166,7 @@ import UIKit
 
         // Do not show the alert for a remote change unless it requires attention
         if selfUser.needsToAcknowledgeLegalHoldStatus {
-            // If there is a current alert, replace it with the latest disclosure
-            dismissAlertIfNeeded(currentState.alert, dismissalHandler: presentDisabledAlert)
+            currentState = .warningAboutDisabled
         }
     }
 
@@ -216,8 +175,10 @@ import UIKit
     /// Dismisses the alert if it's presented, and calls the dismissal handler.
     private func dismissAlertIfNeeded(_ alert: UIAlertController?, dismissalHandler: @escaping () -> Void) {
         if let currentAlert = alert, currentAlert.presentingViewController != nil {
+            presentedAlertController = nil
             currentAlert.dismiss(animated: true, completion: dismissalHandler)
         } else {
+            presentedAlertController = nil
             dismissalHandler()
         }
     }
@@ -225,6 +186,30 @@ import UIKit
     /// Operator to assign the new state from a block parameter.
     private func assignState(_ newValue: DisclosureState) {
         currentState = newValue
+    }
+    
+    private func presentAlertController(for state: DisclosureState) {
+        var alertController: UIAlertController? = nil
+        
+        switch state {
+        case .warningAboutDisabled:
+            alertController = LegalHoldAlertFactory.makeLegalHoldDeactivatedAlert(for: selfUser, suggestedStateChangeHandler: assignState)
+        case .warningAboutEnabled:
+            alertController = LegalHoldAlertFactory.makeLegalHoldActivatedAlert(for: selfUser, suggestedStateChangeHandler: assignState)
+        case .warningAboutPendingRequest(let request):
+            alertController = LegalHoldAlertFactory.makeLegalHoldActivationAlert(for: request, user: selfUser, suggestedStateChangeHandler: assignState)
+        case .warningAboutAcceptationResult(let alert):
+            alertController = alert
+        case .acceptingRequest, .none:
+            break
+        }
+        
+        dismissAlertIfNeeded(presentedAlertController) {
+            if let alertController = alertController {
+                self.presentedAlertController = alertController
+                self.presenter(alertController, true, nil)
+            }
+        }
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/Helpers/LegalHoldAlertFactory.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/LegalHoldAlertFactory.swift
@@ -48,7 +48,7 @@ enum LegalHoldAlertFactory {
         return alert
     }
 
-    static func makeLegalHoldActivationAlert(for legalHoldRequest: LegalHoldRequest, user: SelfUserType, presenter: @escaping ViewControllerPresenter, suggestedStateChangeHandler: SuggestedStateChangeHandler?) -> UIAlertController {
+    static func makeLegalHoldActivationAlert(for legalHoldRequest: LegalHoldRequest, user: SelfUserType, suggestedStateChangeHandler: SuggestedStateChangeHandler?) -> UIAlertController {
         func handleLegalHoldActivationResult(_ error: LegalHoldActivationError?) {
             UIApplication.shared.topmostViewController()?.showLoadingView = false
 
@@ -59,10 +59,9 @@ enum LegalHoldAlertFactory {
                 let alert = UIAlertController.alertWithOKButton(
                     title: "legalhold_request.alert.error_wrong_password".localized,
                     message: "legalhold_request.alert.error_wrong_password".localized,
-                    okActionHandler: { _ in suggestedStateChangeHandler?(.none) }
+                    okActionHandler: { _ in suggestedStateChangeHandler?(.warningAboutPendingRequest(legalHoldRequest)) }
                 )
 
-                presenter(alert, true, nil)
                 suggestedStateChangeHandler?(.warningAboutAcceptationResult(alert))
 
             case .some:
@@ -71,10 +70,9 @@ enum LegalHoldAlertFactory {
                 let alert = UIAlertController.alertWithOKButton(
                     title: "general.failure".localized,
                     message: "general.failure.try_again".localized,
-                    okActionHandler: { _ in suggestedStateChangeHandler?(.none) }
+                    okActionHandler: { _ in suggestedStateChangeHandler?(.warningAboutPendingRequest(legalHoldRequest)) }
                 )
 
-                presenter(alert, true, nil)
                 suggestedStateChangeHandler?(.warningAboutAcceptationResult(alert))
 
             case .none:
@@ -93,9 +91,7 @@ enum LegalHoldAlertFactory {
             suggestedStateChangeHandler?(.acceptingRequest)
 
             ZMUserSession.shared()?.accept(legalHoldRequest: legalHoldRequest, password: password) { error in
-                DispatchQueue.main.async {
-                    handleLegalHoldActivationResult(error)
-                }
+                handleLegalHoldActivationResult(error)
             }
         }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

If you enter the wrong password when legal hold is being requested you don't get a second chance and need to manually open the dialog again.

### Solutions

Show the request dialog again after entering the wrong password.

In order easily do this I removed the associated `UIAlertController` from the view state. This allows me to more easily transition between view states without having to construct an alert at the place where I decide to do a transition.