### PR TITLE
Fix: iOS join button on conversation list is missing 'JOIN' label

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListAccessoryView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListAccessoryView.swift
@@ -43,7 +43,7 @@ import UIKit
         self.mediaPlaybackManager = mediaPlaybackManager
         super.init(frame: .zero)
                 
-        textLabel.setContentCompressionResistancePriority(UILayoutPriority.defaultHigh, for: .horizontal)
+        textLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
         textLabel.setContentCompressionResistancePriority(UILayoutPriority.defaultHigh, for: .vertical)
         textLabel.setContentHuggingPriority(UILayoutPriority.defaultHigh, for: .horizontal)
         textLabel.setContentHuggingPriority(UILayoutPriority.defaultHigh, for: .vertical)


### PR DESCRIPTION
## What's new in this PR?

Prevent compressing "Join" label's width and truncating the text.