### PR TITLE
fix: right to left language navigation item position

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
@@ -118,20 +118,12 @@ extension ConversationViewController {
     }
 
     func updateRightNavigationItemsButtons() {
-        if UIApplication.isLeftToRightLayout {
-            navigationItem.rightBarButtonItems = rightNavigationItems(forConversation: conversation)
-        } else {
-            navigationItem.rightBarButtonItems = leftNavigationItems(forConversation: conversation)
-        }
+        navigationItem.rightBarButtonItems = rightNavigationItems(forConversation: conversation)
     }
 
     /// Update left navigation bar items
     func updateLeftNavigationBarItems() {
-        if UIApplication.isLeftToRightLayout {
-            navigationItem.leftBarButtonItems = leftNavigationItems(forConversation: conversation)
-        } else {
-            navigationItem.leftBarButtonItems = rightNavigationItems(forConversation: conversation)
-        }
+        navigationItem.leftBarButtonItems = leftNavigationItems(forConversation: conversation)
     }
 
     private func shouldShowCollectionsButton() -> Bool {


### PR DESCRIPTION
## What's new in this PR?

This PR fixes the incorrect conversation screen navigation bar bottom assignment. Perviously we have custom swapping navigation bar items but it is not needed.
After the fix the UI is like this, the arrow button is on the right and call button is on the left:

![Simulator Screen Shot - iPhone Xʀ - 2020-02-17 at 15 48 15](https://user-images.githubusercontent.com/11852044/74664851-cf21c180-519e-11ea-9f9c-1f527e94377c.png)

