### PR TITLE
Fix: update conversation selection behaviour

### DIFF
--- a/Wire-iOS Tests/ConversationList/ConversationListViewModel/ConversationListViewModelTests.swift
+++ b/Wire-iOS Tests/ConversationList/ConversationListViewModel/ConversationListViewModelTests.swift
@@ -228,19 +228,14 @@ final class ConversationListViewModelTests: XCTestCase {
 
     // MARK: - state
     func testThatSectionIsExpendedAfterSelected() {
+        ///GIVEN
         sut.folderEnabled = true
-
         let mockConversation = ZMConversation()
-
         fillDummyConversations(mockConversation: mockConversation)
-
-        ///WHEN
         sut.setCollapsed(sectionIndex: Int(sectionGroups), collapsed: true)///todo
 
-        ///THEN
-        XCTAssert(sut.collapsed(at: Int(sectionGroups)))
-
         ///WHEN
+        XCTAssert(sut.collapsed(at: Int(sectionGroups)))
         XCTAssert(sut.select(itemToSelect: mockConversation))
 
         ///THEN

--- a/Wire-iOS Tests/ConversationList/ConversationListViewModel/ConversationListViewModelTests.swift
+++ b/Wire-iOS Tests/ConversationList/ConversationListViewModel/ConversationListViewModelTests.swift
@@ -243,6 +243,7 @@ final class ConversationListViewModelTests: XCTestCase {
     }
 
     func testThatCollapseStateCanBeRestoredAfterFolderDisabled() {
+        ///GIVEN
         sut.folderEnabled = true
 
         let mockConversation = ZMConversation()
@@ -254,18 +255,12 @@ final class ConversationListViewModelTests: XCTestCase {
         ///WHEN
         sut.setCollapsed(sectionIndex: 1, collapsed: true)
 
-        ///THEN
         XCTAssert(sut.collapsed(at: 1))
-
-        ///WHEN
 
         /// all folder are not collapsed when folder disabled
         sut.folderEnabled = false
 
-        ///THEN
         XCTAssertFalse(sut.collapsed(at: 1))
-
-        ///WHEN
         sut.folderEnabled = true
 
         ///THEN

--- a/Wire-iOS Tests/ConversationList/ConversationListViewModel/ConversationListViewModelTests.swift
+++ b/Wire-iOS Tests/ConversationList/ConversationListViewModel/ConversationListViewModelTests.swift
@@ -227,6 +227,26 @@ final class ConversationListViewModelTests: XCTestCase {
     }
 
     // MARK: - state
+    func testThatSectionIsExpendedAfterSelected() {
+        sut.folderEnabled = true
+
+        let mockConversation = ZMConversation()
+
+        fillDummyConversations(mockConversation: mockConversation)
+
+        ///WHEN
+        sut.setCollapsed(sectionIndex: Int(sectionGroups), collapsed: true)///todo
+
+        ///THEN
+        XCTAssert(sut.collapsed(at: Int(sectionGroups)))
+
+        ///WHEN
+        XCTAssert(sut.select(itemToSelect: mockConversation))
+
+        ///THEN
+        XCTAssertFalse(sut.collapsed(at: Int(sectionGroups)))
+    }
+
     func testThatCollapseStateCanBeRestoredAfterFolderDisabled() {
         sut.folderEnabled = true
 

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
@@ -82,10 +82,19 @@ final class ConversationListViewModel: NSObject {
     @objc
     static let contactRequestsItem: ConversationListConnectRequestsItem = ConversationListConnectRequestsItem()
 
-    /// ZMConversaton or ConversationListConnectRequestsItem
-    ///TODO: protocol
+    /// current selected ZMConversaton or ConversationListConnectRequestsItem object
+    ///TODO: create protocol of these 2 classes
     @objc
-    private(set) var selectedItem: AnyHashable?
+    private(set) var selectedItem: AnyHashable? {
+        didSet {
+            /// expend the section if selcted item is update
+            guard selectedItem != oldValue,
+                  let indexPath = self.indexPath(for: selectedItem),
+                  collapsed(at: indexPath.section) else { return }
+
+            setCollapsed(sectionIndex: indexPath.section, collapsed: false, batchUpdate: false)
+        }
+    }
 
     @objc
     weak var delegate: ConversationListViewModelDelegate?


### PR DESCRIPTION
## What's new in this PR?

Expend the collapsed folder when one of the items is selected.