### PR TITLE
fix: client device screen bottomOffset

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/KeyboardAvoidingViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/KeyboardAvoidingViewController.swift
@@ -99,7 +99,8 @@ final class KeyboardAvoidingViewController: UIViewController {
         bottomEdgeConstraint?.isActive = true
     }
     
-    @objc func keyboardFrameWillChange(_ notification: Notification?) {
+    @objc
+    private func keyboardFrameWillChange(_ notification: Notification?) {
         guard let bottomEdgeConstraint = bottomEdgeConstraint else { return }
         
         guard !disabledWhenInsidePopover || !isInsidePopover else {
@@ -122,9 +123,12 @@ final class KeyboardAvoidingViewController: UIViewController {
             bottomOffset = -abs(keyboardFrameInView.size.height)
         }
         
-        // When this controller's view is presented at a form sheet style on iPad, the view is has a top offset and the bottomOffset should be reduced.
-        if modalPresentationStyle == .formSheet, let frame = presentationController?.frameOfPresentedViewInContainerView {
-            bottomOffset += frame.minY
+        // When the keyboard is visible &
+        // this controller's view is presented at a form sheet style on iPad, the view is has a top offset and the bottomOffset should be reduced.
+        if !keyboardFrameInView.origin.y.isInfinite,
+            modalPresentationStyle == .formSheet,
+            let frame = presentationController?.frameOfPresentedViewInContainerView {
+            bottomOffset += frame.minY ///TODO: no need to add when no keyboard
         }
         
         guard bottomEdgeConstraint.constant != bottomOffset else { return }


### PR DESCRIPTION
## What's new in this PR?

### Issues

After removing a device, the bottom inset of client device table is negative and scroll to bottom is impossible.

### Causes

`bottomOffset` should not add `frame.minY` when keyboard is not shown.

### Solutions

Check for this case and not change the `bottomOffset`.