### PR TITLE
Remove FontScheme's objcMembers signature 

### DIFF
--- a/Wire-iOS/Sources/Helpers/FontScheme.swift
+++ b/Wire-iOS/Sources/Helpers/FontScheme.swift
@@ -167,7 +167,7 @@ public func==(left: FontSpec, right: FontSpec) -> Bool {
     return left.size == right.size && left.weight == right.weight && left.fontTextStyle == right.fontTextStyle
 }
 
-@objcMembers public final class FontScheme: NSObject {
+final class FontScheme {
     public typealias FontMapping = [FontSpec: UIFont]
     
     public var fontMapping: FontMapping = [:]
@@ -238,8 +238,6 @@ public func==(left: FontSpec, right: FontSpec) -> Bool {
     
     public init(fontMapping: FontMapping) {
         self.fontMapping = fontMapping
-
-        super.init()
     }
     
     public func font(for fontType: FontSpec) -> UIFont? {


### PR DESCRIPTION
## What's new in this PR?

Remove FontScheme's `objcMembers` signature to reduce the size of the generated header for objc.