### PR TITLE
Fix: Label "EVERYTHING ARCHIVED" is missing from conversation list

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListViewController.swift
@@ -381,22 +381,24 @@ extension ZMConversationList {
 
 fileprivate extension NSAttributedString {
     static var attributedTextForNoConversationLabel: NSAttributedString? {
-        guard let paragraphStyle = NSParagraphStyle.default as? NSMutableParagraphStyle else { return nil }
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.setParagraphStyle(NSParagraphStyle.default)
+
         paragraphStyle.paragraphSpacing = 10
         paragraphStyle.alignment = .center
-        
+
         let titleAttributes: [NSAttributedString.Key : Any] = [
             NSAttributedString.Key.foregroundColor: UIColor.white,
             NSAttributedString.Key.font: UIFont.smallMediumFont,
             NSAttributedString.Key.paragraphStyle: paragraphStyle
         ]
-        
+
         paragraphStyle.paragraphSpacing = 4
-        
+
         let titleString = "conversation_list.empty.all_archived.message".localized
-        
+
         let attributedString = NSAttributedString(string: titleString.uppercased(), attributes: titleAttributes)
-        
+
         return attributedString
     }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Label "EVERYTHING ARCHIVED" is missing from the conversation list

### Causes

`paragraphStyle` is nil 

### Solutions

Creating `paragraphStyle` and assign value with `setParagraphStyle`


### Notes

Snapshot test will be created in another PR.