### PR TITLE
[Fix] invalid SSO code alert not appearing

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Company Login/CompanyLoginController.swift
+++ b/Wire-iOS/Sources/UserInterface/Company Login/CompanyLoginController.swift
@@ -178,8 +178,8 @@ extension CompanyLoginController {
             ssoOnly: ssoOnly,
             error: error,
             completion: { [weak self] input, success in
-                input.apply(inputHandler)
                 self?.ssoAlert = nil
+                input.apply(inputHandler)
                 
                 // stop polling loop when cancel is pressed
                 if !success {


### PR DESCRIPTION
## What's new in this PR?

### Issues

When entering an invalid SSO code after pressing the "Enterprise login" button, we don't show the expected error alert.

### Causes

The error alert is triggered by:

```
input.apply(inputHandler)
```

but it's not shown due to the following guard statement:

```
// Do not repeatly show alert if exist
guard ssoAlert == nil else { return }
```

### Solutions

nil out `ssoAlert` before executing:
```
input.apply(inputHandler)
```

### Notes

JIRA: https://wearezeta.atlassian.net/browse/ZIOS-12922