### PR TITLE
[Fix] Misaligned button

### DIFF
--- a/Wire-iOS/Sources/Authentication/Interface/Views/AccessoryTextField.swift
+++ b/Wire-iOS/Sources/Authentication/Interface/Views/AccessoryTextField.swift
@@ -264,7 +264,6 @@ final class AccessoryTextField: UITextField, TextContainer, Themeable {
         self.addTarget(self, action: #selector(textFieldDidChange(textField:)), for: .editingChanged)
 
         accessoryStack.translatesAutoresizingMaskIntoConstraints = false
-        accessoryContainer.translatesAutoresizingMaskIntoConstraints = false
         accessoryContainer.addSubview(accessoryStack)
 
         NSLayoutConstraint.activate([


### PR DESCRIPTION
## What's new in this PR?

### Issues

When creating a new account via email, the confirmation button is placed at the origin of the enclosing text field.

### Causes

The button is a right accessory view of the text field, thus its layout is handled by UIKit. However, the buttons `translatesAutoresizingMaskIntoConstraints` property was set to `false`. This affects only iOS 13.

### Solutions

Don't set the property to false.