### PR TITLE
Fix: crash when perusing "create guest link" button

### DIFF
--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
@@ -159,6 +159,10 @@ final class GroupDetailsViewController: UIViewController, ZMConversationObserver
         updateLegalHoldIndicator()
         collectionViewController.sections = computeVisibleSections()
         footerView.update(for: conversation)
+        
+        if changeInfo.participantsChanged, !conversation.isSelfAnActiveMember {
+           navigationController?.popToRootViewController(animated: true)
+        }
     }
     
     func footerView(_ view: GroupDetailsFooterView, shouldPerformAction action: GroupDetailsFooterView.Action) {


### PR DESCRIPTION
## What's new in this PR?

### Issues

You can crash the app if 
1. You are navigate to the guest settings the conversation details. 
2. You get removed from the conversation
3. You press "create guest link" button

### Causes

It's an illegal action to create a guest link for a conversation you're not a member of and if you do it we will intentionally crash the app.

### Solutions

Dismiss the guest settings if you are removed from a conversation.