### PR TITLE
Force refreshing roles if missing from a conversation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationRootViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationRootViewController.swift
@@ -62,6 +62,7 @@ import Cartography
         conversationController.didMove(toParent: self)
 
         conversationViewController = conversationController
+        conversation.refreshDataIfNeeded()
 
         configure()
     }
@@ -138,6 +139,18 @@ extension ConversationRootViewController: NetworkStatusBarDelegate {
     func showInIPad(networkStatusViewController: NetworkStatusViewController, with orientation: UIInterfaceOrientation) -> Bool {
         // always show on iPad for any orientation in regular mode
         return true
+    }
+}
+
+extension ZMConversation {
+    
+    /// Check if the conversation data is out of date, and in case update it.
+    /// This in an opportunistic update of the data, with an on-demand strategy.
+    /// Whenever the conversation is opened by the user, we check if anything is missing.
+    fileprivate func refreshDataIfNeeded() {
+        ZMUserSession.shared()?.enqueueChanges {
+            self.markToDownloadRolesIfNeeded()
+        }
     }
 }
 


### PR DESCRIPTION
## What's new in this PR?

This PR adds a check for consistency of the conversation when the conversation is loaded. If we ever end up in a situation where the roles are not present for a conversation, we will try to re-download them.

This is mostly useful for internal users that already have the new data model and were using an early version where roles are not fetched. 