### PR TITLE
[Fix] Dismiss Start UI Before Opening Conversation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/Container/ViewModel/ConversationListViewControllerViewModel+StartUIDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/Container/ViewModel/ConversationListViewControllerViewModel+StartUIDelegate.swift
@@ -41,7 +41,9 @@ extension ConversationListViewController.ViewModel: StartUIDelegate {
     }
 
     func startUI(_ startUI: StartUIViewController, didSelect conversation: ZMConversation) {
-        ZClientViewController.shared?.select(conversation: conversation, focusOnView: true, animated: true)
+        startUI.dismissIfNeeded(animated: true) {
+            ZClientViewController.shared?.select(conversation: conversation, focusOnView: true, animated: true)
+        }
     }
     
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

When tapping on the a `TopPeopleCell` in the Start UI, the conversation for that cell would open as expected. However, immediately after tapping, the conversation list would flash on screen with a transparent background, before the conversation slid in.

### Causes

The start UI view controller was not dismissed before triggering the animation to open the conversation.

### Solutions

Dismiss the start UI first.