### PR TITLE
[Refactor] Remove ZMUser references (Part 1)

### DIFF
--- a/Wire-iOS Tests/ConversationDetail/GroupDetailsViewControllerSnapshotTests.swift
+++ b/Wire-iOS Tests/ConversationDetail/GroupDetailsViewControllerSnapshotTests.swift
@@ -29,11 +29,13 @@ final class GroupDetailsViewControllerSnapshotTests: CoreDataSnapshotTestCase {
 
         groupConversation = createGroupConversation()
         groupConversation.userDefinedName = "iOS Team"
+        SelfUser.provider = selfUserProvider
     }
     
     override func tearDown() {
         sut = nil
         groupConversation = nil
+        SelfUser.provider = nil
         super.tearDown()
     }
     

--- a/Wire-iOS Tests/Utils/CoreDataSnapshotTestCase.swift
+++ b/Wire-iOS Tests/Utils/CoreDataSnapshotTestCase.swift
@@ -24,13 +24,27 @@ import XCTest
 /// of mock objects.
 class CoreDataSnapshotTestCase: ZMSnapshotTestCase {
 
+    private struct SelfProvider: SelfUserProvider {
+
+        let selfUser: UserType & ZMEditableUser
+    }
+
     var selfUserInTeam: Bool = false
     var selfUser: ZMUser!
     var otherUser: ZMUser!
     var otherUserConversation: ZMConversation!
     var team: Team?
     var teamMember: Member?
-    let usernames = ["Anna", "Claire", "Dean", "Erik", "Frank", "Gregor", "Hanna", "Inge", "James", "Laura", "Klaus", "Lena", "Linea", "Lara", "Elliot", "Francois", "Felix", "Brian", "Brett", "Hannah", "Ana", "Paula"]
+
+    let usernames = ["Anna", "Claire", "Dean", "Erik", "Frank", "Gregor", "Hanna", "Inge", "James",
+                     "Laura", "Klaus", "Lena", "Linea", "Lara", "Elliot", "Francois", "Felix", "Brian",
+                     "Brett", "Hannah", "Ana", "Paula"]
+
+    // The provider to use when configuring `SelfUser.provider`, needed only when tested code
+    // invokes `SelfUser.current`. As we slowly migrate to `UserType`, we will use this more
+    // and the `var selfUser: ZMUser!` less.
+    //
+    var selfUserProvider: SelfUserProvider!
 
     override open func setUp() {
         super.setUp()
@@ -38,7 +52,7 @@ class CoreDataSnapshotTestCase: ZMSnapshotTestCase {
         setupTestObjects()
 
         MockUser.setMockSelf(selfUser)
-
+        selfUserProvider = SelfProvider(selfUser: selfUser)
     }
 
     override open func tearDown() {
@@ -49,6 +63,7 @@ class CoreDataSnapshotTestCase: ZMSnapshotTestCase {
         team = nil
 
         MockUser.setMockSelf(nil)
+        selfUserProvider = nil
 
         super.tearDown()
     }

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1018,7 +1018,7 @@
 		EEBFE0C123F1A49200292088 /* MockUserType.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBFE0BF23F1A48D00292088 /* MockUserType.swift */; };
 		EEC6A08F21B7BF7900133BC7 /* ConversationCreateGuestsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC6A08E21B7BF7900133BC7 /* ConversationCreateGuestsCell.swift */; };
 		EEC7E82A2178B55100E32835 /* ConversationNotificationOptionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC7E8292178B55100E32835 /* ConversationNotificationOptionsViewController.swift */; };
-		EEC94D4223BF49D6003AF93D /* UserType+Approval.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC94D4123BF49D6003AF93D /* UserType+Approval.swift */; };
+		EEC94D4223BF49D6003AF93D /* UserType+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC94D4123BF49D6003AF93D /* UserType+Helpers.swift */; };
 		EECDB2542029D7DA00D0D268 /* Down.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EECDB2532029D7D900D0D268 /* Down.framework */; };
 		EECDB2562029F5AB00D0D268 /* MarkdownTextStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECDB2552029F5AB00D0D268 /* MarkdownTextStorage.swift */; };
 		EEDEA26823ED609C000EF7E3 /* ContactsViewController+Invite.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDEA26723ED609C000EF7E3 /* ContactsViewController+Invite.swift */; };
@@ -2726,7 +2726,7 @@
 		EEBFE0BF23F1A48D00292088 /* MockUserType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockUserType.swift; sourceTree = "<group>"; };
 		EEC6A08E21B7BF7900133BC7 /* ConversationCreateGuestsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationCreateGuestsCell.swift; sourceTree = "<group>"; };
 		EEC7E8292178B55100E32835 /* ConversationNotificationOptionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationNotificationOptionsViewController.swift; sourceTree = "<group>"; };
-		EEC94D4123BF49D6003AF93D /* UserType+Approval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserType+Approval.swift"; sourceTree = "<group>"; };
+		EEC94D4123BF49D6003AF93D /* UserType+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserType+Helpers.swift"; sourceTree = "<group>"; };
 		EECDB2532029D7D900D0D268 /* Down.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Down.framework; path = Carthage/Build/iOS/Down.framework; sourceTree = "<group>"; };
 		EECDB2552029F5AB00D0D268 /* MarkdownTextStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownTextStorage.swift; sourceTree = "<group>"; };
 		EEDEA26723ED609C000EF7E3 /* ContactsViewController+Invite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContactsViewController+Invite.swift"; sourceTree = "<group>"; };
@@ -5180,7 +5180,7 @@
 				871DD79C2080C4F6006B1C56 /* Conversation+Participants.swift */,
 				87AC33CA2181C6FB00069C79 /* ClientRemovalObserver.swift */,
 				1661674F223A81CB00779AE3 /* MessageKeyPathObserver.swift */,
-				EEC94D4123BF49D6003AF93D /* UserType+Approval.swift */,
+				EEC94D4123BF49D6003AF93D /* UserType+Helpers.swift */,
 			);
 			path = syncengine;
 			sourceTree = "<group>";
@@ -7139,7 +7139,7 @@
 				A949418B23E09AFB001B0373 /* ConversationContentViewController.swift in Sources */,
 				7C440E83234B35CB00D91B5F /* FolderPickerViewController.swift in Sources */,
 				5E39FC61225CBBEF00C682B8 /* PasswordRules+Shared.swift in Sources */,
-				EEC94D4223BF49D6003AF93D /* UserType+Approval.swift in Sources */,
+				EEC94D4223BF49D6003AF93D /* UserType+Helpers.swift in Sources */,
 				8784B6291D89448700AB71BD /* ProfileSelfPictureViewController.m in Sources */,
 				EF22DC7D224BBE3B001EDE8E /* SearchUserViewConroller.swift in Sources */,
 				87B8C3421DF9788B0015EC89 /* TweetOpening.swift in Sources */,

--- a/Wire-iOS/Sources/AppStateController.swift
+++ b/Wire-iOS/Sources/AppStateController.swift
@@ -240,8 +240,8 @@ extension AppStateController : AuthenticationCoordinatorDelegate {
         return sharedUserSession?.userProfile as? UserProfileUpdateStatus
     }
 
-    var selfUser: ZMUser? {
-        return ZMUser.selfUser()
+    var selfUser: UserType? {
+        return SelfUser.provider?.selfUser
     }
 
     var numberOfAccounts: Int {

--- a/Wire-iOS/Sources/Authentication/Delegates/AuthenticationStatusProvider.swift
+++ b/Wire-iOS/Sources/Authentication/Delegates/AuthenticationStatusProvider.swift
@@ -60,7 +60,7 @@ protocol AuthenticationStatusProvider: class {
      * - returns: The shared user, if any.
      */
 
-    var selfUser: ZMUser? { get }
+    var selfUser: UserType? { get }
 
     /**
      * The authentication coordinator requested the number of accounts.

--- a/Wire-iOS/Sources/Components/AccentColorChangeHandler.swift
+++ b/Wire-iOS/Sources/Components/AccentColorChangeHandler.swift
@@ -24,7 +24,6 @@ final class AccentColorChangeHandler: NSObject, ZMUserObserver {
 
     private var handlerBlock: AccentColorChangeHandlerBlock?
     private var observer: Any?
-    private var selfUser: ZMUser?
     private var userObserverToken: Any?
     
     class func addObserver(_ observer: Any?, handlerBlock changeHandler: @escaping AccentColorChangeHandlerBlock) -> Self {
@@ -35,9 +34,8 @@ final class AccentColorChangeHandler: NSObject, ZMUserObserver {
         super.init()
         handlerBlock = changeHandler
         self.observer = observer
-        
-        selfUser = ZMUser.selfUser()
-        if let selfUser = selfUser, let userSession = ZMUserSession.shared() {
+
+        if let selfUser = SelfUser.provider?.selfUser, let userSession = ZMUserSession.shared() {
             userObserverToken = UserChangeInfo.add(observer: self, for: selfUser, in: userSession)
         }
     }
@@ -48,7 +46,7 @@ final class AccentColorChangeHandler: NSObject, ZMUserObserver {
     
     func userDidChange(_ change: UserChangeInfo) {
         if change.accentColorValueChanged {
-            handlerBlock?(UIColor.accent(), observer)
+            handlerBlock?(change.user.accentColor, observer)
         }
     }
 }

--- a/Wire-iOS/Sources/Helpers/syncengine/Conversation+Participants.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/Conversation+Participants.swift
@@ -57,11 +57,11 @@ extension ZMConversation {
     }
     
     @objc (removeParticipantOrShowError:)
-    func removeOrShowError(participnant user: UserType) {
-        removeOrShowError(participnant: user, completion: nil)
+    func removeOrShowError(participant user: UserType) {
+        removeOrShowError(participant: user, completion: nil)
     }
     
-    func removeOrShowError(participnant user: UserType, completion: ((VoidResult)->())? = nil) {
+    func removeOrShowError(participant user: UserType, completion: ((VoidResult)->())? = nil) {
         guard let session = ZMUserSession.shared(),
             session.networkState != .offline else {
             self.showAlertForRemoval(for: NetworkError.offline)
@@ -69,18 +69,17 @@ extension ZMConversation {
         }
 
         /// if the user is not in this conversation, result = .success
-        self.removeParticipant(user,
-                               userSession: ZMUserSession.shared()!) { result in
-                                switch result {
-                                case .success:
-                                    if let serviceUser = user as? ServiceUser, user.isServiceUser {
-                                        Analytics.shared().tagDidRemoveService(serviceUser)
-                                    }
-                                case .failure(let error):
-                                    self.showAlertForRemoval(for: error)
-                                }
-                                
-                                completion?(result)
+        self.removeParticipant(user, userSession: ZMUserSession.shared()!) { result in
+            switch result {
+            case .success:
+                if let serviceUser = user as? ServiceUser, user.isServiceUser {
+                    Analytics.shared().tagDidRemoveService(serviceUser)
+                }
+            case .failure(let error):
+                self.showAlertForRemoval(for: error)
+            }
+
+            completion?(result)
         }
     }
     

--- a/Wire-iOS/Sources/Helpers/syncengine/UserType+Helpers.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/UserType+Helpers.swift
@@ -20,8 +20,16 @@ import Foundation
 
 extension UserType {
 
-  var isPendingApproval: Bool {
-    return isPendingApprovalBySelfUser || isPendingApprovalByOtherUser
-  }
+    var pov: PointOfView {
+        return self.isSelfUser ? .secondPerson : .thirdPerson
+    }
+
+    var isPendingApproval: Bool {
+        return isPendingApprovalBySelfUser || isPendingApprovalByOtherUser
+    }
+
+    var hasUntrustedClients: Bool {
+        return allClients.contains { !$0.verified }
+    }
 
 }

--- a/Wire-iOS/Sources/Helpers/syncengine/ZMUser+Additions.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMUser+Additions.swift
@@ -20,14 +20,7 @@ import WireDataModel
 
 
 extension ZMUser {
-    var pov: PointOfView {
-        return self.isSelfUser ? .secondPerson : .thirdPerson
-    }
-        
-    var hasUntrustedClients: Bool {
-        return nil != self.clients.first { !$0.verified }
-    }
-    
+
     var canSeeServices: Bool {
         #if ADD_SERVICE_DISABLED
         return false

--- a/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
@@ -375,15 +375,15 @@ final public class AddParticipantsViewController: UIViewController {
 
 extension AddParticipantsViewController : UserSelectionObserver {
     
-    public func userSelection(_ userSelection: UserSelection, didAddUser user: ZMUser) {
+    public func userSelection(_ userSelection: UserSelection, didAddUser user: UserType) {
         updateSelectionValues()
     }
     
-    public func userSelection(_ userSelection: UserSelection, didRemoveUser user: ZMUser) {
+    public func userSelection(_ userSelection: UserSelection, didRemoveUser user: UserType) {
         updateSelectionValues()
     }
     
-    public func userSelection(_ userSelection: UserSelection, wasReplacedBy users: [ZMUser]) {
+    public func userSelection(_ userSelection: UserSelection, wasReplacedBy users: [UserType]) {
         updateSelectionValues()
     }
     

--- a/Wire-iOS/Sources/UserInterface/Availability/AvailabilityStringBuilder.swift
+++ b/Wire-iOS/Sources/UserInterface/Availability/AvailabilityStringBuilder.swift
@@ -18,7 +18,7 @@
 
 @objcMembers public class AvailabilityStringBuilder: NSObject {
 
-    static func string(for user: ZMUser, with style: AvailabilityLabelStyle, color: UIColor? = nil) -> NSAttributedString? {
+    static func string(for user: UserType, with style: AvailabilityLabelStyle, color: UIColor? = nil) -> NSAttributedString? {
         
         var title: String = ""
         var color = color

--- a/Wire-iOS/Sources/UserInterface/Components/Views/ConversationAvatarView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/ConversationAvatarView.swift
@@ -71,7 +71,7 @@ extension Array {
 extension ZMConversation {
     /// Stable random list of the participants in the conversation. The list would be consistent between platforms
     /// because the conversation UUID is used as the random indexes source.
-    var stableRandomParticipants: [ZMUser] {
+    var stableRandomParticipants: [UserType] {
         let allUsers = self.sortedActiveParticipants
         guard let remoteIdentifier = self.remoteIdentifier else {
             return allUsers
@@ -139,7 +139,7 @@ extension Mode {
 final class ConversationAvatarView: UIView {
     enum Context {
         // one or more users requesting connection to self user
-        case connect(users: [ZMUser])
+        case connect(users: [UserType])
         // an established conversation or self user has a pending request to other users
         case conversation(conversation: ZMConversation)
     }
@@ -155,7 +155,7 @@ final class ConversationAvatarView: UIView {
         }
     }
 
-    private var users: [ZMUser] = []
+    private var users: [UserType] = []
     
     private var conversation: ZMConversation? = .none {
         didSet {
@@ -167,7 +167,7 @@ final class ConversationAvatarView: UIView {
 
             accessibilityLabel = "Avatar for \(conversation.displayName)"
 
-            let usersOnAvatar: [ZMUser]
+            let usersOnAvatar: [UserType]
             let stableRandomParticipants = conversation.stableRandomParticipants.filter { !$0.isSelfUser }
 
             if stableRandomParticipants.isEmpty,

--- a/Wire-iOS/Sources/UserInterface/Components/Views/UserCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/UserCell.swift
@@ -273,8 +273,8 @@ extension UserCell {
 extension UserType {
     
     func nameIncludingAvailability(color: UIColor) -> NSAttributedString? {
-        if ZMUser.selfUser().isTeamMember, let user = self as? ZMUser {
-            return AvailabilityStringBuilder.string(for: user, with: .list, color: color)
+        if ZMUser.selfUser().isTeamMember {
+            return AvailabilityStringBuilder.string(for: self, with: .list, color: color)
         } else if let name = name{
             return name && color
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationReadReceiptSettingChangedCellDescription.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationReadReceiptSettingChangedCellDescription.swift
@@ -23,7 +23,7 @@ struct ReadReceiptViewModel {
     let icon: StyleKitIcon
     let iconColor: UIColor?
     let systemMessageType: ZMSystemMessageType
-    let sender: ZMUser
+    let sender: UserType
 
 
     func image() -> UIImage? {
@@ -92,7 +92,7 @@ final class ConversationReadReceiptSettingChangedCellDescription: ConversationMe
     let accessibilityIdentifier: String? = nil
     let accessibilityLabel: String? = nil
 
-    init(sender: ZMUser,
+    init(sender: UserType,
          systemMessageType: ZMSystemMessageType) {
         let viewModel = ReadReceiptViewModel(icon: .eye,
                                              iconColor: UIColor.from(scheme: .textDimmed),

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCell.swift
@@ -43,12 +43,12 @@ class ConversationStartedSystemMessageCell: ConversationIconBasedCell, Conversat
     struct Configuration {
         let title: NSAttributedString?
         let message: NSAttributedString
-        let selectedUsers: [ZMUser]
+        let selectedUsers: [UserType]
         let icon: UIImage?
     }
     
     private let titleLabel = UILabel()
-    private var selectedUsers: [ZMUser] = []
+    private var selectedUsers: [UserType] = []
     
     override func configureSubviews() {
         super.configureSubviews()
@@ -424,7 +424,7 @@ class ConversationRenamedSystemMessageCellDescription: ConversationMessageCellDe
     let accessibilityIdentifier: String? = nil
     let accessibilityLabel: String? = nil
 
-    init(message: ZMConversationMessage, data: ZMSystemMessageData, sender: ZMUser, newName: String) {
+    init(message: ZMConversationMessage, data: ZMSystemMessageData, sender: UserType, newName: String) {
         let senderText = message.senderName
         let titleString = "content.system.renamed_conv.title".localized(pov: sender.pov, args: senderText)
 
@@ -498,7 +498,7 @@ class ConversationMessageTimerCellDescription: ConversationMessageCellDescriptio
     let accessibilityIdentifier: String? = nil
     let accessibilityLabel: String? = nil
 
-    init(message: ZMConversationMessage, data: ZMSystemMessageData, timer: NSNumber, sender: ZMUser) {
+    init(message: ZMConversationMessage, data: ZMSystemMessageData, timer: NSNumber, sender: UserType) {
         let senderText = message.senderName
         let timeoutValue = MessageDestructionTimeoutValue(rawValue: timer.doubleValue)
 
@@ -627,7 +627,7 @@ class ConversationMissingMessagesSystemMessageCellDescription: ConversationMessa
         let boldFont = UIFont.mediumSemiboldFont
         let color = UIColor.from(scheme: .textForeground)
         
-        func attributedLocalizedUppercaseString(_ localizationKey: String, _ users: Set<ZMUser>) -> NSAttributedString? {
+        func attributedLocalizedUppercaseString(_ localizationKey: String, _ users: [UserType]) -> NSAttributedString? {
             guard users.count > 0 else { return nil }
             let userNames = users.map { $0.displayName }.joined(separator: ", ")
             let string = localizationKey.localized(args: userNames + " ", users.count) + ". "
@@ -641,8 +641,8 @@ class ConversationMissingMessagesSystemMessageCellDescription: ConversationMessa
         let addedOrRemovedUsers = !systemMessageData.addedUsers.isEmpty || !systemMessageData.removedUsers.isEmpty
         if !systemMessageData.needsUpdatingUsers && addedOrRemovedUsers {
             title += "\n\n" + "content.system.missing_messages.subtitle_start".localized + " " && font && color
-            title += attributedLocalizedUppercaseString("content.system.missing_messages.subtitle_added", systemMessageData.addedUsers)
-            title += attributedLocalizedUppercaseString("content.system.missing_messages.subtitle_removed", systemMessageData.removedUsers)
+            title += attributedLocalizedUppercaseString("content.system.missing_messages.subtitle_added", Array(systemMessageData.addedUsers))
+            title += attributedLocalizedUppercaseString("content.system.missing_messages.subtitle_removed", Array(systemMessageData.removedUsers))
         }
         
         return title
@@ -676,7 +676,7 @@ class ConversationIgnoredDeviceSystemMessageCellDescription: ConversationMessage
         actionController = nil
     }
     
-    private static func makeAttributedString(systemMessage: ZMSystemMessageData, user: ZMUser) -> NSAttributedString {
+    private static func makeAttributedString(systemMessage: ZMSystemMessageData, user: UserType) -> NSAttributedString {
         
         let youString = "content.system.you_started".localized
         let deviceString : String
@@ -724,7 +724,7 @@ class ConversationCannotDecryptSystemMessageCellDescription: ConversationMessage
     let accessibilityIdentifier: String? = nil
     let accessibilityLabel: String? = nil
 
-    init(message: ZMConversationMessage, data: ZMSystemMessageData, sender: ZMUser, remoteIdentityChanged: Bool) {
+    init(message: ZMConversationMessage, data: ZMSystemMessageData, sender: UserType, remoteIdentityChanged: Bool) {
         let exclamationColor = UIColor(for: .vividRed)
         let icon = StyleKitIcon.exclamationMark.makeImage(size: 16, color: exclamationColor)
         let link: URL = remoteIdentityChanged ? .wr_cannotDecryptNewRemoteIDHelp : .wr_cannotDecryptHelp
@@ -747,7 +747,7 @@ class ConversationCannotDecryptSystemMessageCellDescription: ConversationMessage
     private static let BaseLocalizationString = "content.system.cannot_decrypt"
     private static let IdentityString = ".identity"
 
-    private static func makeAttributedString(systemMessage: ZMSystemMessageData, sender: ZMUser, remoteIDChanged: Bool, link: URL) -> NSAttributedString {
+    private static func makeAttributedString(systemMessage: ZMSystemMessageData, sender: UserType, remoteIDChanged: Bool, link: URL) -> NSAttributedString {
         let name = localizedWhoPart(sender, remoteIDChanged: remoteIDChanged)
 
         let why = NSAttributedString(string: localizedWhyPart(remoteIDChanged),
@@ -768,7 +768,7 @@ class ConversationCannotDecryptSystemMessageCellDescription: ConversationMessage
         return fullString.addAttributes([.font: UIFont.mediumSemiboldFont], toSubstring:name)
     }
 
-    private static func localizedWhoPart(_ sender: ZMUser, remoteIDChanged: Bool) -> String {
+    private static func localizedWhoPart(_ sender: UserType, remoteIDChanged: Bool) -> String {
         switch (sender.isSelfUser, remoteIDChanged) {
         case (true, _):
             return (BaseLocalizationString + (remoteIDChanged ? IdentityString : "") + ".you_part").localized
@@ -833,7 +833,7 @@ class ConversationNewDeviceSystemMessageCellDescription: ConversationMessageCell
         
         let textAttributes = TextAttributes(boldFont: .mediumSemiboldFont, normalFont: .mediumFont, textColor: UIColor.from(scheme: .textForeground), link: View.userClientURL)
         let clients = systemMessage.clients.compactMap ({ $0 as? UserClientType })
-        let users = systemMessage.users.sorted(by: { (a: ZMUser, b: ZMUser) -> Bool in
+        let users = systemMessage.users.sorted(by: { (a: UserType, b: UserType) -> Bool in
             a.displayName.compare(b.displayName) == ComparisonResult.orderedAscending
         })
         

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCell.swift
@@ -165,7 +165,7 @@ class NewDeviceSystemMessageCell: ConversationIconBasedCell, ConversationMessage
     var linkTarget: LinkTarget? = nil
     
     enum LinkTarget {
-        case user(ZMUser)
+        case user(UserType)
         case conversation(ZMConversation)
     }
     
@@ -669,7 +669,7 @@ class ConversationIgnoredDeviceSystemMessageCellDescription: ConversationMessage
     let accessibilityIdentifier: String? = nil
     let accessibilityLabel: String? = nil
     
-    init(message: ZMConversationMessage, data: ZMSystemMessageData, user: ZMUser) {
+    init(message: ZMConversationMessage, data: ZMSystemMessageData, user: UserType) {
         let title = ConversationIgnoredDeviceSystemMessageCellDescription.makeAttributedString(systemMessage: data, user: user)
         
         configuration =  View.Configuration(attributedText: title, icon: WireStyleKit.imageOfShieldnotverified, linkTarget: .user(user))
@@ -858,7 +858,7 @@ class ConversationNewDeviceSystemMessageCellDescription: ConversationMessageCell
         return StyleKitIcon.exclamationMark.makeImage(size: 16, color: .vividRed)
     }
     
-    private static func configureForReactivatedSelfClient(_ selfUser: ZMUser, attributes: TextAttributes) -> View.Configuration {
+    private static func configureForReactivatedSelfClient(_ selfUser: UserType, attributes: TextAttributes) -> View.Configuration {
         let deviceString = NSLocalizedString("content.system.this_device", comment: "")
         let fullString  = String(format: NSLocalizedString("content.system.reactivated_device", comment: ""), deviceString) && attributes.startedUsingAttributes
         let attributedText = fullString.setAttributes(attributes.linkAttributes, toSubstring: deviceString)
@@ -866,7 +866,7 @@ class ConversationNewDeviceSystemMessageCellDescription: ConversationMessageCell
         return View.Configuration(attributedText: attributedText, icon: exclamationMarkIcon, linkTarget: .user(selfUser))
     }
     
-    private static func configureForNewClientOfSelfUser(_ selfUser: ZMUser, clients: [UserClientType], attributes: TextAttributes) -> View.Configuration {
+    private static func configureForNewClientOfSelfUser(_ selfUser: UserType, clients: [UserClientType], attributes: TextAttributes) -> View.Configuration {
         let isSelfClient = clients.first?.isEqual(ZMUserSession.shared()?.selfUserClient()) ?? false
         let senderName = NSLocalizedString("content.system.you_started", comment: "") && attributes.senderAttributes
         let startedUsingString = NSLocalizedString("content.system.started_using", comment: "") && attributes.startedUsingAttributes
@@ -876,7 +876,7 @@ class ConversationNewDeviceSystemMessageCellDescription: ConversationMessageCell
         return View.Configuration(attributedText: attributedText, icon: isSelfClient ? nil : verifiedIcon, linkTarget: .user(selfUser))
     }
     
-    private static func configureForNewCurrentDeviceOfSelfUser(_ selfUser: ZMUser, attributes: TextAttributes) -> View.Configuration {
+    private static func configureForNewCurrentDeviceOfSelfUser(_ selfUser: UserType, attributes: TextAttributes) -> View.Configuration {
         let senderName = NSLocalizedString("content.system.you_started", comment: "") && attributes.senderAttributes
         let startedUsingString = NSLocalizedString("content.system.started_using", comment: "") && attributes.startedUsingAttributes
         let userClientString = NSLocalizedString("content.system.this_device", comment: "") && attributes.linkAttributes
@@ -885,7 +885,7 @@ class ConversationNewDeviceSystemMessageCellDescription: ConversationMessageCell
         return View.Configuration(attributedText: attributedText, icon: nil, linkTarget: .user(selfUser))
     }
     
-    private static func configureForOtherUsers(_ users: [ZMUser], conversation: ZMConversation, clients: [UserClientType], attributes: TextAttributes) -> View.Configuration {
+    private static func configureForOtherUsers(_ users: [UserType], conversation: ZMConversation, clients: [UserClientType], attributes: TextAttributes) -> View.Configuration {
         let displayNamesOfOthers = users.filter {!$0.isSelfUser }.compactMap {$0.displayName as String}
         let firstTwoNames = displayNamesOfOthers.prefix(2)
         let senderNames = firstTwoNames.joined(separator: ", ")

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationPingCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationPingCell.swift
@@ -145,7 +145,7 @@ class ConversationPingCellDescription: ConversationMessageCellDescription {
     let accessibilityIdentifier: String? = nil
     let accessibilityLabel: String? = nil
 
-    init(message: ZMConversationMessage, sender: ZMUser) {
+    init(message: ZMConversationMessage, sender: UserType) {
         let senderText = sender.isSelfUser ? "content.ping.text.you".localized : sender.displayName
         let pingText = "content.ping.text".localized(pov: sender.pov, args: senderText)
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
@@ -26,7 +26,7 @@ protocol ConversationMessageCellDelegate: MessageActionResponder {
     func conversationMessageWantsToOpenUserDetails(_ cell: UIView, user: UserType, sourceView: UIView, frame: CGRect)
     func conversationMessageWantsToOpenMessageDetails(_ cell: UIView, messageDetailsViewController: MessageDetailsViewController)
     func conversationMessageWantsToOpenGuestOptionsFromView(_ cell: UIView, sourceView: UIView)
-    func conversationMessageWantsToOpenParticipantsDetails(_ cell: UIView, selectedUsers: [ZMUser], sourceView: UIView)
+    func conversationMessageWantsToOpenParticipantsDetails(_ cell: UIView, selectedUsers: [UserType], sourceView: UIView)
     func conversationMessageShouldUpdate()
 }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+ConversationMessageCellDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+ConversationMessageCellDelegate.swift
@@ -85,7 +85,7 @@ extension ConversationContentViewController: ConversationMessageCellDelegate {
         delegate?.conversationContentViewController(self, presentGuestOptionsFrom: sourceView)
     }
 
-    func conversationMessageWantsToOpenParticipantsDetails(_ cell: UIView, selectedUsers: [ZMUser], sourceView: UIView) {
+    func conversationMessageWantsToOpenParticipantsDetails(_ cell: UIView, selectedUsers: [UserType], sourceView: UIView) {
         delegate?.conversationContentViewController(self, presentParticipantsDetailsWithSelectedUsers: selectedUsers, from: sourceView)
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewControllerDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewControllerDelegate.swift
@@ -37,7 +37,7 @@ protocol ConversationContentViewControllerDelegate: class {
 
     func conversationContentViewController(_ controller: ConversationContentViewController, presentGuestOptionsFrom sourceView: UIView)
 
-    func conversationContentViewController(_ controller: ConversationContentViewController, presentParticipantsDetailsWithSelectedUsers selectedUsers: [ZMUser], from sourceView: UIView)
+    func conversationContentViewController(_ controller: ConversationContentViewController, presentParticipantsDetailsWithSelectedUsers selectedUsers: [UserType], from sourceView: UIView)
 
     func didTap(onUserAvatar user: UserType, view: UIView, frame: CGRect)
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+ConversationContentViewControllerDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+ConversationContentViewControllerDelegate.swift
@@ -107,7 +107,7 @@ extension ConversationViewController: ConversationContentViewControllerDelegate 
         presentParticipantsViewController(navigationController, from: sourceView)
     }
     
-    func conversationContentViewController(_ controller: ConversationContentViewController, presentParticipantsDetailsWithSelectedUsers selectedUsers: [ZMUser], from sourceView: UIView) {
+    func conversationContentViewController(_ controller: ConversationContentViewController, presentParticipantsDetailsWithSelectedUsers selectedUsers: [UserType], from sourceView: UIView) {
         if let groupDetailsViewController = (participantsController as? UINavigationController)?.topViewController as? GroupDetailsViewController {
                 groupDetailsViewController.presentParticipantsDetails(with: conversation.sortedOtherParticipants, selectedUsers: selectedUsers, animated: false)            
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Private.h
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Private.h
@@ -26,7 +26,6 @@
 @class ZMClientMessage;
 @class ReplyComposingView;
 @class TypingIndicatorView;
-@class ZMUser;
 @class UserImageView;
 
 @interface ConversationInputBarViewController ()

--- a/Wire-iOS/Sources/UserInterface/Conversation/Mentions/ZMUser+Mention.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Mentions/ZMUser+Mention.swift
@@ -43,7 +43,8 @@ extension UserType {
     }
 }
 
-extension ZMUser {
+extension UserType {
+
     static func searchForMentions(in users: [UserType], with query: String) -> [UserType] {
         
         let usersToSearch = users.filter { user in

--- a/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsCellDescription.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsCellDescription.swift
@@ -24,8 +24,9 @@ import UIKit
  */
 
 class MessageDetailsCellDescription: NSObject {
+
     /// The user to display.
-    let user: ZMUser
+    let user: UserType
 
     /// The subtitle string to display under the user name.
     let subtitle: String?
@@ -42,7 +43,7 @@ class MessageDetailsCellDescription: NSObject {
     // MARK: - Initialization
 
     /// Creates a new cell description.
-    init(user: ZMUser, subtitle: String?, accessibleSubtitleLabel: String?, accessibleSubtitleValue: String?) {
+    init(user: UserType, subtitle: String?, accessibleSubtitleLabel: String?, accessibleSubtitleValue: String?) {
         self.user = user
         self.subtitle = subtitle
         self.attributedSubtitle = subtitle.map { $0 && UserCell.boldFont }
@@ -56,7 +57,7 @@ class MessageDetailsCellDescription: NSObject {
 
 extension MessageDetailsCellDescription {
 
-    static func makeReactionCells(_ users: [ZMUser]) -> [MessageDetailsCellDescription] {
+    static func makeReactionCells(_ users: [UserType]) -> [MessageDetailsCellDescription] {
         return users.map {
             let handle = $0.handle.map { "@" + $0 }
             return MessageDetailsCellDescription(user: $0, subtitle: handle,

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListItemView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListItemView.swift
@@ -209,7 +209,7 @@ final class ConversationListItemView: UIView {
     ///   - title: title of the cell
     ///   - subtitle: subtitle of the cell
     ///   - users: the pending user(s) waiting for self user to accept connection request
-    func configure(with title: NSAttributedString?, subtitle: NSAttributedString?, users: [ZMUser]) {
+    func configure(with title: NSAttributedString?, subtitle: NSAttributedString?, users: [UserType]) {
         self.titleText = title
         self.subtitleAttributedText = subtitle
         self.rightAccessory.icon = .pendingConnection

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+CancelRequest.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+CancelRequest.swift
@@ -41,7 +41,7 @@ enum CancelConnectionRequestResult {
         return .init(title: title, style: style) { _ in handler(self) }
     }
     
-    static func title(for user: ZMUser) -> String {
+    static func title(for user: UserType) -> String {
         return "profile.cancel_connection_request_dialog.message".localized(args: user.displayName)
     }
     
@@ -49,7 +49,7 @@ enum CancelConnectionRequestResult {
         return [.cancelRequest, .cancel]
     }
     
-    static func controller(for user: ZMUser, handler: @escaping (CancelConnectionRequestResult) -> Void) -> UIAlertController {
+    static func controller(for user: UserType, handler: @escaping (CancelConnectionRequestResult) -> Void) -> UIAlertController {
         let controller = UIAlertController(title: title(for: user), message: nil, preferredStyle: .actionSheet)
         all.map { $0.action(handler) }.forEach(controller.addAction)
         return controller
@@ -57,7 +57,7 @@ enum CancelConnectionRequestResult {
 }
 
 extension UIAlertController {
-    static func cancelConnectionRequest(for user: ZMUser, completion: @escaping (Bool) -> Void) -> UIAlertController {
+    static func cancelConnectionRequest(for user: UserType, completion: @escaping (Bool) -> Void) -> UIAlertController {
         return CancelConnectionRequestResult.controller(for: user) { result in
             completion(result == .cancel)
         }
@@ -66,7 +66,7 @@ extension UIAlertController {
 
 extension ConversationActionController {
     
-    func requestCancelConnectionRequestResult(for user: ZMUser, handler: @escaping (CancelConnectionRequestResult) -> Void) {
+    func requestCancelConnectionRequestResult(for user: UserType, handler: @escaping (CancelConnectionRequestResult) -> Void) {
         let controller = CancelConnectionRequestResult.controller(for: user, handler: handler)
         present(controller)
     }

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+ClearContent.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+ClearContent.swift
@@ -68,7 +68,7 @@ extension ConversationActionController {
         transitionToListAndEnqueue {
             conversation.clearMessageHistory()
             if leave {
-                conversation.removeOrShowError(participnant: ZMUser.selfUser())
+                conversation.removeOrShowError(participant: ZMUser.selfUser())
             }
         }
     }

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+Leave.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+Leave.swift
@@ -60,7 +60,7 @@ extension ConversationActionController {
                 conversation.clearMessageHistory()
             }
             
-            conversation.removeOrShowError(participnant: ZMUser.selfUser())
+            conversation.removeOrShowError(participant: ZMUser.selfUser())
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/UIAlertController+RemoveAction.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/UIAlertController+RemoveAction.swift
@@ -20,12 +20,14 @@ import Foundation
 
 
 extension UIAlertController {
-    static func remove(_ user: ZMUser, completion: @escaping (Bool) -> Void) -> UIAlertController {
+
+    static func remove(_ user: UserType, completion: @escaping (Bool) -> Void) -> UIAlertController {
         let controller = UIAlertController(
             title: "profile.remove_dialog_message".localized(args: user.displayName),
             message: nil,
             preferredStyle: .actionSheet
         )
+
         controller.addAction(ZMConversation.Action.remove.alertAction { completion(true) })
         controller.addAction(.cancel { completion(false) })
         return controller

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
@@ -271,7 +271,7 @@ extension GroupDetailsViewController: ProfileViewControllerDelegate {
 
 extension GroupDetailsViewController: GroupDetailsSectionControllerDelegate, GroupOptionsSectionControllerDelegate {
 
-    func presentDetails(for user: ZMUser) {
+    func presentDetails(for user: UserType) {
         let viewController = UserDetailViewControllerFactory.createUserDetailViewController(
             user: user,
             conversation: conversation,

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupParticipantsDetail/GroupParticipantsDetailViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupParticipantsDetail/GroupParticipantsDetailViewController.swift
@@ -179,7 +179,7 @@ private final class SelectedUserCell: UserCell {
 
 extension GroupParticipantsDetailViewController: GroupDetailsSectionControllerDelegate {
     
-    func presentDetails(for user: ZMUser) {
+    func presentDetails(for user: UserType) {
         let viewController = UserDetailViewControllerFactory.createUserDetailViewController(
             user: user,
             conversation: viewModel.conversation,

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/GroupDetailsSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/GroupDetailsSectionController.swift
@@ -19,7 +19,7 @@
 import Foundation
 
 protocol GroupDetailsUserDetailPresenter: class {
-    func presentDetails(for user: ZMUser)
+    func presentDetails(for user: UserType)
 }
 
 protocol GroupDetailsSectionControllerDelegate: GroupDetailsUserDetailPresenter {

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/GroupOptionsSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/GroupOptionsSectionController.swift
@@ -32,7 +32,7 @@ final class GroupOptionsSectionController: GroupDetailsSectionController {
 
         case notifications = 0, guests, timeout
         
-        func accessible(in conversation: ZMConversation, by user: ZMUser) -> Bool {
+        func accessible(in conversation: ZMConversation, by user: UserType) -> Bool {
             switch self {
             case .notifications: return user.canModifyNotificationSettings(in: conversation)
             case .guests:        return user.canModifyAccessControlSettings(in: conversation)
@@ -65,7 +65,7 @@ final class GroupOptionsSectionController: GroupDetailsSectionController {
         self.delegate = delegate
         self.conversation = conversation
         self.syncCompleted = syncCompleted
-        self.options = Option.allCases.filter({ $0.accessible(in: conversation, by: ZMUser.selfUser()) })
+        self.options = Option.allCases.filter({ $0.accessible(in: conversation, by: SelfUser.current) })
     }
 
     // MARK: - Collection View

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/ParticipantsSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/ParticipantsSectionController.swift
@@ -219,8 +219,7 @@ final class ParticipantsSectionController: GroupDetailsSectionController {
 
     override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         switch viewModel.rows[indexPath.row] {
-        case .user(let bareUser):
-            guard let user = bareUser as? ZMUser else { return }
+        case .user(let user):
             delegate?.presentDetails(for: user)
         case .showAll:
             delegate?.presentFullParticipantsList(for: viewModel.participants, in: conversation)

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/ServicesSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/ServicesSectionController.swift
@@ -60,8 +60,7 @@ class ServicesSectionController: GroupDetailsSectionController {
     }
     
     override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        guard let user = serviceUsers[indexPath.row] as? ZMUser else { return }
-        delegate?.presentDetails(for: user)
+        delegate?.presentDetails(for: serviceUsers[indexPath.row])
     }
     
 }

--- a/Wire-iOS/Sources/UserInterface/Helpers/UIViewController+removeUserConfirmationUI.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UIViewController+removeUserConfirmationUI.swift
@@ -28,7 +28,7 @@ extension UIViewController {
     ///   - conversation: the current converation contains that user
     ///   - viewControllerDismiser: a ViewControllerDismisser to call when this UIViewController is dismissed
     func presentRemoveDialogue(
-        for participant: ZMUser,
+        for participant: UserType,
         from conversation: ZMConversation,
         dismisser: ViewControllerDismisser? = nil
         ) {

--- a/Wire-iOS/Sources/UserInterface/Helpers/UIViewController+removeUserConfirmationUI.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UIViewController+removeUserConfirmationUI.swift
@@ -36,7 +36,7 @@ extension UIViewController {
         let controller = UIAlertController.remove(participant) { [weak self] remove in
             guard let `self` = self, remove else { return }
             
-            conversation.removeOrShowError(participnant: participant) { result in
+            conversation.removeOrShowError(participant: participant) { result in
                 switch result {
                 case .success:
                     dismisser?.dismiss(viewController: self, completion: nil)

--- a/Wire-iOS/Sources/UserInterface/Helpers/UserDetailViewControllerFactory.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UserDetailViewControllerFactory.swift
@@ -28,13 +28,13 @@ final class UserDetailViewControllerFactory: NSObject {
     ///   - profileViewControllerDelegate: a ProfileViewControllerDelegate for ProfileViewController
     ///   - viewControllerDismisser: a ViewControllerDismisser for returing UIViewController's dismiss action
     /// - Returns: if the user is a serviceUser, return a ProfileHeaderServiceDetailViewController. if the user not a serviceUser, return a ProfileViewController
-    static func createUserDetailViewController(user: ZMUser,
-                                                     conversation: ZMConversation,
-                                                     profileViewControllerDelegate: ProfileViewControllerDelegate,
-                                                     viewControllerDismisser: ViewControllerDismisser) -> UIViewController {
-        if user.isServiceUser {
+    static func createUserDetailViewController(user: UserType,
+                                               conversation: ZMConversation,
+                                               profileViewControllerDelegate: ProfileViewControllerDelegate,
+                                               viewControllerDismisser: ViewControllerDismisser) -> UIViewController {
+        if user.isServiceUser, let serviceUser = user as? ServiceUser {
             let variant = ServiceDetailVariant(colorScheme: ColorScheme.default.variant, opaque: true)
-            let serviceDetailViewController = ServiceDetailViewController(serviceUser: user, actionType: .removeService(conversation), variant: variant, completion: nil)
+            let serviceDetailViewController = ServiceDetailViewController(serviceUser: serviceUser, actionType: .removeService(conversation), variant: variant, completion: nil)
             serviceDetailViewController.viewControllerDismisser = viewControllerDismisser
             return serviceDetailViewController
         } else {

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -648,12 +648,13 @@ final class ZClientViewController: UIViewController {
 
     /// Open the user client list screen
     ///
-    /// - Parameter user: the ZMUser with client list to show
-    func openClientListScreen(for user: ZMUser) {
+    /// - Parameter user: the UserType with client list to show
+    
+    func openClientListScreen(for user: UserType) {
         var viewController: UIViewController?
 
-        if user.isSelfUser {
-            let clientListViewController = ClientListViewController(clientsList: Array(user.clients), credentials: nil, detailedView: true, showTemporary: true, variant: ColorScheme.default.variant)
+        if user.isSelfUser, let clients = user.allClients as? [UserClient] {
+            let clientListViewController = ClientListViewController(clientsList: clients, credentials: nil, detailedView: true, showTemporary: true, variant: ColorScheme.default.variant)
             clientListViewController.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(dismissClientListController(_:)))
             viewController = clientListViewController
         } else {

--- a/Wire-iOS/Sources/UserInterface/Services/ServiceDetailViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Services/ServiceDetailViewController.swift
@@ -199,8 +199,7 @@ final class ServiceDetailViewController: UIViewController {
                     }
                 }
             case let .removeService(conversation):
-                guard let user = serviceUser as? ZMUser else { return }
-                self.presentRemoveDialogue(for: user, from: conversation, dismisser: self.viewControllerDismisser)
+                self.presentRemoveDialogue(for: serviceUser, from: conversation, dismisser: self.viewControllerDismisser)
             case .openConversation:
                 if let existingConversation = ZMConversation.existingConversation(in: userSession.managedObjectContext, service: serviceUser, team: ZMUser.selfUser().team) {
                     completion?(.success(conversation: existingConversation))

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/Contacts/ContactsSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/Contacts/ContactsSectionController.swift
@@ -100,15 +100,15 @@ class ContactsSectionController : SearchSectionController {
 
 extension ContactsSectionController: UserSelectionObserver {
     
-    func userSelection(_ userSelection: UserSelection, wasReplacedBy users: [ZMUser]) {
+    func userSelection(_ userSelection: UserSelection, wasReplacedBy users: [UserType]) {
         collectionView?.reloadData()
     }
     
-    func userSelection(_ userSelection: UserSelection, didAddUser user: ZMUser) {
+    func userSelection(_ userSelection: UserSelection, didAddUser user: UserType) {
         collectionView?.reloadData()
     }
     
-    func userSelection(_ userSelection: UserSelection, didRemoveUser user: ZMUser) {
+    func userSelection(_ userSelection: UserSelection, didRemoveUser user: UserType) {
         collectionView?.reloadData()
     }
     

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/UserSelection.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/UserSelection.swift
@@ -22,9 +22,9 @@ import WireUtilities
 @objc
 protocol UserSelectionObserver {
     
-    func userSelection(_ userSelection: UserSelection, didAddUser user: ZMUser)
-    func userSelection(_ userSelection: UserSelection, didRemoveUser user: ZMUser)
-    func userSelection(_ userSelection: UserSelection, wasReplacedBy users: [ZMUser])
+    func userSelection(_ userSelection: UserSelection, didAddUser user: UserType)
+    func userSelection(_ userSelection: UserSelection, didRemoveUser user: UserType)
+    func userSelection(_ userSelection: UserSelection, wasReplacedBy users: [UserType])
     
 }
 

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchHeaderViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchHeaderViewController.swift
@@ -151,16 +151,16 @@ protocol SearchHeaderViewControllerDelegate : class {
 
 extension SearchHeaderViewController : UserSelectionObserver {
     
-    public func userSelection(_ userSelection: UserSelection, wasReplacedBy users: [ZMUser]) {
+    public func userSelection(_ userSelection: UserSelection, wasReplacedBy users: [UserType]) {
         // this is triggered by the TokenField itself so we should ignore it here
     }
     
-    public func userSelection(_ userSelection: UserSelection, didAddUser user: ZMUser) {
+    public func userSelection(_ userSelection: UserSelection, didAddUser user: UserType) {
         guard allowsMultipleSelection else { return }
         tokenField.addToken(forTitle: user.displayName, representedObject: user)
     }
     
-    public func userSelection(_ userSelection: UserSelection, didRemoveUser user: ZMUser) {
+    public func userSelection(_ userSelection: UserSelection, didRemoveUser user: UserType) {
         guard let token = tokenField.token(forRepresentedObject: user) else { return }
         tokenField.removeToken(token)
         updateClearIndicator(for: tokenField)

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.swift
@@ -444,7 +444,7 @@ extension ProfileViewController: ProfileFooterViewDelegate, IncomingRequestFoote
         )
         
         let removeAction = UIAlertAction(title: "profile.remove_dialog_button_remove_confirm".localized, style: .destructive) { _ in
-            self.viewModel.conversation?.removeOrShowError(participnant: otherUser) { result in
+            self.viewModel.conversation?.removeOrShowError(participant: otherUser) { result in
                 switch result {
                 case .success:
                     self.returnToPreviousScreen()

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewControllerViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewControllerViewModel.swift
@@ -164,7 +164,7 @@ final class ProfileViewControllerViewModel: NSObject {
         transitionToListAndEnqueue {
             self.conversation?.clearMessageHistory()
             if leave {
-                self.conversation?.removeOrShowError(participnant: ZMUser.selfUser())
+                self.conversation?.removeOrShowError(participant: ZMUser.selfUser())
             }
         }
     }


### PR DESCRIPTION
## What's new in this PR?

This PR is part of an ongoing effort to remove references to concrete user objects. See https://github.com/wireapp/ios-architecture/issues/89 for more details.

---

Contained in this PR is general refactoring to replace references of `ZMUser`  with `UserType`. It covers around 40% of the occurrences of `ZMUser` (excluding any calls to `ZMUser.selfUser()` which will be handled separately.
