### PR TITLE
fix: Missing avatar picture and unique username in 1:1 

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Header.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Header.swift
@@ -21,10 +21,9 @@ import Foundation
 extension ConversationContentViewController {
     @objc
     func updateTableViewHeaderView() {
-        guard let userSession = ZMUserSession.shared() else { return }
-        
-        guard dataSource?.hasOlderMessagesToLoad == false ||
-              conversation.conversationType == .connection else {
+        guard let userSession = ZMUserSession.shared(),
+              (dataSource?.hasOlderMessagesToLoad == false ||
+              conversation.conversationType == .connection) else {
                 // Don't display the conversation header if the message window doesn't include the first message and it is not a connection
             return
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Header.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Header.swift
@@ -23,11 +23,12 @@ extension ConversationContentViewController {
     func updateTableViewHeaderView() {
         guard let userSession = ZMUserSession.shared() else { return }
         
-        if dataSource?.hasOlderMessagesToLoad != nil, conversation.conversationType != .connection {
-            // Don't display the conversation header if the message window doesn't include the first message and it is not a connection
+        guard dataSource?.hasOlderMessagesToLoad == false ||
+              conversation.conversationType == .connection else {
+                // Don't display the conversation header if the message window doesn't include the first message and it is not a connection
             return
         }
-        
+
         var headerView: UIView? = nil
         
         let otherParticipant: ZMUser?


### PR DESCRIPTION
## What's new in this PR?

### Issues

Avatar is not display for 1:1 condition

### Causes

In https://github.com/wireapp/wire-ios/pull/3894, the guard logic for hiding header is wrong.

### Solutions

Refactor it to guard and correct the logic.