### PR TITLE
Fix: app crash when calling  conversationListViewController.select

### DIFF
--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -260,7 +260,7 @@ extension ZClientViewController {
 
     @objc(selectConversation:)
     func select(_ conversation: ZMConversation) {
-        conversationListViewController.select(conversation)
+        conversationListViewController.viewModel.select(conversation)
     }
 
     @objc


### PR DESCRIPTION
## What's new in this PR?

Call the viewModel's select coversation method instead of calling `UIResponderStandardEditActions`'s `select`.