### PR TITLE
[Fix] Profile details design fixes

### DIFF
--- a/Wire-iOS Tests/ProfileDetailsViewControllerTests.swift
+++ b/Wire-iOS Tests/ProfileDetailsViewControllerTests.swift
@@ -20,6 +20,13 @@ import SnapshotTesting
 import XCTest
 @testable import Wire
 
+// TODO: tests for group role label:
+//
+// - viewer is admin and other user is/isn't a admin
+// - other is external and admin (labels don't overlap)
+// - profile is from 1:1 (no admin label)
+// - hide admin label if the other user is a wireless user
+
 final class ProfileDetailsViewControllerTests: XCTestCase {
 
     var selfUserTeam: UUID!
@@ -502,8 +509,6 @@ final class ProfileDetailsViewControllerTests: XCTestCase {
             ])
     }
 
-    ///TODO: add test for viewer is admin and other user is/isn't a admin
-    
     func test_Group_OtherUser_NoSCIM_NoEmail() {
         // GIVEN
         let otherUser = MockUser.createConnectedUser(name: "Catherine Jackson", inTeam: selfUserTeam)

--- a/Wire-iOS/Sources/UserInterface/SelfProfile/ProfileHeaderViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/ProfileHeaderViewController.swift
@@ -200,6 +200,7 @@ final class ProfileHeaderViewController: UIViewController, Themeable {
         stackView.wr_addCustomSpacing(32, after: teamNameLabel)
         stackView.wr_addCustomSpacing(24, after: imageView)
         stackView.wr_addCustomSpacing(20, after: guestIndicatorStack)
+        stackView.wr_addCustomSpacing(20, after: externalIndicator)
         
         view.addSubview(stackView)
         applyColorScheme(colorSchemeVariant)

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Details/Cells/IconToggleSubtitleCell.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Details/Cells/IconToggleSubtitleCell.swift
@@ -33,6 +33,10 @@ final class IconToggleSubtitleCell: UITableViewCell, CellConfigurationConfigurab
             styleViews()
         }
     }
+
+    private var subtitleTopConstraint: NSLayoutConstraint?
+    private var subtitleBottomConstraint: NSLayoutConstraint?
+    private let subtitleInsets = UIEdgeInsets(top: 16, left: 16, bottom: 24, right: 16)
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -74,10 +78,10 @@ final class IconToggleSubtitleCell: UITableViewCell, CellConfigurationConfigurab
             topContainer.trailing == contentView.trailing
             topContainer.height == 56
             
-            subtitleLabel.leading == contentView.leading + 16
-            subtitleLabel.trailing == contentView.trailing - 16
-            subtitleLabel.top == topContainer.bottom + 16
-            subtitleLabel.bottom == contentView.bottom - 24
+            subtitleLabel.leading == contentView.leading + self.subtitleInsets.leading
+            subtitleLabel.trailing == contentView.trailing - self.subtitleInsets.trailing
+            self.subtitleTopConstraint = subtitleLabel.top == topContainer.bottom + self.subtitleInsets.top
+            self.subtitleBottomConstraint = subtitleLabel.bottom == contentView.bottom - self.subtitleInsets.bottom
         }
     }
     
@@ -109,6 +113,17 @@ final class IconToggleSubtitleCell: UITableViewCell, CellConfigurationConfigurab
         titleLabel.textColor = mainColor
 
         subtitleLabel.text = subtitle
+
+        if subtitle.isEmpty {
+            subtitleLabel.isHidden = true
+            subtitleTopConstraint?.constant = 0
+            subtitleBottomConstraint?.constant = 0
+        } else {
+            subtitleLabel.isHidden = false
+            subtitleTopConstraint?.constant = subtitleInsets.top
+            subtitleBottomConstraint?.constant = -(subtitleInsets.bottom)
+        }
+
         action = set
         toggle.accessibilityIdentifier = identifier
         titleLabel.accessibilityIdentifier = titleIdentifier


### PR DESCRIPTION
## What's new in this PR?

### Issues

- if the profile is of an external user who is also a group admin, the external and admin indicators overlap
- The spacing after the admin toggle is too large

### Causes

- The admin indicator is placed after the external indicator in a custom spacing stack view, however there was no custom spacing after the external indicator.
- The `IconToggleSubtitleCell` has a top container and subtitle below it. In the case that there is no subtitle, subtitle label has zero height (as expected) but the top and bottom padding for the subtitle label still remains (total of 40pt).

### Solutions

- Add custom spacing of 20pt.
- Hide the subtitle label if there is no subtitle, and addition set the top and bottom margins appropriately.

### Notes

The `IconToggleSubtitleCell` should be unified with the `ToggleSubtitleCell`, since the only differ by the icon. I'll make a ticket to track this issue.