### PR TITLE
[Fix]: Profile Image Not Loaded In Search

### DIFF
--- a/Wire-iOS/Sources/Helpers/syncengine/ProfileImageFetchable.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ProfileImageFetchable.swift
@@ -108,3 +108,4 @@ extension ProfileImageFetchable where Self: UserType {
 }
 
 extension ZMUser: ProfileImageFetchable {}
+extension ZMSearchUser: ProfileImageFetchable {}


### PR DESCRIPTION
## What's new in this PR?

### Issues

Sometimes the profile image in the search result is not loaded

### Causes

`ZMSearchUser` was not conforming the protocol `ProfileImageFetchable`

### Solutions

`ZMSearchUser` now conforms to the protocol `ProfileImageFetchable`

### Dependencies

Jira Ticket: https://wearezeta.atlassian.net/browse/ZIOS-12605