### PR TITLE
Fix: status bar style in presented screens

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsViewController.swift
@@ -23,7 +23,6 @@ import UIKit
  * A view controller wrapping the message details.
  */
 
-@objc
 final class MessageDetailsViewController: UIViewController, ModalTopBarDelegate {
 
     /**
@@ -85,7 +84,7 @@ final class MessageDetailsViewController: UIViewController, ModalTopBarDelegate 
      * - parameter message: The message to display the details of.
      */
 
-    @objc convenience init(message: ZMConversationMessage) {
+    convenience init(message: ZMConversationMessage) {
         self.init(message: message, preferredDisplayMode: .receipts)
     }
 
@@ -97,7 +96,7 @@ final class MessageDetailsViewController: UIViewController, ModalTopBarDelegate 
      * if the data source says it is unavailable for the message.
      */
 
-    @objc init(message: ZMConversationMessage, preferredDisplayMode: MessageDetailsDisplayMode) {
+    init(message: ZMConversationMessage, preferredDisplayMode: MessageDetailsDisplayMode) {
         self.message = message
         self.dataSource = MessageDetailsDataSource(message: message)
 
@@ -132,6 +131,10 @@ final class MessageDetailsViewController: UIViewController, ModalTopBarDelegate 
         fatalError("init(coder:) has not been implemented")
     }
 
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return ColorScheme.default.statusBarStyle
+    }
+    
     // MARK: - Configuration
 
     override func viewDidLoad() {

--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/SettingsClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/SettingsClientViewController.swift
@@ -93,7 +93,7 @@ final class SettingsClientViewController: UIViewController,
     }
     
     override var preferredStatusBarStyle: UIStatusBarStyle {
-        return .lightContent
+        return ColorScheme.default.statusBarStyle
     }
 
     override func viewDidLoad() {

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Devices/ProfileClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Devices/ProfileClientViewController.swift
@@ -21,7 +21,7 @@ import Foundation
 import Cartography
 
 
-@objcMembers class ProfileClientViewController: UIViewController {
+final class ProfileClientViewController: UIViewController {
 
     let userClient: UserClient
     let contentView = UIView()
@@ -86,6 +86,10 @@ import Cartography
         fatalError("init(coder:) has not been implemented")
     }
     
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return ColorScheme.default.statusBarStyle
+    }
+
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return [.portrait]
     }


### PR DESCRIPTION
## What's new in this PR?

Add missing `preferredStatusBarStyle ` overriding to `MessageDetailsViewController`, `SettingsClientViewController` & `ProfileClientViewController`.