### PR TITLE
[Fix] Add the debugging tools section to public builds

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -1159,6 +1159,7 @@
 "self.settings.advanced.title" = "Advanced";
 "self.settings.advanced.troubleshooting.title" = "Troubleshooting";
 "self.settings.advanced.troubleshooting.submit_debug.title" = "Debug Report";
+"self.settings.advanced.troubleshooting.submit_tools.title" = "Debugging Tools";
 "self.settings.advanced.troubleshooting.submit_debug.subtitle" = "This information helps Wire Support diagnose calling problems and improve the overall app experience.";
 "self.settings.advanced.reset_push_token.title" = "Reset Push Notifications Token";
 "self.settings.advanced.reset_push_token.subtitle" = "If you experience problems with push notifications, Wire Support may ask you to reset this token.";

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -1159,7 +1159,9 @@
 "self.settings.advanced.title" = "Advanced";
 "self.settings.advanced.troubleshooting.title" = "Troubleshooting";
 "self.settings.advanced.troubleshooting.submit_debug.title" = "Debug Report";
-"self.settings.advanced.troubleshooting.submit_tools.title" = "Debugging Tools";
+"self.settings.advanced.debugging_tools.title" = "Debugging Tools";
+"self.settings.advanced.debugging_tools.first_unread_conversation_badge_count.title" = "First unread conversation (badge count)";
+"self.settings.advanced.debugging_tools.first_unread_conversation_back_arrow_count.title" = "First unread conversation (back arrow count)";
 "self.settings.advanced.troubleshooting.submit_debug.subtitle" = "This information helps Wire Support diagnose calling problems and improve the overall app experience.";
 "self.settings.advanced.reset_push_token.title" = "Reset Push Notifications Token";
 "self.settings.advanced.reset_push_token.subtitle" = "If you experience problems with push notifications, Wire Support may ask you to reset this token.";

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
@@ -175,6 +175,15 @@ class SettingsCellDescriptorFactory {
         
         let troubleshootingSection = SettingsSectionDescriptor(cellDescriptors: [troubleshootingButton], header: troubleshootingSectionTitle, footer: troubleshootingSectionSubtitle)
         
+        let debuggingToolsTitle = "self.settings.advanced.troubleshooting.submit_tools.title".localized
+        let debuggingToolsButton = SettingsExternalScreenCellDescriptor(title: debuggingToolsTitle) { () -> (UIViewController?) in
+            return SettingsTechnicalReportViewController()
+        }
+
+        let debuggingToolsSection = SettingsSectionDescriptor(cellDescriptors: [debuggingToolsButton], header: .none, footer: .none) { (_) -> (Bool) in
+            return true
+        }
+        
         let pushTitle = "self.settings.advanced.reset_push_token.title".localized
         let pushSectionSubtitle = "self.settings.advanced.reset_push_token.subtitle".localized
         
@@ -208,7 +217,7 @@ class SettingsCellDescriptorFactory {
 
         let versionSection = SettingsSectionDescriptor(cellDescriptors: [versionCell])
 
-        items.append(contentsOf: [troubleshootingSection, pushSection, versionSection])
+        items.append(contentsOf: [troubleshootingSection, debuggingToolsSection, pushSection, versionSection])
         
         return SettingsGroupCellDescriptor(
             items: items,
@@ -268,6 +277,25 @@ class SettingsCellDescriptorFactory {
         let triggerSlowSyncButton = SettingsButtonCellDescriptor(title: "Trigger slow sync", isDestructive: false, selectAction: SettingsCellDescriptorFactory.triggerSlowSync)
         developerCellDescriptors.append(triggerSlowSyncButton)
 
+        return SettingsGroupCellDescriptor(items: [SettingsSectionDescriptor(cellDescriptors:developerCellDescriptors)], title: title, icon: .robot)
+    }
+    
+    func developerGroup1() -> SettingsCellDescriptorType {
+        let title = "self.settings.developer_options.title".localized
+        var developerCellDescriptors: [SettingsCellDescriptorType] = []
+        
+        let devController = SettingsExternalScreenCellDescriptor(title: "Logging") { () -> (UIViewController?) in
+            return DeveloperOptionsController()
+        }
+        
+        developerCellDescriptors.append(devController)
+       
+        let findUnreadBadgeConversationButton = SettingsButtonCellDescriptor(title: "First unread conversation (badge count)", isDestructive: false, selectAction: SettingsCellDescriptorFactory.findUnreadConversationContributingToBadgeCount)
+        developerCellDescriptors.append(findUnreadBadgeConversationButton)
+        let findUnreadBackArrowConversationButton = SettingsButtonCellDescriptor(title: "First unread conversation (back arrow count)", isDestructive: false, selectAction: SettingsCellDescriptorFactory.findUnreadConversationContributingToBackArrowDot)
+        developerCellDescriptors.append(findUnreadBackArrowConversationButton)
+       
+        
         return SettingsGroupCellDescriptor(items: [SettingsSectionDescriptor(cellDescriptors:developerCellDescriptors)], title: title, icon: .robot)
     }
     

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
@@ -175,15 +175,6 @@ class SettingsCellDescriptorFactory {
         
         let troubleshootingSection = SettingsSectionDescriptor(cellDescriptors: [troubleshootingButton], header: troubleshootingSectionTitle, footer: troubleshootingSectionSubtitle)
         
-        let debuggingToolsTitle = "self.settings.advanced.troubleshooting.submit_tools.title".localized
-        let debuggingToolsButton = SettingsExternalScreenCellDescriptor(title: debuggingToolsTitle) { () -> (UIViewController?) in
-            return SettingsTechnicalReportViewController()
-        }
-
-        let debuggingToolsSection = SettingsSectionDescriptor(cellDescriptors: [debuggingToolsButton], header: .none, footer: .none) { (_) -> (Bool) in
-            return true
-        }
-        
         let pushTitle = "self.settings.advanced.reset_push_token.title".localized
         let pushSectionSubtitle = "self.settings.advanced.reset_push_token.subtitle".localized
         
@@ -217,7 +208,7 @@ class SettingsCellDescriptorFactory {
 
         let versionSection = SettingsSectionDescriptor(cellDescriptors: [versionCell])
 
-        items.append(contentsOf: [troubleshootingSection, debuggingToolsSection, pushSection, versionSection])
+        items.append(contentsOf: [troubleshootingSection, debuggingToolsSection(), pushSection, versionSection])
         
         return SettingsGroupCellDescriptor(
             items: items,
@@ -280,23 +271,15 @@ class SettingsCellDescriptorFactory {
         return SettingsGroupCellDescriptor(items: [SettingsSectionDescriptor(cellDescriptors:developerCellDescriptors)], title: title, icon: .robot)
     }
     
-    func developerGroup1() -> SettingsCellDescriptorType {
-        let title = "self.settings.developer_options.title".localized
-        var developerCellDescriptors: [SettingsCellDescriptorType] = []
+    func debuggingToolsSection() -> SettingsSectionDescriptor {
+        let title = "self.settings.advanced.troubleshooting.submit_tools.title".localized
         
-        let devController = SettingsExternalScreenCellDescriptor(title: "Logging") { () -> (UIViewController?) in
-            return DeveloperOptionsController()
-        }
-        
-        developerCellDescriptors.append(devController)
-       
         let findUnreadBadgeConversationButton = SettingsButtonCellDescriptor(title: "First unread conversation (badge count)", isDestructive: false, selectAction: SettingsCellDescriptorFactory.findUnreadConversationContributingToBadgeCount)
-        developerCellDescriptors.append(findUnreadBadgeConversationButton)
-        let findUnreadBackArrowConversationButton = SettingsButtonCellDescriptor(title: "First unread conversation (back arrow count)", isDestructive: false, selectAction: SettingsCellDescriptorFactory.findUnreadConversationContributingToBackArrowDot)
-        developerCellDescriptors.append(findUnreadBackArrowConversationButton)
-       
         
-        return SettingsGroupCellDescriptor(items: [SettingsSectionDescriptor(cellDescriptors:developerCellDescriptors)], title: title, icon: .robot)
+        let findUnreadBackArrowConversationButton = SettingsButtonCellDescriptor(title: "First unread conversation (back arrow count)", isDestructive: false, selectAction: SettingsCellDescriptorFactory.findUnreadConversationContributingToBackArrowDot)
+        
+        let debuggingToolsGroup = SettingsGroupCellDescriptor(items: [SettingsSectionDescriptor(cellDescriptors:[findUnreadBadgeConversationButton, findUnreadBackArrowConversationButton])], title: title)
+        return SettingsSectionDescriptor(cellDescriptors: [debuggingToolsGroup], header: .none, footer: .none)
     }
     
     func requestNumber(_ callback: @escaping (Int)->()) {

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
@@ -272,10 +272,10 @@ class SettingsCellDescriptorFactory {
     }
     
     func debuggingToolsSection() -> SettingsSectionDescriptor {
-        let title = "self.settings.advanced.troubleshooting.submit_tools.title".localized
+        let title = "self.settings.advanced.debugging_tools.title".localized
         
-        let findUnreadBadgeConversationButton = SettingsButtonCellDescriptor(title: "First unread conversation (badge count)", isDestructive: false, selectAction: SettingsCellDescriptorFactory.findUnreadConversationContributingToBadgeCount)
-        let findUnreadBackArrowConversationButton = SettingsButtonCellDescriptor(title: "First unread conversation (back arrow count)", isDestructive: false, selectAction: SettingsCellDescriptorFactory.findUnreadConversationContributingToBackArrowDot)
+        let findUnreadBadgeConversationButton = SettingsButtonCellDescriptor(title: "self.settings.advanced.debugging_tools.first_unread_conversation_badge_count.title".localized, isDestructive: false, selectAction: SettingsCellDescriptorFactory.findUnreadConversationContributingToBadgeCount)
+        let findUnreadBackArrowConversationButton = SettingsButtonCellDescriptor(title: "self.settings.advanced.debugging_tools.first_unread_conversation_back_arrow_count.title".localized, isDestructive: false, selectAction: SettingsCellDescriptorFactory.findUnreadConversationContributingToBackArrowDot)
         let debuggingToolsGroup = SettingsGroupCellDescriptor(items: [SettingsSectionDescriptor(cellDescriptors:[findUnreadBadgeConversationButton, findUnreadBackArrowConversationButton])], title: title)
         return SettingsSectionDescriptor(cellDescriptors: [debuggingToolsGroup], header: .none, footer: .none)
     }

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
@@ -275,9 +275,7 @@ class SettingsCellDescriptorFactory {
         let title = "self.settings.advanced.troubleshooting.submit_tools.title".localized
         
         let findUnreadBadgeConversationButton = SettingsButtonCellDescriptor(title: "First unread conversation (badge count)", isDestructive: false, selectAction: SettingsCellDescriptorFactory.findUnreadConversationContributingToBadgeCount)
-        
         let findUnreadBackArrowConversationButton = SettingsButtonCellDescriptor(title: "First unread conversation (back arrow count)", isDestructive: false, selectAction: SettingsCellDescriptorFactory.findUnreadConversationContributingToBackArrowDot)
-        
         let debuggingToolsGroup = SettingsGroupCellDescriptor(items: [SettingsSectionDescriptor(cellDescriptors:[findUnreadBadgeConversationButton, findUnreadBackArrowConversationButton])], title: title)
         return SettingsSectionDescriptor(cellDescriptors: [debuggingToolsGroup], header: .none, footer: .none)
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues
There's a badge count without unread conversation.

### Solutions
Expose two methods for finding conversations with unread messages under Settings > Advanced > Debugging Tools. It would help to find a badge problem by triggering a debug action.