### PR TITLE
allow Transition 's toView/fromView to be nil

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Transitions/CrossfadeTransition.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Transitions/CrossfadeTransition.swift
@@ -29,15 +29,14 @@ final class CrossfadeTransition: NSObject, UIViewControllerAnimatedTransitioning
     }
 
     func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
-        guard let toView = transitionContext.toView else {
-            return
-        }
-
+        let toView = transitionContext.toView
         let fromView = transitionContext.fromView
 
         let containerView = transitionContext.containerView
 
-        containerView.addSubview(toView)
+        if let toView = toView {
+            containerView.addSubview(toView)
+        }
 
         if !transitionContext.isAnimated || duration == 0 {
             transitionContext.completeTransition(true)
@@ -46,11 +45,11 @@ final class CrossfadeTransition: NSObject, UIViewControllerAnimatedTransitioning
         
         containerView.layoutIfNeeded()
 
-        toView.alpha = 0
+        toView?.alpha = 0
 
         UIView.animate(easing: .easeInOutQuad, duration: duration, animations: {
             fromView?.alpha = 0
-            toView.alpha = 1
+            toView?.alpha = 1
         }) { finished in
             transitionContext.completeTransition(true)
         }

--- a/Wire-iOS/Sources/UserInterface/Components/Transitions/SwizzleTransition.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Transitions/SwizzleTransition.swift
@@ -34,13 +34,14 @@ final class SwizzleTransition: NSObject, UIViewControllerAnimatedTransitioning {
     }
 
     func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
-        guard let toView = transitionContext.toView,
-              let fromView = transitionContext.fromView else {
-            return
-        }
+        let toView = transitionContext.toView
+        let fromView = transitionContext.fromView
+
         let containerView = transitionContext.containerView
 
-        containerView.addSubview(toView)
+        if let toView = toView {
+            containerView.addSubview(toView)
+        }
 
         if !transitionContext.isAnimated {
             transitionContext.completeTransition(true)
@@ -55,25 +56,25 @@ final class SwizzleTransition: NSObject, UIViewControllerAnimatedTransitioning {
         let verticalTransform = CGAffineTransform(translationX: 0, y: 48)
         
         if direction == .horizontal {
-            toView.transform = CGAffineTransform(translationX: 24, y:  0)
+            toView?.transform = CGAffineTransform(translationX: 24, y:  0)
             durationPhase1 = 0.15
             durationPhase2 = 0.55
         } else {
-            toView.transform = verticalTransform
+            toView?.transform = verticalTransform
             durationPhase1 = 0.10
             durationPhase2 = 0.30
         }
-        toView.alpha = 0
+        toView?.alpha = 0
 
         UIView.animate(easing: .easeInQuad, duration: durationPhase1, animations: {
-            fromView.alpha = 0
-            fromView.transform = self.direction == .horizontal ? CGAffineTransform(translationX:48, y:0) : verticalTransform
+            fromView?.alpha = 0
+            fromView?.transform = self.direction == .horizontal ? CGAffineTransform(translationX:48, y:0) : verticalTransform
         }) { finished in
             UIView.animate(easing: .easeOutQuad, duration: durationPhase2, animations: {
-                toView.transform = .identity
-                toView.alpha = 1
+                toView?.transform = .identity
+                toView?.alpha = 1
             }) { finished in
-                fromView.transform = .identity
+                fromView?.transform = .identity
                 transitionContext.completeTransition(true)
             }
         }


### PR DESCRIPTION
## What's new in this PR?

Follow up of https://github.com/wireapp/wire-ios/pull/4141, allow `CrossfadeTransition` and `SwizzleTransition.swift` having nil toView/fromView.