### PR TITLE
clean status label's text when hidden

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
@@ -247,6 +247,12 @@ final class MessageToolboxView: UIView {
         reloadContent(animated: animated)
     }
 
+    private func hideAndCleanStatusLabel() {
+        statusLabel.isHidden = true
+        statusLabel.accessibilityLabel = nil
+        statusLabel.attributedText = nil
+    }
+
     private func reloadContent(animated: Bool) {
         guard let dataSource = self.dataSource else { return }
 
@@ -255,9 +261,6 @@ final class MessageToolboxView: UIView {
             return
         }
 
-        /// clean the accessibilityLabel to nil before animation starts
-        statusLabel.accessibilityLabel = nil
-
         switch dataSource.content {
             
         case .callList(let callListString):
@@ -265,7 +268,7 @@ final class MessageToolboxView: UIView {
                 self.detailsLabel.attributedText = callListString
                 self.detailsLabel.isHidden = false
                 self.detailsLabel.numberOfLines = 0
-                self.statusLabel.isHidden = true
+                self.hideAndCleanStatusLabel()
                 self.timestampSeparatorLabel.isHidden = true
                 self.deleteButton.isHidden = true
                 self.resendButton.isHidden = true
@@ -277,7 +280,7 @@ final class MessageToolboxView: UIView {
                 self.detailsLabel.attributedText = reactionsString
                 self.detailsLabel.isHidden = false
                 self.detailsLabel.numberOfLines = 1
-                self.statusLabel.isHidden = true
+                self.hideAndCleanStatusLabel()
                 self.timestampSeparatorLabel.isHidden = true
                 self.deleteButton.isHidden = true
                 self.resendButton.isHidden = true
@@ -290,7 +293,7 @@ final class MessageToolboxView: UIView {
                 self.detailsLabel.attributedText = detailsString
                 self.detailsLabel.isHidden = false
                 self.detailsLabel.numberOfLines = 1
-                self.statusLabel.isHidden = true
+                self.hideAndCleanStatusLabel()
                 self.timestampSeparatorLabel.isHidden = false
                 self.deleteButton.isHidden = false
                 self.resendButton.isHidden = false


### PR DESCRIPTION
## What's new in this PR?

Follow up of https://github.com/wireapp/wire-ios/pull/3535, try to fix the automation issue which still seeing `statusLabel`'s accessibility label even it is hidden. Set the attributed text to nil to prevent the generation of accessibility info.