### PR TITLE
Update copy on confirm group deletion dialogue

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -770,6 +770,7 @@
 "conversation.delete_request_dialog.title" = "Delete group conversation?";
 "conversation.delete_request_dialog.message" = "This will delete the group and all content for all participants on all devices. There is no option to restore the content. All participants will be notified.";
 "conversation.delete_request_error_dialog.title" = "An error occured while trying to delete the group %@. Please try again.";
+"conversation.delete_request_error_dialog.button_delete_group" = "Delete Group";
 
 // Cancel connection request
 "profile.cancel_connection_request_dialog.title" = "Cancel Request?";

--- a/Wire-iOS/Sources/UserInterface/Conversation Options/UIAlertController+ConfirmRemovingGuests.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/UIAlertController+ConfirmRemovingGuests.swift
@@ -63,13 +63,13 @@ extension UIAlertController {
                                   message: String? = nil,
                                   confirmTitle: String,
                                   completion: @escaping (Bool) -> Void) -> UIAlertController {
-        let removeAction = UIAlertAction(title: confirmTitle, style: .destructive) { _ in
+        let confirmAction = UIAlertAction(title: confirmTitle, style: .destructive) { _ in
             completion(true)
         }
 
         return UIAlertController.confirmController(title: title,
                                                    message: message,
-                                                   confirmAction: removeAction,
+                                                   confirmAction: confirmAction,
                                                    completion: completion)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+DeleteGroup.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+DeleteGroup.swift
@@ -24,7 +24,7 @@ extension ConversationActionController {
         let alertController = UIAlertController.confirmController(
             title: "conversation.delete_request_dialog.title".localized,
             message: "conversation.delete_request_dialog.message".localized,
-            confirmAction: ZMConversation.Action.deleteGroup.alertAction { completion(true) },
+            confirmTitle: "conversation.delete_request_error_dialog.button_delete_group".localized,
             completion: completion
         )
         present(alertController)


### PR DESCRIPTION
## What's new in this PR?

### Issues

Confirm dialogue button says `Delete Group...`. It should not include the `...`

### Solutions

Update copy.