### PR TITLE
[Fix] Name and avatar is not aligned correctly on iPad

### DIFF
--- a/Wire-iOS/Sources/Helpers/UITraitEnvironment+LayoutMargins.swift
+++ b/Wire-iOS/Sources/Helpers/UITraitEnvironment+LayoutMargins.swift
@@ -45,9 +45,6 @@ extension UITraitEnvironment {
     }
 
     func conversationHorizontalMargins(windowWidth: CGFloat? = UIApplication.shared.keyWindow?.frame.width) -> HorizontalMargins {
-        guard traitCollection.horizontalSizeClass == .regular else {
-            return HorizontalMargins(userInterfaceSizeClass: .compact)
-        }
 
         let userInterfaceSizeClass: UIUserInterfaceSizeClass
 


### PR DESCRIPTION
## What's new in this PR?

### Issues
Name and avatar is not aligned correctly on iPad.

### Causes
We use a smaller margin (as for iPhone) to display name and avatar on iPad.

### Solutions
Remove an extra check.
