### PR TITLE
 Fix: [iPad] - app crash when pressing the file share button 

### DIFF
--- a/Wire-iOS/Sources/Helpers/UIActivityViewController+FileSaving.swift
+++ b/Wire-iOS/Sources/Helpers/UIActivityViewController+FileSaving.swift
@@ -28,8 +28,9 @@ extension UIActivityViewController {
 
         configPopover(pointToView: view)
     }
-    
+}
 
+extension UIViewController {
     /// On iPad, UIActivityViewController must be presented in a popover and the popover's source view must be set
     ///
     /// - Parameter pointToView: the view which the popover points to

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+FilesPopover.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+FilesPopover.swift
@@ -132,6 +132,7 @@ extension ConversationInputBarViewController {
 
         controller.addAction(.cancel())
 
+        controller.configPopover(pointToView: sender ?? view)
         return controller
     }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

App crash after https://github.com/wireapp/wire-ios/pull/3591

### Causes

similar to https://github.com/wireapp/wire-ios/pull/3605

### Solutions

same as https://github.com/wireapp/wire-ios/pull/3605