### PR TITLE
[Fix] black search bar when running on iOS 13

### DIFF
--- a/Wire-iOS/Sources/Authentication/Helpers/CountryCode/CountryCodeTableViewController.m
+++ b/Wire-iOS/Sources/Authentication/Helpers/CountryCode/CountryCodeTableViewController.m
@@ -58,6 +58,7 @@
     self.searchController.delegate = self;
     self.searchController.dimsBackgroundDuringPresentation = NO;
     self.searchController.searchBar.delegate = self;
+    self.searchController.searchBar.backgroundColor = UIColor.whiteColor;
 
     self.navigationItem.rightBarButtonItem = [self.navigationController closeItem];
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

Search bar in the country selection screen is black on iOS 13

### Causes

On the iOS 13 the background color of search bar is transparent.

### Solutions

Manually assign the background color to white.