### PR TITLE
Fix: table view section outside bounds

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Views/UpsideDownTableView+Scrolling.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/UpsideDownTableView+Scrolling.swift
@@ -30,7 +30,7 @@ extension UpsideDownTableView {
         guard numberOfSections > 0 else { return }
         
         let rowIndex = numberOfCells(inSection: indexToShow) - 1
-        guard rowIndex >= 0 else { return }
+        guard rowIndex >= 0 && indexToShow < numberOfSections else { return }
         let cellIndexPath = IndexPath(row: rowIndex, section: indexToShow)
         
         scrollToRow(at: cellIndexPath, at: .top, animated: false)


### PR DESCRIPTION
## What's new in this PR?

### Issues

As described in crash from ZIOS-11665, tableview is crashing because the section index passed is outside bounds (`section (9223372036854775807) beyond bounds (4)`)

### Solutions

I've added a condition to avoid scroll if section index is over bounds.