### PR TITLE
[Fix] missing cryptobox logs on public builds

### DIFF
--- a/Wire-iOS/Sources/Components/Settings+Logging.swift
+++ b/Wire-iOS/Sources/Components/Settings+Logging.swift
@@ -43,8 +43,6 @@ extension Settings {
     
     /// Loads from user default the list of logs that are enabled
     @objc public func loadEnabledLogs() {
-        guard Bundle.developerModeEnabled else { return }
-        
         var tagsToEnable: Set<String> = ["AVS", "Network", "SessionManager", "Conversations", "calling", "link previews", "event-processing", "SyncStatus", "OperationStatus", "Push", "Crypto", "cryptobox"]
 
         if let savedTags = UserDefaults.shared().object(forKey: enabledLogsKey) as? Array<String> {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Cryptobox logs are not activated for public builds

### Causes

We don't activate any log tags for public builds

### Solutions

Activate the default log tags for all builds.

### Notes

In order to make easier to test crypto box error logs I've added a debug action for corrupting a session on the device details screen.