### PR TITLE
fix: Status bar turns white after multiple callee alert is shown

### DIFF
--- a/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationCallController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationCallController.swift
@@ -18,18 +18,19 @@
 
 import Foundation
 
-@objcMembers final public class ConversationCallController: NSObject {
+final class ConversationCallController: NSObject {
     
     private unowned let target: UIViewController
     private let conversation: ZMConversation
     
-    @objc public init(conversation: ZMConversation, target: UIViewController) {
+    
+    init(conversation: ZMConversation, target: UIViewController) {
         self.conversation = conversation
         self.target = target
         super.init()
     }
     
-    @objc public func startAudioCall(started: (() -> Void)?) {
+    func startAudioCall(started: (() -> Void)?) {
         let startCall = { [weak self] in
             guard let `self` = self else { return }
             self.conversation.confirmJoiningCallIfNeeded(alertPresenter: self.target) {
@@ -41,21 +42,23 @@ import Foundation
         if conversation.localParticipants.count <= 4 {
             startCall()
         } else {
-            confirmGroupCall { accepted in
+            confirmGroupCall {[weak self] accepted in
+                self?.target.setNeedsStatusBarAppearanceUpdate()
+                
                 guard accepted else { return }
                 startCall()
             }
         }
     }
     
-    @objc public func startVideoCall(started: (() -> Void)?) {
+    func startVideoCall(started: (() -> Void)?) {
         conversation.confirmJoiningCallIfNeeded(alertPresenter: target) { [conversation] in
             started?()
             conversation.startVideoCall()
         }
     }
     
-    @objc public func joinCall() {
+    func joinCall() {
         guard conversation.canJoinCall else { return }
         conversation.confirmJoiningCallIfNeeded(alertPresenter: target) { [conversation] in
             conversation.joinCall() // This will result in joining an ongoing call.
@@ -69,7 +72,10 @@ import Foundation
             participants: conversation.localParticipants.count - 1,
             completion: completion
         )
-        target.present(controller, animated: true)
+
+        target.present(controller, animated: true) {
+            self.target.setNeedsStatusBarAppearanceUpdate()
+        }
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationCallController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationCallController.swift
@@ -19,17 +19,16 @@
 import Foundation
 
 final class ConversationCallController: NSObject {
-    
+
     private unowned let target: UIViewController
     private let conversation: ZMConversation
-    
-    
+
     init(conversation: ZMConversation, target: UIViewController) {
         self.conversation = conversation
         self.target = target
         super.init()
     }
-    
+
     func startAudioCall(started: (() -> Void)?) {
         let startCall = { [weak self] in
             guard let `self` = self else { return }
@@ -38,36 +37,36 @@ final class ConversationCallController: NSObject {
                 self.conversation.startAudioCall()
             }
         }
-        
+
         if conversation.localParticipants.count <= 4 {
             startCall()
         } else {
             confirmGroupCall {[weak self] accepted in
                 self?.target.setNeedsStatusBarAppearanceUpdate()
-                
+
                 guard accepted else { return }
                 startCall()
             }
         }
     }
-    
+
     func startVideoCall(started: (() -> Void)?) {
         conversation.confirmJoiningCallIfNeeded(alertPresenter: target) { [conversation] in
             started?()
             conversation.startVideoCall()
         }
     }
-    
+
     func joinCall() {
         guard conversation.canJoinCall else { return }
         conversation.confirmJoiningCallIfNeeded(alertPresenter: target) { [conversation] in
             conversation.joinCall() // This will result in joining an ongoing call.
         }
     }
-    
+
     // MARK: - Helper
 
-    private func confirmGroupCall(completion: @escaping (_ completion: Bool) -> ()) {
+    private func confirmGroupCall(completion: @escaping (_ completion: Bool) -> Void) {
         let controller = UIAlertController.confirmGroupCall(
             participants: conversation.localParticipants.count - 1,
             completion: completion

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationCallController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationCallController.swift
@@ -73,9 +73,7 @@ final class ConversationCallController: NSObject {
             completion: completion
         )
 
-        target.present(controller, animated: true) {
-            self.target.setNeedsStatusBarAppearanceUpdate()
-        }
+        target.present(controller, animated: true)
     }
 
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

The status bar turns white after multiple callee alert is shown.

### Causes

Unknown, the status bar style is not refreshed by the OS.

### Solutions

Call `setNeedsStatusBarAppearanceUpdate()` after the alert dismissed.