### PR TITLE
convert ConversationContentViewController table delegates

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Header.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Header.swift
@@ -53,3 +53,35 @@ extension ConversationContentViewController {
     }
 
 }
+
+// MARK: - TableView
+extension ConversationContentViewController: UITableViewDelegate {
+    public func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        if onScreen {
+            cell.willDisplayCell()
+        }
+        
+        // using dispatch_async because when this method gets run, the cell is not yet in visible cells,
+        // so the update will fail
+        // dispatch_async runs it with next runloop, when the cell has been added to visible cells
+        DispatchQueue.main.async(execute: {
+            self.updateVisibleMessagesWindow()
+        })
+        
+        cachedRowHeights[indexPath] = NSNumber(value: Float(cell.frame.size.height))
+    }
+    
+    public func tableView(_ tableView: UITableView, didEndDisplaying cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        cell.didEndDisplayingCell()
+        
+        cachedRowHeights[indexPath] = NSNumber(value: Float(cell.frame.size.height))
+    }
+    
+    public func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
+        return cachedRowHeights[indexPath] as? CGFloat ?? UITableView.automaticDimension
+    }
+    
+    public func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
+        return willSelectRow(at: indexPath, tableView: tableView)
+    }
+}

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Header.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Header.swift
@@ -53,35 +53,3 @@ extension ConversationContentViewController {
     }
 
 }
-
-// MARK: - TableView
-extension ConversationContentViewController: UITableViewDelegate {
-    public func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-        if onScreen {
-            cell.willDisplayCell()
-        }
-        
-        // using dispatch_async because when this method gets run, the cell is not yet in visible cells,
-        // so the update will fail
-        // dispatch_async runs it with next runloop, when the cell has been added to visible cells
-        DispatchQueue.main.async(execute: {
-            self.updateVisibleMessagesWindow()
-        })
-        
-        cachedRowHeights[indexPath] = NSNumber(value: Float(cell.frame.size.height))
-    }
-    
-    public func tableView(_ tableView: UITableView, didEndDisplaying cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-        cell.didEndDisplayingCell()
-        
-        cachedRowHeights[indexPath] = NSNumber(value: Float(cell.frame.size.height))
-    }
-    
-    public func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
-        return cachedRowHeights[indexPath] as? CGFloat ?? UITableView.automaticDimension
-    }
-    
-    public func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
-        return willSelectRow(at: indexPath, tableView: tableView)
-    }
-}

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Private.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Private.h
@@ -66,7 +66,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)removeHighlightsAndMenu;
 - (void)setConversationHeaderView:(UIView *)headerView;
-
+- (void)updateVisibleMessagesWindow;
 
 @end
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -36,7 +36,7 @@
 
 #import "Wire-Swift.h"
 
-@interface ConversationContentViewController (TableView) <UITableViewDelegate, UITableViewDataSourcePrefetching>
+@interface ConversationContentViewController (TableView) <UITableViewDataSourcePrefetching>
 @end
 
 @interface ConversationContentViewController (ZMTypingChangeObserver) <ZMTypingChangeObserver>
@@ -269,46 +269,6 @@
 
 @implementation ConversationContentViewController (TableView)
 
-- (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath
-{
-    if ([cell respondsToSelector:@selector(willDisplayCell)] && self.onScreen) {
-        [(id)cell willDisplayCell];
-    }
-    
-	// using dispatch_async because when this method gets run, the cell is not yet in visible cells,
-	// so the update will fail
-	// dispatch_async runs it with next runloop, when the cell has been added to visible cells
-	dispatch_async(dispatch_get_main_queue(), ^{
-		[self updateVisibleMessagesWindow];
-	});
-    
-    [self.cachedRowHeights setObject:@(cell.frame.size.height) forKey:indexPath];
-}
-
-- (void)tableView:(UITableView *)tableView didEndDisplayingCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath
-{
-    if ([cell respondsToSelector:@selector(didEndDisplayingCell)]) {
-        [(id)cell didEndDisplayingCell];
-    }
-    
-    [self.cachedRowHeights setObject:@(cell.frame.size.height) forKey:indexPath];
-}
-
-- (CGFloat)tableView:(UITableView *)tableView estimatedHeightForRowAtIndexPath:(NSIndexPath *)indexPath
-{
-    NSNumber *cachedHeight = [self.cachedRowHeights objectForKey:indexPath];
-    
-    if (cachedHeight != nil) {
-        return cachedHeight.floatValue;
-    } else {
-        return UITableViewAutomaticDimension;
-    }
-}
-
-- (NSIndexPath *)tableView:(UITableView *)tableView willSelectRowAtIndexPath:(NSIndexPath *)indexPath
-{
-    return [self willSelectRowAtIndexPath:indexPath tableView:tableView];
-}
 
 - (void)tableView:(UITableView *)tableView prefetchRowsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths
 {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.m
@@ -36,9 +36,6 @@
 
 #import "Wire-Swift.h"
 
-@interface ConversationContentViewController (TableView) <UITableViewDataSourcePrefetching>
-@end
-
 @interface ConversationContentViewController (ZMTypingChangeObserver) <ZMTypingChangeObserver>
 @end
 
@@ -261,17 +258,6 @@
 - (void)removeHighlightsAndMenu
 {
     [[UIMenuController sharedMenuController] setMenuVisible:NO animated:YES];
-}
-
-@end
-
-
-
-@implementation ConversationContentViewController (TableView)
-
-
-- (void)tableView:(UITableView *)tableView prefetchRowsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths
-{
 }
 
 @end

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
@@ -103,27 +103,27 @@ extension ConversationContentViewController: UITableViewDelegate {
         if onScreen {
             cell.willDisplayCell()
         }
-        
+
         // using dispatch_async because when this method gets run, the cell is not yet in visible cells,
         // so the update will fail
         // dispatch_async runs it with next runloop, when the cell has been added to visible cells
         DispatchQueue.main.async(execute: {
             self.updateVisibleMessagesWindow()
         })
-        
+
         cachedRowHeights[indexPath] = NSNumber(value: Float(cell.frame.size.height))
     }
-    
+
     public func tableView(_ tableView: UITableView, didEndDisplaying cell: UITableViewCell, forRowAt indexPath: IndexPath) {
         cell.didEndDisplayingCell()
-        
+
         cachedRowHeights[indexPath] = NSNumber(value: Float(cell.frame.size.height))
     }
-    
+
     public func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
         return cachedRowHeights[indexPath] as? CGFloat ?? UITableView.automaticDimension
     }
-    
+
     public func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
         return willSelectRow(at: indexPath, tableView: tableView)
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
@@ -65,7 +65,6 @@ extension ConversationContentViewController {
         return ColorScheme.default.statusBarStyle
     }
 
-    @objc(willSelectRowAtIndexPath:tableView:)
     func willSelectRow(at indexPath: IndexPath, tableView: UITableView) -> IndexPath? {
         guard dataSource?.messages.indices.contains(indexPath.section) == true else { return nil }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
@@ -95,3 +95,42 @@ extension ConversationContentViewController {
         }
     }
 }
+
+// MARK: - TableView
+
+extension ConversationContentViewController: UITableViewDelegate {
+    public func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        if onScreen {
+            cell.willDisplayCell()
+        }
+        
+        // using dispatch_async because when this method gets run, the cell is not yet in visible cells,
+        // so the update will fail
+        // dispatch_async runs it with next runloop, when the cell has been added to visible cells
+        DispatchQueue.main.async(execute: {
+            self.updateVisibleMessagesWindow()
+        })
+        
+        cachedRowHeights[indexPath] = NSNumber(value: Float(cell.frame.size.height))
+    }
+    
+    public func tableView(_ tableView: UITableView, didEndDisplaying cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        cell.didEndDisplayingCell()
+        
+        cachedRowHeights[indexPath] = NSNumber(value: Float(cell.frame.size.height))
+    }
+    
+    public func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
+        return cachedRowHeights[indexPath] as? CGFloat ?? UITableView.automaticDimension
+    }
+    
+    public func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
+        return willSelectRow(at: indexPath, tableView: tableView)
+    }
+}
+
+extension ConversationContentViewController: UITableViewDataSourcePrefetching {
+    public func tableView(_ tableView: UITableView, prefetchRowsAt indexPaths: [IndexPath]) {
+        //no-op
+    }
+}


### PR DESCRIPTION
## What's new in this PR?

Convert `UITableViewDelegate` & `UITableViewDataSourcePrefetching` of `ConversationContentViewController` to Swift