### PR TITLE
Fix: [iPad] On Log Out, entering a wrong password does not show error dialog

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsSignOutCellDescriptor.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsSignOutCellDescriptor.swift
@@ -39,12 +39,13 @@ class SettingsSignOutCellDescriptor: SettingsExternalScreenCellDescriptor {
         guard let selfUser = ZMUser.selfUser() else { return }
     
         if selfUser.usesCompanyLogin || password != nil {
-            ZClientViewController.shared?.showLoadingView = true
+            weak var topMostViewController = UIApplication.shared.topmostViewController(onlyFullScreen: false)
+            topMostViewController?.showLoadingView = true
             ZMUserSession.shared()?.logout(credentials: ZMEmailCredentials(email: "", password: password ?? ""), { (result) in
-                ZClientViewController.shared?.showLoadingView = false
+                topMostViewController?.showLoadingView = false
                 
                 if case .failure(let error) = result {
-                    ZClientViewController.shared?.showAlert(for: error)
+                    topMostViewController?.showAlert(for: error)
                 }
             })
         } else {


### PR DESCRIPTION
## What's new in this PR?

### Issues

[iPad] On Log Out, entering a wrong password does not show error dialog.

### Causes

The alert was presented form `ZClientViewController.shared` which is hidden by the sheet style Setting screen.

### Solutions

Present the alert form `UIApplication.shared.topmostViewController(onlyFullScreen: false)` instead.