### PR TITLE
Fix: app crash when accessing ConversationListViewController 's state

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+State.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+State.swift
@@ -19,13 +19,15 @@
 import Foundation
 
 extension ConversationListViewController {
-    @objc
+    @objc(setState:animated:)
     func setState(_ state: ConversationListState, animated: Bool) {
         setState(state, animated: animated, completion: nil)
     }
 
-    @objc
-    func setState(_ state: ConversationListState, animated: Bool, completion: (() -> ())?) {
+    @objc(setState:animated:completion:)
+    func setState(_ state: ConversationListState,
+                  animated: Bool,
+                  completion: (() -> ())?) {
         if self.state == state {
             completion?()
             return

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+State.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController+State.swift
@@ -19,12 +19,12 @@
 import Foundation
 
 extension ConversationListViewController {
-    @objc(setState:animated:)
+    @objc
     func setState(_ state: ConversationListState, animated: Bool) {
         setState(state, animated: animated, completion: nil)
     }
 
-    @objc(setState:animated:completion:)
+    @objc
     func setState(_ state: ConversationListState,
                   animated: Bool,
                   completion: (() -> ())?) {

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController.m
@@ -67,6 +67,7 @@
 @interface ConversationListViewController ()
 
 @property (nonatomic) ZMConversation *selectedConversation;
+@property (nonatomic) ConversationListState state;
 
 @property (nonatomic, weak) id<UserProfile> userProfile;
 @property (nonatomic) NSObject *userProfileObserverToken;


### PR DESCRIPTION
## What's new in this PR?

Fix app crash due to missing `state` in `ConversationListViewController `'s implementation. 