### PR TITLE
[Fix] Transition to the conversation list when the selected conversation is deleted

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/Container/ViewModel/ConversationListViewControllerViewModel+ConversationListContentDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/Container/ViewModel/ConversationListViewControllerViewModel+ConversationListContentDelegate.swift
@@ -24,7 +24,7 @@ extension ConversationListViewController.ViewModel: ConversationListContentDeleg
     }
 
     func conversationList(_ controller: ConversationListContentController?, willSelectIndexPathAfterSelectionDeleted conv: IndexPath?) {
-        ZClientViewController.shared()?.transitionToListIfPossible()
+        ZClientViewController.shared()?.transitionToList(animated: true, completion: nil)
     }
 
     func conversationListDidScroll(_ controller: ConversationListContentController?) {

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController.m
@@ -184,6 +184,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
             [self.collectionView deselectItemAtIndexPath:obj animated:NO];
         }];
         [[ZClientViewController sharedZClientViewController] loadPlaceholderConversationControllerAnimated:YES];
+        [[ZClientViewController sharedZClientViewController] transitionToListAnimated:YES completion:nil];
     }
     else {
         
@@ -303,7 +304,6 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
     if (currentIndexPath == nil) {
         // Current selection is no longer available so we should unload the conversation view
         [self.listViewModel selectItem:nil];
-        [[ZClientViewController sharedZClientViewController] transitionToListAnimated:NO completion:nil];
 
     } else if (![selectedIndexPaths containsObject:currentIndexPath]) {
         // This method doesn't trigger any delegate callbacks, so no worries about special handling

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -35,12 +35,6 @@ extension ZClientViewController {
         return wr_supportedInterfaceOrientations
     }
 
-    func transitionToListIfPossible() {
-        guard splitViewController.layoutSize == .regularPortrait else { return }
-
-        transitionToList(animated: true, completion: nil)
-    }
-
     @objc(transitionToListAnimated:completion:)
     func transitionToList(animated: Bool, completion: (() -> ())?) {
         transitionToList(animated: animated,


### PR DESCRIPTION
## What's new in this PR?

If a conversation is deleted it is confusing to be in the next conversation in the list so we decided to always transition back to conversation list when the currently selected conversation goes away.