### PR TITLE
[Fix] Disable testThatItRendersLocationCellWithoutAddressCorrect

### DIFF
--- a/Wire-iOS Tests/LocationMessageCellTests.swift
+++ b/Wire-iOS Tests/LocationMessageCellTests.swift
@@ -24,13 +24,15 @@ final class LocationMessageCellTests: ConversationCellSnapshotTestCase {
 
     typealias CellConfiguration = (MockMessage) -> Void
 
+    /// Disabled since the MKMApView makes the test flaky
     func disable_testThatItRendersLocationCellWithAddressCorrect() {
         // This is experimental as the MKMapView might break the snapshot tests,
         // Add waitForTextViewToLoad to wait for MapView rendering would fix the issue. (Tested with iOS 12 simulator)
         verify(message: makeMessage(), waitForTextViewToLoad: true)
     }
     
-    func testThatItRendersLocationCellWithoutAddressCorrect() {
+    /// Disabled since the MKMApView makes the test flaky
+    func disabled_testThatItRendersLocationCellWithoutAddressCorrect() {
         verify(message: makeMessage {
             $0.backingLocationMessageData.name = nil
         })


### PR DESCRIPTION
## What's new in this PR?

Disable `testThatItRendersLocationCellWithoutAddressCorrect` since it's flaky.