### PR TITLE
[Fix] conversation camera crash

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
@@ -162,8 +162,9 @@ extension ConversationInputBarViewController: CameraKeyboardViewControllerDelega
                                                          onConfirm: { [unowned self] (editedImage: UIImage?) in
                                                                 self.dismiss(animated: true) {
                                                                     if isFromCamera {
+                                                                        guard let image = UIImage(data: imageData as Data) else { return }
                                                                         let selector = #selector(ConversationInputBarViewController.image(_:didFinishSavingWithError:contextInfo:))
-                                                                        UIImageWriteToSavedPhotosAlbum(UIImage(data: imageData as Data)!, self, selector, nil)
+                                                                        UIImageWriteToSavedPhotosAlbum(image, self, selector, nil)
                                                                     }
 
                                                                     self.sendController.sendMessage(withImageData: editedImage?.pngData() ?? imageData)

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
@@ -159,21 +159,21 @@ extension ConversationInputBarViewController: CameraKeyboardViewControllerDelega
         }
 
         let context = ConfirmAssetViewController.Context(asset: .image(mediaAsset: mediaAsset),
-                                                         onConfirm: { [unowned self] (editedImage: UIImage?) in
-                                                                self.dismiss(animated: true) {
+                                                         onConfirm: { [weak self] (editedImage: UIImage?) in
+                                                                self?.dismiss(animated: true) {
                                                                     if isFromCamera {
                                                                         guard let image = UIImage(data: imageData as Data) else { return }
                                                                         let selector = #selector(ConversationInputBarViewController.image(_:didFinishSavingWithError:contextInfo:))
                                                                         UIImageWriteToSavedPhotosAlbum(image, self, selector, nil)
                                                                     }
 
-                                                                    self.sendController.sendMessage(withImageData: editedImage?.pngData() ?? imageData)
+                                                                    self?.sendController.sendMessage(withImageData: editedImage?.pngData() ?? imageData)
                                                                 }
                                                             },
-                                                         onCancel: { [unowned self] in
-                                                                        self.dismiss(animated: true) {
-                                                                            self.mode = .camera
-                                                                            self.inputBar.textView.becomeFirstResponder()
+                                                         onCancel: { [weak self] in
+                                                                        self?.dismiss(animated: true) {
+                                                                            self?.mode = .camera
+                                                                            self?.inputBar.textView.becomeFirstResponder()
                                                                         }
                                                                     })
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

I couldn't reproduce the crash but it seems that sometimes after loading an image from the camera in a conversation the app crashes.

### Causes

The causes could be 2:
1) force unwrapping on image initialisation from a Data
2) in onConfirm block [unowned self] is nil.

### Solutions

1) use a guard statement to avoid the force unwrapping on the image initialisation
2) [weak self] instead of [unowned self].