### PR TITLE
Fix: archived 1:1 conversation not opening when selected from search

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/Container/ViewModel/ConversationListViewControllerViewModel+StartUIDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/Container/ViewModel/ConversationListViewControllerViewModel+StartUIDelegate.swift
@@ -27,7 +27,9 @@ extension ConversationListViewController.ViewModel: StartUIDelegate {
         }
         
         withConversationForUsers(users, callback: { conversation in
-            if let conversation = conversation {
+            guard let conversation = conversation else { return }
+            
+            conversation.unarchive() {
                 ZClientViewController.shared()?.select(conversation, focusOnView: true, animated: true)
             }
         })


### PR DESCRIPTION
## What's new in this PR?

### Issues

When archiving or deleting the content of a 1:1 conversation, which implicitly archives, it would not open the conversation when selecting it from search.

### Causes

The conversation is not unarchived when we try to select it in the conversation so it fails to open.

### Solutions

Unarchive the conversation before we try to select it in the conversation list.