### PR TITLE
Fix: reset button state and do not allow tapping confirmed button

### DIFF
--- a/Wire-iOS/Sources/Components/Buttons/SpinnerButton.swift
+++ b/Wire-iOS/Sources/Components/Buttons/SpinnerButton.swift
@@ -88,4 +88,9 @@ final class SpinnerButton: Button {
     static func alarmButton() -> SpinnerButton {
         return SpinnerButton(style: .empty, cornerRadius: 6, titleLabelFont: .smallSemiboldFont)
     }
+    
+    func reset() {
+        isLoading = false
+        isEnabled = true
+    }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Poll/ConversationButtonMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Poll/ConversationButtonMessageCell.swift
@@ -64,6 +64,8 @@ final class ConversationButtonMessageCell: UIView, ConversationMessageCell {
     }
     
     func configure(with object: Configuration, animated: Bool) {
+        button.reset()
+
         config = object
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Poll/ConversationButtonMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Poll/ConversationButtonMessageCell.swift
@@ -92,11 +92,13 @@ final class ConversationButtonMessageCell: UIView, ConversationMessageCell {
         configureViews()
         createConstraints()
         
-        button.addTarget(self, action: #selector(buttonTouched), for: .touchUpInside)
+        button.addTarget(self, action: #selector(buttonTouched(sender:)), for: .touchUpInside)
     }
     
     @objc
-    private func buttonTouched() {
+    private func buttonTouched(sender: Any) {
+        guard config?.state != .confirmed else { return }
+        
         button.isLoading = true
         buttonAction?()
     }


### PR DESCRIPTION
## What's new in this PR?

Reset button state before config.
Do not allow tapping confirmed buttons.