### PR TITLE
Fix: crash with creating CIContext

### DIFF
--- a/Wire-iOS/Sources/Helpers/UIImage+ImageUtilities.swift
+++ b/Wire-iOS/Sources/Helpers/UIImage+ImageUtilities.swift
@@ -31,9 +31,9 @@ extension UIImage {
         return scaledImage
     }
 
-    func desaturatedImage(with context: CIContext, saturation: NSNumber) -> UIImage? {
+    func desaturatedImage(with context: CIContext, saturation: Double = 0) -> UIImage? {
         guard let filter = CIFilter(name: "CIColorControls"),
-            let cg = self.cgImage
+            let cg = cgImage
             else { return nil }
 
         let i: CIImage = CIImage(cgImage: cg)
@@ -41,7 +41,7 @@ extension UIImage {
         filter.setValue(i, forKey: kCIInputImageKey)
         filter.setValue(saturation, forKey: "InputSaturation")
 
-        guard let result = filter.value(forKey: kCIOutputImageKey) as? CIImage,
+        guard let result = filter.outputImage,
             let cgImage: CGImage = context.createCGImage(result, from: result.extent) else { return nil }
 
         return UIImage(cgImage: cgImage, scale: scale, orientation: imageOrientation)

--- a/Wire-iOS/Sources/Helpers/syncengine/ProfileImageFetchable.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ProfileImageFetchable.swift
@@ -19,7 +19,9 @@
 import Foundation
 import WireSyncEngine
 
-fileprivate var ciContext = CIContext(options: nil)
+extension CIContext {
+    static var shared: CIContext = CIContext(options: nil)
+}
 
 public var defaultUserImageCache: ImageCache<UIImage> = ImageCache()
 
@@ -91,7 +93,7 @@ extension ProfileImageFetchable where Self: UserType {
             }
 
             if desaturate {
-                image = image?.desaturatedImage(with: ciContext, saturation: 0)
+                image = image?.desaturatedImage(with: CIContext.shared)
             }
 
             if let image = image {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/Data+HEIF.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/Data+HEIF.swift
@@ -23,7 +23,6 @@ extension Data {
         guard let inputImage = CIImage(data: self),
               let colorSpace = inputImage.colorSpace else { return nil }
 
-        let context = CIContext.shared
-        return context.jpegRepresentation(of: inputImage, colorSpace: colorSpace, options: [:])
+        return CIContext.shared.jpegRepresentation(of: inputImage, colorSpace: colorSpace, options: [:])
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/Data+HEIF.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/Data+HEIF.swift
@@ -23,7 +23,7 @@ extension Data {
         guard let inputImage = CIImage(data: self),
               let colorSpace = inputImage.colorSpace else { return nil }
 
-        let context = CIContext(options: nil)
+        let context = CIContext.shared
         return context.jpegRepresentation(of: inputImage, colorSpace: colorSpace, options: [:])
     }
 }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/BackgroundViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/BackgroundViewController.swift
@@ -146,7 +146,7 @@ final class BackgroundViewController: UIViewController {
         dispatchGroup.enter()
         user.imageData(for: .complete, queue: DispatchQueue.global(qos: .background)) { [weak self] (imageData) in
             var image: UIImage? = nil
-            if let imageData = imageData { ///TODO: keep imageData, cache image blurred
+            if let imageData = imageData {
                 image = BackgroundViewController.blurredAppBackground(with: imageData)
             }
             

--- a/Wire-iOS/Sources/UserInterface/ConversationList/BackgroundViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/BackgroundViewController.swift
@@ -146,7 +146,7 @@ final class BackgroundViewController: UIViewController {
         dispatchGroup.enter()
         user.imageData(for: .complete, queue: DispatchQueue.global(qos: .background)) { [weak self] (imageData) in
             var image: UIImage? = nil
-            if let imageData = imageData {
+            if let imageData = imageData { ///TODO: keep imageData, cache image blurred
                 image = BackgroundViewController.blurredAppBackground(with: imageData)
             }
             
@@ -179,14 +179,10 @@ final class BackgroundViewController: UIViewController {
         }
     }
     
-    static let ciContext: CIContext = {
-        return CIContext()
-    }()
-    
     static let backgroundScaleFactor: CGFloat = 1.4
     
     static func blurredAppBackground(with imageData: Data) -> UIImage? {
-        return UIImage(from: imageData, withMaxSize: 40)?.desaturatedImage(with: BackgroundViewController.ciContext, saturation: 2)
+        return UIImage(from: imageData, withMaxSize: 40)?.desaturatedImage(with: CIContext.shared, saturation: 2)
     }
         
     fileprivate func setBackground(color: UIColor) {


### PR DESCRIPTION
## What's new in this PR?

### Issues

App crashes at the line `CIContext.init()`.

### Causes

Unknown, but ref to "Performance Best Practices"
https://developer.apple.com/library/archive/documentation/GraphicsImaging/Conceptual/CoreImaging/ci_performance/ci_performance.html, `CIContext` should not be created repeatedly.

### Solutions

Create `CIContext.shared` and clean up repeated created instances. 
