### PR TITLE
[Fix] AppLock not showed on launch

### DIFF
--- a/Wire-iOS/Sources/AppStateController.swift
+++ b/Wire-iOS/Sources/AppStateController.swift
@@ -122,12 +122,20 @@ final class AppStateController : NSObject {
             zmLog.debug("transitioning to app state: \(newAppState)")
             lastAppState = appState
             appState = newAppState
+            
             delegate?.appStateController(transitionedTo: appState) {
                 completion?()
             }
+            notifyTransition()
         } else {
             completion?()
         }
+    }
+    
+    private func notifyTransition() {
+        NotificationCenter.default.post(name: AppStateController.appStateDidTransition,
+                                        object: nil,
+                                        userInfo: [AppStateController.appStateKey: appState])
     }
 
 }
@@ -245,4 +253,9 @@ extension AppStateController : AuthenticationCoordinatorDelegate {
         updateAppState()
     }
     
+}
+
+extension AppStateController {
+    static let appStateDidTransition = Notification.Name(rawValue: "AppStateDidTransitionNotification")
+    static let appStateKey = "AppState"
 }

--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockPresenter.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockPresenter.swift
@@ -166,6 +166,11 @@ extension AppLockPresenter {
                                                selector: #selector(AppLockPresenter.applicationDidBecomeActive),
                                                name: UIApplication.didBecomeActiveNotification,
                                                object: .none)
+        
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(appStateDidTransition(_:)),
+                                               name: AppStateController.appStateDidTransition,
+                                               object: .none)
     }
     
     @objc func applicationWillResignActive() {
@@ -185,6 +190,18 @@ extension AppLockPresenter {
     
     @objc func applicationDidBecomeActive() {
         requireAuthenticationIfNeeded()
+    }
+
+    @objc func appStateDidTransition(_ notification: Notification) {
+        guard let appState = notification.userInfo?[AppStateController.appStateKey] as? AppState else { return }
+    
+        appLockInteractorInput.appStateDidTransition(to: appState)
+        switch appState {
+        case .authenticated(completedRegistration: _):
+            requireAuthenticationIfNeeded()
+        default:
+            setContents(dimmed: false)
+        }
     }
 }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

AppLock wasn't showing up after app launch

### Causes

We relied on `isUserSessionActive` to decide if we need to show the appLock.
However, on app launch, the userSession is instantiated after checking `isUserSessionActive`.
This leads to the condition evaluating to `false` instead of `true`, therefore the appLock will not show.

### Solutions

Rely on appState transitions instead of userSession.
