### PR TITLE
Fix: check all objc weak delegates are nullable

### DIFF
--- a/Wire-iOS Tests/AudioMessageViewTests.swift
+++ b/Wire-iOS Tests/AudioMessageViewTests.swift
@@ -99,7 +99,7 @@ final class AudioMessageViewTests: XCTestCase {
         })
 
         let mediaPlayBackManager = MediaPlaybackManager(name: "conversationMedia")
-        sut.audioTrackPlayer = mediaPlayBackManager?.audioTrackPlayer
+        sut.audioTrackPlayer = mediaPlayBackManager.audioTrackPlayer
 
         sut.audioTrackPlayer?.load(audioMessage, sourceMessage: audioMessage, completionHandler: nil)
         sut.configure(for: audioMessage, isInitial: true)

--- a/Wire-iOS/Sources/Authentication/Helpers/CountryCode/CountryCodeTableViewController.h
+++ b/Wire-iOS/Sources/Authentication/Helpers/CountryCode/CountryCodeTableViewController.h
@@ -22,6 +22,8 @@
 #import "CountryCodeBaseTableViewController.h"
 
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol CountryCodeTableViewControllerDelegate <NSObject>
 
 @optional
@@ -34,3 +36,5 @@
 @property (nonatomic, weak, nullable) id<CountryCodeTableViewControllerDelegate> delegate;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Wire-iOS/Sources/Authentication/Helpers/CountryCode/CountryCodeTableViewController.h
+++ b/Wire-iOS/Sources/Authentication/Helpers/CountryCode/CountryCodeTableViewController.h
@@ -31,6 +31,6 @@
 
 @interface CountryCodeTableViewController : CountryCodeBaseTableViewController
 
-@property (nonatomic, weak) id<CountryCodeTableViewControllerDelegate> delegate;
+@property (nonatomic, weak, nullable) id<CountryCodeTableViewControllerDelegate> delegate;
 
 @end

--- a/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationCredentialsViewController.swift
+++ b/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationCredentialsViewController.swift
@@ -297,7 +297,7 @@ class AuthenticationCredentialsViewController: AuthenticationStepController, Cou
         // no-op: handled by the input view directly
     }
 
-    func countryCodeTableViewController(_ viewController: UIViewController!, didSelect country: Country!) {
+    func countryCodeTableViewController(_ viewController: UIViewController, didSelect country: Country) {
         phoneInputView.selectCountry(country)
         viewController.dismiss(animated: true)
     }

--- a/Wire-iOS/Sources/Components/AudioPlayer/AudioTrackPlayer.h
+++ b/Wire-iOS/Sources/Components/AudioPlayer/AudioTrackPlayer.h
@@ -32,7 +32,7 @@
 @property (nonatomic, readonly) CGFloat duration;
 @property (nonatomic, readonly) NSTimeInterval elapsedTime;
 @property (nonatomic, readonly, getter=isPlaying) BOOL playing;
-@property (nonatomic, weak) id<MediaPlayerDelegate> mediaPlayerDelegate;
+@property (nonatomic, weak, nullable) id<MediaPlayerDelegate> mediaPlayerDelegate;
 
 /// Start the currently loaded/paused track.
 - (void)play;

--- a/Wire-iOS/Sources/Components/AudioPlayer/AudioTrackPlayer.h
+++ b/Wire-iOS/Sources/Components/AudioPlayer/AudioTrackPlayer.h
@@ -23,6 +23,8 @@
 
 @protocol AudioTrack;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface AudioTrackPlayer : NSObject <MediaPlayer>
 
 - (void)loadTrack:(NSObject<AudioTrack> *)track sourceMessage:(id<ZMConversationMessage>)sourceMessage completionHandler:(void(^)(BOOL loaded, NSError *error))completionHandler;
@@ -41,3 +43,5 @@
 - (void)pause;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Wire-iOS/Sources/Components/AudioPlayer/AudioTrackPlayer.h
+++ b/Wire-iOS/Sources/Components/AudioPlayer/AudioTrackPlayer.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface AudioTrackPlayer : NSObject <MediaPlayer>
 
-- (void)loadTrack:(NSObject<AudioTrack> *)track sourceMessage:(id<ZMConversationMessage>)sourceMessage completionHandler:(void(^)(BOOL loaded, NSError *error))completionHandler;
+- (void)loadTrack:(NSObject<AudioTrack> *)track sourceMessage:(id<ZMConversationMessage>)sourceMessage completionHandler:( void(^ _Nullable )(BOOL loaded, NSError *error))completionHandler;
 
 @property (nonatomic, readonly) NSObject<AudioTrack> *audioTrack;
 @property (nonatomic, readonly) CGFloat progress;

--- a/Wire-iOS/Sources/Components/TokenField/TokenTextAttachment.h
+++ b/Wire-iOS/Sources/Components/TokenField/TokenTextAttachment.h
@@ -38,7 +38,7 @@
 @interface TokenTextAttachment : NSTextAttachment
 
 @property (strong, nonatomic) Token *token;
-@property (weak, nonatomic) TokenField *tokenField;
+@property (weak, nonatomic, nullable) TokenField *tokenField;
 @property (assign, nonatomic, getter=isSelected) BOOL selected;
 
 - (instancetype)initWithToken:(Token *)token tokenField:(TokenField *)tokenField;

--- a/Wire-iOS/Sources/Components/TokenField/TokenTextAttachment.h
+++ b/Wire-iOS/Sources/Components/TokenField/TokenTextAttachment.h
@@ -25,6 +25,8 @@
 @class TokenField;
 
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface TokenSeparatorAttachment : NSTextAttachment
 
 @property (nonatomic) Token *token;
@@ -45,3 +47,5 @@
 - (void)refreshImage;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Wire-iOS/Sources/Components/TokenField/TokenizedTextView.h
+++ b/Wire-iOS/Sources/Components/TokenField/TokenizedTextView.h
@@ -23,7 +23,7 @@
 
 @class TokenizedTextView;
 
-
+NS_ASSUME_NONNULL_BEGIN
 
 @protocol TokenizedTextViewDelegate <UITextViewDelegate>
 
@@ -32,7 +32,7 @@
 
 @end
                           
-                          
+NS_ASSUME_NONNULL_END
                           
 //! Custom UITextView subclass to be used in TokenField.
 //! Shouldn't be used anywhere else.

--- a/Wire-iOS/Sources/Components/TokenField/TokenizedTextView.h
+++ b/Wire-iOS/Sources/Components/TokenField/TokenizedTextView.h
@@ -38,6 +38,6 @@
 //! Shouldn't be used anywhere else.
 @interface TokenizedTextView : TextView
 
-@property (weak, nonatomic) id< TokenizedTextViewDelegate > delegate;
+@property (weak, nonatomic, nullable) id< TokenizedTextViewDelegate > delegate;
 
 @end

--- a/Wire-iOS/Sources/Helpers/KeyValueObserver.h
+++ b/Wire-iOS/Sources/Helpers/KeyValueObserver.h
@@ -21,6 +21,8 @@
 
 
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface KeyValueObserver : NSObject
 
 @property (nonatomic, weak, nullable) id target;
@@ -57,3 +59,4 @@
 @end
 
 
+NS_ASSUME_NONNULL_END

--- a/Wire-iOS/Sources/Helpers/KeyValueObserver.h
+++ b/Wire-iOS/Sources/Helpers/KeyValueObserver.h
@@ -23,7 +23,7 @@
 
 @interface KeyValueObserver : NSObject
 
-@property (nonatomic, weak) id target;
+@property (nonatomic, weak, nullable) id target;
 @property (nonatomic) SEL selector;
 
 /// Create a Key-Value Observing helper object.

--- a/Wire-iOS/Sources/Managers/MediaPlaybackManager.h
+++ b/Wire-iOS/Sources/Managers/MediaPlaybackManager.h
@@ -26,7 +26,7 @@
 @class AudioTrackPlayer;
 @class MediaPlaybackManager;
 
-FOUNDATION_EXPORT NSString *const MediaPlaybackManagerPlayerStateChangedNotification;
+NSString *const MediaPlaybackManagerPlayerStateChangedNotification = @"MediaPlaybackManagerPlayerStateChangedNotification";
 
 /// An object that observes changes in the media playback manager.
 @protocol MediaPlaybackManagerChangeObserver
@@ -44,7 +44,7 @@ FOUNDATION_EXPORT NSString *const MediaPlaybackManagerPlayerStateChangedNotifica
 
 @property (nonatomic, readonly) AudioTrackPlayer *audioTrackPlayer;
 @property (nonatomic, weak, readonly, nullable) id<MediaPlayer> activeMediaPlayer;
-@property (nonatomic, weak) id<MediaPlaybackManagerChangeObserver> changeObserver;
+@property (nonatomic, weak, nullable) id<MediaPlaybackManagerChangeObserver> changeObserver;
 
 - (instancetype)initWithName:(NSString *)name;
 

--- a/Wire-iOS/Sources/Managers/MediaPlaybackManager.h
+++ b/Wire-iOS/Sources/Managers/MediaPlaybackManager.h
@@ -26,7 +26,7 @@
 @class AudioTrackPlayer;
 @class MediaPlaybackManager;
 
-NSString *const MediaPlaybackManagerPlayerStateChangedNotification = @"MediaPlaybackManagerPlayerStateChangedNotification";
+FOUNDATION_EXPORT NSString * _Nonnull const MediaPlaybackManagerPlayerStateChangedNotification;
 
 /// An object that observes changes in the media playback manager.
 @protocol MediaPlaybackManagerChangeObserver
@@ -42,10 +42,10 @@ NSString *const MediaPlaybackManagerPlayerStateChangedNotification = @"MediaPlay
 /// This object is an interface for AVS to control conversation media playback;
 @interface MediaPlaybackManager : NSObject <AVSMedia, MediaPlayerDelegate>
 
-@property (nonatomic, readonly) AudioTrackPlayer *audioTrackPlayer;
+@property (nonatomic, readonly, nonnull) AudioTrackPlayer *audioTrackPlayer;
 @property (nonatomic, weak, readonly, nullable) id<MediaPlayer> activeMediaPlayer;
 @property (nonatomic, weak, nullable) id<MediaPlaybackManagerChangeObserver> changeObserver;
 
-- (instancetype)initWithName:(NSString *)name;
+- (instancetype _Nonnull)initWithName:(NSString * _Nonnull)name;
 
 @end

--- a/Wire-iOS/Sources/Managers/MediaPlaybackManager.m
+++ b/Wire-iOS/Sources/Managers/MediaPlaybackManager.m
@@ -27,8 +27,6 @@
 
 static NSString* ZMLogTag ZM_UNUSED = @"UI";
 
-NSString *const MediaPlaybackManagerPlayerStateChangedNotification = @"MediaPlaybackManagerPlayerStateChangedNotification";
-
 
 @interface MediaPlaybackManager ()
 

--- a/Wire-iOS/Sources/Managers/MediaPlaybackManager.m
+++ b/Wire-iOS/Sources/Managers/MediaPlaybackManager.m
@@ -27,6 +27,8 @@
 
 static NSString* ZMLogTag ZM_UNUSED = @"UI";
 
+NSString *const MediaPlaybackManagerPlayerStateChangedNotification = @"MediaPlaybackManagerPlayerStateChangedNotification";
+
 
 @interface MediaPlaybackManager ()
 

--- a/Wire-iOS/Sources/Permissions/PermissionDeniedViewController.h
+++ b/Wire-iOS/Sources/Permissions/PermissionDeniedViewController.h
@@ -33,6 +33,6 @@
 + (instancetype)pushDeniedViewController;
 
 @property (nonatomic) BOOL backgroundBlurDisabled;
-@property (nonatomic, weak) id<PermissionDeniedViewControllerDelegate> delegate;
+@property (nonatomic, weak, nullable) id<PermissionDeniedViewControllerDelegate> delegate;
 
 @end

--- a/Wire-iOS/Sources/Permissions/PermissionDeniedViewController.h
+++ b/Wire-iOS/Sources/Permissions/PermissionDeniedViewController.h
@@ -21,6 +21,8 @@
 
 @class PermissionDeniedViewController;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol PermissionDeniedViewControllerDelegate <NSObject>
 @optional
 - (void)continueWithoutPermission:(PermissionDeniedViewController *)viewController;
@@ -36,3 +38,5 @@
 @property (nonatomic, weak, nullable) id<PermissionDeniedViewControllerDelegate> delegate;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Wire-iOS/Sources/Permissions/PermissionDeniedViewController.m
+++ b/Wire-iOS/Sources/Permissions/PermissionDeniedViewController.m
@@ -134,14 +134,14 @@
 
 #pragma mark - Actions
 
-- (IBAction)openSettings:(id)sender
+- (void)openSettings:(id)sender
 {
     [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]
                                        options:@{}
                              completionHandler:NULL];
 }
 
-- (IBAction)continueWithoutAccess:(id)sender
+- (void)continueWithoutAccess:(id)sender
 {
     if ([self.delegate respondsToSelector:@selector(continueWithoutPermission:)]) {
         [self.delegate continueWithoutPermission:self];

--- a/Wire-iOS/Sources/Permissions/ShareContactsViewController.h
+++ b/Wire-iOS/Sources/Permissions/ShareContactsViewController.h
@@ -19,6 +19,8 @@
 
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol ShareContactsViewControllerDelegate <NSObject>
 
 - (void)shareContactsViewControllerDidSkip:(UIViewController *)viewController;
@@ -28,7 +30,7 @@
 
 @interface ShareContactsViewController : UIViewController
 
-@property (nonatomic, weak) id<ShareContactsViewControllerDelegate> delegate;
+@property (nonatomic, weak, nullable) id<ShareContactsViewControllerDelegate> delegate;
 
 @property (nonatomic) BOOL uploadAddressBookImmediately;
 @property (nonatomic) BOOL backgroundBlurDisabled;
@@ -37,3 +39,5 @@
 @property (nonatomic, readonly) BOOL showingAddressBookAccessDeniedViewController;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Wire-iOS/Sources/Permissions/ShareContactsViewController.m
+++ b/Wire-iOS/Sources/Permissions/ShareContactsViewController.m
@@ -129,7 +129,7 @@
 
 #pragma mark - Actions
 
-- (IBAction)shareContacts:(id)sender
+- (void)shareContacts:(id)sender
 {
     [AddressBookHelper.sharedHelper requestPermissions:^(BOOL success) {
         if (success) {
@@ -141,7 +141,7 @@
     }];
 }
 
-- (IBAction)shareContactsLater:(id)sender
+- (void)shareContactsLater:(id)sender
 {
     [AddressBookHelper sharedHelper].addressBookSearchWasPostponed = YES;
     [self.delegate shareContactsViewControllerDidSkip:self];

--- a/Wire-iOS/Sources/UserInterface/Camera/CameraController.swift
+++ b/Wire-iOS/Sources/UserInterface/Camera/CameraController.swift
@@ -267,8 +267,6 @@ class CameraController {
         
         @available(iOS 11.0, *)
         func photoOutput(_ output: AVCapturePhotoOutput, didFinishProcessingPhoto photo: AVCapturePhoto, error: Error?) {
-            guard #available(iOS 11, *) else { return }
-
             defer { completion() }
             
             if let error = error {

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/ConfirmAssetViewController/ConfirmAssetViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/ConfirmAssetViewController/ConfirmAssetViewController.m
@@ -138,26 +138,26 @@
 
 #pragma mark - Actions
 
-- (IBAction)acceptImage:(id)sender
+- (void)acceptImage:(id)sender
 {
     if (self.onConfirm) {
         self.onConfirm(nil);
     }
 }
 
-- (IBAction)rejectImage:(id)sender
+- (void)rejectImage:(id)sender
 {
     if (self.onCancel) {
         self.onCancel();
     }
 }
 
-- (IBAction)sketchEdit:(id)sender
+- (void)sketchEdit:(id)sender
 {
     [self openSketchInEditMode:CanvasViewControllerEditModeDraw];
 }
 
-- (IBAction)emojiEdit:(id)sender
+- (void)emojiEdit:(id)sender
 {
     [self openSketchInEditMode:CanvasViewControllerEditModeEmoji];
 }

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.h
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.h
@@ -41,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) UIScrollView *scrollView;
 @property (nonatomic, readonly) id<ZMConversationMessage> message;
 @property (nonatomic) UIView *snapshotBackgroundView;
-@property (nonatomic, weak)   id <MessageActionResponder, ScreenshotProvider, MenuVisibilityController> delegate;
+@property (nonatomic, weak, nullable)   id <MessageActionResponder, ScreenshotProvider, MenuVisibilityController> delegate;
 @property (nonatomic) BOOL swipeToDismiss;
 @property (nonatomic) BOOL showCloseButton;
 @property (nonatomic, copy, nullable) void (^dismissAction)(__nullable dispatch_block_t);

--- a/Wire-iOS/Sources/UserInterface/Components/Loading/ProgressSpinner.h
+++ b/Wire-iOS/Sources/UserInterface/Components/Loading/ProgressSpinner.h
@@ -28,7 +28,7 @@
 @property (nonatomic, assign) BOOL hidesWhenStopped;
 @property (nonatomic, assign, getter=isAnimating) BOOL animating;
 
-- (IBAction)startAnimation:(id)sender;
-- (IBAction)stopAnimation:(id)sender;
+- (void)startAnimation:(id)sender;
+- (void)stopAnimation:(id)sender;
 
 @end

--- a/Wire-iOS/Sources/UserInterface/Components/Views/NextResponderTextView.h
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/NextResponderTextView.h
@@ -19,5 +19,5 @@
 #import "ResizingTextView.h"
 
 @interface NextResponderTextView : ResizingTextView
-@property (nonatomic, weak) UIResponder *overrideNextResponder;
+@property (nonatomic, weak, nullable) UIResponder *overrideNextResponder;
 @end

--- a/Wire-iOS/Sources/UserInterface/Components/Views/UpsideDownTableView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/UpsideDownTableView.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 
-class UpsideDownTableView: UITableView {
+final class UpsideDownTableView: UITableView {
 
     /// The view that allow pan gesture to scroll the tableview
     @objc weak var pannableView: UIView?

--- a/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsViewController.h
+++ b/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsViewController.h
@@ -57,8 +57,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ContactsViewController : UIViewController
 
 @property (nonatomic) ContactsDataSource *__nullable dataSource;
-@property (nonatomic, weak) id<ContactsViewControllerDelegate> __nullable delegate;
-@property (nonatomic, weak) id<ContactsViewControllerContentDelegate> __nullable contentDelegate;
+@property (nonatomic, weak, nullable) id<ContactsViewControllerDelegate> __nullable delegate;
+@property (nonatomic, weak, nullable) id<ContactsViewControllerContentDelegate> __nullable contentDelegate;
 @property (nonatomic) ColorSchemeVariant colorSchemeVariant;
 
 /// Button displayed at the bottom of the screen. If nil a default button is displayed.

--- a/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsViewController.h
+++ b/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsViewController.h
@@ -57,8 +57,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ContactsViewController : UIViewController
 
 @property (nonatomic) ContactsDataSource *__nullable dataSource;
-@property (nonatomic, weak, nullable) id<ContactsViewControllerDelegate> __nullable delegate;
-@property (nonatomic, weak, nullable) id<ContactsViewControllerContentDelegate> __nullable contentDelegate;
+@property (nonatomic, weak, nullable) id<ContactsViewControllerDelegate> delegate;
+@property (nonatomic, weak, nullable) id<ContactsViewControllerContentDelegate> contentDelegate;
 @property (nonatomic) ColorSchemeVariant colorSchemeVariant;
 
 /// Button displayed at the bottom of the screen. If nil a default button is displayed.

--- a/Wire-iOS/Sources/UserInterface/Conversation/ArchivedListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ArchivedListViewController.swift
@@ -175,12 +175,16 @@ extension ArchivedListViewController: ArchivedListViewModelDelegate {
 extension ArchivedListViewController: ConversationListCellDelegate {
 
     func conversationListCellJoinCallButtonTapped(_ cell: ConversationListCell) {
-        startCallController = ConversationCallController(conversation: cell.conversation, target: self)
+        guard let conversation = cell.conversation else { return }
+
+        startCallController = ConversationCallController(conversation: conversation, target: self)
         startCallController?.joinCall()
     }
     
     func conversationListCellOverscrolled(_ cell: ConversationListCell) {
-        actionController = ConversationActionController(conversation: cell.conversation, target: self)
+        guard let conversation = cell.conversation else { return }
+
+        actionController = ConversationActionController(conversation: conversation, target: self)
         actionController?.presentMenu(from: cell, context: .list)
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
@@ -3,16 +3,16 @@
 // Copyright (C) 2016 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
+// it under the terms of the GNU General License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU General Public License for more details.
+// GNU General License for more details.
 //
-// You should have received a copy of the GNU General Public License
+// You should have received a copy of the GNU General License
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
@@ -21,11 +21,11 @@ import Cartography
 
 private let zmLog = ZMSLog(tag: "UI")
 
-@objcMembers final class AudioMessageView: UIView, TransferView {
-    public var fileMessage: ZMConversationMessage?
-    weak public var delegate: TransferViewDelegate?
+final class AudioMessageView: UIView, TransferView {
+    var fileMessage: ZMConversationMessage?
+    weak var delegate: TransferViewDelegate?
     private var _audioTrackPlayer: AudioTrackPlayer?
-    public var audioTrackPlayer: AudioTrackPlayer? {
+    var audioTrackPlayer: AudioTrackPlayer? {
         get {
             if _audioTrackPlayer == nil {
                 _audioTrackPlayer = AppDelegate.shared().mediaPlaybackManager?.audioTrackPlayer
@@ -89,7 +89,7 @@ private let zmLog = ZMSLog(tag: "UI")
     /// flag for resume audio player after incoming call
     private var isPausedForIncomingCall : Bool
 
-    public required override init(frame: CGRect) {
+    required override init(frame: CGRect) {
         isPausedForIncomingCall = false
 
         super.init(frame: frame)
@@ -130,11 +130,11 @@ private let zmLog = ZMSLog(tag: "UI")
         audioPlayerProgressObserver = nil
     }
     
-    public required init?(coder aDecoder: NSCoder) {
+    required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
-    public override var intrinsicContentSize: CGSize {
+    override var intrinsicContentSize: CGSize {
         return CGSize(width: UIView.noIntrinsicMetric, height: 56)
     }
     
@@ -174,17 +174,17 @@ private let zmLog = ZMSLog(tag: "UI")
         
     }
     
-    public override var tintColor: UIColor! {
+    override var tintColor: UIColor! {
         didSet {
             self.downloadProgressView.tintColor = self.tintColor
         }
     }
     
-    public func stopProximitySensor() {
+    func stopProximitySensor() {
         self.proximityMonitorManager?.stopListening()
     }
     
-    public func configure(for message: ZMConversationMessage, isInitial: Bool) {
+    func configure(for message: ZMConversationMessage, isInitial: Bool) {
         self.fileMessage = message
         
         guard let fileMessageData = message.fileMessageData else {
@@ -214,7 +214,7 @@ private let zmLog = ZMSLog(tag: "UI")
         }
     }
     
-    public func willDeleteMessage() {
+    func willDeleteMessage() {
         proximityMonitorManager?.stopListening()
         guard let player = audioTrackPlayer, let source = player.sourceMessage, source.isEqual(self.fileMessage) else { return }
         player.stop()
@@ -328,12 +328,12 @@ private let zmLog = ZMSLog(tag: "UI")
         self.waveformProgressView.setProgress(progress, animated: animated)
     }
     
-    public override func layoutSubviews() {
+    override func layoutSubviews() {
         super.layoutSubviews()
         self.playButton.layer.cornerRadius = self.playButton.bounds.size.width / 2.0
     }
     
-    public func stopPlaying() {
+    func stopPlaying() {
         guard let player = self.audioTrackPlayer, let source = player.sourceMessage, source.isEqual(self.fileMessage) else { return }
         player.pause()
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
@@ -3,16 +3,16 @@
 // Copyright (C) 2016 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General License as published by
+// it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU General License for more details.
+// GNU General Public License for more details.
 //
-// You should have received a copy of the GNU General License
+// You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
@@ -403,8 +403,10 @@ private let zmLog = ZMSLog(tag: "UI")
     }
     
     func setupAudioPlayerObservers() {
-        audioPlayerProgressObserver = KeyValueObserver.observe(_audioTrackPlayer, keyPath: "progress", target: self, selector: #selector(audioProgressChanged(_:)), options: [.initial, .new])
-        audioPlayerStateObserver = KeyValueObserver.observe(_audioTrackPlayer, keyPath: "state", target: self, selector: #selector(audioPlayerStateChanged(_:)), options: [.initial, .new])
+        guard let audioTrackPlayer = _audioTrackPlayer else { return }
+        
+        audioPlayerProgressObserver = KeyValueObserver.observe(audioTrackPlayer, keyPath: "progress", target: self, selector: #selector(audioProgressChanged(_:)), options: [.initial, .new])
+        audioPlayerStateObserver = KeyValueObserver.observe(audioTrackPlayer, keyPath: "state", target: self, selector: #selector(audioPlayerStateChanged(_:)), options: [.initial, .new])
     }
 
     // MARK: - Actions

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.h
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) CGFloat bottomMargin;
 @property (nonatomic, readonly) BOOL isScrolledToBottom;
 @property (nonatomic, weak) ConversationMediaController *mediaController;
-@property (nonatomic) UpsideDownTableView *tableView;
+@property (nonatomic, nonnull) UpsideDownTableView *tableView;
 @property (nonatomic) UIView *bottomContainer;
 @property (nonatomic) NSArray<NSString *> *searchQueries;
 @property (nonatomic) UserSearchResultsViewController *mentionsSearchResultsViewController;

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.h
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) ZMConversation *conversation;
 @property (nonatomic) CGFloat bottomMargin;
 @property (nonatomic, readonly) BOOL isScrolledToBottom;
-@property (nonatomic, weak) ConversationMediaController *mediaController;
+@property (nonatomic, weak, nullable) ConversationMediaController *mediaController;
 @property (nonatomic, nonnull) UpsideDownTableView *tableView;
 @property (nonatomic) UIView *bottomContainer;
 @property (nonatomic) NSArray<NSString *> *searchQueries;

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+Constraints.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+Constraints.swift
@@ -21,9 +21,8 @@ import Foundation
 extension ConversationViewController {
     @objc
     func updateOutgoingConnectionVisibility() {
-        guard let conversation = conversation,
-            contentViewController.tableView != nil else {
-                return
+        guard let conversation = conversation else {
+            return
         }
 
         let outgoingConnection: Bool = conversation.relatedConnectionState == .sent

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InvisibleInputAccessoryView.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InvisibleInputAccessoryView.h
@@ -19,6 +19,7 @@
 
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
 
 @class InvisibleInputAccessoryView;
 
@@ -31,6 +32,8 @@
 - (void)invisibleInputAccessoryView:(InvisibleInputAccessoryView *)view superviewFrameChanged:(CGRect)frame;
 
 @end
+
+NS_ASSUME_NONNULL_END
 
 
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InvisibleInputAccessoryView.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InvisibleInputAccessoryView.h
@@ -36,7 +36,7 @@
 
 @interface InvisibleInputAccessoryView : UIView
 
-@property (nonatomic, weak) id<InvisibleInputAccessoryViewDelegate> delegate;
+@property (nonatomic, weak, nullable) id<InvisibleInputAccessoryViewDelegate> delegate;
 @property (nonatomic, assign, readwrite) CGSize intrinsicContentSize;
 
 @end

--- a/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController+PushPermissions.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController+PushPermissions.swift
@@ -49,17 +49,17 @@ extension ConversationListViewController {
     func showPermissionDeniedViewController() {
         observeApplicationDidBecomeActive()
 
-        if let permissions = PermissionDeniedViewController.push() {
-            permissions.delegate = self
+        let permissions = PermissionDeniedViewController.push()
 
-            addToSelf(permissions)
+        permissions.delegate = self
 
-            permissions.view.translatesAutoresizingMaskIntoConstraints = false
-            permissions.view.fitInSuperview()
-            pushPermissionDeniedViewController = permissions
+        addToSelf(permissions)
 
-            concealContentContainer()
-        }
+        permissions.view.translatesAutoresizingMaskIntoConstraints = false
+        permissions.view.fitInSuperview()
+        pushPermissionDeniedViewController = permissions
+
+        concealContentContainer()
     }
 
     @objc func applicationDidBecomeActive(_ notif: Notification) {

--- a/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController+PushPermissions.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController+PushPermissions.swift
@@ -19,7 +19,7 @@
 import Foundation
 
 extension ConversationListViewController: PermissionDeniedViewControllerDelegate {
-    public func continueWithoutPermission(_ viewController: PermissionDeniedViewController!) {
+    public func continueWithoutPermission(_ viewController: PermissionDeniedViewController) {
         closePushPermissionDeniedDialog()
     }
 }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/Container/ViewModel/ConversationListViewControllerViewModel+StartUIDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/Container/ViewModel/ConversationListViewControllerViewModel+StartUIDelegate.swift
@@ -21,7 +21,7 @@ import Foundation
 fileprivate typealias ConversationCreatedBlock = (ZMConversation?) -> Void
 
 extension ConversationListViewController.ViewModel: StartUIDelegate {
-    func startUI(_ startUI: StartUIViewController!, didSelect users: Set<ZMUser>!) {
+    func startUI(_ startUI: StartUIViewController, didSelect users: Set<ZMUser>) {
         guard users.count > 0 else {
             return
         }
@@ -33,14 +33,14 @@ extension ConversationListViewController.ViewModel: StartUIDelegate {
         })
     }
     
-    func startUI(_ startUI: StartUIViewController!, createConversationWith users: Set<ZMUser>?, name: String!, allowGuests: Bool, enableReceipts: Bool) {
+    func startUI(_ startUI: StartUIViewController, createConversationWith users: Set<ZMUser>, name: String, allowGuests: Bool, enableReceipts: Bool) {
         let createConversationClosure = {
             self.createConversation(withUsers: users, name: name, allowGuests: allowGuests, enableReceipts: enableReceipts)
         }
         (viewController as? UIViewController)?.dismissIfNeeded(completion: createConversationClosure)
     }
 
-    func startUI(_ startUI: StartUIViewController!, didSelect conversation: ZMConversation!) {
+    func startUI(_ startUI: StartUIViewController, didSelect conversation: ZMConversation) {
         ZClientViewController.shared()?.select(conversation, focusOnView: true, animated: true)
     }
     

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListCell.h
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListCell.h
@@ -27,7 +27,7 @@ static const CGFloat MaxVisualDrawerOffsetRevealDistance = 21;
 
 @interface ConversationListCell : SwipeMenuCollectionCell
 
-@property (nonatomic) ZMConversation *conversation;
+@property (nonatomic, nullable) ZMConversation *conversation;
 @property (nonatomic, readonly) ConversationListItemView *itemView;
 @property (nonatomic, weak, nullable) id <ConversationListCellDelegate> delegate;
 - (void)updateAppearance;

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListCell.h
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListCell.h
@@ -28,7 +28,7 @@ static const CGFloat MaxVisualDrawerOffsetRevealDistance = 21;
 @interface ConversationListCell : SwipeMenuCollectionCell
 
 @property (nonatomic, nullable) ZMConversation *conversation;
-@property (nonatomic, readonly) ConversationListItemView *itemView;
+@property (nonatomic, readonly, nonnull) ConversationListItemView *itemView;
 @property (nonatomic, weak, nullable) id <ConversationListCellDelegate> delegate;
 - (void)updateAppearance;
 - (CGSize)sizeInCollectionViewSize:(CGSize)collectionViewSize;

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController+ConversationListCellDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController+ConversationListCellDelegate.swift
@@ -28,7 +28,9 @@ extension ConversationListContentController: ConversationListCellDelegate {
     }
 
     func conversationListCellJoinCallButtonTapped(_ cell: ConversationListCell) {
-        startCallController = ConversationCallController(conversation: cell.conversation, target: self)
+        guard let conversation = cell.conversation else { return }
+        
+        startCallController = ConversationCallController(conversation: conversation, target: self)
         startCallController.joinCall()
     }
 }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController+Internal.h
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController+Internal.h
@@ -23,6 +23,8 @@
 static NSString * const CellReuseIdConnectionRequests = @"CellIdConnectionRequests";
 static NSString * const CellReuseIdConversation = @"CellId";
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface ConversationListContentController () <ConversationListViewModelDelegate, UICollectionViewDelegateFlowLayout>
 
 @property (nonatomic, strong) ConversationListViewModel *listViewModel;
@@ -42,3 +44,5 @@ static NSString * const CellReuseIdConversation = @"CellId";
 @interface ConversationListContentController (PeekAndPop) <UIViewControllerPreviewingDelegate>
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController+Internal.h
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController+Internal.h
@@ -20,8 +20,8 @@
 
 @protocol ConversationListViewModelDelegate;
 
-static NSString * const CellReuseIdConnectionRequests = @"CellIdConnectionRequests";
-static NSString * const CellReuseIdConversation = @"CellId";
+static NSString * _Nullable const CellReuseIdConnectionRequests = @"CellIdConnectionRequests";
+static NSString * _Nullable const CellReuseIdConversation = @"CellId";
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController+Internal.h
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController+Internal.h
@@ -29,12 +29,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong) ConversationListViewModel *listViewModel;
 
-@property (nonatomic) NSObject *activeMediaPlayerObserver;
-@property (nonatomic) MediaPlaybackManager *mediaPlaybackManager;
+@property (nonatomic, nullable) NSObject *activeMediaPlayerObserver;
+@property (nonatomic, nullable) MediaPlaybackManager *mediaPlaybackManager;
 @property (nonatomic) BOOL focusOnNextSelection;
 @property (nonatomic) BOOL animateNextSelection;
-@property (nonatomic) id<ZMConversationMessage> scrollToMessageOnNextSelection;
-@property (nonatomic, copy) dispatch_block_t selectConversationCompletion;
+@property (nonatomic, nullable) id<ZMConversationMessage> scrollToMessageOnNextSelection;
+@property (nonatomic, copy, nullable) dispatch_block_t selectConversationCompletion;
 @property (nonatomic) ConversationListCell *layoutCell;
 @property (nonatomic) ConversationCallController *startCallController;
 

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController.h
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak, nullable) id <ConversationListContentDelegate> contentDelegate;
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
-- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil NS_UNAVAILABLE;
+- (instancetype)initWithNibName:(nullable NSString *)nibNameOrNil bundle:(nullable NSBundle *)nibBundleOrNil NS_UNAVAILABLE;
 - (instancetype)initWithCollectionViewLayout:(UICollectionViewLayout *)layout NS_UNAVAILABLE;
 - (nonnull instancetype)init NS_DESIGNATED_INITIALIZER;
 

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController.h
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController.h
@@ -25,6 +25,8 @@
 @protocol ZMConversationMessage;
 @protocol ConversationListContentDelegate;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface ConversationListContentController : UICollectionViewController
 
 @property (nonatomic, weak, nullable) id <ConversationListContentDelegate> contentDelegate;
@@ -44,3 +46,5 @@
 - (BOOL)selectInboxAndFocusOnView:(BOOL)focus;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/Model/ConversationListViewModel.h
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/Model/ConversationListViewModel.h
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)listViewModel:(ConversationListViewModel *)model didUpdateSectionForReload:(NSUInteger)section;
 /// Delegate MUST call the updateBlock in appropriate place (e.g. collectionView performBatchUpdates:) to update the model.
 - (void)listViewModel:(ConversationListViewModel *)model didUpdateSection:(NSUInteger)section usingBlock:(dispatch_block_t)updateBlock withChangedIndexes:(ZMChangedIndexes *)changedIndexes;
-- (void)listViewModel:(ConversationListViewModel *)model didSelectItem:(id)item;
+- (void)listViewModel:(ConversationListViewModel *)model didSelectItem:(_Nullable id)item;
 - (void)listViewModel:(ConversationListViewModel *)model didUpdateConversationWithChange:(ConversationChangeInfo *)change;
 @end
 
@@ -67,7 +67,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isConversationAtIndexPath:(NSIndexPath *)indexPath;
 - (NSIndexPath *)indexPathForConversation:(id)conversation;
 
-- (BOOL)selectItem:(id)itemToSelect;
+- (BOOL)selectItem:(_Nullable id)itemToSelect;
 
 - (void)updateSection:(SectionIndex)sectionIndex;
 - (void)updateConversationListAnimated;

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/Model/ConversationListViewModel.h
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/Model/ConversationListViewModel.h
@@ -30,6 +30,7 @@ typedef NS_ENUM(NSUInteger, SectionIndex) {
     SectionIndexAll = INT_MAX,
 };
 
+NS_ASSUME_NONNULL_BEGIN
 
 @protocol ConversationListViewModelDelegate <NSObject>
 
@@ -86,3 +87,5 @@ typedef NS_ENUM(NSUInteger, SectionIndex) {
 - (NSIndexPath *)itemAfterIndex:(NSUInteger)index section:(NSUInteger)sectionIndex;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/Model/ConversationListViewModel.h
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/Model/ConversationListViewModel.h
@@ -55,7 +55,7 @@ typedef NS_ENUM(NSUInteger, SectionIndex) {
 
 @property (nonatomic, readonly) id selectedItem;
 
-@property (nonatomic, weak) id<ConversationListViewModelDelegate> delegate;
+@property (nonatomic, weak, nullable) id<ConversationListViewModelDelegate> delegate;
 
 - (NSUInteger)numberOfItemsInSection:(NSUInteger)sectionIndex;
 - (NSArray *)sectionAtIndex:(NSUInteger)sectionIndex;

--- a/Wire-iOS/Sources/UserInterface/Helpers/UIView+Constraints.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UIView+Constraints.swift
@@ -78,7 +78,7 @@ extension UIView {
 
     // MARK: - center alignment
 
-    @discardableResult /*@available(*, deprecated, message: "Use the anchors API instead")*/
+    @discardableResult @available(*, deprecated, message: "Use the anchors API instead")
     func centerInSuperview(activate: Bool = true) -> [NSLayoutConstraint] {
         guard let superview = superview else {
             fatal("Not in view hierarchy: self.superview = nil")
@@ -87,7 +87,7 @@ extension UIView {
         return alignCenter(to: superview, activate: activate)
     }
 
-    @discardableResult /*@available(*, deprecated, message: "Use the anchors API instead")*/
+    @discardableResult @available(*, deprecated, message: "Use the anchors API instead")
     func alignCenter(to view: UIView,
                      with offset: CGPoint = .zero,
                      activate: Bool = true) -> [NSLayoutConstraint] {
@@ -104,7 +104,7 @@ extension UIView {
         return constraints
     }
 
-    @discardableResult /*@available(*, deprecated, message: "Use the anchors API instead")*/
+    @discardableResult @available(*, deprecated, message: "Use the anchors API instead")
     func pinToSuperview(axisAnchor: AxisAnchor,
                         constant: CGFloat = 0,
                         activate: Bool = true) -> NSLayoutConstraint {
@@ -115,7 +115,7 @@ extension UIView {
         return pin(to: superview, axisAnchor: axisAnchor, constant: constant, activate: activate)
     }
 
-    @discardableResult /*@available(*, deprecated, message: "Use the anchors API instead")*/
+    @discardableResult @available(*, deprecated, message: "Use the anchors API instead")
     func pin(to view: UIView,
              axisAnchor: AxisAnchor,
              constant: CGFloat = 0,
@@ -148,7 +148,7 @@ extension UIView {
     ///   - inset: the inset to the edge
     ///   - activate: true by default, set to false if do not activate the NSLayoutConstraint
     /// - Returns: the NSLayoutConstraint created
-    @discardableResult /*@available(*, deprecated, message: "Use the anchors API instead")*/
+    @discardableResult @available(*, deprecated, message: "Use the anchors API instead")
     func pinToSuperview(safely: Bool = false,
                         anchor: Anchor,
                         inset: CGFloat = 0,
@@ -164,7 +164,7 @@ extension UIView {
                    activate: activate)
     }
 
-    @discardableResult /*@available(*, deprecated, message: "Use the anchors API instead")*/
+    @discardableResult @available(*, deprecated, message: "Use the anchors API instead")
     func pin(to view: UIView,
              safely: Bool = false,
              anchor: Anchor,
@@ -203,7 +203,8 @@ extension UIView {
     }
 
     // MARK: - all edges alignment
-    @discardableResult /*@available(*, deprecated, message: "Use the anchors API instead")*/
+
+    @discardableResult @available(*, deprecated, message: "Use the anchors API instead")
     func fitInSuperview(safely: Bool = false,
                         with insets: EdgeInsets = .zero,
                         exclude excludedAnchors: [Anchor] = [],
@@ -220,7 +221,7 @@ extension UIView {
                    activate: activate)
     }
 
-    @discardableResult /*/*@available(*, deprecated, message: "Use the anchors API instead")*/*/
+    @discardableResult @available(*, deprecated, message: "Use the anchors API instead")
     func pin(to view: UIView,
              safely: Bool = false,
              with insets: EdgeInsets = .zero,
@@ -271,20 +272,20 @@ extension UIView {
 
     // MARK: - dimensions
 
-    @discardableResult /*@available(*, deprecated, message: "Use the anchors API instead")*/
+    @discardableResult @available(*, deprecated, message: "Use the anchors API instead")
     func setDimensions(length: CGFloat,
                        activate: Bool = true) -> LengthConstraints {
         return setDimensions(width: length, height: length, activate: activate)
     }
 
-    @discardableResult /*@available(*, deprecated, message: "Use the anchors API instead")*/
+    @discardableResult @available(*, deprecated, message: "Use the anchors API instead")
     func setDimensions(width: CGFloat,
                        height: CGFloat,
                        activate: Bool = true) -> LengthConstraints {
         return setDimensions(size: CGSize(width: width, height: height), activate: activate)
     }
 
-    @discardableResult /*@available(*, deprecated, message: "Use the anchors API instead")*/
+    @discardableResult @available(*, deprecated, message: "Use the anchors API instead")
     func setDimensions(size: CGSize,
                        activate: Bool = true) -> LengthConstraints {
         let constraints: [LengthAnchor: NSLayoutConstraint] = [
@@ -301,7 +302,7 @@ extension UIView {
         return lengthConstraints
     }
 
-    @discardableResult /*@available(*, deprecated, message: "Use the anchors API instead")*/
+    @discardableResult @available(*, deprecated, message: "Use the anchors API instead")
     func topAndBottomEdgesToSuperviewEdges() -> [NSLayoutConstraint] {
         guard let superview = superview else { return [] }
 

--- a/Wire-iOS/Sources/UserInterface/Helpers/UIView+Constraints.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UIView+Constraints.swift
@@ -78,7 +78,7 @@ extension UIView {
 
     // MARK: - center alignment
 
-    @discardableResult @available(*, deprecated, message: "Use the anchors API instead")
+    @discardableResult /*@available(*, deprecated, message: "Use the anchors API instead")*/
     func centerInSuperview(activate: Bool = true) -> [NSLayoutConstraint] {
         guard let superview = superview else {
             fatal("Not in view hierarchy: self.superview = nil")
@@ -87,7 +87,7 @@ extension UIView {
         return alignCenter(to: superview, activate: activate)
     }
 
-    @discardableResult @available(*, deprecated, message: "Use the anchors API instead")
+    @discardableResult /*@available(*, deprecated, message: "Use the anchors API instead")*/
     func alignCenter(to view: UIView,
                      with offset: CGPoint = .zero,
                      activate: Bool = true) -> [NSLayoutConstraint] {
@@ -104,7 +104,7 @@ extension UIView {
         return constraints
     }
 
-    @discardableResult @available(*, deprecated, message: "Use the anchors API instead")
+    @discardableResult /*@available(*, deprecated, message: "Use the anchors API instead")*/
     func pinToSuperview(axisAnchor: AxisAnchor,
                         constant: CGFloat = 0,
                         activate: Bool = true) -> NSLayoutConstraint {
@@ -115,7 +115,7 @@ extension UIView {
         return pin(to: superview, axisAnchor: axisAnchor, constant: constant, activate: activate)
     }
 
-    @discardableResult @available(*, deprecated, message: "Use the anchors API instead")
+    @discardableResult /*@available(*, deprecated, message: "Use the anchors API instead")*/
     func pin(to view: UIView,
              axisAnchor: AxisAnchor,
              constant: CGFloat = 0,
@@ -148,7 +148,7 @@ extension UIView {
     ///   - inset: the inset to the edge
     ///   - activate: true by default, set to false if do not activate the NSLayoutConstraint
     /// - Returns: the NSLayoutConstraint created
-    @discardableResult @available(*, deprecated, message: "Use the anchors API instead")
+    @discardableResult /*@available(*, deprecated, message: "Use the anchors API instead")*/
     func pinToSuperview(safely: Bool = false,
                         anchor: Anchor,
                         inset: CGFloat = 0,
@@ -164,7 +164,7 @@ extension UIView {
                    activate: activate)
     }
 
-    @discardableResult @available(*, deprecated, message: "Use the anchors API instead")
+    @discardableResult /*@available(*, deprecated, message: "Use the anchors API instead")*/
     func pin(to view: UIView,
              safely: Bool = false,
              anchor: Anchor,
@@ -203,8 +203,7 @@ extension UIView {
     }
 
     // MARK: - all edges alignment
-
-    @discardableResult @available(*, deprecated, message: "Use the anchors API instead")
+    @discardableResult /*@available(*, deprecated, message: "Use the anchors API instead")*/
     func fitInSuperview(safely: Bool = false,
                         with insets: EdgeInsets = .zero,
                         exclude excludedAnchors: [Anchor] = [],
@@ -221,7 +220,7 @@ extension UIView {
                    activate: activate)
     }
 
-    @discardableResult @available(*, deprecated, message: "Use the anchors API instead")
+    @discardableResult /*/*@available(*, deprecated, message: "Use the anchors API instead")*/*/
     func pin(to view: UIView,
              safely: Bool = false,
              with insets: EdgeInsets = .zero,
@@ -272,20 +271,20 @@ extension UIView {
 
     // MARK: - dimensions
 
-    @discardableResult @available(*, deprecated, message: "Use the anchors API instead")
+    @discardableResult /*@available(*, deprecated, message: "Use the anchors API instead")*/
     func setDimensions(length: CGFloat,
                        activate: Bool = true) -> LengthConstraints {
         return setDimensions(width: length, height: length, activate: activate)
     }
 
-    @discardableResult @available(*, deprecated, message: "Use the anchors API instead")
+    @discardableResult /*@available(*, deprecated, message: "Use the anchors API instead")*/
     func setDimensions(width: CGFloat,
                        height: CGFloat,
                        activate: Bool = true) -> LengthConstraints {
         return setDimensions(size: CGSize(width: width, height: height), activate: activate)
     }
 
-    @discardableResult @available(*, deprecated, message: "Use the anchors API instead")
+    @discardableResult /*@available(*, deprecated, message: "Use the anchors API instead")*/
     func setDimensions(size: CGSize,
                        activate: Bool = true) -> LengthConstraints {
         let constraints: [LengthAnchor: NSLayoutConstraint] = [
@@ -302,7 +301,7 @@ extension UIView {
         return lengthConstraints
     }
 
-    @discardableResult @available(*, deprecated, message: "Use the anchors API instead")
+    @discardableResult /*@available(*, deprecated, message: "Use the anchors API instead")*/
     func topAndBottomEdgesToSuperviewEdges() -> [NSLayoutConstraint] {
         guard let superview = superview else { return [] }
 

--- a/Wire-iOS/Sources/UserInterface/Overlay/MediaBar/MediaBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Overlay/MediaBar/MediaBarViewController.m
@@ -90,7 +90,7 @@
 
 #pragma mark - Actions
 
-- (IBAction)playPause:(id)sender
+- (void)playPause:(id)sender
 {
     if (self.mediaPlaybackManager.activeMediaPlayer.state == MediaPlayerStatePlaying) {
         [self.mediaPlaybackManager pause];
@@ -99,7 +99,7 @@
     }
 }
 
-- (IBAction)stop:(id)sender
+- (void)stop:(id)sender
 {
     [self.mediaPlaybackManager stop];
 }

--- a/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ChangePhoneViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ChangePhoneViewController.swift
@@ -217,7 +217,7 @@ extension ChangePhoneViewController: PhoneNumberInputViewDelegate {
 }
 
 extension ChangePhoneViewController: CountryCodeTableViewControllerDelegate {
-    func countryCodeTableViewController(_ viewController: UIViewController!, didSelect country: Country!) {
+    func countryCodeTableViewController(_ viewController: UIViewController, didSelect country: Country) {
         state.selectedCountry = country
         viewController.dismiss(animated: true, completion: nil)
         updateSaveButtonState()

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/ProfilePresenter+Internal.h
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/ProfilePresenter+Internal.h
@@ -37,6 +37,6 @@
 @property (nonatomic, copy, nullable)   dispatch_block_t onDismiss;
 @property (nonatomic, nonnull) TransitionDelegate *transitionDelegate;
 
-- (void)dismissViewController:(UIViewController *)profileViewController completion:(dispatch_block_t)completion;
+- (void)dismissViewController:(UIViewController * _Nonnull)profileViewController completion:(dispatch_block_t _Nullable)completion;
 
 @end

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/ProfilePresenter+ProfileViewControllerDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/ProfilePresenter+ProfileViewControllerDelegate.swift
@@ -20,6 +20,8 @@ import Foundation
 
 extension ProfilePresenter: ProfileViewControllerDelegate {
     public func profileViewController(_ controller: ProfileViewController?, wantsToNavigateTo conversation: ZMConversation) {
+        guard let controller = controller else { return }
+        
         dismiss(controller) {
             ZClientViewController.shared()?.select(conversation, focusOnView: true, animated: true)
         }

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/TopPeopleLine/TopPeopleLineCollectionViewController.h
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/TopPeopleLine/TopPeopleLineCollectionViewController.h
@@ -30,5 +30,5 @@
 @interface TopPeopleLineCollectionViewController : NSObject <UICollectionViewDelegate, UICollectionViewDataSource>
 @property (nonatomic) NSArray<ZMConversation *> *topPeople;
 @property (nonatomic) UserSelection *userSelection;
-@property (nonatomic, weak) id<TopPeopleLineCollectionViewControllerDelegate> delegate;
+@property (nonatomic, weak, nullable) id<TopPeopleLineCollectionViewControllerDelegate> delegate;
 @end

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/TopPeopleLine/TopPeopleLineCollectionViewController.h
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/TopPeopleLine/TopPeopleLineCollectionViewController.h
@@ -21,11 +21,15 @@
 
 @class TopPeopleLineSection, UserSelection, ZMConversation;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol TopPeopleLineCollectionViewControllerDelegate <NSObject>
     
 - (void)topPeopleLineCollectionViewControllerDidSelectConversation:(ZMConversation *)conversation;
     
 @end
+
+NS_ASSUME_NONNULL_END
 
 @interface TopPeopleLineCollectionViewController : NSObject <UICollectionViewDelegate, UICollectionViewDataSource>
 @property (nonatomic) NSArray<ZMConversation *> *topPeople;

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/TopPeopleLine/TopPeopleLineCollectionViewController.h
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/TopPeopleLine/TopPeopleLineCollectionViewController.h
@@ -29,10 +29,10 @@ NS_ASSUME_NONNULL_BEGIN
     
 @end
 
-NS_ASSUME_NONNULL_END
-
 @interface TopPeopleLineCollectionViewController : NSObject <UICollectionViewDelegate, UICollectionViewDataSource>
 @property (nonatomic) NSArray<ZMConversation *> *topPeople;
 @property (nonatomic) UserSelection *userSelection;
 @property (nonatomic, weak, nullable) id<TopPeopleLineCollectionViewControllerDelegate> delegate;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/TopPeopleLine/TopPeopleSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/TopPeopleLine/TopPeopleSectionController.swift
@@ -108,7 +108,7 @@ extension TopPeopleSectionController: TopConversationsDirectoryObserver {
 
 extension TopPeopleSectionController: TopPeopleLineCollectionViewControllerDelegate {
 
-    func topPeopleLineCollectionViewControllerDidSelect(_ conversation: ZMConversation!) {
+    func topPeopleLineCollectionViewControllerDidSelect(_ conversation: ZMConversation) {
         delegate?.searchSectionController(self, didSelectConversation: conversation, at: IndexPath(row: 0, section: 0))
     }
 

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+SearchResults.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+SearchResults.swift
@@ -48,7 +48,7 @@ extension StartUIViewController: SearchResultsViewControllerDelegate {
                                             section: SearchResultsViewControllerSection) {
         
         if !user.isConnected && !user.isTeamMember {
-            self.presentProfileViewController(for: user, at: indexPath)
+            presentProfileViewController(for: user, at: indexPath)
         } else if let unboxed = user.zmUser {
             delegate?.startUI(self, didSelect: [unboxed])
         }
@@ -78,20 +78,21 @@ extension StartUIViewController: SearchResultsViewControllerDelegate {
         let detail = ServiceDetailViewController(serviceUser: user,
                                                  actionType: .openConversation,
                                                  variant: ServiceDetailVariant(colorScheme: .dark, opaque: false)) { [weak self] result in
-            guard let `self` = self else { return }
+            guard let weakSelf = self else { return }
+
             if let result = result {
                 switch result {
                 case .success(let conversation):
-                    delegate?.startUI(self, didSelect: conversation)
+                    weakSelf.delegate?.startUI(weakSelf, didSelect: conversation)
                 case .failure(let error):
-                    error.displayAddBotError(in: self)
+                    error.displayAddBotError(in: weakSelf)
                 }
             } else {
-                self.navigationController?.dismiss(animated: true, completion: nil)
+                weakSelf.navigationController?.dismiss(animated: true, completion: nil)
             }
         }
         
-        self.navigationController?.pushViewController(detail, animated: true)
+        navigationController?.pushViewController(detail, animated: true)
     }
     
     public func searchResultsViewController(_ searchResultsViewController: SearchResultsViewController,
@@ -127,14 +128,16 @@ extension StartUIViewController: SearchResultsViewControllerDelegate {
         }
         
         GuestRoomEvent.created.track()
-        self.showLoadingView = true
-        userSession.performChanges {
+        showLoadingView = true
+        userSession.performChanges { [weak self] in
+            guard let weakSelf = self else { return }
+
             let conversation = ZMConversation.insertGroupConversation(intoUserSession: userSession,
                                                                       withParticipants: [],
                                                                       name: "general.guest-room-name".localized,
                                                                       in: ZMUser.selfUser().team,
                                                                       allowGuests: true)
-            delegate?.startUI(self, didSelect: conversation)
+            self?.delegate?.startUI(weakSelf, didSelect: conversation)
         }
     }
 }
@@ -156,8 +159,10 @@ extension StartUIViewController: ConversationCreationControllerDelegate {
                                         participants: Set<ZMUser>,
                                         allowGuests: Bool,
                                         enableReceipts: Bool) {
-        dismiss(controller: controller) {
-            delegate?.startUI(self, createConversationWith: participants, name: name, allowGuests: allowGuests, enableReceipts: enableReceipts)
+        dismiss(controller: controller) { [weak self] in
+            guard let weakSelf = self else { return }
+
+            weakSelf.delegate?.startUI(weakSelf, createConversationWith: participants, name: name, allowGuests: allowGuests, enableReceipts: enableReceipts)
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+SearchResults.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+SearchResults.swift
@@ -50,7 +50,7 @@ extension StartUIViewController: SearchResultsViewControllerDelegate {
         if !user.isConnected && !user.isTeamMember {
             self.presentProfileViewController(for: user, at: indexPath)
         } else if let unboxed = user.zmUser {
-            delegate.startUI(self, didSelect: [unboxed])
+            delegate?.startUI(self, didSelect: [unboxed])
         }
     }
     
@@ -62,13 +62,13 @@ extension StartUIViewController: SearchResultsViewControllerDelegate {
             return
         }
         
-        self.delegate.startUI(self, didSelect: [unboxedUser])
+        delegate?.startUI(self, didSelect: [unboxedUser])
     }
     
     public func searchResultsViewController(_ searchResultsViewController: SearchResultsViewController,
                                             didTapOnConversation conversation: ZMConversation) {
         if conversation.conversationType == .group || conversation.conversationType == .oneOnOne {
-            self.delegate.startUI(self, didSelect: conversation)
+            delegate?.startUI(self, didSelect: conversation)
         }
     }
     
@@ -82,7 +82,7 @@ extension StartUIViewController: SearchResultsViewControllerDelegate {
             if let result = result {
                 switch result {
                 case .success(let conversation):
-                    self.delegate.startUI(self, didSelect: conversation)
+                    delegate?.startUI(self, didSelect: conversation)
                 case .failure(let error):
                     error.displayAddBotError(in: self)
                 }
@@ -134,7 +134,7 @@ extension StartUIViewController: SearchResultsViewControllerDelegate {
                                                                       name: "general.guest-room-name".localized,
                                                                       in: ZMUser.selfUser().team,
                                                                       allowGuests: true)
-            self.delegate.startUI(self, didSelect: conversation)
+            delegate?.startUI(self, didSelect: conversation)
         }
     }
 }
@@ -157,7 +157,7 @@ extension StartUIViewController: ConversationCreationControllerDelegate {
                                         allowGuests: Bool,
                                         enableReceipts: Bool) {
         dismiss(controller: controller) {
-            self.delegate.startUI(self, createConversationWith: participants, name: name, allowGuests: allowGuests, enableReceipts: enableReceipts)
+            delegate?.startUI(self, createConversationWith: participants, name: name, allowGuests: allowGuests, enableReceipts: enableReceipts)
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.h
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.h
@@ -25,7 +25,7 @@
 
 @interface StartUIViewController : UIViewController
 
-@property (nonatomic, weak) id <StartUIDelegate> delegate;
+@property (nonatomic, weak, nullable) id <StartUIDelegate> delegate;
 @property (nonatomic, readonly) UIScrollView *scrollView;
 
 - (void)showKeyboardIfNeeded;

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.h
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.h
@@ -23,6 +23,8 @@
 
 @protocol StartUIDelegate;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface StartUIViewController : UIViewController
 
 @property (nonatomic, weak, nullable) id <StartUIDelegate> delegate;
@@ -38,3 +40,5 @@
 - (void)startUI:(StartUIViewController *)startUI createConversationWithUsers:(NSSet<ZMUser *> *)users name:(NSString *)name allowGuests:(BOOL)allowGuests enableReceipts:(BOOL)enableReceipts;
 - (void)startUI:(StartUIViewController *)startUI didSelectConversation:(ZMConversation *)conversation;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Devices/UserClientListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Devices/UserClientListViewController.swift
@@ -155,7 +155,7 @@ extension UserClientListViewController: ZMUserObserver {
 }
 
 extension UserClientListViewController: ParticipantDeviceHeaderViewDelegate {
-    func participantsDeviceHeaderViewDidTapLearnMore(_ headerView: ParticipantDeviceHeaderView!) {
+    func participantsDeviceHeaderViewDidTapLearnMore(_ headerView: ParticipantDeviceHeaderView) {
         URL.wr_fingerprintLearnMore.openInApp(above: self)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Views/ParticipantDeviceHeaderView+UITextViewDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Views/ParticipantDeviceHeaderView+UITextViewDelegate.swift
@@ -21,7 +21,7 @@ import Foundation
 extension ParticipantDeviceHeaderView: UITextViewDelegate {
 
     public func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
-        delegate.participantsDeviceHeaderViewDidTapLearnMore(self)
+        delegate?.participantsDeviceHeaderViewDidTapLearnMore(self)
 
         return false
     }

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Views/ParticipantDeviceHeaderView.h
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Views/ParticipantDeviceHeaderView.h
@@ -25,7 +25,7 @@
 
 - (instancetype)initWithUserName:(NSString *)userName;
 
-@property (weak, nonatomic) id <ParticipantDeviceHeaderViewDelegate> delegate;
+@property (weak, nonatomic, nullable) id <ParticipantDeviceHeaderViewDelegate> delegate;
 @property (nonatomic, readonly) NSString *userName;
 @property (nonatomic) BOOL showUnencryptedLabel;
 

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Views/ParticipantDeviceHeaderView.h
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Views/ParticipantDeviceHeaderView.h
@@ -21,6 +21,8 @@
 
 @protocol ParticipantDeviceHeaderViewDelegate;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface ParticipantDeviceHeaderView : UIView
 
 - (instancetype)initWithUserName:(NSString *)userName;
@@ -37,3 +39,5 @@
 - (void)participantsDeviceHeaderViewDidTapLearnMore:(ParticipantDeviceHeaderView *)headerView;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Views/ParticipantDeviceHeaderView.h
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Views/ParticipantDeviceHeaderView.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol ParticipantDeviceHeaderViewDelegate <NSObject>
 
-- (void)participantsDeviceHeaderViewDidTapLearnMore:(ParticipantDeviceHeaderView *)headerView;
+- (void)participantsDeviceHeaderViewDidTapLearnMore:(ParticipantDeviceHeaderView * _Nonnull)headerView;
 
 @end
 


### PR DESCRIPTION
## What's new in this PR?

- Add `nullable` for weak delegates
- Add `NS_ASSUME_NONNULL_BEGIN` to reduce warnings
