### PR TITLE
[Fix] SSO error alert is not shown

### DIFF
--- a/Wire-iOS/Sources/AppDelegate+URL.swift
+++ b/Wire-iOS/Sources/AppDelegate+URL.swift
@@ -24,7 +24,7 @@ extension AppDelegate {
         do {
             return try sessionManager?.openURL(url, options: options) ?? false
         } catch let error as LocalizedError {
-            rootViewController.showAlert(for: error)
+            UIApplication.shared.topmostViewController()?.showAlert(for: error)
             return false
         } catch {
             return false

--- a/Wire-iOS/Sources/Components/CompanyLoginFlowOpener.swift
+++ b/Wire-iOS/Sources/Components/CompanyLoginFlowOpener.swift
@@ -122,7 +122,7 @@ class CompanyLoginFlowHandler {
         do {
             _ = try SessionManager.shared?.openURL(url, options: [:])
         } catch let error as LocalizedError {
-            AppDelegate.shared.rootViewController.showAlert(for: error)
+            UIApplication.shared.topmostViewController()?.showAlert(for: error)
         } catch {
             // nop
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

When you try to sign in with SSO and the provider is misconfigured, there should be a error alert.

### Causes

The alert is not shown because it's presented on the rootViewController which isn't in the view hierarchy since a browser view controller currently visible.

### Solutions

Present on `UIApplication.shared.topmostViewController()` instead.