### PR TITLE
Fix: conversation list updates showing an incorrect state

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
@@ -741,17 +741,7 @@ extension ConversationListViewModel: ZMUserObserver {
 
 extension ConversationListViewModel: ConversationDirectoryObserver {
     func conversationDirectoryDidChange(_ changeInfo: ConversationDirectoryChangeInfo) {
-        if changeInfo.reloaded {
-            // If the section was empty in certain cases collection view breaks down on the big amount of conversations,
-            // so we prefer to do the simple reload instead.
-            reload()
-        } else {
-            for updatedList in changeInfo.updatedLists {
-                if let kind = self.kind(of: updatedList) {
-                    updateForConversationType(kind: kind)
-                }
-            }
-        }
+        reload() // NOTE temporarily reloading on all changes.
     }
 
     private func kind(of conversationListType: ConversationListType) -> Section.Kind? {


### PR DESCRIPTION
## What's new in this PR?

### Issues

The conversation list updating is breaking in some cases with the introduction of folders.

### Causes

The collection view update logic is not build to handle multiple sections.

### Solutions

Reload the collection view on changes for now and take the time to implement proper support for multiple section updates.