### PR TITLE
Fix: Wrong visual avatar and user profile for pending outgoing connection

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -744,6 +744,7 @@
 		8FC85459199245770008B66B /* InvisibleInputAccessoryView.m in Sources */ = {isa = PBXBuildFile; fileRef = 8FC851BB199245760008B66B /* InvisibleInputAccessoryView.m */; };
 		8FC85471199245770008B66B /* ZClientViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8FC851F0199245760008B66B /* ZClientViewController.m */; };
 		8FC8563E19924CBA0008B66B /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 8FC8564019924CBA0008B66B /* Localizable.strings */; };
+		A9076C8223B1047E004FD3C9 /* ConversationContentViewController+Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9076C8123B1047E004FD3C9 /* ConversationContentViewController+Header.swift */; };
 		A90800752372F0F600A530FC /* ConversationListHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A90800742372F0F600A530FC /* ConversationListHeaderViewTests.swift */; };
 		A90E4ABC2381B26600468F31 /* Settings+ColorScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = A90E4ABB2381B26600468F31 /* Settings+ColorScheme.swift */; };
 		A90E4ABF2381CD0200468F31 /* AccentColorChangeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A90E4ABE2381CD0200468F31 /* AccentColorChangeHandler.swift */; };
@@ -2453,6 +2454,7 @@
 		8FC853A0199245770008B66B /* Wire-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "Wire-Info.plist"; path = "Wire-iOS/Wire-Info.plist"; sourceTree = "<group>"; };
 		8FC853A1199245770008B66B /* Wire-iOS-Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "Wire-iOS-Prefix.pch"; path = "Wire-iOS/Wire-iOS-Prefix.pch"; sourceTree = "<group>"; };
 		8FC8563F19924CBA0008B66B /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
+		A9076C8123B1047E004FD3C9 /* ConversationContentViewController+Header.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationContentViewController+Header.swift"; sourceTree = "<group>"; };
 		A90800742372F0F600A530FC /* ConversationListHeaderViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationListHeaderViewTests.swift; sourceTree = "<group>"; };
 		A90E4ABB2381B26600468F31 /* Settings+ColorScheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "Settings+ColorScheme.swift"; path = "Wire-iOS/Settings+ColorScheme.swift"; sourceTree = SOURCE_ROOT; };
 		A90E4ABE2381CD0200468F31 /* AccentColorChangeHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccentColorChangeHandler.swift; sourceTree = "<group>"; };
@@ -5496,6 +5498,7 @@
 				8FC851A9199245760008B66B /* ConversationContentViewController.h */,
 				8FC851A6199245760008B66B /* ConversationContentViewController+Private.h */,
 				8FC851AA199245760008B66B /* ConversationContentViewController.m */,
+				A9076C8123B1047E004FD3C9 /* ConversationContentViewController+Header.swift */,
 				EF701A34223C00E0007165E4 /* ConversationContentViewController+CreateView.swift */,
 				EF215ADE2315575200A5C5E9 /* ConversationContentViewController+MediaPlayer.swift */,
 				EFA06E4621FB639700BF2E17 /* ConversationContentViewController+CanvasViewControllerDelegate.swift */,
@@ -8153,6 +8156,7 @@
 				8751BA442069455E00DF8667 /* BackupViewController.swift in Sources */,
 				1610366F20616EBC008AFDD0 /* SelfProfileViewController+NewDeviceAlert.swift in Sources */,
 				D5674610208F39D200DC7F26 /* TintColorCorrectedViewController.swift in Sources */,
+				A9076C8223B1047E004FD3C9 /* ConversationContentViewController+Header.swift in Sources */,
 				87D5E43E1C3E78A000EB8289 /* ProfileClientViewController.swift in Sources */,
 				5E15D31B219DB9060038439D /* ConversationFileMessageCell.swift in Sources */,
 				5E766D9F21147697005242B4 /* AuthenticationCoordinatorDelegate.swift in Sources */,

--- a/Wire-iOS/Sources/UserInterface/Components/Views/ConversationAvatarView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/ConversationAvatarView.swift
@@ -165,10 +165,19 @@ final class ConversationAvatarView: UIView {
                 return
             }
 
+            accessibilityLabel = "Avatar for \(conversation.displayName)"
+
+            let usersOnAvatar: [ZMUser]
             let stableRandomParticipants = conversation.stableRandomParticipants.filter { !$0.isSelfUser }
 
-            accessibilityLabel = "Avatar for \(self.conversation?.displayName ?? "")"
-            users = stableRandomParticipants
+            if stableRandomParticipants.isEmpty,
+                let connectedUser = conversation.connectedUser {
+                usersOnAvatar = [connectedUser]
+            } else {
+                usersOnAvatar = stableRandomParticipants
+            }
+            
+            users = usersOnAvatar
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Header.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Header.swift
@@ -1,0 +1,55 @@
+
+// Wire
+// Copyright (C) 2019 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension ConversationContentViewController {
+    @objc
+    func updateTableViewHeaderView() {
+        guard let userSession = ZMUserSession.shared() else { return }
+        
+        if dataSource?.hasOlderMessagesToLoad != nil {
+            // Don't display the conversation header if the message window doesn't include the first message.
+            return
+        }
+        
+        var headerView: UIView? = nil
+        
+        let otherParticipant: ZMUser?
+        if conversation.conversationType == .connection {
+            otherParticipant = conversation.firstActiveParticipantOtherThanSelf ?? conversation.connectedUser
+        } else {
+            otherParticipant = conversation.firstActiveParticipantOtherThanSelf
+        }
+        
+        let connectionOrOneOnOne = conversation.conversationType == .connection || conversation.conversationType == .oneOnOne
+        
+        if connectionOrOneOnOne, let otherParticipant = otherParticipant {
+            connectionViewController = UserConnectionViewController(userSession: userSession, user: otherParticipant)
+            headerView = connectionViewController.view
+        }
+        
+        if let headerView = headerView {
+            headerView.layoutMargins = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
+            setConversationHeaderView(headerView)
+        } else {
+            tableView.tableHeaderView = nil
+        }
+    }
+
+}

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Header.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Header.swift
@@ -23,8 +23,8 @@ extension ConversationContentViewController {
     func updateTableViewHeaderView() {
         guard let userSession = ZMUserSession.shared() else { return }
         
-        if dataSource?.hasOlderMessagesToLoad != nil {
-            // Don't display the conversation header if the message window doesn't include the first message.
+        if dataSource?.hasOlderMessagesToLoad != nil, conversation.conversationType != .connection {
+            // Don't display the conversation header if the message window doesn't include the first message and it is not a connection
             return
         }
         

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Private.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Private.h
@@ -29,6 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class FLAnimatedImageView;
 @class ConversationTableViewDataSource;
 @class DeletionDialogPresenter;
+@class UserConnectionViewController;
 @protocol SelectableView;
 @protocol ZMUserSessionInterface;
 
@@ -51,8 +52,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, nullable) id<ZMUserSessionInterface> session;
 
+@property (nonatomic) UserConnectionViewController *connectionViewController;
+
 - (void)removeHighlightsAndMenu;
 - (NSIndexPath * _Nullable)willSelectRowAtIndexPath:(NSIndexPath *)indexPath tableView:(UITableView *)tableView;
+- (void)setConversationHeaderView:(UIView *)headerView;
 
 @end
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.h
@@ -56,7 +56,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
 - (instancetype)initWithNibName:(nullable NSString *)nibNameOrNil bundle:(nullable NSBundle *)nibBundleOrNil NS_UNAVAILABLE;
 
-- (void)updateTableViewHeaderView;
 - (void)highlightMessage:(id<ZMConversationMessage>)message;
 
 @end

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -62,7 +62,6 @@
 @property (nonatomic) NSMutableDictionary *cachedRowHeights;
 @property (nonatomic) BOOL hasDoneInitialLayout;
 @property (nonatomic) BOOL onScreen;
-@property (nonatomic) UserConnectionViewController *connectionViewController;
 @property (nonatomic) id<ZMConversationMessage> messageVisibleOnLoad;
 @property (nonatomic) id conversationObserverToken;
 @end
@@ -248,30 +247,6 @@
 {
     ZMLogWarn(@"Received system memory warning.");
     [super didReceiveMemoryWarning];
-}
-
-- (void)updateTableViewHeaderView
-{
-    if (self.dataSource.hasOlderMessagesToLoad) {
-        // Don't display the conversation header if the message window doesn't include the first message.
-        return;
-    }
-    
-    UIView *headerView = nil;
-    ZMUser *otherParticipant = self.conversation.firstActiveParticipantOtherThanSelf;
-    BOOL connectionOrOneOnOne = self.conversation.conversationType == ZMConversationTypeConnection || self.conversation.conversationType == ZMConversationTypeOneOnOne;
-
-    if (connectionOrOneOnOne && nil != otherParticipant) {
-        self.connectionViewController = [[UserConnectionViewController alloc] initWithUserSession:[ZMUserSession sharedSession] user:otherParticipant];
-        headerView = self.connectionViewController.view;
-    }
-    
-    if (headerView) {
-        headerView.layoutMargins = UIEdgeInsetsMake(0, 20, 0, 20);
-        [self setConversationHeaderView:headerView];
-    } else {
-        self.tableView.tableHeaderView = nil;
-    }
 }
 
 - (void)setConversationHeaderView:(UIView *)headerView


### PR DESCRIPTION
## What's new in this PR?

### Issues
For connecting user case:
- no avatar on the conversation list
- no avatar on the conversation screen

### Causes

After changes of the data model, `ZMConversation.localParticipants` and `sortedActiveParticipants` no longer contains connecting user.

### Solutions

add `conversation.connectedUser` when the conversation type is `connection`