### PR TITLE
Fix: app does not keep message when typing a message and switching apps before sending

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+UITextViewDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+UITextViewDelegate.swift
@@ -120,8 +120,7 @@ extension ConversationInputBarViewController: UITextViewDelegate {
         }
         
         guard let textView = textView as? MarkdownTextView else { preconditionFailure("Invalid textView class") }
-        let (text, mentions) = textView.preparedText
-        let draft = DraftMessage(text: text, mentions: mentions, quote: self.quotedMessage as? ZMMessage)
+        let draft = draftMessage(from: textView)
         delegate?.conversationInputBarViewControllerDidComposeDraft(message: draft)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.m
@@ -105,14 +105,6 @@ static NSString* ZMLogTag ZM_UNUSED = @"UI";
     [NSObject cancelPreviousPerformRequestsWithTarget:self];
 }
 
-- (void)didEnterBackground:(NSNotification *)notification
-{
-    NOT_USED(notification);
-    if(self.inputBar.textView.text.length > 0) {
-        [self.conversation setIsTyping:NO];
-    }
-}
-
 - (void)viewDidLoad
 {
     [super viewDidLoad];

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
@@ -25,13 +25,13 @@ extension ConversationInputBarViewController {
 
         return DraftMessage(text: text, mentions: mentions, quote: quotedMessage as? ZMMessage)
     }
-    
+
     @objc
     func didEnterBackground(_ notification: Notification?) {
         if !inputBar.textView.text.isEmpty {
             conversation.setIsTyping(false)
         }
-        
+
         let draft = draftMessage(from: inputBar.textView)
         delegate?.conversationInputBarViewControllerDidComposeDraft(message: draft)
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
@@ -19,12 +19,21 @@ import Foundation
 import MobileCoreServices
 
 extension ConversationInputBarViewController {
+    //MARk: - save draft message
+    func draftMessage(from textView: MarkdownTextView) -> DraftMessage {
+        let (text, mentions) = textView.preparedText
+
+        return DraftMessage(text: text, mentions: mentions, quote: quotedMessage as? ZMMessage)
+    }
     
     @objc
     func didEnterBackground(_ notification: Notification?) {
         guard !inputBar.textView.text.isEmpty else { return }
 
         conversation.setIsTyping(false)
+        
+       let draft = draftMessage(from: inputBar.textView)
+        delegate?.conversationInputBarViewControllerDidComposeDraft(message: draft)
     }
 
     @objc

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
@@ -19,7 +19,7 @@ import Foundation
 import MobileCoreServices
 
 extension ConversationInputBarViewController {
-    //MARk: - save draft message
+    // MARK: - Save draft message
     func draftMessage(from textView: MarkdownTextView) -> DraftMessage {
         let (text, mentions) = textView.preparedText
 
@@ -28,11 +28,11 @@ extension ConversationInputBarViewController {
     
     @objc
     func didEnterBackground(_ notification: Notification?) {
-        guard !inputBar.textView.text.isEmpty else { return }
-
-        conversation.setIsTyping(false)
+        if !inputBar.textView.text.isEmpty {
+            conversation.setIsTyping(false)
+        }
         
-       let draft = draftMessage(from: inputBar.textView)
+        let draft = draftMessage(from: inputBar.textView)
         delegate?.conversationInputBarViewControllerDidComposeDraft(message: draft)
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
@@ -21,6 +21,13 @@ import MobileCoreServices
 extension ConversationInputBarViewController {
     
     @objc
+    func didEnterBackground(_ notification: Notification?) {
+        guard !inputBar.textView.text.isEmpty else { return }
+
+        conversation.setIsTyping(false)
+    }
+
+    @objc
     func updateButtonIcons() {
         audioButton.setIcon(.microphone, size: .tiny, for: .normal)
         


### PR DESCRIPTION
## What's new in this PR?

### Issues

When the app goes to background and switch to other app and then come back to the app, the draft text is cleared.

### Causes

the draft text is not stored in this case. ( currently we only save the draft text when keyboard dismisses, e.g. switching conversations)

### Solutions

Store the draft text when the app goes to the background.