### PR TITLE
Feature: display poll message in conversation list cell status

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -229,7 +229,7 @@
 "conversation.voiceover.value.active" = "active";
 "conversation.voiceover.value.disabled" = "disabled";
 
-"conversation.status.poll.default" = "New Poll";
+"conversation.status.secutity_alert.default" = "New security alert";
 
 "conversation.status.typing" = "Typing a message…";
 "conversation.status.typing.group" = "%@: typing a message…";

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -229,6 +229,8 @@
 "conversation.voiceover.value.active" = "active";
 "conversation.voiceover.value.disabled" = "disabled";
 
+"conversation.status.poll.default" = "New Poll";
+
 "conversation.status.typing" = "Typing a message…";
 "conversation.status.typing.group" = "%@: typing a message…";
 "conversation.status.silenced" = "Muted";

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
@@ -33,6 +33,12 @@ protocol ConversationMessageSectionControllerDelegate: class {
     func messageSectionController(_ controller: ConversationMessageSectionController, didRequestRefreshForMessage message: ZMConversationMessage)
 }
 
+extension ZMConversationMessage {
+    var isComposite: Bool {
+        return (self as? ConversationCompositeMessage)?.isComposite == true
+    }
+}
+
 /**
  * An object that provides an interface to build list sections for a single message.
  *
@@ -121,7 +127,7 @@ final class ConversationMessageSectionController: NSObject, ZMMessageObserver {
 
         if message.isKnock {
             contentCellDescriptions = addPingMessageCells()
-        } else if (message as? ConversationCompositeMessage)?.isComposite == true {
+        } else if message.isComposite {
             contentCellDescriptions = addCompositeMessageCells
         } else if message.isText {
             contentCellDescriptions = ConversationTextMessageCellDescription.cells(for: message, searchQueries: context.searchQueries)

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListItemView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListItemView.swift
@@ -240,7 +240,8 @@ final class ConversationListItemView: UIView {
         // Configure the title and status
         let title: NSAttributedString?
         
-        if SelfUser.current.isTeamMember, let connectedUser = conversation.connectedUser {
+        if SelfUser.current.isTeamMember,
+           let connectedUser = conversation.connectedUser {
             title = AvailabilityStringBuilder.string(for: connectedUser, with: .list)
             
             if connectedUser.availability != .none {

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ZMConversation+Status.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ZMConversation+Status.swift
@@ -341,6 +341,45 @@ final class CallingMatcher: ConversationStatusMatcher {
     var combinesWith: [ConversationStatusMatcher] = []
 }
 
+final class PollMatcher: ConversationStatusMatcher {
+    func isMatching(with status: ConversationStatus) -> Bool {
+        return status.messagesRequiringAttention.contains(where: { $0.isComposite })
+    }
+    
+    func description(with status: ConversationStatus, conversation: ZMConversation) -> NSAttributedString? {
+
+        guard let message = status.messagesRequiringAttention.reversed().first(where: {
+            $0.isComposite
+        }) else {
+            return nil
+        }
+
+        let textItem = (message as? ConversationCompositeMessage)?.compositeMessageData?.items.first(where: {
+            if case let .text(_) = $0 {
+                return true
+            }
+            return false
+        })
+
+        let text: String
+        if let textItem = textItem,
+           case let .text(data) = textItem,
+           let messageText = data.messageText {
+            text = messageText
+        } else {
+            text = "conversation.status.poll.default".localized
+        }
+
+        return text && Swift.type(of: self).regularStyle
+    }
+    
+    func icon(with status: ConversationStatus, conversation: ZMConversation) -> ConversationStatusIcon? {
+        return nil ///TODO: icon for poll message
+    }
+    
+    var combinesWith: [ConversationStatusMatcher] = []
+}
+
 // "A, B, C: typing a message..."
 final class TypingMatcher: ConversationStatusMatcher {
     func isMatching(with status: ConversationStatus) -> Bool {
@@ -693,6 +732,7 @@ final class UnsernameMatcher: ConversationStatusMatcher {
 /*
  Matchers priorities (highest first):
  
+ (Poll)
  (SelfUserLeftMatcher)
  (Blocked)
  (Calling)
@@ -712,7 +752,16 @@ private var allMatchers: [ConversationStatusMatcher] = {
     let failedSendMatcher = FailedSendMatcher()
     failedSendMatcher.combinesWith = [silencedMatcher, newMessageMatcher, groupActivityMatcher]
     
-    return [SelfUserLeftMatcher(), BlockedMatcher(), CallingMatcher(), silencedMatcher, TypingMatcher(), newMessageMatcher, failedSendMatcher, groupActivityMatcher, StartConversationMatcher(), UnsernameMatcher()]
+    return [PollMatcher(),
+            SelfUserLeftMatcher(),
+            BlockedMatcher(),
+            CallingMatcher(),
+            silencedMatcher,
+            TypingMatcher(),
+            newMessageMatcher,
+            failedSendMatcher,
+            groupActivityMatcher,
+            StartConversationMatcher(), UnsernameMatcher()]
 }()
 
 extension ConversationStatus {
@@ -739,7 +788,7 @@ extension ConversationStatus {
     }
     
     func description(for conversation: ZMConversation) -> NSAttributedString {
-        let allMatchers = self.appliedMatchersForDescription(for: conversation)
+        let allMatchers = appliedMatchersForDescription(for: conversation)
         guard allMatchers.count > 0 else {
             return "" && [:]
         }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ZMConversation+Status.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ZMConversation+Status.swift
@@ -732,7 +732,7 @@ final class UnsernameMatcher: ConversationStatusMatcher {
 /*
  Matchers priorities (highest first):
  
- (Poll)
+ (SecurityAlert)
  (SelfUserLeftMatcher)
  (Blocked)
  (Calling)
@@ -843,4 +843,3 @@ extension ZMConversation {
         )
     }
 }
-

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ZMConversation+Status.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ZMConversation+Status.swift
@@ -341,7 +341,7 @@ final class CallingMatcher: ConversationStatusMatcher {
     var combinesWith: [ConversationStatusMatcher] = []
 }
 
-final class PollMatcher: ConversationStatusMatcher {
+final class SecurityAlertMatcher: ConversationStatusMatcher {
     func isMatching(with status: ConversationStatus) -> Bool {
         return status.messagesRequiringAttention.contains(where: { $0.isComposite })
     }
@@ -355,7 +355,7 @@ final class PollMatcher: ConversationStatusMatcher {
         }
 
         let textItem = (message as? ConversationCompositeMessage)?.compositeMessageData?.items.first(where: {
-            if case let .text(_) = $0 {
+            if case .text(_) = $0 {
                 return true
             }
             return false
@@ -748,11 +748,11 @@ private var allMatchers: [ConversationStatusMatcher] = {
     let silencedMatcher = SilencedMatcher()
     let newMessageMatcher = NewMessagesMatcher()
     let groupActivityMatcher = GroupActivityMatcher()
-    
+
     let failedSendMatcher = FailedSendMatcher()
     failedSendMatcher.combinesWith = [silencedMatcher, newMessageMatcher, groupActivityMatcher]
-    
-    return [PollMatcher(),
+
+    return [SecurityAlertMatcher(),
             SelfUserLeftMatcher(),
             BlockedMatcher(),
             CallingMatcher(),


### PR DESCRIPTION
## What's new in this PR?

Create `PollMatcher` to display poll message in the cell's subtitle.

### TODO
- [x] check why status subtitle is override by empty message. (Self poll creation message is overridden)