### PR TITLE
[Fix] app lock when logged out

### DIFF
--- a/Wire-iOS Tests/AppLock/AppLockInteractorTests.swift
+++ b/Wire-iOS Tests/AppLock/AppLockInteractorTests.swift
@@ -99,26 +99,6 @@ final class AppLockInteractorTests: XCTestCase {
         XCTAssertFalse(sut.isAuthenticationNeeded)
     }
     
-    func testThatIsTimeoutReachedReturnsFalseIfTimeoutNotReached() {
-        //given
-        AppLock.rules = AppLockRules(useBiometricsOrAccountPassword: false, forceAppLock: false, appLockTimeout: 900)
-        AppLock.isActive = true
-        AppLock.lastUnlockedDate = Date(timeIntervalSinceNow: -Double(AppLock.rules.appLockTimeout)-100)
-        
-        //when/then
-        XCTAssertTrue(sut.isLockTimeoutReached)
-    }
-    
-    func testThatIsTimeoutReachedReturnsTrueIfTimeoutReached() {
-        //given
-        AppLock.rules = AppLockRules(useBiometricsOrAccountPassword: false, forceAppLock: false, appLockTimeout: 900)
-        AppLock.isActive = true
-        AppLock.lastUnlockedDate = Date(timeIntervalSinceNow: -10)
-        
-        //when/then
-        XCTAssertFalse(sut.isLockTimeoutReached)
-    }
-    
     func testThatEvaluateAuthenticationCompletesWithCorrectResult() {
         //given
         let queue = DispatchQueue(label: "Evaluate authentication test queue", qos: .background)

--- a/Wire-iOS Tests/AppLock/AppLockInteractorTests.swift
+++ b/Wire-iOS Tests/AppLock/AppLockInteractorTests.swift
@@ -75,6 +75,30 @@ final class AppLockInteractorTests: XCTestCase {
         super.tearDown()
     }
     
+    func testThatIsAuthenticationNeededReturnsTrueIfNeeded() {
+        //given
+        set(appLockActive: true, timeoutReached: true)
+        
+        //when / then
+        XCTAssertTrue(sut.isAuthenticationNeeded)
+    }
+    
+    func testThatIsAuthenticationNeededReturnsFalseIfTimeoutNotReached() {
+        //given
+        set(appLockActive: true, timeoutReached: false)
+        
+        //when / then
+        XCTAssertFalse(sut.isAuthenticationNeeded)
+    }
+    
+    func testThatIsAuthenticationNeededReturnsFalseIfAppLockNotActive() {
+        //given - appLock not active
+        set(appLockActive: false, timeoutReached: true)
+        
+        //when / then
+        XCTAssertFalse(sut.isAuthenticationNeeded)
+    }
+    
     func testThatIsTimeoutReachedReturnsFalseIfTimeoutNotReached() {
         //given
         AppLock.rules = AppLockRules(useBiometricsOrAccountPassword: false, forceAppLock: false, appLockTimeout: 900)
@@ -159,5 +183,14 @@ final class AppLockInteractorTests: XCTestCase {
 
         //then
         XCTAssertFalse(AppLockMock.didPersistBiometrics)
+    }
+}
+
+extension AppLockInteractorTests {
+    func set(appLockActive: Bool, timeoutReached: Bool) {
+        AppLock.isActive = appLockActive
+        AppLock.rules = AppLockRules(useBiometricsOrAccountPassword: false, forceAppLock: false, appLockTimeout: 900)
+        let timeInterval = timeoutReached ? -Double(AppLock.rules.appLockTimeout)-100 : -10
+        AppLock.lastUnlockedDate = Date(timeIntervalSinceNow: timeInterval)
     }
 }

--- a/Wire-iOS Tests/AppLock/AppLockPresenterTests.swift
+++ b/Wire-iOS Tests/AppLock/AppLockPresenterTests.swift
@@ -45,12 +45,11 @@ private final class AppLockUserInterfaceMock: AppLockUserInterface {
 }
 
 private final class AppLockInteractorMock: AppLockInteractorInput {
-    var _isLockTimeoutReached: Bool = false
-    
-    var didCallIsLockTimeoutReached: Bool = false
-    var isLockTimeoutReached: Bool {
-        didCallIsLockTimeoutReached = true
-        return _isLockTimeoutReached
+    var _isAuthenticationNeeded: Bool = false
+    var didCallIsAuthenticationNeeded: Bool = false
+    var isAuthenticationNeeded: Bool {
+        didCallIsAuthenticationNeeded = true
+        return _isAuthenticationNeeded
     }
     
     var passwordToVerify: String?
@@ -88,7 +87,7 @@ class AppLockPresenterTests: XCTestCase {
     
     func testThatItEvaluatesAuthenticationOrUpdatesUIIfNeeded() {
         //given
-        set(appLockActive: true, timeoutReached: true, authenticationState: .needed)
+        set(authNeeded: true, authenticationState: .needed)
         resetMocksValues()
         
         //when
@@ -100,7 +99,7 @@ class AppLockPresenterTests: XCTestCase {
         assert(contentsDimmed: true, reauthVisibile: false)
         
         //given
-        set(appLockActive: true, timeoutReached: true, authenticationState: .authenticated)
+        set(authNeeded: true, authenticationState: .authenticated)
         resetMocksValues()
         
         //when
@@ -113,7 +112,7 @@ class AppLockPresenterTests: XCTestCase {
     
     func testThatItDoesntEvaluateAuthenticationOrUpdateUIIfNotNeeded() {
         //given
-        set(appLockActive: true, timeoutReached: false, authenticationState: .needed)
+        set(authNeeded: false, authenticationState: .needed)
         resetMocksValues()
         
         //when
@@ -124,18 +123,7 @@ class AppLockPresenterTests: XCTestCase {
         assert(contentsDimmed: false, reauthVisibile: false)
         
         //given
-        set(appLockActive: false, timeoutReached: true, authenticationState: .needed)
-        resetMocksValues()
-        
-        //when
-        sut.requireAuthenticationIfNeeded()
-        
-        //then
-        XCTAssertFalse(appLockInteractor.didCallEvaluateAuthentication)
-        assert(contentsDimmed: false, reauthVisibile: false)
-        
-        //given
-        set(appLockActive: true, timeoutReached: true, authenticationState: .cancelled)
+        set(authNeeded: true, authenticationState: .cancelled)
         resetMocksValues()
         
         //when
@@ -146,7 +134,7 @@ class AppLockPresenterTests: XCTestCase {
         assert(contentsDimmed: true, reauthVisibile: true)
         
         //given
-        set(appLockActive: true, timeoutReached: true, authenticationState: .pendingPassword)
+        set(authNeeded: true, authenticationState: .pendingPassword)
         resetMocksValues()
         
         //when
@@ -341,15 +329,14 @@ class AppLockPresenterTests: XCTestCase {
         //when
         sut.applicationDidBecomeActive()
         //then
-        XCTAssertTrue(appLockInteractor.didCallIsLockTimeoutReached)
+        XCTAssertTrue(appLockInteractor.didCallIsAuthenticationNeeded)
     }
 }
 
 extension AppLockPresenterTests {
-    func set(appLockActive: Bool, timeoutReached: Bool, authenticationState: AuthenticationState) {
+    func set(authNeeded: Bool, authenticationState: AuthenticationState) {
         sut = AppLockPresenter(userInterface: userInterface, appLockInteractorInput: appLockInteractor, authenticationState: authenticationState)
-        AppLock.isActive = appLockActive
-        appLockInteractor._isLockTimeoutReached = timeoutReached
+        appLockInteractor._isAuthenticationNeeded = authNeeded
     }
     
     func resetMocksValues() {

--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockPresenter.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockPresenter.swift
@@ -83,7 +83,7 @@ class AppLockPresenter {
     }
     
     func requireAuthenticationIfNeeded() {
-        guard AppLock.isActive, appLockInteractorInput.isLockTimeoutReached else {
+        guard appLockInteractorInput.isAuthenticationNeeded else {
             setContents(dimmed: false)
             return
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

GIVEN AppLock is active
AND AppLock uses account password
AND User is logged out
WHEN Wire comes to foreground (on the login screen)
THEN AppLock will ask account password BUT there is no active session to verify the password against

### Solutions

Do not show app lock if user is logged out (= has no active session).
The user will have to log in anyway, so the appLock requirement is fulfilled by the login page.
