### PR TITLE
Remove prefilling of Giphy search box

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -681,8 +681,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
 {
     if (![AppDelegate isOffline]) {
         
-        NSString *searchTerm = [self.inputBar.textView.text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
-        GiphySearchViewController *giphySearchViewController = [[GiphySearchViewController alloc] initWithSearchTerm:searchTerm conversation:self.conversation];
+        GiphySearchViewController *giphySearchViewController = [[GiphySearchViewController alloc] initWithSearchTerm:@"" conversation:self.conversation];
         giphySearchViewController.delegate = self;
         [[ZClientViewController sharedZClientViewController] presentViewController:[giphySearchViewController wrapInsideNavigationController] animated:YES completion:^{
             [[UIApplication sharedApplication] wr_updateStatusBarForCurrentControllerAnimated:YES];


### PR DESCRIPTION
## What's new in this PR?

Clicking on the Giphy search button will not prefill the Giphy search with the message being typed. This has been raised as a security concern (accidental tapping on Giphy) and this is a simple attempt at addressing the issue. In future we could move this to a user preference to allow for both behaviours.

### Testing

This was manually tested on simulator
