### PR TITLE
Fix: iPad - app crash when showing app center update dialog

### DIFF
--- a/Wire-iOS/Sources/AppDelegate+AppCenter.swift
+++ b/Wire-iOS/Sources/AppDelegate+AppCenter.swift
@@ -82,10 +82,12 @@ extension AppDelegate {
 
 extension AppDelegate: MSDistributeDelegate {
     func distribute(_ distribute: MSDistribute!, releaseAvailableWith details: MSReleaseDetails!) -> Bool {
+        guard let window = window else { return false }
         
         let alertController = UIAlertController(title: "Update available \(details?.shortVersion ?? "") (\(details?.version ?? ""))",
             message: "Release Note:\n\n\(details?.releaseNotes ?? "")\n\nDo you want to update?",
-                                                preferredStyle:.actionSheet)
+            preferredStyle:.actionSheet)
+        alertController.configPopover(pointToView: window)
         
         alertController.addAction(UIAlertAction(title: "Update", style: .cancel) {_ in
             MSDistribute.notify(.update)
@@ -94,17 +96,17 @@ extension AppDelegate: MSDistributeDelegate {
         alertController.addAction(UIAlertAction(title: "Postpone", style: .default) {_ in
             MSDistribute.notify(.postpone)
         })
-
+        
         if let url = details.releaseNotesUrl {
             alertController.addAction(UIAlertAction(title: "View release note", style: .default) {_ in
                 UIApplication.shared.open(url, options: [:])
             })
         }
-
+        
         alertController.addAction(UIAlertAction(title: "Cancel", style: .default) {_ in })
         
-        window?.endEditing(true)
-        window?.rootViewController?.present(alertController, animated: true)
+        window.endEditing(true)
+        window.rootViewController?.present(alertController, animated: true)
         
         return true
     }

--- a/Wire-iOS/Sources/AppDelegate+AppCenter.swift
+++ b/Wire-iOS/Sources/AppDelegate+AppCenter.swift
@@ -22,39 +22,38 @@ import AppCenterAnalytics
 import AppCenterCrashes
 import AppCenterDistribute
 
-
 extension AppDelegate {
-    
+
     var zmLog: ZMSLog {
         return ZMSLog(tag: "UI")
     }
-    
-    func setupAppCenter(completion: @escaping () -> ()) {
-        
+
+    func setupAppCenter(completion: @escaping () -> Void) {
+
         let shouldUseAppCenter = AutomationHelper.sharedHelper.useAppCenter || Bundle.useAppCenter
-        
+
         if !shouldUseAppCenter {
             completion()
             return
         }
-        
+
         let userDefaults = UserDefaults.standard
         userDefaults.set(true, forKey: "kBITExcludeApplicationSupportFromBackup") //check
-        
+
         let appCenterTrackingEnabled = !TrackingManager.shared.disableCrashAndAnalyticsSharing
-        
+
         if appCenterTrackingEnabled {
             MSCrashes.setDelegate(self)
             MSDistribute.setDelegate(self)
-            
+
             MSAppCenter.start()
-            
+
             MSAppCenter.setLogLevel(.verbose)
-            
+
             // This method must only be used after Services have been started.
             MSAppCenter.setTrackingEnabled(appCenterTrackingEnabled)
         }
-        
+
         if appCenterTrackingEnabled &&
             MSCrashes.hasCrashedInLastSession() &&
             MSCrashes.timeIntervalCrashInLastSessionOccurred < 5 {
@@ -65,61 +64,61 @@ extension AppDelegate {
             completion()
         }
     }
-    
+
     @objc
     private func crashReportUploadDone() {
-        
+
         zmLog.error("AppCenterIntegration: finished or timed out sending the crash report")
-        
+
         if appCenterInitCompletion != nil {
             appCenterInitCompletion?()
             zmLog.error("AppCenterIntegration: END Waiting for the crash log upload...")
             appCenterInitCompletion = nil
         }
-        
+
     }
 }
 
 extension AppDelegate: MSDistributeDelegate {
     func distribute(_ distribute: MSDistribute!, releaseAvailableWith details: MSReleaseDetails!) -> Bool {
         guard let window = window else { return false }
-        
+
         let alertController = UIAlertController(title: "Update available \(details?.shortVersion ?? "") (\(details?.version ?? ""))",
             message: "Release Note:\n\n\(details?.releaseNotes ?? "")\n\nDo you want to update?",
             preferredStyle:.actionSheet)
         alertController.configPopover(pointToView: window)
-        
+
         alertController.addAction(UIAlertAction(title: "Update", style: .cancel) {_ in
             MSDistribute.notify(.update)
         })
-        
+
         alertController.addAction(UIAlertAction(title: "Postpone", style: .default) {_ in
             MSDistribute.notify(.postpone)
         })
-        
+
         if let url = details.releaseNotesUrl {
             alertController.addAction(UIAlertAction(title: "View release note", style: .default) {_ in
                 UIApplication.shared.open(url, options: [:])
             })
         }
-        
+
         alertController.addAction(UIAlertAction(title: "Cancel", style: .default) {_ in })
-        
+
         window.endEditing(true)
         window.rootViewController?.present(alertController, animated: true)
-        
+
         return true
     }
 }
 
 extension AppDelegate: MSCrashesDelegate {
-    
+
     public func crashes(_ crashes: MSCrashes!, shouldProcessErrorReport errorReport: MSErrorReport!) -> Bool {
         return !TrackingManager.shared.disableCrashAndAnalyticsSharing
     }
-    
+
     public func crashes(_ crashes: MSCrashes!, didSucceedSending errorReport: MSErrorReport!) {
         crashReportUploadDone()
     }
-    
+
 }


### PR DESCRIPTION
## What's new in this PR?

Config the alert's source view to prevent the crash.