### PR TITLE
Fix: button state not change

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Poll/ConversationButtonMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Poll/ConversationButtonMessageCell.swift
@@ -144,6 +144,14 @@ final class ConversationButtonMessageCellDescription: ConversationMessageCellDes
          buttonAction: @escaping Completion) {
         configuration = View.Configuration(text: text, state: state, buttonAction: buttonAction)
     }
+    
+    func isConfigurationEqual(with description: Any) -> Bool {
+        guard let otherButtonMessageDescription = description as? ConversationButtonMessageCellDescription else {
+            return false
+        }
+        
+        return configuration == otherButtonMessageDescription.configuration
+    }
 }
 
 extension ConversationButtonMessageCell.Configuration: Hashable {


### PR DESCRIPTION
## What's new in this PR?

Implement `isConfigurationEqual` to fix button state not updated after tapped issue.