### PR TITLE
Fix: iPad - app crashes when delete message popover shows

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationMessageToolboxCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationMessageToolboxCell.swift
@@ -71,16 +71,16 @@ final class ConversationMessageToolboxCell: UIView, ConversationMessageCell, Mes
         delegate?.conversationMessageWantsToOpenMessageDetails(self, messageDetailsViewController: detailsViewController)
     }
 
-    private func perform(action: MessageAction) {
-        delegate?.perform(action: action, for: message, view: selectionView ?? self)
+    private func perform(action: MessageAction, sender: UIView? = nil) {
+        delegate?.perform(action: action, for: message, view: selectionView ?? sender ?? self)
     }
 
     func messageToolboxViewDidRequestLike(_ messageToolboxView: MessageToolboxView) {
         perform(action: .like)
     }
 
-    func messageToolboxViewDidSelectDelete(_ messageToolboxView: MessageToolboxView) {
-        perform(action: .delete)
+    func messageToolboxViewDidSelectDelete(_ sender: UIView?) {
+        perform(action: .delete, sender: sender)
     }
 
     func messageToolboxViewDidSelectResend(_ messageToolboxView: MessageToolboxView) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
@@ -23,7 +23,7 @@ import WireSyncEngine
 protocol MessageToolboxViewDelegate: class {
     func messageToolboxDidRequestOpeningDetails(_ messageToolboxView: MessageToolboxView, preferredDisplayMode: MessageDetailsDisplayMode)
     func messageToolboxViewDidSelectResend(_ messageToolboxView: MessageToolboxView)
-    func messageToolboxViewDidSelectDelete(_ messageToolboxView: MessageToolboxView)
+    func messageToolboxViewDidSelectDelete(_ sender: UIView?)
     func messageToolboxViewDidRequestLike(_ messageToolboxView: MessageToolboxView)
 }
 
@@ -386,8 +386,8 @@ final class MessageToolboxView: UIView {
     }
 
     @objc
-    private func deleteMessage() {
-        delegate?.messageToolboxViewDidSelectDelete(self)
+    private func deleteMessage(sender: UIView?) {
+        delegate?.messageToolboxViewDidSelectDelete(sender)
     }
 
     func update(for change: MessageChangeInfo) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
@@ -125,6 +125,8 @@ extension ConversationContentViewController {
            let shareViewController = keyboardAvoidingViewController.viewController as? ShareViewController<ZMConversation, ZMMessage> {
             shareViewController.showPreview = traitCollection.horizontalSizeClass != .regular
         }
+
+        updatePopoverSourceRect()
     }
 
     func updatePopover() {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
@@ -20,7 +20,11 @@ import Foundation
 private let zmLog = ZMSLog(tag: "ConversationContentViewController")
 
 /// The main conversation view controller
-final class ConversationContentViewController: UIViewController {
+final class ConversationContentViewController: UIViewController, PopoverPresenter {
+    //MARK: PopoverPresenter
+    var presentedPopover: UIPopoverPresentationController?
+    var popoverPointToView: UIView?
+
     weak var delegate: ConversationContentViewControllerDelegate?
     let conversation: ZMConversation
     var bottomMargin: CGFloat = 0 {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
@@ -181,6 +181,17 @@ final class ConversationContentViewController: UIViewController, PopoverPresente
         return wr_supportedInterfaceOrientations
     }
     
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator?) {
+        
+        guard let coordinator = coordinator else { return }
+        
+        super.viewWillTransition(to: size, with: coordinator)
+        
+        coordinator.animate(alongsideTransition: nil) { _ in
+            self.updatePopoverSourceRect()
+        }
+    }
+    
     func setupMentionsResultsView() {
         mentionsSearchResultsViewController.view.translatesAutoresizingMaskIntoConstraints = false
         


### PR DESCRIPTION
## What's new in this PR?

### Issues

When the user deleting a message (when the message failed to send), app crashes.

### Causes

`ConversationContentViewController` presents the alert and configs, but not conforms to `PopoverPresenter`.

### Solutions

`ConversationContentViewController`  conforms `PopoverPresenter`.

### Note
Change the alert source view form the toolbox cell to the `delete` button.
Call `updatePopoverSourceRect` when the app windows size changes to update the popovers positions.

### TODO
- [ ] make view controller param in`PopoverPresenter` non-optional.