### PR TITLE
[Fix] Login with a phone number

### DIFF
--- a/Wire-iOS/Sources/AppStateController.swift
+++ b/Wire-iOS/Sources/AppStateController.swift
@@ -241,7 +241,7 @@ extension AppStateController : AuthenticationCoordinatorDelegate {
     }
 
     var selfUser: UserType? {
-        return SelfUser.provider?.selfUser
+        return ZMUserSession.shared()?.selfUser
     }
 
     var numberOfAccounts: Int {


### PR DESCRIPTION
## What's new in this PR?

### Issues
App throws "Something went wrong" on First Time Overlay when user logs in with the same phone number for the second time.

### Solutions
To use `ZMUserSession.shared()?.selfUser` when we need to set the user email.
