### PR TITLE
[Feature] Add launch flag for disabling the interactive dismissal of keyboard

### DIFF
--- a/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
+++ b/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
@@ -84,6 +84,10 @@
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
+            argument = "--disable-interactive-keyboard-dismissal"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "-com.apple.CoreData.SQLDebug 1"
             isEnabled = "NO">
          </CommandLineArgument>

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -152,7 +152,7 @@
     self.tableView.delegate = self;
     self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
     self.tableView.delaysContentTouches = NO;
-    self.tableView.keyboardDismissMode = UIScrollViewKeyboardDismissModeInteractive;
+    self.tableView.keyboardDismissMode = AutomationHelper.sharedHelper.disableInteractiveKeyboardDismissal ? UIScrollViewKeyboardDismissModeNone : UIScrollViewKeyboardDismissModeInteractive;
     
     [UIView performWithoutAnimation:^{
         self.tableView.backgroundColor = [UIColor wr_colorFromColorScheme:ColorSchemeColorContentBackground];

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.m
@@ -171,7 +171,10 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
     self.invisibleInputAccessoryView.delegate = self;
     self.invisibleInputAccessoryView.userInteractionEnabled = NO; // make it not block touch events
     self.invisibleInputAccessoryView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
-    self.inputBarController.inputBar.invisibleInputAccessoryView = self.invisibleInputAccessoryView;
+    
+    if (!AutomationHelper.sharedHelper.disableInteractiveKeyboardDismissal) {
+        self.inputBarController.inputBar.invisibleInputAccessoryView = self.invisibleInputAccessoryView;
+    }
 }
 
 - (void)createContentViewController

--- a/WireCommonComponents/AutomationHelper.swift
+++ b/WireCommonComponents/AutomationHelper.swift
@@ -69,7 +69,7 @@ final public class AutomationEmailCredentials: NSObject {
     /// Whether we should disable the call quality survey.
     public let disableCallQualitySurvey: Bool
     
-    /// Wheater we should disable dismissing the conversation input bar keyboard by dragging it downwards.
+    /// Whether we should disable dismissing the conversation input bar keyboard by dragging it downwards.
     public let disableInteractiveKeyboardDismissal: Bool
     
     /// Delay in address book remote search override

--- a/WireCommonComponents/AutomationHelper.swift
+++ b/WireCommonComponents/AutomationHelper.swift
@@ -37,49 +37,52 @@ final public class AutomationEmailCredentials: NSObject {
 /// These values typically do not need to be stored in `Settings`.
 @objcMembers public final class AutomationHelper: NSObject {
     
-    @objc static public let sharedHelper = AutomationHelper()
+    static public let sharedHelper = AutomationHelper()
     
     /// Whether AppCenter should be used
-    @objc public var useAppCenter: Bool {
+    public var useAppCenter: Bool {
         return UserDefaults.standard.bool(forKey: "UseHockey")
     }
     
     /// Whether analytics should be used
-    @objc public var useAnalytics: Bool {
+    public var useAnalytics: Bool {
         return UserDefaults.standard.bool(forKey: "UseAnalytics")
     }
     
     /// Whether to skip the first login alert
-    @objc public var skipFirstLoginAlerts : Bool {
+    public var skipFirstLoginAlerts : Bool {
         return self.automationEmailCredentials != nil
     }
     
     /// The login credentials provides by command line
-    @objc public let automationEmailCredentials: AutomationEmailCredentials?
+    public let automationEmailCredentials: AutomationEmailCredentials?
     
     /// Whether we push notification permissions alert is disabled
-    @objc public let disablePushNotificationAlert : Bool
+    public let disablePushNotificationAlert : Bool
     
     /// Whether autocorrection is disabled
-    @objc public let disableAutocorrection : Bool
+    public let disableAutocorrection : Bool
     
     /// Whether address book upload is enabled on simulator
-    @objc public let uploadAddressbookOnSimulator : Bool
+    public let uploadAddressbookOnSimulator : Bool
 
     /// Whether we should disable the call quality survey.
     public let disableCallQualitySurvey: Bool
+    
+    /// Wheater we should disable dismissing the conversation input bar keyboard by dragging it downwards.
+    public let disableInteractiveKeyboardDismissal: Bool
     
     /// Delay in address book remote search override
     public let delayInAddressBookRemoteSearch : TimeInterval?
     
     /// Debug data to install in the share container
-    @objc public let debugDataToInstall: URL?
+    public let debugDataToInstall: URL?
 
     /// The name of the arguments file in the /tmp directory
     private let fileArgumentsName = "wire_arguments.txt"
 
     /// Whether the backend environment type should be persisted as a setting.
-    @objc public let shouldPersistBackendType: Bool
+    public let shouldPersistBackendType: Bool
 
     override init() {
         let url = URL(string: NSTemporaryDirectory())?.appendingPathComponent(fileArgumentsName)
@@ -90,6 +93,7 @@ final public class AutomationEmailCredentials: NSObject {
         self.uploadAddressbookOnSimulator = arguments.hasFlag(AutomationKey.enableAddressBookOnSimulator)
         self.disableCallQualitySurvey = arguments.hasFlag(AutomationKey.disableCallQualitySurvey)
         self.shouldPersistBackendType = arguments.hasFlag(AutomationKey.persistBackendType)
+        self.disableInteractiveKeyboardDismissal = arguments.hasFlag(AutomationKey.disableInteractiveKeyboardDismissal)
 
         self.automationEmailCredentials = AutomationHelper.credentials(arguments)
         if arguments.hasFlag(AutomationKey.logNetwork) {
@@ -124,6 +128,7 @@ final public class AutomationEmailCredentials: NSObject {
         case debugDataToInstall = "debug-data-to-install"
         case disableCallQualitySurvey = "disable-call-quality-survey"
         case persistBackendType = "persist-backend-type"
+        case disableInteractiveKeyboardDismissal = "disable-interactive-keyboard-dismissal"
     }
     
     /// Returns the login email and password credentials if set in the given arguments


### PR DESCRIPTION
## What's new in this PR?

Adds the launch flag:

`--disable-interactive-keyboard-dismissal`

Which disables the interactive keyboard dismissal of the conversation input bar keyboard. This is necessary since the automation doesn't see the buttons underneath the UITextView `accessoryView` when running on iOS 13.