### PR TITLE
Fix: iPad - availability popover is not properly positioned

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Availability/AvailabilityTitleViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Availability/AvailabilityTitleViewController.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 
-class AvailabilityTitleViewController: UIViewController {
+final class AvailabilityTitleViewController: UIViewController {
     
     private let feedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
     private let options: AvailabilityTitleView.Options
@@ -53,10 +53,10 @@ class AvailabilityTitleViewController: UIViewController {
         let alertViewController = UIAlertController.availabilityPicker { [weak self] (availability) in
             self?.didSelectAvailability(availability)
         }
-        alertViewController.popoverPresentationController?.sourceView = view
-        alertViewController.popoverPresentationController?.sourceRect = view.frame
         
-        self.present(alertViewController, animated: true)
+        alertViewController.configPopover(pointToView: view)
+        
+        present(alertViewController, animated: true)
     }
     
     private func didSelectAvailability(_ availability: Availability) {

--- a/Wire-iOS/Sources/UserInterface/Availability/UIAlertController+Availability.swift
+++ b/Wire-iOS/Sources/UserInterface/Availability/UIAlertController+Availability.swift
@@ -43,7 +43,7 @@ extension UIAlertController {
             }))
         }
         
-        alert.popoverPresentationController?.permittedArrowDirections = [ .up ]
+        alert.popoverPresentationController?.permittedArrowDirections = [ .up, .down ]
         alert.addAction(UIAlertAction(title: "availability.message.cancel".localized, style: .cancel, handler: nil))
         
         return alert


### PR DESCRIPTION
## What's new in this PR?

### Issues

On iPad, the availability popover is not properly positioned.

### Solutions

Config the alert with `configPopover` method.