### PR TITLE
Fix: It's not possible to copy link in a message by long pressing

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Views/LinkInteractionTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/LinkInteractionTextView.swift
@@ -111,8 +111,12 @@ extension LinkInteractionTextView: UITextViewDelegate {
             // if alert shown, link opening is handled in alert actions
             if showAlertIfNeeded(for: URL, in: characterRange) { return false }
 
-            /// workaround for iOS 13 - this delegate method is called multiple times and we only want to handle it when the state == .ended
-            if #available(iOS 13.0, *) {
+            if #available(iOS 13.2, *) {
+                // data detector links should be handle by the system
+                return dataDetectedURLSchemes.contains(URL.scheme ?? "") || !(interactionDelegate?.textView(self, open: URL) ?? false)
+            } else if #available(iOS 13.0, *) {
+                /// workaround for iOS 13 - this delegate method is called multiple times and we only want to handle it when the state == .ended
+                /// the issue is fixed on iOS 13.2 and no need this workaround
                 if textView.gestureRecognizers?.contains(where: {$0.isKind(of: UITapGestureRecognizer.self) && $0.state == .ended}) == true {
 
                     // data detector links should be handle by the system


### PR DESCRIPTION
## What's new in this PR?
Follow up of https://github.com/wireapp/wire-ios/pull/3714/file, tested with an iOS 13.2 beta 2 device and no need to apply for the work-around for that.