### PR TITLE
[Fix] button cell configuration hash

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Poll/ConversationButtonMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Poll/ConversationButtonMessageCell.swift
@@ -193,5 +193,6 @@ extension ConversationButtonMessageCell.Configuration: Hashable {
     func hash(into hasher: inout Hasher) {
         hasher.combine(text)
         hasher.combine(state)
+        hasher.combine(hasError)
     }
 }


### PR DESCRIPTION
## What's new in this PR?

- Add `hasError` to the Configuration hash