### PR TITLE
Fix: AppCenter update dialog - dismiss keyboard before showing

### DIFF
--- a/Wire-iOS/Sources/AppDelegate+AppCenter.swift
+++ b/Wire-iOS/Sources/AppDelegate+AppCenter.swift
@@ -83,8 +83,8 @@ extension AppDelegate {
 extension AppDelegate: MSDistributeDelegate {
     func distribute(_ distribute: MSDistribute!, releaseAvailableWith details: MSReleaseDetails!) -> Bool {
         
-        let alertController = UIAlertController(title: "Update available. \(details?.shortVersion ?? "") (\(details?.version ?? ""))",
-            message: "Release Note:\n\(details?.releaseNotes ?? "")\nDo you want to update?",
+        let alertController = UIAlertController(title: "Update available \(details?.shortVersion ?? "") (\(details?.version ?? ""))",
+            message: "Release Note:\n\n\(details?.releaseNotes ?? "")\n\nDo you want to update?",
                                                 preferredStyle:.actionSheet)
         
         alertController.addAction(UIAlertAction(title: "Update", style: .cancel) {_ in
@@ -102,8 +102,10 @@ extension AppDelegate: MSDistributeDelegate {
         }
 
         alertController.addAction(UIAlertAction(title: "Cancel", style: .default) {_ in })
-
+        
+        window?.endEditing(true)
         window?.rootViewController?.present(alertController, animated: true)
+        
         return true
     }
 }


### PR DESCRIPTION
Fix the issue that AppCenter alert sheet is covered by the keyboard.