### PR TITLE
Fix: Cancel connection request doesn't really cancel

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -198,7 +198,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
         [ZMUserSession.sharedSession enqueueChanges:^{
             switch (action) {
                 case OutgoingConnectionBottomBarActionCancel:
-                    [self.conversation.firstActiveParticipantOtherThanSelf cancelConnectionRequest];
+                    [self.conversation.connectedUser cancelConnectionRequest];
                     break;
                 case OutgoingConnectionBottomBarActionArchive:
                     self.conversation.isArchived = YES;


### PR DESCRIPTION
## What's new in this PR?

Replace  firstActiveParticipantOtherThanSelf with the connectedUser to cancel the connection request.