### PR TITLE
fix: avatar image overlaps user name if user name is very long

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListTopBarViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListTopBarViewController.swift
@@ -76,7 +76,7 @@ final class ConversationListTopBarViewController: UIViewController {
         topBar?.middleView = createTitleView()
     }
     
-    func createTitleView() -> UIView {
+    private func createTitleView() -> UIView {
         if selfUser.isTeamMember {
             let availabilityViewController = AvailabilityTitleViewController(user: selfUser, options: .header)
             availabilityViewController.availabilityTitleView?.colorSchemeVariant = .dark
@@ -91,7 +91,7 @@ final class ConversationListTopBarViewController: UIViewController {
             titleLabel.font = FontSpec(.normal, .semibold).font
             titleLabel.textColor = UIColor.from(scheme: .textForeground, variant: .dark)
             titleLabel.accessibilityTraits = .header
-            titleLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+            titleLabel.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
             titleLabel.setContentCompressionResistancePriority(.required, for: .vertical)
             titleLabel.setContentHuggingPriority(.required, for: .horizontal)
             titleLabel.setContentHuggingPriority(.required, for: .vertical)


### PR DESCRIPTION
## What's new in this PR?

Reduce user name label's `ContentCompressionResistancePriority` to prevent it breaks the leading anchor to the left icon view.