### PR TITLE
Fix: missing ConversationListCellDelegate implemention of ConversationListContentController

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1049,6 +1049,7 @@
 		EF1ABCA82310147C00496A1B /* UIViewController+Invite.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF1ABCA72310147C00496A1B /* UIViewController+Invite.swift */; };
 		EF1BEBCD21F5E8F5001128E0 /* StartUIViewController+Constraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF1BEBCC21F5E8F5001128E0 /* StartUIViewController+Constraints.swift */; };
 		EF1C2E4D2254A1E2007E1CAC /* ConversationViewControllerSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF1C2E4C2254A1E2007E1CAC /* ConversationViewControllerSnapshotTests.swift */; };
+		EF1C7F0D232BC7A200F5DB5B /* ConversationListContentController+ConversationListCellDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF1C7F0C232BC7A200F5DB5B /* ConversationListContentController+ConversationListCellDelegate.swift */; };
 		EF1CB6F522B39CC0004CB458 /* CoreDataFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF1CB6F422B39CBF004CB458 /* CoreDataFixture.swift */; };
 		EF1CB6F722B3C430004CB458 /* CallInfoRootViewControllerSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF1CB6F622B3C430004CB458 /* CallInfoRootViewControllerSnapshotTests.swift */; };
 		EF1D80D92226D6B800BCA8D3 /* MockConversationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF16FC4D1DAFCE9300FF4325 /* MockConversationFactory.swift */; };
@@ -2844,6 +2845,7 @@
 		EF1ABCA72310147C00496A1B /* UIViewController+Invite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Invite.swift"; sourceTree = "<group>"; };
 		EF1BEBCC21F5E8F5001128E0 /* StartUIViewController+Constraints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StartUIViewController+Constraints.swift"; sourceTree = "<group>"; };
 		EF1C2E4C2254A1E2007E1CAC /* ConversationViewControllerSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationViewControllerSnapshotTests.swift; sourceTree = "<group>"; };
+		EF1C7F0C232BC7A200F5DB5B /* ConversationListContentController+ConversationListCellDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationListContentController+ConversationListCellDelegate.swift"; sourceTree = "<group>"; };
 		EF1CB6F422B39CBF004CB458 /* CoreDataFixture.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CoreDataFixture.swift; path = "Wire-iOS Tests/SwiftSnapshotTesting/CoreDataFixture.swift"; sourceTree = SOURCE_ROOT; };
 		EF1CB6F622B3C430004CB458 /* CallInfoRootViewControllerSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallInfoRootViewControllerSnapshotTests.swift; sourceTree = "<group>"; };
 		EF1D80DC22275F8F00BCA8D3 /* MockUser+MockUserArray.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MockUser+MockUserArray.swift"; sourceTree = "<group>"; };
@@ -5148,6 +5150,7 @@
 				8F8913F31A9F287E0056AB0C /* ConversationListContentController.h */,
 				EFEE97CB23229EBC007A4702 /* ConversationListContentController+Internal.h */,
 				8F8913F41A9F287E0056AB0C /* ConversationListContentController.m */,
+				EF1C7F0C232BC7A200F5DB5B /* ConversationListContentController+ConversationListCellDelegate.swift */,
 				EFEE97C523229768007A4702 /* ConversationListContentDelegate.swift */,
 				EF1DF674230E8D2000128BB8 /* ConversationListContentController+ActiveMediaPlayerObserver.swift */,
 				BAEF10F81B8C8849005BFA48 /* AnimatedListMenuView.h */,
@@ -7582,6 +7585,7 @@
 				871BC2501D34F8F800DF0793 /* MediaAsset.m in Sources */,
 				871BC2581D34F8F800DF0793 /* SwizzleTransition.m in Sources */,
 				EF266C612003B75C00A8C136 /* BreathLoadingBar.swift in Sources */,
+				EF1C7F0D232BC7A200F5DB5B /* ConversationListContentController+ConversationListCellDelegate.swift in Sources */,
 				8FC853FE199245770008B66B /* AppDelegate+Hockey.m in Sources */,
 				5E21344F21E3628F00273D0D /* AuthenticationLoginCredentialsInputHandler.swift in Sources */,
 				BFE4186F209B706600503C7C /* CallInfoViewControllerAccessoryType.swift in Sources */,

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1050,6 +1050,7 @@
 		EF1BEBCD21F5E8F5001128E0 /* StartUIViewController+Constraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF1BEBCC21F5E8F5001128E0 /* StartUIViewController+Constraints.swift */; };
 		EF1C2E4D2254A1E2007E1CAC /* ConversationViewControllerSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF1C2E4C2254A1E2007E1CAC /* ConversationViewControllerSnapshotTests.swift */; };
 		EF1C7F0D232BC7A200F5DB5B /* ConversationListContentController+ConversationListCellDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF1C7F0C232BC7A200F5DB5B /* ConversationListContentController+ConversationListCellDelegate.swift */; };
+		EF1C7F0F232BC92B00F5DB5B /* ConversationListCell+Scroll.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF1C7F0E232BC92B00F5DB5B /* ConversationListCell+Scroll.swift */; };
 		EF1CB6F522B39CC0004CB458 /* CoreDataFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF1CB6F422B39CBF004CB458 /* CoreDataFixture.swift */; };
 		EF1CB6F722B3C430004CB458 /* CallInfoRootViewControllerSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF1CB6F622B3C430004CB458 /* CallInfoRootViewControllerSnapshotTests.swift */; };
 		EF1D80D92226D6B800BCA8D3 /* MockConversationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF16FC4D1DAFCE9300FF4325 /* MockConversationFactory.swift */; };
@@ -2846,6 +2847,7 @@
 		EF1BEBCC21F5E8F5001128E0 /* StartUIViewController+Constraints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StartUIViewController+Constraints.swift"; sourceTree = "<group>"; };
 		EF1C2E4C2254A1E2007E1CAC /* ConversationViewControllerSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationViewControllerSnapshotTests.swift; sourceTree = "<group>"; };
 		EF1C7F0C232BC7A200F5DB5B /* ConversationListContentController+ConversationListCellDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationListContentController+ConversationListCellDelegate.swift"; sourceTree = "<group>"; };
+		EF1C7F0E232BC92B00F5DB5B /* ConversationListCell+Scroll.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationListCell+Scroll.swift"; sourceTree = "<group>"; };
 		EF1CB6F422B39CBF004CB458 /* CoreDataFixture.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CoreDataFixture.swift; path = "Wire-iOS Tests/SwiftSnapshotTesting/CoreDataFixture.swift"; sourceTree = SOURCE_ROOT; };
 		EF1CB6F622B3C430004CB458 /* CallInfoRootViewControllerSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallInfoRootViewControllerSnapshotTests.swift; sourceTree = "<group>"; };
 		EF1D80DC22275F8F00BCA8D3 /* MockUser+MockUserArray.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MockUser+MockUserArray.swift"; sourceTree = "<group>"; };
@@ -5138,6 +5140,7 @@
 				EFDB3134217F5E0300D2A7CE /* ConversationListCell+Internal.h */,
 				8F8913F11A9F287E0056AB0C /* ConversationListCell.h */,
 				8F8913F21A9F287E0056AB0C /* ConversationListCell.m */,
+				EF1C7F0E232BC92B00F5DB5B /* ConversationListCell+Scroll.swift */,
 				EFEE97C723229CF5007A4702 /* ConversationListCellDelegate.swift */,
 				EFDB3133217F5E0300D2A7CE /* ConversationListCell.swift */,
 				8F8913F51A9F287E0056AB0C /* ConversationListItemView.h */,
@@ -7267,6 +7270,7 @@
 				879718981D1C767600163C07 /* AudioEffectsPickerViewController.swift in Sources */,
 				8708C6821F50860100845C7D /* AccountSelectorView.swift in Sources */,
 				BF1A81281C9848DB00A96CAA /* ConversationViewController+NavigationBar.swift in Sources */,
+				EF1C7F0F232BC92B00F5DB5B /* ConversationListCell+Scroll.swift in Sources */,
 				F15650F421DD1C8B00210504 /* UIColor+Mixing.m in Sources */,
 				87F18BB61E0154FB00C69D9B /* FileTransferView.swift in Sources */,
 				EFABC922202085A6001F9866 /* UserDetailViewControllerFactory.swift in Sources */,

--- a/Wire-iOS/Sources/UserInterface/Conversation/ArchivedListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ArchivedListViewController.swift
@@ -174,12 +174,12 @@ extension ArchivedListViewController: ArchivedListViewModelDelegate {
 
 extension ArchivedListViewController: ConversationListCellDelegate {
 
-    func conversationListCellJoinCallButtonTapped(_ cell: ConversationListCell!) {
+    func conversationListCellJoinCallButtonTapped(_ cell: ConversationListCell) {
         startCallController = ConversationCallController(conversation: cell.conversation, target: self)
         startCallController?.joinCall()
     }
     
-    func conversationListCellOverscrolled(_ cell: ConversationListCell!) {
+    func conversationListCellOverscrolled(_ cell: ConversationListCell) {
         actionController = ConversationActionController(conversation: cell.conversation, target: self)
         actionController?.presentMenu(from: cell, context: .list)
     }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListCell+Internal.h
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListCell+Internal.h
@@ -18,9 +18,13 @@
 
 @class AnimatedListMenuView;
 
+static const NSTimeInterval IgnoreOverscrollTimeInterval = 0.005;
+static const NSTimeInterval OverscrollRatio = 2.5;
+
 @interface ConversationListCell ()
 
 @property (nonatomic) BOOL hasCreatedInitialConstraints;
 @property (nonatomic) AnimatedListMenuView *menuDotsView;
+@property (nonatomic) NSDate *overscrollStartDate;
 
 @end

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListCell+Scroll.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListCell+Scroll.swift
@@ -18,17 +18,23 @@
 
 import Foundation
 
-extension ConversationListContentController: ConversationListCellDelegate {
-    func conversationListCellOverscrolled(_ cell: ConversationListCell) {
-        guard let conversation = cell.conversation else {
-            return
+extension ConversationListCell {
+    override open func drawerScrollingEnded(withOffset offset: CGFloat) {
+        if menuDotsView.progress >= 1 {
+            var overscrolled = false
+            if offset > frame.width / CGFloat(OverscrollRatio) {
+                overscrolled = true
+            } else if let overscrollStartDate = overscrollStartDate {
+                let diff = Date().timeIntervalSince(overscrollStartDate)
+                overscrolled = diff > TimeInterval(IgnoreOverscrollTimeInterval)
+            }
+
+            if overscrolled {
+                delegate?.conversationListCellOverscrolled(self)
+            }
         }
-
-        contentDelegate?.conversationListContentController(self, wantsActionMenuFor: conversation, fromSourceView: cell)
-    }
-
-    func conversationListCellJoinCallButtonTapped(_ cell: ConversationListCell) {
-        startCallController = ConversationCallController(conversation: cell.conversation, target: self)
-        startCallController.joinCall()
+        overscrollStartDate = nil
     }
 }
+
+

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListCell.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListCell.m
@@ -38,17 +38,11 @@
 #import "Wire-Swift.h"
 
 
-static const NSTimeInterval IgnoreOverscrollTimeInterval = 0.005;
-static const NSTimeInterval OverscrollRatio = 2.5;
-
-
 @interface ConversationListCell () <AVSMediaManagerClientObserver>
 
 @property (nonatomic) ConversationListItemView *itemView;
 
 @property (nonatomic) NSLayoutConstraint *titleBottomMarginConstraint;
-
-@property (nonatomic) NSDate *overscrollStartDate;
 
 @property (nonatomic) id typingObserverToken;
 @end
@@ -198,24 +192,6 @@ static CGSize cachedSize = {0, 0};
 }
 
 #pragma mark - DrawerOverrides
-
-- (void)drawerScrollingEndedWithOffset:(CGFloat)offset
-{
-    if (self.menuDotsView.progress >= 1) {
-        BOOL overscrolled = NO;
-        if (offset > (CGRectGetWidth(self.frame) / OverscrollRatio)) {
-            overscrolled = YES;
-        } else if (self.overscrollStartDate) {
-            NSTimeInterval diff = [[NSDate date] timeIntervalSinceDate:self.overscrollStartDate];
-            overscrolled = (diff > IgnoreOverscrollTimeInterval);
-        }
-
-        if (overscrolled) {
-            [self.delegate conversationListCellOverscrolled:self];
-        }
-    }
-    self.overscrollStartDate = nil;
-}
 
 - (void)drawerScrollingStarts
 {

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController+ConversationListCellDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController+ConversationListCellDelegate.swift
@@ -18,8 +18,18 @@
 
 import Foundation
 
-@objc
-protocol ConversationListCellDelegate: NSObjectProtocol {
-    func conversationListCellOverscrolled(_ cell: ConversationListCell)
-    func conversationListCellJoinCallButtonTapped(_ cell: ConversationListCell)
+extension ConversationListContentController: ConversationListCellDelegate {
+    func conversationListCellOverscrolled(_ cell: ConversationListCell) {
+
+        guard let conversation = cell.conversation else {
+            return
+        }
+
+        contentDelegate?.conversationListContentController(self, wantsActionMenuFor: conversation, fromSourceView: cell)
+    }
+
+    func conversationListCellJoinCallButtonTapped(_ cell: ConversationListCell) {
+        startCallController = ConversationCallController(conversation: cell.conversation, target: self)
+        startCallController.joinCall()
+    }
 }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController.m
@@ -506,4 +506,4 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
     [self selectModelItem:previewViewController.conversation];
 }
 
-@end
+@end  


### PR DESCRIPTION
## What's new in this PR?

After https://github.com/wireapp/wire-ios/pull/3646,  `ConversationListContentController` does not conforms to `ConversationListCellDelegate`
Add back the protocol implementation and convert the caller to Swift to make sure compile error is generated for missing match type casting.