### PR TITLE
Fix: swizzle transition jumps after transition

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/DefaultNavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/DefaultNavigationBar.swift
@@ -67,10 +67,12 @@ class DefaultNavigationBar : UINavigationBar {
 
 extension UIViewController {
 
+    @objc
     func wrapInNavigationController(_ navigationControllerClass: UINavigationController.Type) -> UINavigationController {
         return wrapInNavigationController(navigationControllerClass: navigationControllerClass, navigationBarClass: DefaultNavigationBar.self)
     }
 
+    @objc
     func wrapInNavigationController() -> UINavigationController {
         return wrapInNavigationController(navigationControllerClass: RotationAwareNavigationController.self, navigationBarClass: DefaultNavigationBar.self)
     }

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/DefaultNavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/DefaultNavigationBar.swift
@@ -18,13 +18,13 @@
 
 import UIKit
 
-@objcMembers class LightNavigationBar : DefaultNavigationBar {
+final class LightNavigationBar : DefaultNavigationBar {
     override var colorSchemeVariant: ColorSchemeVariant {
         return .light
     }
 }
 
-@objcMembers class DefaultNavigationBar : UINavigationBar {
+class DefaultNavigationBar : UINavigationBar {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -67,12 +67,10 @@ import UIKit
 
 extension UIViewController {
 
-    @objc
     func wrapInNavigationController(_ navigationControllerClass: UINavigationController.Type) -> UINavigationController {
         return wrapInNavigationController(navigationControllerClass: navigationControllerClass, navigationBarClass: DefaultNavigationBar.self)
     }
 
-    @objc
     func wrapInNavigationController() -> UINavigationController {
         return wrapInNavigationController(navigationControllerClass: RotationAwareNavigationController.self, navigationBarClass: DefaultNavigationBar.self)
     }

--- a/Wire-iOS/Sources/UserInterface/Components/Transitions/CrossfadeTransition.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Transitions/CrossfadeTransition.swift
@@ -43,6 +43,8 @@ final class CrossfadeTransition: NSObject, UIViewControllerAnimatedTransitioning
             transitionContext.completeTransition(true)
             return
         }
+        
+        containerView.layoutIfNeeded()
 
         toView.alpha = 0
 

--- a/Wire-iOS/Sources/UserInterface/Components/Transitions/CrossfadeTransition.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Transitions/CrossfadeTransition.swift
@@ -37,13 +37,12 @@ final class CrossfadeTransition: NSObject, UIViewControllerAnimatedTransitioning
 
         let containerView = transitionContext.containerView
 
-        containerView.addSubview(toView)
-
         if !transitionContext.isAnimated || duration == 0 {
             transitionContext.completeTransition(true)
             return
         }
         
+        containerView.addSubview(toView)
         containerView.layoutIfNeeded()
 
         toView.alpha = 0

--- a/Wire-iOS/Sources/UserInterface/Components/Transitions/CrossfadeTransition.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Transitions/CrossfadeTransition.swift
@@ -37,12 +37,13 @@ final class CrossfadeTransition: NSObject, UIViewControllerAnimatedTransitioning
 
         let containerView = transitionContext.containerView
 
+        containerView.addSubview(toView)
+
         if !transitionContext.isAnimated || duration == 0 {
             transitionContext.completeTransition(true)
             return
         }
         
-        containerView.addSubview(toView)
         containerView.layoutIfNeeded()
 
         toView.alpha = 0

--- a/Wire-iOS/Sources/UserInterface/Components/Transitions/NavigationTransition.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Transitions/NavigationTransition.swift
@@ -66,6 +66,8 @@ final class NavigationTransition: NSObject, UIViewControllerAnimatedTransitionin
 
         containerView.addSubview(toView)
         containerView.addSubview(fromView)
+        
+        containerView.layoutIfNeeded()
 
         UIView.animate(easing: .easeOutExpo,
                           duration: transitionDuration(using: transitionContext),

--- a/Wire-iOS/Sources/UserInterface/Components/Transitions/SwizzleTransition.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Transitions/SwizzleTransition.swift
@@ -40,12 +40,13 @@ final class SwizzleTransition: NSObject, UIViewControllerAnimatedTransitioning {
         }
         let containerView = transitionContext.containerView
 
+        containerView.addSubview(toView)
+
         if !transitionContext.isAnimated {
             transitionContext.completeTransition(true)
             return
         }
         
-        containerView.addSubview(toView)
         containerView.layoutIfNeeded()
 
         let durationPhase1: TimeInterval

--- a/Wire-iOS/Sources/UserInterface/Components/Transitions/SwizzleTransition.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Transitions/SwizzleTransition.swift
@@ -40,13 +40,12 @@ final class SwizzleTransition: NSObject, UIViewControllerAnimatedTransitioning {
         }
         let containerView = transitionContext.containerView
 
-        containerView.addSubview(toView)
-
         if !transitionContext.isAnimated {
             transitionContext.completeTransition(true)
             return
         }
         
+        containerView.addSubview(toView)
         containerView.layoutIfNeeded()
 
         let durationPhase1: TimeInterval

--- a/Wire-iOS/Sources/UserInterface/Components/Transitions/SwizzleTransition.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Transitions/SwizzleTransition.swift
@@ -50,12 +50,15 @@ final class SwizzleTransition: NSObject, UIViewControllerAnimatedTransitioning {
 
         let durationPhase1: TimeInterval
         let durationPhase2: TimeInterval
+        
+        let verticalTransform = CGAffineTransform(translationX: 0, y: 48)
+        
         if direction == .horizontal {
-            toView.layer.transform = CATransform3DMakeTranslation(24, 0, 0)
+            toView.transform = CGAffineTransform(translationX: 24, y:  0)
             durationPhase1 = 0.15
             durationPhase2 = 0.55
         } else {
-            toView.layer.transform = CATransform3DMakeTranslation(0, 48, 0)
+            toView.transform = verticalTransform
             durationPhase1 = 0.10
             durationPhase2 = 0.30
         }
@@ -63,13 +66,13 @@ final class SwizzleTransition: NSObject, UIViewControllerAnimatedTransitioning {
 
         UIView.animate(easing: .easeInQuad, duration: durationPhase1, animations: {
             fromView.alpha = 0
-            fromView.layer.transform = self.direction == .horizontal ? CATransform3DMakeTranslation(48, 0, 0) : CATransform3DMakeTranslation(0, 48, 0)
+            fromView.transform = self.direction == .horizontal ? CGAffineTransform(translationX:48, y:0) : verticalTransform
         }) { finished in
             UIView.animate(easing: .easeOutQuad, duration: durationPhase2, animations: {
-                toView.layer.transform = CATransform3DIdentity
+                toView.transform = .identity
                 toView.alpha = 1
             }) { finished in
-                fromView.layer.transform = CATransform3DIdentity
+                fromView.transform = .identity
                 transitionContext.completeTransition(true)
             }
         }

--- a/Wire-iOS/Sources/UserInterface/Components/Transitions/SwizzleTransition.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Transitions/SwizzleTransition.swift
@@ -46,7 +46,8 @@ final class SwizzleTransition: NSObject, UIViewControllerAnimatedTransitioning {
             transitionContext.completeTransition(true)
             return
         }
-        containerView.setNeedsLayout()
+        
+        containerView.layoutIfNeeded()
 
         let durationPhase1: TimeInterval
         let durationPhase2: TimeInterval

--- a/Wire-iOS/Sources/UserInterface/Components/Transitions/VerticalTransition.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Transitions/VerticalTransition.swift
@@ -48,12 +48,13 @@ final class VerticalTransition: NSObject, UIViewControllerAnimatedTransitioning 
         
         fromView.frame = transitionContext.initialFrame(for: fromViewController)
         
+        containerView.addSubview(toView)
+
         if !transitionContext.isAnimated {
             transitionContext.completeTransition(true)
             return
         }
         
-        containerView.addSubview(toView)
         containerView.layoutIfNeeded()
         
         let sign = copysign(1.0, self.offset)

--- a/Wire-iOS/Sources/UserInterface/Components/Transitions/VerticalTransition.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Transitions/VerticalTransition.swift
@@ -43,8 +43,6 @@ final class VerticalTransition: NSObject, UIViewControllerAnimatedTransitioning 
         guard let toView = transitionContext.toView,
               let toViewController = transitionContext.toViewController else { return }
         
-        containerView.addSubview(toView)
-        
         guard let fromView = transitionContext.fromView,
               let fromViewController = transitionContext.fromViewController else { return }
         
@@ -55,6 +53,7 @@ final class VerticalTransition: NSObject, UIViewControllerAnimatedTransitioning 
             return
         }
         
+        containerView.addSubview(toView)
         containerView.layoutIfNeeded()
         
         let sign = copysign(1.0, self.offset)

--- a/Wire-iOS/Sources/UserInterface/Components/Transitions/VerticalTransition.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Transitions/VerticalTransition.swift
@@ -55,6 +55,8 @@ final class VerticalTransition: NSObject, UIViewControllerAnimatedTransitioning 
             return
         }
         
+        containerView.layoutIfNeeded()
+        
         let sign = copysign(1.0, self.offset)
         let finalRect = transitionContext.finalFrame(for: toViewController)
         let toTransfrom = CGAffineTransform(translationX: 0, y: -self.offset)

--- a/Wire-iOS/Sources/UserInterface/Components/Transitions/ZoomTransition.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Transitions/ZoomTransition.swift
@@ -43,7 +43,7 @@ final class ZoomTransition: NSObject, UIViewControllerAnimatedTransitioning {
             return
         }
 
-        toView.layoutIfNeeded()
+        containerView.layoutIfNeeded()
 
         fromView.alpha = 1
         fromView.layer.needsDisplayOnBoundsChange = false

--- a/Wire-iOS/Sources/UserInterface/Components/Transitions/ZoomTransition.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Transitions/ZoomTransition.swift
@@ -36,13 +36,13 @@ final class ZoomTransition: NSObject, UIViewControllerAnimatedTransitioning {
               let toView = transitionContext.toView else { return }
         let containerView = transitionContext.containerView
 
+        containerView.addSubview(toView)
 
         if !transitionContext.isAnimated {
             transitionContext.completeTransition(true)
             return
         }
 
-        containerView.addSubview(toView)
         containerView.layoutIfNeeded()
 
         fromView.alpha = 1

--- a/Wire-iOS/Sources/UserInterface/Components/Transitions/ZoomTransition.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Transitions/ZoomTransition.swift
@@ -36,13 +36,13 @@ final class ZoomTransition: NSObject, UIViewControllerAnimatedTransitioning {
               let toView = transitionContext.toView else { return }
         let containerView = transitionContext.containerView
 
-        containerView.addSubview(toView)
 
         if !transitionContext.isAnimated {
             transitionContext.completeTransition(true)
             return
         }
 
+        containerView.addSubview(toView)
         containerView.layoutIfNeeded()
 
         fromView.alpha = 1

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListTopBarViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListTopBarViewController.swift
@@ -205,7 +205,7 @@ final class ConversationListTopBarViewController: UIViewController {
 
     @objc
     func presentSettings() {
-        let settingsViewController = createSettingsViewController()
+        let settingsViewController = createSettingsViewController()///TODO: top bar ??
         let keyboardAvoidingViewController = KeyboardAvoidingViewController(viewController: settingsViewController)
         
         if wr_splitViewController?.layoutSize == .compact {

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListTopBarViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListTopBarViewController.swift
@@ -205,7 +205,7 @@ final class ConversationListTopBarViewController: UIViewController {
 
     @objc
     func presentSettings() {
-        let settingsViewController = createSettingsViewController()///TODO: top bar ??
+        let settingsViewController = createSettingsViewController()
         let keyboardAvoidingViewController = KeyboardAvoidingViewController(viewController: settingsViewController)
         
         if wr_splitViewController?.layoutSize == .compact {


### PR DESCRIPTION
## What's new in this PR?

### Issues

When swizzle transition is done, the navigation bar "jumps" down.

### Causes

After https://github.com/wireapp/wire-ios/pull/4088, missing `containerView.layoutIfNeeded()` call.

### Solutions

Add `containerView.layoutIfNeeded()` instead of `containerView.setNeedsLayout()`
Refactoring other Transition classes to call `layoutIfNeeded()` after `addSubView`.
Refactor `CATransform3DMakeTranslation` to simpler `CGAffineTransform`.