### PR TITLE
[Fix] Displaying the badge count without unread conversation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ZMConversation+Status.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ZMConversation+Status.swift
@@ -652,7 +652,10 @@ final class GroupActivityMatcher: TypedConversationStatusMatcher {
     var combinesWith: [ConversationStatusMatcher] = []
     
     func icon(with status: ConversationStatus, conversation: ZMConversation) -> ConversationStatusIcon? {
-        return ConversationStatusIcon.unreadMessages(count: 1)
+        return .unreadMessages(count: status.messagesRequiringAttention
+            .compactMap { StatusMessageType(message: $0) }
+            .filter { matchedTypes.contains($0) }
+            .count)
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ZMConversation+Status.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ZMConversation+Status.swift
@@ -650,6 +650,10 @@ final class GroupActivityMatcher: TypedConversationStatusMatcher {
     }
     
     var combinesWith: [ConversationStatusMatcher] = []
+    
+    func icon(with status: ConversationStatus, conversation: ZMConversation) -> ConversationStatusIcon? {
+        return ConversationStatusIcon.unreadMessages(count: 1)
+    }
 }
 
 // [Someone] started a conversation


### PR DESCRIPTION
## What's new in this PR?

### Issues
We show an unread count for a conversation without indicating it with an unread badge next to it (when the self user has been added to / or kicked from a conversation).

### Causes
We don't display an unread badge next to a conversation, when it's a system message, and display a badge on the folders grouping.

### Solutions
To display an unread badge next to a conversation when the self user has been added to / or kicked from a conversation.

