### PR TITLE
fix: hidden notificationsWindow without using makeKey

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
@@ -26,20 +26,16 @@ extension Notification.Name {
     static let appUnlocked = Notification.Name("AppUnlocked")
 }
 
-@objcMembers final class AppLockViewController: UIViewController {
+final class AppLockViewController: UIViewController {
     fileprivate var lockView: AppLockView!
     fileprivate var localAuthenticationCancelled: Bool = false
     fileprivate var localAuthenticationNeeded: Bool = true
 
     fileprivate var dimContents: Bool = false {
         didSet {
-            self.view.isHidden = !self.dimContents
-                        
-            if dimContents {
-                AppDelegate.shared().notificationsWindow?.makeKey()
-            } else {
-                AppDelegate.shared().window.makeKey()
-            }
+            view.isHidden = !dimContents
+
+            AppDelegate.shared().notificationsWindow?.isHidden = !dimContents
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
@@ -33,9 +33,7 @@ final class AppLockViewController: UIViewController {
 
     fileprivate var dimContents: Bool = false {
         didSet {
-            view.isHidden = !dimContents
-
-            AppDelegate.shared().notificationsWindow?.isHidden = !dimContents
+            view.window?.isHidden = !dimContents
         }
     }
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

In https://github.com/wireapp/wire-ios/pull/3730, we found that the other window in front of main window overrides status bar style and hidden.

### Causes

The notification windows and call windows always exist and cover the main window

### Solutions

Set empty windows hidden instead of calling `makeKey` to prevent it overrides the status bar.