### PR TITLE
Fix: remove KeyValueObserver from MediaPlayerController

### DIFF
--- a/Wire-iOS/Sources/Components/AudioPlayer/MediaPlayerController.swift
+++ b/Wire-iOS/Sources/Components/AudioPlayer/MediaPlayerController.swift
@@ -18,9 +18,8 @@
 
 import Foundation
 
-/**
- Controls and observe the state of a AVPlayer instance for integration with the AVSMediaManager
- */
+/// For playing videos in conversation
+/// Controls and observe the state of a AVPlayer instance for integration with the AVSMediaManager
 final class MediaPlayerController: NSObject {
 
     let message: ZMConversationMessage
@@ -44,6 +43,13 @@ final class MediaPlayerController: NSObject {
         self.delegate?.mediaPlayer(self, didChangeTo: .completed)
     }
 
+    private func playerRateChanged() {
+        if player?.rate > 0 {
+            delegate?.mediaPlayer(self, didChangeTo: MediaPlayerState.playing)
+        } else {
+            delegate?.mediaPlayer(self, didChangeTo: MediaPlayerState.paused)
+        }
+    }
 }
 
 extension MediaPlayerController: MediaPlayer {
@@ -75,13 +81,4 @@ extension MediaPlayerController: MediaPlayer {
     func pause() {
         player?.pause()
     }
-
-    private func playerRateChanged() {
-        if player?.rate > 0 {
-            delegate?.mediaPlayer(self, didChangeTo: MediaPlayerState.playing)
-        } else {
-            delegate?.mediaPlayer(self, didChangeTo: MediaPlayerState.paused)
-        }
-    }
-
 }

--- a/Wire-iOS/Sources/Components/AudioPlayer/MediaPlayerController.swift
+++ b/Wire-iOS/Sources/Components/AudioPlayer/MediaPlayerController.swift
@@ -22,12 +22,12 @@ import Foundation
  Controls and observe the state of a AVPlayer instance for integration with the AVSMediaManager
  */
 @objcMembers
-class MediaPlayerController: NSObject {
+final class MediaPlayerController: NSObject {
 
     let message: ZMConversationMessage
     var player: AVPlayer?
     weak var delegate: MediaPlayerDelegate?
-    fileprivate var playerRateObserver : Any?
+    fileprivate var playerRateObserver : NSKeyValueObservation!
 
     init(player: AVPlayer, message: ZMConversationMessage, delegate: MediaPlayerDelegate) {
         self.player = player
@@ -36,7 +36,9 @@ class MediaPlayerController: NSObject {
 
         super.init()
 
-        self.playerRateObserver = KeyValueObserver.observe(player, keyPath: "rate", target: self, selector: #selector(playerRateChanged))
+        playerRateObserver = player.observe(\AVPlayer.rate) { [weak self] _, _ in
+            self?.playerRateChanged()
+        }
     }
 
     func tearDown() {
@@ -75,11 +77,7 @@ extension MediaPlayerController: MediaPlayer {
         player?.pause()
     }
 
-}
-
-extension MediaPlayerController {
-
-    @objc func playerRateChanged() {
+    private func playerRateChanged() {
         if player?.rate > 0 {
             delegate?.mediaPlayer(self, didChangeTo: MediaPlayerState.playing)
         } else {

--- a/Wire-iOS/Sources/Components/AudioPlayer/MediaPlayerController.swift
+++ b/Wire-iOS/Sources/Components/AudioPlayer/MediaPlayerController.swift
@@ -21,7 +21,6 @@ import Foundation
 /**
  Controls and observe the state of a AVPlayer instance for integration with the AVSMediaManager
  */
-@objcMembers
 final class MediaPlayerController: NSObject {
 
     let message: ZMConversationMessage


### PR DESCRIPTION
## What's new in this PR?

Remove KeyValueObserver from MediaPlayerController. Tested on simulator with player video in conversation.