### PR TITLE
[Fix] Fix cast warning

### DIFF
--- a/Wire-iOS/Sources/Helpers/syncengine/ZMConversation+Calling.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMConversation+Calling.swift
@@ -26,9 +26,7 @@ extension ZMConversation {
     }
     
     var firstCallingParticipantOtherThanSelf : ZMUser? {
-        return voiceChannel?.participants.first(where: { (user) -> Bool in
-            return !ZMUser.selfUser().isEqual(user)
-        }) as? ZMUser
+      return (voiceChannel?.participants.first { !ZMUser.selfUser().isEqual($0.user) })?.user
     }
     
     func startAudioCall() {


### PR DESCRIPTION
## What's new in this PR?

### Issues

- We were equating `CallParticipant` to `ZMUser`
- The cast from `CallParticipant` to `ZMuser` always fails

### Solutions

- Compare `CallParticipant.user` to `ZMUser`
- Remove the cast altogether