### PR TITLE
Fix: set the guestIconView on search UI

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Views/UserCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/UserCell.swift
@@ -201,11 +201,11 @@ class UserCell: SeparatorCollectionViewCell {
         titleLabel.attributedText = attributedTitle
     }
     
-    public func configure(with user: UserType, conversation: ZMConversation? = nil) {
-        configure(with: user, subtitle: subtitle(for: user), conversation: conversation)
+    public func configure(with user: UserType, conversation: ZMConversation? = nil, hideIconView: Bool = false) {
+        configure(with: user, subtitle: subtitle(for: user), conversation: conversation, hideIconView: hideIconView)
     }
 
-    public func configure(with user: UserType, subtitle: NSAttributedString?, conversation: ZMConversation? = nil) {
+    public func configure(with user: UserType, subtitle: NSAttributedString?, conversation: ZMConversation? = nil, hideIconView: Bool = false) {
         self.user = user
 
         avatar.user = user
@@ -214,7 +214,7 @@ class UserCell: SeparatorCollectionViewCell {
         if let conversation = conversation {
             guestIconView.isHidden = !user.isGuest(in: conversation)
         } else {
-            guestIconView.isHidden = !ZMUser.selfUser().isTeamMember || user.isTeamMember || user.isServiceUser
+            guestIconView.isHidden = !ZMUser.selfUser().isTeamMember || user.isTeamMember || user.isServiceUser || hideIconView
         }
 
         if let user = user as? ZMUser {

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/Suggestions/DirectorySectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/Suggestions/DirectorySectionController.swift
@@ -51,7 +51,7 @@ class DirectorySectionController: SearchSectionController {
         let user = suggestions[indexPath.row]
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: UserCell.zm_reuseIdentifier, for: indexPath) as! UserCell
         
-        cell.configure(with: user)
+        cell.configure(with: user, hideIconView: true)
         cell.showSeparator = (suggestions.count - 1) != indexPath.row
         cell.guestIconView.isHidden = true
         cell.accessoryIconView.isHidden = true


### PR DESCRIPTION
…conView

## What's new in this PR?

### Issues
The guest icon is overlapping the + button on search UI.

### Causes
We set the visibility of guestIconView 2 times. That's why, during the search, we show this icon for a moment, and then hide it.

### Solutions
Add a new parameter in the UserCell config method to show/hide guestIconView.
