### PR TITLE
Fix device list sort order

### DIFF
--- a/Wire-iOS/Sources/Helpers/UserClient+Fingerprint.swift
+++ b/Wire-iOS/Sources/Helpers/UserClient+Fingerprint.swift
@@ -33,6 +33,8 @@ extension Sequence where Element: UserClientType {
             
             if lhs.deviceClass == .legalHold {
                 return true
+            } else if rhs.deviceClass == .legalHold {
+                return false
             } else {
                 return lhs.remoteIdentifier < rhs.remoteIdentifier
             }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Legal hold devices we not always displayed first in the list of devices

### Causes

Sort order function didn't handle the case when `lhs = regular` and `rhs = legalhold`.

### Solutions

Return `false` if the right hand side is legal hold device. 