### PR TITLE
Fix redundant copy when entering the wrong password

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Helpers/LegalHoldAlertFactory.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/LegalHoldAlertFactory.swift
@@ -58,7 +58,7 @@ enum LegalHoldAlertFactory {
 
                 let alert = UIAlertController.alertWithOKButton(
                     title: "legalhold_request.alert.error_wrong_password".localized,
-                    message: "legalhold_request.alert.error_wrong_password".localized,
+                    message: "general.failure.try_again".localized,
                     okActionHandler: { _ in suggestedStateChangeHandler?(.warningAboutPendingRequest(legalHoldRequest)) }
                 )
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

Error alert when entering the wrong password had the phrase "Wrong password" twice.

### Solutions

Replace message with "Please try again."