### PR TITLE
Fix: [iPad iOS 13] when having SSO code on clipboard, login page gets stuck in loop

### DIFF
--- a/Wire-iOS Tests/UIAlertViewController+CompanyLoginTests.swift
+++ b/Wire-iOS Tests/UIAlertViewController+CompanyLoginTests.swift
@@ -29,17 +29,17 @@ final class UIAlertControllerCompanyLoginSnapshotTests: XCTestCase {
     }
 
     func testForSSOAndEmailAlert() {
-        sut = UIAlertController.companyLogin(ssoOnly: false, completion: {_ in})
+        sut = UIAlertController.companyLogin(ssoOnly: false, completion: {_,_  in})
         verify(matching: sut)
     }
     
     func testForSSOOnlyAlert() {
-        sut = UIAlertController.companyLogin(ssoOnly: true, completion: {_ in})
+        sut = UIAlertController.companyLogin(ssoOnly: true, completion: {_,_  in})
         verify(matching: sut)
     }
     
     func testForAlertWithError() {
-        sut = UIAlertController.companyLogin(error: .unknown) {_ in}
+        sut = UIAlertController.companyLogin(error: .unknown) {_,_  in}
         verify(matching: sut)
     }
 

--- a/Wire-iOS/Sources/UserInterface/Company Login/CompanyLoginController.swift
+++ b/Wire-iOS/Sources/UserInterface/Company Login/CompanyLoginController.swift
@@ -172,12 +172,12 @@ extension CompanyLoginController {
             prefilledInput: prefilledInput,
             ssoOnly: ssoOnly,
             error: error,
-            completion: { [weak self] input, succeed in
+            completion: { [weak self] input, success in
                 input.apply(inputHandler)
                 self?.ssoAlert = nil
                 
                 // stop polling loop when cancel is pressed
-                if !succeed {
+                if !success {
                     self?.cancelSSOPressed = true
                 }
             }

--- a/Wire-iOS/Sources/UserInterface/Company Login/CompanyLoginController.swift
+++ b/Wire-iOS/Sources/UserInterface/Company Login/CompanyLoginController.swift
@@ -48,9 +48,9 @@ import WireCommonComponents
 /// A concrete implementation of the internally used `SharedIdentitySessionRequester` and
 /// `SharedIdentitySessionRequestDetector` can be provided.
 ///
-@objc public final class CompanyLoginController: NSObject, CompanyLoginRequesterDelegate, CompanyLoginFlowHandlerDelegate {
+final class CompanyLoginController: NSObject, CompanyLoginRequesterDelegate, CompanyLoginFlowHandlerDelegate {
 
-    @objc weak var delegate: CompanyLoginControllerDelegate?
+    weak var delegate: CompanyLoginControllerDelegate?
 
     @objc(autoDetectionEnabled) var isAutoDetectionEnabled = true {
         didSet {
@@ -119,7 +119,7 @@ import WireCommonComponents
     
     private func startPollingTimer() {
         guard UIDevice.current.userInterfaceIdiom == .pad, CompanyLoginController.isPollingEnabled else { return }
-        pollingTimer = .scheduledTimer(withTimeInterval: 1, repeats: true) {
+        pollingTimer = .scheduledTimer(withTimeInterval: 1, repeats: true) { ///TODO: stop when cancel pressed
             [internalDetectSSOCode] _ in internalDetectSSOCode(true)
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Company Login/CompanyLoginController.swift
+++ b/Wire-iOS/Sources/UserInterface/Company Login/CompanyLoginController.swift
@@ -163,7 +163,7 @@ extension CompanyLoginController {
         error: UIAlertController.CompanyLoginError? = nil,
         ssoOnly: Bool = false) {
         
-        // Do not repeatly showing alert if exist
+        // Do not repeatly show alert if exist
         guard ssoAlert == nil else { return }
         
         let inputHandler = ssoOnly ? attemptLogin : parseAndHandle

--- a/Wire-iOS/Sources/UserInterface/Company Login/CompanyLoginController.swift
+++ b/Wire-iOS/Sources/UserInterface/Company Login/CompanyLoginController.swift
@@ -55,6 +55,8 @@ final class CompanyLoginController: NSObject, CompanyLoginRequesterDelegate, Com
         didSet {
             if cancelSSOPressed {
                 stopPollingTimer()
+            } else {
+                startPollingTimer()
             }
         }
     }
@@ -185,6 +187,7 @@ extension CompanyLoginController {
         
         ssoAlert = alertController
         delegate?.controller(self, presentAlert: alertController)
+        cancelSSOPressed = false
     }
 
     // MARK: - Input Handling

--- a/Wire-iOS/Sources/UserInterface/Company Login/UIAlertController+CompanyLogin.swift
+++ b/Wire-iOS/Sources/UserInterface/Company Login/UIAlertController+CompanyLogin.swift
@@ -81,12 +81,12 @@ extension UIAlertController {
     /// - parameter prefilledInput: Input which should be used to prefill the textfield of the controller (optional).
     /// - parameter ssoOnly: A boolean defining if the alert's copy should be for SSO only. default: false.
     /// - parameter error: An (optional) error to display above the textfield
-    /// - parameter completion: The completion closure which will be called with the provided code or nil if cancelled.
+    /// - parameter completion: The completion closure which will be called with the provided code or nil if cancelled. `succeed` flag is false when the user canceled the alert.
     static func companyLogin(
         prefilledInput: String? = nil,
         ssoOnly: Bool = false,
         error: CompanyLoginError? = nil,
-        completion: @escaping (String?, Bool) -> Void) -> UIAlertController {
+        completion: @escaping (_ ssoCode: String?, _ succeed: Bool) -> Void) -> UIAlertController {
         
         let copy = CompanyLoginCopy(ssoOnly: ssoOnly)
         

--- a/Wire-iOS/Sources/UserInterface/Company Login/UIAlertController+CompanyLogin.swift
+++ b/Wire-iOS/Sources/UserInterface/Company Login/UIAlertController+CompanyLogin.swift
@@ -86,8 +86,7 @@ extension UIAlertController {
         prefilledInput: String? = nil,
         ssoOnly: Bool = false,
         error: CompanyLoginError? = nil,
-        completion: @escaping (String?) -> Void
-        ) -> UIAlertController {
+        completion: @escaping (String?, Bool) -> Void) -> UIAlertController {
         
         let copy = CompanyLoginCopy(ssoOnly: ssoOnly)
         
@@ -106,7 +105,7 @@ extension UIAlertController {
         }
         
         let loginAction = UIAlertAction(title: copy.action, style: .default) { [controller] _ in
-            completion(controller.textFields?.first?.text)
+            completion(controller.textFields?.first?.text, true)
         }
         
         controller.addTextField { textField in
@@ -115,7 +114,7 @@ extension UIAlertController {
             textField.placeholder = copy.placeholder
         }
         
-        controller.addAction(.cancel { completion(nil) })
+        controller.addAction(.cancel { completion(nil, false) })
         controller.addAction(loginAction)
         return controller
     }

--- a/Wire-iOS/Sources/UserInterface/Helpers/UIAlertAction+Convenience.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UIAlertAction+Convenience.swift
@@ -17,8 +17,7 @@
 //
 
 extension UIAlertAction {
-    @objc(cancelActionWithCompletion:)
-    static func cancel(_ completion: (() -> Void)? = nil) -> UIAlertAction {
+    static func cancel(_ completion: Completion? = nil) -> UIAlertAction {
         return UIAlertAction(
             title: "general.cancel".localized,
             style: .cancel,
@@ -26,7 +25,6 @@ extension UIAlertAction {
         )
     }
 
-    @objc(okActionWithCompletion:)
     static func ok(_ completion: ((UIAlertAction) -> Void)? = nil) -> UIAlertAction {
         return UIAlertAction.ok(style: .default, handler: completion)
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

When a SSO code in copied to clipboard, it repeatedly appear even cancel is pressed.

### Causes

1. The `pollingTimer` keep creating alert even it is already shown
2. After cancel is pressed, it is still trying to show the alert when going to another screen.

### Solutions

1. Check if there is a exist SSO alert before presenting a new one
2. Stop polling after cancel is pressed, and set the flag `cancelSSOPressed` to true to prevent the alert shows again.