### PR TITLE
Fix: App crash after back from rotated message detail screen

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsViewController.swift
@@ -23,7 +23,8 @@ import UIKit
  * A view controller wrapping the message details.
  */
 
-@objc class MessageDetailsViewController: UIViewController, ModalTopBarDelegate {
+@objc
+final class MessageDetailsViewController: UIViewController, ModalTopBarDelegate {
 
     /**
      * The collection of view controllers displaying the content.
@@ -217,6 +218,9 @@ import UIKit
         dismiss(animated: true, completion: nil)
     }
 
+    override var shouldAutorotate: Bool {
+        return false
+    }
 }
 
 // MARK: - MessageDetailsDataSourceObserver


### PR DESCRIPTION
## What's new in this PR?

### Issues

App crash after back from the rotated message detail screen

### Causes

`MessageDetailsViewController` is not designed for landscape mode.

### Solutions

Override `shouldAutorotate` so that rotation is not allowed.