### PR TITLE
fix: folder picker status bar is black on black

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Folders/FolderPickerViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Folders/FolderPickerViewController.swift
@@ -65,7 +65,11 @@ final class FolderPickerViewController: UIViewController {
         super.viewWillAppear(animated)
         UIApplication.shared.wr_updateStatusBarForCurrentControllerAnimated(animated)
     }
-    
+
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return ColorScheme.default.statusBarStyle
+    }
+
     private func configureNavbar() {
         title = "folder.picker.title".localized(uppercased: true)
         


### PR DESCRIPTION
## What's new in this PR?

Define `preferredStatusBarStyle` to adapt dark/light mode variations. 