### PR TITLE
fix: app crash when accessing MediaAsset.data

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/MediaAsset.h
+++ b/Wire-iOS/Sources/UserInterface/Components/MediaAsset.h
@@ -26,7 +26,7 @@
 
 @property (nonatomic, readonly) CGSize size;
 
-- (NSData *)data;
+- (NSData * _Nullable)data;
 - (BOOL)isGIF;
 - (BOOL)isTransparent;
 

--- a/Wire-iOS/Sources/UserInterface/Components/UIPasteboard+MediaAsset.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/UIPasteboard+MediaAsset.swift
@@ -47,9 +47,10 @@ extension UIPasteboard {
         return nil
     }
 
-    @objc func setMediaAsset(_ image: MediaAsset?) {
-        guard let image = image else { return }
+    func setMediaAsset(_ image: MediaAsset?) {
+        guard let image = image,
+              let data = image.data() else { return }
 
-        UIPasteboard.general.setData(image.data(), forPasteboardType: pasteboardType(forMediaAsset: image))
+        UIPasteboard.general.setData(data, forPasteboardType: pasteboardType(forMediaAsset: image))
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
@@ -20,9 +20,9 @@ import Foundation
 import MobileCoreServices
 
 extension ConversationInputBarViewController {
-    @objc
     func postImage(_ image: MediaAsset) {
-        sendController.sendMessage(withImageData: image.data())
+        guard let data = image.data() else { return }
+        sendController.sendMessage(withImageData: data)
     }
     
     ///TODO: chnage to didSet after ConversationInputBarViewController is converted to Swift


### PR DESCRIPTION
## What's new in this PR?

Change `MediaAsset.data` to optional and unwrapp it before access.