### PR TITLE
[Fix] Permission alerts not showing

### DIFF
--- a/Wire-iOS/Sources/Helpers/UIApplication+Permissions.m
+++ b/Wire-iOS/Sources/Helpers/UIApplication+Permissions.m
@@ -21,6 +21,7 @@
 #import "AppDelegate.h"
 #import "UIAlertController+Wire.h"
 #import "UIResponder+FirstResponder.h"
+#import "Wire-Swift.h"
 
 @import Photos;
 #import <AVFoundation/AVFoundation.h>
@@ -133,38 +134,20 @@ typedef void (^AlertActionHandler)(UIAlertAction *);
 
 + (void)wr_warnAboutMicrophonePermission
 {
-    UIAlertController *noMicrophoneAlert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"voice.alert.microphone_warning.title", nil)
-                                                                               message:NSLocalizedString(@"voice.alert.microphone_warning.explanation", nil)
-                                                                        preferredStyle:UIAlertControllerStyleAlert];
-    
-    void (^completionHandler)(void) = ^() {
-        [[AppDelegate sharedAppDelegate].notificationsWindow.rootViewController dismissViewControllerAnimated:YES completion:nil];
-        [AppDelegate sharedAppDelegate].notificationsWindow.hidden = YES;
-    };
-    
-    AlertActionHandler actionSettingsHandler = ^(UIAlertAction *action) {
-        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString] options:@{} completionHandler:^(BOOL success) {
-            completionHandler();
-        }];
-    };
-    
-    AlertActionHandler actionOkHandler = ^(UIAlertAction *action) {
-        completionHandler();
-    };
+    UIAlertController *noMicrophoneAlert = [UIAlertController alertWithOKButtonWithTitle:NSLocalizedString(@"voice.alert.microphone_warning.title", nil)
+                                                                                 message:NSLocalizedString(@"voice.alert.microphone_warning.explanation", nil)
+                                                                         okActionHandler:nil];
     
     UIAlertAction *actionSettings = [UIAlertAction actionWithTitle:NSLocalizedString(@"general.open_settings", nil)
                                                              style:UIAlertActionStyleDefault
-                                                           handler:actionSettingsHandler];
+                                                           handler:^(UIAlertAction *action) {
+                                                               [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString] options:@{} completionHandler:nil];
+                                                           }
+                                     ];
     
-    UIAlertAction *actionOK = [UIAlertAction actionWithTitle:NSLocalizedString(@"general.ok", nil)
-                                                       style:UIAlertActionStyleCancel
-                                                     handler:actionOkHandler];
-
     [noMicrophoneAlert addAction:actionSettings];
-    [noMicrophoneAlert addAction:actionOK];
-    
-    [AppDelegate sharedAppDelegate].notificationsWindow.hidden = NO;
-    [[AppDelegate sharedAppDelegate].notificationsWindow.rootViewController presentViewController:noMicrophoneAlert animated:YES completion:nil];
+
+    [[AppDelegate sharedAppDelegate].window.rootViewController presentViewController:noMicrophoneAlert animated:YES completion:nil];
 }
 
 + (void)wr_warnAboutPhotoLibraryRestricted

--- a/Wire-iOS/Sources/Helpers/UIApplication+Permissions.m
+++ b/Wire-iOS/Sources/Helpers/UIApplication+Permissions.m
@@ -27,7 +27,6 @@
 #import <AVFoundation/AVFoundation.h>
 
 NSString * const UserGrantedAudioPermissionsNotification = @"UserGrantedAudioPermissionsNotification";
-typedef void (^AlertActionHandler)(UIAlertAction *);
 
 @implementation UIApplication (Permissions)
 

--- a/Wire-iOS/Sources/Helpers/UIApplication+Permissions.m
+++ b/Wire-iOS/Sources/Helpers/UIApplication+Permissions.m
@@ -103,32 +103,26 @@ typedef void (^AlertActionHandler)(UIAlertAction *);
         [currentResponder endEditing:YES];
     }
     
-    UIAlertController *noVideoAlert =
-    [UIAlertController alertControllerWithTitle:NSLocalizedString(@"voice.alert.camera_warning.title", nil)
-                                        message:NSLocalizedString(@"voice.alert.camera_warning.explanation", nil)
-                                 preferredStyle:UIAlertControllerStyleAlert];
+    UIAlertController *noVideoAlert = [UIAlertController alertWithOKButtonWithTitle:NSLocalizedString(@"voice.alert.camera_warning.title", nil)
+                                                                            message:NSLocalizedString(@"voice.alert.camera_warning.explanation", nil)
+                                                                    okActionHandler:^(UIAlertAction * _Nonnull action) {
+                                                                        if (completion) completion();
+                                                                    }
+                                       ];
     
     UIAlertAction *actionSettings = [UIAlertAction actionWithTitle:NSLocalizedString(@"general.open_settings", nil)
                                                              style:UIAlertActionStyleDefault
                                                            handler:^(UIAlertAction * _Nonnull action) {
-        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]
-                                           options:@{}
-                                 completionHandler:NULL];
-        if (nil != completion) completion();
-    }];
+                                                               [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]
+                                                                                                  options:@{}
+                                                                                        completionHandler:NULL];
+                                                               if (completion) completion();
+                                                           }
+                                     ];
     
     [noVideoAlert addAction:actionSettings];
     
-    UIAlertAction *actionOK = [UIAlertAction actionWithTitle:NSLocalizedString(@"general.ok", nil)
-                                                       style:UIAlertActionStyleCancel
-                                                     handler:^(UIAlertAction * _Nonnull action) {
-         [[AppDelegate sharedAppDelegate].notificationsWindow.rootViewController dismissViewControllerAnimated:YES completion:nil];
-         if (nil != completion) completion();
-                                                     }];
-    
-    [noVideoAlert addAction:actionOK];
-    
-    [[AppDelegate sharedAppDelegate].notificationsWindow.rootViewController presentViewController:noVideoAlert animated:YES completion:nil];
+    [[AppDelegate sharedAppDelegate].window.rootViewController presentViewController:noVideoAlert animated:YES completion:nil];
 }
 
 
@@ -156,7 +150,7 @@ typedef void (^AlertActionHandler)(UIAlertAction *);
                                                                                     message:NSLocalizedString(@"library.alert.permission_warning.restrictions.explaination", nil)
                                                                           cancelButtonTitle:NSLocalizedString(@"general.ok", nil)];
 
-    [[AppDelegate sharedAppDelegate].notificationsWindow.rootViewController presentViewController:libraryRestrictedAlert animated:YES completion:nil];
+    [[AppDelegate sharedAppDelegate].window.rootViewController presentViewController:libraryRestrictedAlert animated:YES completion:nil];
 }
 
 + (void)wr_warnAboutPhotoLibaryDenied
@@ -171,7 +165,7 @@ typedef void (^AlertActionHandler)(UIAlertAction *);
                                  completionHandler:NULL];
     }]];
 
-    [[AppDelegate sharedAppDelegate].notificationsWindow.rootViewController presentViewController:deniedAlert animated:YES completion:nil];
+    [[AppDelegate sharedAppDelegate].window.rootViewController presentViewController:deniedAlert animated:YES completion:nil];
 }
 
 @end

--- a/Wire-iOS/Sources/UserInterface/Helpers/UIViewController+Alert.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UIViewController+Alert.swift
@@ -28,7 +28,7 @@ extension UIAlertController {
     ///   - message: message of the alert
     ///   - okActionHandler: a nullable closure for the OK button
     /// - Returns: the alert presented
-    static func alertWithOKButton(title: String? = nil,
+    @objc static func alertWithOKButton(title: String? = nil,
                                   message: String,
                                   okActionHandler: ((UIAlertAction) -> Void)? = nil) -> UIAlertController {
         let alert = UIAlertController(title: title,

--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
@@ -240,7 +240,7 @@ final class ClientListViewController: UIViewController,
         self.editingList = true
     }
     
-    @objc func endEditing(_ sender: AnyObject!) {
+    @objc private func endEditing(_ sender: AnyObject!) {
         self.editingList = false
     }
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

For the case of microphone permission:

GIVEN microphone permissions are revoked
WHEN user accepts an incoming call
THEN call overlay is dismissed without asking user to grant microphone permissions

### Causes

The logic responsible for displaying the alert asking the user to grant permissions failed to make the `notificationsWindow` visible

### Solutions

- Make `notificationsWindow` visible when displaying permissions alert
- Hide `notificationsWindow` upon completion of the alert

### Attachments

<img src=https://user-images.githubusercontent.com/6436181/68848951-75a68400-06d1-11ea-8ae1-13a6859f84e1.jpeg width=300 />

