### PR TITLE
[Fix] Remove all whitespaces at the end of a search string

### DIFF
--- a/Wire-iOS/Sources/Helpers/TextTransform/String+Transform.swift
+++ b/Wire-iOS/Sources/Helpers/TextTransform/String+Transform.swift
@@ -63,3 +63,11 @@ extension NSAttributedString {
         return mutableCopy
     }
 }
+
+
+extension String {
+    
+    func trim() -> String {
+        return self.trimmingCharacters(in: .whitespaces)
+    }
+}

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupParticipantsDetail/GroupParticipantsDetailViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupParticipantsDetail/GroupParticipantsDetailViewModel.swift
@@ -80,7 +80,7 @@ final class GroupParticipantsDetailViewModel: NSObject, SearchHeaderViewControll
     }
     
     private func filterPredicate(for query: String) -> NSPredicate {
-        let trimmedQuery = query.trimmingCharacters(in: .whitespaces)
+        let trimmedQuery = query.trim()
         var predicates = [
             NSPredicate(format: "name contains[cd] %@", trimmedQuery),
             NSPredicate(format: "handle contains[cd] %@", trimmedQuery)

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupParticipantsDetail/GroupParticipantsDetailViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupParticipantsDetail/GroupParticipantsDetailViewModel.swift
@@ -80,13 +80,14 @@ final class GroupParticipantsDetailViewModel: NSObject, SearchHeaderViewControll
     }
     
     private func filterPredicate(for query: String) -> NSPredicate {
+        let trimmedQuery = query.trimmingCharacters(in: .whitespaces)
         var predicates = [
-            NSPredicate(format: "name contains[cd] %@", query),
-            NSPredicate(format: "handle contains[cd] %@", query)
+            NSPredicate(format: "name contains[cd] %@", trimmedQuery),
+            NSPredicate(format: "handle contains[cd] %@", trimmedQuery)
         ]
 
         if query.hasPrefix("@") {
-            predicates.append(.init(format: "handle contains[cd] %@", String(query.dropFirst())))
+            predicates.append(.init(format: "handle contains[cd] %@", String(trimmedQuery.dropFirst())))
         }
         
         return NSCompoundPredicate(orPredicateWithSubpredicates: predicates)

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
@@ -250,7 +250,7 @@ extension UIViewController {
         var options = options
         options.updateForSelfUserTeamRole(selfUser: ZMUser.selfUser())
 
-        let request = SearchRequest(query: query, searchOptions: options, team: ZMUser.selfUser().team)
+        let request = SearchRequest(query: query.trim(), searchOptions: options, team: ZMUser.selfUser().team)
         if let task = searchDirectory?.perform(request) {
             task.onResult({ [weak self] in self?.handleSearchResult(result: $0, isCompleted: $1)})
             task.start()
@@ -261,8 +261,7 @@ extension UIViewController {
 
     @objc
     public func searchForUsers(withQuery query: String) {
-        let trimmedQuery = query.trimmingCharacters(in: .whitespaces)
-        self.performSearch(query: trimmedQuery, options: [.conversations, .contacts, .teamMembers, .directory])
+        self.performSearch(query: query, options: [.conversations, .contacts, .teamMembers, .directory])
     }
 
     @objc

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
@@ -261,7 +261,8 @@ extension UIViewController {
 
     @objc
     public func searchForUsers(withQuery query: String) {
-        self.performSearch(query: query, options: [.conversations, .contacts, .teamMembers, .directory])
+        let trimmedQuery = query.trimmingCharacters(in: .whitespaces)
+        self.performSearch(query: trimmedQuery, options: [.conversations, .contacts, .teamMembers, .directory])
     }
 
     @objc


### PR DESCRIPTION
## What's new in this PR?

### Issues
Extra space at the end is a cause that the user disappears in the search UI.

### Causes
We use the original search string (with spaces) to search.

### Solutions
Remove whitespaces.
