### PR TITLE
Fix: Sharing a GIF via share extension loss animation

### DIFF
--- a/Wire-iOS Share Extension/PostContent.swift
+++ b/Wire-iOS Share Extension/PostContent.swift
@@ -23,7 +23,7 @@ import MobileCoreServices
 
 
 /// Content that is shared on a share extension post attempt
-class PostContent {
+final class PostContent {
     
     /// Conversation to post to
     var target: Conversation? = nil

--- a/Wire-iOS Share Extension/SendController.swift
+++ b/Wire-iOS Share Extension/SendController.swift
@@ -45,7 +45,7 @@ enum SendingState {
 /// During the sending procress the current state of the operation is reported through the passed in
 /// `SendingCallState` in the `send` method. In comparison to the `PostContent` class, the `SendController`
 /// itself has no knowledge about conversation degradation.
-class SendController {
+final class SendController {
 
     private var observer: SendableBatchObserver? = nil
     private var isCancelled = false
@@ -63,7 +63,9 @@ class SendController {
         var linkAttachment : NSItemProvider?
         
         var sendables: [UnsentSendable] = attachments.compactMap {
-            if $0.hasImage {
+            if $0.hasGifImage {
+                return UnsentGifImageSendable(conversation: conversation, sharingSession: sharingSession, attachment: $0)
+            } else if $0.hasImage {
                 return UnsentImageSendable(conversation: conversation, sharingSession: sharingSession, attachment: $0)
             } else if $0.hasURL {
                 linkAttachment = $0

--- a/Wire-iOS Share Extension/ShareExtensionAnalytics.swift
+++ b/Wire-iOS Share Extension/ShareExtensionAnalytics.swift
@@ -106,6 +106,9 @@ final class ExtensionActivity {
 }
 
 extension NSItemProvider {
+    var hasGifImage: Bool {
+        return hasItemConformingToTypeIdentifier(kUTTypeGIF as String)
+    }
 
     var hasImage: Bool {
         return hasItemConformingToTypeIdentifier(kUTTypeImage as String)

--- a/Wire-iOS Share Extension/ShareExtensionViewController.swift
+++ b/Wire-iOS Share Extension/ShareExtensionViewController.swift
@@ -19,7 +19,6 @@
 import UIKit
 import Social
 import WireShareEngine
-import Cartography
 import MobileCoreServices
 import WireDataModel
 import WireCommonComponents

--- a/Wire-iOS Share Extension/UnsentGifImageSendable.swift
+++ b/Wire-iOS Share Extension/UnsentGifImageSendable.swift
@@ -1,0 +1,57 @@
+
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireShareEngine
+import MobileCoreServices
+
+/// `UnsentSendable` implementation to send GIF image messages
+final class UnsentGifImageSendable: UnsentSendableBase, UnsentSendable {
+    private var gifImageData: Data?
+    private let attachment: NSItemProvider
+    
+    init?(conversation: Conversation, sharingSession: SharingSession, attachment: NSItemProvider) {
+        guard attachment.hasItemConformingToTypeIdentifier(kUTTypeGIF as String) else { return nil }
+        self.attachment = attachment
+        super.init(conversation: conversation, sharingSession: sharingSession)
+        needsPreparation = true
+    }
+    
+    func prepare(completion: @escaping () -> Void) {
+        precondition(needsPreparation, "Ensure this objects needs preparation, c.f. `needsPreparation`")
+        needsPreparation = false
+        
+        self.attachment.loadItem(forTypeIdentifier: kUTTypeGIF as String, options: nil, dataCompletionHandler: { [weak self] (data, error) in
+            
+            error?.log(message: "Unable to load image from attachment")
+            
+            if let data = data {
+                self?.gifImageData = data
+            }
+            
+            completion()
+        })
+    }
+    
+    func send(completion: @escaping (Sendable?) -> Void) {
+        sharingSession.enqueue { [weak self] in
+            guard let `self` = self else { return }
+            completion(self.gifImageData.flatMap(self.conversation.appendImage))
+        }
+    }
+}

--- a/Wire-iOS Share Extension/UnsentSendable.swift
+++ b/Wire-iOS Share Extension/UnsentSendable.swift
@@ -106,9 +106,8 @@ class UnsentTextSendable: UnsentSendableBase, UnsentSendable {
     }
 }
 
-
 /// `UnsentSendable` implementation to send image messages
-class UnsentImageSendable: UnsentSendableBase, UnsentSendable {
+final class UnsentImageSendable: UnsentSendableBase, UnsentSendable {
 
     private let attachment: NSItemProvider
     private var imageData: Data?

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1148,6 +1148,7 @@
 		EF2D6D3A228C507C00D8DBF4 /* SnapshotTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EF2D6D39228C507C00D8DBF4 /* SnapshotTesting.framework */; };
 		EF2D6D3B228C517F00D8DBF4 /* SnapshotTesting.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = EF2D6D39228C507C00D8DBF4 /* SnapshotTesting.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		EF2D6D43228C741500D8DBF4 /* PhotoPermissionsControllerStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2D6D42228C741500D8DBF4 /* PhotoPermissionsControllerStrategy.swift */; };
+		EF2DB834231678360055BDB4 /* UnsentGifImageSendable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2DB833231678360055BDB4 /* UnsentGifImageSendable.swift */; };
 		EF2E2F6E223BAF410038D7D9 /* MediaBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FC8524A199245760008B66B /* MediaBar.swift */; };
 		EF2E2F6F223BB6560038D7D9 /* NotificationWindowRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FC85255199245760008B66B /* NotificationWindowRootViewController.swift */; };
 		EF2E2F71223BC4A60038D7D9 /* VersionInfoViewControllerSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2E2F70223BC4A60038D7D9 /* VersionInfoViewControllerSnapshotTests.swift */; };
@@ -2965,6 +2966,7 @@
 		EF2D6D37228C1FB300D8DBF4 /* MockPhotoLibrary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPhotoLibrary.swift; sourceTree = "<group>"; };
 		EF2D6D39228C507C00D8DBF4 /* SnapshotTesting.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SnapshotTesting.framework; path = Carthage/Build/iOS/SnapshotTesting.framework; sourceTree = "<group>"; };
 		EF2D6D42228C741500D8DBF4 /* PhotoPermissionsControllerStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPermissionsControllerStrategy.swift; sourceTree = "<group>"; };
+		EF2DB833231678360055BDB4 /* UnsentGifImageSendable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsentGifImageSendable.swift; sourceTree = "<group>"; };
 		EF2E2F70223BC4A60038D7D9 /* VersionInfoViewControllerSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionInfoViewControllerSnapshotTests.swift; sourceTree = "<group>"; };
 		EF2EA63021F8AB31000E12CA /* RestrictedButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestrictedButton.swift; sourceTree = "<group>"; };
 		EF2EA63221F8AFB2000E12CA /* ServiceDetailViewControllerSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceDetailViewControllerSnapshotTests.swift; sourceTree = "<group>"; };
@@ -3660,6 +3662,7 @@
 			children = (
 				BF96A6C71E2FC7B60057974A /* SendController.swift */,
 				BF96A6C31E2F845E0057974A /* UnsentSendable.swift */,
+				EF2DB833231678360055BDB4 /* UnsentGifImageSendable.swift */,
 				545BA2181E2D3C4900AA373E /* PostContent.swift */,
 				BF96A6C91E2FD3340057974A /* NSExtensionContext+Attachments.swift */,
 				5EDD2536213FD5C300C0E254 /* SLComposeServiceViewController+Preview.swift */,
@@ -7139,6 +7142,7 @@
 			files = (
 				7CB082DC1FB2137100972488 /* ShareExtensionNetworkObserver.swift in Sources */,
 				7CD0154A218053FF00DE7E3F /* NSString+URL.swift in Sources */,
+				EF2DB834231678360055BDB4 /* UnsentGifImageSendable.swift in Sources */,
 				BF96A6CA1E2FD3340057974A /* NSExtensionContext+Attachments.swift in Sources */,
 				BF6EC90A1EB1FD0C009D9A69 /* ExtensionBackupExcluder.swift in Sources */,
 				BF96A6C61E2FA1790057974A /* UnsentSendable.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Issues

Sharing a GIF via share extension from Photo app or other app loss animations after sent

### Causes

GIF image is treated as a normal image.

### Solutions

Create a new `UnsentGifImageSendable` to handle GIF sharing

### Discussion
- We can show animated GIF preview in the preview image view after upgrading the GIF library. (using current `FLAnimatedImageView` library have to refactor a lot.)