### PR TITLE
Fix: iOS13: unable to create group 

### DIFF
--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+SearchResults.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+SearchResults.swift
@@ -119,14 +119,14 @@ extension StartUIViewController: SearchResultsViewControllerDelegate {
 }
 
 extension StartUIViewController: ConversationCreationControllerDelegate {
-    func dismiss(controller: ConversationCreationController) {
+    func dismiss(controller: ConversationCreationController, completion: (() -> Void)? = nil) {
         if traitCollection.horizontalSizeClass == .compact {
             navigationController?.popToRootViewController(animated: true) {
                 UIApplication.shared.wr_updateStatusBarForCurrentControllerAnimated(true)
+                completion?()
             }
-        }
-        else {
-            controller.navigationController?.dismiss(animated: true)
+        } else {
+            controller.navigationController?.dismiss(animated: true, completion: completion)
         }
     }
     
@@ -135,8 +135,9 @@ extension StartUIViewController: ConversationCreationControllerDelegate {
                                         participants: Set<ZMUser>,
                                         allowGuests: Bool,
                                         enableReceipts: Bool) {
-        dismiss(controller: controller)
-        delegate.startUI(self, createConversationWith: participants, name: name, allowGuests: allowGuests, enableReceipts: enableReceipts)
+        dismiss(controller: controller) {
+            self.delegate.startUI(self, createConversationWith: participants, name: name, allowGuests: allowGuests, enableReceipts: enableReceipts)
+        }
     }
     
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

On iOS 13 beta 8, app freezes after adding participants when creating a group.

### Causes

Unknown, but it seems like related to animation workload is too high/the invisible view does not reposed to response to display call.

### Solutions

Dismiss `ConversationCreationController` first, then show the conversation in complete closure.