### PR TITLE
Fix/more than 5 admins in conversation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/CallParticipantsView/ShowAllParticipantsCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallParticipantsView/ShowAllParticipantsCell.swift
@@ -54,7 +54,6 @@ class ShowAllParticipantsCell: UICollectionViewCell, SectionListCellType {
     }
     
     fileprivate func setup() {
-//        accessibilityIdentifier = "cell.call.show_all_participants"
         participantIconView.translatesAutoresizingMaskIntoConstraints = false
         participantIconView.contentMode = .scaleAspectFit
         participantIconView.setContentHuggingPriority(UILayoutPriority.required, for: .horizontal)

--- a/Wire-iOS/Sources/UserInterface/Calling/CallParticipantsView/ShowAllParticipantsCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallParticipantsView/ShowAllParticipantsCell.swift
@@ -18,12 +18,15 @@
 
 import Foundation
 
-class ShowAllParticipantsCell: UICollectionViewCell {
+class ShowAllParticipantsCell: UICollectionViewCell, SectionListCellType {
     
     let participantIconView = UIImageView()
     let titleLabel = UILabel()
     let accessoryIconView = UIImageView()
     var contentStackView : UIStackView!
+    
+    var sectionName: String?
+    var cellIdentifier: String?
     
     override var isHighlighted: Bool {
         didSet {
@@ -51,7 +54,7 @@ class ShowAllParticipantsCell: UICollectionViewCell {
     }
     
     fileprivate func setup() {
-        accessibilityIdentifier = "cell.call.show_all_participants"
+//        accessibilityIdentifier = "cell.call.show_all_participants"
         participantIconView.translatesAutoresizingMaskIntoConstraints = false
         participantIconView.contentMode = .scaleAspectFit
         participantIconView.setContentHuggingPriority(UILayoutPriority.required, for: .horizontal)
@@ -113,6 +116,7 @@ extension ShowAllParticipantsCell: ParticipantsCellConfigurable {
         guard case let .showAll(count) = rowType else { preconditionFailure() }
         titleLabel.text = "call.participants.show_all".localized(args: String(count))
         backgroundColor = .from(scheme: .barBackground)
-
+        cellIdentifier = "cell.call.show_all_participants"
+        accessibilityIdentifier = identifier
     }
 }

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupParticipantsDetail/GroupParticipantsDetailViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupParticipantsDetail/GroupParticipantsDetailViewController.swift
@@ -145,8 +145,8 @@ final class GroupParticipantsDetailViewController: UIViewController {
     }
     
     private func computeSections() -> [CollectionViewSectionController] {
-        let adminsSection = ParticipantsSectionController(participants: viewModel.admins, teamRole: .admin, conversation: viewModel.conversation, delegate: self, clipSection: false)
-        let membersSection = ParticipantsSectionController(participants: viewModel.members, teamRole: .member, conversation: viewModel.conversation, delegate: self, clipSection: false)
+        let adminsSection = ParticipantsSectionController(participants: viewModel.admins, teamRole: .admin, conversation: viewModel.conversation, delegate: self, totalParticipantsCount: viewModel.admins.count, clipSection: false)
+        let membersSection = ParticipantsSectionController(participants: viewModel.members, teamRole: .member, conversation: viewModel.conversation, delegate: self, totalParticipantsCount: viewModel.members.count, clipSection: false)
         sections = []
         viewModel.admins.isEmpty ? () : sections.append(adminsSection)
         viewModel.members.isEmpty ? () : sections.append(membersSection)

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/ParticipantsSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/ParticipantsSectionController.swift
@@ -54,7 +54,6 @@ enum ParticipantsRowType {
 }
 
 private struct ParticipantsSectionViewModel {
-    static private let maxParticipants = 7
     let rows: [ParticipantsRowType]
     let participants: [UserType]    
     let teamRole: TeamRole
@@ -92,16 +91,19 @@ private struct ParticipantsSectionViewModel {
     /// - Parameters:
     ///   - participants: list of conversation participants
     ///   - teamRole: participant's role
-    ///   - showAllRows: enable/disable the display of the “ShowAll” button
-    init(participants: [UserType], teamRole: TeamRole, clipSection: Bool = true) {
+    ///   - totalParticipantsCount: the number of all participants in the conversation
+    ///   - clipSection: enable/disable the display of the “ShowAll” button
+    ///   - maxParticipants: max number of participants we can display
+    ///   - maxDisplayedParticipants: max number of participants we can display, if there are more than maxParticipants participants
+    init(participants: [UserType], teamRole: TeamRole, totalParticipantsCount: Int, clipSection: Bool = true, maxParticipants: Int = 7, maxDisplayedParticipants: Int = 5) {
         self.participants = participants
         self.teamRole = teamRole
-        rows = clipSection ? ParticipantsSectionViewModel.computeRows(participants) : participants.map(ParticipantsRowType.init)
+        rows = clipSection ? ParticipantsSectionViewModel.computeRows(participants, totalParticipantsCount: totalParticipantsCount, maxParticipants: maxParticipants, maxDisplayedParticipants: maxDisplayedParticipants) : participants.map(ParticipantsRowType.init)
     }
     
-    static func computeRows(_ participants: [UserType]) -> [ParticipantsRowType] {
+    static func computeRows(_ participants: [UserType], totalParticipantsCount: Int, maxParticipants: Int, maxDisplayedParticipants: Int) -> [ParticipantsRowType] {
         guard participants.count > maxParticipants else { return participants.map(ParticipantsRowType.init) }
-        return participants[0..<5].map(ParticipantsRowType.init) + [.showAll(participants.count)]
+        return participants[0..<maxDisplayedParticipants].map(ParticipantsRowType.init) + [.showAll(totalParticipantsCount)]
     }
 }
 
@@ -132,8 +134,11 @@ final class ParticipantsSectionController: GroupDetailsSectionController {
          teamRole: TeamRole,
          conversation: ZMConversation,
          delegate: GroupDetailsSectionControllerDelegate,
-         clipSection: Bool = true) {
-        viewModel = .init(participants: participants, teamRole: teamRole, clipSection: clipSection)
+         totalParticipantsCount: Int,
+         clipSection: Bool = true,
+         maxParticipants: Int = 7,
+         maxDisplayedParticipants: Int = 5) {
+        viewModel = .init(participants: participants, teamRole: teamRole, totalParticipantsCount: totalParticipantsCount, clipSection: clipSection, maxParticipants: maxParticipants, maxDisplayedParticipants: maxDisplayedParticipants)
         self.conversation = conversation
         self.delegate = delegate
         super.init()


### PR DESCRIPTION
## What's new in this PR?

### Issues
> 5 Admins in conversation there is no "Show All" button in Conversation Admins section.

### Solutions
Check the count of admins/members and hide or display the `ShowAll` button.
