### PR TITLE
Fix: app goes back to search ui after unblocking user 

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/RotationAwareNavigationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/RotationAwareNavigationController.swift
@@ -24,6 +24,14 @@ final class RotationAwareNavigationController: UINavigationController, PopoverPr
         super.dismiss(animated: flag, completion: completion)///TODO: also called when dismiss child
     } ///TODO: viewDidDismiss??
 
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+    }
+
     // PopoverPresenter
     weak var presentedPopover: UIPopoverPresentationController?
     weak var popoverPointToView: UIView?    

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/RotationAwareNavigationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/RotationAwareNavigationController.swift
@@ -20,17 +20,6 @@
 import Foundation
 
 final class RotationAwareNavigationController: UINavigationController, PopoverPresenter {
-    override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
-        super.dismiss(animated: flag, completion: completion)///TODO: also called when dismiss child
-    } ///TODO: viewDidDismiss??
-
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-    }
-
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-    }
 
     // PopoverPresenter
     weak var presentedPopover: UIPopoverPresentationController?

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/RotationAwareNavigationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/RotationAwareNavigationController.swift
@@ -20,7 +20,10 @@
 import Foundation
 
 final class RotationAwareNavigationController: UINavigationController, PopoverPresenter {
-    
+    override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+        super.dismiss(animated: flag, completion: completion)///TODO: also called when dismiss child
+    } ///TODO: viewDidDismiss??
+
     // PopoverPresenter
     weak var presentedPopover: UIPopoverPresentationController?
     weak var popoverPointToView: UIView?    

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsViewController.swift
@@ -31,6 +31,10 @@ final class ProfileDetailsViewController: UIViewController, Themeable {
         super.viewDidAppear(animated)
     }
 
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+    }
+
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
     }

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsViewController.swift
@@ -23,6 +23,9 @@ import UIKit
  */
 
 final class ProfileDetailsViewController: UIViewController, Themeable {
+    override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+        super.dismiss(animated: flag, completion: completion)
+    }
 
     /// The user whose profile is displayed.
     let user: UserType

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsViewController.swift
@@ -27,6 +27,14 @@ final class ProfileDetailsViewController: UIViewController, Themeable {
         super.dismiss(animated: flag, completion: completion)
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+    }
+
     /// The user whose profile is displayed.
     let user: UserType
 

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsViewController.swift
@@ -23,21 +23,6 @@ import UIKit
  */
 
 final class ProfileDetailsViewController: UIViewController, Themeable {
-    override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
-        super.dismiss(animated: flag, completion: completion)
-    }
-
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-    }
-
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-    }
-
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-    }
 
     /// The user whose profile is displayed.
     let user: UserType

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileActionsFactory.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileActionsFactory.swift
@@ -141,17 +141,14 @@ final class ProfileActionsFactory: NSObject {
             conversation = selfConversation
         } else if context == .profileViewer {
             conversation = nil
-        } else {
-            if !user.isConnected {
-                if user.isPendingApprovalByOtherUser {
-                    return [.cancelConnectionRequest]
-                } else if !user.isPendingApprovalBySelfUser {
-                    return [.connect]
-                }
+        } else if !user.isConnected {
+            if user.isPendingApprovalByOtherUser {
+                return [.cancelConnectionRequest]
+            } else if !user.isPendingApprovalBySelfUser {
+                return [.connect]
             }
-
-            return []
         }
+
 
         var actions: [ProfileAction] = []
 
@@ -174,6 +171,7 @@ final class ProfileActionsFactory: NSObject {
             }
 
         case (.profileViewer, .none),
+             (.search, .none),
              (_, .group?):
             // Do nothing if the viewer is a wireless user because they can't have 1:1's
             if viewer.isWirelessUser {

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileActionsFactory.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileActionsFactory.swift
@@ -115,10 +115,9 @@ final class ProfileActionsFactory: NSObject {
 
     // MARK: - Calculating the Actions
 
-    /**
-     * Calculates the list of actions to display to the user.
-     */
-
+    /// Calculates the list of actions to display to the user.
+    ///
+    /// - Returns: array of availble actions
     func makeActionsList() -> [ProfileAction] {
         // Do nothing if the user was deleted
         if user.isAccountDeleted {

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController+Extension.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController+Extension.swift
@@ -20,21 +20,6 @@ import Foundation
 
 // MARK: - Keyboard frame observer
 extension ProfileViewController {
-    open override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
-        super.dismiss(animated: flag, completion: completion)
-    }
-
-//    open override func viewDidAppear(_ animated: Bool) {
-//        super.viewDidAppear(animated)
-//    }
-
-    open override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-    }
-
-    open override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-    }
 
     @objc func setupKeyboardFrameNotification() {
         NotificationCenter.default.addObserver(self,
@@ -310,6 +295,9 @@ extension ProfileViewController: ProfileFooterViewDelegate, IncomingRequestFoote
     // MARK: Block
 
     private func presentBlockRequest(from targetView: UIView) {
+//        handleBlockResult(BlockResult.block(isBlocked: true))
+//        return
+
         let controller = UIAlertController(title: BlockResult.title(for: bareUser), message: nil, preferredStyle: .actionSheet)
         BlockResult.all(isBlocked: bareUser.isBlocked).map { $0.action(handleBlockResult) }.forEach(controller.addAction)
         presentAlert(controller, targetView: targetView)

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController+Extension.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController+Extension.swift
@@ -20,8 +20,20 @@ import Foundation
 
 // MARK: - Keyboard frame observer
 extension ProfileViewController {
-    override open func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+    open override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
         super.dismiss(animated: flag, completion: completion)
+    }
+
+//    open override func viewDidAppear(_ animated: Bool) {
+//        super.viewDidAppear(animated)
+//    }
+
+    open override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+    }
+
+    open override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
     }
 
     @objc func setupKeyboardFrameNotification() {

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController+Extension.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController+Extension.swift
@@ -317,9 +317,20 @@ extension ProfileViewController: ProfileFooterViewDelegate, IncomingRequestFoote
 
     private func handleBlockResult(_ result: BlockResult) {
         guard case .block = result else { return }
-        transitionToListAndEnqueue {
+
+        let updateClosure = {
             self.fullUser()?.toggleBlocked()
             self.updateFooterViews()
+        }
+
+        switch context {
+            case .search:
+                /// stay on this VC and let user to decise what to do next
+                updateClosure()
+            default:
+                transitionToListAndEnqueue {
+                    updateClosure()
+                }
         }
     }
 

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController+Extension.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController+Extension.swift
@@ -295,8 +295,6 @@ extension ProfileViewController: ProfileFooterViewDelegate, IncomingRequestFoote
     // MARK: Block
 
     private func presentBlockRequest(from targetView: UIView) {
-//        handleBlockResult(BlockResult.block(isBlocked: true))
-//        return
 
         let controller = UIAlertController(title: BlockResult.title(for: bareUser), message: nil, preferredStyle: .actionSheet)
         BlockResult.all(isBlocked: bareUser.isBlocked).map { $0.action(handleBlockResult) }.forEach(controller.addAction)

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController+Extension.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController+Extension.swift
@@ -31,10 +31,9 @@ extension ProfileViewController {
     @objc func keyboardFrameDidChange(notification: Notification) {
         updatePopoverFrame()
     }
-}
 
-// MARK: - init
-extension ProfileViewController {
+    // MARK: - init
+
     override open var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return wr_supportedInterfaceOrientations
     }
@@ -75,6 +74,35 @@ extension ProfileViewController {
         
         addToSelf(tabsController)
     }
+
+    // MARK : - constraints
+
+    @objc
+    func setupConstraints() {
+        usernameDetailsView.translatesAutoresizingMaskIntoConstraints = false
+        tabsController.view.translatesAutoresizingMaskIntoConstraints = false
+        profileFooterView.translatesAutoresizingMaskIntoConstraints = false
+
+        usernameDetailsView.fitInSuperview(exclude: [.bottom])
+        tabsController.view?.topAnchor.constraint(equalTo: usernameDetailsView.bottomAnchor).isActive = true
+        tabsController.view.fitInSuperview(exclude: [.top])
+        profileFooterView.fitInSuperview(exclude: [.top])
+
+        incomingRequestFooter.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            incomingRequestFooter.bottomAnchor.constraint(equalTo: profileFooterView.topAnchor),
+            incomingRequestFooter.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            incomingRequestFooter.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+            ])
+    }
+
+    // MARK: - Factories
+
+    @objc func makeUserNameDetailViewModel() -> UserNameDetailViewModel {
+        return UserNameDetailViewModel(user: bareUser, fallbackName: bareUser.displayName, addressBookName: bareUser.zmUser?.addressBookEntry?.cachedName)
+    }
+
 }
 
 extension ProfileViewController: ViewControllerDismisser {
@@ -353,39 +381,4 @@ extension ProfileViewController: ProfileFooterViewDelegate, IncomingRequestFoote
 
         presentAlert(controller, targetView: view)
     }
-}
-
-// MARK : - constraints
-
-extension ProfileViewController {
-
-    @objc
-    func setupConstraints() {
-        usernameDetailsView.translatesAutoresizingMaskIntoConstraints = false
-        tabsController.view.translatesAutoresizingMaskIntoConstraints = false
-        profileFooterView.translatesAutoresizingMaskIntoConstraints = false
-
-        usernameDetailsView.fitInSuperview(exclude: [.bottom])
-        tabsController.view?.topAnchor.constraint(equalTo: usernameDetailsView.bottomAnchor).isActive = true
-        tabsController.view.fitInSuperview(exclude: [.top])
-        profileFooterView.fitInSuperview(exclude: [.top])
-
-        incomingRequestFooter.translatesAutoresizingMaskIntoConstraints = false
-
-        NSLayoutConstraint.activate([
-            incomingRequestFooter.bottomAnchor.constraint(equalTo: profileFooterView.topAnchor),
-            incomingRequestFooter.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            incomingRequestFooter.trailingAnchor.constraint(equalTo: view.trailingAnchor)
-            ])
-    }
-}
-
-// MARK: - Factories
-
-extension ProfileViewController {
-
-    @objc func makeUserNameDetailViewModel() -> UserNameDetailViewModel {
-        return UserNameDetailViewModel(user: bareUser, fallbackName: bareUser.displayName, addressBookName: bareUser.zmUser?.addressBookEntry?.cachedName)
-    }
-
 }

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController+Extension.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController+Extension.swift
@@ -20,6 +20,10 @@ import Foundation
 
 // MARK: - Keyboard frame observer
 extension ProfileViewController {
+    override open func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+        super.dismiss(animated: flag, completion: completion)
+    }
+
     @objc func setupKeyboardFrameNotification() {
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(keyboardFrameDidChange(notification:)),

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.m
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.m
@@ -47,7 +47,7 @@
 @end
 
 
-
+///TODO:when dismiss??
 @implementation ProfileViewController
 
 - (id)initWithUser:(id<UserType>)user viewer:(id<UserType>)viewer context:(ProfileViewControllerContext)context

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.m
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.m
@@ -47,7 +47,6 @@
 @end
 
 
-///TODO:when dismiss??
 @implementation ProfileViewController
 
 - (id)initWithUser:(id<UserType>)user viewer:(id<UserType>)viewer context:(ProfileViewControllerContext)context


### PR DESCRIPTION
## What's new in this PR?

### Issues

When unblocking a user form search UI, the profile screen dismisses immediately.

### Causes

`transitionToListAndEnqueue` is called for all the cases.

### Solutions

When the context is `search` do not call `transitionToListAndEnqueue` and update the footer bar to let the user opens the conversation.