### PR TITLE
[Fix] Group call streams arrangement 

### DIFF
--- a/Wire-iOS Tests/Calling/VoiceChannelVideoStreamArrangmentTests.swift
+++ b/Wire-iOS Tests/Calling/VoiceChannelVideoStreamArrangmentTests.swift
@@ -1,0 +1,125 @@
+//
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+
+@testable import Wire
+
+class VoiceChannelVideoStreamArrangementTests: XCTestCase {
+    private var sut: MockVoiceChannel!
+    var mockUser1: ZMUser!
+    var mockUser2: ZMUser!
+    
+    override func setUp() {
+        super.setUp()
+        let mockConversation = ((MockConversation.oneOnOneConversation() as Any) as! ZMConversation)
+        sut = MockVoiceChannel(conversation: mockConversation)
+        mockUser1 = MockUser.mockUsers()[0]
+        mockUser1.remoteIdentifier = UUID()
+        mockUser2 = MockUser.mockUsers()[1]
+        mockUser2.remoteIdentifier = UUID()
+    }
+    
+    override func tearDown() {
+        sut = nil
+        super.tearDown()
+    }
+    
+    private func participantStub(for user: ZMUser, videoEnabled: Bool) -> CallParticipant {
+        let state: VideoState = videoEnabled ? .started : .stopped
+        return CallParticipant(user: user, state: .connected(videoState: state, clientId: UUID().transportString()))
+    }
+    
+    // MARK - participantsActiveVideoStates
+    
+    func testThatWithOneParticipantWithoutVideoItReturnsEmpty() {
+        let participant = participantStub(for: mockUser1, videoEnabled: false)
+        sut.mockParticipants = [participant]
+        
+        XCTAssert(sut.participantsActiveVideoStreams.isEmpty)
+    }
+    
+    func testThatWithOneParticipantWithVideoItReturnsOneParticipantVideoState() {
+        let participant = participantStub(for: mockUser1, videoEnabled: true)
+        sut.mockParticipants = [participant]
+        
+        XCTAssert(sut.participantsActiveVideoStreams.count == 1)
+    }
+    
+    func testThatWithTwoParticipantsWithoutVideoItReturnsEmpty() {
+        let participant1 = participantStub(for: mockUser1, videoEnabled: false)
+        let participant2 = participantStub(for: mockUser2, videoEnabled: false)
+        
+        sut.mockParticipants = [participant1, participant2]
+        
+        XCTAssert(sut.participantsActiveVideoStreams.isEmpty)
+    }
+    
+    func testThatWithTwoParticipantsWithOneStartedAndOneStoppedVideoItReturnsOnlyOneVideoState() {
+        let participant1 = participantStub(for: mockUser1, videoEnabled: false)
+        let participant2 = participantStub(for: mockUser2, videoEnabled: true)
+        
+        sut.mockParticipants = [participant1, participant2]
+        
+        XCTAssert(sut.participantsActiveVideoStreams.count == 1)
+    }
+    
+    func testThatWithTwoParticipantsWithTwoStartedVideosItReturnsTwoVideoStates() {
+        let participant1 = participantStub(for: mockUser1, videoEnabled: true)
+        let participant2 = participantStub(for: mockUser2, videoEnabled: true)
+        
+        sut.mockParticipants = [participant1, participant2]
+        
+        XCTAssert(sut.participantsActiveVideoStreams.count == 2)
+    }
+    
+    // MARK - arrangeVideoStreams
+    
+    func videoStreamStub() -> VideoStream {
+        return VideoStream(stream: Stream(userId: UUID(), clientId: UUID().transportString()), isPaused: false)
+    }
+    
+    func testThatWithoutSelfStreamItReturnsNilPreviewAndParticipantsVideoStateGrid() {
+        let participantVideoStreams = [videoStreamStub(), videoStreamStub()]
+        
+        let videoStreamArrangement = sut.arrangeVideoStreams(for: nil, participantsStreams: participantVideoStreams)
+        XCTAssert(videoStreamArrangement.grid.elementsEqual(participantVideoStreams))
+        XCTAssert(videoStreamArrangement.preview == nil)
+    }
+    
+    func testThatWithSelfStreamAndOneParticipantItReturnsSelfStreamAsPreviewAndOtherParticipantsVideoStatesAsGrid() {
+        let participantVideoStreams = [videoStreamStub()]
+        let selfStream = videoStreamStub()
+        
+        let videoStreamArrangement = sut.arrangeVideoStreams(for: selfStream, participantsStreams: participantVideoStreams)
+        XCTAssert(videoStreamArrangement.grid.elementsEqual(participantVideoStreams))
+        XCTAssert(videoStreamArrangement.preview == selfStream)
+    }
+    
+    func testThatWithSelfStreamAndMultipleParticipantsItReturnsNilAsPreviewAndSelfStreamPlusOtherParticipantsVideoStatesAsGrid()  {
+        let participantVideoStreams = [videoStreamStub(), videoStreamStub()]
+        let selfStream = videoStreamStub()
+        
+        let videoStreamArrangement = sut.arrangeVideoStreams(for: selfStream, participantsStreams: participantVideoStreams)
+        let expectedStreams = [selfStream] + participantVideoStreams
+        XCTAssert(videoStreamArrangement.grid.elementsEqual(expectedStreams))
+        XCTAssert(videoStreamArrangement.preview == nil)
+    }
+}
+
+

--- a/Wire-iOS Tests/VideoGridViewControllerSnapshotTests.swift
+++ b/Wire-iOS Tests/VideoGridViewControllerSnapshotTests.swift
@@ -20,9 +20,9 @@ import XCTest
 @testable import Wire
 
 final class MockVideoGridConfiguration: VideoGridConfiguration {
-    var floatingVideoStream: ParticipantVideoState?
+    var floatingVideoStream: VideoStream?
 
-    var videoStreams: [ParticipantVideoState] = []
+    var videoStreams: [VideoStream] = []
 
     var isMuted: Bool = false
 

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -413,6 +413,7 @@
 		5EFD915921CBCB5300080599 /* UIResponder+VoiceOver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EFD915821CBCB5300080599 /* UIResponder+VoiceOver.swift */; };
 		5EFE9BFF21246483007932A6 /* RegistrationFinalErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EFE9BFE21246483007932A6 /* RegistrationFinalErrorHandler.swift */; };
 		5EFE9C19212C1D6E007932A6 /* RegistrationActivationCodeSentEventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EFE9C18212C1D6E007932A6 /* RegistrationActivationCodeSentEventHandler.swift */; };
+		6340EF96237AE93500EF8506 /* VoiceChannelVideoStreamArrangmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6340EF95237AE93500EF8506 /* VoiceChannelVideoStreamArrangmentTests.swift */; };
 		7C0BB6E61FE682A200386A19 /* AccountSelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C0BB6E41FE680F200386A19 /* AccountSelectionViewController.swift */; };
 		7C17ECA81F7508980056600C /* PreviewHeightCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C17ECA71F7508980056600C /* PreviewHeightCalculator.swift */; };
 		7C23A26D20247500005FEB54 /* ShareViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C23A26B20247474005FEB54 /* ShareViewControllerTests.swift */; };
@@ -2001,6 +2002,7 @@
 		5EFD915821CBCB5300080599 /* UIResponder+VoiceOver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIResponder+VoiceOver.swift"; sourceTree = "<group>"; };
 		5EFE9BFE21246483007932A6 /* RegistrationFinalErrorHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationFinalErrorHandler.swift; sourceTree = "<group>"; };
 		5EFE9C18212C1D6E007932A6 /* RegistrationActivationCodeSentEventHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationActivationCodeSentEventHandler.swift; sourceTree = "<group>"; };
+		6340EF95237AE93500EF8506 /* VoiceChannelVideoStreamArrangmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceChannelVideoStreamArrangmentTests.swift; sourceTree = "<group>"; };
 		7C0BB6E41FE680F200386A19 /* AccountSelectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSelectionViewController.swift; sourceTree = "<group>"; };
 		7C17ECA71F7508980056600C /* PreviewHeightCalculator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreviewHeightCalculator.swift; sourceTree = "<group>"; };
 		7C23A26B20247474005FEB54 /* ShareViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewControllerTests.swift; sourceTree = "<group>"; };
@@ -2472,6 +2474,7 @@
 		A978D992236C587B00B568AE /* ZMUserSession+Shared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUserSession+Shared.swift"; sourceTree = "<group>"; };
 		A98ECDF0232A94DD006A57FD /* ConversationListViewControllerViewModelSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationListViewControllerViewModelSnapshotTests.swift; sourceTree = "<group>"; };
 		A98ECDF2232A9564006A57FD /* MockConversationListContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockConversationListContainer.swift; sourceTree = "<group>"; };
+		A9991374237072C600E1ABBB /* ColorSchemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorSchemeTests.swift; sourceTree = "<group>"; };
 		A9B02231209B6E4E00DF25D8 /* AppCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCenter.swift; sourceTree = "<group>"; };
 		A9C7BEBD237B0538005D676A /* UIColor+MixingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+MixingTests.swift"; sourceTree = "<group>"; };
 		A9C7BEBF237C0FFB005D676A /* ColorSchemeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorSchemeTests.swift; sourceTree = "<group>"; };
@@ -4223,6 +4226,14 @@
 			path = Input;
 			sourceTree = "<group>";
 		};
+		6340EF8E237AE90700EF8506 /* Calling */ = {
+			isa = PBXGroup;
+			children = (
+				6340EF95237AE93500EF8506 /* VoiceChannelVideoStreamArrangmentTests.swift */,
+			);
+			path = Calling;
+			sourceTree = "<group>";
+		};
 		7C25D7532149118D002E22BF /* Mentions */ = {
 			isa = PBXGroup;
 			children = (
@@ -5770,6 +5781,7 @@
 			isa = PBXGroup;
 			children = (
 				A9E844F723730CC7001D1C47 /* Color */,
+				6340EF8E237AE90700EF8506 /* Calling */,
 				EF37AB742366F6BA00C1F5D9 /* Status */,
 				EFD4B9CA22F09C3D008CA042 /* AppLockTests.swift */,
 				EFD4B9C922F082BE008CA042 /* UIImage */,
@@ -8382,6 +8394,7 @@
 				7C440E8123473F8500D91B5F /* FolderCreationControllerSnapshotTests.swift in Sources */,
 				5EBF47C621B2FA6D0021CFFC /* MockReadReceipt.swift in Sources */,
 				5E52376220E7E50F00649241 /* ColorTilesViewController.swift in Sources */,
+				6340EF96237AE93500EF8506 /* VoiceChannelVideoStreamArrangmentTests.swift in Sources */,
 				EF1FCE5021B69381003E0BE2 /* ReadReceiptViewModelTests.swift in Sources */,
 				EF4478522090BF8700BD9827 /* FullscreenImageViewControllerTests.swift in Sources */,
 				F127BD571E262E9F0093B2F1 /* CollectionsViewControllerTests.swift in Sources */,

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/VideoConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/VideoConfiguration.swift
@@ -45,9 +45,10 @@ fileprivate extension VoiceChannel {
     
     var videoStreamArrangment: (preview: ParticipantVideoState?, grid: [ParticipantVideoState]) {
         let otherParticipants: [ParticipantVideoState] = participants.compactMap { participant in
-            if case .connected(videoState: let videoState, clientId: let clientId) = participant.state {
+            switch participant.state {
+            case .connected(let videoState, let clientId) where videoState != .stopped:
                 return .init(stream: Stream(userId: participant.user.remoteIdentifier, clientId: clientId), isPaused: videoState == .paused)
-            } else {
+            default:
                 return nil
             }
         }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/VideoConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/VideoConfiguration.swift
@@ -17,8 +17,8 @@
 //
 
 struct VideoConfiguration: VideoGridConfiguration {
-    let floatingVideoStream: ParticipantVideoState?
-    let videoStreams: [ParticipantVideoState]
+    let floatingVideoStream: VideoStream?
+    let videoStreams: [VideoStream]
     let isMuted: Bool
     let networkQuality: NetworkQuality
 
@@ -30,9 +30,9 @@ struct VideoConfiguration: VideoGridConfiguration {
     }
 }
 
-fileprivate extension VoiceChannel {
+extension VoiceChannel {
     
-    var selfStream: ParticipantVideoState? {
+    private var selfStream: VideoStream? {
         switch (isUnconnectedOutgoingVideoCall, videoState) {
         case (true, _), (_, .started), (_, .badConnection), (_, .screenSharing):
             return .init(stream: ZMUser.selfUser().selfStream, isPaused: false)
@@ -43,8 +43,30 @@ fileprivate extension VoiceChannel {
         }
     }
     
-    var videoStreamArrangment: (preview: ParticipantVideoState?, grid: [ParticipantVideoState]) {
-        let otherParticipants: [ParticipantVideoState] = participants.compactMap { participant in
+    fileprivate var videoStreamArrangment: (preview: VideoStream?, grid: [VideoStream]) {
+        guard isEstablished else { return (nil, selfStream.map { [$0] } ?? [] ) }
+        
+        return arrangeVideoStreams(for: selfStream, participantsStreams: participantsActiveVideoStreams)
+    }
+    
+    private var isEstablished: Bool {
+        return state == .established
+    }
+    
+    func arrangeVideoStreams(for selfStream: VideoStream?, participantsStreams: [VideoStream]) -> (preview: VideoStream?, grid: [VideoStream]) {
+        guard let selfStream = selfStream else {
+            return (nil, participantsStreams)
+        }
+        
+        if 1 == participantsStreams.count {
+            return (selfStream, participantsStreams)
+        } else {
+            return (nil, [selfStream] + participantsStreams)
+        }
+    }
+    
+    var participantsActiveVideoStreams: [VideoStream] {
+        return participants.compactMap { participant in
             switch participant.state {
             case .connected(let videoState, let clientId) where videoState != .stopped:
                 return .init(stream: Stream(userId: participant.user.remoteIdentifier, clientId: clientId), isPaused: videoState == .paused)
@@ -52,29 +74,12 @@ fileprivate extension VoiceChannel {
                 return nil
             }
         }
-        
-        guard isEstablished else { return (nil, selfStream.map { [$0] } ?? [] ) }
-        
-        if let selfStream = selfStream {
-            if 1 == otherParticipants.count {
-                return (selfStream, otherParticipants)
-            } else {
-                return (nil, [selfStream] + otherParticipants)
-            }
-        } else {
-            return (nil, otherParticipants)
-        }
     }
     
-    var isUnconnectedOutgoingVideoCall: Bool {
+   private var isUnconnectedOutgoingVideoCall: Bool {
         switch (state, isVideoCall) {
         case (.outgoing, true): return true
         default: return false
         }
-    }
-    
-    var isEstablished: Bool {
-        guard case .established = state else { return false }
-        return true
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridView.swift
@@ -24,14 +24,14 @@ struct Stream: Equatable {
     let clientId: String?
 }
 
-struct ParticipantVideoState: Equatable {
+struct VideoStream: Equatable {
     let stream: Stream
     let isPaused: Bool
 }
 
 protocol VideoGridConfiguration {
-    var floatingVideoStream: ParticipantVideoState? { get }
-    var videoStreams: [ParticipantVideoState] { get }
+    var floatingVideoStream: VideoStream? { get }
+    var videoStreams: [VideoStream] { get }
     var isMuted: Bool { get }
     var networkQuality: NetworkQuality { get }
 }
@@ -224,7 +224,7 @@ final class VideoGridViewController: UIViewController {
         Log.calling.debug("\nUpdated video configuration to:\n\(videoConfigurationDescription())")
     }
 
-    private func updateFloatingVideo(with state: ParticipantVideoState?) {
+    private func updateFloatingVideo(with state: VideoStream?) {
         // No stream, remove floating video if there is any
         guard let state = state else {
             Log.calling.debug("Removing self video from floating preview")
@@ -276,7 +276,7 @@ final class VideoGridViewController: UIViewController {
         """
     }
 
-    private func updateVideoGrid(with videoStreams: [ParticipantVideoState]) {
+    private func updateVideoGrid(with videoStreams: [VideoStream]) {
         let streams = videoStreams.map { $0.stream }
         let removed = gridVideoStreams.filter { !streams.contains($0) }
         let added = streams.filter { !gridVideoStreams.contains($0) }
@@ -287,7 +287,7 @@ final class VideoGridViewController: UIViewController {
         updatePausedStates(with: videoStreams)
     }
 
-    private func updatePausedStates(with videoStreams: [ParticipantVideoState]) {
+    private func updatePausedStates(with videoStreams: [VideoStream]) {
         videoStreams.forEach {
             (streamView(for: $0.stream) as? VideoPreviewView)?.isPaused = $0.isPaused
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

GIVEN a group call with 3 participants (A, B, C)
WHEN participant A enables its video stream
THEN participant C (on iOS) sees A's video stream 
BUT also sees a black screen for B, who hasn't enabled video

### Causes

`videoStreamArrangment` in `VoiceChannel` extension would fail to filter out the video streams that weren't active and thus returned an array of all the connected streams. In our case, we only need to get the active video streams in order to display them.

### Solutions

Update logic of `videoStreamArrangment` to only select and return the active video streams.

