### PR TITLE
fix: crash with ConversationContentViewController viewWillAppear

### DIFF
--- a/Wire-iOS/Sources/Managers/MediaPlaybackManager.swift
+++ b/Wire-iOS/Sources/Managers/MediaPlaybackManager.swift
@@ -35,6 +35,7 @@ extension Notification.Name {
 /// This object is an interface for AVS to control conversation media playback
 final class MediaPlaybackManager: NSObject, AVSMedia {
     var audioTrackPlayer: AudioTrackPlayer = AudioTrackPlayer()
+    @objc
     private(set) weak var activeMediaPlayer: MediaPlayer?
     weak var changeObserver: MediaPlaybackManagerChangeObserver?
     private var titleObserver: NSObject?


### PR DESCRIPTION
## What's new in this PR?

Fix crash due to missing @objc signature of `activeMediaPlayer`, which causing it is not KVC-compliant.