### PR TITLE
Prevent keyboard showing up when app lock is active

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
@@ -34,6 +34,12 @@ extension Notification.Name {
     fileprivate var dimContents: Bool = false {
         didSet {
             self.view.isHidden = !self.dimContents
+                        
+            if dimContents {
+                AppDelegate.shared().notificationsWindow?.makeKey()
+            } else {
+                AppDelegate.shared().window.makeKey()
+            }
         }
     }
     
@@ -83,18 +89,6 @@ extension Notification.Name {
         }
         
         self.dimContents = false
-    }
-    
-    fileprivate func resignKeyboardIfNeeded() {
-        if self.dimContents {
-            self.resignKeyboard()
-        }
-    }
-    
-    fileprivate func resignKeyboard() {
-        delay(1) {
-            UIApplication.shared.keyWindow?.endEditing(true)
-        }
     }
     
     fileprivate func showUnlockIfNeeded() {
@@ -158,7 +152,6 @@ extension Notification.Name {
 extension AppLockViewController {
     @objc func applicationWillResignActive() {
         if AppLock.isActive {
-            self.resignKeyboard()
             self.dimContents = true
         }
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

When there's no passcode set and app lock is required the keyboard would be shown on top of the app lock screen.

### Causes

The below the app lock the login screen would make the e-mail field first responder and trigger the keyboard to be shown. If the passcode was set the authentication window would dismiss it again.

### Solutions

Make the app lock window the key window when it's displayed on top of the app, this will prevent the login screen from triggering the keyboard to be shown.