### PR TITLE
[Fix] Always show availability status of other users

### DIFF
--- a/Wire-iOS Tests/AvailabilityStringBuilderTests.swift
+++ b/Wire-iOS Tests/AvailabilityStringBuilderTests.swift
@@ -47,35 +47,8 @@ final class AvailabilityStringBuilderTests: XCTestCase {
         super.tearDown()
     }
     
-    func testThatTheresNoAvailabilityInformationIfLimitIsReachedAndOtherUserIsTeammate() {
+    func testThatTheresAvailabilityInformationOtherUserIsNotTeammate() {
         // given
-        for _ in 1...(Team.membersOptimalLimit - 2) { // Saving two users for later
-            team1.members.insert(Member.insertNewObject(in: fixture.uiMOC))
-        }
-        let member = Member.insertNewObject(in: fixture.uiMOC)
-        member.user = otherUser
-        member.team = team1
-        
-        let selfMember = Member.insertNewObject(in: fixture.uiMOC)
-        selfMember.user = selfUser
-        selfMember.team = team1
-        
-        // when
-        let listString = AvailabilityStringBuilder.string(for: otherUser, with: .list)
-        let participantsString = AvailabilityStringBuilder.string(for: otherUser, with: .participants)
-        let placeholderString = AvailabilityStringBuilder.string(for: otherUser, with: .placeholder)
-        
-        // then
-        XCTAssertTrue(listString!.allAttachments.isEmpty)
-        XCTAssertTrue(participantsString!.allAttachments.isEmpty)
-        XCTAssertNil(placeholderString)
-    }
-    
-    func testThatTheresAvailabilityInformationIfLimitIsReachedAndOtherUserIsntTeammate() {
-        // given
-        for _ in 1...(Team.membersOptimalLimit - 1) { // Saving one users for later
-            team1.members.insert(Member.insertNewObject(in: fixture.uiMOC))
-        }
         let member = Member.insertNewObject(in: fixture.uiMOC)
         member.user = otherUser
         member.team = team2
@@ -96,11 +69,7 @@ final class AvailabilityStringBuilderTests: XCTestCase {
         XCTAssertNotNil(placeholderString)
     }
     
-    func testThatTheresAvailabilityInformationIfLimitIsntReached() {
-        // given
-        for _ in 1...(Team.membersOptimalLimit - 3) { // Saving two users for later + going under limit
-            team1.members.insert(Member.insertNewObject(in: fixture.uiMOC))
-        }
+    func testThatTheresAvailabilityInformationIfOtherUserIsTeamMember() {
         let member = Member.insertNewObject(in: fixture.uiMOC)
         member.user = otherUser
         member.team = team1
@@ -123,10 +92,6 @@ final class AvailabilityStringBuilderTests: XCTestCase {
     
     func testThatTheresAvailabilityInformationIfSelfUser() {
         // given
-        for _ in 1...(Team.membersOptimalLimit - 1) { // Saving one user for later
-            team1.members.insert(Member.insertNewObject(in: fixture.uiMOC))
-        }
-        
         let selfMember = Member.insertNewObject(in: fixture.uiMOC)
         selfMember.user = selfUser
         selfMember.team = team1

--- a/Wire-iOS Tests/Mocks/MockUser.m
+++ b/Wire-iOS Tests/Mocks/MockUser.m
@@ -141,7 +141,6 @@ static id<UserType> mockSelfUser = nil;
 @synthesize richProfile;
 @synthesize canCreateService;
 @synthesize oneToOneConversation;
-@synthesize shouldHideAvailability;
 @synthesize refreshDataCount;
 @synthesize refreshRichProfileCount;
 @synthesize refreshMembershipCount;

--- a/Wire-iOS Tests/Mocks/MockUserType.swift
+++ b/Wire-iOS Tests/Mocks/MockUserType.swift
@@ -154,8 +154,6 @@ class MockUserType: NSObject, UserType, Decodable {
 
     var isUnderLegalHold: Bool = false
 
-    var shouldHideAvailability: Bool = false
-
     var needsRichProfileUpdate: Bool = false
 
     // MARK: - Capabilities

--- a/Wire-iOS/Sources/UserInterface/Availability/AvailabilityStringBuilder.swift
+++ b/Wire-iOS/Sources/UserInterface/Availability/AvailabilityStringBuilder.swift
@@ -41,7 +41,7 @@
                 color = UIColor.from(scheme: .textForeground)
             }
             case .placeholder: do {
-                guard availability != .none && !user.shouldHideAvailability else { //Should use the default placeholder string
+                guard availability != .none else { //Should use the default placeholder string
                     return nil
                 }
                 title = "availability.\(availability.canonicalName)".localized.localizedUppercase
@@ -49,7 +49,7 @@
         }
         
         guard let textColor = color else { return nil }
-        let icon = user.shouldHideAvailability ? nil : AvailabilityStringBuilder.icon(for: availability, with: textColor, and: fontSize)
+        let icon = AvailabilityStringBuilder.icon(for: availability, with: textColor, and: fontSize)
         let attributedText = IconStringsBuilder.iconString(with: icon, title: title, interactive: false, color: textColor)
         return attributedText
     }

--- a/Wire-iOS/Sources/UserInterface/SelfProfile/ProfileHeaderViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/ProfileHeaderViewController.swift
@@ -296,13 +296,7 @@ final class ProfileHeaderViewController: UIViewController, Themeable {
     }
     
     private func updateAvailabilityVisibility() {
-        let isHidden: Bool
-        if user.shouldHideAvailability {
-            isHidden = true
-        } else {
-            isHidden = options.contains(.hideAvailability) || !options.contains(.allowEditingAvailability) && user.availability == .none
-        }
-        
+        let isHidden = options.contains(.hideAvailability) || !options.contains(.allowEditingAvailability) && user.availability == .none
         availabilityTitleViewController.view?.isHidden = isHidden
     }
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

Currently there exists code that disables displaying statuses of other users if the team contains more than 400 members. It has been decided that we now want to show the availability of all other users, if they have one.

### Solutions

Remove the related code.

### Dependencies

- [x] https://github.com/wireapp/wire-ios-data-model/pull/942
- [x] https://github.com/wireapp/wire-ios-request-strategy/pull/210

### Attachments

**JIRA:** https://wearezeta.atlassian.net/browse/ZIOS-12885