### PR TITLE
Fix: download-assets.sh failed to run

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -13,7 +13,7 @@ platform :ios do
         else
             override_folder = options[:override_folder]
             if override_folder.nil? 
-                override_folder = "CI\ configuration"
+                override_folder = "CI configuration"
             end
 
 
@@ -31,7 +31,7 @@ platform :ios do
             build = Build.new(options: options)
             # We need to update the AVS version before running setup script
             build.update_avs_version()
-            sh "cd .. && ./setup.sh -c #{config_repo} -b #{config_branch} -o wire-ios-build-assets/#{override_folder}/#{build_type}"
+            sh "cd .. && ./setup.sh -c #{config_repo} -b #{config_branch} -o \'wire-ios-build-assets/#{override_folder}/#{build_type}\'"
             # Adding extra information to the icon must be done after we check them out in setup script
             build.process_icon()
         end

--- a/setup.sh
+++ b/setup.sh
@@ -50,7 +50,7 @@ echo "ℹ️  Downloading AVS library..."
 echo ""
 
 echo "ℹ️  Downloading additional assets..."
-./Scripts/download-assets.sh $@
+./Scripts/download-assets.sh "$@"
 echo ""
 
 echo "ℹ️  Doing additional postprocessing..."


### PR DESCRIPTION
## What's new in this PR?

### Issues

`download-assets.sh` failed to run

### Causes

When the path contains a space and pass to `download-assets.sh` via `setup.sh`, the unquoted path is treated as 2 arguments.

### Solutions

Quote the path and pass the arguments with double-quote to keep the single quote.