### PR TITLE
Don't delete resource if we are not copying and add informative logging

### DIFF
--- a/Scripts/embed-internal-resources
+++ b/Scripts/embed-internal-resources
@@ -3,11 +3,7 @@
 if [ $IS_INTERNAL_BUILD == '1' ]; then
     for(( i=0; i < $SCRIPT_INPUT_FILE_COUNT; i++ )); do
         INPUT_FILE="SCRIPT_INPUT_FILE_$i"
+	echo "Copying internal build file: ${!INPUT_FILE}"
         cp -Ra "${!INPUT_FILE}" "$BUILT_PRODUCTS_DIR/$PRODUCT_NAME.app/"
-    done
-else
-    for(( i=0; i < $SCRIPT_OUTPUT_FILE_COUNT; i++ )); do
-        OUTPUT_FILE="SCRIPT_INPUT_FILE_$i"
-        rm -rf "${!OUTPUT_FILE}"
     done
 fi

--- a/Scripts/embed-internal-resources
+++ b/Scripts/embed-internal-resources
@@ -3,7 +3,7 @@
 if [ $IS_INTERNAL_BUILD == '1' ]; then
     for(( i=0; i < $SCRIPT_INPUT_FILE_COUNT; i++ )); do
         INPUT_FILE="SCRIPT_INPUT_FILE_$i"
-	echo "Copying internal build file: ${!INPUT_FILE}"
+        echo "Copying internal build file: ${!INPUT_FILE}"
         cp -Ra "${!INPUT_FILE}" "$BUILT_PRODUCTS_DIR/$PRODUCT_NAME.app/"
     done
 fi


### PR DESCRIPTION
## What's new in this PR?

### Issues

If you build the app with `IS_INTERNAL_BUILD = 0` it will delete `Settings.bundle` and any subsequent builds with `IS_INTERNAL_BUILD = 1` will fail.

### Solutions

`Settings.bundle` does not belong to any target by default and the script `embed-internal-resources` manually copying to the build product directory if `IS_INTERNAL_BUILD = 1`, so it's not necessary to delete `Settings.bundle` if are not copying it.