### PR TITLE
[Fix] AVS script

### DIFF
--- a/Scripts/download-avs.sh
+++ b/Scripts/download-avs.sh
@@ -32,7 +32,7 @@ AVS_FRAMEWORK_NAME="avs.framework"
 # prepare credentials if needed
 
 # if git is installed
-if command -v git >dev/null; then
+if hash git 2>/dev/null; then
   GITHUB_USERNAME="`git config user.email`"
   if [[ -n "${GITHUB_ACCESS_TOKEN}" ]] && [[ -n "${GITHUB_USERNAME}" ]]; then
     CREDENTIALS="${GITHUB_USERNAME}:${GITHUB_ACCESS_TOKEN}"

--- a/Scripts/download-avs.sh
+++ b/Scripts/download-avs.sh
@@ -26,18 +26,6 @@ cd $DIR/..
 source avs-versions
 AVS_FRAMEWORK_NAME="avs.framework"
 
-##################################
-# CREDENTIALS
-##################################
-# prepare credentials if needed
-
-# if git is installed
-if hash git 2>/dev/null; then
-  GITHUB_USERNAME="`git config user.email`"
-  if [[ -n "${GITHUB_ACCESS_TOKEN}" ]] && [[ -n "${GITHUB_USERNAME}" ]]; then
-    CREDENTIALS="${GITHUB_USERNAME}:${GITHUB_ACCESS_TOKEN}"
-  fi
-fi
 
 ##################################
 # SET UP PATHS
@@ -94,6 +82,29 @@ if [ -e "${AVS_FILENAME}" ]; then
 else
 	# DOWNLOAD
 	echo "ℹ️  Downloading ${AVS_RELEASE_TAG_PATH}..."
+
+  # prepare credentials
+  if hash git 2>/dev/null; then
+    GITHUB_USERNAME="`git config user.email`"
+
+    # guard username exists
+    if [[ -z "${GITHUB_USERNAME}" ]]; then
+      echo "❌  Git email not found. Configure it with: git config user.name ⚠️"
+      exit 1
+    fi
+
+    # guard access token exists
+    if [[ -z "${GITHUB_ACCESS_TOKEN}" ]]; then
+      echo "❌  GITHUB_ACCESS_TOKEN not set ⚠️"
+      exit 1
+    fi
+
+    CREDENTIALS="${GITHUB_USERNAME}:${GITHUB_ACCESS_TOKEN}"
+
+  else
+    echo "❌  Can't find git. Please make sure it is installed ⚠️"
+    exit 1
+  fi
 	
 	# Get tag json: need to parse json to get assed URL
 	TEMP_FILE=`mktemp`


### PR DESCRIPTION
## What's new in this PR?

### Issues

The check for git was incorrect, causing the credentials not to be set. 

### Causes

The check was `command -v git >dev/null` when it should have been `command -v git >/dev/null` (note the missing forward slash).

### Solutions

Although inserting the forward slash is fine, I decided to use the same checks we do in `setup.sh` when we check for Carthage. It uses `hash` instead.

Also I moved the credential checks further down the script to the point before we try to download the avs binary. This will prevent issues with the credential checking in the case they're not even needed.

Some helpful error messages are now returned when either git or the credentials are not found.
