### PR TITLE
[Chore] Clean up redundant objc interoperability

### DIFF
--- a/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
@@ -85,14 +85,14 @@ extension AddParticipantsViewController.Context {
     }
 }
 
-final public class AddParticipantsViewController: UIViewController {
+final class AddParticipantsViewController: UIViewController {
     
-    public enum CreateAction {
+    enum CreateAction {
         case updatedUsers(Set<ZMUser>)
         case create
     }
     
-    public enum Context {
+    enum Context {
         case add(ZMConversation)
         case create(ConversationCreationValues)
     }
@@ -124,20 +124,20 @@ final public class AddParticipantsViewController: UIViewController {
         userSelection.remove(observer: self)
     }
     
-    required public init?(coder aDecoder: NSCoder) {
+    required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
-    convenience public init(conversation: ZMConversation) {
+    convenience init(conversation: ZMConversation) {
         self.init(context: .add(conversation))
     }
     
-    public override func viewWillDisappear(_ animated: Bool) {
+    override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         searchHeaderViewController.tokenField.resignFirstResponder()
     }
 
-    override public var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return wr_supportedInterfaceOrientations
     }
 
@@ -375,15 +375,15 @@ final public class AddParticipantsViewController: UIViewController {
 
 extension AddParticipantsViewController : UserSelectionObserver {
     
-    public func userSelection(_ userSelection: UserSelection, didAddUser user: UserType) {
+    func userSelection(_ userSelection: UserSelection, didAddUser user: UserType) {
         updateSelectionValues()
     }
     
-    public func userSelection(_ userSelection: UserSelection, didRemoveUser user: UserType) {
+    func userSelection(_ userSelection: UserSelection, didRemoveUser user: UserType) {
         updateSelectionValues()
     }
     
-    public func userSelection(_ userSelection: UserSelection, wasReplacedBy users: [UserType]) {
+    func userSelection(_ userSelection: UserSelection, wasReplacedBy users: [UserType]) {
         updateSelectionValues()
     }
     
@@ -391,7 +391,7 @@ extension AddParticipantsViewController : UserSelectionObserver {
 
 extension AddParticipantsViewController : SearchHeaderViewControllerDelegate {
     
-    public func searchHeaderViewControllerDidConfirmAction(_ searchHeaderViewController: SearchHeaderViewController) {
+    func searchHeaderViewControllerDidConfirmAction(_ searchHeaderViewController: SearchHeaderViewController) {
         if case .add(let conversation) = viewModel.context {
             self.dismiss(animated: true) {
                 self.addSelectedParticipants(to: conversation)
@@ -400,7 +400,7 @@ extension AddParticipantsViewController : SearchHeaderViewControllerDelegate {
         }
     }
     
-    public func searchHeaderViewController(_ searchHeaderViewController: SearchHeaderViewController, updatedSearchQuery query: String) {
+    func searchHeaderViewController(_ searchHeaderViewController: SearchHeaderViewController, updatedSearchQuery query: String) {
         self.performSearch()
     }
     
@@ -408,34 +408,34 @@ extension AddParticipantsViewController : SearchHeaderViewControllerDelegate {
 
 extension AddParticipantsViewController : UIPopoverPresentationControllerDelegate {
 
-    public func adaptivePresentationStyle(for controller: UIPresentationController) -> UIModalPresentationStyle {
+    func adaptivePresentationStyle(for controller: UIPresentationController) -> UIModalPresentationStyle {
         return UIModalPresentationStyle.overFullScreen
     }
     
-    public func adaptivePresentationStyle(for controller: UIPresentationController, traitCollection: UITraitCollection) -> UIModalPresentationStyle {
+    func adaptivePresentationStyle(for controller: UIPresentationController, traitCollection: UITraitCollection) -> UIModalPresentationStyle {
         return UIModalPresentationStyle.overFullScreen
     }
     
 }
 
 extension AddParticipantsViewController: SearchResultsViewControllerDelegate {
-    public func searchResultsViewController(_ searchResultsViewController: SearchResultsViewController, didTapOnUser user: UserType, indexPath: IndexPath, section: SearchResultsViewControllerSection) {
+    func searchResultsViewController(_ searchResultsViewController: SearchResultsViewController, didTapOnUser user: UserType, indexPath: IndexPath, section: SearchResultsViewControllerSection) {
         // no-op
     }
     
-    public func searchResultsViewController(_ searchResultsViewController: SearchResultsViewController, didDoubleTapOnUser user: UserType, indexPath: IndexPath) {
+    func searchResultsViewController(_ searchResultsViewController: SearchResultsViewController, didDoubleTapOnUser user: UserType, indexPath: IndexPath) {
         // no-op
     }
     
-    public func searchResultsViewController(_ searchResultsViewController: SearchResultsViewController, didTapOnConversation conversation: ZMConversation) {
+    func searchResultsViewController(_ searchResultsViewController: SearchResultsViewController, didTapOnConversation conversation: ZMConversation) {
         // no-op
     }
     
-    public func searchResultsViewController(_ searchResultsViewController: SearchResultsViewController, wantsToPerformAction action: SearchResultsViewControllerAction) {
+    func searchResultsViewController(_ searchResultsViewController: SearchResultsViewController, wantsToPerformAction action: SearchResultsViewControllerAction) {
         // no-op
     }
 
-    public func searchResultsViewController(_ searchResultsViewController: SearchResultsViewController, didTapOnSeviceUser user: ServiceUser) {
+    func searchResultsViewController(_ searchResultsViewController: SearchResultsViewController, didTapOnSeviceUser user: ServiceUser) {
         guard case let .add(conversation) = viewModel.context else { return }
         let detail = ServiceDetailViewController(
             serviceUser: user,

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/UserSelection.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/UserSelection.swift
@@ -21,42 +21,39 @@ import WireUtilities
 
 @objc
 protocol UserSelectionObserver {
-    
+
     func userSelection(_ userSelection: UserSelection, didAddUser user: UserType)
     func userSelection(_ userSelection: UserSelection, didRemoveUser user: UserType)
     func userSelection(_ userSelection: UserSelection, wasReplacedBy users: [UserType])
     
 }
 
-@objcMembers
-public class UserSelection : NSObject {
+class UserSelection: NSObject {
     
-    public fileprivate(set) var users : Set<ZMUser> = Set()
-    fileprivate var observers : [UnownedObject<UserSelectionObserver>] = []
+    private(set) var users : Set<ZMUser> = Set()
+    private var observers : [UnownedObject<UserSelectionObserver>] = []
     
-    public func replace(_ users: [ZMUser]) {
+    func replace(_ users: [ZMUser]) {
         self.users = Set(users)
         observers.forEach({ $0.unbox?.userSelection(self, wasReplacedBy: users) })
     }
     
-    public func add(_ user: ZMUser) {
+    func add(_ user: ZMUser) {
         users.insert(user)
         observers.forEach({ $0.unbox?.userSelection(self, didAddUser: user) })
     }
     
-    public func remove(_ user: ZMUser) {
+    func remove(_ user: ZMUser) {
         users.remove(user)
         observers.forEach({ $0.unbox?.userSelection(self, didRemoveUser: user) })
     }
-    
-    @objc(addObserver:)
+
     func add(observer: UserSelectionObserver) {
         guard !observers.contains(where: { $0.unbox === observer}) else { return }
         
         observers.append(UnownedObject(observer))
     }
     
-    @objc(removeObserver:)
     func remove(observer: UserSelectionObserver) {
         guard let index = observers.firstIndex(where: { $0.unbox === observer}) else { return }
         
@@ -65,16 +62,16 @@ public class UserSelection : NSObject {
     
     // MARK: - Limit
     
-    public private(set) var limit: Int?
+    private(set) var limit: Int?
     private var limitReachedHandler: (() -> Void)?
     
-    public var hasReachedLimit: Bool {
+    var hasReachedLimit: Bool {
         guard let limit = limit, users.count >= limit else { return false }
         limitReachedHandler?()
         return true
     }
     
-    public func setLimit(_ limit: Int, handler: @escaping () -> Void) {
+    func setLimit(_ limit: Int, handler: @escaping () -> Void) {
         self.limit = limit
         self.limitReachedHandler = handler
     }

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchGroupSelector.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchGroupSelector.swift
@@ -19,11 +19,10 @@
 
 import Foundation
 
-@objcMembers
 final class SearchGroupSelector: UIView, TabBarDelegate {
-    @objc public var onGroupSelected: ((SearchGroup)->())? = nil
+    var onGroupSelected: ((SearchGroup)->())? = nil
 
-    @objc public var group: SearchGroup = .people {
+    var group: SearchGroup = .people {
         didSet {
             onGroupSelected?(group)
         }

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchHeaderViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchHeaderViewController.swift
@@ -26,7 +26,7 @@ protocol SearchHeaderViewControllerDelegate : class {
     func searchHeaderViewControllerDidConfirmAction(_ searchHeaderViewController : SearchHeaderViewController)
 }
 
-@objcMembers public class SearchHeaderViewController : UIViewController {
+class SearchHeaderViewController : UIViewController {
     
     let tokenFieldContainer = UIView()
     let tokenField = TokenField()
@@ -35,15 +35,14 @@ protocol SearchHeaderViewControllerDelegate : class {
     let userSelection : UserSelection
     let colorSchemeVariant : ColorSchemeVariant
     var allowsMultipleSelection: Bool = true
-    
-    @objc
+
     weak var delegate : SearchHeaderViewControllerDelegate? = nil
     
-    public var query : String {
+    var query : String {
         return tokenField.filterText
     }
     
-    required public init?(coder aDecoder: NSCoder) {
+    required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
@@ -57,7 +56,7 @@ protocol SearchHeaderViewControllerDelegate : class {
         userSelection.add(observer: self)
     }
     
-    public override func viewDidLoad() {
+    override func viewDidLoad() {
         super.viewDidLoad()
 
         view.backgroundColor = UIColor.from(scheme: .barBackground, variant: colorSchemeVariant)
@@ -91,7 +90,7 @@ protocol SearchHeaderViewControllerDelegate : class {
         createConstraints()
     }
     
-    fileprivate func createConstraints() {
+    private func createConstraints() {
         constrain(tokenFieldContainer, tokenField, searchIcon, clearButton) { container, tokenField, searchIcon, clearButton in
             searchIcon.centerY == tokenField.centerY
             searchIcon.leading == tokenField.leading + 8
@@ -125,25 +124,25 @@ protocol SearchHeaderViewControllerDelegate : class {
         }
     }
     
-    @objc fileprivate dynamic func onClearButtonPressed() {
+    @objc private dynamic func onClearButtonPressed() {
         tokenField.clearFilterText()
         tokenField.removeAllTokens()
         resetQuery()
         updateClearIndicator(for: tokenField)
     }
     
-    public func clearInput() {
+    func clearInput() {
         tokenField.removeAllTokens()
         tokenField.clearFilterText()
         userSelection.replace([])
     }
     
-    public func resetQuery() {
+    func resetQuery() {
         tokenField.filterUnwantedAttachments()
         delegate?.searchHeaderViewController(self, updatedSearchQuery: tokenField.filterText)
     }
     
-    fileprivate func updateClearIndicator(for tokenField: TokenField) {
+    private func updateClearIndicator(for tokenField: TokenField) {
         clearButton.isHidden = tokenField.filterText.isEmpty && tokenField.tokens.isEmpty
     }
     
@@ -151,16 +150,16 @@ protocol SearchHeaderViewControllerDelegate : class {
 
 extension SearchHeaderViewController : UserSelectionObserver {
     
-    public func userSelection(_ userSelection: UserSelection, wasReplacedBy users: [UserType]) {
+    func userSelection(_ userSelection: UserSelection, wasReplacedBy users: [UserType]) {
         // this is triggered by the TokenField itself so we should ignore it here
     }
     
-    public func userSelection(_ userSelection: UserSelection, didAddUser user: UserType) {
+    func userSelection(_ userSelection: UserSelection, didAddUser user: UserType) {
         guard allowsMultipleSelection else { return }
         tokenField.addToken(forTitle: user.name ?? "", representedObject: user)
     }
     
-    public func userSelection(_ userSelection: UserSelection, didRemoveUser user: UserType) {
+    func userSelection(_ userSelection: UserSelection, didRemoveUser user: UserType) {
         guard let token = tokenField.token(forRepresentedObject: user) else { return }
         tokenField.removeToken(token)
         updateClearIndicator(for: tokenField)

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
@@ -19,7 +19,7 @@
 import Foundation
 import WireSyncEngine
 
-@objc enum SearchGroup: Int {
+enum SearchGroup: Int {
     case people
     case services
 }
@@ -54,8 +54,7 @@ extension SearchGroup {
     }
 }
 
-@objc
-protocol SearchResultsViewControllerDelegate {
+protocol SearchResultsViewControllerDelegate: class {
     
     func searchResultsViewController(_ searchResultsViewController: SearchResultsViewController, didTapOnUser user: UserType, indexPath: IndexPath, section: SearchResultsViewControllerSection)
     func searchResultsViewController(_ searchResultsViewController: SearchResultsViewController, didDoubleTapOnUser user: UserType, indexPath: IndexPath)
@@ -64,20 +63,17 @@ protocol SearchResultsViewControllerDelegate {
     func searchResultsViewController(_ searchResultsViewController: SearchResultsViewController, wantsToPerformAction action: SearchResultsViewControllerAction)
 }
 
-@objc
 public enum SearchResultsViewControllerAction : Int {
     case createGroup
     case createGuestRoom
 }
 
-@objc
 public enum SearchResultsViewControllerMode : Int {
     case search
     case selection
     case list
 }
 
-@objc
 public enum SearchResultsViewControllerSection : Int {
     case unknown
     case topPeople
@@ -129,7 +125,7 @@ extension UIViewController {
     }
 }
 
-@objcMembers public class SearchResultsViewController : UIViewController {
+class SearchResultsViewController : UIViewController {
 
     var searchResultsView: SearchResultsView?
     var searchDirectory: SearchDirectory!
@@ -153,12 +149,12 @@ extension UIViewController {
         }
     }
 
-    public var filterConversation: ZMConversation? = nil
-    public let shouldIncludeGuests: Bool
+    var filterConversation: ZMConversation? = nil
+    let shouldIncludeGuests: Bool
 
     weak var delegate: SearchResultsViewControllerDelegate? = nil
 
-    public var mode: SearchResultsViewControllerMode = .search {
+    var mode: SearchResultsViewControllerMode = .search {
         didSet {
             updateVisibleSections()
         }
@@ -168,8 +164,7 @@ extension UIViewController {
         searchDirectory?.tearDown()
     }
 
-    @objc
-    public init(userSelection: UserSelection, isAddingParticipants: Bool = false, shouldIncludeGuests: Bool) {
+    init(userSelection: UserSelection, isAddingParticipants: Bool = false, shouldIncludeGuests: Bool) {
         self.userSelection = userSelection
         self.isAddingParticipants = isAddingParticipants
         self.mode = .list
@@ -210,23 +205,23 @@ extension UIViewController {
         inviteTeamMemberSection.delegate = self
     }
 
-    required public init?(coder aDecoder: NSCoder) {
+    required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    public override func loadView() {
+    override func loadView() {
         searchResultsView  = SearchResultsView()
         searchResultsView?.parentViewController = self
         view = searchResultsView
     }
 
-    override public func viewWillAppear(_ animated: Bool) {
+    override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         sectionController.collectionView?.reloadData()
         sectionController.collectionView?.collectionViewLayout.invalidateLayout()
     }
 
-    public override func viewDidLoad() {
+    override func viewDidLoad() {
         super.viewDidLoad()
 
         sectionController.collectionView = searchResultsView?.collectionView
@@ -237,7 +232,7 @@ extension UIViewController {
     }
 
     @objc
-    public func cancelPreviousSearch() {
+    func cancelPreviousSearch() {
         pendingSearchTask?.cancel()
         pendingSearchTask = nil
     }
@@ -259,22 +254,18 @@ extension UIViewController {
         }
     }
 
-    @objc
-    public func searchForUsers(withQuery query: String) {
+    func searchForUsers(withQuery query: String) {
         self.performSearch(query: query, options: [.conversations, .contacts, .teamMembers, .directory])
     }
 
-    @objc
-    public func searchForLocalUsers(withQuery query: String) {
+    func searchForLocalUsers(withQuery query: String) {
         self.performSearch(query: query, options: [.contacts, .teamMembers])
     }
 
-    @objc
-    public func searchForServices(withQuery query: String) {
+    func searchForServices(withQuery query: String) {
         self.performSearch(query: query, options: [.services])
     }
 
-    @objc
     func searchContactList() {
         searchForLocalUsers(withQuery: "")
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

There is a lot a lot of redundant public access and `@objc` annotations. This can lead to some issues where other types must also be unnecessarily marked public because some public API exposes it.

### Causes

It's likely that several of the Objective C classes that have been converted to Swift recently made this interoperability redundant.

### Solutions

Remove public access modifiers and `@objc` annotations where possible.

### Notes

By no means is this a comprehensive clean up, it just covers a few of the classes I've encountered.
