### PR TITLE
Show device list for all users

### DIFF
--- a/Wire-iOS/Sources/Helpers/syncengine/ZMUser+Permissions.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMUser+Permissions.swift
@@ -51,14 +51,6 @@ extension UserType {
     
 }
 
-extension UserType {
-
-    /// Returns whether the current user (viewer) can see the devices list of another user.
-    func canSeeDevices(of otherUser: UserType) -> Bool {
-        return otherUser.isConnected || self.canAccessCompanyInformation(of: otherUser) || otherUser.isWirelessUser
-    }
-}
-
 /// Conform to this protocol to mark an object as being restricted. This
 /// indicates that the self user permissions need to be checked in order
 /// to use the object. By defining `requiredPermissions`, the rest of the

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController+Extension.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController+Extension.swift
@@ -61,11 +61,11 @@ extension ProfileViewController {
         let profileDetailsViewController = setupProfileDetailsViewController()
         viewControllers.append(profileDetailsViewController)
 
-        if let fullUser = self.fullUser(), context != .profileViewer, viewer.canSeeDevices(of: bareUser) {
+        if let fullUser = self.fullUser(), context != .search && context != .profileViewer {
             let userClientListViewController = UserClientListViewController(user: fullUser)
             viewControllers.append(userClientListViewController)
         }
-
+        
         tabsController = TabBarController(viewControllers: viewControllers)
         tabsController.delegate = self
         


### PR DESCRIPTION
## What's new in this PR?

It was decided to show the devices tab for all users, it was previously hidden for guests.

### Solutions

Always add the devices tab except when viewing the profile in search or through a user link.