### PR TITLE
Fix: Crash - controllerToPresentOn is nil after allowing contact permissions

### DIFF
--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/ProfilePresenter+Internal.h
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/ProfilePresenter+Internal.h
@@ -16,6 +16,9 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
+// ui
+#import "ProfileViewController.h"
+
 @protocol ViewControllerDismisser;
 @protocol ProfileViewControllerDelegate;
 
@@ -26,12 +29,13 @@
 
 @end
 
+
 @interface ProfilePresenter () <ProfileViewControllerDelegate>
 
 @property (nonatomic, assign) CGRect presentedFrame;
-@property (nonatomic, weak)   UIView *viewToPresentOn;
-@property (nonatomic, weak)   UIViewController *controllerToPresentOn;
-@property (nonatomic, copy)   dispatch_block_t onDismiss;
-@property (nonatomic) TransitionDelegate *transitionDelegate;
+@property (nonatomic, weak, nullable)   UIView *viewToPresentOn;
+@property (nonatomic, weak, nullable)   UIViewController *controllerToPresentOn;
+@property (nonatomic, copy, nullable)   dispatch_block_t onDismiss;
+@property (nonatomic, nonnull) TransitionDelegate *transitionDelegate;
 
 @end

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/ProfilePresenter+Orientation.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/ProfilePresenter+Orientation.swift
@@ -22,15 +22,16 @@ extension ProfilePresenter {
 
     @objc
     func deviceOrientationChanged(_ notification: Notification?) {
-        if controllerToPresentOn.isIPadRegular() && controllerToPresentOn != nil {
-            ZClientViewController.shared()?.transitionToList(animated: false, completion: nil)
+        guard let controllerToPresentOn = controllerToPresentOn,
+            controllerToPresentOn.isIPadRegular() else { return }
 
-            if viewToPresentOn != nil,
-                let presentedViewController = controllerToPresentOn.presentedViewController{
+        ZClientViewController.shared()?.transitionToList(animated: false, completion: nil)
 
-                presentedViewController.popoverPresentationController?.sourceRect = presentedFrame
-                presentedViewController.preferredContentSize = presentedViewController.view.frame.insetBy(dx: -0.01, dy: 0.0).size
-            }
+        if let _ = viewToPresentOn,
+            let presentedViewController = controllerToPresentOn.presentedViewController {
+
+            presentedViewController.popoverPresentationController?.sourceRect = presentedFrame
+            presentedViewController.preferredContentSize = presentedViewController.view.frame.insetBy(dx: -0.01, dy: 0.0).size
         }
     }
 

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/ProfilePresenter.m
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/ProfilePresenter.m
@@ -21,7 +21,6 @@
 #import "ProfilePresenter+Internal.h"
 
 // ui
-#import "ProfileViewController.h"
 #import "ZClientViewController.h"
 
 #import "ZoomTransition.h"


### PR DESCRIPTION
## What's new in this PR?

### Issues

https://github.com/wireapp/wire-ios/issues/3642

### Causes

After merging https://github.com/wireapp/wire-ios/pull/3640,  accessing `controllerToPresentOn` in Swift without unwrapping causes the crash.

### Solutions

Define the properties' nullability and unwrapping the parameters before access.