### PR TITLE
[Fix] system message links not working in iOS 12

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Views/WebLinkTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/WebLinkTextView.swift
@@ -38,6 +38,15 @@ import UIKit
     }
 
     private func setup() {
+        
+        // WORKAROUND: isEditable needs to true on iOS 13 for links to be visible as an accessiblity element
+        // and set to false in iOS 12 or earlier for links to be tappable.
+        if #available(iOS 13.0, *) {
+            isEditable = true
+        } else {
+            isEditable = false
+        }
+        
         isScrollEnabled = false
         bounces = false
         backgroundColor = UIColor.clear
@@ -58,7 +67,7 @@ import UIKit
     }
 
     override func addGestureRecognizer(_ gestureRecognizer: UIGestureRecognizer) {
-        //Prevent long press to show the magnifying glass
+        // Prevent long press to show the magnifying glass
         if gestureRecognizer is UILongPressGestureRecognizer {
             gestureRecognizer.isEnabled = false
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

The "You device" link in system message are not tappable on iOS 12

### Causes

`isEditable` was set to true in https://github.com/wireapp/wire-ios/pull/3963 to fix an issue with automation.

### Solutions

Only set `isEditable` to true in iOS 13 or above.