### PR TITLE
Fix: Crash in PLPhotoLibrary

### DIFF
--- a/Wire-iOS Tests/CameraKeyboardViewControllerTests.swift
+++ b/Wire-iOS Tests/CameraKeyboardViewControllerTests.swift
@@ -21,7 +21,7 @@ import AVFoundation
 import Photos
 @testable import Wire
 
-class CameraKeyboardViewControllerDelegateMock: CameraKeyboardViewControllerDelegate {
+final class CameraKeyboardViewControllerDelegateMock: CameraKeyboardViewControllerDelegate {
     
     var cameraKeyboardWantsToOpenCameraRollHitCount: UInt = 0
     @objc func cameraKeyboardViewControllerWantsToOpenCameraRoll(_ controller: CameraKeyboardViewController) {
@@ -59,6 +59,7 @@ private final class MockAssetLibrary: AssetLibrary {
 }
 
 private final class MockImageManager: ImageManagerProtocol {
+
     func cancelImageRequest(_ requestID: PHImageRequestID) {
         // no op
     }
@@ -74,6 +75,8 @@ private final class MockImageManager: ImageManagerProtocol {
     func requestExportSession(forVideo asset: PHAsset, options: PHVideoRequestOptions?, exportPreset: String, resultHandler: @escaping (AVAssetExportSession?, [AnyHashable : Any]?) -> Void) -> PHImageRequestID {
         return 0
     }
+
+    static var defaultInstance: ImageManagerProtocol = MockImageManager()
 }
 
 fileprivate final class CallingMockCameraKeyboardViewController: CameraKeyboardViewController {
@@ -135,7 +138,7 @@ final class CameraKeyboardViewControllerTests: CoreDataSnapshotTestCase {
     private func setupSut(permissions: PhotoPermissionsController) {
         sut = CameraKeyboardViewController(splitLayoutObservable: splitView,
                                            assetLibrary: mockAssetLibrary,
-                                           imageManager: mockImageManager,
+                                           imageManagerType: MockImageManager.self,
                                            permissions: permissions)
     }
 
@@ -143,7 +146,7 @@ final class CameraKeyboardViewControllerTests: CoreDataSnapshotTestCase {
         let permissions = MockPhotoPermissionsController(camera: true, library: true)
         sut = CallingMockCameraKeyboardViewController(splitLayoutObservable: splitView,
                                                       assetLibrary: mockAssetLibrary,
-                                                      imageManager: mockImageManager,
+                                                      imageManagerType: MockImageManager.self,
                                                       permissions: permissions)
 
         verify(view: prepareForSnapshot())

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ImageManagerProtocol.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ImageManagerProtocol.swift
@@ -29,6 +29,12 @@ protocol ImageManagerProtocol {
 
     @discardableResult
     func requestExportSession(forVideo asset: PHAsset, options: PHVideoRequestOptions?, exportPreset: String, resultHandler: @escaping (AVAssetExportSession?, [AnyHashable : Any]?) -> Void) -> PHImageRequestID
+
+    static var `default`: ImageManagerProtocol { get }
 }
 
-extension PHImageManager: ImageManagerProtocol {}
+extension PHImageManager: ImageManagerProtocol {
+    static var `default`: ImageManagerProtocol {
+        return PHImageManager.default()
+    }
+}

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ImageManagerProtocol.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ImageManagerProtocol.swift
@@ -30,11 +30,11 @@ protocol ImageManagerProtocol {
     @discardableResult
     func requestExportSession(forVideo asset: PHAsset, options: PHVideoRequestOptions?, exportPreset: String, resultHandler: @escaping (AVAssetExportSession?, [AnyHashable : Any]?) -> Void) -> PHImageRequestID
 
-    static var `default`: ImageManagerProtocol { get }
+    static var defaultInstance: ImageManagerProtocol { get }
 }
 
 extension PHImageManager: ImageManagerProtocol {
-    static var `default`: ImageManagerProtocol {
+    static var defaultInstance: ImageManagerProtocol {
         return PHImageManager.default()
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
@@ -61,7 +61,7 @@ open class CameraKeyboardViewController: UIViewController {
     }
     
     let assetLibrary: AssetLibrary
-    let imageManager: ImageManagerProtocol
+    let imageManagerType: PHImageManager.Type//ImageManagerProtocol
     internal var collectionView: UICollectionView!
     internal let goBackButton = IconButton()
     internal let cameraRollButton = IconButton()
@@ -75,11 +75,12 @@ open class CameraKeyboardViewController: UIViewController {
     
     init(splitLayoutObservable: SplitLayoutObservable,
          assetLibrary: AssetLibrary = AssetLibrary(),
-         imageManager: ImageManagerProtocol = PHImageManager.default(),
+//         imageManager: ImageManagerProtocol = PHImageManager.default(), ///TODO: inject class instead
+        imageManagerType: PHImageManager.Type,
          permissions: PhotoPermissionsController = PhotoPermissionsControllerStrategy()) {
         self.splitLayoutObservable = splitLayoutObservable
         self.assetLibrary = assetLibrary
-        self.imageManager = imageManager
+        self.imageManagerType = imageManagerType
         self.permissions = permissions
         super.init(nibName: nil, bundle: nil)
         self.assetLibrary.delegate = self
@@ -241,7 +242,7 @@ open class CameraKeyboardViewController: UIViewController {
             options.resizeMode = .exact
             options.isSynchronous = false
 
-            imageManager.requestImage(for: asset, targetSize: CGSize(width:limit, height:limit), contentMode: .aspectFit, options: options, resultHandler: { image, info in
+            imageManagerType.default().requestImage(for: asset, targetSize: CGSize(width:limit, height:limit), contentMode: .aspectFit, options: options, resultHandler: { image, info in
                 if let image = image {
                     let data = image.jpegData(compressionQuality: 0.9)
                     completeBlock(data, info?["PHImageFileUTIKey"] as? String)
@@ -251,7 +252,7 @@ open class CameraKeyboardViewController: UIViewController {
                         self.showLoadingView = true
                     })
 
-                    self.imageManager.requestImage(for: asset, targetSize: CGSize(width:limit, height:limit), contentMode: .aspectFit, options: options, resultHandler: { image, info in
+                    self.imageManagerType.default().requestImage(for: asset, targetSize: CGSize(width:limit, height:limit), contentMode: .aspectFit, options: options, resultHandler: { image, info in
                         DispatchQueue.main.async(execute: {
                             self.showLoadingView = false
                         })
@@ -272,7 +273,7 @@ open class CameraKeyboardViewController: UIViewController {
             options.isNetworkAccessAllowed = false
             options.isSynchronous = false
 
-            imageManager.requestImageData(for: asset, options: options, resultHandler: { data, uti, orientation, info in
+            imageManagerType.default().requestImageData(for: asset, options: options, resultHandler: { data, uti, orientation, info in
 
                 guard let data = data else {
                     options.isNetworkAccessAllowed = true
@@ -280,7 +281,7 @@ open class CameraKeyboardViewController: UIViewController {
                         self.showLoadingView = true
                     })
 
-                    self.imageManager.requestImageData(for: asset, options: options, resultHandler: { data, uti, orientation, info in
+                    self.imageManagerType.default().requestImageData(for: asset, options: options, resultHandler: { data, uti, orientation, info in
                         DispatchQueue.main.async(execute: {
                             self.showLoadingView = false
                         })
@@ -308,7 +309,7 @@ open class CameraKeyboardViewController: UIViewController {
 
         self.showLoadingView = true
 
-        imageManager.requestExportSession(forVideo: asset, options: options, exportPreset: AVAssetExportPresetMediumQuality) { exportSession, info in
+        imageManagerType.default().requestExportSession(forVideo: asset, options: options, exportPreset: AVAssetExportPresetMediumQuality) { exportSession, info in
             
             DispatchQueue.main.async(execute: {
             
@@ -418,7 +419,7 @@ extension CameraKeyboardViewController: UICollectionViewDelegateFlowLayout, UICo
             
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: AssetCell.reuseIdentifier, for: indexPath) as! AssetCell
 
-            cell.manager = imageManager
+            cell.manager = imageManagerType.default()
 
             if let asset = try? assetLibrary.asset(atIndex: UInt((indexPath as NSIndexPath).row)) {
                 cell.asset = asset

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
@@ -36,7 +36,7 @@ public protocol CameraKeyboardViewControllerDelegate: class {
 }
 
 
-open class CameraKeyboardViewController: UIViewController {
+open final class CameraKeyboardViewController: UIViewController {
     
     fileprivate var permissions: PhotoPermissionsController!
     fileprivate var lastLayoutSize = CGSize.zero
@@ -75,8 +75,7 @@ open class CameraKeyboardViewController: UIViewController {
     
     init(splitLayoutObservable: SplitLayoutObservable,
          assetLibrary: AssetLibrary = AssetLibrary(),
-//         imageManager: ImageManagerProtocol = PHImageManager.default(), ///TODO: inject class instead
-        imageManagerType: ImageManagerProtocol.Type,
+         imageManagerType: ImageManagerProtocol.Type = PHImageManager.self,
          permissions: PhotoPermissionsController = PhotoPermissionsControllerStrategy()) {
         self.splitLayoutObservable = splitLayoutObservable
         self.assetLibrary = assetLibrary
@@ -242,7 +241,7 @@ open class CameraKeyboardViewController: UIViewController {
             options.resizeMode = .exact
             options.isSynchronous = false
 
-            imageManagerType.default.requestImage(for: asset, targetSize: CGSize(width:limit, height:limit), contentMode: .aspectFit, options: options, resultHandler: { image, info in
+            imageManagerType.defaultInstance.requestImage(for: asset, targetSize: CGSize(width:limit, height:limit), contentMode: .aspectFit, options: options, resultHandler: { image, info in
                 if let image = image {
                     let data = image.jpegData(compressionQuality: 0.9)
                     completeBlock(data, info?["PHImageFileUTIKey"] as? String)
@@ -252,7 +251,7 @@ open class CameraKeyboardViewController: UIViewController {
                         self.showLoadingView = true
                     })
 
-                    self.imageManagerType.default.requestImage(for: asset, targetSize: CGSize(width:limit, height:limit), contentMode: .aspectFit, options: options, resultHandler: { image, info in
+                    self.imageManagerType.defaultInstance.requestImage(for: asset, targetSize: CGSize(width:limit, height:limit), contentMode: .aspectFit, options: options, resultHandler: { image, info in
                         DispatchQueue.main.async(execute: {
                             self.showLoadingView = false
                         })
@@ -273,7 +272,7 @@ open class CameraKeyboardViewController: UIViewController {
             options.isNetworkAccessAllowed = false
             options.isSynchronous = false
 
-            imageManagerType.default.requestImageData(for: asset, options: options, resultHandler: { data, uti, orientation, info in
+            imageManagerType.defaultInstance.requestImageData(for: asset, options: options, resultHandler: { data, uti, orientation, info in
 
                 guard let data = data else {
                     options.isNetworkAccessAllowed = true
@@ -281,7 +280,7 @@ open class CameraKeyboardViewController: UIViewController {
                         self.showLoadingView = true
                     })
 
-                    self.imageManagerType.default.requestImageData(for: asset, options: options, resultHandler: { data, uti, orientation, info in
+                    self.imageManagerType.defaultInstance.requestImageData(for: asset, options: options, resultHandler: { data, uti, orientation, info in
                         DispatchQueue.main.async(execute: {
                             self.showLoadingView = false
                         })
@@ -309,7 +308,7 @@ open class CameraKeyboardViewController: UIViewController {
 
         self.showLoadingView = true
 
-        imageManagerType.default.requestExportSession(forVideo: asset, options: options, exportPreset: AVAssetExportPresetMediumQuality) { exportSession, info in
+        imageManagerType.defaultInstance.requestExportSession(forVideo: asset, options: options, exportPreset: AVAssetExportPresetMediumQuality) { exportSession, info in
             
             DispatchQueue.main.async(execute: {
             
@@ -419,7 +418,7 @@ extension CameraKeyboardViewController: UICollectionViewDelegateFlowLayout, UICo
             
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: AssetCell.reuseIdentifier, for: indexPath) as! AssetCell
 
-            cell.manager = imageManagerType.default
+            cell.manager = imageManagerType.defaultInstance
 
             if let asset = try? assetLibrary.asset(atIndex: UInt((indexPath as NSIndexPath).row)) {
                 cell.asset = asset

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
@@ -36,7 +36,7 @@ public protocol CameraKeyboardViewControllerDelegate: class {
 }
 
 
-open final class CameraKeyboardViewController: UIViewController {
+open class CameraKeyboardViewController: UIViewController {
     
     fileprivate var permissions: PhotoPermissionsController!
     fileprivate var lastLayoutSize = CGSize.zero

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
@@ -61,7 +61,7 @@ open class CameraKeyboardViewController: UIViewController {
     }
     
     let assetLibrary: AssetLibrary
-    let imageManagerType: PHImageManager.Type//ImageManagerProtocol
+    let imageManagerType: ImageManagerProtocol.Type
     internal var collectionView: UICollectionView!
     internal let goBackButton = IconButton()
     internal let cameraRollButton = IconButton()
@@ -76,7 +76,7 @@ open class CameraKeyboardViewController: UIViewController {
     init(splitLayoutObservable: SplitLayoutObservable,
          assetLibrary: AssetLibrary = AssetLibrary(),
 //         imageManager: ImageManagerProtocol = PHImageManager.default(), ///TODO: inject class instead
-        imageManagerType: PHImageManager.Type,
+        imageManagerType: ImageManagerProtocol.Type,
          permissions: PhotoPermissionsController = PhotoPermissionsControllerStrategy()) {
         self.splitLayoutObservable = splitLayoutObservable
         self.assetLibrary = assetLibrary
@@ -242,7 +242,7 @@ open class CameraKeyboardViewController: UIViewController {
             options.resizeMode = .exact
             options.isSynchronous = false
 
-            imageManagerType.default().requestImage(for: asset, targetSize: CGSize(width:limit, height:limit), contentMode: .aspectFit, options: options, resultHandler: { image, info in
+            imageManagerType.default.requestImage(for: asset, targetSize: CGSize(width:limit, height:limit), contentMode: .aspectFit, options: options, resultHandler: { image, info in
                 if let image = image {
                     let data = image.jpegData(compressionQuality: 0.9)
                     completeBlock(data, info?["PHImageFileUTIKey"] as? String)
@@ -252,7 +252,7 @@ open class CameraKeyboardViewController: UIViewController {
                         self.showLoadingView = true
                     })
 
-                    self.imageManagerType.default().requestImage(for: asset, targetSize: CGSize(width:limit, height:limit), contentMode: .aspectFit, options: options, resultHandler: { image, info in
+                    self.imageManagerType.default.requestImage(for: asset, targetSize: CGSize(width:limit, height:limit), contentMode: .aspectFit, options: options, resultHandler: { image, info in
                         DispatchQueue.main.async(execute: {
                             self.showLoadingView = false
                         })
@@ -273,7 +273,7 @@ open class CameraKeyboardViewController: UIViewController {
             options.isNetworkAccessAllowed = false
             options.isSynchronous = false
 
-            imageManagerType.default().requestImageData(for: asset, options: options, resultHandler: { data, uti, orientation, info in
+            imageManagerType.default.requestImageData(for: asset, options: options, resultHandler: { data, uti, orientation, info in
 
                 guard let data = data else {
                     options.isNetworkAccessAllowed = true
@@ -281,7 +281,7 @@ open class CameraKeyboardViewController: UIViewController {
                         self.showLoadingView = true
                     })
 
-                    self.imageManagerType.default().requestImageData(for: asset, options: options, resultHandler: { data, uti, orientation, info in
+                    self.imageManagerType.default.requestImageData(for: asset, options: options, resultHandler: { data, uti, orientation, info in
                         DispatchQueue.main.async(execute: {
                             self.showLoadingView = false
                         })
@@ -309,7 +309,7 @@ open class CameraKeyboardViewController: UIViewController {
 
         self.showLoadingView = true
 
-        imageManagerType.default().requestExportSession(forVideo: asset, options: options, exportPreset: AVAssetExportPresetMediumQuality) { exportSession, info in
+        imageManagerType.default.requestExportSession(forVideo: asset, options: options, exportPreset: AVAssetExportPresetMediumQuality) { exportSession, info in
             
             DispatchQueue.main.async(execute: {
             
@@ -419,7 +419,7 @@ extension CameraKeyboardViewController: UICollectionViewDelegateFlowLayout, UICo
             
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: AssetCell.reuseIdentifier, for: indexPath) as! AssetCell
 
-            cell.manager = imageManagerType.default()
+            cell.manager = imageManagerType.default
 
             if let asset = try? assetLibrary.asset(atIndex: UInt((indexPath as NSIndexPath).row)) {
                 cell.asset = asset

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
@@ -54,7 +54,7 @@ extension ConversationInputBarViewController: CameraKeyboardViewControllerDelega
     
     @objc public func createCameraKeyboardViewController() {
         guard let splitViewController = ZClientViewController.shared()?.splitViewController else { return }
-        let cameraKeyboardViewController = CameraKeyboardViewController(splitLayoutObservable: splitViewController)
+        let cameraKeyboardViewController = CameraKeyboardViewController(splitLayoutObservable: splitViewController, imageManagerType: PHImageManager.self)
         cameraKeyboardViewController.delegate = self
         
         self.cameraKeyboardViewController = cameraKeyboardViewController


### PR DESCRIPTION
## What's new in this PR?

### Issues

Prevent passing an instance of `PHImageManager` (`PHImageManager.default()`) which may be cleaned after passed to `CameraKeyboardViewController`. Pass the type of `PHImageManager` instead and call its `defaultInstance` property when needed.