### PR TITLE
Fix: Applock unlock needs two fingerprint scans to unlock. 

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
@@ -91,8 +91,7 @@ final class AppLockViewController: UIViewController {
         
             if self.localAuthenticationCancelled {
                 self.lockView.showReauth = true
-            }
-            else {
+            } else {
                 self.lockView.showReauth = false
                 self.requireLocalAuthenticationIfNeeded { result in
                     
@@ -107,8 +106,7 @@ final class AppLockViewController: UIViewController {
                     }
                 }
             }
-        }
-        else {
+        } else {
             self.lockView.showReauth = false
             self.dimContents = false
         }
@@ -128,7 +126,7 @@ final class AppLockViewController: UIViewController {
             callback(.granted)
             return
         }
-        
+
         AppLock.evaluateAuthentication(description: "self.settings.privacy_security.lock_app.description".localized) { result in
             DispatchQueue.main.async {
                 callback(result)
@@ -139,11 +137,9 @@ final class AppLockViewController: UIViewController {
             }
         }
     }
-}
 
-// MARK: - Application state observators
+    // MARK: - Application state observators
 
-extension AppLockViewController {
     @objc func applicationWillResignActive() {
         if AppLock.isActive {
             self.dimContents = true

--- a/WireCommonComponents/AppLock.swift
+++ b/WireCommonComponents/AppLock.swift
@@ -56,15 +56,18 @@ final public class AppLock {
         case unavailable
     }
 
-    private static weak var context: LAContext? = nil
+
+    /// a weak reference to LAContext, it should be nil when evaluatePolicy is done.
+    private static weak var weakLAContext: LAContext? = nil
+
     // Creates a new LAContext and evaluates the authentication settings of the user.
     public static func evaluateAuthentication(description: String, with callback: @escaping (AuthenticationResult) -> Void) {
-        guard AppLock.context == nil else { return }
+        guard AppLock.weakLAContext == nil else { return }
 
         let context: LAContext = LAContext()
         var error: NSError?
 
-        AppLock.context = context
+        AppLock.weakLAContext = context
         if context.canEvaluatePolicy(LAPolicy.deviceOwnerAuthentication, error: &error) {
             context.evaluatePolicy(LAPolicy.deviceOwnerAuthentication, localizedReason: description, reply: { (success, error) -> Void in
                 callback(success ? .granted : .denied)

--- a/WireCommonComponents/AppLock.swift
+++ b/WireCommonComponents/AppLock.swift
@@ -55,13 +55,16 @@ final public class AppLock {
         /// There's no authenticated method available (no passcode is set)
         case unavailable
     }
-    
+
+    private static weak var context: LAContext? = nil
     // Creates a new LAContext and evaluates the authentication settings of the user.
     public static func evaluateAuthentication(description: String, with callback: @escaping (AuthenticationResult) -> Void) {
-    
+        guard AppLock.context == nil else { return }
+
         let context: LAContext = LAContext()
         var error: NSError?
-    
+
+        AppLock.context = context
         if context.canEvaluatePolicy(LAPolicy.deviceOwnerAuthentication, error: &error) {
             context.evaluatePolicy(LAPolicy.deviceOwnerAuthentication, localizedReason: description, reply: { (success, error) -> Void in
                 callback(success ? .granted : .denied)


### PR DESCRIPTION
## What's new in this PR?

### Issues

The `AppLock` screen requires to unlock twice.

### Causes

When the app become active, `applicationWillResignActive` notification is fired, then when the Touch ID system dialog dismisses, `applicationWillResignActive` notification is fired second time and calls `evaluateAuthentication` again. At the moment the first `evaluateAuthentication` request is not yet done.

### Solutions

Keep a weak reference to `LAContext`, if it is not nil, i.e. `evaluateAuthentication` is not done, do not start a new request.