### PR TITLE
[Fix] Make links accessible to automation on iOS 13

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Views/WebLinkTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/WebLinkTextView.swift
@@ -38,8 +38,6 @@ import UIKit
     }
 
     private func setup() {
-        isSelectable = true
-        isEditable = false
         isScrollEnabled = false
         bounces = false
         backgroundColor = UIColor.clear


### PR DESCRIPTION
## What's new in this PR?

### Issues

When running on iOS 13 the "this device" link, included in a system message, is no longer exposed to automation/accessibility.

### Causes

By trial and error I discovered that `isEditable` must now be true for links to exposed as accessibility elements in iOS 13.

### Solutions

Remove code which sets `isEditable` to `false`. The textview is still not editable since we override `canBecomeFirstResponder` and the gesture recogniser.