### PR TITLE
Fix: Crash in FirstReponderView

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController+ViewLifeCycle.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController+ViewLifeCycle.swift
@@ -33,4 +33,8 @@ extension FullscreenImageViewController {
         return ColorScheme.default.statusBarStyle
     }
 
+    override var canBecomeFirstResponder: Bool {
+        return true
+    }
+
 }

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController+ViewLifeCycle.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController+ViewLifeCycle.swift
@@ -33,7 +33,7 @@ extension FullscreenImageViewController {
         return ColorScheme.default.statusBarStyle
     }
 
-    override var canBecomeFirstResponder: Bool {
+    override open var canBecomeFirstResponder: Bool {
         return true
     }
 

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.m
@@ -322,7 +322,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
          */
         [self.view.window makeKeyWindow];
         [self.view.window becomeFirstResponder];
-        [self.view becomeFirstResponder];
+        [self becomeFirstResponder];
         
         UIMenuController *menuController = UIMenuController.sharedMenuController;
         menuController.menuItems = ConversationMessageActionController.allMessageActions;
@@ -332,7 +332,6 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
         [self setSelectedByMenu:YES animated:YES];
     }
 }
-
 
 #pragma mark - Actions
 

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.m
@@ -45,25 +45,6 @@
 
 static NSString* ZMLogTag ZM_UNUSED = @"UI";
 
-@interface FirstReponderView : UIView
-@end
-
-
-@implementation FirstReponderView
-
-- (BOOL)canBecomeFirstResponder
-{
-    return YES;
-}
-
-- (BOOL)becomeFirstResponder
-{
-    BOOL result = [super becomeFirstResponder];
-    return result;
-}
-
-@end
-
 @interface FullscreenImageViewController (MessageObserver) <ZMMessageObserver>
 
 @end
@@ -115,10 +96,6 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
     }
 
     return self;
-}
-
-- (void)loadView {
-    self.view = [[FirstReponderView alloc] init];
 }
 
 - (void)dismissWithCompletion:(dispatch_block_t)completion


### PR DESCRIPTION
## What's new in this PR?

Remove unnecessary `FirstReponderView` which replaced the view of `FullscreenImageViewController`