### PR TITLE
Fix: conversation screen - size not adjusted after keyboard appear

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
@@ -118,7 +118,7 @@ extension ConversationViewController: InvisibleInputAccessoryViewDelegate {
         var distanceFromBottom: CGFloat = 0
         
         // On iOS 8, the frame goes to zero when the accessory view is hidden
-        if frame?.equalTo(.zero) == false {
+        if frame?.equalTo(.zero) == false {//frame = (0.0, 568.0, 320.0, 365.0), (0.0, 203.0, 320.0, 365.0)
             
             let convertedFrame = view.convert(view.superview?.frame ?? .zero, from: view.superview?.superview)
             
@@ -131,11 +131,11 @@ extension ConversationViewController: InvisibleInputAccessoryViewDelegate {
             distanceFromBottom = max(0, distanceFromBottom)
         }
         
-        let closure: () -> () = {
-            self.inputBarBottomMargin?.constant = -distanceFromBottom ///TODO: 0?
-            
-            view.layoutIfNeeded()
-        }
+//        let closure: () -> () = {
+//            self.inputBarBottomMargin?.constant = -distanceFromBottom ///TODO: 0?
+//
+//            view.layoutIfNeeded()
+//        }
         
         if isAppearing {
             UIView.performWithoutAnimation() {

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
@@ -125,7 +125,9 @@ extension ConversationViewController: InvisibleInputAccessoryViewDelegate {
             // We have to use intrinsicContentSize here because the frame may not have actually been updated yet
             let newViewHeight = view.intrinsicContentSize.height
             
-            distanceFromBottom = view.frame.size.height - convertedFrame.origin.y - newViewHeight
+            distanceFromBottom = view.frame.size.height - convertedFrame.origin.y - newViewHeight //convertedFrame = (0.0, 0.0, 320.0, 365.0), same
+            
+            //newViewHeight = 112
             distanceFromBottom = max(0, distanceFromBottom)
         }
         
@@ -136,9 +138,18 @@ extension ConversationViewController: InvisibleInputAccessoryViewDelegate {
         }
         
         if isAppearing {
-            UIView.performWithoutAnimation(closure)
+            UIView.performWithoutAnimation() {
+                self.inputBarBottomMargin?.constant = -distanceFromBottom ///TODO: 0?
+                
+                view.layoutIfNeeded()
+
+            }
         } else {
-            closure()
+//            closure()
+            self.inputBarBottomMargin?.constant = -distanceFromBottom ///TODO: 0?
+            
+            view.layoutIfNeeded()
+
         }
         
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
@@ -113,45 +113,33 @@ extension ConversationViewController {
 extension ConversationViewController: InvisibleInputAccessoryViewDelegate {
     
     // WARNING: DO NOT TOUCH THIS UNLESS YOU KNOW WHAT YOU ARE DOING
-    func invisibleInputAccessoryView(_ view: InvisibleInputAccessoryView, superviewFrameChanged frame: CGRect?) {
+    func invisibleInputAccessoryView(_ invisibleInputAccessoryView: InvisibleInputAccessoryView, superviewFrameChanged frame: CGRect?) {
         // Adjust the input bar distance from bottom based on the invisibleAccessoryView
         var distanceFromBottom: CGFloat = 0
         
         // On iOS 8, the frame goes to zero when the accessory view is hidden
-        if frame?.equalTo(.zero) == false {//frame = (0.0, 568.0, 320.0, 365.0), (0.0, 203.0, 320.0, 365.0)
+        if frame?.equalTo(.zero) == false {
             
-            let convertedFrame = view.convert(view.superview?.frame ?? .zero, from: view.superview?.superview)
+            let convertedFrame = view.convert(invisibleInputAccessoryView.superview?.frame ?? .zero, from: invisibleInputAccessoryView.superview?.superview)
             
             // We have to use intrinsicContentSize here because the frame may not have actually been updated yet
-            let newViewHeight = view.intrinsicContentSize.height
+            let newViewHeight = invisibleInputAccessoryView.intrinsicContentSize.height
             
-            distanceFromBottom = view.frame.size.height - convertedFrame.origin.y - newViewHeight //convertedFrame = (0.0, 0.0, 320.0, 365.0), same
+            distanceFromBottom = view.frame.size.height - convertedFrame.origin.y - newViewHeight
             
-            //newViewHeight = 112
             distanceFromBottom = max(0, distanceFromBottom)
         }
         
-//        let closure: () -> () = {
-//            self.inputBarBottomMargin?.constant = -distanceFromBottom ///TODO: 0?
-//
-//            view.layoutIfNeeded()
-//        }
-        
-        if isAppearing {
-            UIView.performWithoutAnimation() {
-                self.inputBarBottomMargin?.constant = -distanceFromBottom ///TODO: 0?
-                
-                view.layoutIfNeeded()
-
-            }
-        } else {
-//            closure()
-            self.inputBarBottomMargin?.constant = -distanceFromBottom ///TODO: 0?
-            
-            view.layoutIfNeeded()
-
+        let closure: () -> () = {
+            self.inputBarBottomMargin?.constant = -distanceFromBottom
+            self.view.layoutIfNeeded()
         }
         
+        if isAppearing {
+            UIView.performWithoutAnimation(closure)
+        } else {
+            closure()
+        }        
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
@@ -120,7 +120,7 @@ extension ConversationViewController: InvisibleInputAccessoryViewDelegate {
         // On iOS 8, the frame goes to zero when the accessory view is hidden
         if frame?.equalTo(.zero) == false {
             
-            let convertedFrame = view.convert(view.superview?.frame ?? CGRect.zero, from: view.superview?.superview)
+            let convertedFrame = view.convert(view.superview?.frame ?? .zero, from: view.superview?.superview)
             
             // We have to use intrinsicContentSize here because the frame may not have actually been updated yet
             let newViewHeight = view.intrinsicContentSize.height
@@ -130,7 +130,7 @@ extension ConversationViewController: InvisibleInputAccessoryViewDelegate {
         }
         
         let closure: () -> () = {
-            self.inputBarBottomMargin?.constant = -distanceFromBottom
+            self.inputBarBottomMargin?.constant = -distanceFromBottom ///TODO: 0?
             
             view.layoutIfNeeded()
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InvisibleInputAccessoryView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InvisibleInputAccessoryView.swift
@@ -22,7 +22,7 @@ import Foundation
 // is being done to us and report back
 
 protocol InvisibleInputAccessoryViewDelegate: class {
-    func invisibleInputAccessoryView(_ view: InvisibleInputAccessoryView, superviewFrameChanged frame: CGRect?)
+    func invisibleInputAccessoryView(_ invisibleInputAccessoryView: InvisibleInputAccessoryView, superviewFrameChanged frame: CGRect?)
 }
 
 final class InvisibleInputAccessoryView: UIView {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InvisibleInputAccessoryView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InvisibleInputAccessoryView.swift
@@ -43,12 +43,8 @@ final class InvisibleInputAccessoryView: UIView {
     override func didMoveToWindow() {
         super.didMoveToWindow()
         
-        if window != nil,
-           let superview = superview {
-            
-            let keypath = "center"
-            
-            frameObserver = KeyValueObserver.observe(superview, keyPath: keypath, target: self, selector: #selector(superviewFrameChanged(_:)))
+        if window != nil {
+            frameObserver = KeyValueObserver.observe(superview!, keyPath: #keyPath(UIView.center), target: self, selector: #selector(superviewFrameChanged(_:)))
         } else {
             frameObserver = nil
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

After https://github.com/wireapp/wire-ios/pull/3953, on conversation screen, view size is not reduced after the keyboard pops up

### Causes

The calculation of constraint is wrong due to name conflict. 

### Solutions

Rename parameter from `view` to `invisibleInputAccessoryView` to prevent conflicting with `self.view`.