### PR TITLE
Fix user getting stuck when logging out from "add email & password"-screen

### DIFF
--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -217,7 +217,9 @@ final class AppRootViewController: UIViewController {
             AccessoryTextField.appearance(whenContainedInInstancesOf: [AuthenticationStepController.self]).tintColor = UIColor.Team.activeButton
 
             // Only execute handle events if there is no current flow
-            guard authenticationCoordinator == nil || error?.userSessionErrorCode == .addAccountRequested else {
+            guard authenticationCoordinator == nil ||
+                  error?.userSessionErrorCode == .addAccountRequested ||
+                  error?.userSessionErrorCode == .accountDeleted else {
                 break
             }
 

--- a/Wire-iOS/Sources/UserInterface/Sketchpad/CanvasViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Sketchpad/CanvasViewController.swift
@@ -29,7 +29,8 @@ import Cartography
     case emoji
 }
 
-@objcMembers class CanvasViewController: UIViewController, UINavigationControllerDelegate {
+@objcMembers
+final class CanvasViewController: UIViewController, UINavigationControllerDelegate {
     
     weak var delegate : CanvasViewControllerDelegate?
     var canvas = Canvas()
@@ -375,14 +376,18 @@ extension CanvasViewController : UIImagePickerControllerDelegate {
     
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
 
-        UIImagePickerController.image(fromMediaInfo: info) { image in
-            if let image = image, let cgImage = image.cgImage {
-                self.canvas.referenceImage = UIImage(cgImage: cgImage, scale: 2, orientation: image.imageOrientation)
-                self.canvas.mode = .draw
-                self.updateButtonSelection()
-            }
+        defer {
             picker.dismiss(animated: true, completion: nil)
         }
+
+        guard let image = info[.editedImage] as? UIImage ?? info[.originalImage] as? UIImage else {
+
+            return
+        }
+
+        canvas.referenceImage = image
+        canvas.mode = .draw
+        updateButtonSelection()
     }
     
     func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {


### PR DESCRIPTION
## What's new in this PR?

### Issues

If you tried to logout from the "add emails & password" screen you would get stuck on a spinner.

### Causes

When you delete an account we now correctly signal this with the error `.accountDeleted` instead of `.addAccountRequested` which we didn't handle correctly if the account was deleted during the login flow.

### Solutions

Restart the unauthenticated flow on `.accountDeleted` 