### PR TITLE
fix: disable testThatItRendersLocationCellWithAddressCorrect

### DIFF
--- a/Wire-iOS Tests/LocationMessageCellTests.swift
+++ b/Wire-iOS Tests/LocationMessageCellTests.swift
@@ -24,7 +24,7 @@ final class LocationMessageCellTests: ConversationCellSnapshotTestCase {
 
     typealias CellConfiguration = (MockMessage) -> Void
 
-    func testThatItRendersLocationCellWithAddressCorrect() {
+    func disable_testThatItRendersLocationCellWithAddressCorrect() {
         // This is experimental as the MKMapView might break the snapshot tests,
         // Add waitForTextViewToLoad to wait for MapView rendering would fix the issue. (Tested with iOS 12 simulator)
         verify(message: makeMessage(), waitForTextViewToLoad: true)


### PR DESCRIPTION
## What's new in this PR?

disable `testThatItRendersLocationCellWithAddressCorrect` which snapshots a `MKMapView`.