### PR TITLE
[iPad] Fixed text field cropping after rotation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
@@ -170,6 +170,12 @@ final class ConversationCreationController: UIViewController {
         nameSection.becomeFirstResponder()
     }
     
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        coordinator.animate(alongsideTransition: { (context) in
+            self.collectionViewController.collectionView?.collectionViewLayout.invalidateLayout()
+        })
+    }
+    
     private func setupViews() {
         // TODO: if keyboard is open, it should scroll.
         let collectionView = UICollectionView(forGroupedSections: ())


### PR DESCRIPTION
## What's new in this PR?

### Issues

On 'ConversationCreationController' after rotating in compact mode, the cell's content may be clipped by the boundary.

### Causes

The cells' layouts do not refresh after rotation.

### Solutions

Call 'invalidateLayout' when 'viewWillTransition'.

