### PR TITLE
Fix: Add a conversation change observer to a cell

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
@@ -27,7 +27,7 @@ protocol ConversationMessageCellDelegate: MessageActionResponder {
     func conversationMessageWantsToOpenMessageDetails(_ cell: UIView, messageDetailsViewController: MessageDetailsViewController)
     func conversationMessageWantsToOpenGuestOptionsFromView(_ cell: UIView, sourceView: UIView)
     func conversationMessageWantsToOpenParticipantsDetails(_ cell: UIView, selectedUsers: [ZMUser], sourceView: UIView)
-    
+    func conversationMessageShouldUpdate()
 }
 
 /**

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+ConversationMessageCellDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+ConversationMessageCellDelegate.swift
@@ -90,4 +90,8 @@ extension ConversationContentViewController: ConversationMessageCellDelegate {
         delegate?.conversationContentViewController(self, presentParticipantsDetailsWithSelectedUsers: selectedUsers, from: sourceView)
     }
 
+    func conversationMessageShouldUpdate() {
+        dataSource?.loadMessages(forceRecalculate: true)
+    }
+    
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Scrolling.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Scrolling.swift
@@ -60,9 +60,3 @@ extension ConversationContentViewController {
         updateTableViewHeaderView()
     }
 }
-
-extension ConversationContentViewController: ZMConversationObserver {
-    public func conversationDidChange(_ note: ConversationChangeInfo) {
-        guard note.createdRemotelyChanged else { return }        
-    }
-}

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Scrolling.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Scrolling.swift
@@ -63,8 +63,6 @@ extension ConversationContentViewController {
 
 extension ConversationContentViewController: ZMConversationObserver {
     public func conversationDidChange(_ note: ConversationChangeInfo) {
-        guard note.createdRemotelyChanged else { return }
-        
-        dataSource?.loadMessages(forceRecalculate: true)
+        guard note.createdRemotelyChanged else { return }        
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -63,7 +63,6 @@
 @property (nonatomic) BOOL hasDoneInitialLayout;
 @property (nonatomic) BOOL onScreen;
 @property (nonatomic) id<ZMConversationMessage> messageVisibleOnLoad;
-@property (nonatomic) id conversationObserverToken;
 @end
 
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -97,7 +97,6 @@
         self.messagePresenter.modalTargetController = self.parentViewController;
         self.session = session;
 
-        self.conversationObserverToken = [ConversationChangeInfo addObserver:self forConversation:self.conversation];
     }
     
     return self;


### PR DESCRIPTION
## What's new in this PR?

### Issues
No response when tapping badge item (Reply/Share/Delete) .

### Causes
The conversationDidChange event reloads all tableView.

### Solutions
Add an observer of the conversation change in the cell.
