### PR TITLE
Fix: It's not possible to copy link in a message by long pressing

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Views/LinkInteractionTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/LinkInteractionTextView.swift
@@ -102,16 +102,25 @@ extension LinkInteractionTextView: UITextViewDelegate {
     
     func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
         switch interaction {
-        case .invokeDefaultAction:
+        case .invokeDefaultAction: ///TODO: tap on iOS 12 sim link goes to here
+            
             guard !UIMenuController.shared.isMenuVisible else {
                 return false // Don't open link/show alert if menu controller is visible
             }
-            
+
             // if alert shown, link opening is handled in alert actions
             if showAlertIfNeeded(for: URL, in: characterRange) { return false }
-            // data detector links should be handle by the system
-            return dataDetectedURLSchemes.contains(URL.scheme ?? "") || !(interactionDelegate?.textView(self, open: URL) ?? false)
-        case .presentActions:
+
+            if textView.gestureRecognizers?.contains(where: {$0.isKind(of: UITapGestureRecognizer.self) && $0.state == .ended}) == true {
+                
+                // data detector links should be handle by the system
+                return dataDetectedURLSchemes.contains(URL.scheme ?? "") || !(interactionDelegate?.textView(self, open: URL) ?? false)
+            }
+            
+            return true
+            
+            
+        case .presentActions:///TODO: check iOS13 goes to here?
             interactionDelegate?.textViewDidLongPress(self)
             return false
         case .preview:

--- a/Wire-iOS/Sources/UserInterface/Components/Views/LinkInteractionTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/LinkInteractionTextView.swift
@@ -18,7 +18,7 @@
 
 
 import UIKit
- 
+
 protocol TextViewInteractionDelegate: class {
     func textView(_ textView: LinkInteractionTextView, open url: URL) -> Bool
     func textViewDidLongPress(_ textView: LinkInteractionTextView)
@@ -111,22 +111,22 @@ extension LinkInteractionTextView: UITextViewDelegate {
             // if alert shown, link opening is handled in alert actions
             if showAlertIfNeeded(for: URL, in: characterRange) { return false }
 
-            let shouldInteractWithURL = dataDetectedURLSchemes.contains(URL.scheme ?? "") || !(interactionDelegate?.textView(self, open: URL) ?? false)
-
+            /// workaround for iOS 13 - this delegate method is called multiple times and we only want to handle it when the state == .ended
             if #available(iOS 13.0, *) {
                 if textView.gestureRecognizers?.contains(where: {$0.isKind(of: UITapGestureRecognizer.self) && $0.state == .ended}) == true {
+
                     // data detector links should be handle by the system
-                    return shouldInteractWithURL
-                } else {
-                    return false
+                    return dataDetectedURLSchemes.contains(URL.scheme ?? "") || !(interactionDelegate?.textView(self, open: URL) ?? false)
                 }
+
+                return true
             } else {
-                return shouldInteractWithURL
+                // data detector links should be handle by the system
+                return dataDetectedURLSchemes.contains(URL.scheme ?? "") || !(interactionDelegate?.textView(self, open: URL) ?? false)
             }
-        case .presentActions:
-            interactionDelegate?.textViewDidLongPress(self)
-            return false
-        case .preview:
+            
+        case .presentActions,
+             .preview:
             // do not allow peeking links, as it blocks showing the menu for replies
             interactionDelegate?.textViewDidLongPress(self)
             return false

--- a/Wire-iOS/Sources/UserInterface/Components/Views/LinkInteractionTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/LinkInteractionTextView.swift
@@ -19,17 +19,17 @@
 
 import UIKit
  
-@objc public protocol TextViewInteractionDelegate: NSObjectProtocol {
+protocol TextViewInteractionDelegate: class {
     func textView(_ textView: LinkInteractionTextView, open url: URL) -> Bool
     func textViewDidLongPress(_ textView: LinkInteractionTextView)
 }
 
 
-final public class LinkInteractionTextView: UITextView {
+final class LinkInteractionTextView: UITextView {
     
-    public weak var interactionDelegate: TextViewInteractionDelegate?
+    weak var interactionDelegate: TextViewInteractionDelegate?
 
-    override public var selectedTextRange: UITextRange? {
+    override var selectedTextRange: UITextRange? {
         get { return nil }
         set { /* no-op */ }
     }
@@ -46,11 +46,11 @@ final public class LinkInteractionTextView: UITextView {
         }
     }
     
-    required public init?(coder aDecoder: NSCoder) {
+    required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override public func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
         let isInside = super.point(inside: point, with: event)
         guard !UIMenuController.shared.isMenuVisible else { return false }
         guard let position = characterRange(at: point), isInside else { return false }
@@ -94,13 +94,13 @@ final public class LinkInteractionTextView: UITextView {
 
 extension LinkInteractionTextView: UITextViewDelegate {
     
-    public func textView(_ textView: UITextView, shouldInteractWith textAttachment: NSTextAttachment, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
+    func textView(_ textView: UITextView, shouldInteractWith textAttachment: NSTextAttachment, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
         guard interaction == .presentActions else { return true }
         interactionDelegate?.textViewDidLongPress(self)
         return false
     }
     
-    public func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
+    func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
         switch interaction {
         case .invokeDefaultAction:
             guard !UIMenuController.shared.isMenuVisible else {
@@ -128,7 +128,7 @@ extension LinkInteractionTextView: UITextViewDelegate {
 @available(iOS 11.0, *)
 extension LinkInteractionTextView: UITextDragDelegate {
     
-    public func textDraggableView(_ textDraggableView: UIView & UITextDraggable, itemsForDrag dragRequest: UITextDragRequest) -> [UIDragItem] {
+    func textDraggableView(_ textDraggableView: UIView & UITextDraggable, itemsForDrag dragRequest: UITextDragRequest) -> [UIDragItem] {
         
         func isMentionLink(_ attributeTuple: (NSAttributedString.Key, Any)) -> Bool {
             return attributeTuple.0 == NSAttributedString.Key.link && (attributeTuple.1 as? NSURL)?.scheme ==  Mention.mentionScheme

--- a/Wire-iOS/Sources/UserInterface/Components/Views/LinkInteractionTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/LinkInteractionTextView.swift
@@ -102,7 +102,7 @@ extension LinkInteractionTextView: UITextViewDelegate {
     
     func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
         switch interaction {
-        case .invokeDefaultAction: ///TODO: tap on iOS 12 sim link goes to here
+        case .invokeDefaultAction:
             
             guard !UIMenuController.shared.isMenuVisible else {
                 return false // Don't open link/show alert if menu controller is visible
@@ -111,16 +111,19 @@ extension LinkInteractionTextView: UITextViewDelegate {
             // if alert shown, link opening is handled in alert actions
             if showAlertIfNeeded(for: URL, in: characterRange) { return false }
 
-            if textView.gestureRecognizers?.contains(where: {$0.isKind(of: UITapGestureRecognizer.self) && $0.state == .ended}) == true {
-                
-                // data detector links should be handle by the system
-                return dataDetectedURLSchemes.contains(URL.scheme ?? "") || !(interactionDelegate?.textView(self, open: URL) ?? false)
+            let shouldInteractWithURL = dataDetectedURLSchemes.contains(URL.scheme ?? "") || !(interactionDelegate?.textView(self, open: URL) ?? false)
+
+            if #available(iOS 13.0, *) {
+                if textView.gestureRecognizers?.contains(where: {$0.isKind(of: UITapGestureRecognizer.self) && $0.state == .ended}) == true {
+                    // data detector links should be handle by the system
+                    return shouldInteractWithURL
+                } else {
+                    return false
+                }
+            } else {
+                return shouldInteractWithURL
             }
-            
-            return true
-            
-            
-        case .presentActions:///TODO: check iOS13 goes to here?
+        case .presentActions:
             interactionDelegate?.textViewDidLongPress(self)
             return false
         case .preview:


### PR DESCRIPTION
## What's new in this PR?

### Issues

On iOS13, when pressing a link, it is opened immediately and the user can not trigger the menu.

### Causes

Seems like a bug of iOS 13. `shouldInteractWith` delegate method is called multiple times.

### Solutions

Check the tap gesture has `.ended` state before opens the URL.