### PR TITLE
Fix: Don't ask for a password on logout if the user doesn't have a password

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsSignOutCellDescriptor.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsSignOutCellDescriptor.swift
@@ -32,22 +32,57 @@ class SettingsSignOutCellDescriptor: SettingsExternalScreenCellDescriptor {
                    icon: nil,
                    accessoryViewMode: .default)
         
-        requestPasswordController = RequestPasswordController(context: .logout, callback: { (password) in
-            guard let password = password else { return }
-            
+
+    }
+    
+    func logout(password: String? = nil) {
+        guard let selfUser = ZMUser.selfUser() else { return }
+    
+        if selfUser.usesCompanyLogin || password != nil {
             ZClientViewController.shared()?.showLoadingView = true
-            ZMUserSession.shared()?.logout(credentials: ZMEmailCredentials(email: "", password: password), { (result) in
+            ZMUserSession.shared()?.logout(credentials: ZMEmailCredentials(email: "", password: password ?? ""), { (result) in
                 ZClientViewController.shared()?.showLoadingView = false
                 
                 if case .failure(let error) = result {
                     ZClientViewController.shared()?.showAlert(forError: error)
                 }
             })
-        })
+        } else {
+            guard let account = SessionManager.shared?.accountManager.selectedAccount else { return }
+            
+            SessionManager.shared?.delete(account: account)
+        }
+        
     }
     
     override func generateViewController() -> UIViewController? {
-        return requestPasswordController?.alertController
+        guard let selfUser = ZMUser.selfUser() else { return nil }
+        
+        var viewController: UIViewController? = nil
+        
+        if selfUser.emailAddress == nil || selfUser.usesCompanyLogin {
+            let alert = UIAlertController(title: "self.settings.account_details.log_out.alert.title".localized,
+                                          message: "self.settings.account_details.log_out.alert.message".localized,
+                                          preferredStyle: .alert)
+            let actionCancel = UIAlertAction(title: "general.cancel".localized, style: .cancel, handler: nil)
+            let actionLogout = UIAlertAction(title: "general.ok".localized, style: .destructive, handler: { [weak self] _ in
+                self?.logout()
+            })
+            alert.addAction(actionCancel)
+            alert.addAction(actionLogout)
+            
+            viewController = alert
+        } else {
+            requestPasswordController = RequestPasswordController(context: .logout, callback: { [weak self] (password) in
+                guard let password = password else { return }
+                
+                self?.logout(password: password)
+            })
+            
+            viewController = requestPasswordController?.alertController
+        }
+        
+        return viewController
     }
     
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

We started to remove the client when logging out from an account which normally requires the login password. User's who logged in via SSO or phone number doesn't have a password associated with their account though.

### Solutions

- Don't attempt to delete client for phone login users.
- Don't ask for a password if the user uses SSO since the backend doesn't require it in this case.