### PR TITLE
Fix Call window status bar and rotation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/CallDegradationViewController/CallDegradationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallDegradationViewController/CallDegradationController.swift
@@ -75,9 +75,9 @@ final class CallDegradationController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         viewIsReady = true
-        presentAlertIfNeeded()  
+        presentAlertIfNeeded()
     }
-    
+
     private func presentAlertIfNeeded() {
         guard
             viewIsReady,

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoRootViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoRootViewController.swift
@@ -61,14 +61,6 @@ final class CallInfoRootViewController: UIViewController, UINavigationController
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    override var childForStatusBarStyle: UIViewController? {
-        return contentNavigationController
-    }
-    
-    override var childForStatusBarHidden: UIViewController? {
-        return contentNavigationController
-    }
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoViewController.swift
@@ -98,7 +98,7 @@ final class CallInfoViewController: UIViewController, CallActionsViewDelegate, C
         super.viewWillAppear(animated)
         updateState()
     }
-
+    
     private func setupViews() {
         addToSelf(backgroundViewController)
 

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallStatusView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallStatusView.swift
@@ -153,7 +153,7 @@ extension CallStatusViewInputType {
     
     var effectiveColorVariant: ColorSchemeVariant {
         guard !isVideoCall else { return .dark }
-        return variant == .dark ? .dark : .light
+        return variant
     }
     
 }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -130,7 +130,7 @@ final class CallViewController: UIViewController {
         setupApplicationStateObservers()
         updateIdleTimer()
     }
-
+    
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         proximityMonitorManager?.stopListening()
@@ -160,6 +160,10 @@ final class CallViewController: UIViewController {
     
     override var prefersStatusBarHidden: Bool {
         return !isOverlayVisible
+    }
+    
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return wr_supportedInterfaceOrientations
     }
 
     @objc private func resumeVideoIfNeeded() {

--- a/Wire-iOS/Sources/UserInterface/Calling/CallWindow/CallWindowRootViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallWindow/CallWindowRootViewController.swift
@@ -40,8 +40,6 @@ final class CallWindowRootViewController: UIViewController {
         return callController?.activeCallViewController ?? topmostViewController()
     }
 
-
-
     override var childForStatusBarStyle: UIViewController? {
         return child
     }
@@ -51,7 +49,11 @@ final class CallWindowRootViewController: UIViewController {
     }
 
     override var shouldAutorotate: Bool {
-        return topmostViewController()?.shouldAutorotate ?? true
+        if isHorizontalSizeClassRegular {
+            return topmostViewController()?.shouldAutorotate ?? true
+        }
+        
+        return false
     }
     
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
@@ -83,6 +85,9 @@ final class CallWindowRootViewController: UIViewController {
 
     override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
         view.window?.isHidden = false
-        super.present(viewControllerToPresent, animated: flag, completion: completion)
+        super.present(viewControllerToPresent, animated: flag) {
+            completion?()
+            viewControllerToPresent.setNeedsStatusBarAppearanceUpdate()
+        }
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallWindow/CallWindowRootViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallWindow/CallWindowRootViewController.swift
@@ -85,9 +85,6 @@ final class CallWindowRootViewController: UIViewController {
 
     override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
         view.window?.isHidden = false
-        super.present(viewControllerToPresent, animated: flag) {
-            completion?()
-            viewControllerToPresent.setNeedsStatusBarAppearanceUpdate()
-        }
+        super.present(viewControllerToPresent, animated: flag, completion: completion)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Helpers/InteractiveModalTransition.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/InteractiveModalTransition.swift
@@ -166,8 +166,12 @@ final class ModalPresentationViewController: UIViewController, UIViewControllerT
         fatalError("init(coder:) has not been implemented")
     }
     
-    override var preferredStatusBarStyle: UIStatusBarStyle {
-        return ColorScheme.default.statusBarStyle
+    override var childForStatusBarStyle: UIViewController? {
+        return viewController
+    }
+    
+    override var childForStatusBarHidden: UIViewController? {
+        return viewController
     }
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {

--- a/Wire-iOS/Sources/UserInterface/Helpers/InteractiveModalTransition.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/InteractiveModalTransition.swift
@@ -158,6 +158,7 @@ final class ModalPresentationViewController: UIViewController, UIViewControllerT
         super.init(nibName: nil, bundle: nil)
         setupViews(with: viewController)
         createConstraints()
+        modalPresentationCapturesStatusBarAppearance = true
     }
     
     @available(*, unavailable)

--- a/Wire-iOS/Sources/UserInterface/Helpers/InteractiveModalTransition.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/InteractiveModalTransition.swift
@@ -39,11 +39,11 @@ final private class ModalPresentationTransition: NSObject, UIViewControllerAnima
         super.init()
     }
     
-    public func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
+    func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
         return configuration.duration
     }
     
-    public func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
+    func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
         guard let toVC = transitionContext.viewController(forKey: .to) as? ModalPresentationViewController else { preconditionFailure("No ModalPresentationViewController") }
         
         transitionContext.containerView.addSubview(toVC.view)
@@ -79,11 +79,11 @@ final private class ModalDismissalTransition: NSObject, UIViewControllerAnimated
         super.init()
     }
     
-    public func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
+    func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
         return configuration.duration
     }
     
-    public func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
+    func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
         guard let fromVC = transitionContext.viewController(forKey: .from) as? ModalPresentationViewController else { preconditionFailure("No ModalPresentationViewController") }
         guard let toVC = transitionContext.viewController(forKey: .to) else { preconditionFailure("No view controller to present") }
         
@@ -152,7 +152,7 @@ final class ModalPresentationViewController: UIViewController, UIViewControllerT
     private let interactionController = ModalInteractionController()
     private let configuration: ModalPresentationConfiguration
     
-    public init(viewController: UIViewController, configuration: ModalPresentationConfiguration = .init(alpha: 0.3, duration: 0.3)) {
+    init(viewController: UIViewController, configuration: ModalPresentationConfiguration = .init(alpha: 0.3, duration: 0.3)) {
         self.viewController = viewController
         self.configuration = configuration
         super.init(nibName: nil, bundle: nil)
@@ -161,7 +161,7 @@ final class ModalPresentationViewController: UIViewController, UIViewControllerT
     }
     
     @available(*, unavailable)
-    required public init?(coder aDecoder: NSCoder) {
+    required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
@@ -188,15 +188,15 @@ final class ModalPresentationViewController: UIViewController, UIViewControllerT
         dismiss(animated: true, completion: nil)
     }
     
-    public func animationController(forPresented presented: UIViewController, presenting: UIViewController, source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+    func animationController(forPresented presented: UIViewController, presenting: UIViewController, source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
         return ModalPresentationTransition(configuration: configuration)
     }
     
-    public func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+    func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
         return ModalDismissalTransition(configuration: configuration)
     }
     
-    public func interactionControllerForDismissal(using animator: UIViewControllerAnimatedTransitioning) -> UIViewControllerInteractiveTransitioning? {
+    func interactionControllerForDismissal(using animator: UIViewControllerAnimatedTransitioning) -> UIViewControllerInteractiveTransitioning? {
         return interactionController.interactionInProgress ? interactionController : nil
     }
     

--- a/Wire-iOS/Sources/UserInterface/Helpers/InteractiveModalTransition.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/InteractiveModalTransition.swift
@@ -166,6 +166,14 @@ final class ModalPresentationViewController: UIViewController, UIViewControllerT
         fatalError("init(coder:) has not been implemented")
     }
     
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return ColorScheme.default.statusBarStyle
+    }
+
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return wr_supportedInterfaceOrientations
+    }
+
     private func setupViews(with viewController: UIViewController) {
         transitioningDelegate = self
         interactionController.setupWith(viewController: self)

--- a/Wire-iOS/Sources/UserInterface/Overlay/ActiveCallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/ActiveCallViewController.swift
@@ -77,12 +77,16 @@ final class ActiveCallViewController : UIViewController {
         updateVisibleVoiceChannelViewController()
     }
 
-    override var prefersStatusBarHidden: Bool {
-        return visibleVoiceChannelViewController.prefersStatusBarHidden
+    override var childForStatusBarStyle: UIViewController? {
+        return visibleVoiceChannelViewController
     }
     
-    override var preferredStatusBarStyle: UIStatusBarStyle {
-        return visibleVoiceChannelViewController.preferredStatusBarStyle
+    override var childForStatusBarHidden: UIViewController? {
+        return visibleVoiceChannelViewController
+    }
+
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return wr_supportedInterfaceOrientations
     }
 
     override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {

--- a/Wire-iOS/Sources/UserInterface/Overlay/ActiveCallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/ActiveCallViewController.swift
@@ -84,7 +84,7 @@ final class ActiveCallViewController : UIViewController {
     override var childForStatusBarHidden: UIViewController? {
         return visibleVoiceChannelViewController
     }
-
+    
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return wr_supportedInterfaceOrientations
     }

--- a/Wire-iOS/Sources/UserInterface/Overlay/CallTopOverlayController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/CallTopOverlayController.swift
@@ -222,7 +222,8 @@ final class CallTopOverlayController: UIViewController {
         callDurationTimer = nil
     }
     
-    @objc dynamic func openCall(_ sender: UITapGestureRecognizer?) {
+    @objc
+    private func openCall(_ sender: UITapGestureRecognizer?) {
         delegate?.voiceChannelTopOverlayWantsToRestoreCall(self)
     }
 }


### PR DESCRIPTION
Do not allow rotation in `CallWindowRootViewController`. 
In `InteractiveModalTransition`, set `modalPresentationCapturesStatusBarAppearance = true` to fix status bar not updated in presented view controller issue.