### PR TITLE
Fix: app crashes when expanding a section

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
@@ -333,9 +333,6 @@ extension ConversationListContentController: ConversationListViewModelDelegate {
     }
 
     func listViewModel(_ model: ConversationListViewModel?, didUpdateSectionForReload section: Int, animated: Bool) {
-        // do not reload if section is not visible
-        guard collectionView.indexPathsForVisibleItems.map({$0.section}).contains(section) else { return }
-
         let reloadClosure = {
             self.collectionView.reloadSections(IndexSet(integer: section))
             self.ensureCurrentSelection()

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
@@ -584,6 +584,13 @@ final class ConversationListViewModel: NSObject {
         return state.collapsed.contains(kind.identifier)
     }
 
+
+    /// set a collpase state of a section
+    ///
+    /// - Parameters:
+    ///   - sectionIndex: section to update
+    ///   - collapsed: collapsed or expanded
+    ///   - batchUpdate: true for update with difference kit comparison, false for reload the section animated
     func setCollapsed(sectionIndex: Int,
                       collapsed: Bool,
                       batchUpdate: Bool = true) {
@@ -613,7 +620,7 @@ final class ConversationListViewModel: NSObject {
             }
         } else {
             sections = newValue
-            delegate?.listViewModel(self, didUpdateSectionForReload: sectionIndex, animated: false)
+            delegate?.listViewModel(self, didUpdateSectionForReload: sectionIndex, animated: true)
         }
     }
 

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
@@ -510,7 +510,7 @@ final class ConversationListViewModel: NSObject {
         return nil
     }
 
-    private func updateForConversationType(kind: Section.Kind) {
+    private func update(for kind: Section.Kind) {
         guard let conversationDirectory = userSession?.conversationDirectory else { return }
         
         var newValue: [Section]
@@ -567,7 +567,7 @@ final class ConversationListViewModel: NSObject {
     private func internalSelect(itemToSelect: ConversationListItem?) {
         selectedItem = itemToSelect
 
-        if let itemToSelect = itemToSelect as? ConversationListItem {
+        if let itemToSelect = itemToSelect {
             delegate?.listViewModel(self, didSelectItem: itemToSelect)
         }
     }
@@ -691,7 +691,7 @@ extension ConversationListViewModel: ConversationDirectoryObserver {
             /// TODO: wait for SE update for returning multiple items in changeInfo.updatedLists
             for updatedList in changeInfo.updatedLists {
                 if let kind = self.kind(of: updatedList) {
-                    updateForConversationType(kind: kind)
+                    update(for kind: kind)
                 }
             }
         }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
@@ -691,7 +691,7 @@ extension ConversationListViewModel: ConversationDirectoryObserver {
             /// TODO: wait for SE update for returning multiple items in changeInfo.updatedLists
             for updatedList in changeInfo.updatedLists {
                 if let kind = self.kind(of: updatedList) {
-                    update(for kind: kind)
+                    update(for: kind)
                 }
             }
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

When a favourite conversation is selected and the favourite folder is collapsed, app crash

### Causes

When the favourite conversation, the favourite folder is not expanded and hence the calculation of collection view index path is incorrect.

### Solutions

Remove the guard for reloading the section.
Change the reload section to animated.