### PR TITLE
Fix: app crash at ConversationContentViewController.willSelectRow

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Private.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Private.h
@@ -65,7 +65,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 
 - (void)removeHighlightsAndMenu;
-- (NSIndexPath * _Nullable)willSelectRowAtIndexPath:(NSIndexPath *)indexPath tableView:(UITableView *)tableView;
 - (void)setConversationHeaderView:(UIView *)headerView;
 
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -263,35 +263,6 @@
     [[UIMenuController sharedMenuController] setMenuVisible:NO animated:YES];
 }
 
-- (NSIndexPath *) willSelectRowAtIndexPath:(NSIndexPath *)indexPath tableView:(UITableView *)tableView
-{
-    ZMMessage *message = (ZMMessage *)[self.dataSource.messages objectAtIndex:indexPath.section];
-    NSIndexPath *selectedIndexPath = nil;
-
-    // If the menu is visible, hide it and do nothing
-    if (UIMenuController.sharedMenuController.isMenuVisible) {
-        [UIMenuController.sharedMenuController setMenuVisible:NO animated:YES];
-        return nil;
-    }
-
-    if ([message isEqual:self.dataSource.selectedMessage]) {
-
-        // If this cell is already selected, deselect it.
-        self.dataSource.selectedMessage  = nil;
-        [self.dataSource deselectWithIndexPath:indexPath];
-        [tableView deselectRowAtIndexPath:indexPath animated:YES];
-    } else {
-        if (tableView.indexPathForSelectedRow != nil) {
-            [self.dataSource deselectWithIndexPath:tableView.indexPathForSelectedRow];
-        }
-        self.dataSource.selectedMessage = message;
-        [self.dataSource selectWithIndexPath:indexPath];
-        selectedIndexPath = indexPath;
-    }
-
-    return selectedIndexPath;
-}
-
 @end
 
 
@@ -336,7 +307,7 @@
 
 - (NSIndexPath *)tableView:(UITableView *)tableView willSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    return [self willSelectRowAtIndexPath:indexPath tableView:tableView];
+    return [self willSelectRowAtIndexPath:indexPath tableView:tableView]; ///TODO:
 }
 
 - (void)tableView:(UITableView *)tableView prefetchRowsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -307,7 +307,7 @@
 
 - (NSIndexPath *)tableView:(UITableView *)tableView willSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    return [self willSelectRowAtIndexPath:indexPath tableView:tableView]; ///TODO:
+    return [self willSelectRowAtIndexPath:indexPath tableView:tableView];
 }
 
 - (void)tableView:(UITableView *)tableView prefetchRowsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
@@ -64,26 +64,26 @@ extension ConversationContentViewController {
     open override var preferredStatusBarStyle: UIStatusBarStyle {
         return ColorScheme.default.statusBarStyle
     }
-    
+
     @objc(willSelectRowAtIndexPath:tableView:)
     func willSelectRow(at indexPath: IndexPath, tableView: UITableView) -> IndexPath? {
         guard dataSource?.messages.indices.contains(indexPath.section) == true else { return nil }
-        
+
         // If the menu is visible, hide it and do nothing
         if UIMenuController.shared.isMenuVisible {
             UIMenuController.shared.setMenuVisible(false, animated: true)
             return nil
         }
-        
+
         let message = dataSource?.messages[indexPath.section] as? ZMMessage
 
         if message == dataSource?.selectedMessage {
-            
+
             // If this cell is already selected, deselect it.
             dataSource?.selectedMessage = nil
             dataSource?.deselect(indexPath: indexPath)
             tableView.deselectRow(at: indexPath, animated: true)
-            
+
             return nil
         } else {
             if let indexPathForSelectedRow = tableView.indexPathForSelectedRow {
@@ -91,7 +91,7 @@ extension ConversationContentViewController {
             }
             dataSource?.selectedMessage = message
             dataSource?.select(indexPath: indexPath)
-            
+
             return indexPath
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
@@ -64,4 +64,35 @@ extension ConversationContentViewController {
     open override var preferredStatusBarStyle: UIStatusBarStyle {
         return ColorScheme.default.statusBarStyle
     }
+    
+    @objc(willSelectRowAtIndexPath:tableView:)
+    func willSelectRow(at indexPath: IndexPath, tableView: UITableView) -> IndexPath? {
+        guard dataSource?.messages.indices.contains(indexPath.section) == true else { return nil }
+        
+        // If the menu is visible, hide it and do nothing
+        if UIMenuController.shared.isMenuVisible {
+            UIMenuController.shared.setMenuVisible(false, animated: true)
+            return nil
+        }
+        
+        let message = dataSource?.messages[indexPath.section] as? ZMMessage
+
+        if message == dataSource?.selectedMessage {
+            
+            // If this cell is already selected, deselect it.
+            dataSource?.selectedMessage = nil
+            dataSource?.deselect(indexPath: indexPath)
+            tableView.deselectRow(at: indexPath, animated: true)
+            
+            return nil
+        } else {
+            if let indexPathForSelectedRow = tableView.indexPathForSelectedRow {
+                dataSource?.deselect(indexPath: indexPathForSelectedRow)
+            }
+            dataSource?.selectedMessage = message
+            dataSource?.select(indexPath: indexPath)
+            
+            return indexPath
+        }
+    }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

App crash with accessing `dataSource?.messages`

### Causes

It may access out of bound elements

### Solutions

Add a guard to check whatever `indexPath.section` is within `dataSource?.messages.indices`