### PR TITLE
fix crashes when the app goes to background or sending bug report

### DIFF
--- a/Wire-iOS/Sources/Components/Settings.swift
+++ b/Wire-iOS/Sources/Components/Settings.swift
@@ -136,7 +136,7 @@ final class Settings {
 
         startLogging()
 
-        NotificationCenter.default.addObserver(self, selector: #selector(UIApplicationDelegate.applicationDidEnterBackground(_:)), name: UIApplication.didEnterBackgroundNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(applicationDidEnterBackground(_:)), name: UIApplication.didEnterBackgroundNotification, object: nil)
     }
 
     func migrateAppCenterAndOptOutSettingsToSharedDefaults() {
@@ -160,7 +160,8 @@ final class Settings {
         UserDefaults.standard.synchronize()
     }
 
-    func applicationDidEnterBackground(_ application: UIApplication) {
+    @objc
+    private func applicationDidEnterBackground(_ application: UIApplication) {
         synchronize()
     }
 

--- a/Wire-iOS/Sources/Developer/DebugAlert.swift
+++ b/Wire-iOS/Sources/Developer/DebugAlert.swift
@@ -20,7 +20,7 @@ import Foundation
 import MessageUI
 
 /// Presents debug alerts
-@objcMembers public class DebugAlert: NSObject {
+final class DebugAlert: NSObject {
     
     private struct Action {
         let text: String
@@ -105,7 +105,7 @@ import MessageUI
 }
 
 /// Sends debug logs by email
-@objcMembers public class DebugLogSender: NSObject, MFMailComposeViewControllerDelegate {
+final class DebugLogSender: NSObject, MFMailComposeViewControllerDelegate {
 
     private var mailViewController : MFMailComposeViewController? = nil
     static private var senderInstance: DebugLogSender? = nil
@@ -124,7 +124,7 @@ import MessageUI
         }
         
         // Prepare subject & body
-        let user = SelfUser.current as? ZMUser
+        let user = SelfUser.provider?.selfUser as? ZMUser
         let userID = user?.remoteIdentifier?.transportString() ?? ""
         let device = UIDevice.current.name
         let userDescription = "\(user?.name ?? "") [user: \(userID)] [device: \(device)]"


### PR DESCRIPTION
## What's new in this PR?

### Issues

App crashes when goes to background, or sending a bug report.

### Causes

1. called `UIApplicationDelegate.applicationDidEnterBackground` instead of `Setting.applicationDidEnterBackground`
2. `SelfUser.current` may be nil when sending the debug report.

### Solutions

Fix with calling property method.