### PR TITLE
[Fix] ephemeral timer not being visible to voice over / automation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
@@ -123,6 +123,7 @@ final class MessageToolboxView: UIView {
         label.lineBreakMode = .byTruncatingMiddle
         label.numberOfLines = 1
         label.accessibilityIdentifier = "EphemeralCountdown"
+        label.isAccessibilityElement = true
         label.setContentHuggingPriority(.required, for: .horizontal)
         label.setContentCompressionResistancePriority(.required, for: .horizontal)
         return label


### PR DESCRIPTION
## What's new in this PR?

### Issues

The ephemeral timer below a message is not visible to automation on iOS 13

### Causes

The label displaying the timer is not visible to voice over

### Solutions

Set `isAccessibilityElement = true` on the label.