### PR TITLE
Fix: clean up objc and objcmember signatures

### DIFF
--- a/Wire-iOS Tests/CameraKeyboardViewControllerTests.swift
+++ b/Wire-iOS Tests/CameraKeyboardViewControllerTests.swift
@@ -45,9 +45,9 @@ final class CameraKeyboardViewControllerDelegateMock: CameraKeyboardViewControll
 }
 
 
-@objcMembers class SplitLayoutObservableMock: NSObject, SplitLayoutObservable {
-    @objc var layoutSize: SplitViewControllerLayoutSize = .compact
-    @objc var leftViewControllerWidth: CGFloat = 0
+final class SplitLayoutObservableMock: NSObject, SplitLayoutObservable {
+    var layoutSize: SplitViewControllerLayoutSize = .compact
+    var leftViewControllerWidth: CGFloat = 0
 }
 
 private final class MockAssetLibrary: AssetLibrary {

--- a/Wire-iOS/Sources/Components/CustomSpacingStackView.swift
+++ b/Wire-iOS/Sources/Components/CustomSpacingStackView.swift
@@ -18,7 +18,7 @@
 
 import UIKit
 
-@objcMembers class CustomSpacingStackView: UIView {
+final class CustomSpacingStackView: UIView {
 
     private var stackView: UIStackView
     

--- a/Wire-iOS/Sources/Helpers/sound/MediaManagerLoader.swift
+++ b/Wire-iOS/Sources/Helpers/sound/MediaManagerLoader.swift
@@ -58,7 +58,7 @@ extension MediaManagerState {
     }
 }
 
-@objcMembers final class MediaManagerLoader: NSObject {
+final class MediaManagerLoader: NSObject {
     
     private var flowManagerObserver: AnyObject?
     private var state: MediaManagerState = .initial {

--- a/Wire-iOS/Sources/UserInterface/Availability/AvailabilityTitleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Availability/AvailabilityTitleView.swift
@@ -22,7 +22,7 @@ import UIKit
  * A title view subclass that displays the availability of the user.
  */
 
-class AvailabilityTitleView: TitleView, Themeable, ZMUserObserver {
+final class AvailabilityTitleView: TitleView, Themeable, ZMUserObserver {
     
     /// The available options for this view.
     struct Options: OptionSet {

--- a/Wire-iOS/Sources/UserInterface/Availability/TitleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Availability/TitleView.swift
@@ -21,12 +21,12 @@ import UIKit
 import Cartography
 
 
-@objcMembers public class TitleView: UIView {
+public class TitleView: UIView {
     
     internal var titleColor, titleColorSelected: UIColor?
     internal var titleFont: UIFont?
     internal let titleButton = UIButton()
-    public var tapHandler: ((UIButton) -> Void)? = nil
+    @objc public var tapHandler: ((UIButton) -> Void)? = nil
     
     public init(color: UIColor? = nil, selectedColor: UIColor? = nil, font: UIFont? = nil) {
         super.init(frame: CGRect.zero)
@@ -53,7 +53,7 @@ import Cartography
         addSubview(titleButton)
     }
     
-    func titleButtonTapped(_ sender: UIButton) {
+    @objc func titleButtonTapped(_ sender: UIButton) {
         tapHandler?(sender)
     }
     

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionCellHeader.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionCellHeader.swift
@@ -20,7 +20,7 @@
 import Foundation
 import Cartography
 
-@objcMembers public final class CollectionCellHeader: UIView {
+public final class CollectionCellHeader: UIView {
     public var message: ZMConversationMessage? {
         didSet {
             guard let message = self.message, let serverTimestamp = message.serverTimestamp, let sender = message.sender else {

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionHeaderView.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionHeaderView.swift
@@ -19,7 +19,7 @@
 import Foundation
 import Cartography
 
-@objcMembers final public class CollectionHeaderView: UICollectionReusableView {
+final public class CollectionHeaderView: UICollectionReusableView {
     
     public var section: CollectionsSectionSet = .none {
         didSet {

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/BrowserViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/BrowserViewController.swift
@@ -19,11 +19,10 @@
 import Foundation
 import SafariServices
 
-@objcMembers
 final class BrowserViewController: SFSafariViewController {
 
-    @objc var completion: (() -> Void)?
-    @objc var onDismiss: (() -> Void)?
+    var completion: (() -> Void)?
+    var onDismiss: (() -> Void)?
 
     // MARK: - Tint Color
 

--- a/Wire-iOS/Sources/UserInterface/Components/ImageMessageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/ImageMessageView.swift
@@ -21,7 +21,7 @@ import Cartography
 import WireDataModel
 import FLAnimatedImage
 
-@objcMembers public class ImageMessageView: UIView {
+final public class ImageMessageView: UIView {
     
     private let imageView = FLAnimatedImageView()
     private let userImageView = UserImageView(size: .tiny)

--- a/Wire-iOS/Sources/UserInterface/Components/Views/MarkdownTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/MarkdownTextView.swift
@@ -24,7 +24,7 @@ extension Notification.Name {
     static let MarkdownTextViewDidChangeActiveMarkdown = Notification.Name("MarkdownTextViewDidChangeActiveMarkdown")
 }
 
-@objcMembers class MarkdownTextView: NextResponderTextView {
+final class MarkdownTextView: NextResponderTextView {
     
     enum ListType {
         case number, bullet

--- a/Wire-iOS/Sources/UserInterface/Components/Views/TextSearchInputView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/TextSearchInputView.swift
@@ -26,7 +26,7 @@ public protocol TextSearchInputViewDelegate: class {
     func searchViewShouldReturn(_ searchView: TextSearchInputView) -> Bool
 }
 
-@objcMembers public final class TextSearchInputView: UIView {
+public final class TextSearchInputView: UIView {
     public let iconView = UIImageView()
     public let searchInput = UITextView()
     public let placeholderLabel = UILabel()

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
@@ -21,7 +21,7 @@ import Cartography
 
 private let zmLog = ZMSLog(tag: "UI")
 
-@objcMembers final class AudioMessageView: UIView, TransferView {
+final class AudioMessageView: UIView, TransferView {
     public var fileMessage: ZMConversationMessage?
     weak public var delegate: TransferViewDelegate?
     private var _audioTrackPlayer: AudioTrackPlayer?

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/VideoMessageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/VideoMessageView.swift
@@ -19,7 +19,7 @@
 import Foundation
 import Cartography
 
-@objcMembers final class VideoMessageView: UIView, TransferView {
+final class VideoMessageView: UIView, TransferView {
     public var fileMessage: ZMConversationMessage?
     weak public var delegate: TransferViewDelegate?
     

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/GradientView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/GradientView.swift
@@ -19,12 +19,12 @@
 
 import Foundation
 
-@objcMembers open class GradientView: UIView {
-    override open class var layerClass : AnyClass {
+final class GradientView: UIView {
+    override public class var layerClass : AnyClass {
         return CAGradientLayer.self;
     }
     
-    open var gradientLayer: CAGradientLayer {
+    public var gradientLayer: CAGradientLayer {
         get {
             if let gradientLayer = self.layer as? CAGradientLayer {
                 return gradientLayer

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/WaveformProgressView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/WaveformProgressView.swift
@@ -82,45 +82,45 @@ import Cartography
     }
 }
 
-@objcMembers open class WaveformProgressView: UIView {
+final public class WaveformProgressView: UIView {
     
     fileprivate let backgroundWaveform = WaveformBarsView()
     fileprivate let foregroundWaveform = WaveformBarsView()
     fileprivate var maskShape = CAShapeLayer()
     
-    open var samples : [Float] = [] {
+    public var samples : [Float] = [] {
         didSet {
             backgroundWaveform.samples = samples
             foregroundWaveform.samples = samples
         }
     }
     
-    open var barColor : UIColor = UIColor.gray {
+    public var barColor : UIColor = UIColor.gray {
         didSet {
             backgroundWaveform.barColor = barColor
         }
     }
     
-    open var highlightedBarColor : UIColor = UIColor.accent() {
+    public var highlightedBarColor : UIColor = UIColor.accent() {
         didSet {
             foregroundWaveform.barColor = highlightedBarColor
         }
     }
     
-    open var progress : Float = 0.0 {
+    public var progress : Float = 0.0 {
         didSet {
             setProgress(progress, animated: false)
         }
     }
     
-    open override var backgroundColor: UIColor? {
+    public override var backgroundColor: UIColor? {
         didSet {
             backgroundWaveform.backgroundColor = backgroundColor
             foregroundWaveform.backgroundColor = backgroundColor
         }
     }
     
-    open func setProgress(_ progress: Float, animated: Bool) {
+    public func setProgress(_ progress: Float, animated: Bool) {
         let path = UIBezierPath(rect: CGRect(x: 0, y: 0, width: self.bounds.width * CGFloat(progress), height: self.bounds.height)).cgPath
         
         if (animated) {
@@ -136,7 +136,7 @@ import Cartography
         maskShape.path = path
     }
     
-    open override var bounds: CGRect {
+    public override var bounds: CGRect {
         didSet {
             maskShape.path = UIBezierPath(rect: CGRect(x: 0, y: 0, width: self.bounds.width * CGFloat(progress), height: self.bounds.height)).cgPath
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationTitleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationTitleView.swift
@@ -20,7 +20,7 @@
 import UIKit
 import Cartography
 
-class ConversationTitleView: TitleView {
+final class ConversationTitleView: TitleView {
     var conversation: ZMConversation
     var interactive: Bool = true
     

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarEditView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarEditView.swift
@@ -27,7 +27,7 @@ import Cartography
     func inputBarEditViewDidLongPressUndoButton(_ editView: InputBarEditView)
 }
 
-@objcMembers public final class InputBarEditView: UIView {
+public final class InputBarEditView: UIView {
     private static var iconButtonTemplate: IconButton {
         let iconButton = IconButton()
         iconButton.setIconColor(.from(scheme: .iconNormal), for: .normal)

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/RecordingDotView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/RecordingDotView.swift
@@ -19,7 +19,7 @@
 
 import UIKit
 
-@objcMembers final class RecordingDotView: UIView {
+final class RecordingDotView: UIView {
     
     public init() {
         super.init(frame: CGRect.zero)

--- a/Wire-iOS/Sources/UserInterface/Location/LocationSendViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Location/LocationSendViewController.swift
@@ -23,7 +23,7 @@ import Cartography
     func locationSendViewControllerSendButtonTapped(_ viewController: LocationSendViewController)
 }
 
-@objcMembers public final class LocationSendViewController: UIViewController {
+public final class LocationSendViewController: UIViewController {
     
     public let sendButton = Button(style: .full)
     public let addressLabel: UILabel = {

--- a/Wire-iOS/Sources/UserInterface/Settings/AccentColorPickerController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/AccentColorPickerController.swift
@@ -26,7 +26,7 @@ public protocol ColorPickerControllerDelegate {
     func colorPickerWantsToDismiss(_ colotPicker: ColorPickerController)
 }
 
-@objcMembers open class ColorPickerController: UIViewController {
+public class ColorPickerController: UIViewController {
     public let overlayView = UIView()
     public let contentView = UIView()
     public let tableView = UITableView()
@@ -37,8 +37,8 @@ public protocol ColorPickerControllerDelegate {
     static fileprivate let rowHeight: CGFloat = 44
     
     public let colors: [UIColor]
-    open var currentColor: UIColor?
-    open var delegate: ColorPickerControllerDelegate?
+    public var currentColor: UIColor?
+    public var delegate: ColorPickerControllerDelegate?
     
     public init(colors: [UIColor]) {
         self.colors = colors
@@ -51,13 +51,13 @@ public protocol ColorPickerControllerDelegate {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override open var title: String? {
+    override public var title: String? {
         didSet {
             self.titleLabel.text = self.title
         }
     }
     
-    override open func viewDidLoad() {
+    override public func viewDidLoad() {
         super.viewDidLoad()
         
         self.view.addSubview(self.contentView)
@@ -114,13 +114,13 @@ public protocol ColorPickerControllerDelegate {
         self.tableView.separatorStyle = .none
     }
     
-    override open var prefersStatusBarHidden: Bool {
+    override public var prefersStatusBarHidden: Bool {
         get {
             return false
         }
     }
 
-    override open var preferredStatusBarStyle: UIStatusBarStyle {
+    override public var preferredStatusBarStyle: UIStatusBarStyle {
         get {
             return .lightContent
         }
@@ -169,7 +169,7 @@ public protocol ColorPickerControllerDelegate {
         
     }
     
-    @objc open func didPressDismiss(_ sender: AnyObject?) {
+    @objc public func didPressDismiss(_ sender: AnyObject?) {
         self.delegate?.colorPickerWantsToDismiss(self)
     }
 }
@@ -205,7 +205,6 @@ extension ColorPickerController: UITableViewDelegate, UITableViewDataSource {
 
 final class AccentColorPickerController: ColorPickerController {
     fileprivate let allAccentColors: [AccentColor]
-    
     
     public init() {
         self.allAccentColors = AccentColor.allSelectable()

--- a/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ConfirmEmailViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ConfirmEmailViewController.swift
@@ -52,7 +52,7 @@ extension UITableView {
     }
 }
 
-@objcMembers final class ConfirmEmailViewController: SettingsBaseTableViewController {
+final class ConfirmEmailViewController: SettingsBaseTableViewController {
     fileprivate weak var userProfile = ZMUserSession.shared()?.userProfile
     weak var delegate: ConfirmEmailDelegate?
 

--- a/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ConfirmPhoneViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ConfirmPhoneViewController.swift
@@ -34,7 +34,7 @@ protocol ConfirmPhoneDelegate: class {
     func didConfirmPhone(inController controller: ConfirmPhoneViewController)
 }
 
-@objcMembers final class ConfirmPhoneViewController: SettingsBaseTableViewController {
+final class ConfirmPhoneViewController: SettingsBaseTableViewController {
     fileprivate weak var userProfile = ZMUserSession.shared()?.userProfile
     fileprivate var observer: NSObjectProtocol?
     fileprivate var observerToken: Any?

--- a/Wire-iOS/Sources/UserInterface/Settings/SettingsCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/SettingsCell.swift
@@ -37,7 +37,7 @@ protocol SettingsCellType: class {
     var icon: StyleKitIcon? {get set}
 }
 
-@objcMembers class SettingsTableCell: UITableViewCell, SettingsCellType {
+class SettingsTableCell: UITableViewCell, SettingsCellType {
     let iconImageView = UIImageView()
     public let cellNameLabel: UILabel = {
         let label = UILabel()

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Devices/UserClientListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Devices/UserClientListViewController.swift
@@ -19,7 +19,7 @@
 import Foundation
 
 
-class UserClientListViewController: UIViewController, UICollectionViewDelegateFlowLayout, UICollectionViewDataSource {
+final class UserClientListViewController: UIViewController, UICollectionViewDelegateFlowLayout, UICollectionViewDataSource {
     
     fileprivate let headerView: ParticipantDeviceHeaderView
     fileprivate let collectionView = UICollectionView(forGroupedSections: ())

--- a/WireCommonComponents/AutomationHelper.swift
+++ b/WireCommonComponents/AutomationHelper.swift
@@ -20,7 +20,7 @@
 import Foundation
 import WireSystem
 
-@objcMembers public class AutomationEmailCredentials: NSObject {
+final public class AutomationEmailCredentials: NSObject {
     public var email: String
     public var password: String
     


### PR DESCRIPTION
## What's new in this PR?

Remove `objc` and` objcmember` signatures to reduce building time.