### PR TITLE
Fix: incorrect status bar style

### DIFF
--- a/Wire-iOS/Sources/Helpers/ColorScheme+Helper.swift
+++ b/Wire-iOS/Sources/Helpers/ColorScheme+Helper.swift
@@ -20,12 +20,8 @@ import Foundation
 
 extension ColorScheme {
 
-    @objc var statusBarStyle: UIStatusBarStyle {
+    var statusBarStyle: UIStatusBarStyle {
         return variant == .light ? .default : .lightContent
-    }
-
-    @objc var indicatorStyle: UIScrollView.IndicatorStyle {
-        return variant == .light ? .default : .white
     }
 
     func isCurrentAccentColor(_ accentColor: UIColor) -> Bool {

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -183,8 +183,10 @@ final class CallViewController: UIViewController {
     }
     
     fileprivate func minimizeOverlay() {
+        weak var rootViewController = view.window?.rootViewController
         dismiss(animated: true, completion: {
             self.dismisser?.dismiss(viewController: self, completion: nil)
+            rootViewController?.setNeedsStatusBarAppearanceUpdate()
         })
     }
 

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/ClearBackgroundNavigationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/ClearBackgroundNavigationController.swift
@@ -35,6 +35,10 @@ final class ClearBackgroundNavigationController: UINavigationController {
         self.setup()
     }
     
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return .lightContent
+    }
+    
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         self.setup()

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/ClearBackgroundNavigationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/ClearBackgroundNavigationController.swift
@@ -35,10 +35,6 @@ final class ClearBackgroundNavigationController: UINavigationController {
         self.setup()
     }
     
-    override var preferredStatusBarStyle: UIStatusBarStyle {
-        return .lightContent
-    }
-    
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         self.setup()

--- a/Wire-iOS/Sources/UserInterface/ConnectRequests/UserConnectionViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConnectRequests/UserConnectionViewController.swift
@@ -66,7 +66,6 @@ final class IncomingConnectionViewController: UIViewController {
     
 }
 
-@objcMembers
 final class UserConnectionViewController: UIViewController {
 
     fileprivate var userConnectionView: UserConnectionView!

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -34,7 +34,11 @@ final class ZClientViewController: UIViewController {
     var userObserverToken: Any?
     
     private let topOverlayContainer: UIView = UIView()
-    private var topOverlayViewController: UIViewController?
+    private var topOverlayViewController: UIViewController? {
+        didSet {
+            setNeedsStatusBarAppearanceUpdate()
+        }
+    }
     private var contentTopRegularConstraint: NSLayoutConstraint!
     private var contentTopCompactConstraint: NSLayoutConstraint!
     // init value = false which set to true, set to false after data usage permission dialog is displayed
@@ -587,18 +591,13 @@ final class ZClientViewController: UIViewController {
                 self.topOverlayViewController = viewController
                 self.updateSplitViewTopConstraint()
                 
-                self.view.setNeedsLayout()
-                self.view.layoutIfNeeded()
-                
                 UIView.animate(withDuration: 0.35, delay: 0, options: [.curveEaseOut, .beginFromCurrentState], animations: {
                     heightConstraint.isActive = false
-                    self.view.setNeedsLayout()
                     self.view.layoutIfNeeded()
-                }) { _ in
-                            }
+                })
             }
             else {
-                        topOverlayViewController = viewController
+                topOverlayViewController = viewController
                 updateSplitViewTopConstraint()
             }
         }

--- a/Wire-iOS/Sources/UserInterface/Overlay/CallTopOverlayController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/CallTopOverlayController.swift
@@ -108,7 +108,7 @@ final class CallTopOverlayController: UIViewController {
             self?.openCall(nil)
         })
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(openCall(_:)))

--- a/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ChangePhoneViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ChangePhoneViewController.swift
@@ -82,12 +82,17 @@ final class ChangePhoneViewController: SettingsBaseTableViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
+        super.viewWillAppear(animated)
         observerToken = userProfile?.add(observer: self)
     }
     
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        setNeedsStatusBarAppearanceUpdate()
+    }
+
     override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillAppear(animated)
+        super.viewWillDisappear(animated)
         observerToken = nil
     }
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

Conversation screen has a white status bar after call ends.
`CallTopOverlayController` has a dark status bar
`ChangePhoneViewController`'s status bar is dark on dark after dismissed country screen

### Solutions

Call `setNeedsStatusBarAppearanceUpdate` in these cases.
Clean up the animation code.