### PR TITLE
Fix: [iPad] When rotating the app in split view with the conversation details open, some text is displayed outside of the visible area

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/SectionCollectionViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/SectionCollectionViewController.swift
@@ -26,16 +26,9 @@ protocol CollectionViewSectionController: UICollectionViewDataSource, UICollecti
     
 }
 
-final class TraitAwarenessCollectionView: UICollectionView {
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        reloadData()
-    }
-}
-
 final class SectionCollectionViewController: NSObject {
     
-    var collectionView : TraitAwarenessCollectionView? = nil {
+    var collectionView : UICollectionView? = nil {
         didSet {
             collectionView?.dataSource = self
             collectionView?.delegate = self
@@ -120,7 +113,7 @@ extension SectionCollectionViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForFooterInSection section: Int) -> CGSize {
         return visibleSections[section].collectionView?(collectionView, layout: collectionViewLayout, referenceSizeForFooterInSection: section) ?? .zero
     }
-    
+
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         return visibleSections[indexPath.section].collectionView?(collectionView, layout: collectionViewLayout, sizeForItemAt: indexPath) ?? .zero
     }

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/SectionCollectionViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/SectionCollectionViewController.swift
@@ -26,9 +26,16 @@ protocol CollectionViewSectionController: UICollectionViewDataSource, UICollecti
     
 }
 
-class SectionCollectionViewController: NSObject {
+final class TraitAwarenessCollectionView: UICollectionView {
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        reloadData()
+    }
+}
+
+final class SectionCollectionViewController: NSObject {
     
-    var collectionView : UICollectionView? = nil {
+    var collectionView : TraitAwarenessCollectionView? = nil {
         didSet {
             collectionView?.dataSource = self
             collectionView?.delegate = self
@@ -58,7 +65,6 @@ class SectionCollectionViewController: NSObject {
     init(sections : [CollectionViewSectionController] = []) {
         self.sections = sections
     }
-    
 }
 
 extension SectionCollectionViewController: UICollectionViewDelegate {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
@@ -171,7 +171,7 @@ final public class ConversationCreationValues {
     
     private func setupViews() {
         // TODO: if keyboard is open, it should scroll.
-        let collectionView = UICollectionView(forGroupedSections: ())
+        let collectionView = TraitAwarenessCollectionView(forGroupedSections: ())
         
         if #available(iOS 11.0, *) {
             collectionView.contentInsetAdjustmentBehavior = .never

--- a/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
@@ -61,7 +61,7 @@ final public class ConversationCreationValues {
     
 }
 
-@objcMembers public final class ConversationCreationController: UIViewController {
+final class ConversationCreationController: UIViewController {
 
     static let mainViewHeight: CGFloat = 56
     fileprivate let colorSchemeVariant = ColorScheme.default.variant
@@ -117,7 +117,8 @@ final public class ConversationCreationValues {
 
     fileprivate var values = ConversationCreationValues()
     fileprivate let source: LinearGroupCreationFlowEvent.Source
-    
+
+    @objc
     weak var delegate: ConversationCreationControllerDelegate?
     private var preSelectedParticipants: Set<ZMUser>?
     
@@ -171,7 +172,7 @@ final public class ConversationCreationValues {
     
     private func setupViews() {
         // TODO: if keyboard is open, it should scroll.
-        let collectionView = TraitAwarenessCollectionView(forGroupedSections: ())
+        let collectionView = UICollectionView(forGroupedSections: ())
         
         if #available(iOS 11.0, *) {
             collectionView.contentInsetAdjustmentBehavior = .never

--- a/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsContentViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsContentViewController.swift
@@ -22,7 +22,7 @@ import UIKit
  * Displays the list of users for a specified message detail content type.
  */
 
-class MessageDetailsContentViewController: UIViewController {
+final class MessageDetailsContentViewController: UIViewController {
 
     /// The type of the displayed content.
     enum ContentType {
@@ -93,6 +93,12 @@ class MessageDetailsContentViewController: UIViewController {
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         collectionView.map(updateFooterPosition)
+    }
+
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        coordinator.animate(alongsideTransition: { (context) in
+            self.collectionView.collectionViewLayout.invalidateLayout()
+        })
     }
 
     private func configureSubviews() {

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
@@ -43,6 +43,12 @@ final class GroupDetailsViewController: UIViewController, ZMConversationObserver
         return ColorScheme.default.statusBarStyle
     }
 
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        coordinator.animate(alongsideTransition: { (context) in
+            self.collectionViewController.collectionView?.collectionViewLayout.invalidateLayout()
+        })
+    }
+
     @objc
     public init(conversation: ZMConversation) {
         self.conversation = conversation
@@ -64,7 +70,7 @@ final class GroupDetailsViewController: UIViewController, ZMConversationObserver
     }
 
     func createSubviews() {
-        let collectionView = TraitAwarenessCollectionView(forGroupedSections: ())
+        let collectionView = UICollectionView(forGroupedSections: ())
         collectionView.accessibilityIdentifier = "group_details.list"
 
         if #available(iOS 11.0, *) {

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
@@ -43,12 +43,6 @@ final class GroupDetailsViewController: UIViewController, ZMConversationObserver
         return ColorScheme.default.statusBarStyle
     }
 
-    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        coordinator.animate(alongsideTransition: { (context) in
-            self.collectionViewController.collectionView?.collectionViewLayout.invalidateLayout()
-        })
-    }
-
     @objc
     public init(conversation: ZMConversation) {
         self.conversation = conversation
@@ -109,7 +103,13 @@ final class GroupDetailsViewController: UIViewController, ZMConversationObserver
         navigationItem.rightBarButtonItem = navigationController?.closeItem()
         collectionViewController.collectionView?.reloadData()
     }
-    
+
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        coordinator.animate(alongsideTransition: { (context) in
+            self.collectionViewController.collectionView?.collectionViewLayout.invalidateLayout()
+        })
+    }
+
     func updateLegalHoldIndicator() {
         navigationItem.leftBarButtonItem = conversation.isUnderLegalHold ? legalholdItem : nil
     }

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
@@ -19,7 +19,7 @@
 import UIKit
 import Cartography
 
-@objcMembers class GroupDetailsViewController: UIViewController, ZMConversationObserver, GroupDetailsFooterViewDelegate {
+final class GroupDetailsViewController: UIViewController, ZMConversationObserver, GroupDetailsFooterViewDelegate {
     
     fileprivate let collectionViewController: SectionCollectionViewController
     fileprivate let conversation: ZMConversation
@@ -42,7 +42,8 @@ import Cartography
     override var preferredStatusBarStyle: UIStatusBarStyle {
         return ColorScheme.default.statusBarStyle
     }
-    
+
+    @objc
     public init(conversation: ZMConversation) {
         self.conversation = conversation
         collectionViewController = SectionCollectionViewController()
@@ -63,7 +64,7 @@ import Cartography
     }
 
     func createSubviews() {
-        let collectionView = UICollectionView(forGroupedSections: ())
+        let collectionView = TraitAwarenessCollectionView(forGroupedSections: ())
         collectionView.accessibilityIdentifier = "group_details.list"
 
         if #available(iOS 11.0, *) {
@@ -193,7 +194,8 @@ extension GroupDetailsViewController {
         item.tintColor = .vividRed
         return item
     }
-    
+
+    @objc
     func presentLegalHoldDetails() {
         LegalHoldDetailsViewController.present(in: self, conversation: conversation)
     }

--- a/Wire-iOS/Sources/UserInterface/LegalHoldDetails/LegalHoldDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/LegalHoldDetails/LegalHoldDetailsViewController.swift
@@ -20,7 +20,7 @@ import UIKit
 
 final class LegalHoldDetailsViewController: UIViewController {
     
-    fileprivate let collectionView = TraitAwarenessCollectionView(forGroupedSections: ())
+    fileprivate let collectionView = UICollectionView(forGroupedSections: ())
     fileprivate let collectionViewController: SectionCollectionViewController
     fileprivate let conversation: ZMConversation
     

--- a/Wire-iOS/Sources/UserInterface/LegalHoldDetails/LegalHoldDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/LegalHoldDetails/LegalHoldDetailsViewController.swift
@@ -20,7 +20,7 @@ import UIKit
 
 final class LegalHoldDetailsViewController: UIViewController {
     
-    fileprivate let collectionView = UICollectionView(forGroupedSections: ())
+    fileprivate let collectionView = TraitAwarenessCollectionView(forGroupedSections: ())
     fileprivate let collectionViewController: SectionCollectionViewController
     fileprivate let conversation: ZMConversation
     

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsView.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsView.swift
@@ -24,7 +24,7 @@ final class SearchResultsView : UIView {
     let emptyResultContainer = UIView()
 
     @objc
-    let collectionView : TraitAwarenessCollectionView
+    let collectionView : UICollectionView
     let collectionViewLayout : UICollectionViewFlowLayout
     let accessoryContainer = UIView()
     var lastLayoutBounds : CGRect = CGRect.zero
@@ -38,7 +38,7 @@ final class SearchResultsView : UIView {
         collectionViewLayout.minimumInteritemSpacing = 12
         collectionViewLayout.minimumLineSpacing = 0
         
-        collectionView = TraitAwarenessCollectionView(frame: CGRect.zero, collectionViewLayout: collectionViewLayout)
+        collectionView = UICollectionView(frame: CGRect.zero, collectionViewLayout: collectionViewLayout)
         collectionView.backgroundColor = UIColor.clear
         collectionView.allowsMultipleSelection = true
         collectionView.keyboardDismissMode = .onDrag

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsView.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsView.swift
@@ -18,11 +18,13 @@
 
 import Foundation
 
-@objcMembers class SearchResultsView : UIView {
+final class SearchResultsView : UIView {
     
     let accessoryViewMargin : CGFloat = 16.0
     let emptyResultContainer = UIView()
-    let collectionView : UICollectionView
+
+    @objc
+    let collectionView : TraitAwarenessCollectionView
     let collectionViewLayout : UICollectionViewFlowLayout
     let accessoryContainer = UIView()
     var lastLayoutBounds : CGRect = CGRect.zero
@@ -36,7 +38,7 @@ import Foundation
         collectionViewLayout.minimumInteritemSpacing = 12
         collectionViewLayout.minimumLineSpacing = 0
         
-        collectionView = UICollectionView(frame: CGRect.zero, collectionViewLayout: collectionViewLayout)
+        collectionView = TraitAwarenessCollectionView(frame: CGRect.zero, collectionViewLayout: collectionViewLayout)
         collectionView.backgroundColor = UIColor.clear
         collectionView.allowsMultipleSelection = true
         collectionView.keyboardDismissMode = .onDrag
@@ -98,7 +100,8 @@ import Foundation
         
         super.layoutSubviews()
     }
-    
+
+    @objc
     var accessoryView : UIView? {
         didSet {
             guard oldValue != accessoryView else { return }
@@ -124,7 +127,8 @@ import Foundation
             updateContentInset()
         }
     }
-    
+
+    @objc
     var emptyResultView : UIView? {
         didSet {
             guard oldValue != emptyResultView else { return }


### PR DESCRIPTION
## What's new in this PR?

### Issues

On `GroupDetailsViewController` when switching between `regular` and `compact` mode, the cell's content may be clipped by the boundary.

### Causes

The cells' layouts do not refresh after rotation.

### Solutions

Call `invalidateLayout` when `viewWillTransition`.

### TODO
- [x] same issue occurs on message detail screen