### PR TITLE
Fix: After app start, legal hold activation alert appear twice if not accept it

### DIFF
--- a/Wire-iOS/Sources/Managers/LegalHoldDisclosureController.swift
+++ b/Wire-iOS/Sources/Managers/LegalHoldDisclosureController.swift
@@ -24,7 +24,7 @@ import UIKit
 
 @objc class LegalHoldDisclosureController: NSObject, ZMUserObserver {
 
-    enum DisclosureState {
+    enum DisclosureState: Equatable {
         /// No legal hold status is being disclosed.
         case none
 
@@ -72,6 +72,7 @@ import UIKit
     /// The current state of legal hold disclosure. Defaults to none.
     var currentState: DisclosureState = .none {
         didSet {
+            guard currentState != oldValue else { return }
             presentAlertController(for: currentState)
         }
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

After app start, legal hold activation alert appears twice if not accept it. (The second time the alert dismisses immediately)

### Causes

The `currentState` changes in this order
1. .none
2. .warningAboutPendingRequest(LegalHoldRequest)
3. (The user pressed the "not now" button) .warningAboutPendingRequest(LegalHoldRequest)
4. .none

The alert appears twice for every time the `currentState` is set to `.warningAboutPendingRequest(LegalHoldRequest)` 

### Solutions

Present the alert only when the `currentState`'s value is different form `oldValue`