### PR TITLE
[Fix] Crash when adding new account

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
@@ -69,9 +69,7 @@ final class ConversationListContentController: UICollectionViewController {
 
         // viewWillAppear: can get called also when dismissing the controller above this one.
         // The user session might not be there anymore in some cases, e.g. when logging out
-        guard let _ = ZMUserSession.shared() else {
-            return
-        }
+        guard SelfUser.provider != nil else { return }
 
         updateVisibleCells()
 

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
@@ -68,7 +68,7 @@ final class ConversationListContentController: UICollectionViewController {
         super.viewWillAppear(animated)
 
         // viewWillAppear: can get called also when dismissing the controller above this one.
-        // The user session might not be there anymore in some cases, e.g. when logging out
+        // The self user might not be there anymore in some cases, e.g. when logging out
         guard SelfUser.provider != nil else { return }
 
         updateVisibleCells()

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListItemView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListItemView.swift
@@ -240,7 +240,7 @@ final class ConversationListItemView: UIView {
         // Configure the title and status
         let title: NSAttributedString?
         
-        if let selfUser = SelfUser.provider?.selfUser, selfUser.isTeamMember, let connectedUser = conversation.connectedUser {
+        if SelfUser.current.isTeamMember, let connectedUser = conversation.connectedUser {
             title = AvailabilityStringBuilder.string(for: connectedUser, with: .list)
             
             if connectedUser.availability != .none {

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListItemView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListItemView.swift
@@ -240,7 +240,7 @@ final class ConversationListItemView: UIView {
         // Configure the title and status
         let title: NSAttributedString?
         
-        if SelfUser.current.isTeamMember, let connectedUser = conversation.connectedUser {
+        if let selfUser = SelfUser.provider?.selfUser, selfUser.isTeamMember, let connectedUser = conversation.connectedUser {
             title = AvailabilityStringBuilder.string(for: connectedUser, with: .list)
             
             if connectedUser.availability != .none {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Adding a second account crashes the app.

### Causes

When adding a second account, we log out of the current account and the app transitions to an `unauthenticated` state. This causes the `SelfUser.provider` to be set to `nil`. Any calls to `SelfUser.current` will cause a crash.

The offending call to `SelfUser.current` is in `ConversationListItemView` --- a descendant of the `ConversationListContentController`. It is triggered  the content controller's `viewWillAppear(:)` is called. As a comment already notes, `viewWillAppear` may be called when the parent view controller is dismissed (which happens when we transition to the landing page), and a check that the shared user session exists is there to prevent loading the UI.

Unfortunately, this check fails when there is no self user.

### Solutions

Update the guard to check explicitly for `SelfUser.provider`.

### Attachments

https://wearezeta.atlassian.net/browse/ZIOS-12714
