### PR TITLE
Fix: If there's no email client and sending debug report, alert shows 2 OK buttons

### DIFF
--- a/Wire-iOS/Sources/Developer/DebugAlert.swift
+++ b/Wire-iOS/Sources/Developer/DebugAlert.swift
@@ -20,7 +20,7 @@ import Foundation
 import MessageUI
 
 /// Presents debug alerts
-final class DebugAlert: NSObject {
+final class DebugAlert {
     
     private struct Action {
         let text: String
@@ -92,7 +92,7 @@ final class DebugAlert: NSObject {
                                                   sourceView: UIView? = nil) {
         let alert = UIAlertController(title: "self.settings.technical_report_section.title".localized,
                                       message: "self.settings.technical_report.no_mail_alert".localized + email,
-                                      alertAction: .ok(style: .cancel))
+                                      alertAction: .cancel())
         alert.addAction(UIAlertAction(title: "general.ok".localized, style: .default, handler: { (action) in
             let activity = UIActivityViewController(activityItems: logPaths, applicationActivities: nil)
             activity.configPopover(pointToView: sourceView ?? controller.view)


### PR DESCRIPTION
## What's new in this PR?

Correct the alert button text. Change the cancel action button title from OK to cancel.