### PR TITLE
[Fix] share extension not working with a custom backend

### DIFF
--- a/Wire-iOS Share Extension/Info.plist
+++ b/Wire-iOS Share Extension/Info.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>AppIdentifierPrefix</key>
 	<string>${AppIdentifierPrefix}</string>
-	<key>ApplicationGroupIdentifier</key>
-	<string>group.${WIRE_BUNDLE_ID}</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		06F2664223881A0D006BD21F /* LabelIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06F2664123881A0D006BD21F /* LabelIndicator.swift */; };
 		16030DAD21A846A200F8032E /* ConversationVideoMessageCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16030DAC21A846A200F8032E /* ConversationVideoMessageCellTests.swift */; };
 		1607359B1EB2393000528965 /* SettingsShareDatabaseCellDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1607359A1EB2393000528965 /* SettingsShareDatabaseCellDescriptor.swift */; };
+		160782E023C8ED960065392B /* UserDefaults+ApplicationGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 160782DF23C8ED950065392B /* UserDefaults+ApplicationGroup.swift */; };
 		160C311F1E4C78480012E4BC /* CustomMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 160C311E1E4C78480012E4BC /* CustomMessageView.swift */; };
 		160C31211E4C7E770012E4BC /* UnknownMessageCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 160C31201E4C7E770012E4BC /* UnknownMessageCellTests.swift */; };
 		160D691C212AC94100096EAD /* ImageResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 164A55DB20F60A5700AE62A6 /* ImageResource.swift */; };
@@ -1552,6 +1553,7 @@
 		095275931B7E834400123BAF /* WireSyncEngine.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WireSyncEngine.framework; path = Carthage/Build/iOS/WireSyncEngine.framework; sourceTree = "<group>"; };
 		16030DAC21A846A200F8032E /* ConversationVideoMessageCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationVideoMessageCellTests.swift; sourceTree = "<group>"; };
 		1607359A1EB2393000528965 /* SettingsShareDatabaseCellDescriptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsShareDatabaseCellDescriptor.swift; sourceTree = "<group>"; };
+		160782DF23C8ED950065392B /* UserDefaults+ApplicationGroup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UserDefaults+ApplicationGroup.swift"; sourceTree = "<group>"; };
 		160C311E1E4C78480012E4BC /* CustomMessageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomMessageView.swift; sourceTree = "<group>"; };
 		160C31201E4C7E770012E4BC /* UnknownMessageCellTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnknownMessageCellTests.swift; sourceTree = "<group>"; };
 		160D6915212AB95100096EAD /* ImageResourceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageResourceView.swift; sourceTree = "<group>"; };
@@ -6756,6 +6758,7 @@
 				F1FEA14C21DCEB1700790A54 /* WireCommonComponents.h */,
 				870534001DD6265100A7F822 /* AttributedStringOperators.swift */,
 				BF4A15D11D4900930051E8BA /* AutomationHelper.swift */,
+				160782DF23C8ED950065392B /* UserDefaults+ApplicationGroup.swift */,
 				F15650B121DD018700210504 /* Bundle+Identifiers.swift */,
 				F1FEA14D21DCEB1700790A54 /* Info.plist */,
 				F156509D21DCF1DA00210504 /* Dummy.swift */,
@@ -8617,6 +8620,7 @@
 				5E001FA82298152200F22CDD /* UIColor+AccentColor.swift in Sources */,
 				F156509F21DCF2A100210504 /* NetworkStatus.m in Sources */,
 				F15650C221DD0A8A00210504 /* BackendEnvironment+Shared.swift in Sources */,
+				160782E023C8ED960065392B /* UserDefaults+ApplicationGroup.swift in Sources */,
 				F15650BF21DD08F100210504 /* AVAsset+VideoConvert.swift in Sources */,
 				F15650AC21DCFBC000210504 /* SharedConstants.swift in Sources */,
 				F15650C421DD0AB200210504 /* UIApplication+ShareExtension.swift in Sources */,

--- a/WireCommonComponents/BackendEnvironment+Shared.swift
+++ b/WireCommonComponents/BackendEnvironment+Shared.swift
@@ -24,12 +24,11 @@ extension BackendEnvironment {
     public static let backendSwitchNotification = Notification.Name("backendEnvironmentSwitchNotification")
     
     public static var shared: BackendEnvironment = {
-        let bundle = Bundle.backendBundle
-        guard let environment = BackendEnvironment(userDefaults: .standard, configurationBundle: .backendBundle) else { fatalError("Malformed backend configuration data") }
+        guard let environment = BackendEnvironment(userDefaults: .applicationGroupCombinedWithStandard, configurationBundle: .backendBundle) else { fatalError("Malformed backend configuration data") }
         return environment
         }() {
         didSet {
-            shared.save(in: .standard)
+            shared.save(in: .applicationGroup)
             NotificationCenter.default.post(name: backendSwitchNotification, object: shared)
         }
     }

--- a/WireCommonComponents/UserDefaults+ApplicationGroup.swift
+++ b/WireCommonComponents/UserDefaults+ApplicationGroup.swift
@@ -1,6 +1,6 @@
-////
+//
 // Wire
-// Copyright (C) 2019 Wire Swiss GmbH
+// Copyright (C) 2020 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -18,13 +18,20 @@
 
 import Foundation
 
-extension Bundle {
-    public var applicationGroupIdentifier: String? {
-        guard let groupId = infoDictionary?["WireGroupId"] as? String else { return nil }
-        return "group.\(groupId)"
+extension UserDefaults {
+    
+    public static var applicationGroup: UserDefaults {
+        return UserDefaults(suiteName: Bundle.main.applicationGroupIdentifier) ?? .standard
     }
     
-    public var hostBundleIdentifier: String? {
-        return infoDictionary?["HostBundleIdentifier"] as? String
+    public static var applicationGroupCombinedWithStandard: UserDefaults {
+        let userDefaults = UserDefaults.standard
+        
+        if let applicationGroupIdentifier = Bundle.main.applicationGroupIdentifier {
+            userDefaults.addSuite(named: applicationGroupIdentifier)
+        }
+        
+        return userDefaults
     }
+    
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Share extension didn't run when Wire was running against a custom backend.

### Causes

The custom backend was stored in the `.standard` user defaults which are not accessible by the share extension.

### Solutions

Store the custom backend info in the user defaults shared tied to the application group, which is accessible by the share extension.