### PR TITLE
fix: folder badge - Exclude the muted conversations

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
@@ -579,7 +579,9 @@ final class ConversationListViewModel: NSObject {
     
     func folderBadge(at sectionIndex: Int) -> Int {
         return sections[sectionIndex].items.filter({
-            ($0.item as? ZMConversation)?.status.messagesRequiringAttention.isEmpty == false
+             let status = ($0.item as? ZMConversation)?.status
+             return status?.messagesRequiringAttention.isEmpty == false &&
+                    status?.showingAllMessages == true
         }).count
     }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

The muted conversations are counted in folder badge.

### Causes

We did not consider the muted status of the conversation.

### Solutions

Check the `showingAllMessages` property of the conversation and only count it when it is true.