### PR TITLE
[Fix] Show a mention list if necessary.

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Mentions.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Mentions.swift
@@ -81,7 +81,7 @@ extension ConversationInputBarViewController {
         mentionsView?.dismiss()
     }
 
-    func triggerMentionsIfNeeded(from textView: UITextView, with selection: UITextRange? = nil) {
+    @objc func triggerMentionsIfNeeded(from textView: UITextView, with selection: UITextRange? = nil) {
         if let position = MentionsHandler.cursorPosition(in: textView, range: selection) {
             mentionsHandler = MentionsHandler(text: textView.text, cursorPosition: position)
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -211,6 +211,7 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
     [self updateRightAccessoryView];
     [self.inputBar updateReturnKey];
     [self.inputBar updateEphemeralState];
+    [self updateMentionList];
 }
 
 - (void)viewWillDisappear:(BOOL)animated
@@ -350,6 +351,11 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
 - (void)updateInputBarVisibility
 {
     self.view.hidden = self.conversation.isReadOnly;
+}
+
+- (void)updateMentionList
+{
+    [self triggerMentionsIfNeededFrom: self.inputBar.textView with:nil];
 }
 
 #pragma mark - Keyboard Shortcuts


### PR DESCRIPTION
## What's new in this PR?

### Issues
Suggested mention list does not stay when navigating to conversation list and navigating back to conversation.

### Causes
We show a mention list only after editing the textView.

### Solutions
Check in the `viewWillAppear` method of `ConversationInputBarViewController` if we need show a mention list.
