### PR TITLE
Fix/swipe gesture zios 12322

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController+Constraint.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController+Constraint.swift
@@ -20,13 +20,12 @@ import Foundation
 
 extension SplitViewController {
     @objc func setupInitialConstraints() {
-        guard let leftView = leftView,
-            let rightView = rightView else { return }
+        guard let leftView = leftView, let rightView = rightView else { return }
 
-        leftViewOffsetConstraint = leftView.leadingAnchor.constraint(equalTo: view.leadingAnchor)
-        leftViewOffsetConstraint.priority = UILayoutPriority.defaultHigh
-        rightViewOffsetConstraint = rightView.leadingAnchor.constraint(equalTo: view.leadingAnchor)
-        rightViewOffsetConstraint.priority = UILayoutPriority.defaultHigh
+        leftViewLeadingConstraint = leftView.leadingAnchor.constraint(equalTo: view.leadingAnchor)
+        leftViewLeadingConstraint.priority = UILayoutPriority.defaultHigh
+        rightViewLeadingConstraint = rightView.leadingAnchor.constraint(equalTo: view.leadingAnchor)
+        rightViewLeadingConstraint.priority = UILayoutPriority.defaultHigh
 
         leftViewWidthConstraint = leftView.widthAnchor.constraint(equalToConstant: 0)
         rightViewWidthConstraint = rightView.widthAnchor.constraint(equalToConstant: 0)
@@ -38,8 +37,8 @@ extension SplitViewController {
         let constraints: [NSLayoutConstraint] =
             [leftView.topAnchor.constraint(equalTo: view.topAnchor), leftView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
              rightView.topAnchor.constraint(equalTo: view.topAnchor), rightView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-             leftViewOffsetConstraint,
-             rightViewOffsetConstraint,
+             leftViewLeadingConstraint,
+             rightViewLeadingConstraint,
              leftViewWidthConstraint,
              rightViewWidthConstraint,
              pinLeftViewOffsetConstraint]

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController+UIGestureRecognizerDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController+UIGestureRecognizerDelegate.swift
@@ -58,23 +58,14 @@ extension SplitViewController {
             leftView?.isHidden = false
         case .changed:
             if let width = leftViewController?.view.bounds.size.width {
-                if isLeftViewControllerRevealed {
-                    if offset.x > 0 {
-                        offset.x = 0
-                    }
-                    if abs(offset.x) > width {
-                        offset.x = -width
-                    }
-                    openPercentage = 1.0 - abs(offset.x) / width
-                } else {
-                    if offset.x < 0 {
-                        offset.x = 0
-                    }
-                    if abs(offset.x) > width {
-                        offset.x = width
-                    }
-                    openPercentage = abs(offset.x) / width
-                    }
+                if offset.x > 0, view.isRightToLeft {
+                    offset.x = 0
+                } else if offset.x < 0, !view.isRightToLeft {
+                    offset.x = 0
+                } else if abs(offset.x) > width {
+                    offset.x = width
+                }
+                openPercentage = abs(offset.x) / width
                 view.layoutIfNeeded()
             }
         case .cancelled,
@@ -83,7 +74,6 @@ extension SplitViewController {
             let didCompleteTransition = isRevealed != isLeftViewControllerRevealed
             
             setLeftViewControllerRevealed(isRevealed, animated: true) { [weak self] in
-                
                 if didCompleteTransition {
                     self?.leftViewController?.endAppearanceTransition()
                     self?.rightViewController?.endAppearanceTransition()

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController+internal.h
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController+internal.h
@@ -29,8 +29,8 @@ typedef NS_ENUM(NSInteger, SplitViewControllerTransition) {
 
 @property (nonatomic) CGFloat openPercentage;
 
-@property (nonatomic) NSLayoutConstraint *leftViewOffsetConstraint;
-@property (nonatomic) NSLayoutConstraint *rightViewOffsetConstraint;
+@property (nonatomic) NSLayoutConstraint *leftViewLeadingConstraint;
+@property (nonatomic) NSLayoutConstraint *rightViewLeadingConstraint;
 
 @property (nonatomic) NSLayoutConstraint *leftViewWidthConstraint;
 @property (nonatomic) NSLayoutConstraint *rightViewWidthConstraint;

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.m
@@ -389,8 +389,8 @@ NSString *SplitLayoutObservableDidChangeToLayoutSizeNotification = @"SplitLayout
 
 - (void)updateRightAndLeftEdgeConstraints:(CGFloat)percentage
 {
-    self.rightViewOffsetConstraint.constant = self.leftViewWidthConstraint.constant * percentage;
-    self.leftViewOffsetConstraint.constant = 64.0f * (1.0f - percentage);
+    self.rightViewLeadingConstraint.constant = self.leftViewWidthConstraint.constant * percentage;
+    self.leftViewLeadingConstraint.constant = 64.0f * (1.0f - percentage);
 }
 
 @end

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
@@ -60,7 +60,10 @@ extension ConversationViewController {
 
     var backButton: UIBarButtonItem {
         let hasUnreadInOtherConversations = self.conversation.hasUnreadMessagesInOtherConversations
-        let arrowIcon: StyleKitIcon = hasUnreadInOtherConversations ? .backArrowWithDot : .backArrow
+        let arrowIcon: StyleKitIcon = view.isRightToLeft
+            ? (hasUnreadInOtherConversations ? .forwardArrowWithDot : .forwardArrow)
+            : (hasUnreadInOtherConversations ? .backArrowWithDot : .backArrow)
+        
         let icon: StyleKitIcon = (self.parent?.wr_splitViewController?.layoutSize == .compact) ? arrowIcon : .hamburger
         let action = #selector(ConversationViewController.onBackButtonPressed(_:))
         let button = UIBarButtonItem(icon: icon, target: self, action: action)


### PR DESCRIPTION
## What's new in this PR?

### Issues

When the device uses right to left languages the push and pop animations of the conversation screen move in the wrong direction.

### Solutions

- Managed correctly the swipe gesture considering the case when 'isRightToLeft'.
- Removed not necessary code form the swipe gesture state '.changed'
- Renamed in a more descriptive way the leading constraints for the SplitViewController

### Dependencies

https://wearezeta.atlassian.net/browse/ZIOS-12322

