### PR TITLE
Fix broken tests

### DIFF
--- a/Wire-iOS Tests/AppLockTests.swift
+++ b/Wire-iOS Tests/AppLockTests.swift
@@ -24,6 +24,13 @@ final class AppLockTests: XCTestCase {
 
     let decoder = JSONDecoder()
     
+    override func tearDown() {
+        super.tearDown()
+        
+        AppLock.isActive = false
+        AppDelegate.shared().window.makeKey()
+    }
+    
     func testThatForcedAppLockDoesntAffectSettings() {
 
         //given


### PR DESCRIPTION
## What's new in this PR?

### Issues

https://github.com/wireapp/wire-ios/pull/3572 introduced some failing tests

### Causes

After https://github.com/wireapp/wire-ios/pull/3572 the key window gets changed in the `AppLockTests` which causes some other snapshots to fail due to minor pixel changes.

### Solutions

Restore the key window in the `AppLockTests` tearDown method.