### PR TITLE
Fix: button spinner animation unstable behaviour

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -714,6 +714,7 @@
 		A923F1C02428C12A003F361F /* URLs+zip.swift in Sources */ = {isa = PBXBuildFile; fileRef = A923F1BF2428C12A003F361F /* URLs+zip.swift */; };
 		A923F1C72428C71A003F361F /* ZipFileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A923F1C42428C572003F361F /* ZipFileTests.swift */; };
 		A9275F5F24221AD6007CB2BC /* TextTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9275F5E24221AD6007CB2BC /* TextTransform.swift */; };
+		A92CA24924323E2600A29896 /* Spinner.swift in Sources */ = {isa = PBXBuildFile; fileRef = A92CA24824323E2600A29896 /* Spinner.swift */; };
 		A92CB35723CDF6D100F12797 /* ConversationContentViewControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A92CB35623CDF6D100F12797 /* ConversationContentViewControllerDelegate.swift */; };
 		A92CB35923CDF97800F12797 /* ConversationViewController+ConversationContentViewControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A92CB35823CDF97800F12797 /* ConversationViewController+ConversationContentViewControllerDelegate.swift */; };
 		A92E731C2407F54A007C1FFE /* AttributedStringOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870534001DD6265100A7F822 /* AttributedStringOperators.swift */; };
@@ -733,9 +734,9 @@
 		A955D3D923F5791100304851 /* String+URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 168A16A31D95964B005CFA6C /* String+URL.swift */; };
 		A955D3DA23F57F4600304851 /* ZMUserSession+RequestProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAED82B81B307AEE004D027F /* ZMUserSession+RequestProxy.swift */; };
 		A956554E23ED9D460004720E /* TokenizedTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EE9DCB11B5F9A6D00E347DF /* TokenizedTextView.swift */; };
+		A95B63F024250DA8008A2974 /* FileManager+TempDirectory.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95B63EF24250DA8008A2974 /* FileManager+TempDirectory.swift */; };
 		A95C76C0240E87440047CD29 /* ConversationButtonMessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95C76BF240E87440047CD29 /* ConversationButtonMessageCell.swift */; };
 		A95C76C2240E915D0047CD29 /* CompositeMessageCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95C76C1240E915D0047CD29 /* CompositeMessageCellTests.swift */; };
-		A95B63F024250DA8008A2974 /* FileManager+TempDirectory.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95B63EF24250DA8008A2974 /* FileManager+TempDirectory.swift */; };
 		A95E31C723DEF01000258C43 /* UIView+Zeta.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871BC2181D34F8F800DF0793 /* UIView+Zeta.swift */; };
 		A95E561123FBF0C0005F8E8D /* UIViewControllerContextTransitioning+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95E561023FBF0C0005F8E8D /* UIViewControllerContextTransitioning+Helper.swift */; };
 		A95FB36B23ED7F030095247C /* PassthroughTouchesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871BC1CE1D34F8F800DF0793 /* PassthroughTouchesView.swift */; };
@@ -2326,6 +2327,7 @@
 		A923F1BF2428C12A003F361F /* URLs+zip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLs+zip.swift"; sourceTree = "<group>"; };
 		A923F1C42428C572003F361F /* ZipFileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZipFileTests.swift; sourceTree = "<group>"; };
 		A9275F5E24221AD6007CB2BC /* TextTransform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextTransform.swift; sourceTree = "<group>"; };
+		A92CA24824323E2600A29896 /* Spinner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Spinner.swift; sourceTree = "<group>"; };
 		A92CB35623CDF6D100F12797 /* ConversationContentViewControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationContentViewControllerDelegate.swift; sourceTree = "<group>"; };
 		A92CB35823CDF97800F12797 /* ConversationViewController+ConversationContentViewControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationViewController+ConversationContentViewControllerDelegate.swift"; sourceTree = "<group>"; };
 		A92E731D2407F587007C1FFE /* String+Localized.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Localized.swift"; sourceTree = "<group>"; };
@@ -2341,9 +2343,9 @@
 		A955D3D223F54AC400304851 /* AuthenticationCoordinatedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationCoordinatedViewController.swift; sourceTree = "<group>"; };
 		A955D3D423F576F400304851 /* URL+String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+String.swift"; sourceTree = "<group>"; };
 		A955D3D723F5775700304851 /* URL+StringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+StringTests.swift"; sourceTree = "<group>"; };
+		A95B63EF24250DA8008A2974 /* FileManager+TempDirectory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+TempDirectory.swift"; sourceTree = "<group>"; };
 		A95C76BF240E87440047CD29 /* ConversationButtonMessageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationButtonMessageCell.swift; sourceTree = "<group>"; };
 		A95C76C1240E915D0047CD29 /* CompositeMessageCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompositeMessageCellTests.swift; sourceTree = "<group>"; };
-		A95B63EF24250DA8008A2974 /* FileManager+TempDirectory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+TempDirectory.swift"; sourceTree = "<group>"; };
 		A95E561023FBF0C0005F8E8D /* UIViewControllerContextTransitioning+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewControllerContextTransitioning+Helper.swift"; sourceTree = "<group>"; };
 		A961319F23E81CC300194608 /* ParticipantDeviceHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantDeviceHeaderView.swift; sourceTree = "<group>"; };
 		A9614EF723C38C810012A718 /* ConnectRequestsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectRequestsViewController.swift; sourceTree = "<group>"; };
@@ -3431,6 +3433,7 @@
 			children = (
 				D524BE62207BA15300542A4E /* SpinnerSubtitleView.swift */,
 				EFF9A65E22394E1900CCEC85 /* ProgressSpinner.swift */,
+				A92CA24824323E2600A29896 /* Spinner.swift */,
 				D5168F42200F6F2300F8222A /* CABasicAnimation+Rotation.swift */,
 				1E8C25381BBC279B00FC373F /* UIViewController+LoadingView.h */,
 				1E8C25391BBC279B00FC373F /* UIViewController+LoadingView.m */,
@@ -7425,6 +7428,7 @@
 				EF29CDC222D3907000EB2380 /* ConversationListViewControllerViewModel+ConversationListContentDelegate.swift in Sources */,
 				8744D5BE1C41D6C2000F8F93 /* SettingsClientViewController.swift in Sources */,
 				D54224C620513BFD00526A57 /* CellConfiguration+ConversationOptions.swift in Sources */,
+				A92CA24924323E2600A29896 /* Spinner.swift in Sources */,
 				A955D3D523F576F400304851 /* URL+String.swift in Sources */,
 				5EF5CDA520EF739200CC98B0 /* DataTaskSession.swift in Sources */,
 				EF19EF3A230701CF00696D95 /* ImagePickerConfirmationController.swift in Sources */,

--- a/Wire-iOS/Sources/Components/Buttons/SpinnerButton.swift
+++ b/Wire-iOS/Sources/Components/Buttons/SpinnerButton.swift
@@ -43,9 +43,12 @@ final class SpinnerButton: Button {
 
     var isLoading: Bool = false {
         didSet {
+            guard oldValue != isLoading else {
+                return
+            }
+            
             spinner.isHidden = !isLoading
-
-            isLoading ? spinner.startAnimation() : spinner.stopAnimation()
+            spinner.isAnimating = isLoading
         }
     }
 
@@ -95,6 +98,10 @@ final class SpinnerButton: Button {
     // MARK: - factory method
     static func alarmButton() -> SpinnerButton {
         return SpinnerButton(style: .empty, cornerRadius: 6, titleLabelFont: .smallSemiboldFont)
+    }
+    
+    func reset() {
+        spinner.isAnimating = false
     }
     
 }

--- a/Wire-iOS/Sources/Components/Buttons/SpinnerButton.swift
+++ b/Wire-iOS/Sources/Components/Buttons/SpinnerButton.swift
@@ -46,7 +46,7 @@ final class SpinnerButton: Button {
             guard oldValue != isLoading else {
                 return
             }
-            
+
             spinner.isHidden = !isLoading
             spinner.isAnimating = isLoading
         }
@@ -77,7 +77,7 @@ final class SpinnerButton: Button {
     override func updateFullStyle() {
         setBackgroundImageColor(.accent(), for: .disabled)
         setBackgroundImageColor(.accent(), for: .normal)
-        
+
         setTitleColor(.white, for: .normal)
         setTitleColor(.white, for: .highlighted)
         setTitleColor(.white, for: .disabled)
@@ -103,5 +103,5 @@ final class SpinnerButton: Button {
     // MARK: - factory method
     static func alarmButton() -> SpinnerButton {
         return SpinnerButton(style: .empty, cornerRadius: 6, titleLabelFont: .smallSemiboldFont)
-    }    
+    }
 }

--- a/Wire-iOS/Sources/Components/Buttons/SpinnerButton.swift
+++ b/Wire-iOS/Sources/Components/Buttons/SpinnerButton.swift
@@ -47,8 +47,9 @@ final class SpinnerButton: Button {
                 return
             }
             
-            spinner.isHidden = !isLoading
             spinner.isAnimating = isLoading
+            
+            print("🧼 isLoading = \(isLoading), style = \(String(describing: style))")
         }
     }
 
@@ -98,10 +99,5 @@ final class SpinnerButton: Button {
     // MARK: - factory method
     static func alarmButton() -> SpinnerButton {
         return SpinnerButton(style: .empty, cornerRadius: 6, titleLabelFont: .smallSemiboldFont)
-    }
-    
-    func reset() {
-        spinner.isAnimating = false
-    }
-    
+    }    
 }

--- a/Wire-iOS/Sources/Components/Buttons/SpinnerButton.swift
+++ b/Wire-iOS/Sources/Components/Buttons/SpinnerButton.swift
@@ -20,25 +20,25 @@ import Foundation
 /// A button with spinner at the trailing side. Title text is non truncated.
 final class SpinnerButton: Button {
 
-    private lazy var spinner: ProgressSpinner = {
-        let progressSpinner = ProgressSpinner()
+    private lazy var spinner: Spinner = {
+        let spinner = Spinner()
 
         // the spinner covers the text with alpha BG
-        progressSpinner.backgroundColor = UIColor.from(scheme: .contentBackground).withAlphaComponent(CGFloat.SpinnerButton.spinnerBackgroundAlpha)
-        progressSpinner.color = .accent()
-        progressSpinner.iconSize = CGFloat.SpinnerButton.iconSize
+        spinner.backgroundColor = UIColor.from(scheme: .contentBackground).withAlphaComponent(CGFloat.SpinnerButton.spinnerBackgroundAlpha)
+        spinner.color = .accent()
+        spinner.iconSize = CGFloat.SpinnerButton.iconSize
 
-        addSubview(progressSpinner)
+        addSubview(spinner)
 
-        progressSpinner.translatesAutoresizingMaskIntoConstraints = false
+        spinner.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            progressSpinner.centerYAnchor.constraint(equalTo: centerYAnchor),
-            progressSpinner.trailingAnchor.constraint(equalTo: trailingAnchor),
-            progressSpinner.widthAnchor.constraint(equalToConstant: 48),
-            progressSpinner.topAnchor.constraint(equalTo: topAnchor),
-            progressSpinner.bottomAnchor.constraint(equalTo: bottomAnchor)])
+            spinner.centerYAnchor.constraint(equalTo: centerYAnchor),
+            spinner.trailingAnchor.constraint(equalTo: trailingAnchor),
+            spinner.widthAnchor.constraint(equalToConstant: 48),
+            spinner.topAnchor.constraint(equalTo: topAnchor),
+            spinner.bottomAnchor.constraint(equalTo: bottomAnchor)])
 
-        return progressSpinner
+        return spinner
     }()
 
     var isLoading: Bool = false {
@@ -47,9 +47,8 @@ final class SpinnerButton: Button {
                 return
             }
             
+            spinner.isHidden = !isLoading
             spinner.isAnimating = isLoading
-            
-            print("🧼 isLoading = \(isLoading), style = \(String(describing: style))")
         }
     }
 

--- a/Wire-iOS/Sources/Components/Buttons/SpinnerButton.swift
+++ b/Wire-iOS/Sources/Components/Buttons/SpinnerButton.swift
@@ -77,15 +77,20 @@ final class SpinnerButton: Button {
     override func updateFullStyle() {
         setBackgroundImageColor(.accent(), for: .disabled)
         setBackgroundImageColor(.accent(), for: .normal)
-        setTitleColor(UIColor.white, for: .normal)
-        setTitleColor(UIColor.white, for: .disabled)
         
+        setTitleColor(.white, for: .normal)
+        setTitleColor(.white, for: .highlighted)
+        setTitleColor(.white, for: .disabled)
+
         setTitleColor(UIColor.from(scheme: .textDimmed, variant: variant), for: .highlighted)
     }
 
     ///custom empty style with accent color for disabled state.
     override func updateEmptyStyle() {
+        // remember reset background image colors when style is switch
+        setBackgroundImageColor(.clear, for: .disabled)
         setBackgroundImageColor(.clear, for: .normal)
+
         layer.borderWidth = 1
         setTitleColor(.buttonEmptyText(variant: variant), for: .normal)
         setTitleColor(.buttonEmptyText(variant: variant), for: .highlighted)

--- a/Wire-iOS/Sources/UserInterface/Components/Loading/ProgressSpinner.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Loading/ProgressSpinner.swift
@@ -44,13 +44,11 @@ final class ProgressSpinner: UIView {
 
     var isAnimating = false {
         didSet {
-            guard oldValue != isAnimating else { return }
-            
-            if isAnimating {
-                startAnimationInternal()
-            } else {
-                stopAnimationInternal()
+            guard oldValue != isAnimating else {
+                return                
             }
+            
+            isAnimating ? startAnimationInternal() : stopAnimationInternal()
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/Components/Loading/Spinner.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Loading/Spinner.swift
@@ -17,8 +17,6 @@
 
 import Foundation
 
-import Foundation
-
 final class Spinner: UIView {
 
     var color: UIColor = .white {

--- a/Wire-iOS/Sources/UserInterface/Components/Loading/Spinner.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Loading/Spinner.swift
@@ -1,4 +1,3 @@
-
 // Wire
 // Copyright (C) 2020 Wire Swiss GmbH
 //
@@ -21,87 +20,85 @@ import Foundation
 import Foundation
 
 final class Spinner: UIView {
-    
+
     var color: UIColor = .white {
         didSet {
             updateSpinnerIcon()
         }
     }
-    
+
     var iconSize: CGFloat = 32 {
         didSet {
             updateSpinnerIcon()
         }
     }
-    
-    
+
     var isAnimating = false {
         didSet {
             guard oldValue != isAnimating else {
                 return
             }
-            
+
             isAnimating ? startAnimationInternal() : stopAnimationInternal()
         }
     }
-    
+
     private let spinner: UIImageView = UIImageView()
-    
+
     private var isAnimationRunning: Bool {
         return spinner.layer.animation(forKey: "rotateAnimation") != nil
     }
-    
+
     init() {
         super.init(frame: .zero)
         setup()
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     private func setup() {
         createSpinner()
         setupConstraints()
     }
-    
+
     override func layoutSubviews() {
         super.layoutSubviews()
-        
+
         let frame = spinner.layer.frame
         spinner.layer.anchorPoint = CGPoint(x: 0.5, y: 0.5)
         spinner.layer.frame = frame
     }
-    
+
     private func createSpinner() {
         spinner.contentMode = .center
         spinner.translatesAutoresizingMaskIntoConstraints = false
         addSubview(spinner)
-        
+
         updateSpinnerIcon()
     }
-    
+
     override var intrinsicContentSize: CGSize {
         return spinner.image?.size ?? super.intrinsicContentSize
     }
-    
-    
+
     private func setupConstraints() {
         spinner.translatesAutoresizingMaskIntoConstraints = false
         spinner.centerInSuperview()
     }
-    
+
     private func startAnimationInternal() {
         isHidden = false
         stopAnimationInternal()
-        
+
         spinner.layer.add(CABasicAnimation(rotationSpeed: 1.4, beginTime: 0, delegate: nil), forKey: "rotateAnimation")
     }
-    
+
     private func stopAnimationInternal() {
         spinner.layer.removeAllAnimations()
     }
-    
+
     func updateSpinnerIcon() {
         spinner.image = UIImage.imageForIcon(.spinner, size: iconSize, color: color)
     }

--- a/Wire-iOS/Sources/UserInterface/Components/Loading/Spinner.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Loading/Spinner.swift
@@ -1,0 +1,108 @@
+
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+import Foundation
+
+final class Spinner: UIView {
+    
+    var color: UIColor = .white {
+        didSet {
+            updateSpinnerIcon()
+        }
+    }
+    
+    var iconSize: CGFloat = 32 {
+        didSet {
+            updateSpinnerIcon()
+        }
+    }
+    
+    
+    var isAnimating = false {
+        didSet {
+            guard oldValue != isAnimating else {
+                return
+            }
+            
+            isAnimating ? startAnimationInternal() : stopAnimationInternal()
+        }
+    }
+    
+    private let spinner: UIImageView = UIImageView()
+    
+    private var isAnimationRunning: Bool {
+        return spinner.layer.animation(forKey: "rotateAnimation") != nil
+    }
+    
+    init() {
+        super.init(frame: .zero)
+        setup()
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setup() {
+        createSpinner()
+        setupConstraints()
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        let frame = spinner.layer.frame
+        spinner.layer.anchorPoint = CGPoint(x: 0.5, y: 0.5)
+        spinner.layer.frame = frame
+    }
+    
+    private func createSpinner() {
+        spinner.contentMode = .center
+        spinner.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(spinner)
+        
+        updateSpinnerIcon()
+    }
+    
+    override var intrinsicContentSize: CGSize {
+        return spinner.image?.size ?? super.intrinsicContentSize
+    }
+    
+    
+    private func setupConstraints() {
+        spinner.translatesAutoresizingMaskIntoConstraints = false
+        spinner.centerInSuperview()
+    }
+    
+    private func startAnimationInternal() {
+        isHidden = false
+        stopAnimationInternal()
+        
+        spinner.layer.add(CABasicAnimation(rotationSpeed: 1.4, beginTime: 0, delegate: nil), forKey: "rotateAnimation")
+    }
+    
+    private func stopAnimationInternal() {
+        spinner.layer.removeAllAnimations()
+    }
+    
+    func updateSpinnerIcon() {
+        spinner.image = UIImage.imageForIcon(.spinner, size: iconSize, color: color)
+    }
+}

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Poll/ConversationButtonMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Poll/ConversationButtonMessageCell.swift
@@ -67,22 +67,24 @@ final class ConversationButtonMessageCell: UIView, ConversationMessageCell {
             return
         }
 
+        button.reset()
+        
         buttonAction = config.buttonAction
         button.setTitle(config.text, for: .normal)
 
         switch config.state {
         case .unselected:
-            button.style = .empty
             button.isLoading = false
             button.isEnabled = true
-        case .selected:
             button.style = .empty
+        case .selected:
             button.isLoading = true
             button.isEnabled = false
+            button.style = .empty
         case .confirmed:
-            button.style = .full
             button.isLoading = false
             button.isEnabled = false
+            button.style = .full
         }
 
         button.accessibilityValue = config.state.localizedName

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Poll/ConversationButtonMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Poll/ConversationButtonMessageCell.swift
@@ -54,6 +54,8 @@ final class ConversationButtonMessageCell: UIView, ConversationMessageCell {
 
     private var config: Configuration? {
         didSet {
+            buttonAction = config?.buttonAction
+
             guard config != oldValue else {
                 return
             }
@@ -66,25 +68,22 @@ final class ConversationButtonMessageCell: UIView, ConversationMessageCell {
         guard let config = config else {
             return
         }
-
-        button.reset()
         
-        buttonAction = config.buttonAction
         button.setTitle(config.text, for: .normal)
 
         switch config.state {
         case .unselected:
+            button.style = .empty
             button.isLoading = false
             button.isEnabled = true
-            button.style = .empty
         case .selected:
+            button.style = .empty
             button.isLoading = true
             button.isEnabled = false
-            button.style = .empty
         case .confirmed:
+            button.style = .full
             button.isLoading = false
             button.isEnabled = false
-            button.style = .full
         }
 
         button.accessibilityValue = config.state.localizedName


### PR DESCRIPTION
## What's new in this PR?

### Issues

1. `SpinnerButton` animation may not start with changing its `isAnimating` property
2. Spinner may be visible when the button has a solid color background

### Causes

1. `ProgressSpinner` has some code related to `UIWindow` and `UIApplication` which causes side effects to animation
2. `SpinnerButton`'s background image is not updated when switching style.

### Solutions

1. Create a simpler `Spinner` class just for `SpinnerButton`
2. Reset`SpinnerButton`'s background image when switching style.
