### PR TITLE
Fix: upload dsym for testing builds to app center

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -162,7 +162,9 @@ platform :ios do
           app_name: app_name,
           ipa: "#{build.artifact_path(with_filename: true)}.ipa",
           release_notes: changelog,
-          notify_testers: true
+          notify_testers: true,
+          mandatory_update: true,
+          dsym: "#{build.artifact_path(with_filename: true)}.app.dSYM.zip"
         )
     end
 


### PR DESCRIPTION
## What's new in this PR?

Upload dsym to AppCenter to resolve the crash reasons