### PR TITLE
Fix: iOS 13 navigation bar titles

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/DefaultNavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/DefaultNavigationBar.swift
@@ -43,6 +43,12 @@ import UIKit
     func configure() {
         tintColor = UIColor.from(scheme: .textForeground, variant: colorSchemeVariant)
         titleTextAttributes = DefaultNavigationBar.titleTextAttributes(for: colorSchemeVariant)
+        if #available(iOS 13.0, *) {
+            let appearance = UINavigationBarAppearance()
+            appearance.titleTextAttributes = titleTextAttributes
+            standardAppearance = appearance
+        }
+        
         configureBackground()
 
         let backIndicatorInsets = UIEdgeInsets(top: 0, left: 4, bottom: 2.5, right: 0)


### PR DESCRIPTION
## What's new in this PR?

### Issues

Navigation bar items are using the default font size and weight on iOS 13.0 (e.g. "FOR COMPANIES").

![IMG_0646](https://user-images.githubusercontent.com/2906234/64409865-046fa280-d08a-11e9-855c-a210d01ebce4.jpg)

### Causes

This is probably caused by the new `UINavigationBarAppearance` object introduced in iOS 13.0: https://developer.apple.com/documentation/uikit/uinavigationbarappearance

### Solutions

I've added a possible fix by setting the `titleTextAttributes` also to the new `standardAppearance` property. **This needs to be tested on iOS 13.0**, so let's wait for the switch to Xcode 11.