### PR TITLE
fix: Endless spinner on my Devices page when I only have 1 device

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
@@ -175,7 +175,8 @@ final class ClientListViewController: UIViewController,
     }
     
     private func dismissLoadingView() {
-        (navigationController as? SpinnerCapableViewController ?? self).isLoadingViewVisible = false
+        (navigationController as? SpinnerCapableViewController)?.isLoadingViewVisible = false        
+        isLoadingViewVisible = false
     }
     
     override var preferredStatusBarStyle: UIStatusBarStyle {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Spinner does not dismiss on `ClientListViewController`

### Causes

The spinner is show on `ClientListViewController` when init. But the dismiss method tries to dismiss it on its `navigationController `

### Solutions

Dismiss both spinners if presented.