### PR TITLE
[Fix] Update the App Lock setting when the app comes into foreground

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptor.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptor.swift
@@ -119,24 +119,28 @@ class SettingsSectionDescriptor: SettingsSectionDescriptorType {
         }
     }
     var visible: Bool {
-        get {
-            if let visibilityAction = self.visibilityAction {
-                return visibilityAction(self)
-            }
-            else {
-                return true
-            }
-        }
+        return visibilityAction?(self) ?? true
     }
     let visibilityAction: ((SettingsSectionDescriptorType) -> (Bool))?
 
-    let header: String?
-    let footer: String?
+    var header: String? {
+        return headerGenerator()
+    }
+    var footer: String? {
+        return footerGenerator()
+    }
     
-    init(cellDescriptors: [SettingsCellDescriptorType], header: String? = .none, footer: String? = .none, visibilityAction: ((SettingsSectionDescriptorType) -> (Bool))? = .none) {
+    let headerGenerator: () -> String?
+    let footerGenerator: () -> String?
+    
+    convenience init(cellDescriptors: [SettingsCellDescriptorType], header: String? = .none, footer: String? = .none, visibilityAction: ((SettingsSectionDescriptorType) -> (Bool))? = .none) {
+        self.init(cellDescriptors: cellDescriptors, headerGenerator: { return header }, footerGenerator: { return footer}, visibilityAction: visibilityAction)
+    }
+    
+    init(cellDescriptors: [SettingsCellDescriptorType], headerGenerator: @escaping () -> String?, footerGenerator: @escaping () -> String?, visibilityAction: ((SettingsSectionDescriptorType) -> (Bool))? = .none) {
         self.cellDescriptors = cellDescriptors
-        self.header = header
-        self.footer = footer
+        self.headerGenerator = headerGenerator
+        self.footerGenerator = footerGenerator
         self.visibilityAction = visibilityAction
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Options.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Options.swift
@@ -181,15 +181,13 @@ extension SettingsCellDescriptorFactory {
         
         cellDescriptors.append(byPopularDemandDarkThemeSection)
         
-        let context: LAContext = LAContext()
-        var error: NSError?
-        
-        if context.canEvaluatePolicy(LAPolicy.deviceOwnerAuthentication, error: &error) {
-            let lockApp = SettingsPropertyToggleCellDescriptor(settingsProperty: self.settingsPropertyFactory.property(.lockApp))
-            lockApp.settingsProperty.enabled = !AppLock.rules.forceAppLock
-            let section = SettingsSectionDescriptor(cellDescriptors: [lockApp], footer: appLockSectionSubtitle)
-            cellDescriptors.append(section)
-        }
+        let lockApp = SettingsPropertyToggleCellDescriptor(settingsProperty: self.settingsPropertyFactory.property(.lockApp))
+        lockApp.settingsProperty.enabled = !AppLock.rules.forceAppLock
+        let section = SettingsSectionDescriptor(cellDescriptors: [lockApp],
+                                                headerGenerator: { return nil },
+                                                footerGenerator: { return SettingsCellDescriptorFactory.appLockSectionSubtitle },
+                                                visibilityAction: { _ in return LAContext().canEvaluatePolicy(LAPolicy.deviceOwnerAuthentication, error: nil) })
+        cellDescriptors.append(section)
         
         let linkPreviewDescriptor = SettingsPropertyToggleCellDescriptor(settingsProperty: settingsPropertyFactory.property(.disableLinkPreviews), inverse: true)
         let linkPreviewSection = SettingsSectionDescriptor(
@@ -203,7 +201,7 @@ extension SettingsCellDescriptorFactory {
         return SettingsGroupCellDescriptor(items: cellDescriptors, title: "self.settings.options_menu.title".localized, icon: .settingsOptions)
     }
     
-    private var appLockSectionSubtitle: String {
+    private static var appLockSectionSubtitle: String {
         let timeout = TimeInterval(AppLock.rules.appLockTimeout)
         guard let amount = SettingsCellDescriptorFactory.appLockFormatter.string(from: timeout) else { return "" }
         let lockDescription = "self.settings.privacy_security.lock_app.subtitle.lock_description".localized(args: amount)


### PR DESCRIPTION
## What's new in this PR?

### Issues

App Lock setting would still be visible if you disable your passcode until you close & re-open the settings.

### Causes

The AppLock cell descriptor is only calculated once when the Setting screen is opened.

### Solutions

- Hide/show the App Lock setting dynamically by implementing the `visibilityAction` on the cell descriptor
- Add support for dynamic headers & footers so that we can display the correct AppLock subtitle
- Reload the settings tableview when the app becomes active.

### Notes

I re-factored the `SettingsTableViewController` to only calculate the visible section when necessary since it's expensive now that we query the `LAContext` in the `visibilityAction`.