### PR TITLE
[Refactor] Remove calls to ZMUser.selfUser()

### DIFF
--- a/Wire-iOS Tests/AddParticipantsViewControllerSnapshotTests.swift
+++ b/Wire-iOS Tests/AddParticipantsViewControllerSnapshotTests.swift
@@ -23,8 +23,14 @@ final class AddParticipantsViewControllerSnapshotTests: CoreDataSnapshotTestCase
     
     var sut: AddParticipantsViewController!
 
+    override func setUp() {
+        super.setUp()
+        SelfUser.provider = selfUserProvider
+    }
+
     override func tearDown() {
         sut = nil
+        SelfUser.provider = nil
         super.tearDown()
     }
 

--- a/Wire-iOS Tests/ConversationList/ConversationListCell/ConversationListCellTests.swift
+++ b/Wire-iOS Tests/ConversationList/ConversationListCell/ConversationListCellTests.swift
@@ -32,10 +32,13 @@ final class ConversationListCellTests: CoreDataSnapshotTestCase {
         accentColor = .strongBlue
         ///The cell must higher than 64, otherwise it breaks the constraints.
         sut = ConversationListCell(frame: CGRect(x: 0, y: 0, width: 375, height: ConversationListItemView.minHeight))
+
+        SelfUser.provider = selfUserProvider
     }
     
     override func tearDown() {
         sut = nil
+        SelfUser.provider = nil
         super.tearDown()
     }
     

--- a/Wire-iOS Tests/GroupDetailsViewControllerTests.swift
+++ b/Wire-iOS Tests/GroupDetailsViewControllerTests.swift
@@ -22,9 +22,15 @@ import XCTest
 final class GroupDetailsFooterViewTests: CoreDataSnapshotTestCase {
     
     var sut: GroupDetailsFooterView!
+
+    override func setUp() {
+        super.setUp()
+        SelfUser.provider = selfUserProvider
+    }
     
     override func tearDown() {
         sut = nil
+        SelfUser.provider = nil
         super.tearDown()
     }
 

--- a/Wire-iOS Tests/StartUIViewControllerSnapshotTests.swift
+++ b/Wire-iOS Tests/StartUIViewControllerSnapshotTests.swift
@@ -61,13 +61,14 @@ final class StartUIViewControllerSnapshotTests: CoreDataSnapshotTestCase {
 
     override func setUp() {
         super.setUp()
-
         mockAddressBookHelper = MockAddressBookHelper()
+        SelfUser.provider = selfUserProvider
     }
 
     override func tearDown() {
         sut = nil
         mockAddressBookHelper = nil
+        SelfUser.provider = nil
         super.tearDown()
     }
 

--- a/Wire-iOS/Sources/Analytics/Events/Analytics+CallEvents.swift
+++ b/Wire-iOS/Sources/Analytics/Events/Analytics+CallEvents.swift
@@ -76,9 +76,9 @@ extension Analytics {
     private func attributesForUser(in conversation: ZMConversation) -> [String : Any] {
         var userType: String
         
-        if ZMUser.selfUser().isWirelessUser {
+        if SelfUser.current.isWirelessUser {
             userType = "temporary_guest"
-        } else if ZMUser.selfUser().isGuest(in: conversation) {
+        } else if SelfUser.current.isGuest(in: conversation) {
             userType = "guest"
         } else {
             userType = "user"

--- a/Wire-iOS/Sources/Analytics/Events/Analytics+Guests.swift
+++ b/Wire-iOS/Sources/Analytics/Events/Analytics+Guests.swift
@@ -22,7 +22,7 @@ extension Analytics {
     @objc public func guestAttributes(in conversation: ZMConversation) -> [String : Any] {
         return [
             "is_allow_guests" : conversation.allowGuests,
-            "user_type" : ZMUser.selfUser().isGuest(in: conversation) ? "guest" : "user"
+            "user_type" : SelfUser.current.isGuest(in: conversation) ? "guest" : "user"
         ]
     }
 }

--- a/Wire-iOS/Sources/AppStateController.swift
+++ b/Wire-iOS/Sources/AppStateController.swift
@@ -229,7 +229,8 @@ extension AppStateController : AuthenticationCoordinatorDelegate {
     }
 
     var authenticatedUserNeedsEmailCredentials: Bool {
-        return ZMUser.selfUser()?.emailAddress?.isEmpty == true
+        guard let emailAddress = selfUser?.emailAddress else { return false }
+        return emailAddress.isEmpty
     }
 
     var sharedUserSession: ZMUserSession? {

--- a/Wire-iOS/Sources/Developer/DebugAlert.swift
+++ b/Wire-iOS/Sources/Developer/DebugAlert.swift
@@ -124,7 +124,7 @@ import MessageUI
         }
         
         // Prepare subject & body
-        let user = ZMUser.selfUser()
+        let user = SelfUser.current as? ZMUser
         let userID = user?.remoteIdentifier?.transportString() ?? ""
         let device = UIDevice.current.name
         let userDescription = "\(user?.name ?? "") [user: \(userID)] [device: \(device)]"

--- a/Wire-iOS/Sources/Helpers/syncengine/ZMConversation+Calling.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMConversation+Calling.swift
@@ -26,7 +26,8 @@ extension ZMConversation {
     }
     
     var firstCallingParticipantOtherThanSelf : ZMUser? {
-      return (voiceChannel?.participants.first { !ZMUser.selfUser().isEqual($0.user) })?.user
+        let participant = voiceChannel?.participants.first { !$0.user.isSelfUser }
+        return participant?.user
     }
     
     func startAudioCall() {

--- a/Wire-iOS/Sources/Managers/ColorSchemeController.swift
+++ b/Wire-iOS/Sources/Managers/ColorSchemeController.swift
@@ -34,7 +34,7 @@ class ColorSchemeController: NSObject {
         super.init()
 
         if let session = ZMUserSession.shared() {
-            userObserverToken = UserChangeInfo.add(observer:self, for: ZMUser.selfUser(), in: session)
+            userObserverToken = UserChangeInfo.add(observer:self, for: SelfUser.current, in: session)
         }
 
         NotificationCenter.default.addObserver(self, selector: #selector(settingsColorSchemeDidChange(notification:)), name: .SettingsColorSchemeChanged, object: nil)

--- a/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
@@ -179,7 +179,7 @@ final class AddParticipantsViewController: UIViewController {
                                                                   isAddingParticipants: true,
                                                                   shouldIncludeGuests: viewModel.context.includeGuests)
 
-        emptyResultView = EmptySearchResultsView(variant: self.variant, isSelfUserAdmin: ZMUser.selfUser().canManageTeam)
+        emptyResultView = EmptySearchResultsView(variant: self.variant, isSelfUserAdmin: SelfUser.current.canManageTeam)
         super.init(nibName: nil, bundle: nil)
         
         emptyResultView.delegate = self

--- a/Wire-iOS/Sources/UserInterface/ConnectRequests/ConnectRequestsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConnectRequests/ConnectRequestsViewController.swift
@@ -43,7 +43,7 @@ final class ConnectRequestsViewController: UIViewController, UITableViewDataSour
                                                                                  for: pendingConnectionsList,
                                                                                  userSession: userSession)
             
-            userObserverToken = UserChangeInfo.add(observer: self, for: ZMUser.selfUser(), in: userSession)
+            userObserverToken = UserChangeInfo.add(observer: self, for: userSession.selfUser, in: userSession)
             
             connectionRequests = pendingConnectionsList as? [ZMConversation] ?? []
         }

--- a/Wire-iOS/Sources/UserInterface/ContactsUI/ZMAddressBookContact+LocalInvitation.swift
+++ b/Wire-iOS/Sources/UserInterface/ContactsUI/ZMAddressBookContact+LocalInvitation.swift
@@ -66,8 +66,7 @@ extension ZMAddressBookContact {
 
     private func invitationBody() -> String {
         guard
-            let selfUser = SelfUser.provider?.selfUser,
-            let handle = selfUser.handle
+            let handle = SelfUser.provider?.selfUser.handle
         else {
             return "send_invitation_no_email.text".localized
         }

--- a/Wire-iOS/Sources/UserInterface/ContactsUI/ZMAddressBookContact+LocalInvitation.swift
+++ b/Wire-iOS/Sources/UserInterface/ContactsUI/ZMAddressBookContact+LocalInvitation.swift
@@ -65,10 +65,13 @@ extension ZMAddressBookContact {
     }
 
     private func invitationBody() -> String {
-        if let handle = ZMUser.selfUser(inUserSession: ZMUserSession.shared()!).handle {
-            return "send_invitation.text".localized(args: "@" + handle)
-        } else {
+        guard
+            let selfUser = SelfUser.provider?.selfUser,
+            let handle = selfUser.handle
+        else {
             return "send_invitation_no_email.text".localized
         }
+
+        return "send_invitation.text".localized(args: "@" + handle)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationListBottomBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationListBottomBar.swift
@@ -136,7 +136,7 @@ final class ConversationListBottomBarController: UIViewController {
     private func addObservers() {
         guard let userSession = ZMUserSession.shared() else { return }
         
-        userObserverToken = UserChangeInfo.add(observer: self, for: ZMUser.selfUser(), in: userSession)
+        userObserverToken = UserChangeInfo.add(observer: self, for: userSession.selfUser, in: userSession)
     }
     
     fileprivate func updateColorScheme() {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsContentViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsContentViewController.swift
@@ -273,7 +273,7 @@ extension MessageDetailsContentViewController: UICollectionViewDataSource, UICol
         let user = cells[indexPath.item].user
         let cell = collectionView.cellForItem(at: indexPath) as! UserCell
 
-        let profileViewController = ProfileViewController(user: user, viewer: ZMUser.selfUser(), conversation: conversation)
+        let profileViewController = ProfileViewController(user: user, viewer: SelfUser.current, conversation: conversation)
         profileViewController.delegate = self
         profileViewController.viewControllerDismisser = self
 

--- a/Wire-iOS/Sources/UserInterface/ConversationList/Container/ViewModel/ConversationListViewControllerViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/Container/ViewModel/ConversationListViewControllerViewModel.swift
@@ -91,10 +91,8 @@ extension ConversationListViewController {
 
 extension ConversationListViewController.ViewModel {
     func setupObservers() {
-        if let userSession = ZMUserSession.shared(),
-            let selfUser = ZMUser.selfUser() {
-            userObserverToken = UserChangeInfo.add(observer: self, for: selfUser, in: userSession) as Any
-
+        if let userSession = ZMUserSession.shared(){
+            userObserverToken = UserChangeInfo.add(observer: self, for: userSession.selfUser, in: userSession) as Any
             initialSyncObserverToken = ZMUserSession.addInitialSyncCompletionObserver(self, userSession: userSession)
         }
 
@@ -135,7 +133,7 @@ extension ConversationListViewController.ViewModel {
         guard let session = ZMUserSession.shared(),
             let userProfile = userProfile else { return }
 
-        if nil == ZMUser.selfUser()?.handle,
+        if nil == session.selfUser.handle,
             session.hasCompletedInitialSync == true,
             session.isPendingHotFixChanges == false {
 

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListItemView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListItemView.swift
@@ -240,7 +240,7 @@ final class ConversationListItemView: UIView {
         // Configure the title and status
         let title: NSAttributedString?
         
-        if ZMUser.selfUser().isTeamMember, let connectedUser = conversation.connectedUser {
+        if SelfUser.current.isTeamMember, let connectedUser = conversation.connectedUser {
             title = AvailabilityStringBuilder.string(for: connectedUser, with: .list)
             
             if connectedUser.availability != .none {

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+ClearContent.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+ClearContent.swift
@@ -68,7 +68,7 @@ extension ConversationActionController {
         transitionToListAndEnqueue {
             conversation.clearMessageHistory()
             if leave {
-                conversation.removeOrShowError(participant: ZMUser.selfUser())
+                conversation.removeOrShowError(participant: SelfUser.current)
             }
         }
     }

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+Leave.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+Leave.swift
@@ -60,7 +60,7 @@ extension ConversationActionController {
                 conversation.clearMessageHistory()
             }
             
-            conversation.removeOrShowError(participant: ZMUser.selfUser())
+            conversation.removeOrShowError(participant: SelfUser.current)
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsFooterView.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsFooterView.swift
@@ -31,7 +31,7 @@ final class GroupDetailsFooterView: ConversationDetailFooterView {
     }
     
     func update(for conversation: ZMConversation) {
-        leftButton.isHidden = !(ZMUser.selfUser()?.canAddUser(to: conversation) ?? false)
+        leftButton.isHidden = !SelfUser.current.canAddUser(to: conversation)
         leftButton.isEnabled = conversation.freeParticipantSlots > 0
     }
     

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
@@ -168,17 +168,12 @@ final class GroupDetailsViewController: UIViewController, ZMConversationObserver
             sections.append(optionsSectionController)
         }
         
-        if let selfUser = ZMUser.selfUser(),
-            conversation.teamRemoteIdentifier != nil,
-            selfUser.canModifyReadReceiptSettings(in: conversation)
-        {
+        if conversation.teamRemoteIdentifier != nil && SelfUser.current.canModifyReadReceiptSettings(in: conversation) {
             let receiptOptionsSectionController = ReceiptOptionsSectionController(conversation: conversation,
                                                                                   syncCompleted: didCompleteInitialSync,
                                                                                   collectionView: self.collectionViewController.collectionView!,
                                                                                   presentingViewController: self)
             sections.append(receiptOptionsSectionController)
-           
-            
         }
         
         // MARK: services sections
@@ -304,14 +299,4 @@ extension GroupDetailsViewController: GroupDetailsSectionControllerDelegate, Gro
         navigationController?.pushViewController(menu, animated: animated)
     }
     
-}
-
-extension Array where Element: UserType {
-    func addSelfUserAndSorted() -> [UserType] {
-        var arr: [UserType] = self
-        if let selfUser = ZMUser.selfUser() {
-            arr.append(selfUser)
-        }
-        return arr.sorted { $0.name < $1.name } as! Array<Element>
-    }
 }

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/ReceiptOptionsSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/ReceiptOptionsSectionController.swift
@@ -34,7 +34,7 @@ final class ReceiptOptionsSectionController: GroupDetailsSectionController {
     private weak var presentingViewController: UIViewController?
     
     override var isHidden: Bool {
-        return !(ZMUser.selfUser()?.canModifyReadReceiptSettings(in: conversation) ?? false)
+        return !SelfUser.current.canModifyReadReceiptSettings(in: conversation)
     }
 
     init(conversation: ZMConversation,

--- a/Wire-iOS/Sources/UserInterface/Helpers/UIColor+Accent.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UIColor+Accent.swift
@@ -29,8 +29,8 @@ extension UIColor {
     ///
     /// - Parameter accentColor: the accent color
     class func setAccent(_ accentColor: ZMAccentColor) {
-        ZMUserSession.shared()?.enqueue({
-            ZMUser.selfUser()?.accentColorValue = accentColor
+        ZMUserSession.shared()?.enqueueChanges({
+            SelfUser.provider?.selfUser.accentColorValue = accentColor
         })
     }
     
@@ -39,15 +39,17 @@ extension UIColor {
         if overridenAccentColor != .undefined {
             return overridenAccentColor
         }
-        
-        guard let activeUserSession = SessionManager.shared?.activeUserSession,
-            ZMUser.selfUser(inUserSession: activeUserSession).accentColorValue != .undefined else {
-                // priority 3: default color
-                return .strongBlue
+
+        guard
+            let activeUserSession = SessionManager.shared?.activeUserSession,
+            activeUserSession.selfUser.accentColorValue != .undefined
+        else {
+            // priority 3: default color
+            return .strongBlue
         }
         
         // priority 2: color from self user
-        return ZMUser.selfUser(inUserSession: activeUserSession).accentColorValue
+        return activeUserSession.selfUser.accentColorValue
     }
     
     

--- a/Wire-iOS/Sources/UserInterface/Helpers/UIColor+Accent.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UIColor+Accent.swift
@@ -29,9 +29,9 @@ extension UIColor {
     ///
     /// - Parameter accentColor: the accent color
     class func setAccent(_ accentColor: ZMAccentColor) {
-        ZMUserSession.shared()?.enqueueChanges({
+        ZMUserSession.shared()?.enqueue {
             SelfUser.provider?.selfUser.accentColorValue = accentColor
-        })
+        }
     }
     
     class func indexedAccentColor() -> ZMAccentColor {

--- a/Wire-iOS/Sources/UserInterface/Helpers/UserDetailViewControllerFactory.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UserDetailViewControllerFactory.swift
@@ -39,7 +39,7 @@ final class UserDetailViewControllerFactory: NSObject {
             return serviceDetailViewController
         } else {
             // TODO: Do not present the details if the user is not connected.
-            let profileViewController = ProfileViewController(user: user, viewer: ZMUser.selfUser(), conversation: conversation)
+            let profileViewController = ProfileViewController(user: user, viewer: SelfUser.current, conversation: conversation)
             profileViewController.delegate = profileViewControllerDelegate
             profileViewController.viewControllerDismisser = viewControllerDismisser
             return profileViewController

--- a/Wire-iOS/Sources/UserInterface/LegalHoldDetails/LegalHoldDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/LegalHoldDetails/LegalHoldDetailsViewController.swift
@@ -116,7 +116,7 @@ final class LegalHoldDetailsViewController: UIViewController {
 extension LegalHoldDetailsViewController: LegalHoldParticipantsSectionControllerDelegate {
     
     func legalHoldParticipantsSectionWantsToPresentUserProfile(for user: UserType) {
-        let profileViewController = ProfileViewController(user: user, viewer: ZMUser.selfUser(), context: .deviceList)
+        let profileViewController = ProfileViewController(user: user, viewer: SelfUser.current, context: .deviceList)
         show(profileViewController, sender: nil)
     }
     

--- a/Wire-iOS/Sources/UserInterface/LegalHoldDetails/LegalHoldHeaderView.swift
+++ b/Wire-iOS/Sources/UserInterface/LegalHoldDetails/LegalHoldHeaderView.swift
@@ -39,9 +39,11 @@ class LegalHoldHeaderView: UIView {
     }()
     
     let descriptionLabel: UILabel = {
+        let text = SelfUser.current.isUnderLegalHold
+            ? "legalhold.header.self_description"
+            : "legalhold.header.other_description"
+
         let label = UILabel(frame: .zero)
-        let text = ZMUser.selfUser()?.isUnderLegalHold == true ? "legalhold.header.self_description" : "legalhold.header.other_description"
-        
         label.attributedText = text.localized && .paragraphSpacing(8)
         label.font = UIFont.normalFont
         label.numberOfLines = 0

--- a/Wire-iOS/Sources/UserInterface/LegalHoldDetails/LegalHoldHeaderView.swift
+++ b/Wire-iOS/Sources/UserInterface/LegalHoldDetails/LegalHoldHeaderView.swift
@@ -39,11 +39,9 @@ class LegalHoldHeaderView: UIView {
     }()
     
     let descriptionLabel: UILabel = {
-        let text = SelfUser.current.isUnderLegalHold
-            ? "legalhold.header.self_description"
-            : "legalhold.header.other_description"
-
         let label = UILabel(frame: .zero)
+        let text = ZMUser.selfUser()?.isUnderLegalHold == true ? "legalhold.header.self_description" : "legalhold.header.other_description"
+        
         label.attributedText = text.localized && .paragraphSpacing(8)
         label.font = UIFont.normalFont
         label.numberOfLines = 0

--- a/Wire-iOS/Sources/UserInterface/SelfProfile/AccountView.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/AccountView.swift
@@ -161,7 +161,7 @@ class BaseAccountView: UIView {
         }
 
         if let userSession = SessionManager.shared?.activeUserSession {
-            selfUserObserver = UserChangeInfo.add(observer: self, for: ZMUser.selfUser(inUserSession: userSession), in: userSession)
+            selfUserObserver = UserChangeInfo.add(observer: self, for: userSession.selfUser, in: userSession)
         }
 
         selectionView.hostedLayer.strokeColor = UIColor.accent().cgColor

--- a/Wire-iOS/Sources/UserInterface/SelfProfile/ProfileHeaderViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/ProfileHeaderViewController.swift
@@ -120,7 +120,7 @@ final class ProfileHeaderViewController: UIViewController, Themeable {
      * - note: You can change the options later through the `options` property.
      */
     
-    init(user: UserType, viewer: UserType = ZMUser.selfUser(), conversation: ZMConversation? = nil, options: Options) {
+    init(user: UserType, viewer: UserType = SelfUser.current, conversation: ZMConversation? = nil, options: Options) {
         self.user = user
         isAdminRole = conversation.map(self.user.isGroupAdmin) ?? false
         self.viewer = viewer

--- a/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ChangeHandleViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ChangeHandleViewController.swift
@@ -195,7 +195,7 @@ final class ChangeHandleViewController: SettingsBaseTableViewController {
     var popOnSuccess = true
 
     convenience init() {
-        self.init(state: HandleChangeState(currentHandle: ZMUser.selfUser().handle ?? nil, newHandle: nil, availability: .unknown))
+        self.init(state: HandleChangeState(currentHandle: SelfUser.current.handle ?? nil, newHandle: nil, availability: .unknown))
     }
 
     convenience init(suggestedHandle handle: String) {

--- a/Wire-iOS/Sources/UserInterface/Settings/SettingsTableViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/SettingsTableViewController.swift
@@ -166,7 +166,7 @@ class SettingsTableViewController: SettingsBaseTableViewController {
         }
 
         if let userSession = ZMUserSession.shared() {
-            self.selfUserObserver = UserChangeInfo.add(observer: self, for: ZMUser.selfUser(), in: userSession)
+            self.selfUserObserver = UserChangeInfo.add(observer: self, for: userSession.selfUser, in: userSession)
         }
         
         NotificationCenter.default.addObserver(self, selector: #selector(applicationDidBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/InviteActionSheet/ShareItemProvider.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/InviteActionSheet/ShareItemProvider.swift
@@ -23,8 +23,7 @@ final class ShareItemProvider: UIActivityItemProvider {
 
     override func activityViewController(_ activityViewController: UIActivityViewController, itemForActivityType activityType: UIActivity.ActivityType?) -> Any? {
         guard
-            let selfUser = SelfUser.provider?.selfUser,
-            let handle = selfUser.handle
+            let handle = SelfUser.provider?.selfUser.handle
         else {
             return "send_invitation_no_email.text".localized
         }

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/InviteActionSheet/ShareItemProvider.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/InviteActionSheet/ShareItemProvider.swift
@@ -22,13 +22,14 @@ final class ShareItemProvider: UIActivityItemProvider {
     }
 
     override func activityViewController(_ activityViewController: UIActivityViewController, itemForActivityType activityType: UIActivity.ActivityType?) -> Any? {
-        let fullSelfUser = ZMUser.selfUser(inUserSession: ZMUserSession.shared()!)
-
-        if let handle = fullSelfUser.handle {
-            let displayHandle = "@\(handle)"
-            return String(format: "send_invitation.text".localized, displayHandle)
+        guard
+            let selfUser = SelfUser.provider?.selfUser,
+            let handle = selfUser.handle
+        else {
+            return "send_invitation_no_email.text".localized
         }
 
-        return "send_invitation_no_email.text".localized
+        let displayHandle = "@\(handle)"
+        return String(format: "send_invitation.text".localized, displayHandle)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/ProfilePresenter.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/ProfilePresenter.swift
@@ -68,7 +68,7 @@ class ProfilePresenter: NSObject, ViewControllerDismisser {
 
         self.onDismiss = onDismiss
 
-        let profileViewController = ProfileViewController(user: user, viewer: ZMUser.selfUser(), context: .search)
+        let profileViewController = ProfileViewController(user: user, viewer: SelfUser.current, context: .search)
         profileViewController.delegate = self
         profileViewController.viewControllerDismisser = self
 

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/Create Group/CreateGroupSection.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/Create Group/CreateGroupSection.swift
@@ -26,13 +26,13 @@ final class CreateGroupSection: NSObject, CollectionViewSectionController {
     }
     
     private var data: [Row] {
-        return ZMUser.selfUser().isTeamMember ? [Row.createGroup, Row.createGuestRoom] : [Row.createGroup]
+        return SelfUser.current.isTeamMember ? [Row.createGroup, Row.createGuestRoom] : [Row.createGroup]
     }
     
     weak var delegate: SearchSectionControllerDelegate?
 
     var isHidden: Bool {
-        return !ZMUser.selfUser().canCreateConversation(type: .group)
+        return !SelfUser.current.canCreateConversation(type: .group)
     }
     
     func prepareForUse(in collectionView: UICollectionView?) {

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/Suggestions/DirectorySectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/Suggestions/DirectorySectionController.swift
@@ -69,7 +69,9 @@ class DirectorySectionController: SearchSectionController {
         let user = suggestions[indexPath.row]
         
         ZMUserSession.shared()?.enqueue {
-            let messageText = "missive.connection_request.default_message".localized(args: user.name ?? "", ZMUser.selfUser().name ?? "")
+            let username = user.name ?? ""
+            let selfUsername = SelfUser.current.name ?? ""
+            let messageText = "missive.connection_request.default_message".localized(args: username, selfUsername)
             user.connect(message: messageText)
         }
     }

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.swift
@@ -83,7 +83,7 @@ final class StartUIViewController: UIViewController {
     }
 
     var selfUser: UserType {
-        return ZMUser.selfUser()
+        return SelfUser.current
     }
     
     // MARK: - Overloaded methods

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewControllerViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewControllerViewModel.swift
@@ -172,7 +172,7 @@ final class ProfileViewControllerViewModel: NSObject {
         transitionToListAndEnqueue {
             self.conversation?.clearMessageHistory()
             if leave {
-                self.conversation?.removeOrShowError(participant: ZMUser.selfUser())
+                self.conversation?.removeOrShowError(participant: SelfUser.current)
             }
         }
     }


### PR DESCRIPTION
## What's new in this PR?

This PR is part of an ongoing effort to remove references to concrete user objects. See https://github.com/wireapp/ios-architecture/issues/89 for more details.

---

This PR removes *some* invocations to `ZMUser.selfUser` by replacing them with `SelfUser.current` or through other refactorings.

