### PR TITLE
[Fix] Don't assume list of call participant doesn't contain any duplicates

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/Haptic Feedback/CallHapticsController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/Haptic Feedback/CallHapticsController.swift
@@ -86,9 +86,7 @@ final class CallHapticsController {
     }
     
     private func createVideoStateMap(using participants: [CallParticipant]) -> [CallParticipant : Bool] {
-        return Dictionary(uniqueKeysWithValues: participants.map {
-            ($0, $0.state.isSendingVideo)
-        })
+        return Dictionary(participants.map { ($0, $0.state.isSendingVideo) }, uniquingKeysWith: { (first, _) in first })
     }
 }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

The app sometimes crashes in group calls.

### Causes

The `CallHapticsController` tries to generate a dictionary with the call participants using the call participant itself as the key, this crashes if a call participant exists twice in the list.

### Solutions

Don't assume that call participant list doesn't contain any duplicates and employ a uniquing strategy.