### PR TITLE
Fix share extension when running against a non standard backend

### DIFF
--- a/WireCommonComponents/BackendEnvironment+Shared.swift
+++ b/WireCommonComponents/BackendEnvironment+Shared.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import WireTransport
+import WireUtilities
 
 extension BackendEnvironment {
     
@@ -25,11 +26,11 @@ extension BackendEnvironment {
     
     public static var shared: BackendEnvironment = {
         let bundle = Bundle.backendBundle
-        guard let environment = BackendEnvironment(userDefaults: .standard, configurationBundle: .backendBundle) else { fatalError("Malformed backend configuration data") }
+        guard let environment = BackendEnvironment(userDefaults: .shared(), configurationBundle: .backendBundle) else { fatalError("Malformed backend configuration data") }
         return environment
         }() {
         didSet {
-            shared.save(in: .standard)
+            shared.save(in: .shared())
             NotificationCenter.default.post(name: backendSwitchNotification, object: shared)
         }
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

The app would get logged out if you tried to use the share extension when running against any backend other than production.

### Causes

The backend environment was being read from the user defaults. The share extension however has its own user defaults since it is being run as a separate process. That means when we launch the share extension it will attempt to read the backend environment and fail since it doesn't exists and then fall back to the production environment.

### Solutions

Read the backend environment form the shared user defaults which can be accessed by all applications within the same app group. This will work since in `setupBackendEnvironment`, which is executed on every launch, we copy any environment found in there standard user defaults into the shared user defaults. 