### PR TITLE
Fix: iPad - app lock screen does not cover the main screen

### DIFF
--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -65,17 +65,20 @@ final class AppRootViewController: UIViewController {
 
     fileprivate var performWhenShowContentDelegateIsAvailable: ((ShowContentDelegate)->())?
 
-    func updateOverlayWindowFrame() {
-        self.overlayWindow.frame = UIApplication.shared.keyWindow?.frame ?? UIScreen.main.bounds
+    func updateOverlayWindowFrame(size: CGSize? = nil) {
+        if let size = size {
+            overlayWindow.frame.size = size
+        } else {
+            overlayWindow.frame = UIApplication.shared.keyWindow?.frame ?? UIScreen.main.bounds
+        }
     }
 
     override public func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
         
         mainWindow.frame.size = size
-
         coordinator.animate(alongsideTransition: nil, completion: { _ in
-            self.updateOverlayWindowFrame()
+            self.updateOverlayWindowFrame(size: size)
         })
     }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

When iPad is rotated of switching split mode, the main window is not fully covered by the app lock screen.

### Causes

`NotificationWidow` is not resized correctly.

### Solutions

Pass the new size to `updateOverlayWindowFrame` and resize to the new size instead of the old size.