### PR TITLE
Fix: conversation message status label accessibilityLabel does not updated after liked

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
@@ -255,6 +255,9 @@ final class MessageToolboxView: UIView {
             return
         }
 
+        /// clean the accessibilityLabel to nil before animation starts
+        statusLabel.accessibilityLabel = nil
+
         switch dataSource.content {
             
         case .callList(let callListString):


### PR DESCRIPTION
## What's new in this PR?

For automation, we found that conversation message status label's `accessibilityLabel` does not refesh after the messaged is liked. The status label is hidden after the animation is completed and it may cause an issue for automation. 

As a work-a-round, set status label's `accessibilityLabel` to `nil` before the animation starts. 