### PR TITLE
fix: iPad status bar style

### DIFF
--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -188,6 +188,7 @@ final class ZClientViewController: UIViewController {
         return presentedViewController?.shouldAutorotate ?? true
     }
     
+    // MARK: Status bar
     private var child: UIViewController? {
         if nil != topOverlayViewController {
             return topOverlayViewController
@@ -198,13 +199,24 @@ final class ZClientViewController: UIViewController {
         return nil
     }
     
+    private var childForStatusBar: UIViewController? {
+        // For iPad regular mode, there is a black bar area and we always use light style and non hidden status bar
+        return isIPadRegular() ? nil : child
+    }
+    
     override var childForStatusBarStyle: UIViewController? {
-        return child
+        return childForStatusBar
     }
     
     override var childForStatusBarHidden: UIViewController? {
-        return child
+        return childForStatusBar
     }
+    
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return .lightContent
+    }
+
+    // MARK: trait
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
@@ -222,7 +234,7 @@ final class ZClientViewController: UIViewController {
         view.setNeedsLayout()
     }
     
-    // MARK: - Public API
+    // MARK: - Singleton
     @objc(sharedZClientViewController)
     static var shared: ZClientViewController? {
         return AppDelegate.shared.rootViewController.children.first(where: {$0 is ZClientViewController}) as? ZClientViewController

--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/SettingsClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/SettingsClientViewController.swift
@@ -30,7 +30,7 @@ enum ClientSection: Int {
     case removeDevice = 3
 }
 
-class SettingsClientViewController: UIViewController,
+final class SettingsClientViewController: UIViewController,
                                     UITableViewDelegate,
                                     UITableViewDataSource,
                                     UserClientObserver,
@@ -92,6 +92,10 @@ class SettingsClientViewController: UIViewController,
         return [.portrait]
     }
     
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return .lightContent
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
         


### PR DESCRIPTION
## What's new in this PR?

### Issues

iPad status bar is always dark after refactoring

### Causes

iPad has a black bar area and status bar is always invisible

### Solutions

Do not follow child view's status bar config when iPad is in regular mode
Fixed `SettingsClientViewController` status bar style