### PR TITLE
Show read receipts toggle only if conversation is a team conversation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
@@ -170,7 +170,10 @@ final class GroupDetailsViewController: UIViewController, ZMConversationObserver
             sections.append(optionsSectionController)
         }
         
-        if let selfUser = ZMUser.selfUser(), selfUser.canModifyReceiptMode(in: conversation) {
+        if let selfUser = ZMUser.selfUser(),
+            conversation.teamRemoteIdentifier != nil,
+            selfUser.canModifyReceiptMode(in: conversation)
+        {
             let receiptOptionsSectionController = ReceiptOptionsSectionController(conversation: conversation,
                                                                                   syncCompleted: didCompleteInitialSync,
                                                                                   collectionView: self.collectionViewController.collectionView!,


### PR DESCRIPTION
## What's new in this PR?

Read receipt toggles is visible in every conversation. It should not be visible for personal conversations. 

This PR makes sure that the read receipt switch is visible only if the conversation is a team conversation.