### PR TITLE
Fix: iOS13  - can not share video via input bars's file button or camera keyboard's image picker

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
@@ -62,9 +62,10 @@ open class CameraKeyboardViewController: UIViewController {
     
     let assetLibrary: AssetLibrary
     let imageManagerType: ImageManagerProtocol.Type
-    internal var collectionView: UICollectionView!
-    internal let goBackButton = IconButton()
-    internal let cameraRollButton = IconButton()
+
+    var collectionView: UICollectionView!
+    let goBackButton = IconButton()
+    let cameraRollButton = IconButton()
     
     public let splitLayoutObservable: SplitLayoutObservable
     open weak var delegate: CameraKeyboardViewControllerDelegate?

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Files.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Files.m
@@ -248,44 +248,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
     
     NSString* mediaType = info[UIImagePickerControllerMediaType];
     if ([mediaType isEqual:(id)kUTTypeMovie]) {
-        NSURL* videoURL = info[UIImagePickerControllerMediaURL];
-        
-        if (videoURL == nil) {
-            [self.parentViewController dismissViewControllerAnimated:YES completion:nil];
-            ZMLogError(@"Video not provided form %@: info %@", picker, info);
-            return;
-        }
-        
-        NSURL *videoTempURL = [NSURL fileURLWithPath:[[NSTemporaryDirectory() stringByAppendingPathComponent:[NSString filenameForSelfUser]] stringByAppendingPathExtension:videoURL.pathExtension]];
-        
-        if ([[NSFileManager defaultManager] fileExistsAtPath:videoTempURL.path]) {
-            NSError *deleteError = nil;
-            [[NSFileManager defaultManager] removeItemAtURL:videoTempURL error:&deleteError];
-            if (deleteError != nil) {
-                ZMLogError(@"Cannot delete old tmp video at %@: %@", videoTempURL, deleteError);
-            }
-        }
-        
-        NSError *moveError = nil;
-        [[NSFileManager defaultManager] moveItemAtURL:videoURL toURL:videoTempURL error:&moveError];
-        if (moveError != nil) {
-            ZMLogError(@"Cannot move video from %@ to %@: %@", videoURL, videoTempURL, moveError);
-        }
-        
-        if (picker.sourceType == UIImagePickerControllerSourceTypeCamera && UIVideoAtPathIsCompatibleWithSavedPhotosAlbum(videoTempURL.path)) {
-            UISaveVideoAtPathToSavedPhotosAlbum(videoTempURL.path, self, @selector(video:didFinishSavingWithError:contextInfo:), NULL);
-        }
-        
-        picker.showLoadingView = YES;
-        [AVAsset wr_convertVideoAtURL:videoTempURL toUploadFormatWithCompletion:^(NSURL *resultURL, AVAsset *asset, NSError *error) {
-            if (error == nil && resultURL != nil) {
-                [self uploadFileAtURL:resultURL];
-            }
-            
-            [self.parentViewController dismissViewControllerAnimated:YES completion:^() {
-                picker.showLoadingView = NO;
-            }];
-        }];
+        [self processVideoWithInfo: info picker:picker];
     }
     else if ([mediaType isEqual:(id)kUTTypeImage]) {
         UIImage *image = info[UIImagePickerControllerEditedImage];

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+ImagePicker.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+ImagePicker.swift
@@ -90,7 +90,8 @@ extension ConversationInputBarViewController {
             return
         }
 
-        let videoTempURL = URL(fileURLWithPath: URL(fileURLWithPath: URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(String.filenameForSelfUser()).absoluteString).appendingPathExtension(videoURL.pathExtension).absoluteString)
+        let videoTempURL = URL(fileURLWithPath: NSTemporaryDirectory(),
+            isDirectory: true).appendingPathComponent(String.filenameForSelfUser()).appendingPathExtension(videoURL.pathExtension)
 
         if FileManager.default.fileExists(atPath: videoTempURL.path) {
             do {
@@ -101,10 +102,11 @@ extension ConversationInputBarViewController {
         }
 
         do {
-            try FileManager.default.moveItem(at: videoURL, to: videoTempURL)
-        } catch let moveError {
-            zmLog.error("Cannot move video from \(videoURL) to \(videoTempURL): \(moveError)")
-        } ///TODO: error here?
+            try FileManager.default.copyItem(at: videoURL, to: videoTempURL)
+        } catch let error {
+            zmLog.error("Cannot copy video from \(videoURL) to \(videoTempURL): \(error)")
+            return
+        }
 
         if picker.sourceType == UIImagePickerController.SourceType.camera && UIVideoAtPathIsCompatibleWithSavedPhotosAlbum(videoTempURL.path) {
             UISaveVideoAtPathToSavedPhotosAlbum(videoTempURL.path, self, #selector(video(_:didFinishSavingWithError:contextInfo:)), nil)

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+ImagePicker.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+ImagePicker.swift
@@ -18,6 +18,8 @@
 
 import Foundation
 
+private let zmLog = ZMSLog(tag: "ConversationInputBarViewController - Image Picker")
+
 extension ConversationInputBarViewController {
 
     @objc(presentImagePickerWithSourceType:mediaTypes:allowsEditing:pointToView:)
@@ -51,7 +53,7 @@ extension ConversationInputBarViewController {
             pickerController.videoMaximumDuration = ZMUserSession.shared()!.maxVideoLength()
 
             if let popover = pickerController.popoverPresentationController,
-               let imageView = pointToView {
+                let imageView = pointToView {
                 popover.config(from: rootViewController,
                                pointToView: imageView,
                                sourceView: rootViewController.view)
@@ -78,4 +80,46 @@ extension ConversationInputBarViewController {
             presentController()
         }
     }
+
+    @objc
+    func processVideo(info: [UIImagePickerController.InfoKey: Any],
+                      picker: UIImagePickerController) {
+        guard let videoURL = info[UIImagePickerController.InfoKey.mediaURL] as? URL else {
+            parent?.dismiss(animated: true)
+            zmLog.error("Video not provided form \(picker): info \(info)")
+            return
+        }
+
+        let videoTempURL = URL(fileURLWithPath: URL(fileURLWithPath: URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(String.filenameForSelfUser()).absoluteString).appendingPathExtension(videoURL.pathExtension).absoluteString)
+
+        if FileManager.default.fileExists(atPath: videoTempURL.path) {
+            do {
+                try FileManager.default.removeItem(at: videoTempURL)
+            } catch let deleteError {
+                zmLog.error("Cannot delete old tmp video at \(videoTempURL): \(deleteError)")
+            }
+        }
+
+        do {
+            try FileManager.default.moveItem(at: videoURL, to: videoTempURL)
+        } catch let moveError {
+            zmLog.error("Cannot move video from \(videoURL) to \(videoTempURL): \(moveError)")
+        } ///TODO: error here?
+
+        if picker.sourceType == UIImagePickerController.SourceType.camera && UIVideoAtPathIsCompatibleWithSavedPhotosAlbum(videoTempURL.path) {
+            UISaveVideoAtPathToSavedPhotosAlbum(videoTempURL.path, self, #selector(video(_:didFinishSavingWithError:contextInfo:)), nil)
+        }
+
+        picker.showLoadingView = true
+        AVAsset.wr_convertVideo(at: videoTempURL, toUploadFormatWithCompletion: { resultURL, asset, error in
+            if error == nil && resultURL != nil {
+                self.uploadFile(at: resultURL)
+            }
+
+            self.parent?.dismiss(animated: true) {
+                picker.showLoadingView = false
+            }
+        })
+    }
+
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

on iOS13, the user can not share video via input bars's file button or camera keyboard's image picker

### Causes

Can not move a file from a URL given by `UIImagePickerController`'s info
`[[NSFileManager defaultManager] moveItemAtURL:videoURL toURL:videoTempURL error:&moveError];`

### Solutions

Copy the file instead for moving