### PR TITLE
fix: deprecated IPA parameter

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -160,7 +160,7 @@ platform :ios do
           api_token: ENV["APPCENTER_API_TOKEN"],
           owner_name: ENV["APPCENTER_OWNER_NAME"],
           app_name: app_name,
-          ipa: "#{build.artifact_path(with_filename: true)}.ipa",
+          file: "#{build.artifact_path(with_filename: true)}.ipa",
           release_notes: changelog,
           notify_testers: true,
           mandatory_update: true,


### PR DESCRIPTION
## What's new in this PR?

### Issues

Fastlane failed to update to appCenter for `Using deprecated option: '--ipa' (true)`

### Causes

`ipa` option is deprecated.

### Solutions

Replace with `file` option

### Notice
run `fastlane update_plugins` to bump app center plugin