### PR TITLE
undo: Fix: Applock unlock needs two fingerprint scans to unlock. 

### DIFF
--- a/WireCommonComponents/AppLock.swift
+++ b/WireCommonComponents/AppLock.swift
@@ -57,17 +57,12 @@ final public class AppLock {
     }
 
 
-    /// a weak reference to LAContext, it should be nil when evaluatePolicy is done.
-    private static weak var weakLAContext: LAContext? = nil
-
     // Creates a new LAContext and evaluates the authentication settings of the user.
     public static func evaluateAuthentication(description: String, with callback: @escaping (AuthenticationResult) -> Void) {
-        guard AppLock.weakLAContext == nil else { return }
 
         let context: LAContext = LAContext()
         var error: NSError?
 
-        AppLock.weakLAContext = context
         if context.canEvaluatePolicy(LAPolicy.deviceOwnerAuthentication, error: &error) {
             context.evaluatePolicy(LAPolicy.deviceOwnerAuthentication, localizedReason: description, reply: { (success, error) -> Void in
                 callback(success ? .granted : .denied)


### PR DESCRIPTION
## What's new in this PR?

Undo the changes in https://github.com/wireapp/wire-ios/pull/3754 as the issue still reproducible.