### PR TITLE
[Feature]: digital signature show error

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageAction.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageAction.swift
@@ -94,7 +94,11 @@ extension ConversationContentViewController {
             }
         case .digitallySign:
             dataSource.selectedMessage = message
-            digitalSignatureToken = message.fileMessageData?.signPDFDocument(observer: self)
+            guard let token = message.fileMessageData?.signPDFDocument(observer: self) else {
+                didFailSignature()
+                return
+            }
+            digitalSignatureToken = token
         case .edit:
             dataSource.editingMessage = message
             delegate?.conversationContentViewController(self, didTriggerEditing: message)


### PR DESCRIPTION
## What's new in this PR?

when we have no message data in the cache to start the digital signature process an error is shown.
