### PR TITLE
After login on iPad wrong conversation is opened instead none

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+ViewLifeCycle.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+ViewLifeCycle.swift
@@ -24,9 +24,7 @@ extension ConversationViewController {
 
         updateLeftNavigationBarItems()
 
-        if isIPadRegular() {
-            becomeFirstResponder()
-        } else if isFocused {
+        if isFocused {
             // We are presenting the conversation screen so mark it as the last viewed screen,
             // but only if we are acutally focused (otherwise we would be shown on the next launch)
             Settings.shared().lastViewedScreen = .conversation

--- a/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController.swift
@@ -157,7 +157,7 @@ final class ConversationListViewController: UIViewController {
         super.viewDidAppear(animated)
 
         if !isIPadRegular() {
-            Settings.shared().lastViewedScreen = SettingsLastScreen.list
+            Settings.shared().lastViewedScreen = .list
         }
 
         state = .conversationList

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -126,13 +126,9 @@ final class ZClientViewController: UIViewController {
                 stateRestored = attemptToLoadLastViewedConversation(withFocus: false, animated: false)
             }
         case .conversation:
-            
             stateRestored = attemptToLoadLastViewedConversation(withFocus: true, animated: false)
         default:
-            // If there's no previously selected screen
-            if isConversationViewVisible {
-                selectListItemWhenNoPreviousItemSelected()
-            }
+            break
         }
         return stateRestored
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

On iPad when is in landscape after logging in a conversation was opened, but it shouldn't

### Causes

Managed incorrectly to present the initial conversation

### Solutions

fix issue to present the initial conversation