### PR TITLE
[Fix] Enabled log tags are not restored when running on a device

### DIFF
--- a/Wire-iOS/Sources/Components/Settings+Logging.swift
+++ b/Wire-iOS/Sources/Components/Settings+Logging.swift
@@ -27,7 +27,6 @@ extension Settings {
     
     /// Enable/disable a log
     func set(logTag: String, enabled: Bool) {
-
         ZMSLog.set(level: enabled ? .debug : .warn, tag: logTag)
         saveEnabledLogs()
     }
@@ -40,18 +39,18 @@ extension Settings {
         } as NSArray
         
         UserDefaults.shared().set(enabledLogs, forKey: enabledLogsKey)
-        setLogRecording(enabled: enabledLogs.count > 0)
     }
     
     /// Loads from user default the list of logs that are enabled
     @objc public func loadEnabledLogs() {
+        guard Bundle.developerModeEnabled else { return }
+        
         var tagsToEnable: Set<String> = ["AVS", "Network", "SessionManager", "Conversations", "calling", "link previews", "event-processing", "SyncStatus", "OperationStatus", "Push", "Crypto", "cryptobox"]
 
-        if isInternal {
-            if let savedTags = UserDefaults.shared().object(forKey: enabledLogsKey) as? Array<String> {
-                tagsToEnable = Set(savedTags)
-            }
+        if let savedTags = UserDefaults.shared().object(forKey: enabledLogsKey) as? Array<String> {
+            tagsToEnable = Set(savedTags)
         }
+        
         enableLogs(tagsToEnable)
     }
     
@@ -59,19 +58,6 @@ extension Settings {
         tags.forEach { (tag) in
             ZMSLog.set(level: .debug, tag: tag)
         }
-        setLogRecording(enabled: !tags.isEmpty)
     }
     
-    /// Sets whether recording is enabled
-    private func setLogRecording(enabled: Bool) {
-        if enabled {
-            ZMSLog.startRecording(isInternal: isInternal)
-        } else {
-            ZMSLog.stopRecording()
-        }
-    }
-    
-    private var isInternal: Bool {
-        return Bundle.developerModeEnabled
-    }
 }

--- a/Wire-iOS/Sources/Components/Settings.swift
+++ b/Wire-iOS/Sources/Components/Settings.swift
@@ -21,10 +21,10 @@ import Foundation
 extension Settings {
     @objc
     func startLogging() {
-        #if targetEnvironment(simulator)
+        #if !targetEnvironment(simulator)
         loadEnabledLogs()
-        #else
-        ZMSLog.startRecording(isInternal: Bundle.developerModeEnabled)
         #endif
+        
+        ZMSLog.startRecording(isInternal: Bundle.developerModeEnabled)
     }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

If you enable log tags under the develop menu they are not restored on the next re-launch when running on a device.

### Causes

Log tags are only restored when running on the simulator.

### Solutions

1. It's only interesting to restore log tags when running on a device since when we run on a simulator the log tags are supplied via a launch argument. I will therefore invert this logic and only restore log tags when running on a device.

2. We always want to start the log recording so I'm removing the logic for starting/stopping when enabled/disabling log tags.