### PR TITLE
fix: When I open a 1:1 conversation, close it and open it again, app is stuck on wire logo

### DIFF
--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -300,7 +300,8 @@ final class ZClientViewController: UIViewController {
               animated: Bool,
               completion: Completion? = nil) {
         var conversationRootController: ConversationRootViewController? = nil
-        if conversation == currentConversation {
+        if conversation === currentConversation,
+           conversationRootController != nil {
             if let message = message {
                 conversationRootController?.scroll(to: message)
             }


### PR DESCRIPTION
## What's new in this PR?

### Issues

When I open a 1:1 conversation, close it and open it again, app is stuck on wire logo

### Causes

Conversation view controller is not loaded after https://github.com/wireapp/wire-ios/pull/3915/files#diff-0c732e18693b9c2c28bbd3cc2bdd252f

### Solutions

Compare conversation object with `===`, when conversationRootController is not created, create it.