### PR TITLE
Fix: iPhone without notch - full screen image viewer can not re-show the navigation bar

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Collections/ConversationImagesViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/ConversationImagesViewController.swift
@@ -451,12 +451,7 @@ extension ConversationImagesViewController: UIPageViewControllerDelegate, UIPage
 extension ConversationImagesViewController: MenuVisibilityController {
     
     var menuVisible: Bool {
-        var isVisible = buttonsBar.isHidden && separator.isHidden
-        if !UIScreen.hasNotch {
-            isVisible = isVisible && UIApplication.shared.isStatusBarHidden
-        }
-
-        return isVisible
+        return buttonsBar.isHidden && separator.isHidden
     }
     
     func fadeAndHideMenu(_ hidden: Bool) {
@@ -485,5 +480,5 @@ extension ConversationImagesViewController {
     override var previewActionItems: [UIPreviewActionItem] {
         return currentActionController?.makePreviewActions() ?? []
     }
-
+ 
 }

--- a/Wire-iOS/Sources/UserInterface/Collections/ConversationImagesViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/ConversationImagesViewController.swift
@@ -120,6 +120,10 @@ final class ConversationImagesViewController: TintColorCorrectedViewController {
     override var prefersStatusBarHidden: Bool {
         return navigationController?.isNavigationBarHidden ?? false
     }
+    
+    override var preferredStatusBarUpdateAnimation: UIStatusBarAnimation {
+        return .fade
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -468,13 +472,11 @@ extension ConversationImagesViewController: MenuVisibilityController {
     }
 
     private func showNavigationBarVisible(hidden: Bool) {
-        let duration = UIApplication.shared.statusBarOrientationAnimationDuration
+        guard let view = navigationController?.view else { return }
 
-        UIView.animate(withDuration: duration, animations: {
-            self.navigationController?.navigationBar.alpha = hidden ? 0 : 1
-        }) { _ in
+        UIView.transition(with: view, duration: UIApplication.shared.statusBarOrientationAnimationDuration, animations: {
             self.navigationController?.setNavigationBarHidden(hidden, animated: false)
-        }
+        })
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Collections/ConversationImagesViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/ConversationImagesViewController.swift
@@ -116,6 +116,10 @@ final class ConversationImagesViewController: TintColorCorrectedViewController {
     override var preferredStatusBarStyle: UIStatusBarStyle {
         return ColorScheme.default.statusBarStyle
     }
+    
+    override var prefersStatusBarHidden: Bool {
+        return navigationController?.isNavigationBarHidden ?? false
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/BrowserViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/BrowserViewController.swift
@@ -27,8 +27,6 @@ final class BrowserViewController: SFSafariViewController {
     // MARK: - Tint Color
 
     private var overrider = TintColorOverrider()
-    private var originalStatusBarStyle: UIStatusBarStyle = .default
-    private var originalStatusBarVisibility: Bool = true
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -38,8 +36,6 @@ final class BrowserViewController: SFSafariViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        originalStatusBarStyle = UIApplication.shared.statusBarStyle
-        originalStatusBarVisibility = UIApplication.shared.isStatusBarHidden
         overrider.override()
     }
 


### PR DESCRIPTION
## What's new in this PR?

Remove the notch check when hiding the bars. 
Refactoring animation code of fading out/in navigation bar.