### PR TITLE
Fix: Conversaton list cell - accessibilityValue for status other than muted

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListAccessoryView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListAccessoryView.swift
@@ -42,9 +42,7 @@ import UIKit
     @objc init(mediaPlaybackManager: MediaPlaybackManager) {
         self.mediaPlaybackManager = mediaPlaybackManager
         super.init(frame: .zero)
-        
-        self.isAccessibilityElement = true
-        
+                
         textLabel.setContentCompressionResistancePriority(UILayoutPriority.defaultHigh, for: .horizontal)
         textLabel.setContentCompressionResistancePriority(UILayoutPriority.defaultHigh, for: .vertical)
         textLabel.setContentHuggingPriority(UILayoutPriority.defaultHigh, for: .horizontal)

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListItemView+Update.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListItemView+Update.swift
@@ -93,8 +93,8 @@ extension ConversationListItemView {
         }
         self.rightAccessory.icon = statusIcon
 
-        if case .silenced? = statusIcon {
-            statusComponents.append("conversation.status.silenced".localized)
+        if let statusIconAccessibilityValue = rightAccessory.accessibilityValue {
+            statusComponents.append(statusIconAccessibilityValue)
         }
 
         accessibilityValue = FormattedText.list(from: statusComponents)


### PR DESCRIPTION
## What's new in this PR?

### Issues

In the conversaton list cell, if the status icon has a status other than muted, e.g. number of unread message, calling, ..., the `accessibilityValue` does not show the corresponding value.

### Causes

Missing handling of those cases.

### Solutions

Append the icon's `accessibilityValue` to the cell's `accessibilityValue`.