### PR TITLE
ZIOS-11562: Force app lock and make time configurable from build config

### DIFF
--- a/Wire-iOS Tests/AppLockTests.swift
+++ b/Wire-iOS Tests/AppLockTests.swift
@@ -1,0 +1,110 @@
+//
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+@testable import Wire
+@testable import WireCommonComponents
+
+class AppLockTests: XCTestCase {
+
+    let decoder = JSONDecoder()
+    
+    func testThatForcedAppLockDoesntAffectSettings() {
+
+        //given
+        let fileData = "{\"forceAppLock\":true,\"timeout\":900}".data(using: .utf8)!
+        AppLockRules.shared = try! decoder.decode(AppLockRules.self, from: fileData)
+        
+        //when
+        XCTAssertTrue(AppLockRules.shared.forceAppLock)
+        XCTAssertEqual(AppLockRules.shared.timeout, 900)
+        
+        //then
+        XCTAssertTrue(AppLock.isActive)
+        AppLock.isActive = false
+        XCTAssertTrue(AppLock.isActive)
+        AppLock.isActive = true
+        XCTAssertTrue(AppLock.isActive)
+    }
+    
+    func testThatAppLockAffectsSettings() {
+        
+        //given
+        let fileData = "{\"forceAppLock\":false,\"timeout\":10}".data(using: .utf8)!
+        AppLockRules.shared = try! decoder.decode(AppLockRules.self, from: fileData)
+        
+        //when
+        XCTAssertFalse(AppLockRules.shared.forceAppLock)
+        XCTAssertEqual(AppLockRules.shared.timeout, 10)
+        
+        //then
+        AppLock.isActive = false
+        XCTAssertFalse(AppLock.isActive)
+        AppLock.isActive = true
+        XCTAssertTrue(AppLock.isActive)
+    }
+    
+    
+    func testThatCustomTimeoutRequiresAuthenticationAfterExpiration() {
+        
+        //given
+        let fileData = "{\"forceAppLock\":false,\"timeout\":900}".data(using: .utf8)!
+        AppLockRules.shared = try! decoder.decode(AppLockRules.self, from: fileData)
+        AppLock.isActive = true
+        AppLock.lastUnlockedDate = Date(timeIntervalSinceNow: -Double(AppLockRules.shared.timeout)-100)
+        
+        let appLockVC = AppLockViewController.shared
+        
+        //when
+        let exp = expectation(description: "App lock authentication")
+        exp.isInverted = true
+        
+        appLockVC.requireLocalAuthenticationIfNeeded { (result) in
+            exp.fulfill()
+        }
+        
+        //then
+        // Authentication dialog presented, expectation should expire without result
+        waitForExpectations(timeout: 2.0) { (error) in
+            XCTAssertNil(error)
+        }
+    }
+    
+    func testThatCustomTimeoutDoesntRequireAuthenticationBeforeExpiration() {
+        
+        //given
+        let fileData = "{\"forceAppLock\":false,\"timeout\":900}".data(using: .utf8)!
+        AppLockRules.shared = try! decoder.decode(AppLockRules.self, from: fileData)
+        AppLock.isActive = true
+        AppLock.lastUnlockedDate = Date(timeIntervalSinceNow: -10)
+        
+        let appLockVC = AppLockViewController.shared
+        
+        //when
+        let exp = expectation(description: "App lock authentication")
+        appLockVC.requireLocalAuthenticationIfNeeded { (result) in
+            guard let result = result else { XCTFail(); return }
+            XCTAssertTrue(result)
+            exp.fulfill()
+        }
+        
+        //then
+        waitForExpectations(timeout: 2.0, handler: nil)
+    }
+    
+}

--- a/Wire-iOS Tests/AppLockTests.swift
+++ b/Wire-iOS Tests/AppLockTests.swift
@@ -27,12 +27,11 @@ class AppLockTests: XCTestCase {
     func testThatForcedAppLockDoesntAffectSettings() {
 
         //given
-        let fileData = "{\"forceAppLock\":true,\"timeout\":900}".data(using: .utf8)!
-        AppLockRules.shared = try! decoder.decode(AppLockRules.self, from: fileData)
+        AppLock.rules = AppLockRules(forceAppLock: true, timeout: 900)
         
         //when
-        XCTAssertTrue(AppLockRules.shared.forceAppLock)
-        XCTAssertEqual(AppLockRules.shared.timeout, 900)
+        XCTAssertTrue(AppLock.rules.forceAppLock)
+        XCTAssertEqual(AppLock.rules.timeout, 900)
         
         //then
         XCTAssertTrue(AppLock.isActive)
@@ -45,12 +44,11 @@ class AppLockTests: XCTestCase {
     func testThatAppLockAffectsSettings() {
         
         //given
-        let fileData = "{\"forceAppLock\":false,\"timeout\":10}".data(using: .utf8)!
-        AppLockRules.shared = try! decoder.decode(AppLockRules.self, from: fileData)
+        AppLock.rules = AppLockRules(forceAppLock: false, timeout: 10)
         
         //when
-        XCTAssertFalse(AppLockRules.shared.forceAppLock)
-        XCTAssertEqual(AppLockRules.shared.timeout, 10)
+        XCTAssertFalse(AppLock.rules.forceAppLock)
+        XCTAssertEqual(AppLock.rules.timeout, 10)
         
         //then
         AppLock.isActive = false
@@ -63,10 +61,9 @@ class AppLockTests: XCTestCase {
     func testThatCustomTimeoutRequiresAuthenticationAfterExpiration() {
         
         //given
-        let fileData = "{\"forceAppLock\":false,\"timeout\":900}".data(using: .utf8)!
-        AppLockRules.shared = try! decoder.decode(AppLockRules.self, from: fileData)
+        AppLock.rules = AppLockRules(forceAppLock: false, timeout: 900)
         AppLock.isActive = true
-        AppLock.lastUnlockedDate = Date(timeIntervalSinceNow: -Double(AppLockRules.shared.timeout)-100)
+        AppLock.lastUnlockedDate = Date(timeIntervalSinceNow: -Double(AppLock.rules.timeout)-100)
         
         let appLockVC = AppLockViewController.shared
         
@@ -88,8 +85,7 @@ class AppLockTests: XCTestCase {
     func testThatCustomTimeoutDoesntRequireAuthenticationBeforeExpiration() {
         
         //given
-        let fileData = "{\"forceAppLock\":false,\"timeout\":900}".data(using: .utf8)!
-        AppLockRules.shared = try! decoder.decode(AppLockRules.self, from: fileData)
+        AppLock.rules = AppLockRules(forceAppLock: false, timeout: 900)
         AppLock.isActive = true
         AppLock.lastUnlockedDate = Date(timeIntervalSinceNow: -10)
         
@@ -107,4 +103,14 @@ class AppLockTests: XCTestCase {
         waitForExpectations(timeout: 2.0, handler: nil)
     }
     
+    func testThatAppLockRulesObjectIsDecodedCorrectly() {
+        //given
+        let json = "{\"forceAppLock\":true,\"timeout\":900}"
+        //when
+        let sut = AppLockRules.fromData(json.data(using: .utf8)!)
+        //then
+        XCTAssertTrue(sut.forceAppLock)
+        XCTAssertEqual(sut.timeout, 900)
+    }
+
 }

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -418,6 +418,7 @@
 		7C25D755214911AC002E22BF /* UserSearchResultsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C25D754214911AC002E22BF /* UserSearchResultsViewController.swift */; };
 		7C25D75B21494E4B002E22BF /* UserSearchResultsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C25D75A21494E4B002E22BF /* UserSearchResultsViewControllerTests.swift */; };
 		7C3083AC1FE15FBF0036AFCC /* CustomSpacingStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C3083AB1FE15FBF0036AFCC /* CustomSpacingStackView.swift */; };
+		7C30DD9322D7342900263807 /* AppLockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C30DD9122D7340A00263807 /* AppLockTests.swift */; };
 		7C374E4B1FDE7B8C00A43B9C /* unsplash_matterhorn_small_height.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 7C374E471FDE7B8B00A43B9C /* unsplash_matterhorn_small_height.jpg */; };
 		7C374E4C1FDE7B8C00A43B9C /* unsplash_matterhorn_exact_size.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 7C374E481FDE7B8B00A43B9C /* unsplash_matterhorn_exact_size.jpg */; };
 		7C374E4D1FDE7B8C00A43B9C /* unsplash_matterhorn_small_size.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 7C374E491FDE7B8C00A43B9C /* unsplash_matterhorn_small_size.jpg */; };
@@ -1970,6 +1971,7 @@
 		7C25D754214911AC002E22BF /* UserSearchResultsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSearchResultsViewController.swift; sourceTree = "<group>"; };
 		7C25D75A21494E4B002E22BF /* UserSearchResultsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSearchResultsViewControllerTests.swift; sourceTree = "<group>"; };
 		7C3083AB1FE15FBF0036AFCC /* CustomSpacingStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomSpacingStackView.swift; sourceTree = "<group>"; };
+		7C30DD9122D7340A00263807 /* AppLockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockTests.swift; sourceTree = "<group>"; };
 		7C374E471FDE7B8B00A43B9C /* unsplash_matterhorn_small_height.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = unsplash_matterhorn_small_height.jpg; sourceTree = "<group>"; };
 		7C374E481FDE7B8B00A43B9C /* unsplash_matterhorn_exact_size.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = unsplash_matterhorn_exact_size.jpg; sourceTree = "<group>"; };
 		7C374E491FDE7B8C00A43B9C /* unsplash_matterhorn_small_size.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = unsplash_matterhorn_small_size.jpg; sourceTree = "<group>"; };
@@ -5919,6 +5921,7 @@
 				EF4FFB3422830BD200B69851 /* String+WholeRangeTests.swift */,
 				EFDBA24622942FBB00874A15 /* UIAlertViewController+CompanyLoginTests.swift */,
 				7CCB8F7E229D67BD005BBC10 /* URL+WireTests.swift */,
+				7C30DD9122D7340A00263807 /* AppLockTests.swift */,
 			);
 			path = "Wire-iOS Tests";
 			sourceTree = "<group>";
@@ -8172,6 +8175,7 @@
 				8759DB851E6B696C000A832D /* ImageMessageViewTests.swift in Sources */,
 				EF159F381FD59607006E0A9C /* TextFieldValidatorTests.swift in Sources */,
 				1658C19620A1E2FA00148F6D /* MockVoiceChannel.swift in Sources */,
+				7C30DD9322D7342900263807 /* AppLockTests.swift in Sources */,
 				5502C6E522B7B800000684B7 /* LegalHoldAlertFactoryTests.swift in Sources */,
 				BF5127161CC9119400F23DEA /* ZMSnapshotTestCase.swift in Sources */,
 				EF305247208742F300613C45 /* ConfirmPhoneViewControllerTests.swift in Sources */,

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -437,6 +437,7 @@
 		7CB082DC1FB2137100972488 /* ShareExtensionNetworkObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CB082D51FB20E0E00972488 /* ShareExtensionNetworkObserver.swift */; };
 		7CB1B0C5200E13A600BD7CE9 /* MockPhotoPermissionsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C72F03E200E1000001231D3 /* MockPhotoPermissionsController.swift */; };
 		7CC085461F7AA30F0010F96B /* DotView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CC085451F7AA30F0010F96B /* DotView.swift */; };
+		7CC0FDA022D62B3F00B67B9D /* applock.json in Resources */ = {isa = PBXBuildFile; fileRef = 7CC0FD9F22D62B3F00B67B9D /* applock.json */; };
 		7CCA7CC2221AEC7B00A7CA2A /* ConversationDetailFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CCA7CC1221AEC7B00A7CA2A /* ConversationDetailFooterView.swift */; };
 		7CCA7CC4221AF55300A7CA2A /* ProfileFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CCA7CC3221AF55300A7CA2A /* ProfileFooterView.swift */; };
 		7CCB8F7F229D67BD005BBC10 /* URL+WireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CCB8F7E229D67BD005BBC10 /* URL+WireTests.swift */; };
@@ -1989,6 +1990,7 @@
 		7CAB951120650EE6004BAFC4 /* ShareDestinationCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareDestinationCellTests.swift; sourceTree = "<group>"; };
 		7CB082D51FB20E0E00972488 /* ShareExtensionNetworkObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareExtensionNetworkObserver.swift; sourceTree = "<group>"; };
 		7CC085451F7AA30F0010F96B /* DotView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DotView.swift; sourceTree = "<group>"; };
+		7CC0FD9F22D62B3F00B67B9D /* applock.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = applock.json; sourceTree = "<group>"; };
 		7CCA7CC1221AEC7B00A7CA2A /* ConversationDetailFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationDetailFooterView.swift; sourceTree = "<group>"; };
 		7CCA7CC3221AF55300A7CA2A /* ProfileFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileFooterView.swift; sourceTree = "<group>"; };
 		7CCB8F7E229D67BD005BBC10 /* URL+WireTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+WireTests.swift"; sourceTree = "<group>"; };
@@ -6465,6 +6467,7 @@
 		F12C48952199CBB600F49548 /* Configuration */ = {
 			isa = PBXGroup;
 			children = (
+				7CC0FD9F22D62B3F00B67B9D /* applock.json */,
 				EF2B0DD021CA8DF7003B2882 /* url.json */,
 				5E39FC5E225CBBD300C682B8 /* password_rules.json */,
 				F1FDF2C521ADA3F000E037A1 /* Images.xcassets */,
@@ -6825,6 +6828,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7CC0FDA022D62B3F00B67B9D /* applock.json in Resources */,
 				1658D2041D3E742A00249609 /* new_message.caf in Resources */,
 				BF732A761D9C14C7003077DB /* emoji_nature.plist in Resources */,
 				BF732A781D9C14C7003077DB /* emoji_people.plist in Resources */,

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -1075,7 +1075,7 @@
 "self.settings.privacy_contacts_menu.description_disabled.title" = "This helps you connect with others. We anonymize all the information and do not share it with anyone else. Allow access via Settings > Privacy > Contacts.";
 
 "self.settings.privacy_security.lock_app" = "Lock With Passcode";
-"self.settings.privacy_security.lock_app.subtitle.lock_description" = "Lock Wire after 10 seconds in the background.";
+"self.settings.privacy_security.lock_app.subtitle.lock_description" = "Lock Wire after %@ in the background.";
 "self.settings.privacy_security.lock_app.subtitle.touch_id" = "Unlock with Touch ID or enter your passcode.";
 "self.settings.privacy_security.lock_app.subtitle.face_id" = "Unlock with Face ID or enter your passcode.";
 "self.settings.privacy_security.lock_app.subtitle.none" = "Unlock by entering your passcode.";

--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
@@ -133,7 +133,7 @@ extension Notification.Name {
         
         // The app was authenticated at least N seconds ago
         let timeSinceAuth = -lastAuthDate.timeIntervalSinceNow
-        if timeSinceAuth >= 0 && timeSinceAuth < Double(AppLockRules.shared.timeout) {
+        if timeSinceAuth >= 0 && timeSinceAuth < Double(AppLock.rules.timeout) {
             callback(true)
             return
         }

--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
@@ -28,7 +28,6 @@ extension Notification.Name {
 
 @objcMembers final class AppLockViewController: UIViewController {
     fileprivate var lockView: AppLockView!
-    fileprivate static let authenticationPersistancePeriod: TimeInterval = 10
     fileprivate var localAuthenticationCancelled: Bool = false
     fileprivate var localAuthenticationNeeded: Bool = true
 
@@ -134,7 +133,7 @@ extension Notification.Name {
         
         // The app was authenticated at least N seconds ago
         let timeSinceAuth = -lastAuthDate.timeIntervalSinceNow
-        if timeSinceAuth >= 0 && timeSinceAuth < type(of: self).authenticationPersistancePeriod {
+        if timeSinceAuth >= 0 && timeSinceAuth < Double(AppLockRules.shared.timeout) {
             callback(true)
             return
         }

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Options.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Options.swift
@@ -186,6 +186,7 @@ extension SettingsCellDescriptorFactory {
         
         if context.canEvaluatePolicy(LAPolicy.deviceOwnerAuthentication, error: &error) {
             let lockApp = SettingsPropertyToggleCellDescriptor(settingsProperty: self.settingsPropertyFactory.property(.lockApp))
+            lockApp.settingsProperty.enabled = !AppLockRules.shared.forceAppLock
             let section = SettingsSectionDescriptor(cellDescriptors: [lockApp], footer: appLockSectionSubtitle)
             cellDescriptors.append(section)
         }
@@ -203,7 +204,9 @@ extension SettingsCellDescriptorFactory {
     }
     
     private var appLockSectionSubtitle: String {
-        let lockDescription = "self.settings.privacy_security.lock_app.subtitle.lock_description".localized
+        let timeout = TimeInterval(AppLockRules.shared.timeout)
+        guard let amount = SettingsCellDescriptorFactory.appLockFormatter.string(from: timeout) else { return "" }
+        let lockDescription = "self.settings.privacy_security.lock_app.subtitle.lock_description".localized(args: amount)
         let typeKey: String = {
             switch AuthenticationType.current {
             case .none: return "self.settings.privacy_security.lock_app.subtitle.none"
@@ -272,5 +275,11 @@ extension SettingsCellDescriptorFactory {
         return SettingsGroupCellDescriptor(items: [section], title: property.propertyName.settingsPropertyLabelText, identifier: nil, previewGenerator: preview)
     }
     
-
+    static var appLockFormatter: DateComponentsFormatter {
+        let formatter = DateComponentsFormatter()
+        formatter.unitsStyle = .full
+        formatter.allowedUnits = [.day, .hour, .minute, .second]
+        formatter.zeroFormattingBehavior = .dropAll
+        return formatter
+    }
 }

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Options.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Options.swift
@@ -186,7 +186,7 @@ extension SettingsCellDescriptorFactory {
         
         if context.canEvaluatePolicy(LAPolicy.deviceOwnerAuthentication, error: &error) {
             let lockApp = SettingsPropertyToggleCellDescriptor(settingsProperty: self.settingsPropertyFactory.property(.lockApp))
-            lockApp.settingsProperty.enabled = !AppLockRules.shared.forceAppLock
+            lockApp.settingsProperty.enabled = !AppLock.rules.forceAppLock
             let section = SettingsSectionDescriptor(cellDescriptors: [lockApp], footer: appLockSectionSubtitle)
             cellDescriptors.append(section)
         }
@@ -204,7 +204,7 @@ extension SettingsCellDescriptorFactory {
     }
     
     private var appLockSectionSubtitle: String {
-        let timeout = TimeInterval(AppLockRules.shared.timeout)
+        let timeout = TimeInterval(AppLock.rules.timeout)
         guard let amount = SettingsCellDescriptorFactory.appLockFormatter.string(from: timeout) else { return "" }
         let lockDescription = "self.settings.privacy_security.lock_app.subtitle.lock_description".localized(args: amount)
         let typeKey: String = {

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsPropertyToggleCellDescriptor.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsPropertyToggleCellDescriptor.swift
@@ -60,6 +60,7 @@ class SettingsPropertyToggleCellDescriptor: SettingsPropertyCellDescriptorType {
             
             toggleCell.switchView.isOn = boolValue
             toggleCell.switchView.accessibilityLabel = identifier
+            toggleCell.switchView.isEnabled = self.settingsProperty.enabled
         }
     }
     

--- a/WireCommonComponents/AppLock.swift
+++ b/WireCommonComponents/AppLock.swift
@@ -24,6 +24,7 @@ public class AppLock {
     // Returns true if user enabled the app lock feature.
     public static var isActive: Bool {
         get {
+            guard !AppLockRules.shared.forceAppLock else { return true }
             guard let data = ZMKeychain.data(forAccount: SettingsPropertyName.lockApp.rawValue),
                 data.count != 0 else {
                     return false
@@ -32,6 +33,7 @@ public class AppLock {
             return String(data: data, encoding: .utf8) == "YES"
         }
         set {
+            guard !AppLockRules.shared.forceAppLock else { return }
             let data = (newValue ? "YES" : "NO").data(using: .utf8)!
             ZMKeychain.setData(data, forAccount: SettingsPropertyName.lockApp.rawValue)
         }
@@ -91,4 +93,19 @@ public class AppLock {
         }
     }
     
+}
+
+
+public struct AppLockRules: Decodable {
+    
+    public let forceAppLock: Bool
+    public let timeout: UInt
+    
+    /// The shared rule set.
+    public static let shared: AppLockRules = {
+        let fileURL = Bundle.main.url(forResource: "applock", withExtension: "json")!
+        let fileData = try! Data(contentsOf: fileURL)
+        let decoder = JSONDecoder()
+        return try! decoder.decode(AppLockRules.self, from: fileData)
+    }()
 }

--- a/WireCommonComponents/AppLock.swift
+++ b/WireCommonComponents/AppLock.swift
@@ -22,9 +22,12 @@ import LocalAuthentication
 
 public class AppLock {
     // Returns true if user enabled the app lock feature.
+    
+    public static var rules = AppLockRules.fromBundle()
+    
     public static var isActive: Bool {
         get {
-            guard !AppLockRules.shared.forceAppLock else { return true }
+            guard !rules.forceAppLock else { return true }
             guard let data = ZMKeychain.data(forAccount: SettingsPropertyName.lockApp.rawValue),
                 data.count != 0 else {
                     return false
@@ -33,7 +36,7 @@ public class AppLock {
             return String(data: data, encoding: .utf8) == "YES"
         }
         set {
-            guard !AppLockRules.shared.forceAppLock else { return }
+            guard !rules.forceAppLock else { return }
             let data = (newValue ? "YES" : "NO").data(using: .utf8)!
             ZMKeychain.setData(data, forAccount: SettingsPropertyName.lockApp.rawValue)
         }
@@ -101,11 +104,14 @@ public struct AppLockRules: Decodable {
     public let forceAppLock: Bool
     public let timeout: UInt
     
-    /// The shared rule set.
-    public static var shared: AppLockRules = {
+    public static func fromBundle() -> AppLockRules {
         let fileURL = Bundle.main.url(forResource: "applock", withExtension: "json")!
         let fileData = try! Data(contentsOf: fileURL)
+        return fromData(fileData)
+    }
+    
+    public static func fromData(_ data: Data) -> AppLockRules {
         let decoder = JSONDecoder()
-        return try! decoder.decode(AppLockRules.self, from: fileData)
-    }()
+        return try! decoder.decode(AppLockRules.self, from: data)
+    }
 }

--- a/WireCommonComponents/AppLock.swift
+++ b/WireCommonComponents/AppLock.swift
@@ -102,7 +102,7 @@ public struct AppLockRules: Decodable {
     public let timeout: UInt
     
     /// The shared rule set.
-    public static let shared: AppLockRules = {
+    public static var shared: AppLockRules = {
         let fileURL = Bundle.main.url(forResource: "applock", withExtension: "json")!
         let fileData = try! Data(contentsOf: fileURL)
         let decoder = JSONDecoder()


### PR DESCRIPTION
## What's new in this PR?

Implemented custom timer on app lock and possibility to force it by a custom `applock.json` file in the configuration folder. TODO: tests.