### PR TITLE
Fix: Hide a "Group admin" label in the Profile screen

### DIFF
--- a/Wire-iOS/Sources/UserInterface/SelfProfile/ProfileHeaderViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/ProfileHeaderViewController.swift
@@ -257,7 +257,7 @@ final class ProfileHeaderViewController: UIViewController, Themeable {
     }
 
     private func updateGroupRoleIndicator() {
-        groupRoleIndicator.isHidden = !(conversation.map(user.isAdminGroup) ?? false)
+        groupRoleIndicator.isHidden = !(conversation.map(user.isAdminGroup) ?? false) || (conversation?.conversationType != .group)
     }
     
     private func applyOptions() {

--- a/Wire-iOS/Sources/UserInterface/SelfProfile/ProfileHeaderViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/ProfileHeaderViewController.swift
@@ -257,7 +257,15 @@ final class ProfileHeaderViewController: UIViewController, Themeable {
     }
 
     private func updateGroupRoleIndicator() {
-        groupRoleIndicator.isHidden = !(conversation.map(user.isAdminGroup) ?? false) || (conversation?.conversationType != .group)
+        let groupRoleIndicatorHidden: Bool
+        switch conversation?.conversationType {
+        case .group?:
+            groupRoleIndicatorHidden = !(conversation.map(user.isAdminGroup) ?? false)
+        default:
+            groupRoleIndicatorHidden = true
+        }
+        groupRoleIndicator.isHidden = groupRoleIndicatorHidden
+
     }
     
     private func applyOptions() {


### PR DESCRIPTION

## What's new in this PR?

Hide a "Group admin" label in the Profile screen if it's not a group conversation.