### PR TITLE
Fix: sending a 4K video is allowed and it is not viewable on android

### DIFF
--- a/Wire-iOS Share Extension/UnsentSendable.swift
+++ b/Wire-iOS Share Extension/UnsentSendable.swift
@@ -286,9 +286,7 @@ class UnsentFileSendable: UnsentSendableBase, UnsentSendable {
             try data.write(to: tempFileURL)
 
             if UTTypeConformsTo(UTI as CFString, kUTTypeMovie) {
-                ///TODO: get from constant
-                AVURLAsset.convertVideoToUploadFormat(at: tempFileURL,
-                                                      fileLengthLimit: Int64.max) { (url, _, error) in
+                AVURLAsset.convertVideoToUploadFormat(at: tempFileURL) { (url, _, error) in
                     completion(url, error)
                 }
             } else {

--- a/Wire-iOS Share Extension/UnsentSendable.swift
+++ b/Wire-iOS Share Extension/UnsentSendable.swift
@@ -286,7 +286,9 @@ class UnsentFileSendable: UnsentSendableBase, UnsentSendable {
             try data.write(to: tempFileURL)
 
             if UTTypeConformsTo(UTI as CFString, kUTTypeMovie) {
-                AVURLAsset.convertVideoToUploadFormat(at: tempFileURL) { (url, _, error) in
+                ///TODO: get from constant
+                AVURLAsset.convertVideoToUploadFormat(at: tempFileURL,
+                                                      fileLengthLimit: Int64.max) { (url, _, error) in
                     completion(url, error)
                 }
             } else {

--- a/Wire-iOS Tests/CameraKeyboardViewControllerTests.swift
+++ b/Wire-iOS Tests/CameraKeyboardViewControllerTests.swift
@@ -80,7 +80,7 @@ private final class MockImageManager: ImageManagerProtocol {
 }
 
 fileprivate final class CallingMockCameraKeyboardViewController: CameraKeyboardViewController {
-    @objc override var shouldBlockCallingRelatedActions: Bool {
+    override var shouldBlockCallingRelatedActions: Bool {
         return true
     }
 }

--- a/Wire-iOS/Sources/Helpers/syncengine/ZMUserSession+Shared.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMUserSession+Shared.swift
@@ -20,6 +20,7 @@ import WireSyncEngine
 
 
 extension ZMUserSession {
+    static let MaxVideoWidth: UInt64 = 1920 // FullHD
     static let MaxFileSize: UInt64 = 25 * 1024 * 1024 // 25 megabytes
     private static let MaxTeamFileSize: UInt64 = 100 * 1024 * 1024 // 100 megabytes
     

--- a/Wire-iOS/Sources/Helpers/syncengine/ZMUserSession+Shared.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMUserSession+Shared.swift
@@ -16,20 +16,19 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
 import WireSyncEngine
 
-private let MaxFileSize: UInt64 = 25 * 1024 * 1024 // 25 megabytes
-private let MaxTeamFileSize: UInt64 = 100 * 1024 * 1024 // 100 megabytes
-
-private let MaxAudioLength: TimeInterval = 25 * 60.0 // 25 minutes
-private let MaxTeamAudioLength: TimeInterval = 100 * 60.0 // 100 minutes
-
-private let MaxVideoLength: TimeInterval = 4.0 * 60.0 // 4 minutes
-private let MaxTeamVideoLength: TimeInterval = 16.0 * 60.0 // 16 minutes
 
 extension ZMUserSession {
-    @objc(sharedSession)
+    private static let MaxFileSize: UInt64 = 25 * 1024 * 1024 // 25 megabytes
+    private static let MaxTeamFileSize: UInt64 = 100 * 1024 * 1024 // 100 megabytes
+    
+    private static let MaxAudioLength: TimeInterval = 25 * 60.0 // 25 minutes
+    private static let MaxTeamAudioLength: TimeInterval = 100 * 60.0 // 100 minutes
+    
+    private static let MaxVideoLength: TimeInterval = 4.0 * 60.0 // 4 minutes
+    private static let MaxTeamVideoLength: TimeInterval = 16.0 * 60.0 // 16 minutes
+
     static func shared() -> ZMUserSession? {
         return SessionManager.shared?.activeUserSession
     }
@@ -38,15 +37,15 @@ extension ZMUserSession {
         return ZMUser.selfUser(inUserSession: self).hasTeam
     }
     
-    func maxUploadFileSize() -> UInt64 {
-        return selfUserHasTeam ? MaxTeamFileSize : MaxFileSize
+    var maxUploadFileSize: UInt64 {
+        return selfUserHasTeam ? ZMUserSession.MaxTeamFileSize : ZMUserSession.MaxFileSize
     }
     
-    func maxAudioLength() -> TimeInterval {
-        return selfUserHasTeam ? MaxTeamAudioLength : MaxAudioLength
+    var maxAudioLength: TimeInterval {
+        return selfUserHasTeam ? ZMUserSession.MaxTeamAudioLength : ZMUserSession.MaxAudioLength
     }
     
-    func maxVideoLength() -> TimeInterval {
-        return selfUserHasTeam ? MaxTeamVideoLength : MaxVideoLength
+    var maxVideoLength: TimeInterval {
+        return selfUserHasTeam ? ZMUserSession.MaxTeamVideoLength : ZMUserSession.MaxVideoLength
     }
 }

--- a/Wire-iOS/Sources/Helpers/syncengine/ZMUserSession+Shared.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMUserSession+Shared.swift
@@ -18,34 +18,33 @@
 
 import WireSyncEngine
 
-
 extension ZMUserSession {
     static let MaxVideoWidth: UInt64 = 1920 // FullHD
     static let MaxFileSize: UInt64 = 25 * 1024 * 1024 // 25 megabytes
     private static let MaxTeamFileSize: UInt64 = 100 * 1024 * 1024 // 100 megabytes
-    
+
     private static let MaxAudioLength: TimeInterval = 25 * 60.0 // 25 minutes
     private static let MaxTeamAudioLength: TimeInterval = 100 * 60.0 // 100 minutes
-    
+
     private static let MaxVideoLength: TimeInterval = 4.0 * 60.0 // 4 minutes
     private static let MaxTeamVideoLength: TimeInterval = 16.0 * 60.0 // 16 minutes
 
     static func shared() -> ZMUserSession? {
         return SessionManager.shared?.activeUserSession
     }
-    
+
     private var selfUserHasTeam: Bool {
         return ZMUser.selfUser(inUserSession: self).hasTeam
     }
-    
+
     var maxUploadFileSize: UInt64 {
         return selfUserHasTeam ? ZMUserSession.MaxTeamFileSize : ZMUserSession.MaxFileSize
     }
-    
+
     var maxAudioLength: TimeInterval {
         return selfUserHasTeam ? ZMUserSession.MaxTeamAudioLength : ZMUserSession.MaxAudioLength
     }
-    
+
     var maxVideoLength: TimeInterval {
         return selfUserHasTeam ? ZMUserSession.MaxTeamVideoLength : ZMUserSession.MaxVideoLength
     }

--- a/Wire-iOS/Sources/Helpers/syncengine/ZMUserSession+Shared.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMUserSession+Shared.swift
@@ -20,7 +20,7 @@ import WireSyncEngine
 
 
 extension ZMUserSession {
-    private static let MaxFileSize: UInt64 = 25 * 1024 * 1024 // 25 megabytes
+    static let MaxFileSize: UInt64 = 25 * 1024 * 1024 // 25 megabytes
     private static let MaxTeamFileSize: UInt64 = 100 * 1024 * 1024 // 100 megabytes
     
     private static let MaxAudioLength: TimeInterval = 25 * 60.0 // 25 minutes

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
@@ -73,12 +73,11 @@ final class AudioRecordKeyboardViewController: UIViewController, AudioRecordBase
     
     // MARK: - Life Cycle
     
-    @objc convenience init() {
+    convenience init() {
         self.init(audioRecorder: AudioRecorder(
             format: .wav,
-            maxRecordingDuration: ZMUserSession.shared()?.maxAudioLength() ,
-            maxFileSize: ZMUserSession.shared()?.maxUploadFileSize()
-        ))
+            maxRecordingDuration: ZMUserSession.shared()?.maxAudioLength ,
+            maxFileSize: ZMUserSession.shared()?.maxUploadFileSize))
     }
     
     init(audioRecorder: AudioRecorderType) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordViewController.swift
@@ -72,8 +72,8 @@ final class AudioRecordViewController: UIViewController, AudioRecordBaseViewCont
     }
     
     init(audioRecorder: AudioRecorderType? = nil) {
-        let maxAudioLength = ZMUserSession.shared()?.maxAudioLength()
-        let maxUploadSize = ZMUserSession.shared()?.maxUploadFileSize()
+        let maxAudioLength = ZMUserSession.shared()?.maxAudioLength
+        let maxUploadSize = ZMUserSession.shared()?.maxUploadFileSize
         self.recorder = audioRecorder ?? AudioRecorder(format: .wav, maxRecordingDuration: maxAudioLength, maxFileSize: maxUploadSize)
         
         super.init(nibName: nil, bundle: nil)

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/AssetLibrary.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/AssetLibrary.swift
@@ -24,7 +24,7 @@ protocol AssetLibraryDelegate: class {
     func assetLibraryDidChange(_ library: AssetLibrary)
 }
 
-final class AssetLibrary: NSObject, PHPhotoLibraryChangeObserver {
+class AssetLibrary: NSObject, PHPhotoLibraryChangeObserver {
     weak var delegate: AssetLibraryDelegate?
     fileprivate var fetchingAssets = false
     public let synchronous: Bool

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/AssetLibrary.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/AssetLibrary.swift
@@ -24,13 +24,13 @@ protocol AssetLibraryDelegate: class {
     func assetLibraryDidChange(_ library: AssetLibrary)
 }
 
-class AssetLibrary: NSObject, PHPhotoLibraryChangeObserver {
+final class AssetLibrary: NSObject, PHPhotoLibraryChangeObserver {
     weak var delegate: AssetLibraryDelegate?
     fileprivate var fetchingAssets = false
     public let synchronous: Bool
     let photoLibrary: PhotoLibraryProtocol
 
-    open var count: UInt {
+    var count: UInt {
         guard let fetch = self.fetch else {
             return 0
         }
@@ -41,7 +41,7 @@ class AssetLibrary: NSObject, PHPhotoLibraryChangeObserver {
         case outOfRange, notLoadedError
     }
     
-    open func asset(atIndex index: UInt) throws -> PHAsset {
+    func asset(atIndex index: UInt) throws -> PHAsset {
         guard let fetch = self.fetch else {
             throw AssetError.notLoadedError
         }
@@ -52,7 +52,7 @@ class AssetLibrary: NSObject, PHPhotoLibraryChangeObserver {
         return fetch.object(at: Int(index))
     }
     
-    open func refetchAssets(synchronous: Bool = false) {
+    func refetchAssets(synchronous: Bool = false) {
         guard !self.fetchingAssets else {
             return
         }
@@ -74,7 +74,7 @@ class AssetLibrary: NSObject, PHPhotoLibraryChangeObserver {
         }
     }
 
-    open func photoLibraryDidChange(_ changeInstance: PHChange) {
+    public func photoLibraryDidChange(_ changeInstance: PHChange) {
 
         guard let fetch = self.fetch else {
             return

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
@@ -313,13 +313,15 @@ class CameraKeyboardViewController: UIViewController, SpinnerCapable {
             })
 
             AVURLAsset.convertVideoToUploadFormat(at: url, fileLengthLimit: Int64(fileLengthLimit)) { resultURL, asset, error in
+                DispatchQueue.main.async(execute: {
+                    self.isLoadingViewVisible = false
+                })
+                
                 guard error == nil,
                     let resultURL = resultURL,
                     let asset = asset else { return }
                 
                 DispatchQueue.main.async(execute: {
-                    self.isLoadingViewVisible = false
-
                     self.delegate?.cameraKeyboardViewController(self, didSelectVideo: resultURL, duration: CMTimeGetSeconds(asset.duration))
                 })
             }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
@@ -299,7 +299,8 @@ class CameraKeyboardViewController: UIViewController, SpinnerCapable {
 
     fileprivate func forwardSelectedVideoAsset(_ asset: PHAsset) {
         isLoadingViewVisible = true
-
+        guard let fileLengthLimit: UInt64 = ZMUserSession.shared()?.maxUploadFileSize else { return }
+        
         asset.getVideoURL() { url in
             DispatchQueue.main.async(execute: {
                 self.isLoadingViewVisible = false
@@ -311,15 +312,16 @@ class CameraKeyboardViewController: UIViewController, SpinnerCapable {
                 self.isLoadingViewVisible = true
             })
 
-            AVURLAsset.convertVideoToUploadFormat(at: url, fileLengthLimit: Int64(ZMUserSession.shared()!.maxUploadFileSize)) { resultURL, asset, error in
-                if error == nil,
-                    let resultURL = resultURL {
-                    DispatchQueue.main.async(execute: {
-                        self.isLoadingViewVisible = false
+            AVURLAsset.convertVideoToUploadFormat(at: url, fileLengthLimit: Int64(fileLengthLimit)) { resultURL, asset, error in
+                guard error == nil,
+                    let resultURL = resultURL,
+                    let asset = asset else { return }
+                
+                DispatchQueue.main.async(execute: {
+                    self.isLoadingViewVisible = false
 
-                        self.delegate?.cameraKeyboardViewController(self, didSelectVideo: resultURL, duration: CMTimeGetSeconds(asset!.duration))
-                    })
-                }
+                    self.delegate?.cameraKeyboardViewController(self, didSelectVideo: resultURL, duration: CMTimeGetSeconds(asset.duration))
+                })
             }
         }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
@@ -300,6 +300,7 @@ final class CameraKeyboardViewController: UIViewController, SpinnerCapable {
         }
     }
     
+    ///TODO: same process as pick from file
     fileprivate func forwardSelectedVideoAsset(_ asset: PHAsset) {
         let options = PHVideoRequestOptions()
         options.deliveryMode = .highQualityFormat
@@ -318,7 +319,7 @@ final class CameraKeyboardViewController: UIViewController, SpinnerCapable {
             }
                 
             let exportURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("video-export.mp4")
-            
+            ///TODO: no need to export video??
             exportSession.exportVideo(exportURL: exportURL) { url, error in
                 DispatchQueue.main.async(execute: {
                     self.isLoadingViewVisible = false

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
@@ -17,13 +17,10 @@
 // 
 
 
-import Foundation
 import Photos
 import Cartography
 import AVFoundation
 import UIKit
-import WireSystem
-import WireDataModel
 import WireSyncEngine
 
 private let zmLog = ZMSLog(tag: "UI")
@@ -39,7 +36,7 @@ protocol CameraKeyboardViewControllerDelegate: class {
 }
 
 
-class CameraKeyboardViewController: UIViewController, SpinnerCapable {
+final class CameraKeyboardViewController: UIViewController, SpinnerCapable {
     var dismissSpinner: SpinnerCompletion?
     
     fileprivate var permissions: PhotoPermissionsController!

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
@@ -353,31 +353,6 @@ final class CameraKeyboardViewController: UIViewController, SpinnerCapable {
     
 }
 
-extension PHAsset {
-    
-    func getVideoURL(completionHandler : @escaping ((_ responseURL : URL?) -> Void)){
-        guard mediaType == .video else {
-            completionHandler(nil)
-            return
-        }
-        
-            let options: PHVideoRequestOptions = PHVideoRequestOptions()
-            options.version = .current
-            options.deliveryMode = .highQualityFormat
-            options.isNetworkAccessAllowed = true
-            
-            PHImageManager.default().requestAVAsset(forVideo: self, options: options, resultHandler: {(asset: AVAsset?, audioMix: AVAudioMix?, info: [AnyHashable : Any]?) -> Void in
-                if let urlAsset = asset as? AVURLAsset {
-                    let localVideoUrl: URL = urlAsset.url as URL
-                    completionHandler(localVideoUrl)
-                } else {
-                    completionHandler(nil)
-                }
-            })
-        
-    }
-}
-
 extension CameraKeyboardViewController: UICollectionViewDelegateFlowLayout, UICollectionViewDelegate, UICollectionViewDataSource {
     func numberOfSections(in collectionView: UICollectionView) -> Int {
         defer { setupPhotoKeyboardAppearance() }
@@ -539,3 +514,26 @@ extension CameraKeyboardViewController: WireCallCenterCallStateObserver {
     }
 }
 
+extension PHAsset {
+    
+    func getVideoURL(completionHandler : @escaping ((_ responseURL : URL?) -> Void)){
+        guard mediaType == .video else {
+            completionHandler(nil)
+            return
+        }
+        
+        let options: PHVideoRequestOptions = PHVideoRequestOptions()
+        options.version = .current
+        options.deliveryMode = .highQualityFormat
+        options.isNetworkAccessAllowed = true
+        
+        PHImageManager.default().requestAVAsset(forVideo: self, options: options, resultHandler: {(asset: AVAsset?, audioMix: AVAudioMix?, info: [AnyHashable : Any]?) -> Void in
+            if let urlAsset = asset as? AVURLAsset {
+                let localVideoUrl: URL = urlAsset.url as URL
+                completionHandler(localVideoUrl)
+            } else {
+                completionHandler(nil)
+            }
+        })
+    }
+}

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import Photos
 import Cartography
 import AVFoundation
@@ -35,10 +34,9 @@ protocol CameraKeyboardViewControllerDelegate: class {
     func cameraKeyboardViewControllerWantsToOpenCameraRoll(_ controller: CameraKeyboardViewController)
 }
 
-
 final class CameraKeyboardViewController: UIViewController, SpinnerCapable {
     var dismissSpinner: SpinnerCompletion?
-    
+
     fileprivate var permissions: PhotoPermissionsController!
     fileprivate var lastLayoutSize = CGSize.zero
     fileprivate let collectionViewLayout = UICollectionViewFlowLayout()
@@ -51,8 +49,7 @@ final class CameraKeyboardViewController: UIViewController, SpinnerCapable {
                 UIView.animate(withDuration: 0.35, animations: {
                     self.goBackButton.alpha = self.goBackButtonRevealed ? 1 : 0
                 })
-            }
-            else {
+            } else {
                 self.goBackButton.alpha = 0
             }
         }
@@ -60,21 +57,21 @@ final class CameraKeyboardViewController: UIViewController, SpinnerCapable {
     fileprivate enum CameraKeyboardSection: UInt {
         case camera = 0, photos = 1
     }
-    
+
     let assetLibrary: AssetLibrary
     let imageManagerType: ImageManagerProtocol.Type
 
     var collectionView: UICollectionView!
     let goBackButton = IconButton()
     let cameraRollButton = IconButton()
-    
+
     let splitLayoutObservable: SplitLayoutObservable
     weak var delegate: CameraKeyboardViewControllerDelegate?
 
     deinit {
         NotificationCenter.default.removeObserver(self)
     }
-    
+
     init(splitLayoutObservable: SplitLayoutObservable,
          assetLibrary: AssetLibrary = AssetLibrary(),
          imageManagerType: ImageManagerProtocol.Type = PHImageManager.self,
@@ -87,16 +84,16 @@ final class CameraKeyboardViewController: UIViewController, SpinnerCapable {
         self.assetLibrary.delegate = self
         NotificationCenter.default.addObserver(self, selector: #selector(splitLayoutChanged(_:)), name: NSNotification.Name.SplitLayoutObservableDidChangeToLayoutSize, object: self.splitLayoutObservable)
         NotificationCenter.default.addObserver(self, selector: #selector(applicationDidBecomeActive(_:)), name: UIApplication.didBecomeActiveNotification, object: nil)
-        
+
         if let userSession = ZMUserSession.shared() {
             self.callStateObserverToken = WireCallCenterV3.addCallStateObserver(observer: self, userSession: userSession)
         }
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         if !self.lastLayoutSize.equalTo(self.view.bounds.size) {
@@ -105,14 +102,14 @@ final class CameraKeyboardViewController: UIViewController, SpinnerCapable {
             self.collectionView.reloadData()
         }
     }
-    
+
     @objc func applicationDidBecomeActive(_ notification: Notification!) {
         self.assetLibrary.refetchAssets()
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         setupViews()
         createConstraints()
     }
@@ -155,7 +152,7 @@ final class CameraKeyboardViewController: UIViewController, SpinnerCapable {
             cameraRollButton.centerY == goBackButton.centerY
         }
     }
-    
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.collectionViewLayout.invalidateLayout()
@@ -164,22 +161,22 @@ final class CameraKeyboardViewController: UIViewController, SpinnerCapable {
             self.assetLibrary.refetchAssets()
         }
     }
-    
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        
+
         // For right-to-left layout first cell is at the far right corner.
         // We need to scroll to it when initially showing controller and it seems there is no other way...
         DispatchQueue.main.async {
             self.scrollToCamera(animated: false)
         }
     }
-    
+
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         self.viewWasHidden = true
     }
-    
+
     fileprivate func createCollectionView() {
         self.collectionViewLayout.scrollDirection = .horizontal
         self.collectionView = UICollectionView(frame: CGRect.zero, collectionViewLayout: collectionViewLayout)
@@ -195,20 +192,20 @@ final class CameraKeyboardViewController: UIViewController, SpinnerCapable {
         self.collectionView.backgroundColor = UIColor.clear
         self.collectionView.bounces = false
     }
-    
+
     func scrollToCamera(animated: Bool) {
         let endOfListX = UIApplication.isLeftToRightLayout ? 0 : self.collectionView.contentSize.width - 10
         self.collectionView.scrollRectToVisible(CGRect(x: endOfListX, y: 0, width: 10, height: 10), animated: animated)
     }
-    
+
     @objc func goBackPressed(_ sender: AnyObject) {
         scrollToCamera(animated: true)
     }
-    
+
     @objc func openCameraRollPressed(_ sender: AnyObject) {
         self.delegate?.cameraKeyboardViewControllerWantsToOpenCameraRoll(self)
     }
-    
+
     @objc func splitLayoutChanged(_ notification: Notification!) {
         self.collectionViewLayout.invalidateLayout()
         self.collectionView.reloadData()
@@ -299,17 +296,17 @@ final class CameraKeyboardViewController: UIViewController, SpinnerCapable {
             })
         }
     }
-    
+
     fileprivate func forwardSelectedVideoAsset(_ asset: PHAsset) {
         isLoadingViewVisible = true
 
-        asset.getVideoURL(){ url in
+        asset.getVideoURL() { url in
             DispatchQueue.main.async(execute: {
                 self.isLoadingViewVisible = false
             })
-            
+
             guard let url = url else { return }
-                
+
             DispatchQueue.main.async(execute: {
                 self.isLoadingViewVisible = true
             })
@@ -325,11 +322,11 @@ final class CameraKeyboardViewController: UIViewController, SpinnerCapable {
                 }
             }
         }
-        
+
     }
-    
+
     fileprivate func setupPhotoKeyboardAppearance() {
-        
+
         if permissions.areCameraAndPhotoLibraryAuthorized {
             self.view.backgroundColor = .white
             self.collectionView.delaysContentTouches = true
@@ -337,7 +334,7 @@ final class CameraKeyboardViewController: UIViewController, SpinnerCapable {
             self.view.backgroundColor = .graphite
             self.collectionView.delaysContentTouches = false
         }
-        
+
         if permissions.isPhotoLibraryAuthorized {
             self.collectionViewLayout.minimumLineSpacing = 1
             self.collectionViewLayout.minimumInteritemSpacing = 0.5
@@ -350,7 +347,7 @@ final class CameraKeyboardViewController: UIViewController, SpinnerCapable {
             self.cameraRollButton.isHidden = true
         }
     }
-    
+
 }
 
 extension CameraKeyboardViewController: UICollectionViewDelegateFlowLayout, UICollectionViewDelegate, UICollectionViewDataSource {
@@ -361,10 +358,10 @@ extension CameraKeyboardViewController: UICollectionViewDelegateFlowLayout, UICo
         }
         return 2
     }
-    
+
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         guard permissions.areCameraOrPhotoLibraryAuthorized else { return 1 }
-        
+
         switch CameraKeyboardSection(rawValue: UInt(section))! {
         case .camera:
             return 1
@@ -372,34 +369,34 @@ extension CameraKeyboardViewController: UICollectionViewDelegateFlowLayout, UICo
             return permissions.isPhotoLibraryAuthorized ? Int(assetLibrary.count) : 1
         }
     }
-    
+
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        
+
         guard permissions.areCameraOrPhotoLibraryAuthorized else {
             return deniedAuthorizationCell(for: .cameraAndPhotos, collectionView: collectionView, indexPath: indexPath)
         }
-        
+
         switch CameraKeyboardSection(rawValue: UInt((indexPath as NSIndexPath).section))! {
         case .camera:
-            
+
             guard permissions.isCameraAuthorized else {
                 return deniedAuthorizationCell(for: .camera, collectionView: collectionView, indexPath: indexPath)
             }
-            
+
             if shouldBlockCallingRelatedActions {
                 return deniedAuthorizationCell(for: .ongoingCall, collectionView: collectionView, indexPath: indexPath)
             }
-            
+
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CameraCell.reuseIdentifier, for: indexPath) as! CameraCell
             cell.delegate = self
             return cell
-            
+
         case .photos:
-            
+
             guard permissions.isPhotoLibraryAuthorized else {
                 return deniedAuthorizationCell(for: .photos, collectionView: collectionView, indexPath: indexPath)
             }
-            
+
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: AssetCell.reuseIdentifier, for: indexPath) as! AssetCell
 
             cell.manager = imageManagerType.defaultInstance
@@ -408,38 +405,37 @@ extension CameraKeyboardViewController: UICollectionViewDelegateFlowLayout, UICo
                 cell.asset = asset
             }
 
-
             return cell
         }
     }
-    
+
     ///TODO: a protocol for this for testing
     @objc var shouldBlockCallingRelatedActions: Bool {
         return ZMUserSession.shared()?.isCallOngoing ?? false
     }
-    
+
     private func deniedAuthorizationCell(for type: DeniedAuthorizationType, collectionView: UICollectionView, indexPath: IndexPath) -> CameraKeyboardPermissionsCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CameraKeyboardPermissionsCell.reuseIdentifier,
                                                       for: indexPath) as! CameraKeyboardPermissionsCell
         cell.configure(deniedAuthorization: type)
         return cell
     }
-    
+
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         guard permissions.areCameraOrPhotoLibraryAuthorized else { return collectionView.frame.size }
-        
+
         switch CameraKeyboardSection(rawValue: UInt((indexPath as NSIndexPath).section))! {
         case .camera: return cameraCellSize
         case .photos:
             guard permissions.isPhotoLibraryAuthorized else {
                 return CGSize(width: self.view.bounds.size.width - cameraCellSize.width, height: self.view.bounds.size.height)
             }
-            
+
             let photoSize = self.view.bounds.size.height / 2 - 0.5
             return CGSize(width: photoSize, height: photoSize)
         }
     }
-    
+
     private var cameraCellSize: CGSize {
         switch self.splitLayoutObservable.layoutSize {
         case .compact:
@@ -448,41 +444,41 @@ extension CameraKeyboardViewController: UICollectionViewDelegateFlowLayout, UICo
             return CGSize(width: self.splitLayoutObservable.leftViewControllerWidth, height: self.view.bounds.size.height)
         }
     }
-    
+
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        
+
         guard permissions.areCameraOrPhotoLibraryAuthorized else { return }
-        
+
         switch CameraKeyboardSection(rawValue: UInt((indexPath as NSIndexPath).section))! {
         case .camera:
             break
         case .photos:
             guard permissions.isPhotoLibraryAuthorized else { return }
-            
+
             let asset = try! assetLibrary.asset(atIndex: UInt((indexPath as NSIndexPath).row))
-            
+
             switch asset.mediaType {
             case .video:
                 self.forwardSelectedVideoAsset(asset)
-            
+
             case .image:
                 self.forwardSelectedPhotoAsset(asset)
-                
+
             default:
                 // not supported
-                break;
+                break
             }
         }
     }
-    
+
     func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
         if cell is CameraCell || cell is CameraKeyboardPermissionsCell {
             self.goBackButtonRevealed = true
         }
     }
-    
+
     func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
-        if cell is CameraCell || cell is CameraKeyboardPermissionsCell  {
+        if cell is CameraCell || cell is CameraKeyboardPermissionsCell {
             self.goBackButtonRevealed = false
 
             (cell as? CameraCell)?.updateVideoOrientation()
@@ -490,12 +486,11 @@ extension CameraKeyboardViewController: UICollectionViewDelegateFlowLayout, UICo
     }
 }
 
-
 extension CameraKeyboardViewController: CameraCellDelegate {
     func cameraCellWantsToOpenFullCamera(_ cameraCell: CameraCell) {
         self.delegate?.cameraKeyboardViewControllerWantsToOpenFullScreenCamera(self)
     }
-    
+
     func cameraCell(_ cameraCell: CameraCell, didPickImageData imageData: Data) {
         self.delegate?.cameraKeyboardViewController(self, didSelectImageData: imageData, isFromCamera: true, uti: nil)
     }
@@ -508,26 +503,26 @@ extension CameraKeyboardViewController: AssetLibraryDelegate {
 }
 
 extension CameraKeyboardViewController: WireCallCenterCallStateObserver {
-    func callCenterDidChange(callState: CallState, conversation: ZMConversation, caller: UserType, timestamp: Date?, previousCallState: CallState?)  {
+    func callCenterDidChange(callState: CallState, conversation: ZMConversation, caller: UserType, timestamp: Date?, previousCallState: CallState?) {
         /// TODO fix undesired camera keyboard openings here
         self.collectionView.reloadItems(at: [IndexPath(item: 0, section: 0)])
     }
 }
 
 extension PHAsset {
-    
-    func getVideoURL(completionHandler : @escaping ((_ responseURL : URL?) -> Void)){
+
+    func getVideoURL(completionHandler : @escaping ((_ responseURL: URL?) -> Void)) {
         guard mediaType == .video else {
             completionHandler(nil)
             return
         }
-        
+
         let options: PHVideoRequestOptions = PHVideoRequestOptions()
         options.version = .current
         options.deliveryMode = .highQualityFormat
         options.isNetworkAccessAllowed = true
-        
-        PHImageManager.default().requestAVAsset(forVideo: self, options: options, resultHandler: {(asset: AVAsset?, audioMix: AVAudioMix?, info: [AnyHashable : Any]?) -> Void in
+
+        PHImageManager.default().requestAVAsset(forVideo: self, options: options, resultHandler: {(asset: AVAsset?, audioMix: AVAudioMix?, info: [AnyHashable: Any]?) -> Void in
             if let urlAsset = asset as? AVURLAsset {
                 let localVideoUrl: URL = urlAsset.url as URL
                 completionHandler(localVideoUrl)

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
@@ -34,7 +34,7 @@ protocol CameraKeyboardViewControllerDelegate: class {
     func cameraKeyboardViewControllerWantsToOpenCameraRoll(_ controller: CameraKeyboardViewController)
 }
 
-final class CameraKeyboardViewController: UIViewController, SpinnerCapable {
+class CameraKeyboardViewController: UIViewController, SpinnerCapable {
     var dismissSpinner: SpinnerCompletion?
 
     fileprivate var permissions: PhotoPermissionsController!

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
@@ -54,7 +54,7 @@ extension ConversationInputBarViewController: CameraKeyboardViewControllerDelega
         cameraKeyboardViewController.delegate = self
 
         self.cameraKeyboardViewController = cameraKeyboardViewController
-        
+
         return cameraKeyboardViewController
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
@@ -216,7 +216,7 @@ extension ConversationInputBarViewController: CameraKeyboardViewControllerDelega
 
         let videoURLAsset = AVURLAsset(url: NSURL(fileURLWithPath: inputPath) as URL)
 
-        videoURLAsset.convert(filename: filename) { URL, videoAsset, error in
+        videoURLAsset.convert(filename: filename, fileLengthLimit: Int64(ZMUserSession.shared()!.maxUploadFileSize)) { URL, videoAsset, error in
             guard let resultURL = URL, error == nil else {
                 completion(false, .none, 0)
                 return

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
@@ -92,7 +92,7 @@ extension ConversationInputBarViewController: CameraKeyboardViewControllerDelega
                 self.present(videoEditor, animated: true) {
                     }
             }
-        } else {
+        } else { ///TODO: no need ConfirmAssetViewController?
             let context = ConfirmAssetViewController.Context(asset: .video(url: videoURL),
                                                              onConfirm: { [unowned self] (editedImage: UIImage?) in
                                                                             self.dismiss(animated: true)

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
@@ -58,13 +58,14 @@ extension ConversationInputBarViewController: CameraKeyboardViewControllerDelega
         return cameraKeyboardViewController
     }
 
+    ///TODO: same process as select video
     func cameraKeyboardViewController(_ controller: CameraKeyboardViewController, didSelectVideo videoURL: URL, duration: TimeInterval) {
         // Video can be longer than allowed to be uploaded. Then we need to add user the possibility to trim it.
-        if duration > ZMUserSession.shared()!.maxVideoLength() {
+        if duration > ZMUserSession.shared()!.maxVideoLength {
             let videoEditor = StatusBarVideoEditorController()
             videoEditor.transitioningDelegate = FastTransitioningDelegate.sharedDelegate
             videoEditor.delegate = self
-            videoEditor.videoMaximumDuration = ZMUserSession.shared()!.maxVideoLength()
+            videoEditor.videoMaximumDuration = ZMUserSession.shared()!.maxVideoLength
             videoEditor.videoPath = videoURL.path
             videoEditor.videoQuality = .typeMedium
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
@@ -58,7 +58,6 @@ extension ConversationInputBarViewController: CameraKeyboardViewControllerDelega
         return cameraKeyboardViewController
     }
 
-    ///TODO: same process as select video
     func cameraKeyboardViewController(_ controller: CameraKeyboardViewController, didSelectVideo videoURL: URL, duration: TimeInterval) {
         // Video can be longer than allowed to be uploaded. Then we need to add user the possibility to trim it.
         if duration > ZMUserSession.shared()!.maxVideoLength {
@@ -92,7 +91,7 @@ extension ConversationInputBarViewController: CameraKeyboardViewControllerDelega
                 self.present(videoEditor, animated: true) {
                     }
             }
-        } else { ///TODO: no need ConfirmAssetViewController?
+        } else {
             let context = ConfirmAssetViewController.Context(asset: .video(url: videoURL),
                                                              onConfirm: { [unowned self] (editedImage: UIImage?) in
                                                                             self.dismiss(animated: true)

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Files.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Files.swift
@@ -109,7 +109,7 @@ extension ConversationInputBarViewController {
     ///
     /// - Parameter url: the URL of the file
     func uploadFile(at url: URL) {
-        guard let maxUploadFileSize = ZMUserSession.shared()?.maxUploadFileSize() else { return }
+        guard let maxUploadFileSize = ZMUserSession.shared()?.maxUploadFileSize else { return }
 
         let completion: Completion = { [weak self] in
             self?.removeItem(atPath: url.path)
@@ -179,7 +179,7 @@ extension ConversationInputBarViewController {
     }
 
     private func showAlertForFileTooBig() {
-        guard let maxUploadFileSize = ZMUserSession.shared()?.maxUploadFileSize() else { return }
+        guard let maxUploadFileSize = ZMUserSession.shared()?.maxUploadFileSize else { return }
 
         let maxSizeString = ByteCountFormatter.string(fromByteCount: Int64(maxUploadFileSize), countStyle: .binary)
         let errorMessage = String(format: "content.file.too_big".localized, maxSizeString)

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Files.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Files.swift
@@ -126,7 +126,7 @@ extension ConversationInputBarViewController {
             return
         }
 
-        guard (fileSize ?? UInt64.max) <= maxUploadFileSize else {
+        guard (fileSize ?? UInt64.max) <= maxUploadFileSize else {//TODO: file size still  beyond limit after setting file size 66MB
             // file exceeds maximum allowed upload size
             parent?.dismiss(animated: false)
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Files.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Files.swift
@@ -126,7 +126,7 @@ extension ConversationInputBarViewController {
             return
         }
 
-        guard (fileSize ?? UInt64.max) <= maxUploadFileSize else {//TODO: file size still  beyond limit after setting file size 66MB
+        guard (fileSize ?? UInt64.max) <= maxUploadFileSize else {
             // file exceeds maximum allowed upload size
             parent?.dismiss(animated: false)
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+FilesPopover.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+FilesPopover.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
 import MobileCoreServices
 import WireSyncEngine
 
@@ -72,7 +71,7 @@ extension ConversationInputBarViewController {
                                            style: .default,
                                            handler: plistHandler))
 
-        let size = UInt(ZMUserSession.shared()?.maxUploadFileSize() ?? 0) + 1
+        let size = UInt(ZMUserSession.shared()?.maxUploadFileSize ?? 0) + 1
         let humanReadableSize = size / 1024 / 1024
         controller.addAction(uploadTestAlertAction(size: size, title: "Big file (size = \(humanReadableSize) MB)", fileName: "BigFile.bin"))
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+ImagePicker.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+ImagePicker.swift
@@ -42,6 +42,7 @@ extension ConversationInputBarViewController {
             // Don't crash on Simulator
         }
 
+        ///TODO: camera keyboard, trim?
         let presentController = {() -> Void in
 
             let context = ImagePickerPopoverPresentationContext(presentViewController: rootViewController,
@@ -112,7 +113,7 @@ extension ConversationInputBarViewController {
         if picker.sourceType == UIImagePickerController.SourceType.camera && UIVideoAtPathIsCompatibleWithSavedPhotosAlbum(videoTempURL.path) {
             UISaveVideoAtPathToSavedPhotosAlbum(videoTempURL.path, self, #selector(video(_:didFinishSavingWithError:contextInfo:)), nil)
         }
-
+        ///TODO: use this for the camera keyboard
         AVURLAsset.convertVideoToUploadFormat(at: videoTempURL) { resultURL, asset, error in
             if error == nil,
                let resultURL = resultURL {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+ImagePicker.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+ImagePicker.swift
@@ -42,7 +42,6 @@ extension ConversationInputBarViewController {
             // Don't crash on Simulator
         }
 
-        ///TODO: camera keyboard, trim?
         let presentController = {() -> Void in
 
             let context = ImagePickerPopoverPresentationContext(presentViewController: rootViewController,
@@ -89,7 +88,6 @@ extension ConversationInputBarViewController {
 
     func processVideo(info: [UIImagePickerController.InfoKey: Any],
                       picker: UIImagePickerController) {
-        ///TODO: we can use PHAsset key?
         guard let videoURL = info[UIImagePickerController.InfoKey.mediaURL] as? URL else {
             parent?.dismiss(animated: true)
             zmLog.error("Video not provided form \(picker): info \(info)")
@@ -117,7 +115,7 @@ extension ConversationInputBarViewController {
         if picker.sourceType == UIImagePickerController.SourceType.camera && UIVideoAtPathIsCompatibleWithSavedPhotosAlbum(videoTempURL.path) {
             UISaveVideoAtPathToSavedPhotosAlbum(videoTempURL.path, self, #selector(video(_:didFinishSavingWithError:contextInfo:)), nil)
         }
-        ///TODO: use this for the camera keyboard
+
         AVURLAsset.convertVideoToUploadFormat(at: videoTempURL, fileLengthLimit: Int64(ZMUserSession.shared()!.maxUploadFileSize)) { resultURL, asset, error in
             if error == nil,
                let resultURL = resultURL {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+ImagePicker.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+ImagePicker.swift
@@ -86,6 +86,7 @@ extension ConversationInputBarViewController {
 
     func processVideo(info: [UIImagePickerController.InfoKey: Any],
                       picker: UIImagePickerController) {
+        ///TODO: we can use PHAsset key?
         guard let videoURL = info[UIImagePickerController.InfoKey.mediaURL] as? URL else {
             parent?.dismiss(animated: true)
             zmLog.error("Video not provided form \(picker): info \(info)")
@@ -114,7 +115,7 @@ extension ConversationInputBarViewController {
             UISaveVideoAtPathToSavedPhotosAlbum(videoTempURL.path, self, #selector(video(_:didFinishSavingWithError:contextInfo:)), nil)
         }
         ///TODO: use this for the camera keyboard
-        AVURLAsset.convertVideoToUploadFormat(at: videoTempURL) { resultURL, asset, error in
+        AVURLAsset.convertVideoToUploadFormat(at: videoTempURL, fileLengthLimit: Int64(ZMUserSession.shared()!.maxUploadFileSize)) { resultURL, asset, error in
             if error == nil,
                let resultURL = resultURL {
                 self.uploadFile(at: resultURL)

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+ImagePicker.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+ImagePicker.swift
@@ -51,7 +51,7 @@ extension ConversationInputBarViewController {
             pickerController.delegate = self
             pickerController.allowsEditing = allowsEditing
             pickerController.mediaTypes = mediaTypes
-            pickerController.videoMaximumDuration = ZMUserSession.shared()!.maxVideoLength()
+            pickerController.videoMaximumDuration = ZMUserSession.shared()!.maxVideoLength
 
             if let popover = pickerController.popoverPresentationController,
                 let imageView = pointToView {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+ImagePicker.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+ImagePicker.swift
@@ -53,6 +53,9 @@ extension ConversationInputBarViewController {
             pickerController.allowsEditing = allowsEditing
             pickerController.mediaTypes = mediaTypes
             pickerController.videoMaximumDuration = ZMUserSession.shared()!.maxVideoLength
+            if #available(iOS 11.0, *) {
+                pickerController.videoExportPreset = AVURLAsset.defaultVideoQuality
+            }
 
             if let popover = pickerController.popoverPresentationController,
                 let imageView = pointToView {

--- a/WireCommonComponents/AVAsset+VideoConvert.swift
+++ b/WireCommonComponents/AVAsset+VideoConvert.swift
@@ -85,8 +85,20 @@ extension AVURLAsset {
         let filename = url.deletingPathExtension().lastPathComponent + ".mp4"
         let asset: AVURLAsset = AVURLAsset(url: url, options: nil)
         
+        guard let track = AVAsset(url: url as URL).tracks(withMediaType: AVMediaType.video).first else { return }
+        let size = track.naturalSize
+
+        
+        let cappedQuality: String
+        
+        if size.width > 1920 || size.height > 1920 {
+            cappedQuality = AVAssetExportPreset1920x1080
+        } else {
+            cappedQuality = quality
+        }
+        
         asset.convert(filename: filename,
-                      quality: quality, fileLengthLimit: fileLengthLimit) { URL, asset, error in
+                      quality: cappedQuality, fileLengthLimit: fileLengthLimit) { URL, asset, error in
             
             completion(URL, asset, error)
             

--- a/WireCommonComponents/AVAsset+VideoConvert.swift
+++ b/WireCommonComponents/AVAsset+VideoConvert.swift
@@ -80,7 +80,7 @@ extension AVURLAsset {
     public static func convertVideoToUploadFormat(at url: URL,
                                                   quality: String = AVURLAsset.defaultVideoQuality,
                                                   deleteSourceFile: Bool = true,
-                                                  fileLengthLimit: Int64,
+                                                  fileLengthLimit: Int64? = nil,
                                                   completion: @escaping ConvertVideoCompletion ) {
         let filename = url.deletingPathExtension().lastPathComponent + ".mp4"
         let asset: AVURLAsset = AVURLAsset(url: url, options: nil)
@@ -114,7 +114,7 @@ extension AVURLAsset {
 
     public func convert(filename: String,
                         quality: String = defaultVideoQuality,
-                        fileLengthLimit: Int64,
+                        fileLengthLimit: Int64? = nil,
                         completion: @escaping ConvertVideoCompletion) {
         let outputURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(filename)
         
@@ -126,10 +126,11 @@ extension AVURLAsset {
             }
         }
         
-        ///TODO: size
         guard let exportSession = AVAssetExportSession(asset: self, presetName: quality) else { return }
         
-        exportSession.fileLengthLimit = fileLengthLimit
+        if let fileLengthLimit = fileLengthLimit {
+            exportSession.fileLengthLimit = fileLengthLimit
+        }
         
         exportSession.exportVideo(exportURL: outputURL) { url, error in
             DispatchQueue.main.async(execute: {

--- a/WireCommonComponents/AVAsset+VideoConvert.swift
+++ b/WireCommonComponents/AVAsset+VideoConvert.swift
@@ -100,7 +100,7 @@ extension AVURLAsset {
     }
 
     public func convert(filename: String,
-                        quality: String = AVAssetExportPresetHighestQuality,
+                        quality: String = defaultVideoQuality,
                         completion: @escaping ConvertVideoCompletion) {
         let outputURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(filename)
         


### PR DESCRIPTION
## What's new in this PR?

### Issues

When sending a video from camera keyboard, the file can exceed file size limit and not visible on Android devices. (Sending form image picker has no such issue)

### Causes

If pick a 4K video from the camera keyboard, the video is not resized. (Pick from image picker would have default quality, which is 720p)

### Solutions

If the video has a width wider than 1920px, Export the video with `AVAssetExportPreset1920x1080`.
Set default video preset when select a video from image picker.
Set `fileLengthLimit` to self user's max file size limit.