### PR TITLE
fix: app crash when calling TextView.setAttributedText

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/TextView/TextView+Placeholder.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/TextView/TextView+Placeholder.swift
@@ -19,7 +19,17 @@
 import Foundation
 
 extension TextView {
-
+    override open var text: String! {
+        didSet {
+            showOrHidePlaceholder()
+        }
+    }
+    
+    override open var attributedText: NSAttributedString! {
+        didSet {
+            showOrHidePlaceholder()
+        }
+    }
 
     /// custom inset for placeholder, only left and right inset value is applied (The placeholder is align center vertically)
     @objc

--- a/Wire-iOS/Sources/UserInterface/Components/TextView/TextView.m
+++ b/Wire-iOS/Sources/UserInterface/Components/TextView/TextView.m
@@ -110,18 +110,6 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
     self.placeholderLabel.textColor = placeholderTextColor;
 }
 
-- (void)setText:(NSString *)text
-{
-    [super setText:text];
-    [self showOrHidePlaceholder];
-}
-
-- (void)setAttributedText:(NSAttributedString *)attributedText
-{
-    [super setAttributedText:attributedText];
-    [self showOrHidePlaceholder];
-}
-
 - (void)setPlaceholderFont:(UIFont *)placeholderFont
 {
     _placeholderFont = placeholderFont;


### PR DESCRIPTION
## What's new in this PR?

### Issues

App crash at the line `[super setAttributedText:attributedText];`

### Causes

Unknown. But we should be calling super.setAttributedText since it may cause race condition, e.g. the attributedText may be changed by dictation at the same time.

### Solutions

Observe value change with `didSet` and update the placeholder.