### PR TITLE
Fix: newly created group doesnt open and show up in recent list view

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/Container/ViewModel/ConversationListViewControllerViewModel+StartUIDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/Container/ViewModel/ConversationListViewControllerViewModel+StartUIDelegate.swift
@@ -86,7 +86,7 @@ extension ConversationListViewController.ViewModel: StartUIDelegate {
             conversation = ZMConversation.insertGroupConversation(intoUserSession: userSession, withParticipants: Array(users), name: name, in: ZMUser.selfUser().team, allowGuests: allowGuests, readReceipts: enableReceipts)
         }, completionHandler:{
             delay(0.3) {
-                ZClientViewController.shared()?.select(conversation, focusOnView: true, animated: true)
+                ZClientViewController.shared()?.select(conversation, focusOnView: true, animated: true)///TODO: convo not on list??
             }
         })
     }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/Container/ViewModel/ConversationListViewControllerViewModel+StartUIDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/Container/ViewModel/ConversationListViewControllerViewModel+StartUIDelegate.swift
@@ -86,7 +86,7 @@ extension ConversationListViewController.ViewModel: StartUIDelegate {
             conversation = ZMConversation.insertGroupConversation(intoUserSession: userSession, withParticipants: Array(users), name: name, in: ZMUser.selfUser().team, allowGuests: allowGuests, readReceipts: enableReceipts)
         }, completionHandler:{
             delay(0.3) {
-                ZClientViewController.shared()?.select(conversation, focusOnView: true, animated: true)///TODO: convo not on list??
+                ZClientViewController.shared()?.select(conversation, focusOnView: true, animated: true)
             }
         })
     }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.m
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.m
@@ -253,7 +253,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
 - (BOOL)selectModelItem:(id)itemToSelect
 {
     return [self.listViewModel selectItem:itemToSelect];
-}
+}///TODO: mv to VM
 
 - (void)deselectAll
 {

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
@@ -664,14 +664,14 @@ extension ConversationListViewModel: ConversationDirectoryObserver {
             reload()
         } else {
             for updatedList in changeInfo.updatedLists {
-                if let kind = self.kind(conversationListType: updatedList) {
+                if let kind = self.kind(of: updatedList) {
                     updateForConversationType(kind: kind)
                 }
             }
         }
     }
 
-    private func kind(conversationListType: ConversationListType) -> Section.Kind? {
+    private func kind(of conversationListType: ConversationListType) -> Section.Kind? {
 
         let kind: Section.Kind?
 

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
@@ -444,20 +444,20 @@ final class ConversationListViewModel: NSObject {
     }
     
     @discardableResult
-    private func updateForConversationType(section: Section.Kind) -> Bool {
-        guard let sectionNumber = self.sectionNumber(for: section) else { return false }
+    private func updateForConversationType(kind: Section.Kind) -> Bool {
+        guard let sectionNumber = self.sectionNumber(for: kind) else { return false }
 
-        let newConversationList = ConversationListViewModel.newList(for: section, userSession: userSession)
+        let newConversationList = ConversationListViewModel.newList(for: kind, userSession: userSession)
 
         /// no need to update collapsed section's cells but the section header, update the stored list
 
         if collapsed(at: sectionNumber), newConversationList.count > 0 {
-            update(kind: section, with: newConversationList)
+            update(kind: kind, with: newConversationList)
             delegate?.listViewModel(self, didUpdateSectionForReload: UInt(sectionNumber))
             return true
         }
 
-        if let oldConversationList = sectionItems(for: section),
+        if let oldConversationList = sectionItems(for: kind),
             oldConversationList != newConversationList {
 
 
@@ -471,7 +471,7 @@ final class ConversationListViewModel: NSObject {
                 // It is important to keep the data source of the collection view consistent, since
                 // any inconsistency in the delta update would make it throw an exception.
                 let modelUpdates = {
-                    self.update(kind: section, with: newConversationList)
+                    self.update(kind: kind, with: newConversationList)
                 }
                 
                 delegate?.listViewModel(self, didUpdateSection: UInt(sectionNumber), usingBlock: modelUpdates, with: changedIndexes)
@@ -490,7 +490,7 @@ final class ConversationListViewModel: NSObject {
             reload()
         } else {
             sectionKinds.forEach() {
-                updateForConversationType(section: $0)
+                updateForConversationType(kind: $0)
             }
         }
     }
@@ -524,7 +524,7 @@ final class ConversationListViewModel: NSObject {
 
     private func internalSelect(itemToSelect: AnyHashable?) {
         selectedItem = itemToSelect
-        delegate?.listViewModel(self, didSelectItem: itemToSelect)
+        delegate?.listViewModel(self, didSelectItem: itemToSelect)/// TODO: nil item later?
     }
 
     func subscribeToTeamsUpdates() {
@@ -677,7 +677,7 @@ extension ConversationListViewModel: ConversationDirectoryObserver {
                 case .archived:
                     continue
                 }
-                updateForConversationType(section: kind)
+                updateForConversationType(kind: kind)
             }
         }
     }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
@@ -669,11 +669,11 @@ extension ConversationListViewModel: ConversationDirectoryObserver {
                 case .unarchived:
                     kind = .conversations
                 case .contacts:
-                    kind = .contacts
+                    kind = folderEnabled ? .contacts : .conversations 
                 case .pending:
                     kind = .contactRequests
                 case .groups:
-                    kind = .group
+                    kind = folderEnabled ? .group : .conversations
                 case .archived:
                     continue
                 }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
@@ -524,7 +524,7 @@ final class ConversationListViewModel: NSObject {
 
     private func internalSelect(itemToSelect: AnyHashable?) {
         selectedItem = itemToSelect
-        delegate?.listViewModel(self, didSelectItem: itemToSelect)/// TODO: nil item later?
+        delegate?.listViewModel(self, didSelectItem: itemToSelect)
     }
 
     func subscribeToTeamsUpdates() {
@@ -669,7 +669,7 @@ extension ConversationListViewModel: ConversationDirectoryObserver {
                 case .unarchived:
                     kind = .conversations
                 case .contacts:
-                    kind = folderEnabled ? .contacts : .conversations 
+                    kind = folderEnabled ? .contacts : .conversations
                 case .pending:
                     kind = .contactRequests
                 case .groups:

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
@@ -664,21 +664,33 @@ extension ConversationListViewModel: ConversationDirectoryObserver {
             reload()
         } else {
             for updatedList in changeInfo.updatedLists {
-                let kind: Section.Kind
-                switch updatedList {
-                case .unarchived:
-                    kind = .conversations
-                case .contacts:
-                    kind = folderEnabled ? .contacts : .conversations
-                case .pending:
-                    kind = .contactRequests
-                case .groups:
-                    kind = folderEnabled ? .group : .conversations
-                case .archived:
-                    continue
+                if let kind = self.kind(conversationListType: updatedList) {
+                    updateForConversationType(kind: kind)
                 }
-                updateForConversationType(kind: kind)
             }
         }
+    }
+
+    private func kind(conversationListType: ConversationListType) -> Section.Kind? {
+
+        let kind: Section.Kind?
+
+        switch (conversationListType, folderEnabled) {
+        case (.unarchived, _),
+             (.contacts, false),
+             (.groups, false):
+            kind = .conversations
+        case (.contacts, true):
+            kind = .contacts
+        case (.pending, _):
+            kind = .contactRequests
+        case (.groups, true):
+            kind = .group
+        case (.archived, _):
+            kind = nil
+        }
+
+        return kind
+
     }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

After a user creates a new group, the conversation is not opened

### Causes

The new created conversation is not on the conversation list. The conversation screen is dismissed after selected a nil conversation.

### Solutions

When `ConversationDirectoryChangeInfo` contains a `groups` in the list, update the conversation list for non folder enabled mode.