### PR TITLE
Feature: support sharing all file type

### DIFF
--- a/Wire-iOS Share Extension/Info.plist
+++ b/Wire-iOS Share Extension/Info.plist
@@ -32,8 +32,18 @@
 		<dict>
 			<key>NSExtensionActivationRule</key>
 			<string>
-				TRUEPREDICATE
-			</string>
+                SUBQUERY(extensionItems, $extensionItem, SUBQUERY($extensionItem.attachments, $attachment, ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.plain-text").@count &gt;= 1).@count &gt;= 1
+                
+                OR SUBQUERY(extensionItems, $extensionItem, SUBQUERY($extensionItem.attachments, $attachment, SUBQUERY($attachment.registeredTypeIdentifiers, $uti, $uti UTI-CONFORMS-TO "public.url").@count &gt;= 1).@count &gt;= 1).@count &gt;= 1
+                
+                OR SUBQUERY(extensionItems,$extensionItem,SUBQUERY($extensionItem.attachments,$attachment,ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.image").@count == $extensionItem.attachments.@count AND $extensionItem.attachments.@count &lt;= 20).@count == 1
+                
+                OR SUBQUERY(extensionItems,$extensionItem,SUBQUERY($extensionItem.attachments,$attachment,ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.movie").@count == $extensionItem.attachments.@count AND $extensionItem.attachments.@count &lt;= 1).@count == 1
+                
+                OR SUBQUERY(extensionItems,$extensionItem,SUBQUERY($extensionItem.attachments,$attachment,ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.apple.pkpass").@count == $extensionItem.attachments.@count AND $extensionItem.attachments.@count &lt;= 1).@count == 1
+                
+                OR SUBQUERY(extensionItems,$extensionItem,SUBQUERY($extensionItem.attachments,$attachment,ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.content").@count == $extensionItem.attachments.@count AND $extensionItem.attachments.@count &lt;= 1).@count == 1
+            </string>
 		</dict>
 		<key>NSExtensionMainStoryboard</key>
 		<string>MainInterface</string>

--- a/Wire-iOS Share Extension/Info.plist
+++ b/Wire-iOS Share Extension/Info.plist
@@ -32,18 +32,8 @@
 		<dict>
 			<key>NSExtensionActivationRule</key>
 			<string>
-                SUBQUERY(extensionItems, $extensionItem, SUBQUERY($extensionItem.attachments, $attachment, ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.plain-text").@count &gt;= 1).@count &gt;= 1
-                
-                OR SUBQUERY(extensionItems, $extensionItem, SUBQUERY($extensionItem.attachments, $attachment, SUBQUERY($attachment.registeredTypeIdentifiers, $uti, $uti UTI-CONFORMS-TO "public.url" AND NOT $uti UTI-CONFORMS-TO "public.file-url").@count &gt;= 1).@count &gt;= 1).@count &gt;= 1
-                
-                OR SUBQUERY(extensionItems,$extensionItem,SUBQUERY($extensionItem.attachments,$attachment,ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.image").@count == $extensionItem.attachments.@count AND $extensionItem.attachments.@count &lt;= 20).@count == 1
-                
-                OR SUBQUERY(extensionItems,$extensionItem,SUBQUERY($extensionItem.attachments,$attachment,ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.movie").@count == $extensionItem.attachments.@count AND $extensionItem.attachments.@count &lt;= 1).@count == 1
-                
-                OR SUBQUERY(extensionItems,$extensionItem,SUBQUERY($extensionItem.attachments,$attachment,ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.apple.pkpass").@count == $extensionItem.attachments.@count AND $extensionItem.attachments.@count &lt;= 1).@count == 1
-                
-                OR SUBQUERY(extensionItems,$extensionItem,SUBQUERY($extensionItem.attachments,$attachment,ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.content").@count == $extensionItem.attachments.@count AND $extensionItem.attachments.@count &lt;= 1).@count == 1
-            </string>
+				TRUEPREDICATE
+			</string>
 		</dict>
 		<key>NSExtensionMainStoryboard</key>
 		<string>MainInterface</string>

--- a/Wire-iOS Share Extension/NSExtensionContext+Attachments.swift
+++ b/Wire-iOS Share Extension/NSExtensionContext+Attachments.swift
@@ -48,6 +48,8 @@ extension Array where Element == NSItemProvider {
                 attachments[.rawFile, default: []].append(attachment)
             } else if attachment.hasURL {
                 attachments[.url, default: []].append(attachment)
+            } else if attachment.hasFileURL {
+                attachments[.fileUrl, default: []].append(attachment)
             }
         }
 
@@ -83,6 +85,8 @@ extension Dictionary where Key == AttachmentType, Value == [NSItemProvider] {
             return (.rawFile, fileItem)
         } else if let urlItem = sortedAttachments[.url]?.first {
             return (.url, urlItem)
+        } else if let fileUrlItem = sortedAttachments[.fileUrl]?.first {
+            return (.fileUrl, fileUrlItem)
         }
 
         return nil

--- a/Wire-iOS Share Extension/NSExtensionContext+Attachments.swift
+++ b/Wire-iOS Share Extension/NSExtensionContext+Attachments.swift
@@ -75,7 +75,7 @@ extension Dictionary where Key == AttachmentType, Value == [NSItemProvider] {
     var main: (AttachmentType, NSItemProvider)? {
         let sortedAttachments = self
 
-        for attachmentType in AttachmentType.allCases.sorted() {
+        for attachmentType in AttachmentType.allCases {
             if let item = sortedAttachments[attachmentType]?.first {
                 return (attachmentType, item)
             }

--- a/Wire-iOS Share Extension/NSExtensionContext+Attachments.swift
+++ b/Wire-iOS Share Extension/NSExtensionContext+Attachments.swift
@@ -75,18 +75,10 @@ extension Dictionary where Key == AttachmentType, Value == [NSItemProvider] {
     var main: (AttachmentType, NSItemProvider)? {
         let sortedAttachments = self
 
-        if let passItem = sortedAttachments[.walletPass]?.first {
-            return (.walletPass, passItem)
-        } else if let videoItem = sortedAttachments[.video]?.first {
-            return (.video, videoItem)
-        } else if let photoItem = sortedAttachments[.image]?.first {
-            return (.image, photoItem)
-        } else if let fileItem = sortedAttachments[.rawFile]?.first {
-            return (.rawFile, fileItem)
-        } else if let urlItem = sortedAttachments[.url]?.first {
-            return (.url, urlItem)
-        } else if let fileUrlItem = sortedAttachments[.fileUrl]?.first {
-            return (.fileUrl, fileUrlItem)
+        for attachmentType in AttachmentType.allCases.sorted() {
+            if let item = sortedAttachments[attachmentType]?.first {
+                return (attachmentType, item)
+            }
         }
 
         return nil

--- a/Wire-iOS Share Extension/SLComposeServiceViewController+Preview.swift
+++ b/Wire-iOS Share Extension/SLComposeServiceViewController+Preview.swift
@@ -49,7 +49,8 @@ extension SLComposeServiceViewController {
 
         DispatchQueue.global(qos: .userInitiated).async {
 
-            guard let attachments = self.appendLinkFromTextIfNeeded(), let (attachmentType, attachment) = attachments.main else {
+            guard let attachments = self.appendLinkFromTextIfNeeded(),
+                  let (attachmentType, attachment) = attachments.main else {
                 completeTask(nil, nil)
                 return
             }
@@ -68,7 +69,8 @@ extension SLComposeServiceViewController {
                     completeTask(image, defaultDisplayMode.combine(with: preferredDisplayMode) ?? .video)
                 }
 
-            case .rawFile:
+            case .rawFile,
+                 .fileUrl:
                 let fallbackIcon = self.fallbackIcon(forAttachment: attachment, ofType: .rawFile)
                 completeTask(.placeholder(fallbackIcon), defaultDisplayMode.combine(with: .placeholder))
             case .url:
@@ -146,7 +148,8 @@ extension SLComposeServiceViewController {
             return .movie
         case .image:
             return .photo
-        case .walletPass:
+        case .walletPass,
+             .fileUrl:
             return .document
         case .rawFile:
             if item.hasItemConformingToTypeIdentifier(kUTTypeAudio as String) {

--- a/Wire-iOS Share Extension/ShareExtensionAnalytics.swift
+++ b/Wire-iOS Share Extension/ShareExtensionAnalytics.swift
@@ -25,6 +25,7 @@ enum AttachmentType {
     case image
     case video
     case url
+    case fileUrl
     case rawFile
     case walletPass
 }
@@ -126,6 +127,10 @@ extension NSItemProvider {
 
     var hasURL: Bool {
         return hasItemConformingToTypeIdentifier(kUTTypeURL as String) && registeredTypeIdentifiers.count == 1 
+    }
+
+    var hasFileURL: Bool {
+        return hasItemConformingToTypeIdentifier(kUTTypeFileURL as String)
     }
 
     var hasVideo: Bool {

--- a/Wire-iOS Share Extension/ShareExtensionAnalytics.swift
+++ b/Wire-iOS Share Extension/ShareExtensionAnalytics.swift
@@ -21,7 +21,7 @@ import WireCommonComponents
 import MobileCoreServices
 import WireDataModel
 
-enum AttachmentType:Int, CaseIterable, Comparable {
+enum AttachmentType:Int, CaseIterable {
     static func < (lhs: AttachmentType, rhs: AttachmentType) -> Bool {
         return lhs.rawValue < rhs.rawValue
     }

--- a/Wire-iOS Share Extension/ShareExtensionAnalytics.swift
+++ b/Wire-iOS Share Extension/ShareExtensionAnalytics.swift
@@ -21,13 +21,17 @@ import WireCommonComponents
 import MobileCoreServices
 import WireDataModel
 
-enum AttachmentType {
-    case image
+enum AttachmentType:Int, CaseIterable, Comparable {
+    static func < (lhs: AttachmentType, rhs: AttachmentType) -> Bool {
+        return lhs.rawValue < rhs.rawValue
+    }
+
+    case walletPass = 1
     case video
+    case image
+    case rawFile
     case url
     case fileUrl
-    case rawFile
-    case walletPass
 }
 
 class ExtensionActivity {

--- a/Wire-iOS Share Extension/ShareExtensionAnalytics.swift
+++ b/Wire-iOS Share Extension/ShareExtensionAnalytics.swift
@@ -34,7 +34,7 @@ enum AttachmentType:Int, CaseIterable {
     case fileUrl
 }
 
-class ExtensionActivity {
+final class ExtensionActivity {
 
     static private var openedEventName = "share_extension_opened"
     static private var sentEventName = "share_extension_sent"

--- a/Wire-iOS Share Extension/ShareExtensionViewController.swift
+++ b/Wire-iOS Share Extension/ShareExtensionViewController.swift
@@ -215,6 +215,8 @@ final class ShareExtensionViewController: SLComposeServiceViewController {
         }
     }
 
+
+    /// If there is a File URL attachment, copy the filename of the URL attachment into the text field
     private func appendFileTextToEditor() {
         guard let urlItems = extensionActivity?.attachments[.fileUrl] else {
             return

--- a/Wire-iOS Share Extension/ShareExtensionViewController.swift
+++ b/Wire-iOS Share Extension/ShareExtensionViewController.swift
@@ -36,7 +36,7 @@ private enum LocalAuthenticationStatus {
     case granted
 }
 
-class ShareExtensionViewController: SLComposeServiceViewController {
+final class ShareExtensionViewController: SLComposeServiceViewController {
 
     // MARK: - Elements
 

--- a/Wire-iOS Share Extension/ShareExtensionViewController.swift
+++ b/Wire-iOS Share Extension/ShareExtensionViewController.swift
@@ -127,6 +127,7 @@ final class ShareExtensionViewController: SLComposeServiceViewController {
         self.postContent = PostContent(attachments: extensionContext?.attachments ?? [])
         self.setupNavigationBar()
         self.appendTextToEditor()
+        appendFileTextToEditor()
         self.updatePreview()
         self.placeholder = "share_extension.input.placeholder".localized
     }
@@ -212,6 +213,26 @@ final class ShareExtensionViewController: SLComposeServiceViewController {
                 self.textView.delegate?.textViewDidChange?(self.textView)
             }
         }
+    }
+
+    private func appendFileTextToEditor() {
+        guard let urlItems = extensionActivity?.attachments[.fileUrl] else {
+            return
+        }
+
+        urlItems.first?.loadItem(forTypeIdentifier: kUTTypeFileURL as String, options: nil, urlCompletionHandler: { (url, error) in
+            error?.log(message: "Unable to fetch URL for type URL")
+            guard let url = url, url.isFileURL else { return }
+
+            let filename = url.lastPathComponent
+            let separator = self.textView.text.isEmpty ? "" : "\n"
+
+            DispatchQueue.main.async {
+                self.textView.text = self.textView.text + separator + filename
+                self.textView.delegate?.textViewDidChange?(self.textView)
+            }
+
+        })
     }
 
     /// Invoked when the user wants to post.

--- a/Wire-iOS Tests/EmptySearchResultsViewTests.swift
+++ b/Wire-iOS Tests/EmptySearchResultsViewTests.swift
@@ -64,7 +64,7 @@ extension EmptySearchResultsViewTestState: CustomStringConvertible {
 }
 
 extension ColorSchemeVariant: CaseIterable {
-    static var allCases: [ColorSchemeVariant] {
+    public static var allCases: [ColorSchemeVariant] {
         return [.light, .dark]
     }
 }

--- a/Wire-iOS Tests/Utils/VariantsBuilder.swift
+++ b/Wire-iOS Tests/Utils/VariantsBuilder.swift
@@ -49,13 +49,8 @@ func ==<T>(lhs: WritableKeyPathApplicator<T>, rhs: WritableKeyPathApplicator<T>)
     return lhs.keyPath == rhs.keyPath
 }
 
-// Available in Swift 4.2 out of the box.
-protocol CaseIterable {
-    static var allCases: [Self] { get }
-}
-
 extension Bool: CaseIterable {
-    static var allCases: [Bool] {
+    public static var allCases: [Bool] {
         return [true, false]
     }
 }
@@ -73,7 +68,7 @@ class VariantsBuilder<Type: Copyable> {
     }
     
     func add<ValueType: CaseIterable>(keyPath: WritableKeyPath<Type, ValueType>) {
-        possibleValuesForKeyPath[WritableKeyPathApplicator(keyPath)] = ValueType.allCases
+        possibleValuesForKeyPath[WritableKeyPathApplicator(keyPath)] = ValueType.allCases as? [Any]
     }
     
     var possibleValuesForKeyPath: [WritableKeyPathApplicator<Type>: [Any]] = [:]


### PR DESCRIPTION
## What's new in this PR?

Support share all file types via Safari or File app (with `UTI = public.fileurl`).
The filename is extracted from the file URL and prefilled in the text editor.