### PR TITLE
fix: Badge count not updating when collapsed folder and added to group conversation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
@@ -539,8 +539,15 @@ final class ConversationListViewModel: NSObject {
                 self.sections = data
             }
         }
+        
 
         if let sectionNumber = sectionNumber(for: kind) {
+            
+            ///When the section is collaped, the setData closure of the reload() above is not called and we need to set here to make sure the folder badge calculation is correct
+            if collapsed(at: sectionNumber) {
+                sections = newValue
+            }
+            
             delegate?.listViewModel(self, didUpdateSection: sectionNumber)
         }
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Badge count not updating when collapsed folder and added to group conversation

### Causes

The differenceKit method `UICollectionView.reload()` does not call the completion closure `setData` when the section to reload has no cell (when the section is collapsed)

### Solutions

Do it manually in this case.