### PR TITLE
Fix: share extesnion crash due to missing bundle file

### DIFF
--- a/Wire-iOS Tests/AppLockTests.swift
+++ b/Wire-iOS Tests/AppLockTests.swift
@@ -1,0 +1,116 @@
+//
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+@testable import Wire
+@testable import WireCommonComponents
+
+final class AppLockTests: XCTestCase {
+
+    let decoder = JSONDecoder()
+    
+    func testThatForcedAppLockDoesntAffectSettings() {
+
+        //given
+        AppLock.rules = AppLockRules(forceAppLock: true, timeout: 900)
+        
+        //when
+        XCTAssertTrue(AppLock.rules.forceAppLock)
+        XCTAssertEqual(AppLock.rules.timeout, 900)
+        
+        //then
+        XCTAssertTrue(AppLock.isActive)
+        AppLock.isActive = false
+        XCTAssertTrue(AppLock.isActive)
+        AppLock.isActive = true
+        XCTAssertTrue(AppLock.isActive)
+    }
+    
+    func testThatAppLockAffectsSettings() {
+        
+        //given
+        AppLock.rules = AppLockRules(forceAppLock: false, timeout: 10)
+        
+        //when
+        XCTAssertFalse(AppLock.rules.forceAppLock)
+        XCTAssertEqual(AppLock.rules.timeout, 10)
+        
+        //then
+        AppLock.isActive = false
+        XCTAssertFalse(AppLock.isActive)
+        AppLock.isActive = true
+        XCTAssertTrue(AppLock.isActive)
+    }
+    
+    
+    func testThatCustomTimeoutRequiresAuthenticationAfterExpiration() {
+        
+        //given
+        AppLock.rules = AppLockRules(forceAppLock: false, timeout: 900)
+        AppLock.isActive = true
+        AppLock.lastUnlockedDate = Date(timeIntervalSinceNow: -Double(AppLock.rules.timeout)-100)
+        
+        let appLockVC = AppLockViewController.shared
+        
+        //when
+        let exp = expectation(description: "App lock authentication")
+        exp.isInverted = true
+        
+        appLockVC.requireLocalAuthenticationIfNeeded { (result) in
+            exp.fulfill()
+        }
+        
+        //then
+        // Authentication dialog presented, expectation should expire without result
+        waitForExpectations(timeout: 2.0) { (error) in
+            XCTAssertNil(error)
+        }
+    }
+    
+    func testThatCustomTimeoutDoesntRequireAuthenticationBeforeExpiration() {
+        
+        //given
+        AppLock.rules = AppLockRules(forceAppLock: false, timeout: 900)
+        AppLock.isActive = true
+        AppLock.lastUnlockedDate = Date(timeIntervalSinceNow: -10)
+        
+        let appLockVC = AppLockViewController.shared
+        
+        //when
+        let exp = expectation(description: "App lock authentication")
+        appLockVC.requireLocalAuthenticationIfNeeded { (result) in
+            guard let result = result else { XCTFail(); return }
+            XCTAssertTrue(result)
+            exp.fulfill()
+        }
+        
+        //then
+        waitForExpectations(timeout: 2.0, handler: nil)
+    }
+    
+    func testThatAppLockRulesObjectIsDecodedCorrectly() {
+        //given
+        let json = "{\"forceAppLock\":true,\"timeout\":900}"
+        //when
+        let sut = AppLockRules.fromData(json.data(using: .utf8)!)
+        //then
+        XCTAssertTrue(sut.forceAppLock)
+        XCTAssertEqual(sut.timeout, 900)
+    }
+
+}

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1076,6 +1076,7 @@
 		EF1EE76F2253AE2800E7B6E3 /* ConversationViewController+Constraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF1EE76E2253AE2800E7B6E3 /* ConversationViewController+Constraints.swift */; };
 		EF1F9A021FBB1FD800969DD1 /* LandingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF1F9A011FBB1FD800969DD1 /* LandingButton.swift */; };
 		EF1FCE5021B69381003E0BE2 /* ReadReceiptViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF1FCE4E21B69381003E0BE2 /* ReadReceiptViewModelTests.swift */; };
+		EF1FD00222F1910E00E3ACAA /* applock.json in Resources */ = {isa = PBXBuildFile; fileRef = 7CC0FD9F22D62B3F00B67B9D /* applock.json */; };
 		EF1FDC7C21DE0E4100C9CEB1 /* UIViewController+PopoverFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF1FDC7B21DE0E4100C9CEB1 /* UIViewController+PopoverFrame.swift */; };
 		EF1FDC7E21DE255C00C9CEB1 /* NSString+EmoticonSubstitutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF1FDC7D21DE255C00C9CEB1 /* NSString+EmoticonSubstitutionTests.swift */; };
 		EF1FDC8021DE47AB00C9CEB1 /* NSString+EmoticonSubstitution.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF1FDC7F21DE47AB00C9CEB1 /* NSString+EmoticonSubstitution.swift */; };
@@ -6842,6 +6843,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EF1FD00222F1910E00E3ACAA /* applock.json in Resources */,
 				168A16AF1D9597C2005CFA6C /* MainInterface.storyboard in Resources */,
 				BF2ADF461E27C3DB00E81B1E /* Localizable.strings in Resources */,
 			);

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1286,6 +1286,7 @@
 		EFD43FF821B82BC70050ABC5 /* XCTestCase+DeviceSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFD43FF621B82BB00050ABC5 /* XCTestCase+DeviceSize.swift */; };
 		EFD43FFA21B82C500050ABC5 /* ChangePhoneViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFD43FF921B82C500050ABC5 /* ChangePhoneViewControllerTests.swift */; };
 		EFD4B9C822F08297008CA042 /* UIImage+DownsizeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFD4B9C722F08297008CA042 /* UIImage+DownsizeTests.swift */; };
+		EFD4B9CB22F09C3E008CA042 /* AppLockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFD4B9CA22F09C3D008CA042 /* AppLockTests.swift */; };
 		EFD514AD21886CC600D7C7E0 /* ConversationListItemView+Constraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFD514AC21886CC600D7C7E0 /* ConversationListItemView+Constraints.swift */; };
 		EFD5CF4E2189C68D00BEC99E /* NSMutableAttributedString+ReplaceEmojiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFD5CF4C2189C5F700BEC99E /* NSMutableAttributedString+ReplaceEmojiTests.swift */; };
 		EFDACAB920FF715A00791207 /* ConversationInputBarViewController+OrientationAndSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFDACAB820FF715A00791207 /* ConversationInputBarViewController+OrientationAndSize.swift */; };
@@ -3105,6 +3106,7 @@
 		EFD43FF621B82BB00050ABC5 /* XCTestCase+DeviceSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+DeviceSize.swift"; sourceTree = "<group>"; };
 		EFD43FF921B82C500050ABC5 /* ChangePhoneViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangePhoneViewControllerTests.swift; sourceTree = "<group>"; };
 		EFD4B9C722F08297008CA042 /* UIImage+DownsizeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+DownsizeTests.swift"; sourceTree = "<group>"; };
+		EFD4B9CA22F09C3D008CA042 /* AppLockTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppLockTests.swift; sourceTree = "<group>"; };
 		EFD514AC21886CC600D7C7E0 /* ConversationListItemView+Constraints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationListItemView+Constraints.swift"; sourceTree = "<group>"; };
 		EFD5CF4C2189C5F700BEC99E /* NSMutableAttributedString+ReplaceEmojiTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMutableAttributedString+ReplaceEmojiTests.swift"; sourceTree = "<group>"; };
 		EFDACAB820FF715A00791207 /* ConversationInputBarViewController+OrientationAndSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationInputBarViewController+OrientationAndSize.swift"; sourceTree = "<group>"; };
@@ -5740,6 +5742,7 @@
 		BACB88521AF7C48900DDCDB0 /* Wire-iOS Tests */ = {
 			isa = PBXGroup;
 			children = (
+				EFD4B9CA22F09C3D008CA042 /* AppLockTests.swift */,
 				EFD4B9C922F082BE008CA042 /* UIImage */,
 				8787BDD31BF374420096B1B5 /* Settings */,
 				EF2121982292EEA4006C4293 /* SwiftSnapshotTesting */,
@@ -8348,6 +8351,7 @@
 				EF1D80D92226D6B800BCA8D3 /* MockConversationFactory.swift in Sources */,
 				87909076211DE898006219B4 /* EmptySearchResultsViewTests.swift in Sources */,
 				EFBFABAA2257948F005D83C0 /* TopPeopleCellSnapshotTests.swift in Sources */,
+				EFD4B9CB22F09C3E008CA042 /* AppLockTests.swift in Sources */,
 				16271BC81DA5213400689486 /* TypingIndicatorViewTests.swift in Sources */,
 				EFC57A1021BABCC90008DBE6 /* ConversationInputBarViewControllerAudioRecorderSnapshotTests.swift in Sources */,
 				EF8DD90E211DE14300E970F1 /* MessagePresenterTests.swift in Sources */,

--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
@@ -28,7 +28,6 @@ extension Notification.Name {
 
 @objcMembers final class AppLockViewController: UIViewController {
     fileprivate var lockView: AppLockView!
-    fileprivate static let authenticationPersistancePeriod: TimeInterval = 10
     fileprivate var localAuthenticationCancelled: Bool = false
     fileprivate var localAuthenticationNeeded: Bool = true
 
@@ -134,7 +133,7 @@ extension Notification.Name {
         
         // The app was authenticated at least N seconds ago
         let timeSinceAuth = -lastAuthDate.timeIntervalSinceNow
-        if timeSinceAuth >= 0 && timeSinceAuth < type(of: self).authenticationPersistancePeriod {
+        if timeSinceAuth >= 0 && timeSinceAuth < Double(AppLock.rules.timeout) {
             callback(true)
             return
         }

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Options.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Options.swift
@@ -186,6 +186,7 @@ extension SettingsCellDescriptorFactory {
         
         if context.canEvaluatePolicy(LAPolicy.deviceOwnerAuthentication, error: &error) {
             let lockApp = SettingsPropertyToggleCellDescriptor(settingsProperty: self.settingsPropertyFactory.property(.lockApp))
+            lockApp.settingsProperty.enabled = !AppLock.rules.forceAppLock
             let section = SettingsSectionDescriptor(cellDescriptors: [lockApp], footer: appLockSectionSubtitle)
             cellDescriptors.append(section)
         }
@@ -203,7 +204,9 @@ extension SettingsCellDescriptorFactory {
     }
     
     private var appLockSectionSubtitle: String {
-        let lockDescription = "self.settings.privacy_security.lock_app.subtitle.lock_description".localized
+        let timeout = TimeInterval(AppLock.rules.timeout)
+        guard let amount = SettingsCellDescriptorFactory.appLockFormatter.string(from: timeout) else { return "" }
+        let lockDescription = "self.settings.privacy_security.lock_app.subtitle.lock_description".localized(args: amount)
         let typeKey: String = {
             switch AuthenticationType.current {
             case .none: return "self.settings.privacy_security.lock_app.subtitle.none"
@@ -272,5 +275,11 @@ extension SettingsCellDescriptorFactory {
         return SettingsGroupCellDescriptor(items: [section], title: property.propertyName.settingsPropertyLabelText, identifier: nil, previewGenerator: preview)
     }
     
-
+    static var appLockFormatter: DateComponentsFormatter {
+        let formatter = DateComponentsFormatter()
+        formatter.unitsStyle = .full
+        formatter.allowedUnits = [.day, .hour, .minute, .second]
+        formatter.zeroFormattingBehavior = .dropAll
+        return formatter
+    }
 }

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsPropertyToggleCellDescriptor.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsPropertyToggleCellDescriptor.swift
@@ -60,6 +60,7 @@ class SettingsPropertyToggleCellDescriptor: SettingsPropertyCellDescriptorType {
             
             toggleCell.switchView.isOn = boolValue
             toggleCell.switchView.accessibilityLabel = identifier
+            toggleCell.switchView.isEnabled = self.settingsProperty.enabled
         }
     }
     

--- a/WireCommonComponents/AppLock.swift
+++ b/WireCommonComponents/AppLock.swift
@@ -20,11 +20,11 @@ import Foundation
 import WireDataModel
 import LocalAuthentication
 
-public class AppLock {
+final public class AppLock {
     // Returns true if user enabled the app lock feature.
     
     public static var rules = AppLockRules.fromBundle()
-    
+
     public static var isActive: Bool {
         get {
             guard !rules.forceAppLock else { return true }

--- a/WireCommonComponents/AppLock.swift
+++ b/WireCommonComponents/AppLock.swift
@@ -105,9 +105,12 @@ public struct AppLockRules: Decodable {
     public let timeout: UInt
     
     public static func fromBundle() -> AppLockRules {
-        let fileURL = Bundle.main.url(forResource: "applock", withExtension: "json")!
-        let fileData = try! Data(contentsOf: fileURL)
-        return fromData(fileData)
+        if let fileURL = Bundle.main.url(forResource: "applock", withExtension: "json"),
+            let fileData = try? Data(contentsOf: fileURL) {
+            return fromData(fileData)
+        } else {
+            fatalError("appLock.json not exist")
+        }
     }
     
     public static func fromData(_ data: Data) -> AppLockRules {

--- a/WireCommonComponents/AppLock.swift
+++ b/WireCommonComponents/AppLock.swift
@@ -22,8 +22,12 @@ import LocalAuthentication
 
 public class AppLock {
     // Returns true if user enabled the app lock feature.
+    
+    public static var rules = AppLockRules.fromBundle()
+    
     public static var isActive: Bool {
         get {
+            guard !rules.forceAppLock else { return true }
             guard let data = ZMKeychain.data(forAccount: SettingsPropertyName.lockApp.rawValue),
                 data.count != 0 else {
                     return false
@@ -32,6 +36,7 @@ public class AppLock {
             return String(data: data, encoding: .utf8) == "YES"
         }
         set {
+            guard !rules.forceAppLock else { return }
             let data = (newValue ? "YES" : "NO").data(using: .utf8)!
             ZMKeychain.setData(data, forAccount: SettingsPropertyName.lockApp.rawValue)
         }
@@ -91,4 +96,22 @@ public class AppLock {
         }
     }
     
+}
+
+
+public struct AppLockRules: Decodable {
+    
+    public let forceAppLock: Bool
+    public let timeout: UInt
+    
+    public static func fromBundle() -> AppLockRules {
+        let fileURL = Bundle.main.url(forResource: "applock", withExtension: "json")!
+        let fileData = try! Data(contentsOf: fileURL)
+        return fromData(fileData)
+    }
+    
+    public static func fromData(_ data: Data) -> AppLockRules {
+        let decoder = JSONDecoder()
+        return try! decoder.decode(AppLockRules.self, from: data)
+    }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

share extension crashes after https://github.com/wireapp/wire-ios/pull/3528 is merged

### Causes

Missing `applock.json` in share extension target 

### Solutions

add the missing file in the share extension target and add a fatal message if missing.