### PR TITLE
Fix read receipts not displayed for admin personal users

### DIFF
--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
@@ -170,7 +170,7 @@ final class GroupDetailsViewController: UIViewController, ZMConversationObserver
             sections.append(optionsSectionController)
         }
         
-        if let selfUser = ZMUser.selfUser(), selfUser.isTeamMember, conversation.team == selfUser.team, selfUser.canModifyReceiptMode(in: conversation) {
+        if let selfUser = ZMUser.selfUser(), selfUser.canModifyReceiptMode(in: conversation) {
             let receiptOptionsSectionController = ReceiptOptionsSectionController(conversation: conversation,
                                                                                   syncCompleted: didCompleteInitialSync,
                                                                                   collectionView: self.collectionViewController.collectionView!,


### PR DESCRIPTION
## What's new in this PR?
The visibility of the read receipt toggle should be based on the conversation role of the user and not on its team membership
