### PR TITLE
Fix: retire conversationLayoutMargins

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -52,7 +52,7 @@
 		163BB6141BEAA52A00606381 /* InviteContactsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 163BB6131BEAA52A00606381 /* InviteContactsViewController.m */; };
 		163BB8101EE1648100DF9384 /* ContactsDataSource+Searching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163BB80F1EE1648100DF9384 /* ContactsDataSource+Searching.swift */; };
 		163E8C7921E363FE0030BD8D /* ConversationGuestsAllowedCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163E8C7821E363FE0030BD8D /* ConversationGuestsAllowedCell.swift */; };
-		163FB98F20514DB700E74F83 /* UIView+LayoutMargins.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163FB98E20514DB700E74F83 /* UIView+LayoutMargins.swift */; };
+		163FB98F20514DB700E74F83 /* UITraitEnvironment+LayoutMargins.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163FB98E20514DB700E74F83 /* UITraitEnvironment+LayoutMargins.swift */; };
 		163FB99120518BF400E74F83 /* UIFont+FontSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163FB99020518BF400E74F83 /* UIFont+FontSpec.swift */; };
 		1642362621F0F8DE00D810B5 /* DifferenceKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1642362521F0F8DE00D810B5 /* DifferenceKit.framework */; };
 		1648EEED20498E1300CC6B37 /* SearchSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1648EEEC20498E1300CC6B37 /* SearchSectionController.swift */; };
@@ -1558,7 +1558,7 @@
 		163BB6131BEAA52A00606381 /* InviteContactsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = InviteContactsViewController.m; sourceTree = "<group>"; };
 		163BB80F1EE1648100DF9384 /* ContactsDataSource+Searching.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ContactsDataSource+Searching.swift"; sourceTree = "<group>"; };
 		163E8C7821E363FE0030BD8D /* ConversationGuestsAllowedCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationGuestsAllowedCell.swift; sourceTree = "<group>"; };
-		163FB98E20514DB700E74F83 /* UIView+LayoutMargins.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+LayoutMargins.swift"; sourceTree = "<group>"; };
+		163FB98E20514DB700E74F83 /* UITraitEnvironment+LayoutMargins.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITraitEnvironment+LayoutMargins.swift"; sourceTree = "<group>"; };
 		163FB99020518BF400E74F83 /* UIFont+FontSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+FontSpec.swift"; sourceTree = "<group>"; };
 		1642362521F0F8DE00D810B5 /* DifferenceKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DifferenceKit.framework; path = Carthage/Build/iOS/DifferenceKit.framework; sourceTree = "<group>"; };
 		1648EEEC20498E1300CC6B37 /* SearchSectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchSectionController.swift; sourceTree = "<group>"; };
@@ -5280,7 +5280,7 @@
 				162836132016574D0027082D /* ProcessInfo+Tests.swift */,
 				7C4789842021F40E00A38442 /* AddBotError+UIHandler.swift */,
 				1682AEC420484B9B003A052A /* Themeable.swift */,
-				163FB98E20514DB700E74F83 /* UIView+LayoutMargins.swift */,
+				163FB98E20514DB700E74F83 /* UITraitEnvironment+LayoutMargins.swift */,
 				BFB5972220E62EB6008720ED /* CancelableItem.swift */,
 				5E936E8E20B590530060E6AA /* UIDevice+Platform.swift */,
 				5E35F77B2182124E00D3F4FE /* PerformanceDebugger.swift */,
@@ -7417,7 +7417,7 @@
 				BFBB03061D5DF4CB0065AF4F /* InputBarButtonsView.swift in Sources */,
 				7C5836641FD5ABE7001CC843 /* AvailabilityTitleView.swift in Sources */,
 				5EDD25412140240B00C0E254 /* SettingsStaticTextCellDescriptor.swift in Sources */,
-				163FB98F20514DB700E74F83 /* UIView+LayoutMargins.swift in Sources */,
+				163FB98F20514DB700E74F83 /* UITraitEnvironment+LayoutMargins.swift in Sources */,
 				EF82E1C020EE79EC001B5196 /* ZMConversationMessage+CountDown.swift in Sources */,
 				D5CA8E572045718900D2F16E /* UINavigationController+CloseButton.swift in Sources */,
 				8FC853A5199245770008B66B /* main.m in Sources */,

--- a/Wire-iOS/Sources/Helpers/UITraitEnvironment+LayoutMargins.swift
+++ b/Wire-iOS/Sources/Helpers/UITraitEnvironment+LayoutMargins.swift
@@ -22,6 +22,11 @@ struct HorizontalMargins {
     var left: CGFloat
     var right: CGFloat
 
+    init(left: CGFloat, right: CGFloat) {
+        self.left = left
+        self.right = right
+    }
+
     init(userInterfaceSizeClass: UIUserInterfaceSizeClass) {
         switch userInterfaceSizeClass {
         case .regular:
@@ -56,18 +61,14 @@ extension UITraitEnvironment {
 
         return HorizontalMargins(userInterfaceSizeClass: userInterfaceSizeClass)
     }
-}
 
-extension UIView {
+    var directionAwareConversationLayoutMargins: HorizontalMargins {
+        let margins = conversationHorizontalMargins
 
-    class var directionAwareConversationLayoutMargins: UIEdgeInsets {
-        let margins = conversationLayoutMargins
-        
         if UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft {
-            return UIEdgeInsets(top: margins.top, left: margins.right, bottom: margins.bottom, right: margins.left)
+            return HorizontalMargins(left: margins.right, right: margins.left)
         } else {
             return margins
         }
     }
-    
 }

--- a/Wire-iOS/Sources/Helpers/UIView+LayoutMargins.swift
+++ b/Wire-iOS/Sources/Helpers/UIView+LayoutMargins.swift
@@ -60,15 +60,6 @@ extension UITraitEnvironment {
 
 extension UIView {
 
-    @available(*, deprecated, message: "Use UITraitEnvironment.conversationHorizontalMargins instead")
-    class var conversationLayoutMargins: UIEdgeInsets {
-
-        // keyWindow can be nil, in case when running tests or the view is not added to view hierachy
-        let horizontalMargins = UIApplication.shared.keyWindow?.conversationHorizontalMargins ?? HorizontalMargins(userInterfaceSizeClass: .compact)
-
-        return UIEdgeInsets(top: 0, left: horizontalMargins.left, bottom: 0, right: horizontalMargins.right)
-    }
-    
     class var directionAwareConversationLayoutMargins: UIEdgeInsets {
         let margins = conversationLayoutMargins
         

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/CellComponents/SenderCellComponent.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/CellComponents/SenderCellComponent.swift
@@ -94,7 +94,7 @@ class SenderCellComponent: UIView {
     }
     
     func createConstraints() {
-        let avatarSpacerWidthConstraint = avatarSpacer.widthAnchor.constraint(equalToConstant: UIView.conversationLayoutMargins.left)
+        let avatarSpacerWidthConstraint = avatarSpacer.widthAnchor.constraint(equalToConstant: conversationHorizontalMargins.left)
         self.avatarSpacerWidthConstraint = avatarSpacerWidthConstraint
         
         NSLayoutConstraint.activate([

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/CellComponents/SenderNameCellComponent.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/CellComponents/SenderNameCellComponent.swift
@@ -70,7 +70,7 @@ class SenderNameCellComponent: UIView {
         label.setContentCompressionResistancePriority(.required, for: .vertical)
         indicatorView.translatesAutoresizingMaskIntoConstraints = false
 
-        indicatorImageViewTrailing = indicatorView.trailingAnchor.constraint(lessThanOrEqualTo: self.trailingAnchor, constant: -UIView.conversationLayoutMargins.right)
+        indicatorImageViewTrailing = indicatorView.trailingAnchor.constraint(lessThanOrEqualTo: self.trailingAnchor, constant: -conversationHorizontalMargins.right)
 
         NSLayoutConstraint.activate([
             // indicatorView
@@ -87,7 +87,7 @@ class SenderNameCellComponent: UIView {
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        indicatorImageViewTrailing.constant = -UIView.conversationLayoutMargins.right
+        indicatorImageViewTrailing.constant = -conversationHorizontalMargins.right
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationIconBasedCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationIconBasedCell.swift
@@ -62,7 +62,7 @@ class ConversationIconBasedCell: UIView {
     }
     
     private var trailingTextMargin: CGFloat {
-        return -UIView.conversationLayoutMargins.right * 2
+        return -conversationHorizontalMargins.right * 2
     }
 
     override init(frame: CGRect) {
@@ -111,7 +111,7 @@ class ConversationIconBasedCell: UIView {
         lineView.translatesAutoresizingMaskIntoConstraints = false
 
         topContentViewTrailingConstraint = topContentView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: trailingTextMargin)
-        containerWidthConstraint = imageContainer.widthAnchor.constraint(equalToConstant: UIView.conversationLayoutMargins.left)
+        containerWidthConstraint = imageContainer.widthAnchor.constraint(equalToConstant: conversationHorizontalMargins.left)
         textLabelTrailingConstraint = textLabel.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: trailingTextMargin)
         textLabelTopConstraint = textLabel.topAnchor.constraint(equalTo: topContentView.bottomAnchor)
         
@@ -160,7 +160,7 @@ class ConversationIconBasedCell: UIView {
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        containerWidthConstraint.constant = UIView.conversationLayoutMargins.left
+        containerWidthConstraint.constant = conversationHorizontalMargins.left
         textLabelTrailingConstraint.constant = trailingTextMargin
         topContentViewTrailingConstraint.constant = trailingTextMargin
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSenderMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSenderMessageCell.swift
@@ -63,7 +63,7 @@ class ConversationSenderMessageCell: UIView, ConversationMessageCell {
         senderView.translatesAutoresizingMaskIntoConstraints = false
         indicatorImageView.translatesAutoresizingMaskIntoConstraints = false
 
-        indicatorImageViewTrailing = indicatorImageView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -UIView.conversationLayoutMargins.right)
+        indicatorImageViewTrailing = indicatorImageView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -conversationHorizontalMargins.right)
 
         NSLayoutConstraint.activate([
             // indicatorImageView
@@ -80,7 +80,7 @@ class ConversationSenderMessageCell: UIView, ConversationMessageCell {
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        indicatorImageViewTrailing.constant = -UIView.conversationLayoutMargins.right
+        indicatorImageViewTrailing.constant = -conversationHorizontalMargins.right
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
@@ -179,8 +179,8 @@ extension ConversationMessageCellDescription {
         let bottom = view.bottomAnchor.constraint(equalTo: container.bottomAnchor)
         
         top.constant = CGFloat(topMargin)
-        leading.constant = isFullWidth ? 0 : UIView.conversationLayoutMargins.left
-        trailing.constant = isFullWidth ? 0 : -UIView.conversationLayoutMargins.right
+        leading.constant = isFullWidth ? 0 : view.conversationHorizontalMargins.left
+        trailing.constant = isFullWidth ? 0 : -view.conversationHorizontalMargins.right
         
         NSLayoutConstraint.activate([leading, trailing, top, bottom])
         

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCellBurstTimestampView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConversationCellBurstTimestampView.swift
@@ -100,7 +100,7 @@ import Cartography
             view.height == 40
             
             leftSeparator.leading == view.leading
-            leftSeparator.width == UIView.conversationLayoutMargins.left - inset
+            leftSeparator.width == conversationHorizontalMargins.left - inset
             leftSeparator.centerY == view.centerY
             
             label.centerY == view.centerY

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
@@ -178,7 +178,7 @@ final class MessageToolboxView: UIView {
         heightConstraint = heightAnchor.constraint(greaterThanOrEqualToConstant: 28)
         heightConstraint.priority = UILayoutPriority(999)
 
-        likeButtonWidth = likeButtonContainer.widthAnchor.constraint(equalToConstant: UIView.conversationLayoutMargins.left)
+        likeButtonWidth = likeButtonContainer.widthAnchor.constraint(equalToConstant: conversationHorizontalMargins.left)
 
         NSLayoutConstraint.activate([
             heightConstraint,
@@ -193,7 +193,7 @@ final class MessageToolboxView: UIView {
 
             // statusTextView align vertically center
             contentStack.leadingAnchor.constraint(equalTo: likeButtonContainer.trailingAnchor),
-            contentStack.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -UIView.conversationLayoutMargins.right),
+            contentStack.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -conversationHorizontalMargins.right),
             contentStack.topAnchor.constraint(equalTo: topAnchor),
             contentStack.bottomAnchor.constraint(equalTo: bottomAnchor)
         ])
@@ -228,7 +228,7 @@ final class MessageToolboxView: UIView {
     // MARK: - Configuration
 
     private var contentWidth: CGFloat {
-        return bounds.width - UIView.conversationLayoutMargins.left - UIView.conversationLayoutMargins.right
+        return bounds.width - conversationHorizontalMargins.left - conversationHorizontalMargins.right
     }
 
     func configureForMessage(_ message: ZMConversationMessage, forceShowTimestamp: Bool, animated: Bool = false) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordViewController.swift
@@ -181,7 +181,7 @@ final class AudioRecordViewController: UIViewController, AudioRecordBaseViewCont
 
     private func createConstraints() {
         let button = buttonOverlay.audioButton
-        let margin: CGFloat = (UIView.conversationLayoutMargins.left / 2) - (StyleKitIcon.Size.tiny.rawValue / 2)
+        let margin: CGFloat = (conversationHorizontalMargins.left / 2) - (StyleKitIcon.Size.tiny.rawValue / 2)
 
         [bottomContainerView,
          topContainerView,

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
@@ -113,7 +113,7 @@ private struct InputBarConstants {
     public let rightAccessoryStackView: UIStackView = {
         let stackView = UIStackView()
 
-        let rightInset = (UIView.conversationLayoutMargins.left - rightIconSize) / 2
+        let rightInset = (stackView.conversationHorizontalMargins.left - rightIconSize) / 2
 
         stackView.spacing = 16
         stackView.axis = .horizontal
@@ -271,7 +271,7 @@ private struct InputBarConstants {
             leftAccessoryView.leading == leftAccessoryView.superview!.leading
             leftAccessoryView.top == leftAccessoryView.superview!.top
             leftAccessoryView.bottom == buttonContainer.top
-            leftAccessoryViewWidthConstraint = leftAccessoryView.width == UIView.conversationLayoutMargins.left
+            leftAccessoryViewWidthConstraint = leftAccessoryView.width == conversationHorizontalMargins.left
 
             rightAccessoryView.trailing == rightAccessoryView.superview!.trailing
             rightAccessoryView.top == rightAccessoryView.superview!.top
@@ -326,11 +326,11 @@ private struct InputBarConstants {
     }
     
     fileprivate func updateLeftAccessoryViewWidth() {
-        leftAccessoryViewWidthConstraint?.constant = UIView.conversationLayoutMargins.left
+        leftAccessoryViewWidthConstraint?.constant = conversationHorizontalMargins.left
     }
     
     fileprivate func updateRightAccessoryStackViewLayoutMargins() {
-        let rightInset = (UIView.conversationLayoutMargins.left - InputBar.rightIconSize) / 2
+        let rightInset = (conversationHorizontalMargins.left - InputBar.rightIconSize) / 2
         rightAccessoryStackView.layoutMargins = UIEdgeInsets(top: 0, left: rightInset, bottom: 0, right: rightInset)
     }
     

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarButtonsView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarButtonsView.swift
@@ -124,7 +124,7 @@ public final class InputBarButtonsView: UIView {
     // MARK: - Button Layout
     
     fileprivate var buttonMargin: CGFloat {
-        return UIView.conversationLayoutMargins.left / 2 - StyleKitIcon.Size.tiny.rawValue / 2
+        return conversationHorizontalMargins.left / 2 - StyleKitIcon.Size.tiny.rawValue / 2
     }
     
     fileprivate func layoutAndConstrainButtonRows() {
@@ -221,7 +221,7 @@ public final class InputBarButtonsView: UIView {
     fileprivate func setupInsets(forButtons buttons: [UIButton], rowIsFull: Bool) {
         let firstButton = buttons.first!
         let firstButtonLabelSize = firstButton.titleLabel!.intrinsicContentSize
-        let firstTitleMargin = (UIView.conversationLayoutMargins.left / 2) - constants.iconSize - (firstButtonLabelSize.width / 2)
+        let firstTitleMargin = (conversationHorizontalMargins.left / 2) - constants.iconSize - (firstButtonLabelSize.width / 2)
         firstButton.contentHorizontalAlignment = .left
         firstButton.imageEdgeInsets = UIEdgeInsets(top: 0, left: buttonMargin, bottom: 0, right: 0)
         firstButton.titleEdgeInsets = UIEdgeInsets(top: constants.iconSize + firstButtonLabelSize.height + constants.titleTopMargin, left: firstTitleMargin, bottom: 0, right: 0)
@@ -229,7 +229,7 @@ public final class InputBarButtonsView: UIView {
         if rowIsFull {
             let lastButton = buttons.last!
             let lastButtonLabelSize = lastButton.titleLabel!.intrinsicContentSize
-            let lastTitleMargin = UIView.conversationLayoutMargins.left / 2.0 - lastButtonLabelSize.width / 2.0
+            let lastTitleMargin = conversationHorizontalMargins.left / 2.0 - lastButtonLabelSize.width / 2.0
             lastButton.contentHorizontalAlignment = .right
             lastButton.imageEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: buttonMargin - lastButtonLabelSize.width)
             lastButton.titleEdgeInsets = UIEdgeInsets(top: constants.iconSize + lastButtonLabelSize.height + constants.titleTopMargin, left: 0, bottom: 0, right: lastTitleMargin - 1)

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ReplyComposingView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ReplyComposingView.swift
@@ -122,7 +122,7 @@ final class ReplyComposingView: UIView {
     }
     
     private func setupConstraints() {
-        let margins = UIView.directionAwareConversationLayoutMargins
+        let margins = directionAwareConversationLayoutMargins
         
         let constraints: [NSLayoutConstraint] = [
             leftSideView.leadingAnchor.constraint(equalTo: leadingAnchor),

--- a/Wire-iOS/Sources/UserInterface/Conversation/Mentions/UserSearchResultsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Mentions/UserSearchResultsViewController.swift
@@ -268,7 +268,7 @@ extension UserSearchResultsViewController: UICollectionViewDataSource {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: UserCell.reuseIdentifier, for: indexPath) as! UserCell
         cell.configure(with: user)
         cell.showSeparator = false
-        cell.avatarSpacing = UIView.conversationLayoutMargins.left
+        cell.avatarSpacing = conversationHorizontalMargins.left
 
         // hightlight the lowest cell if keyboard is collapsed
         if isKeyboardCollapsed || UIDevice.current.userInterfaceIdiom == .pad {

--- a/Wire-iOS/Sources/UserInterface/MarkdownBarView.swift
+++ b/Wire-iOS/Sources/UserInterface/MarkdownBarView.swift
@@ -45,7 +45,7 @@ public final class MarkdownBarView: UIView {
     public var activeModes = [Markdown]()
 
     private var buttonMargin: CGFloat {
-        return UIView.conversationLayoutMargins.left / 2 - StyleKitIcon.Size.tiny.rawValue / 2
+        return conversationHorizontalMargins.left / 2 - StyleKitIcon.Size.tiny.rawValue / 2
     }
     
     required public init() {


### PR DESCRIPTION
## What's new in this PR?

Follow up of https://github.com/wireapp/wire-ios/pull/3633, retire `conversationLayoutMargins` and rewrite `directionAwareConversationLayoutMargins`