### PR TITLE
fix: lock screen - status bar is dark on dark

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Helpers/UIApplication+StatusBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UIApplication+StatusBar.swift
@@ -28,7 +28,7 @@ extension UIApplication {
     /// 2. CallWindowRootViewController is in use and voice channel controller is active
     /// 3. the window's rootViewController is AppRootViewController
     var topMostVisibleWindow: UIWindow? {
-        let orderedWindows = self.windows.sorted { win1, win2 in
+        let orderedWindows = windows.sorted { win1, win2 in
             win1.windowLevel < win2.windowLevel
         }
 
@@ -41,9 +41,9 @@ extension UIApplication {
                 return callWindowRootController.isDisplayingCallOverlay
             } else if controller is AppRootViewController  {
                 return true
-            } else {
-                return false
             }
+            
+            return false
         }
 
         return visibleWindow.last

--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
@@ -53,6 +53,10 @@ final class AppLockViewController: UIViewController {
         self.init(nibName:nil, bundle:nil)
     }
     
+    override var prefersStatusBarHidden: Bool {
+        return true
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         

--- a/Wire-iOS/Sources/UserInterface/Overlay/NotificationWindowRootViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/NotificationWindowRootViewController.swift
@@ -47,32 +47,38 @@ final class NotificationWindowRootViewController: UIViewController {
 
     // MARK: - Rotation handling (should match up with root)
 
-    private func topmostViewController() -> UIViewController? {
+    private var topmostViewController: UIViewController? {
         guard let topmostViewController = UIApplication.shared.topmostViewController() else { return nil}
 
         if topmostViewController != self && !(topmostViewController is NotificationWindowRootViewController) {
             return topmostViewController
-        } else {
-            return nil
         }
-    }
-
-    override var childForStatusBarStyle: UIViewController? {
-        return topmostViewController()
-    }
-    
-    override var childForStatusBarHidden: UIViewController? {
-        return topmostViewController()
+        
+        return nil
     }
 
     override var shouldAutorotate: Bool {
-        return topmostViewController()?.shouldAutorotate ?? true
+        return topmostViewController?.shouldAutorotate ?? true
     }
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-        return topmostViewController()?.supportedInterfaceOrientations ?? wr_supportedInterfaceOrientations
+        return topmostViewController?.supportedInterfaceOrientations ?? wr_supportedInterfaceOrientations
     }
-
+    
+    // MARK: - status bar
+    
+    override var childForStatusBarStyle: UIViewController? {
+        return appLockViewController
+    }
+    
+    override var childForStatusBarHidden: UIViewController? {
+        return appLockViewController
+    }
+    
+    override var prefersStatusBarHidden: Bool {
+        return true
+    }
+    
 }
 
 // MARK : - Child


### PR DESCRIPTION
## What's new in this PR?

### Issues

app lock screen: status bar is dark on dark.

### Causes

`NotificationWindowRootViewController` get `childForStatusBarHidden` from `topmostViewController`, which is `AppRootViewController` and behind the lock screen.

### Solutions

Get `childForStatusBarHidden` instead from `AppLockViewController`. Hide the status bar in this case.