### PR TITLE
Remove wrapInNavigationController objc interfaces

### DIFF
--- a/Wire-iOS Tests/ChangeEmailViewControllerTests.swift
+++ b/Wire-iOS Tests/ChangeEmailViewControllerTests.swift
@@ -33,7 +33,7 @@ class ChangeEmailViewControllerTests: ZMSnapshotTestCase {
 
         // WHEN
         let sut = ChangeEmailViewController(user: mockUser)
-        let viewController = sut.wrapInNavigationController(SettingsStyleNavigationController.self)
+        let viewController = sut.wrapInNavigationController(navigationControllerClass: SettingsStyleNavigationController.self)
 
         // THEN
         verify(view: viewController.view)
@@ -46,7 +46,7 @@ class ChangeEmailViewControllerTests: ZMSnapshotTestCase {
 
         // WHEN
         let sut = ChangeEmailViewController(user: mockUser)
-        let viewController = sut.wrapInNavigationController(SettingsStyleNavigationController.self)
+        let viewController = sut.wrapInNavigationController(navigationControllerClass: SettingsStyleNavigationController.self)
 
         // THEN
         verify(view: viewController.view)

--- a/Wire-iOS Tests/ChangeHandleViewControllerTests.swift
+++ b/Wire-iOS Tests/ChangeHandleViewControllerTests.swift
@@ -56,7 +56,7 @@ class ChangeHandleViewControllerTests: ZMSnapshotTestCase {
 fileprivate extension UIViewController {
 
     func prepareForSnapshots() -> UIView {
-        let navigationController = self.wrapInNavigationController(ClearBackgroundNavigationController.self)
+        let navigationController = wrapInNavigationController(navigationControllerClass: ClearBackgroundNavigationController.self)
         navigationController.navigationBar.tintColor = .brightOrange
 
         beginAppearanceTransition(true, animated: false)

--- a/Wire-iOS Tests/ContactsViewControllerSnapshotTests.swift
+++ b/Wire-iOS Tests/ContactsViewControllerSnapshotTests.swift
@@ -104,7 +104,7 @@ final class ContactsViewControllerSnapshotTests: XCTestCase {
     }
 
     private func wrapInNavigationController() {
-        let navigationController = UIViewController().wrapInNavigationController(ClearBackgroundNavigationController.self)
+        let navigationController = UIViewController().wrapInNavigationController(navigationControllerClass: ClearBackgroundNavigationController.self)
         navigationController.pushViewController(sut, animated: false)
         sut.tableView.reloadData()
     }

--- a/Wire-iOS Tests/Settings/SettingsTechnicalReportViewControllerSnapshotTests.swift
+++ b/Wire-iOS Tests/Settings/SettingsTechnicalReportViewControllerSnapshotTests.swift
@@ -33,7 +33,7 @@ final class SettingsTechnicalReportViewControllerSnapshotTests: XCTestCase {
     }
 
     func testForInitState() {
-        let naviViewController = sut.wrapInNavigationController(SettingsStyleNavigationController.self)
+        let naviViewController = sut.wrapInNavigationController(navigationControllerClass: SettingsStyleNavigationController.self)
         naviViewController.view.backgroundColor = .black
         verify(matching: naviViewController)
     }

--- a/Wire-iOS Tests/StartUIViewControllerSnapshotTests.swift
+++ b/Wire-iOS Tests/StartUIViewControllerSnapshotTests.swift
@@ -80,7 +80,7 @@ final class StartUIViewControllerSnapshotTests: CoreDataSnapshotTestCase {
         nonTeamTest {
             setupSut()
 
-            let navigationController = UIViewController().wrapInNavigationController(ClearBackgroundNavigationController.self)
+            let navigationController = UIViewController().wrapInNavigationController(navigationControllerClass: ClearBackgroundNavigationController.self)
 
             navigationController.pushViewController(sut, animated: false)
 

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/DefaultNavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/DefaultNavigationBar.swift
@@ -67,16 +67,6 @@ import UIKit
 
 extension UIViewController {
 
-    @objc
-    func wrapInNavigationController(_ navigationControllerClass: UINavigationController.Type) -> UINavigationController {
-        return wrapInNavigationController(navigationControllerClass: navigationControllerClass, navigationBarClass: DefaultNavigationBar.self)
-    }
-
-    @objc
-    func wrapInNavigationController() -> UINavigationController {
-        return wrapInNavigationController(navigationControllerClass: RotationAwareNavigationController.self, navigationBarClass: DefaultNavigationBar.self)
-    }
-    
     func wrapInNavigationController(navigationControllerClass: UINavigationController.Type = RotationAwareNavigationController.self,
                                     navigationBarClass: AnyClass? = DefaultNavigationBar.self) -> UINavigationController {
         let navigationController = navigationControllerClass.init(navigationBarClass: navigationBarClass, toolbarClass: nil)

--- a/Wire-iOS/Sources/UserInterface/Components/TextView/TextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/TextView/TextView.swift
@@ -175,6 +175,7 @@ class TextView: UITextView {
         return super.canPerformAction(action, withSender: sender)
     }
 
+    @discardableResult
     override func resignFirstResponder() -> Bool {
         let resigned = super.resignFirstResponder()
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -62,13 +62,6 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
 
 @end
 
-@interface ConversationInputBarViewController (Sketch)
-
-- (void)sketchButtonPressed:(nullable id)sender;
-
-@end
-
-
 @interface  ConversationInputBarViewController (UIGestureRecognizerDelegate) <UIGestureRecognizerDelegate>
 
 @end
@@ -492,21 +485,6 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
 @interface ZMAssetMetaDataEncoder (Test)
 
 + (CGSize)imageSizeForImageData:(NSData *)imageData;
-
-@end
-
-@implementation ConversationInputBarViewController (Sketch)
-
-- (void)sketchButtonPressed:(id)sender
-{
-    [self.inputBar.textView resignFirstResponder];
-    
-    CanvasViewController *viewController = [[CanvasViewController alloc] init];
-    viewController.delegate = self;
-    viewController.title = self.conversation.displayName.uppercaseString;
-    
-    [self.parentViewController presentViewController:[viewController wrapInNavigationController] animated:YES completion:nil];
-}
 
 @end
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
@@ -144,7 +144,21 @@ extension ConversationInputBarViewController: UIImagePickerControllerDelegate {
             }
         }
     }
+    
+    //MARK: - Sketch
+    
+    @objc
+    func sketchButtonPressed(_ sender: Any?) {
+        inputBar.textView.resignFirstResponder()
+        
+        let viewController = CanvasViewController()
+        viewController.delegate = self
+        viewController.title = conversation.displayName.uppercased()
+        
+        parent?.present(viewController.wrapInNavigationController(), animated: true)
+    }
 }
+
 
 // MARK: - Informal TextView delegate methods
 

--- a/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController+State.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController+State.swift
@@ -40,7 +40,7 @@ extension ConversationListViewController {
             }
         case .peoplePicker:
             let startUIViewController = createPeoplePickerController()
-            let navigationWrapper = startUIViewController.wrapInNavigationController(ClearBackgroundNavigationController.self)
+            let navigationWrapper = startUIViewController.wrapInNavigationController(navigationControllerClass: ClearBackgroundNavigationController.self)
 
             show(navigationWrapper, animated: true) {
                 startUIViewController.showKeyboardIfNeeded()


### PR DESCRIPTION
Remove `wrapInNavigationController` objc interfaces and convert their callers to Swift.