### PR TITLE
[Fix] browser not being dismissed when a SSO login error occurs

### DIFF
--- a/Wire-iOS/Sources/AppDelegate+URL.swift
+++ b/Wire-iOS/Sources/AppDelegate+URL.swift
@@ -24,11 +24,21 @@ extension AppDelegate {
         do {
             return try sessionManager?.openURL(url, options: options) ?? false
         } catch let error as LocalizedError {
-            UIApplication.shared.topmostViewController()?.showAlert(for: error)
+            if error is CompanyLoginError {
+                rootViewController.authenticationCoordinator?.cancelCompanyLogin()
+                
+                UIApplication.shared.topmostViewController()?.dismissIfNeeded(animated: true, completion: {
+                    UIApplication.shared.topmostViewController()?.showAlert(for: error)
+                })
+            } else {
+                UIApplication.shared.topmostViewController()?.showAlert(for: error)
+            }
+            
             return false
         } catch {
             return false
         }
     }
+    
 }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

When SSO is not configured correctly we show an error alert describing the problem. This works but we should also dismiss the inline browser before we display it.

### Solutions

Dismiss any presented view controller before presenting the error alert.