### PR TITLE
Fix crash due to present view controller on itself

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/DefaultNavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/DefaultNavigationBar.swift
@@ -86,7 +86,7 @@ extension UIViewController {
 
     // MARK: - present
     func wrapInNavigationControllerAndPresent(from viewController: UIViewController) -> UINavigationController {
-        let navigationController = viewController.wrapInNavigationController()
+        let navigationController = wrapInNavigationController()
         navigationController.modalPresentationStyle = .formSheet
         viewController.present(navigationController, animated: true)
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

LegalHoldDetailsViewController was presented on it self.

### Causes

`wrapInNavigationController()` Was executed on the presenting view controller 

### Solutions

Execute `wrapInNavigationController()` on the view controller that's being presented.
