### PR TITLE
[Fix] Can't login after first failed attempt

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Helpers/UIViewController+ErrorAlert.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UIViewController+ErrorAlert.swift
@@ -17,8 +17,7 @@
 // 
 
 extension UIViewController {
-    func showAlert(for error: Error,
-                   handler: AlertActionHandler? = nil) {
+    func showAlert(for error: Error, handler: AlertActionHandler? = nil) {
         let nsError: NSError = error as NSError
         var message = ""
 
@@ -80,7 +79,7 @@ extension UIViewController {
             message = error.localizedDescription
         }
 
-        let alert = UIAlertController.alertWithOKButton(message: message)
+        let alert = UIAlertController.alertWithOKButton(message: message, okActionHandler: handler)
         present(alert, animated: true)
     }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

After the first failed attempt to log in, any subsequent attempt is ignored.

### Causes

When the first attempt fails an error alert is shown as expected. Dismissing the alert should unwind the authentication state so that new attempt can be made. Unfortunately, the dismissing the alert does not invoke the necessary closure to unwind the state. This is due to a recent refactoring where the `handler` parameter is not passed to the `UIAlertController`.

### Solutions

Pass the parameter to the alert controller.

