### PR TITLE
[Feature] Refresh team metadata daily

### DIFF
--- a/Wire-iOS Tests/TeamMetadataRefresherTests.swift
+++ b/Wire-iOS Tests/TeamMetadataRefresherTests.swift
@@ -1,0 +1,134 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+@testable import Wire
+
+class TeamMetadataRefresherTests: XCTestCase {
+
+    private var mockSelfUser: MockUserType!
+
+    override func setUp() {
+        super.setUp()
+        SelfUser.provider = self
+        mockSelfUser = .createSelfUser(name: "Alice", inTeam: UUID())
+    }
+
+    override func tearDown() {
+        SelfUser.provider = nil
+        mockSelfUser = nil
+    }
+
+    func test_it_does_not_crash_if_no_self_user() throws {
+        // Given
+        let sut = TeamMetadataRefresher()
+        SelfUser.provider = nil
+
+        // When
+        sut.triggerRefreshIfNeeded()
+
+        // Then nothing
+    }
+
+    func test_it_refreshes_for_a_team_member() {
+        // Given
+        let sut = TeamMetadataRefresher()
+
+        // Then
+        XCTAssertEqual(mockSelfUser.refreshTeamDataCount, 0)
+
+        // When
+        sut.triggerRefreshIfNeeded()
+
+        // Then
+        XCTAssertEqual(mockSelfUser.refreshTeamDataCount, 1)
+    }
+
+    func test_it_does_not_refresh_for_non_team_member() {
+        // Given
+        let sut = TeamMetadataRefresher()
+        mockSelfUser.teamIdentifier = nil
+
+        // Then
+        XCTAssertEqual(mockSelfUser.refreshTeamDataCount, 0)
+
+        // When
+        sut.triggerRefreshIfNeeded()
+
+        // Then
+        XCTAssertEqual(mockSelfUser.refreshTeamDataCount, 0)
+    }
+
+    func test_it_refreshes_if_timeout_expired() {
+        // Given
+        let sut = TeamMetadataRefresher(refreshInterval: 0.5)
+
+        // Then
+        XCTAssertEqual(mockSelfUser.refreshTeamDataCount, 0)
+
+        // When
+        sut.triggerRefreshIfNeeded()
+
+        // Then
+        XCTAssertEqual(mockSelfUser.refreshTeamDataCount, 1)
+
+        // When
+        let triggeredSecondRefresh = expectation(description: "triggered second refresh")
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            sut.triggerRefreshIfNeeded()
+            triggeredSecondRefresh.fulfill()
+        }
+
+        wait(for: [triggeredSecondRefresh], timeout: 2)
+
+        // Then
+        XCTAssertEqual(mockSelfUser.refreshTeamDataCount, 2)
+    }
+
+    func test_it_does_not_refresh_if_timeout_not_expired() {
+        // Given
+        let sut = TeamMetadataRefresher(refreshInterval: .oneMinute)
+
+        // Then
+        XCTAssertEqual(mockSelfUser.refreshTeamDataCount, 0)
+
+        // When
+        sut.triggerRefreshIfNeeded()
+
+        // Then
+        XCTAssertEqual(mockSelfUser.refreshTeamDataCount, 1)
+
+        // When
+        sut.triggerRefreshIfNeeded()
+
+        // Then
+        XCTAssertEqual(mockSelfUser.refreshTeamDataCount, 1)
+    }
+
+}
+
+// MARK: - Self User Provider
+
+extension TeamMetadataRefresherTests: SelfUserProvider {
+
+    public var selfUser: UserType & ZMEditableUser {
+        return mockSelfUser
+    }
+
+}

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1000,6 +1000,9 @@
 		EE1AFBFE2124330B003D1AE1 /* UNUserNotificationCenter+Permission.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1AFBFD2124330B003D1AE1 /* UNUserNotificationCenter+Permission.swift */; };
 		EE2538852166151C00932606 /* ConversationActionController+Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2538842166151C00932606 /* ConversationActionController+Notifications.swift */; };
 		EE2FC1D81F56F89800A9A418 /* ConversationImagesViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2FC1D71F56F89800A9A418 /* ConversationImagesViewControllerTests.swift */; };
+		EE34D6D924336A6600F5BD1C /* TeamMetadataRefresher.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE34D6D824336A6600F5BD1C /* TeamMetadataRefresher.swift */; };
+		EE34D6E1243373B100F5BD1C /* TimeInterval+Units.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE34D6E0243373B100F5BD1C /* TimeInterval+Units.swift */; };
+		EE34D6E32433767500F5BD1C /* TeamMetadataRefresherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE34D6E22433767500F5BD1C /* TeamMetadataRefresherTests.swift */; };
 		EE373FAB23FBF44B008C1E52 /* ConversationInputBarViewControllerDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE373FA923FBF438008C1E52 /* ConversationInputBarViewControllerDelegateTests.swift */; };
 		EE4332491F1A67E500096D90 /* PopUpIconButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4332481F1A67E500096D90 /* PopUpIconButton.swift */; };
 		EE43324B1F1A785800096D90 /* PopUpIconButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE43324A1F1A785800096D90 /* PopUpIconButtonView.swift */; };
@@ -2676,6 +2679,9 @@
 		EE1AFBFD2124330B003D1AE1 /* UNUserNotificationCenter+Permission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UNUserNotificationCenter+Permission.swift"; sourceTree = "<group>"; };
 		EE2538842166151C00932606 /* ConversationActionController+Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationActionController+Notifications.swift"; sourceTree = "<group>"; };
 		EE2FC1D71F56F89800A9A418 /* ConversationImagesViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConversationImagesViewControllerTests.swift; sourceTree = "<group>"; };
+		EE34D6D824336A6600F5BD1C /* TeamMetadataRefresher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamMetadataRefresher.swift; sourceTree = "<group>"; };
+		EE34D6E0243373B100F5BD1C /* TimeInterval+Units.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TimeInterval+Units.swift"; sourceTree = "<group>"; };
+		EE34D6E22433767500F5BD1C /* TeamMetadataRefresherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TeamMetadataRefresherTests.swift; path = "Wire-iOS Tests/TeamMetadataRefresherTests.swift"; sourceTree = SOURCE_ROOT; };
 		EE373FA923FBF438008C1E52 /* ConversationInputBarViewControllerDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationInputBarViewControllerDelegateTests.swift; sourceTree = "<group>"; };
 		EE4332481F1A67E500096D90 /* PopUpIconButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PopUpIconButton.swift; sourceTree = "<group>"; };
 		EE43324A1F1A785800096D90 /* PopUpIconButtonView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PopUpIconButtonView.swift; sourceTree = "<group>"; };
@@ -5085,6 +5091,8 @@
 				EEB8CD042410FFCC006FDE0B /* UserSet.swift */,
 				870534001DD6265100A7F822 /* AttributedStringOperators.swift */,
 				546B17632417A3D70091F4B3 /* CIContext+Shared.swift */,
+				EE34D6E0243373B100F5BD1C /* TimeInterval+Units.swift */,
+				EE34D6D824336A6600F5BD1C /* TeamMetadataRefresher.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -5564,6 +5572,7 @@
 				EE118BFF2031D17000BC68D6 /* MarkdownTextViewTests.swift */,
 				EE75B773203C6F5300855099 /* MarkdownTextStorageTests.swift */,
 				1651F9BA1D352C5300A9FAE8 /* ArticleViewTests.swift */,
+				EE34D6E22433767500F5BD1C /* TeamMetadataRefresherTests.swift */,
 				BFAD3A1B1CD1078500F0FBED /* Resources */,
 				5EA73D8D20D9038F0001D106 /* CheckmarkCellTests.swift */,
 				160D40F82410EC41002924A0 /* LoggingTest.swift */,
@@ -7618,6 +7627,7 @@
 				EF3BD6A0225CD4FE00ABB9B6 /* ShareContactsViewController.swift in Sources */,
 				5E936E8F20B590530060E6AA /* UIDevice+Platform.swift in Sources */,
 				EF1A461A21AD60510009B6B9 /* ReceiptOptionsSectionController.swift in Sources */,
+				EE34D6E1243373B100F5BD1C /* TimeInterval+Units.swift in Sources */,
 				5E423CD92295674900A5DB3A /* ConversationViewController+PrivacyAlert.swift in Sources */,
 				EEB8A2D01F628D1100958881 /* Settings+Account.swift in Sources */,
 				5E0EB1FB2100D80B00B5DC2B /* CompanyLoginFlowOpener.swift in Sources */,
@@ -7648,6 +7658,7 @@
 				D5DBAAAC20064DD700E9F65B /* TeamMemberInviteHeaderView.swift in Sources */,
 				EFDB3135217F5E0300D2A7CE /* ConversationListCell.swift in Sources */,
 				EEDEA26823ED609C000EF7E3 /* ContactsViewController+Invite.swift in Sources */,
+				EE34D6D924336A6600F5BD1C /* TeamMetadataRefresher.swift in Sources */,
 				EE1AFBFE2124330B003D1AE1 /* UNUserNotificationCenter+Permission.swift in Sources */,
 				A949418723E08AF6001B0373 /* Settings.swift in Sources */,
 				7C25D755214911AC002E22BF /* UserSearchResultsViewController.swift in Sources */,
@@ -8284,6 +8295,7 @@
 				162AE748219B26AF00581D98 /* ConversationSystemMessageTests.swift in Sources */,
 				EF1CB6F522B39CC0004CB458 /* CoreDataFixture.swift in Sources */,
 				EF01D28022B136A9009754B2 /* Data+FingerprintStringTests.swift in Sources */,
+				EE34D6E32433767500F5BD1C /* TeamMetadataRefresherTests.swift in Sources */,
 				EF91A0561FF3A05A00FE2F53 /* GiphySearchViewControllerTests.swift in Sources */,
 				EF2D6D38228C1FB300D8DBF4 /* MockPhotoLibrary.swift in Sources */,
 				EF15A7B620BC34F700A045C7 /* XCTestCase+ImageFromBundle.swift in Sources */,

--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -49,6 +49,8 @@ final class AppRootViewController: UIViewController {
 
     var authenticationCoordinator: AuthenticationCoordinator?
 
+    private let teamMetadataRefresher = TeamMetadataRefresher()
+
     // PopoverPresenter
     weak var presentedPopover: UIPopoverPresentationController?
     weak var popoverPointToView: UIView?
@@ -511,6 +513,7 @@ extension AppRootViewController {
 
     @objc fileprivate func applicationDidBecomeActive() {
         updateOverlayWindowFrame()
+        teamMetadataRefresher.triggerRefreshIfNeeded()
     }
 }
 

--- a/Wire-iOS/Sources/Helpers/TeamMetadataRefresher.swift
+++ b/Wire-iOS/Sources/Helpers/TeamMetadataRefresher.swift
@@ -1,0 +1,66 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/// A utility class to help trigger downloading team metadata for the self user.
+///
+/// It ensures the trigger is not made more than once within a specified time interval.
+
+final class TeamMetadataRefresher {
+
+    // MARK: - Properties
+
+    /// The minimum interval of time between consecutive refreshes. Defaults to 24 hours.
+
+    let refreshInterval: TimeInterval
+
+    // MARK: - Private Properties
+
+    private var dateOfLastRefresh: Date?
+
+    private var isTimeoutExpired: Bool {
+        guard let dateOfLastRefresh = dateOfLastRefresh else { return true }
+        let intervalSinceLastRefresh = -dateOfLastRefresh.timeIntervalSinceNow
+        return intervalSinceLastRefresh > refreshInterval
+    }
+
+    // MARK: - Init
+
+    init(refreshInterval: TimeInterval = .oneDay) {
+        self.refreshInterval = refreshInterval
+    }
+
+    // MARK: - Methods
+
+    /// Triggers a refresh of the team metadata of the self user, if needed.
+
+    func triggerRefreshIfNeeded() {
+        guard
+            let selfUser = SelfUser.provider?.selfUser,
+            selfUser.isTeamMember,
+            isTimeoutExpired
+        else {
+            return
+        }
+
+        selfUser.refreshTeamData()
+        dateOfLastRefresh = Date()
+    }
+
+}

--- a/Wire-iOS/Sources/Helpers/TimeInterval+Units.swift
+++ b/Wire-iOS/Sources/Helpers/TimeInterval+Units.swift
@@ -1,0 +1,28 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension TimeInterval {
+
+    static let oneDay: TimeInterval = 24 * oneHour
+    static let oneHour: TimeInterval = 60 * oneMinute
+    static let oneMinute: TimeInterval = 60 * oneSecond
+    static let oneSecond: TimeInterval = 1
+
+}


### PR DESCRIPTION
## What's new in this PR?

### Issues

Clients will no longer receive update events when the team metadata changes (e.g. team name, logo). Therefore the client needs to regularly fetch the team metadata from the backend.

### Solutions

It is sufficient to refresh the team metadata only once in a 24 hour period. `TeamMetadataRefresher` is a helper class that exposes the method `triggerRefreshIfNeeded()`. This method is called whenever the app becomes active. The method will only trigger a refresh if it has been 24 hours since the last refresh.

### Attachments

**JIRA:**  https://wearezeta.atlassian.net/browse/ZIOS-12822
