### PR TITLE
[Fix] Simplify debugging tools sections

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -1160,8 +1160,7 @@
 "self.settings.advanced.troubleshooting.title" = "Troubleshooting";
 "self.settings.advanced.troubleshooting.submit_debug.title" = "Debug Report";
 "self.settings.advanced.debugging_tools.title" = "Debugging Tools";
-"self.settings.advanced.debugging_tools.first_unread_conversation_badge_count.title" = "First unread conversation (badge count)";
-"self.settings.advanced.debugging_tools.first_unread_conversation_back_arrow_count.title" = "First unread conversation (back arrow count)";
+"self.settings.advanced.debugging_tools.first_unread_conversation.title" = "Find first unread conversation";
 "self.settings.advanced.troubleshooting.submit_debug.subtitle" = "This information helps Wire Support diagnose calling problems and improve the overall app experience.";
 "self.settings.advanced.reset_push_token.title" = "Reset Push Notifications Token";
 "self.settings.advanced.reset_push_token.subtitle" = "If you experience problems with push notifications, Wire Support may ask you to reset this token.";

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
@@ -273,9 +273,8 @@ class SettingsCellDescriptorFactory {
     func debuggingToolsSection() -> SettingsSectionDescriptor {
         let title = "self.settings.advanced.debugging_tools.title".localized
         
-        let findUnreadBadgeConversationButton = SettingsButtonCellDescriptor(title: "self.settings.advanced.debugging_tools.first_unread_conversation_badge_count.title".localized, isDestructive: false, selectAction: SettingsCellDescriptorFactory.findUnreadConversationContributingToBadgeCount)
-        let findUnreadBackArrowConversationButton = SettingsButtonCellDescriptor(title: "self.settings.advanced.debugging_tools.first_unread_conversation_back_arrow_count.title".localized, isDestructive: false, selectAction: SettingsCellDescriptorFactory.findUnreadConversationContributingToBackArrowDot)
-        let debuggingToolsGroup = SettingsGroupCellDescriptor(items: [SettingsSectionDescriptor(cellDescriptors:[findUnreadBadgeConversationButton, findUnreadBackArrowConversationButton])], title: title)
+        let findUnreadConversationButton = SettingsButtonCellDescriptor(title: "self.settings.advanced.debugging_tools.first_unread_conversation.title".localized, isDestructive: false, selectAction: SettingsCellDescriptorFactory.findUnreadConversationContributingToBadgeCount)
+        let debuggingToolsGroup = SettingsGroupCellDescriptor(items: [SettingsSectionDescriptor(cellDescriptors:[findUnreadConversationButton,])], title: title)
         return SettingsSectionDescriptor(cellDescriptors: [debuggingToolsGroup], header: .none, footer: .none)
     }
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

CS raised a concern that the new debugging tools section under settings is confusing.

The section currently contains:
First unread conversation (badge count)
First unread conversation (back arrow count)

### Solutions

1. Remove "First unread conversation (back arrow count)" since it's doing the same as "First unread conversation (badge count)" but doesn't include pending connection requests.
2. Rename "First unread conversation (badge count)" to "Find first unread conversation" so that it's more clear what the button does.