### PR TITLE
Use correct URL for the device's link attribute

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCell.swift
@@ -684,7 +684,7 @@ class ConversationIgnoredDeviceSystemMessageCellDescription: ConversationMessage
         let attributedString = NSMutableAttributedString(string: endResult)
         attributedString.addAttributes([.font: UIFont.mediumFont, .foregroundColor: UIColor.from(scheme: .textForeground)], range:NSRange(location: 0, length: endResult.count))
         attributedString.addAttributes([.font: UIFont.mediumSemiboldFont, .foregroundColor: UIColor.from(scheme: .textForeground)], range: youRange)
-        attributedString.addAttributes([.font: UIFont.mediumFont, .link: link], range: deviceRange)
+        attributedString.addAttributes([.font: UIFont.mediumFont, .link: View.userClientURL], range: deviceRange)
         
         return  NSAttributedString(attributedString: attributedString)
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

The system message for un-verifying a device would not display the to the device.

### Causes

The `link` attribute in the attributed string didn't contain a valid URL which caused it not be displayed at all.

### Solutions

Use correct URL.