### PR TITLE
[Fix] incorrect bottom offset in the KeyboardAvoidingController 

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/KeyboardAvoidingViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/KeyboardAvoidingViewController.swift
@@ -83,6 +83,7 @@ class KeyboardAvoidingViewController: UIViewController {
         view.isOpaque = false
         addChild(viewController)
         view.addSubview(viewController.view)
+        view.backgroundColor = viewController.view.backgroundColor
         viewController.view.translatesAutoresizingMaskIntoConstraints = false
         viewController.didMove(toParent: self)
         
@@ -114,11 +115,18 @@ class KeyboardAvoidingViewController: UIViewController {
         }
         
         guard let userInfo = notification?.userInfo,
-            let duration = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? TimeInterval
-            else { return }
+              let duration = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? TimeInterval
+        else { return }
         
         let keyboardFrameInView = UIView.keyboardFrame(in: self.view, forKeyboardNotification: notification)
-        var bottomOffset: CGFloat = -abs(keyboardFrameInView.size.height)
+        var bottomOffset: CGFloat
+        
+        if #available(iOS 11.0, *) {
+            // The keyboard frame includes the safe area so we need to substract it since the bottomEdgeConstraint is attached to the safe area.
+            bottomOffset = -keyboardFrameInView.intersection(view.safeAreaLayoutGuide.layoutFrame).height
+        } else {
+            bottomOffset = -abs(keyboardFrameInView.size.height)
+        }
         
         // When this controller's view is presented at a form sheet style on iPad, the view is has a top offset and the bottomOffset should be reduced.
         if modalPresentationStyle == .formSheet, let frame = presentationController?.frameOfPresentedViewInContainerView {


### PR DESCRIPTION
## What's new in this PR?

### Issues

On devices that have a safe area at the bottom (iPhone X), the KeyboardAvoidingViewController would show a black bar above the keyboard.

![Simulator Screen Shot - iPhone X - 2020-01-17 at 13 32 43](https://user-images.githubusercontent.com/7156/72614023-7c4fb280-3931-11ea-84d2-ea5671e7da8b.png)
![Simulator Screen Shot - iPhone X - 2020-01-17 at 13 32 43](https://user-images.githubusercontent.com/7156/72614025-7e197600-3931-11ea-9509-eb0b3469f538.png)

### Causes

This happens because we include the safe area twice when calculating the offset from the bottom.

1.  The view controller is attached to the `safeAreaLayoutGuide.bottomAnchor`
2. The keyboard frame includes safe areas.

### Solutions

Exclude safe areas from the keyboard frame calculating the intersection between keyboard frame and the `safeAreaLayoutGuide.layoutFrame`

Additionally the KeyboardAvoidingViewController copies the background color of the view controller to avoid a black safe area.