### PR TITLE
Wrong text on profile action item to unblock and user.

### DIFF
--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileActionsFactory.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileActionsFactory.swift
@@ -39,11 +39,15 @@ enum ProfileAction: Equatable {
     var buttonText: String {
         switch self {
         case .createGroup: return "profile.create_conversation_button_title".localized
-        case .mute(let isMuted): return isMuted ? "meta.menu.silence.unmute".localized : "meta.menu.silence.mute".localized
+        case .mute(let isMuted): return isMuted
+            ? "meta.menu.silence.unmute".localized
+            : "meta.menu.silence.mute".localized
         case .manageNotifications: return "meta.menu.configure_notifications".localized
         case .archive: return "meta.menu.archive".localized
         case .deleteContents: return "meta.menu.clear_content".localized
-        case .block(let isBlocked): return isBlocked ? "profile.unblock_button_title".localized : "profile.block_button_title".localized
+        case .block(let isBlocked): return isBlocked
+            ? "profile.unblock_button_title_action".localized
+            : "profile.block_button_title".localized
         case .openOneToOne: return "profile.open_conversation_button_title".localized
         case .removeFromGroup: return "profile.remove_dialog_button_remove".localized
         case .connect: return "profile.connection_request_dialog.button_connect".localized

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.swift
@@ -295,20 +295,26 @@ extension ProfileViewController: ProfileFooterViewDelegate, IncomingRequestFoote
         performAction(action, targetView: footerView.leftButton)
     }
     
-    func footerView(_ footerView: ProfileFooterView, shouldPresentMenuWithActions actions: [ProfileAction]) {
-        let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+    func footerView(_ footerView: ProfileFooterView,
+                    shouldPresentMenuWithActions actions: [ProfileAction]) {
+        let actionSheet = UIAlertController(title: nil,
+                                            message: nil,
+                                            preferredStyle: .actionSheet)
         
-        for action in actions {
-            let sheetAction = UIAlertAction(title: action.buttonText, style: .default) { _ in
-                self.performAction(action, targetView: footerView)
-            }
-            
-            actionSheet.addAction(sheetAction)
-        }
-        
+        actions.map { buildProfileAction($0, footerView: footerView) }
+            .forEach(actionSheet.addAction)
         actionSheet.addAction(.cancel())
         presentAlert(actionSheet, targetView: footerView)
     }
+    
+    private func buildProfileAction(_ action: ProfileAction,
+                                    footerView: ProfileFooterView) -> UIAlertAction {
+        return UIAlertAction(title: action.buttonText,
+                             style: .default) { _ in
+                                self.performAction(action, targetView: footerView)
+        }
+    }
+
     
     private func performAction(_ action: ProfileAction,
                        targetView: UIView) {


### PR DESCRIPTION
## What's new in this PR?

### Issues

The profile acton item to unblock an user had the wrong text, It has to be changed form "unblock..." to "unblock".

### Causes

wrong localisable string used.

### Solutions

changed the localisable string for the text of the action item.

### Dependencies

Jira Ticket: https://wearezeta.atlassian.net/browse/ZIOS-12570