### PR TITLE
[Fix] Connection request modal not showing on iPad

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Transitions/ZoomTransition.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Transitions/ZoomTransition.swift
@@ -32,11 +32,14 @@ final class ZoomTransition: NSObject, UIViewControllerAnimatedTransitioning {
     }
 
     func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
-        guard let fromView = transitionContext.fromView,
-              let toView = transitionContext.toView else { return }
+        
+        let toView = transitionContext.toView
+        let fromView = transitionContext.fromView
         let containerView = transitionContext.containerView
 
-        containerView.addSubview(toView)
+        if let toView = toView {
+            containerView.addSubview(toView)
+        }
 
         if !transitionContext.isAnimated {
             transitionContext.completeTransition(true)
@@ -45,50 +48,52 @@ final class ZoomTransition: NSObject, UIViewControllerAnimatedTransitioning {
 
         containerView.layoutIfNeeded()
 
-        fromView.alpha = 1
-        fromView.layer.needsDisplayOnBoundsChange = false
+        fromView?.alpha = 1
+        fromView?.layer.needsDisplayOnBoundsChange = false
 
         if reversed {
 
             UIView.animate(easing: .easeInExpo, duration: 0.35, animations: {
-                fromView.alpha = 0
-                fromView.transform = CGAffineTransform(scaleX: 0.5, y: 0.5)
+                fromView?.alpha = 0
+                fromView?.transform = CGAffineTransform(scaleX: 0.5, y: 0.5)
             }) { finished in
-                fromView.transform = .identity
+                fromView?.transform = .identity
             }
 
-            toView.alpha = 0
-            toView.transform = CGAffineTransform(scaleX: 2, y: 2)
+            toView?.alpha = 0
+            toView?.transform = CGAffineTransform(scaleX: 2, y: 2)
 
             UIView.animate(easing: .easeOutExpo, duration: 0.35, animations: {
-                toView.alpha = 1
-                toView.transform = .identity
+                toView?.alpha = 1
+                toView?.transform = .identity
             }) { finished in
                 transitionContext.completeTransition(true)
             }
         } else {
 
-            var frame = fromView.frame
-            fromView.layer.anchorPoint = interactionPoint
-            fromView.frame = frame
-
-            UIView.animate(easing: .easeInExpo, duration: 0.35, animations: {
-                fromView.alpha = 0
-                fromView.transform = CGAffineTransform(scaleX: 2, y: 2)
-            }) { finished in
-                fromView.transform = .identity
+            if let frame = fromView?.frame {
+                fromView?.layer.anchorPoint = interactionPoint
+                fromView?.frame = frame
             }
 
-            frame = toView.frame
-            toView.layer.anchorPoint = interactionPoint
-            toView.frame = frame
+            UIView.animate(easing: .easeInExpo, duration: 0.35, animations: {
+                fromView?.alpha = 0
+                fromView?.transform = CGAffineTransform(scaleX: 2, y: 2)
+            }) { finished in
+                fromView?.transform = .identity
+            }
 
-            toView.alpha = 0
-            toView.transform = CGAffineTransform(scaleX: 0.5, y: 0.5)
+            if let frame = toView?.frame  {
+                toView?.layer.anchorPoint = interactionPoint
+                toView?.frame = frame
+            }
+
+            toView?.alpha = 0
+            toView?.transform = CGAffineTransform(scaleX: 0.5, y: 0.5)
 
             UIView.animate(easing: .easeOutExpo, duration: 0.35, delayTime: 0.3, animations: {
-                toView.alpha = 1
-                toView.transform = .identity
+                toView?.alpha = 1
+                toView?.transform = .identity
             }) { finished in
                 transitionContext.completeTransition(true)
             }


### PR DESCRIPTION
## What's new in this PR?

### Issues

The connection request modal is not presented on iPad

### Causes

The custom transition animation is never completed because we guard against `transitionContext.fromView` being nil, and return early. When presenting using the `.formSheet` presentationStyle the `fromView` is not set when presenting and `toView` is not set when dismissing.

### Solutions

Don't assume `toView` and `fromView` is always available.