### PR TITLE
AppCenter distribution alert with readable message

### DIFF
--- a/Wire-iOS/Sources/AppDelegate+AppCenter.swift
+++ b/Wire-iOS/Sources/AppDelegate+AppCenter.swift
@@ -50,6 +50,7 @@ extension AppDelegate {
         
         if appCenterTrackingEnabled {
             MSCrashes.setDelegate(self)
+            MSDistribute.setDelegate(self)
             
             MSAppCenter.start()
             
@@ -81,6 +82,26 @@ extension AppDelegate {
             appCenterInitCompletion = nil
         }
         
+    }
+}
+
+extension AppDelegate: MSDistributeDelegate {
+    func distribute(_ distribute: MSDistribute!, releaseAvailableWith details: MSReleaseDetails!) -> Bool {
+        
+        let alertController = UIAlertController(title: "Update available. (\(String(describing: details.version)))",
+            message: "Release Note:\n\(String(describing: details.releaseNotes))\nDo you want to update?",
+                                                preferredStyle:.alert)
+        
+        alertController.addAction(UIAlertAction(title: "Update", style: .cancel) {_ in
+            MSDistribute.notify(.update)
+        })
+        
+        alertController.addAction(UIAlertAction(title: "Postpone", style: .default) {_ in
+            MSDistribute.notify(.postpone)
+        })
+        
+        window?.rootViewController?.present(alertController, animated: true)
+        return true
     }
 }
 


### PR DESCRIPTION
Implement `MSDistributeDelegate` and display release info in the update dialog.