### PR TITLE
Fix: message details screen rotating by limiting supported orientations

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsViewController.swift
@@ -221,6 +221,10 @@ final class MessageDetailsViewController: UIViewController, ModalTopBarDelegate 
     override var shouldAutorotate: Bool {
         return false
     }
+    
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return wr_supportedInterfaceOrientations
+    }
 }
 
 // MARK: - MessageDetailsDataSourceObserver


### PR DESCRIPTION
## What's new in this PR?

### Issues

Message details screen would appear rotated if you return to this screen while holding the phone in landscape mode.

### Causes

`shouldAutorotate` prevents the screen form rotating when it's the front most screen but not when when it's covered by another modal screen.

### Solutions

Implement `supportedInterfaceOrientations` to limit the orientation to `.portrait`.