### PR TITLE
Fix: Crash when opening opening app from push

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+ConversationMessageCellDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+ConversationMessageCellDelegate.swift
@@ -47,6 +47,7 @@ extension ConversationContentViewController: ConversationMessageCellDelegate {
     // MARK: - MessageActionResponder
 
     public func perform(action: MessageAction, for message: ZMConversationMessage!, view: UIView) {
+        guard let dataSource = dataSource else { return }
         let actionView = view.targetView(for: message, dataSource: dataSource)
         let shouldDismissModal = action != .delete && action != .copy
 
@@ -65,11 +66,11 @@ extension ConversationContentViewController: ConversationMessageCellDelegate {
     }
 
     func conversationMessageWantsToOpenUserDetails(_ cell: UIView, user: UserType, sourceView: UIView, frame: CGRect) {
-        delegate.didTap?(onUserAvatar: user, view: sourceView, frame: frame)
+        delegate?.didTap?(onUserAvatar: user, view: sourceView, frame: frame)
     }
 
     func conversationMessageShouldBecomeFirstResponderWhenShowingMenuForCell(_ cell: UIView) -> Bool {
-        return delegate.conversationContentViewController(self, shouldBecomeFirstResponderWhenShowMenuFromCell: cell)
+        return delegate?.conversationContentViewController(self, shouldBecomeFirstResponderWhenShowMenuFromCell: cell) ?? false
     }
 
     func conversationMessageWantsToOpenMessageDetails(_ cell: UIView, messageDetailsViewController: MessageDetailsViewController) {
@@ -77,11 +78,11 @@ extension ConversationContentViewController: ConversationMessageCellDelegate {
     }
 
     func conversationMessageWantsToOpenGuestOptionsFromView(_ cell: UIView, sourceView: UIView) {
-        delegate.conversationContentViewController(self, presentGuestOptionsFrom: sourceView)
+        delegate?.conversationContentViewController(self, presentGuestOptionsFrom: sourceView)
     }
 
     func conversationMessageWantsToOpenParticipantsDetails(_ cell: UIView, selectedUsers: [ZMUser], sourceView: UIView) {
-        delegate.conversationContentViewController(self, presentParticipantsDetailsWithSelectedUsers: selectedUsers, from: sourceView)
+        delegate?.conversationContentViewController(self, presentParticipantsDetailsWithSelectedUsers: selectedUsers, from: sourceView)
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MediaPlayer.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MediaPlayer.swift
@@ -33,11 +33,11 @@ extension ConversationContentViewController {
             !displaysMessage(mediaPlayingMessage),
             !mediaPlayingMessage.isVideo {
             DispatchQueue.main.async(execute: {
-                self.delegate.conversationContentViewController(self, didEndDisplayingActiveMediaPlayerFor: mediaPlayingMessage)
+                self.delegate?.conversationContentViewController(self, didEndDisplayingActiveMediaPlayerFor: mediaPlayingMessage)
             })
         } else {
             DispatchQueue.main.async(execute: {
-                self.delegate.conversationContentViewController(self, willDisplayActiveMediaPlayerFor: mediaPlayingMessage)
+                self.delegate?.conversationContentViewController(self, willDisplayActiveMediaPlayerFor: mediaPlayingMessage)
             })
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageAction.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageAction.swift
@@ -32,7 +32,8 @@ extension ConversationContentViewController {
         let isImage = Message.isImage(message)
         let isLocation = Message.isLocation(message)
 
-        guard isFile || isImage || isLocation else {
+        guard isFile || isImage || isLocation,
+            let dataSource = dataSource else {
             return
         }
 
@@ -98,7 +99,7 @@ extension ConversationContentViewController {
             }
         case .edit:
             dataSource?.editingMessage = message
-            delegate.conversationContentViewController(self, didTriggerEditing: message)
+            delegate?.conversationContentViewController(self, didTriggerEditing: message)
         case .sketchDraw:
             openSketch(for: message, in: .draw)
         case .sketchEmoji:
@@ -143,7 +144,7 @@ extension ConversationContentViewController {
                 message.fileMessageData?.requestFileDownload()
             })
         case .reply:
-            delegate.conversationContentViewController(self, didTriggerReplyingTo: message)
+            delegate?.conversationContentViewController(self, didTriggerReplyingTo: message)
 
         case .openQuote:
             if let quote = message.textMessageData?.quote {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+PeekPop.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+PeekPop.swift
@@ -34,10 +34,9 @@ extension ConversationContentViewController: UIViewControllerPreviewingDelegate 
               let cell = tableView.cellForRow(at: cellIndexPath) as? SelectableView & UIView else {
             return .none
         }
-        
-        let message = self.dataSource.messages[cellIndexPath.section]
 
-        guard message.isObfuscated == false else {
+        guard let message = self.dataSource?.messages[cellIndexPath.section],
+                message.isObfuscated == false else {
             return nil
         }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+SaveImage.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+SaveImage.swift
@@ -39,7 +39,7 @@ extension ConversationContentViewController {
             savableImage.saveToLibrary { success in
                 guard nil != self.view.window, success else { return }
                 snapshot?.translatesAutoresizingMaskIntoConstraints = true
-                self.delegate.conversationContentViewController(self, performImageSaveAnimation: snapshot, sourceRect: sourceRect)
+                self.delegate?.conversationContentViewController(self, performImageSaveAnimation: snapshot, sourceRect: sourceRect)
             }
         } else {
             savableImage.saveToLibrary()

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+ScrollViewDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+ScrollViewDelegate.swift
@@ -25,10 +25,10 @@ extension ConversationContentViewController: UIScrollViewDelegate {
     }
     
     public func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        dataSource.didScroll(tableView: scrollView as! UITableView)
+        dataSource?.didScroll(tableView: scrollView as! UITableView)
     }
     
     public func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-        dataSource.scrollViewDidEndDecelerating(scrollView)
+        dataSource?.scrollViewDidEndDecelerating(scrollView)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Scrolling.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Scrolling.swift
@@ -27,7 +27,7 @@ extension ConversationContentViewController {
             if message.hasBeenDeleted {
                 presentAlertWithOKButton(message: "conversation.alert.message_deleted".localized)
             } else {
-                dataSource.loadMessages(near: message) { index in
+                dataSource?.loadMessages(near: message) { index in
 
                     guard message.conversation == self.conversation else {
                         fatal("Message from the wrong conversation")
@@ -45,7 +45,7 @@ extension ConversationContentViewController {
                 }
             }
         } else {
-            dataSource.loadMessages()
+            dataSource?.loadMessages()
         }
         
         updateTableViewHeaderView()
@@ -54,7 +54,7 @@ extension ConversationContentViewController {
     @objc public func scrollToBottom() {
         guard !isScrolledToBottom else { return }
         
-        dataSource.loadMessages()
+        dataSource?.loadMessages()
         tableView.scroll(toIndex: 0)
         
         updateTableViewHeaderView()

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.h
@@ -33,7 +33,9 @@
 /// The main conversation view controller
 @interface ConversationContentViewController : UIViewController
 
-@property (nonatomic, weak) id <ConversationContentViewControllerDelegate> delegate;
+NS_ASSUME_NONNULL_BEGIN
+
+@property (nonatomic, weak, nullable) id <ConversationContentViewControllerDelegate> delegate;
 @property (nonatomic, readonly) ZMConversation *conversation;
 @property (nonatomic) CGFloat bottomMargin;
 @property (nonatomic, readonly) BOOL isScrolledToBottom;
@@ -42,17 +44,17 @@
 @property (nonatomic) UIView *bottomContainer;
 @property (nonatomic) NSArray<NSString *> *searchQueries;
 @property (nonatomic) UserSearchResultsViewController *mentionsSearchResultsViewController;
-@property (nonatomic) ConversationTableViewDataSource* dataSource;
+@property (nonatomic, nullable) ConversationTableViewDataSource* dataSource;
 
 - (instancetype)initWithConversation:(ZMConversation *)conversation
-                mediaPlaybackManager:(MediaPlaybackManager *)mediaPlaybackManager
-                             session:(id<ZMUserSessionInterface>)session;
+                mediaPlaybackManager:(MediaPlaybackManager * _Nullable)mediaPlaybackManager
+                             session:(id<ZMUserSessionInterface> _Nullable)session;
 - (instancetype)initWithConversation:(ZMConversation *)conversation
                              message:(id<ZMConversationMessage>)message
                 mediaPlaybackManager:(MediaPlaybackManager *)mediaPlaybackManager
                              session:(id<ZMUserSessionInterface>) session NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
-- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil NS_UNAVAILABLE;
+- (instancetype)initWithNibName:(nullable NSString *)nibNameOrNil bundle:(nullable NSBundle *)nibBundleOrNil NS_UNAVAILABLE;
 
 - (void)updateTableViewHeaderView;
 - (void)highlightMessage:(id<ZMConversationMessage>)message;
@@ -62,5 +64,6 @@
 @interface ConversationContentViewController (EditMessages)
 
 - (void)didFinishEditingMessage:(id<ZMConversationMessage>)message;
+NS_ASSUME_NONNULL_END
 
 @end


### PR DESCRIPTION
## What's new in this PR?

### Issues

App crashes for `Selector name found in current argument registers: delegate` when calling a method of `ConversationContentViewControllerDelegate`

### Causes

`ConversationContentViewController`'s `delegate` is marked as weak but not `nullable`. It crashes when force unwrapping `delegate` when it is nil.

### Solutions

Mark `delegate` as nullable and optional unwrap it.