### PR TITLE
Allow config config_folder and hockey_app_id in fastfile 

### DIFF
--- a/Wire-iOS/Resources/Configuration/Version.xcconfig
+++ b/Wire-iOS/Resources/Configuration/Version.xcconfig
@@ -16,4 +16,4 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-WIRE_SHORT_VERSION = 3.41
+WIRE_SHORT_VERSION = 3.42

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -11,10 +11,15 @@ platform :ios do
         if build_type.nil? 
             sh "cd .. && ./setup.sh"
         else
+            config_folder = options[:config_folder]
+            if config_folder.nil? 
+                config_folder = "CI\ configuration"
+            end
+
             build = Build.new(options: options)
             # We need to update the AVS version before running setup script
             build.update_avs_version()
-            sh "cd .. && ./setup.sh --override_with wire-ios-build-assets/CI\ configuration/#{build_type}"
+            sh "cd .. && ./setup.sh --override_with wire-ios-build-assets/#{config_folder}/#{build_type}"
             # Adding extra information to the icon must be done after we check them out in setup script
             build.process_icon()
         end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -136,9 +136,15 @@ platform :ios do
                 pretty: "* [%an] %s",
             )
         end
+
+        hockey_app_id = options[:hockey_app_id]
+        if hockey_app_id.nil? 
+            hockey_app_id = build.hockey_app_id
+        end
+        
         hockey(
           api_token: ENV["HOCKEY_APP_TOKEN"],
-          public_identifier: build.hockey_app_id,
+          public_identifier: hockey_app_id,
           ipa: "#{build.artifact_path(with_filename: true)}.ipa",
           notes: changelog,
           notify: "0"


### PR DESCRIPTION
## What's new in this PR?

Reopen of https://github.com/wireapp/wire-ios/pull/3577.

To allow submitting a build to Hockey app with custom configuration sets and send it under different hockey_app_id. New options are added to `fastfile`.

- add `config_folder` option to `prepare` lane
- add `hockey_app_id` option to `upload_hockey` lane

If the options are not provided, the default value will be applied.