### PR TITLE
fix: pass searchDirectory to ContactsDataSource.search

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsDataSource+Searching.swift
+++ b/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsDataSource+Searching.swift
@@ -22,8 +22,9 @@ import Foundation
 extension ContactsDataSource {
     
     @objc
-    public func search(withQuery query: String) {
-        guard let searchDirectory = self.searchDirectory else { return }
+    public func search(withQuery query: String,
+                       searchDirectory: SearchDirectory?) {
+        guard let searchDirectory = searchDirectory else { return }
         
         let request = SearchRequest(query: query, searchOptions: [.contacts, .addressBook])
         let task = searchDirectory.perform(request)

--- a/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsDataSource.m
+++ b/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsDataSource.m
@@ -84,7 +84,7 @@ NS_ASSUME_NONNULL_END
     
     _searchQuery = searchQuery;
     
-    [self searchWithQuery:searchQuery];
+    [self searchWithQuery:searchQuery searchDirectory:self.searchDirectory];
 }
 
 #pragma mark - Grouping

--- a/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsViewController+ShareContacts.m
+++ b/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsViewController+ShareContacts.m
@@ -45,7 +45,7 @@
 - (void)shareContactsViewControllerDidFinish:(UIViewController *)viewController
 {
     // Reload data source
-    [self.dataSource searchWithQuery:@""];
+    [self.dataSource searchWithQuery:@"" searchDirectory:self.dataSource.searchDirectory];
     
     [self dismissChildViewController:viewController];
 }


### PR DESCRIPTION
## What's new in this PR?

For an unknown reason `ContactsDataSource.search` can not compile on CI sevser due to `searchDirectory` member property is not seen by this Swift extension. Pass it by parameter to try to solve it.

### TODO:
- [ ] convert ContactsDataSource to Swift