### PR TITLE
Fix: [iPad] - app crash when share a guest link 

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation Options/CellConfiguration+ConversationOptions.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/CellConfiguration+ConversationOptions.swift
@@ -31,7 +31,7 @@ extension CellConfiguration {
         )
     }
     
-    static func createLinkButton(action: @escaping () -> Void) -> CellConfiguration {
+    static func createLinkButton(action: @escaping Action) -> CellConfiguration {
         return .leadingButton(
             title: "guest_room.link.button.title".localized,
             identifier: "",
@@ -39,7 +39,7 @@ extension CellConfiguration {
         )
     }
     
-    static func copyLink(action: @escaping () -> Void) -> CellConfiguration {
+    static func copyLink(action: @escaping Action) -> CellConfiguration {
         return .iconAction(
             title: "guest_room.actions.copy_link".localized,
             icon: .copy,
@@ -52,10 +52,10 @@ extension CellConfiguration {
             title: "guest_room.actions.copied_link".localized,
             icon: .checkmark,
             color: nil,
-            action: {}
+            action: {_ in }
         )
     
-    static func shareLink(action: @escaping () -> Void) -> CellConfiguration {
+    static func shareLink(action: @escaping Action) -> CellConfiguration {
         return .iconAction(
             title: "guest_room.actions.share_link".localized,
             icon: .export,
@@ -64,7 +64,7 @@ extension CellConfiguration {
         )
     }
     
-    static func revokeLink(action: @escaping () -> Void) -> CellConfiguration {
+    static func revokeLink(action: @escaping Action) -> CellConfiguration {
         return .iconAction(
             title: "guest_room.actions.revoke_link".localized,
             icon: .cross,

--- a/Wire-iOS/Sources/UserInterface/Conversation Options/CellConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/CellConfiguration.swift
@@ -23,13 +23,13 @@ protocol CellConfigurationConfigurable: Reusable {
 }
 
 enum CellConfiguration {
-    typealias Action = () -> Void
+    typealias Action = (UIView?) -> Void
     case toggle(title: String, subtitle: String, identifier: String, get: () -> Bool, set: (Bool) -> Void)
     case linkHeader
-    case leadingButton(title: String, identifier: String, action: () -> Void)
+    case leadingButton(title: String, identifier: String, action: Action)
     case loading
     case text(String)
-    case iconAction(title: String, icon: StyleKitIcon, color: UIColor?, action: () -> Void)
+    case iconAction(title: String, icon: StyleKitIcon, color: UIColor?, action: Action)
     
     var cellType: CellConfigurationConfigurable.Type {
         switch self {

--- a/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationOptionsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationOptionsViewController.swift
@@ -105,9 +105,20 @@ final class ConversationOptionsViewController: UIViewController, UITableViewDele
         present(UIAlertController.confirmRevokingLink(completion), animated: true)
     }
     
-    func viewModel(_ viewModel: ConversationOptionsViewModel, wantsToShareMessage message: String) {
+    func viewModel(_ viewModel: ConversationOptionsViewModel, wantsToShareMessage message: String, sourceView: UIView? = nil) {
         let activityController = TintCorrectedActivityViewController(activityItems: [message], applicationActivities: nil)
         present(activityController, animated: true)
+
+        ///TODO: UIActivityViewController extension
+
+        if let popover = activityController.popoverPresentationController,
+            let pointToView = sourceView ?? view,
+            let rootViewController = UIApplication.shared.keyWindow?.rootViewController as? PopoverPresenter & UIViewController{
+            popover.config(from: rootViewController,
+                pointToView: pointToView,
+                sourceView: rootViewController.view)
+        }
+
     }
 
     // MARK: – UITableViewDelegate & UITableViewDataSource
@@ -133,7 +144,8 @@ final class ConversationOptionsViewController: UIViewController, UITableViewDele
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-        viewModel.state.rows[indexPath.row].action?()
+        let cell = tableView.cellForRow(at: indexPath)
+        viewModel.state.rows[indexPath.row].action?(cell)
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationOptionsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationOptionsViewController.swift
@@ -79,7 +79,7 @@ final class ConversationOptionsViewController: UIViewController, UITableViewDele
             tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
-        ])
+            ])
     }
 
     // MARK: – ConversationOptionsViewModelDelegate
@@ -109,16 +109,7 @@ final class ConversationOptionsViewController: UIViewController, UITableViewDele
         let activityController = TintCorrectedActivityViewController(activityItems: [message], applicationActivities: nil)
         present(activityController, animated: true)
 
-        ///TODO: UIActivityViewController extension
-
-        if let popover = activityController.popoverPresentationController,
-            let pointToView = sourceView ?? view,
-            let rootViewController = UIApplication.shared.keyWindow?.rootViewController as? PopoverPresenter & UIViewController{
-            popover.config(from: rootViewController,
-                pointToView: pointToView,
-                sourceView: rootViewController.view)
-        }
-
+        activityController.configPopover(pointToView: sourceView ?? view)
     }
 
     // MARK: – UITableViewDelegate & UITableViewDataSource
@@ -148,4 +139,19 @@ final class ConversationOptionsViewController: UIViewController, UITableViewDele
         viewModel.state.rows[indexPath.row].action?(cell)
     }
 
+}
+
+extension UIActivityViewController {
+
+    /// On iPad, UIActivityViewController must be presented in a popover and the popover's source view must be set
+    ///
+    /// - Parameter pointToView: the view which the popover points to
+    func configPopover(pointToView: UIView) {
+        guard let popover = popoverPresentationController,
+            let rootViewController = UIApplication.shared.keyWindow?.rootViewController as? PopoverPresenter & UIViewController else { return }
+
+        popover.config(from: rootViewController,
+                       pointToView: pointToView,
+                       sourceView: rootViewController.view)
+    }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationOptionsViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationOptionsViewModel.swift
@@ -35,7 +35,7 @@ protocol ConversationOptionsViewModelDelegate: class {
     func viewModel(_ viewModel: ConversationOptionsViewModel, didReceiveError error: Error)
     func viewModel(_ viewModel: ConversationOptionsViewModel, confirmRemovingGuests completion: @escaping (Bool) -> Void) -> UIAlertController?
     func viewModel(_ viewModel: ConversationOptionsViewModel, confirmRevokingLink completion: @escaping (Bool) -> Void)
-    func viewModel(_ viewModel: ConversationOptionsViewModel, wantsToShareMessage message: String)
+    func viewModel(_ viewModel: ConversationOptionsViewModel, wantsToShareMessage message: String, sourceView: UIView?)
 }
 
 class ConversationOptionsViewModel {
@@ -110,11 +110,12 @@ class ConversationOptionsViewModel {
                 // Check if we have a link already
                 if let link = link {
                     rows.append(.text(link))
-                    rows.append(copyInProgress ? .copiedLink : .copyLink { [weak self] in self?.copyLink() })
-                    rows.append(.shareLink { [weak self] in self?.shareLink() })
-                    rows.append(.revokeLink { [weak self] in self?.revokeLink() })
+                    rows.append(copyInProgress ? .copiedLink : .copyLink { [weak self] _ in self?.copyLink() })
+                    rows.append(.shareLink { [weak self] view in self?.shareLink(view: view) })
+                    rows.append(.revokeLink { [weak self] _ in self?.revokeLink() })
                 } else {
-                    rows.append(.createLinkButton { [weak self] in self?.createLink() })
+                    rows.append(.createLinkButton { [weak self] _ in 
+                        self?.createLink() })
                 }
             }
         }
@@ -146,12 +147,16 @@ class ConversationOptionsViewModel {
             }
         })
     }
-    
-    private func shareLink() {
+
+
+    /// share a conversation link
+    ///
+    /// - Parameter view: the source view which triggers shareLink action
+    private func shareLink(view: UIView? = nil) {
         guard let link = link else { return }
         GuestLinkEvent.shared.track()
         let message = "guest_room.share.message".localized(args: link)
-        delegate?.viewModel(self, wantsToShareMessage: message)
+        delegate?.viewModel(self, wantsToShareMessage: message, sourceView: view)
     }
     
     private func copyLink() {


### PR DESCRIPTION
## What's new in this PR?

### Issues

App crashes when sharing a conversation link.

### Causes

`In its current trait environment, the modalPresentationStyle of a Wire.TintCorrectedActivityViewController with this style is UIModalPresentationPopover. You must provide location information for this popover through the view controller's popoverPresentationController. You must provide either a sourceView and sourceRect or a barButtonItem. If this information is not known when you present the view controller, you may provide it in the UIPopoverPresentationControllerDelegate method -prepareForPopoverPresentation.' `

### Solutions

Config the popover and assign `sourceview` to the popover.

### Todo
- [ ] fix crash when sending bug report
- [ ] check all places using `UIActivityViewController` have this issue or not.
- [ ] refactor `wr_presentInviteActivityViewControllerWithSourceView`