### PR TITLE
Fix: Hide a groupAdminStatus for the wirelessUser

### DIFF
--- a/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsContentController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsContentController.swift
@@ -152,7 +152,7 @@ final class ProfileDetailsContentController: NSObject,
             ///Do not show group admin toggle for self user or requesting connection user
             var items: [ProfileDetailsContentController.Content] = []
             if let conversation = conversation {
-                if (viewer.zmUser?.canModifyOtherMember(in: conversation) ?? false) {
+                if (viewer.zmUser?.canModifyOtherMember(in: conversation) ?? false) && !user.isWirelessUser {
                     items.append(.groupAdminStatus(enabled: groupAdminEnabled))
                 }
             }

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsContentController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsContentController.swift
@@ -152,7 +152,9 @@ final class ProfileDetailsContentController: NSObject,
             ///Do not show group admin toggle for self user or requesting connection user
             var items: [ProfileDetailsContentController.Content] = []
             if let conversation = conversation {
-                if (viewer.zmUser?.canModifyOtherMember(in: conversation) ?? false) && !user.isWirelessUser {
+                let viewerCanChangeOtherRoles = viewer.zmUser?.canModifyOtherMember(in: conversation) ?? false
+                let userCanHaveRoleChanged = !user.isWirelessUser
+                if viewerCanChangeOtherRoles && userCanHaveRoleChanged {
                     items.append(.groupAdminStatus(enabled: groupAdminEnabled))
                 }
             }


### PR DESCRIPTION
## What's new in this PR?

Hide a groupAdminStatus if the user is a  wireless guest.