### PR TITLE
[Refactor] Move ZMTypingChangeObserver conformance to Swift

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+TypingIndicator.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+TypingIndicator.swift
@@ -18,7 +18,11 @@
 
 import Foundation
 
-extension ConversationInputBarViewController {
+extension ConversationInputBarViewController: ZMTypingChangeObserver {
+
+    public func typingDidChange(conversation: ZMConversation, typingUsers: [UserType]) {
+        updateTypingIndicator()
+    }
 
     @objc
     func updateTypingIndicator() {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -725,16 +725,6 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
 @end
 
 
-@implementation ConversationInputBarViewController (ZMTypingChangeObserver)
-
-- (void)typingDidChangeWithConversation:(ZMConversation *)conversation typingUsers:(NSArray<id<UserType>> *)typingUsers
-{
-    [self updateTypingIndicator];
-}
-
-@end
-
-
 @implementation ConversationInputBarViewController (UIGestureRecognizerDelegate)
 
 #pragma mark - UIGestureRecognizerDelegate

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -54,9 +54,6 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
 @interface ConversationInputBarViewController (ZMUserObserver) <ZMUserObserver>
 @end
 
-@interface ConversationInputBarViewController (ZMTypingChangeObserver) <ZMTypingChangeObserver>
-@end
-
 @interface ConversationInputBarViewController (Giphy)
 
 - (void)giphyButtonPressed:(id)sender;


### PR DESCRIPTION
## What's new in this PR?

This PR is part of an ongoing effort to improve the use of `UserType`. Part of our aim is to make `UserType` a Swift only protocol, so that we are able to conform to `Hashable` in the future. To set this up, we must first remove all objective c references to the `UserType`.

This PR moves the `ZMTypingChangeObserver` conformance of `ConversationInputBarViewController` over to Swift.
