### PR TITLE
Create isConfigurationEqual for View.Configuration : Equatable

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCell.swift
@@ -396,14 +396,6 @@ class ConversationParticipantsChangedSystemMessageCellDescription: ConversationM
         configuration = View.Configuration(icon: model.image(), attributedText: model.attributedTitle(), showLine: true, warning: model.warning())
         actionController = nil
     }
-
-    func isConfigurationEqual(with description: Any) -> Bool {
-        guard let otherSystemMessageDescription = description as? ConversationParticipantsChangedSystemMessageCellDescription else {
-            return false
-        }
-
-        return self.configuration == otherSystemMessageDescription.configuration
-    }
 }
 
 class ConversationRenamedSystemMessageCellDescription: ConversationMessageCellDescription {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Poll/ConversationButtonMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Poll/ConversationButtonMessageCell.swift
@@ -144,14 +144,6 @@ final class ConversationButtonMessageCellDescription: ConversationMessageCellDes
          buttonAction: @escaping Completion) {
         configuration = View.Configuration(text: text, state: state, buttonAction: buttonAction)
     }
-    
-    func isConfigurationEqual(with description: Any) -> Bool {
-        guard let otherButtonMessageDescription = description as? ConversationButtonMessageCellDescription else {
-            return false
-        }
-        
-        return configuration == otherButtonMessageDescription.configuration
-    }
 }
 
 extension ConversationButtonMessageCell.Configuration: Hashable {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationTextMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationTextMessageCell.swift
@@ -157,12 +157,6 @@ class ConversationTextMessageCellDescription: ConversationMessageCellDescription
         cell.cellView.menuPresenter = cell
         return cell
     }
-    
-    func isConfigurationEqual(with other: Any) -> Bool {
-        guard let otherDescription = other as? ConversationTextMessageCellDescription else { return false }
-        
-        return configuration == otherDescription.configuration
-    }
 }
 
 // MARK: - Factory

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
@@ -207,6 +207,11 @@ extension ConversationMessageCellDescription {
         }
     }
     
+    
+    /// Default impletmentation of isConfigurationEqual. If the configure is Equatable, see below Conditionally Conforming for View.Configuration : Equatable
+    ///
+    /// - Parameter other: other object to compare
+    /// - Returns: true if both self and other having same type
     func isConfigurationEqual(with other: Any) -> Bool {
         return type(of: self) == type(of: other)
     }
@@ -214,6 +219,11 @@ extension ConversationMessageCellDescription {
 }
 
 extension ConversationMessageCellDescription where View.Configuration : Equatable {
+    
+    /// Default impletmentation of isConfigurationEqual
+    ///
+    /// - Parameter other: other object to compare
+    /// - Returns: true if both self and other having same type, and configures are equal
     func isConfigurationEqual(with other: Any) -> Bool {
         guard let otherConfig = (other as? Self)?.configuration else { return false }
         

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
@@ -213,6 +213,14 @@ extension ConversationMessageCellDescription {
     
 }
 
+extension ConversationMessageCellDescription where View.Configuration : Equatable {
+    func isConfigurationEqual(with other: Any) -> Bool {
+        guard let otherConfig = (other as? Self)?.configuration else { return false }
+        
+        return configuration == otherConfig
+    }
+}
+
 /**
  * A type erased box containing a conversation message cell description.
  */


### PR DESCRIPTION
## What's new in this PR?

Create default impletement of `isConfigurationEqual` for where `View.Configuration : Equatable`.
Remove repeated implementation in cell classes where `Configuration` are `Equatable`.