### PR TITLE
Fix: App crash when numberOfRowsInSection

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
@@ -411,6 +411,8 @@ extension ConversationTableViewDataSource: UITableViewDataSource {
     }
     
     public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        guard currentSections.indices.contains(section) else { return 0 }
+        
         return currentSections[section].elements.count
     }
     


### PR DESCRIPTION
Prevent possible out-of-bound access of array in `numberOfRowsInSection`