### PR TITLE
Fix: TextView missing accessibility value

### DIFF
--- a/Wire-iOS/Sources/Helpers/TextTransform/String+Transform.swift
+++ b/Wire-iOS/Sources/Helpers/TextTransform/String+Transform.swift
@@ -54,8 +54,7 @@ extension NSAttributedString {
      * Creates a new string by applying the given transform.
      */
 
-    @objc(stringByApplyingTextTransform:)
-    public func applying(transform: TextTransform) -> NSAttributedString {
+    func applying(transform: TextTransform) -> NSAttributedString {
         let newString = self.string.applying(transform: transform)
 
         let mutableCopy = self.mutableCopy() as! NSMutableAttributedString

--- a/Wire-iOS/Sources/Helpers/TextTransform/String+Transform.swift
+++ b/Wire-iOS/Sources/Helpers/TextTransform/String+Transform.swift
@@ -21,7 +21,7 @@ import Foundation
 extension String {
 
     /// Creates a new string by applying the given transform.
-    public func applying(transform: TextTransform) -> String {
+    func applying(transform: TextTransform) -> String {
         switch transform {
         case .none: return self
         case .capitalize: return self.localizedCapitalized
@@ -38,7 +38,7 @@ extension NSString {
      */
 
     @objc(stringByApplyingTextTransform:)
-    public func applying(transform: TextTransform) -> NSString {
+    func applying(transform: TextTransform) -> NSString {
         switch transform {
         case .none: return self
         case .capitalize: return self.localizedCapitalized as NSString

--- a/Wire-iOS/Sources/Helpers/TextTransform/TransformLabel.swift
+++ b/Wire-iOS/Sources/Helpers/TextTransform/TransformLabel.swift
@@ -22,16 +22,16 @@ import UIKit
  * A label that can automatically transform the text it presents.
  */
 
-@objc public class TransformLabel: UILabel {
+final class TransformLabel: UILabel {
 
     /// The transform to apply to the text.
-    @objc public var textTransform: TextTransform = .none {
+    var textTransform: TextTransform = .none {
         didSet {
             attributedText = attributedText?.applying(transform: textTransform)
         }
     }
 
-    @objc public override var text: String? {
+    override var text: String? {
         get {
             return super.text
         }
@@ -40,7 +40,7 @@ import UIKit
         }
     }
 
-    @objc public override var attributedText: NSAttributedString? {
+    override var attributedText: NSAttributedString? {
         get {
             return super.attributedText
         }

--- a/Wire-iOS/Sources/Helpers/TextTransform/TransformLabel.swift
+++ b/Wire-iOS/Sources/Helpers/TextTransform/TransformLabel.swift
@@ -24,6 +24,16 @@ import UIKit
 
 final class TransformLabel: UILabel {
 
+    override var accessibilityValue: String? {
+        set {
+            super.accessibilityValue = newValue
+        }
+        
+        get {
+            return attributedText?.string ?? text
+        }
+    }
+
     /// The transform to apply to the text.
     var textTransform: TextTransform = .none {
         didSet {

--- a/Wire-iOS/Sources/UserInterface/Components/TextView/TextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/TextView/TextView.swift
@@ -92,6 +92,16 @@ class TextView: UITextView {
 
     private var shouldDrawPlaceholder = false
 
+    override var accessibilityValue: String? {
+        set {
+            super.accessibilityValue = newValue
+        }
+        
+        get {
+            return text.isEmpty ? placeholderLabel.accessibilityValue : super.accessibilityValue
+        }
+    }
+    
     override open var text: String! {
         didSet {
             showOrHidePlaceholder()
@@ -134,7 +144,7 @@ class TextView: UITextView {
 
     @objc
     func showOrHidePlaceholder() {
-            placeholderLabel.alpha = text.isEmpty ? 1 : 0
+        placeholderLabel.alpha = text.isEmpty ? 1 : 0
     }
 
     // MARK: - Copy/Pasting

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
@@ -206,7 +206,7 @@ final class InputBar: UIView {
         textView.isScrollEnabled = false
         textView.isScrollEnabled = true
     }
-    
+
     deinit {
         notificationCenter.removeObserver(self)
     }
@@ -250,7 +250,8 @@ final class InputBar: UIView {
     }
     
     fileprivate func setupViews() {
-        textView.accessibilityIdentifier = "inputField" ///TODO: value??
+        textView.accessibilityIdentifier = "inputField"
+        
         updatePlaceholder()
         textView.lineFragmentPadding = 0
         textView.textAlignment = .natural
@@ -355,7 +356,6 @@ final class InputBar: UIView {
     func updatePlaceholder() {
         textView.attributedPlaceholder = placeholderText(for: inputBarState)
         textView.setNeedsLayout()
-        textView.layoutIfNeeded()
     }
 
     func placeholderText(for state: InputBarState) -> NSAttributedString? {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
@@ -28,7 +28,7 @@ extension Settings {
     }
 }
 
-public enum EphemeralState: Equatable {
+enum EphemeralState: Equatable {
     case conversation
     case message
     case none
@@ -38,7 +38,7 @@ public enum EphemeralState: Equatable {
     }
 }
 
-public enum InputBarState: Equatable {
+enum InputBarState: Equatable {
     case writing(ephemeral: EphemeralState)
     case editing(originalText: String, mentions: [Mention])
     case markingDown(ephemeral: EphemeralState)
@@ -105,12 +105,12 @@ private struct InputBarConstants {
 final class InputBar: UIView {
 
     private let inputBarVerticalInset: CGFloat = 34
-    public static let rightIconSize: CGFloat = 32
+    static let rightIconSize: CGFloat = 32
 
     @objc
     let textView = MarkdownTextView(with: DownStyle.compact)
-    public let leftAccessoryView  = UIView()
-    public let rightAccessoryStackView: UIStackView = {
+    let leftAccessoryView  = UIView()
+    let rightAccessoryStackView: UIStackView = {
         let stackView = UIStackView()
 
         let rightInset = (stackView.conversationHorizontalMargins.left - rightIconSize) / 2
@@ -125,27 +125,27 @@ final class InputBar: UIView {
     }()
     
     // Contains and clips the buttonInnerContainer
-    public let buttonContainer = UIView()
+    let buttonContainer = UIView()
     
     // Contains editingView and mardownView
-    public let secondaryButtonsView: InputBarSecondaryButtonsView
+    let secondaryButtonsView: InputBarSecondaryButtonsView
     
-    public let buttonsView: InputBarButtonsView
-    public let editingView = InputBarEditView()
+    let buttonsView: InputBarButtonsView
+    let editingView = InputBarEditView()
     
     @objc
     let markdownView = MarkdownBarView()
     
-    public var editingBackgroundColor = UIColor.brightYellow
-    public var barBackgroundColor: UIColor? = UIColor.from(scheme: .barBackground)
-    public var writingSeparatorColor: UIColor? = .from(scheme: .separator)
-    public var ephemeralColor: UIColor {
+    var editingBackgroundColor = UIColor.brightYellow
+    var barBackgroundColor: UIColor? = UIColor.from(scheme: .barBackground)
+    var writingSeparatorColor: UIColor? = .from(scheme: .separator)
+    var ephemeralColor: UIColor {
         return .accent()
     }
     
     @objc
     var placeholderColor: UIColor = .from(scheme: .textPlaceholder)
-    public var textColor: UIColor? = .from(scheme: .textForeground)
+    var textColor: UIColor? = .from(scheme: .textForeground)
 
     fileprivate var rowTopInsetConstraint: NSLayoutConstraint? = nil
     
@@ -174,7 +174,7 @@ final class InputBar: UIView {
         }
     }
 
-    public func changeEphemeralState(to newState: EphemeralState) {
+    func changeEphemeralState(to newState: EphemeralState) {
         inputBarState.changeEphemeralState(to: newState)
     }
 
@@ -192,13 +192,13 @@ final class InputBar: UIView {
         }
     }
     
-    override public var bounds: CGRect {
+    override var bounds: CGRect {
         didSet {
             invisibleInputAccessoryView?.overriddenIntrinsicContentSize = CGSize(width: UIView.noIntrinsicMetric, height: bounds.height)
         }
     }
         
-    override public func didMoveToWindow() {
+    override func didMoveToWindow() {
         super.didMoveToWindow()
 
         // This is a workaround for UITextView truncating long contents.
@@ -211,7 +211,7 @@ final class InputBar: UIView {
         notificationCenter.removeObserver(self)
     }
 
-    required public init(buttons: [UIButton]) {
+    required init(buttons: [UIButton]) {
         buttonsView = InputBarButtonsView(buttons: buttons)
         secondaryButtonsView = InputBarSecondaryButtonsView(editBarView: editingView, markdownBarView: markdownView)
         
@@ -245,12 +245,12 @@ final class InputBar: UIView {
         updateReturnKey()
     }
 
-    required public init?(coder aDecoder: NSCoder) {
+    required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
     fileprivate func setupViews() {
-        textView.accessibilityIdentifier = "inputField"
+        textView.accessibilityIdentifier = "inputField" ///TODO: value??
         updatePlaceholder()
         textView.lineFragmentPadding = 0
         textView.textAlignment = .natural
@@ -323,7 +323,7 @@ final class InputBar: UIView {
         }
     }
     
-    public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         
         guard traitCollection.horizontalSizeClass != previousTraitCollection?.horizontalSizeClass else { return }
@@ -376,7 +376,7 @@ final class InputBar: UIView {
     
     // MARK: - Disable interactions on the lower part to not to interfere with the keyboard
     
-    override public func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
         if self.textView.isFirstResponder {
             if super.point(inside: point, with: event) {
                 let locationInButtonRow = buttonInnerContainer.convert(point, from: self)
@@ -393,7 +393,7 @@ final class InputBar: UIView {
 
     // MARK: - InputBarState
 
-    public func setInputBarState(_ state: InputBarState, animated: Bool) {
+    func setInputBarState(_ state: InputBarState, animated: Bool) {
         let oldState = inputBarState
         inputBarState = state
         updateInputBar(withState: state, oldState: oldState, animated: animated)
@@ -490,14 +490,14 @@ final class InputBar: UIView {
 
     // MARK: – Editing View State
 
-    public func setInputBarText(_ text: String, mentions: [Mention]) {
+    func setInputBarText(_ text: String, mentions: [Mention]) {
         textView.setText(text, withMentions: mentions)
         textView.setContentOffset(.zero, animated: false)
         textView.undoManager?.removeAllActions()
         updateEditViewState()
     }
 
-    public func undo() {
+    func undo() {
         guard inputBarState.isEditing else { return }
         guard let undoManager = textView.undoManager , undoManager.canUndo else { return }
         undoManager.undo()


### PR DESCRIPTION
## What's new in this PR?

### Issues
After https://github.com/wireapp/wire-ios/pull/4050/, the `TextView` can not use display accessibility value. (It was the text of placeholder)

### Causes

Unknown, but accessibility value should be customized in this case.

### Solutions

override accessibility value and use the placeholder's text if it is shown.

### Note
Clean up unnecessary `public` and `@objc` signatures. 