### PR TITLE
[Fix] Avatar image overlaps user name

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListTopBarViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListTopBarViewController.swift
@@ -243,11 +243,8 @@ extension ConversationListTopBarViewController: UIViewControllerTransitioningDel
 extension ConversationListTopBarViewController: ZMUserObserver {
     
     func userDidChange(_ changeInfo: UserChangeInfo) {
-        if changeInfo.nameChanged {
+        if changeInfo.nameChanged || changeInfo.teamsChanged {
             updateTitleView()
-        }
-
-        if changeInfo.teamsChanged {
             updateAccountView()
         }
         

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListTopBarViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListTopBarViewController.swift
@@ -361,7 +361,6 @@ final class TopBar: UIView {
     private var leftSeparatorInsetConstraint: NSLayoutConstraint!
     private var rightSeparatorInsetConstraint: NSLayoutConstraint!
     
-    
     override init(frame: CGRect) {
         super.init(frame: frame)
         layoutMargins = UIEdgeInsets(top: 0, left: CGFloat.ConversationList.horizontalMargin, bottom: 0, right: CGFloat.ConversationList.horizontalMargin)

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListTopBarViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListTopBarViewController.swift
@@ -91,6 +91,7 @@ final class ConversationListTopBarViewController: UIViewController {
             titleLabel.font = FontSpec(.normal, .semibold).font
             titleLabel.textColor = UIColor.from(scheme: .textForeground, variant: .dark)
             titleLabel.accessibilityTraits = .header
+            titleLabel.accessibilityValue = selfUser.name
             titleLabel.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
             titleLabel.setContentCompressionResistancePriority(.required, for: .vertical)
             titleLabel.setContentHuggingPriority(.required, for: .horizontal)


### PR DESCRIPTION
## What's new in this PR?

## Issues
The long user name overlaps the avatar image in the conversation list header after the username  changing.

## Causes
We do not update avatar constraints.

## Solutions
Update title and avatar constraints.
