### PR TITLE
[Fix] Hide verified shield if it's a connection

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCell.swift
@@ -305,8 +305,10 @@ final class ConversationSystemMessageCellDescription {
             return [AnyConversationMessageCellDescription(timerCell)]
 
         case .conversationIsSecure:
-            let shieldCell = ConversationVerifiedSystemMessageSectionDescription()
-            return [AnyConversationMessageCellDescription(shieldCell)]
+            if conversation.conversationType != .connection {
+                let shieldCell = ConversationVerifiedSystemMessageSectionDescription()
+                return [AnyConversationMessageCellDescription(shieldCell)]
+            }
 
         case .decryptionFailed:
             let decryptionCell = ConversationCannotDecryptSystemMessageCellDescription(message: message, data: systemMessageData, sender: sender, remoteIdentityChanged: false)

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationTitleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationTitleView.swift
@@ -20,7 +20,13 @@
 import UIKit
 
 final class ConversationTitleView: TitleView {
-    var conversation: ZMConversation
+    private var shouldShowVerifiedShield: Bool = false
+    public var conversation: ZMConversation {
+        didSet {
+            shouldShowVerifiedShield = conversation.securityLevel == .secure && conversation.conversationType != .connection
+        }
+    }
+
     var interactive: Bool = true
     
     @objc init(conversation: ZMConversation, interactive: Bool = true) {
@@ -46,7 +52,7 @@ final class ConversationTitleView: TitleView {
             attachments.append(.legalHold())
         }
         
-        if conversation.securityLevel == .secure && conversation.conversationType != .connection {
+        if shouldShowVerifiedShield {
             attachments.append(.verifiedShield())
         }
         
@@ -57,7 +63,7 @@ final class ConversationTitleView: TitleView {
         var components: [String] = []
         components.append(conversation.displayName.localizedUppercase)
         
-        if conversation.securityLevel == .secure {
+        if shouldShowVerifiedShield {
             components.append("conversation.voiceover.verified".localized)
         }
         

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationTitleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationTitleView.swift
@@ -46,7 +46,7 @@ final class ConversationTitleView: TitleView {
             attachments.append(.legalHold())
         }
         
-        if conversation.securityLevel == .secure {
+        if conversation.securityLevel == .secure && conversation.conversationType != .connection {
             attachments.append(.verifiedShield())
         }
         

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationTitleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationTitleView.swift
@@ -20,13 +20,7 @@
 import UIKit
 
 final class ConversationTitleView: TitleView {
-    private var shouldShowVerifiedShield: Bool = false
-    public var conversation: ZMConversation {
-        didSet {
-            shouldShowVerifiedShield = conversation.securityLevel == .secure && conversation.conversationType != .connection
-        }
-    }
-
+    var conversation: ZMConversation
     var interactive: Bool = true
     
     @objc init(conversation: ZMConversation, interactive: Bool = true) {
@@ -52,7 +46,7 @@ final class ConversationTitleView: TitleView {
             attachments.append(.legalHold())
         }
         
-        if shouldShowVerifiedShield {
+        if conversation.shouldShowVerifiedShield {
             attachments.append(.verifiedShield())
         }
         
@@ -63,7 +57,7 @@ final class ConversationTitleView: TitleView {
         var components: [String] = []
         components.append(conversation.displayName.localizedUppercase)
         
-        if shouldShowVerifiedShield {
+        if conversation.shouldShowVerifiedShield {
             components.append("conversation.voiceover.verified".localized)
         }
         
@@ -102,3 +96,9 @@ extension NSTextAttachment {
     }
 }
 
+private extension ZMConversation {
+    var shouldShowVerifiedShield: Bool {
+        return self.securityLevel == .secure &&
+            self.conversationType != .connection
+    }
+}


### PR DESCRIPTION
## What's new in this PR?

### Issues
The verified shield is shown on the connection request page, overlapping the "Cancel" label/button.

### Solutions
Check if the conversation is a connection.

### Dependencies
Jira Ticket: https://wearezeta.atlassian.net/browse/ZIOS-12573