### PR TITLE
Fix: crash in UITextView replace method

### DIFF
--- a/Wire-iOS Tests/UITextView+ReplaceTests.swift
+++ b/Wire-iOS Tests/UITextView+ReplaceTests.swift
@@ -44,7 +44,7 @@ class UITextView_ReplaceTests: XCTestCase {
         sut.replace(range, withAttributedText: attributedText!)
         
         // THEN
-        XCTAssertEqual(sut.text, text, "Should have been a success")
+        XCTAssertEqual(sut.text, text)
     }
     
     func testRangeIsInsideTheReplacementString() {
@@ -58,7 +58,7 @@ class UITextView_ReplaceTests: XCTestCase {
         sut.replace(range, withAttributedText: attributedText!)
         
         // THEN
-        XCTAssertEqual(sut.text, "12345678🐶5678🐶", "Should have been a success")
+        XCTAssertEqual(sut.text, "12345678🐶5678🐶")
     }
     
     func testGivenRangeIsOutsideTheWholeRange() {
@@ -72,6 +72,6 @@ class UITextView_ReplaceTests: XCTestCase {
         sut.replace(range, withAttributedText: attributedText!)
         
         // THEN
-        XCTAssertEqual(sut.text, text, "Should have been a success")
+        XCTAssertEqual(sut.text, text)
     }
 }

--- a/Wire-iOS Tests/UITextView+ReplaceTests.swift
+++ b/Wire-iOS Tests/UITextView+ReplaceTests.swift
@@ -1,0 +1,63 @@
+//
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+@testable import Wire
+
+class UITextView_ReplaceTests: XCTestCase {
+
+    var sut: UITextView!
+    
+    override func setUp() {
+        super.setUp()
+        sut = UITextView()
+    }
+
+    override func tearDown() {
+        sut = nil
+        super.tearDown()
+    }
+    
+    func testRangeIsOutsideTheReplacementString() {
+        // GIVEN
+        let text = "12345678"
+        sut.text = text
+        let attributedText = sut.attributedText
+        let range = NSRange(location: 0, length: 24)
+        
+        // WHEN
+        sut.replace(range, withAttributedText: attributedText!)
+        
+        // THEN
+        XCTAssertEqual(sut.text, text, "Should have been a success")
+    }
+    
+    func testRangeIsInsideTheReplacementString() {
+        // GIVEN
+        let text = "12345678"
+        sut.text = text
+        let attributedText = sut.attributedText
+        let range = NSRange(location: 0, length: 4)
+        
+        // WHEN
+        sut.replace(range, withAttributedText: attributedText!)
+        
+        // THEN
+        XCTAssertEqual(sut.text, "123456785678", "Should have been a success")
+    }
+}

--- a/Wire-iOS Tests/UITextView+ReplaceTests.swift
+++ b/Wire-iOS Tests/UITextView+ReplaceTests.swift
@@ -49,7 +49,7 @@ class UITextView_ReplaceTests: XCTestCase {
     
     func testRangeIsInsideTheReplacementString() {
         // GIVEN
-        let text = "12345678"
+        let text = "12345678🐶"
         sut.text = text
         let attributedText = sut.attributedText
         let range = NSRange(location: 0, length: 4)
@@ -58,6 +58,20 @@ class UITextView_ReplaceTests: XCTestCase {
         sut.replace(range, withAttributedText: attributedText!)
         
         // THEN
-        XCTAssertEqual(sut.text, "123456785678", "Should have been a success")
+        XCTAssertEqual(sut.text, "12345678🐶5678🐶", "Should have been a success")
+    }
+    
+    func testGivenRangeIsOutsideTheWholeRange() {
+        // GIVEN
+        let text = "12345678"
+        sut.text = text
+        let attributedText = sut.attributedText
+        let range = NSRange(location: 4, length: 6)
+        
+        // WHEN
+        sut.replace(range, withAttributedText: attributedText!)
+        
+        // THEN
+        XCTAssertEqual(sut.text, text, "Should have been a success")
     }
 }

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		061282632379C25500C1A53C /* UITextView+ReplaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 061282622379C25500C1A53C /* UITextView+ReplaceTests.swift */; };
 		16030DAD21A846A200F8032E /* ConversationVideoMessageCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16030DAC21A846A200F8032E /* ConversationVideoMessageCellTests.swift */; };
 		1607359B1EB2393000528965 /* SettingsShareDatabaseCellDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1607359A1EB2393000528965 /* SettingsShareDatabaseCellDescriptor.swift */; };
 		160C311F1E4C78480012E4BC /* CustomMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 160C311E1E4C78480012E4BC /* CustomMessageView.swift */; };
@@ -1536,6 +1537,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		061282622379C25500C1A53C /* UITextView+ReplaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextView+ReplaceTests.swift"; sourceTree = "<group>"; };
 		095275931B7E834400123BAF /* WireSyncEngine.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WireSyncEngine.framework; path = Carthage/Build/iOS/WireSyncEngine.framework; sourceTree = "<group>"; };
 		16030DAC21A846A200F8032E /* ConversationVideoMessageCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationVideoMessageCellTests.swift; sourceTree = "<group>"; };
 		1607359A1EB2393000528965 /* SettingsShareDatabaseCellDescriptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsShareDatabaseCellDescriptor.swift; sourceTree = "<group>"; };
@@ -2470,7 +2472,6 @@
 		A98ECDF0232A94DD006A57FD /* ConversationListViewControllerViewModelSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationListViewControllerViewModelSnapshotTests.swift; sourceTree = "<group>"; };
 		A98ECDF2232A9564006A57FD /* MockConversationListContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockConversationListContainer.swift; sourceTree = "<group>"; };
 		A9991374237072C600E1ABBB /* ColorSchemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorSchemeTests.swift; sourceTree = "<group>"; };
-		A9B02231209B6E4E00DF25D8 /* Hockey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Hockey.swift; sourceTree = "<group>"; };
 		A9B02231209B6E4E00DF25D8 /* AppCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCenter.swift; sourceTree = "<group>"; };
 		AF36C5A61E9F6F2000FADECC /* WireCanvas.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WireCanvas.framework; path = Carthage/Build/iOS/WireCanvas.framework; sourceTree = "<group>"; };
 		AFD4E7291E449925002A4732 /* Analytics+StorableTrackingEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Analytics+StorableTrackingEvent.swift"; sourceTree = "<group>"; };
@@ -5951,6 +5952,7 @@
 				7C440E7E23473A0F00D91B5F /* FolderCreationControllerSnapshotTests.swift */,
 				7C440E84234B460100D91B5F /* FolderPickerControllerSnapshotTests.swift */,
 				A9991374237072C600E1ABBB /* ColorSchemeTests.swift */,
+				061282622379C25500C1A53C /* UITextView+ReplaceTests.swift */,
 			);
 			path = "Wire-iOS Tests";
 			sourceTree = "<group>";
@@ -8420,6 +8422,7 @@
 				EF5741EE2102001A0041AD47 /* MessageTests.swift in Sources */,
 				5EF7BA61221AB89300815625 /* ProfileViewTests.swift in Sources */,
 				87C39A90206BF00A008DA100 /* BackupViewControllerTests.swift in Sources */,
+				061282632379C25500C1A53C /* UITextView+ReplaceTests.swift in Sources */,
 				EF27CD9F20C161500077FE55 /* ProfileClientViewControllerTests.swift in Sources */,
 				EF2A8DE7214A816D002C9058 /* StartUIViewControllerSnapshotTests.swift in Sources */,
 				164B533C20A0A5E800EC8265 /* CallInfoConfigurationTests.swift in Sources */,

--- a/Wire-iOS/Sources/UserInterface/Components/Views/UITextView+Replace.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/UITextView+Replace.swift
@@ -20,7 +20,7 @@ import Foundation
 
 extension UITextView {
     func replace(_ range: NSRange, withAttributedText replacement: NSAttributedString) {
-        guard range.length <= self.text.count else {
+        guard NSMaxRange(self.attributedText.wholeRange) >= NSMaxRange(range)  else {
             return
         }
         let updatedString = NSMutableAttributedString(attributedString: attributedText)

--- a/Wire-iOS/Sources/UserInterface/Components/Views/UITextView+Replace.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/UITextView+Replace.swift
@@ -20,6 +20,9 @@ import Foundation
 
 extension UITextView {
     func replace(_ range: NSRange, withAttributedText replacement: NSAttributedString) {
+        guard range.length <= self.text.count else {
+            return
+        }
         let updatedString = NSMutableAttributedString(attributedString: attributedText)
         updatedString.replaceCharacters(in: range, with: replacement)
 

--- a/Wire-iOS/Sources/UserInterface/Components/Views/UITextView+Replace.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/UITextView+Replace.swift
@@ -20,9 +20,10 @@ import Foundation
 
 extension UITextView {
     func replace(_ range: NSRange, withAttributedText replacement: NSAttributedString) {
-        guard NSMaxRange(self.attributedText.wholeRange) >= NSMaxRange(range)  else {
-            return
-        }
+        guard
+            range.lowerBound >= attributedText.wholeRange.lowerBound,
+            range.upperBound <= attributedText.wholeRange.upperBound
+            else { return }
         let updatedString = NSMutableAttributedString(attributedString: attributedText)
         updatedString.replaceCharacters(in: range, with: replacement)
 


### PR DESCRIPTION
Fix: crash in UITextView replace method

## What's new in this PR?

### Issues
Crash when replacing text in TextView.

### Causes
Replacing text with a given range that >  string length.

### Solutions
Add a range length check.