### PR TITLE
Fix: no applock displayed after restarting the app

### DIFF
--- a/Wire-iOS/Sources/Analytics/Events/Analytics+Settings.swift
+++ b/Wire-iOS/Sources/Analytics/Events/Analytics+Settings.swift
@@ -27,7 +27,6 @@ extension Analytics {
     
     internal func tagSettingsChanged(for propertyName: SettingsPropertyName, to value: SettingsPropertyValue) {
         guard let value = value.value(),
-              propertyName != SettingsPropertyName.lockAppLastDate &&
                 propertyName != SettingsPropertyName.disableCrashAndAnalyticsSharing else {
             return
         }

--- a/Wire-iOS/Sources/Components/Settings/SettingsPropertyFactory.swift
+++ b/Wire-iOS/Sources/Components/Settings/SettingsPropertyFactory.swift
@@ -304,19 +304,6 @@ class SettingsPropertyFactory {
                     default: throw SettingsPropertyError.WrongValue("Incorrect type \(value) for key \(propertyName)")
                     }
             })
-        case .lockAppLastDate:
-            return SettingsBlockProperty(
-                propertyName: propertyName,
-                getAction: { _ in
-                    return SettingsPropertyValue(AppLock.lastUnlockDateAsInt)
-            },
-                setAction: { _, value in
-                    switch value {
-                    case .number(value: let lockAppLastDate):
-                        AppLock.lastUnlockDateAsInt = lockAppLastDate.uint32Value
-                    default: throw SettingsPropertyError.WrongValue("Incorrect type \(value) for key \(propertyName)")
-                    }
-            })
         
         case .callingConstantBitRate:
             return SettingsBlockProperty(

--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
@@ -43,6 +43,9 @@ extension Notification.Name {
         return shared.dimContents
     }
 
+     /// flag to identify the app is just launched. the value is false until applicationDidBecomeActive is called
+    static var becameActive: Bool = false
+
     convenience init() {
         self.init(nibName:nil, bundle:nil)
         
@@ -177,6 +180,13 @@ extension AppLockViewController {
     }
     
     @objc func applicationDidBecomeActive() {
-        self.showUnlockIfNeeded()
+        if !AppLockViewController.becameActive {
+            AppLockViewController.becameActive = true
+
+            /// invlidate lastUnlockedDate to shwo the app lock
+            AppLock.lastUnlockedDate = Date.init(timeIntervalSince1970: 0)
+        }
+
+        showUnlockIfNeeded()
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
@@ -180,10 +180,6 @@ extension AppLockViewController {
     }
     
     @objc func applicationDidBecomeActive() {
-        if !AppLockViewController.becameActive {
-            AppLockViewController.becameActive = true
-        }
-
         showUnlockIfNeeded()
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
@@ -182,9 +182,6 @@ extension AppLockViewController {
     @objc func applicationDidBecomeActive() {
         if !AppLockViewController.becameActive {
             AppLockViewController.becameActive = true
-
-            /// invlidate lastUnlockedDate, app lock will show since the timeout is reached
-            AppLock.lastUnlockedDate = Date.init(timeIntervalSince1970: 0)
         }
 
         showUnlockIfNeeded()

--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
@@ -43,9 +43,6 @@ extension Notification.Name {
         return shared.dimContents
     }
 
-     /// flag to identify the app is just launched. the value is false until applicationDidBecomeActive is called
-    static var becameActive: Bool = false
-
     convenience init() {
         self.init(nibName:nil, bundle:nil)
         

--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
@@ -183,7 +183,7 @@ extension AppLockViewController {
         if !AppLockViewController.becameActive {
             AppLockViewController.becameActive = true
 
-            /// invlidate lastUnlockedDate to shwo the app lock
+            /// invlidate lastUnlockedDate, app lock will show since the timeout is reached
             AppLock.lastUnlockedDate = Date.init(timeIntervalSince1970: 0)
         }
 

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptor.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptor.swift
@@ -247,8 +247,6 @@ extension SettingsPropertyName {
             return "Use AssetCollectionBatched"
         case .lockApp:
             return "self.settings.privacy_security.lock_app".localized
-        case .lockAppLastDate:
-            return "Last app lock date"
         case .callingConstantBitRate:
             return "self.settings.vbr.title".localized
         case .disableLinkPreviews:

--- a/WireCommonComponents/AppLock.swift
+++ b/WireCommonComponents/AppLock.swift
@@ -44,19 +44,8 @@ final public class AppLock {
         }
     }
     
-    // Returns the time since last lock happened as number of seconds since the reference date.
-    private static var lastUnlockDateAsInt: UInt32 = 0
-    
     // Returns the time since last lock happened.
-    public static var lastUnlockedDate: Date {
-        get {
-            return Date(timeIntervalSinceReferenceDate: TimeInterval(self.lastUnlockDateAsInt))
-        }
-        
-        set {
-            lastUnlockDateAsInt = UInt32(newValue.timeIntervalSinceReferenceDate)
-        }
-    }
+    public static var lastUnlockedDate: Date = Date(timeIntervalSince1970: 0)
     
     public enum AuthenticationResult {
         /// User sucessfully authenticated

--- a/WireCommonComponents/AppLock.swift
+++ b/WireCommonComponents/AppLock.swift
@@ -45,30 +45,7 @@ final public class AppLock {
     }
     
     // Returns the time since last lock happened as number of seconds since the reference date.
-    public static var lastUnlockDateAsInt: UInt32 {
-        get {
-            guard let data = ZMKeychain.data(forAccount: SettingsPropertyName.lockAppLastDate.rawValue),
-                data.count != 0 else {
-                    return 0
-            }
-            
-            let intBits = data.withUnsafeBytes({(bytePointer: UnsafeRawBufferPointer) -> UInt32 in
-                bytePointer.bindMemory(to: UInt8.self).baseAddress!.withMemoryRebound(to: UInt32.self, capacity: 4) { pointer in
-                    return pointer.pointee
-                }
-            })
-            
-            return UInt32(littleEndian: intBits)
-        }
-        set {
-            var value: UInt32 = newValue
-            let data = withUnsafePointer(to: &value) {
-                Data(bytes: UnsafePointer($0), count: MemoryLayout.size(ofValue: newValue))
-            }
-            
-            ZMKeychain.setData(data, forAccount: SettingsPropertyName.lockAppLastDate.rawValue)
-        }
-    }
+    private static var lastUnlockDateAsInt: UInt32 = 0
     
     // Returns the time since last lock happened.
     public static var lastUnlockedDate: Date {
@@ -77,7 +54,7 @@ final public class AppLock {
         }
         
         set {
-            self.lastUnlockDateAsInt = UInt32(newValue.timeIntervalSinceReferenceDate)
+            lastUnlockDateAsInt = UInt32(newValue.timeIntervalSinceReferenceDate)
         }
     }
     

--- a/WireCommonComponents/SettingsPropertyName.swift
+++ b/WireCommonComponents/SettingsPropertyName.swift
@@ -78,8 +78,7 @@ public enum SettingsPropertyName: String, CustomStringConvertible {
     case enableBatchCollections = "EnableBatchCollections"
 
     case lockApp = "lockApp"
-    case lockAppLastDate = "lockAppLastDate"
-    
+
     case readReceiptsEnabled = "readReceiptsEnabled"
     
     public var changeNotificationName: String {


### PR DESCRIPTION
## What's new in this PR?

### Issues

When `forceAppLock` is enabled, no applock displayed after restarting the app.

### Causes

If the `timeout` is not reached, applock is not shown.

### Solutions

~~When the app launches, set `lastUnlockedDate` to invalid value and app lock screen will be shown.~~ Set `lastUnlockedDate` to an invalid value so that app lock always appear when app launches.

Remove `lockAppLastDate` from `SettingsPropertyFactory` and not save the value in the keychain.