### PR TITLE
Bump AVS to 5.5.10.

### DIFF
--- a/avs-versions
+++ b/avs-versions
@@ -17,4 +17,4 @@
 # along with this program. If not, see http://www.gnu.org/licenses/.
 #
 
-export APPSTORE_AVS_VERSION=5.5.6
+export APPSTORE_AVS_VERSION=5.5.10


### PR DESCRIPTION
## What's new in this PR?

Bump AVS to 5.5.10

There are 2 important bug fixes that should make it into a release as soon as possible:

- Decrease amount of logging such that debug reports can be sent by email again
- Remove an unnecessary UPDATE for video call signaling
