### PR TITLE
Fix: incorrect status bar style when showing the folder picker

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Folders/FolderPickerViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Folders/FolderPickerViewController.swift
@@ -61,6 +61,11 @@ final class FolderPickerViewController: UIViewController {
         configureConstraints()
     }
     
+    override public func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        UIApplication.shared.wr_updateStatusBarForCurrentControllerAnimated(animated)
+    }
+    
     private func configureNavbar() {
         title = "folder.picker.title".localized(uppercased: true)
         


### PR DESCRIPTION
## What's new in this PR?

### Issues

Status bar would be white on white when showing the folder picker.

### Causes

We weren't updating the status bar style when displaying the folder picker

### Solutions

Update status bar style.
