### PR TITLE
[Feature] Rename Contacts section to Recents for teams

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -56,7 +56,7 @@
 "peoplepicker.header.conversations" = "Groups";
 "peoplepicker.header.team_conversations" = "%@ Groups";
 "peoplepicker.header.send_invitation" = "Invite";
-"peoplepicker.header.contacts" = "Contacts";
+"peoplepicker.header.contacts" = "Recents";
 "peoplepicker.header.contacts_personal" = "Personal Contacts";
 "peoplepicker.header.directory" = "Connect";
 

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
@@ -176,7 +176,7 @@ class SearchResultsViewController : UIViewController {
         sectionController = SectionCollectionViewController()
         contactsSection = ContactsSectionController()
         contactsSection.selection = userSelection
-        contactsSection.title = team != nil ? "peoplepicker.header.contacts_personal".localized : "peoplepicker.header.contacts".localized
+        contactsSection.title = "peoplepicker.header.contacts_personal".localized
         contactsSection.allowsSelection = isAddingParticipants
         teamMemberAndContactsSection = ContactsSectionController()
         teamMemberAndContactsSection.allowsSelection = isAddingParticipants


### PR DESCRIPTION
## What's new in this PR?

We are renaming the "Contacts" section in search to "Recents", since it will no longer contain all your team members.