### PR TITLE
Fix: LegalHoldDetailsViewController status bar style when opening from conversation list screen

### DIFF
--- a/Wire-iOS/Sources/UserInterface/LegalHoldDetails/LegalHoldDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/LegalHoldDetails/LegalHoldDetailsViewController.swift
@@ -46,6 +46,9 @@ final class LegalHoldDetailsViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return ColorScheme.default.statusBarStyle
+    }
 
     @discardableResult
     static func present(in parentViewController: UIViewController, user: ZMUser) -> UINavigationController? {
@@ -72,6 +75,7 @@ final class LegalHoldDetailsViewController: UIViewController {
         super.viewWillAppear(animated)
         
         navigationItem.rightBarButtonItem = navigationController?.closeItem()
+        updateStatusBar()
     }
     
     override func viewDidAppear(_ animated: Bool) {


### PR DESCRIPTION
## What's new in this PR?

### Issues

When opening  `LegalHoldDetailsViewController` from the conversation list screen, the status bar is still in the light style

### Causes

same as https://github.com/wireapp/wire-ios/pull/3316

### Solutions

same as https://github.com/wireapp/wire-ios/pull/3316

