### PR TITLE
[Feature] Digital Signature download alert

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -426,6 +426,7 @@
 
 // Digital signature
 "digital_signature.alert.error" = "Unfortunately, your digital signature failed.";
+"digital_signature.alert.download_necessary" = "Please download the document before sign in";
 
 // New conversation participants added / removed / started system message
 

--- a/Wire-iOS/Sources/Helpers/syncengine/ZMMessage+Actions.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMMessage+Actions.swift
@@ -22,7 +22,12 @@ extension ZMConversationMessage {
 
     /// Whether the message can be digitally signed in.
     var canBeDigitallySigned: Bool {
-        guard SelfUser.current.phoneNumber != nil else {
+        guard
+            SelfUser.current.phoneNumber != nil
+            // TO DO: uncomment before QA test in production.
+            // Development BE doean't support Team Membership.
+//            SelfUser.current.isTeamMember
+        else {
             return false
         }
         return isPDF

--- a/Wire-iOS/Sources/Helpers/syncengine/ZMMessage+Actions.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMMessage+Actions.swift
@@ -22,10 +22,7 @@ extension ZMConversationMessage {
 
     /// Whether the message can be digitally signed in.
     var canBeDigitallySigned: Bool {
-        guard
-            isFileDownloaded(),
-            SelfUser.current.phoneNumber != nil
-        else {
+        guard SelfUser.current.phoneNumber != nil else {
             return false
         }
         return isPDF

--- a/Wire-iOS/Sources/Helpers/syncengine/ZMMessage+Actions.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMMessage+Actions.swift
@@ -22,7 +22,10 @@ extension ZMConversationMessage {
 
     /// Whether the message can be digitally signed in.
     var canBeDigitallySigned: Bool {
-        guard SelfUser.current.phoneNumber != nil else {
+        guard
+            isFileDownloaded(),
+            SelfUser.current.phoneNumber != nil
+        else {
             return false
         }
         return isPDF

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageAction.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageAction.swift
@@ -171,11 +171,8 @@ extension ConversationContentViewController {
                                                 message: alertMessage,
                                                 preferredStyle: .alert)
         let downloadAction = UIAlertAction(title: "content.message.download".localized,
-                                           style: .default) { [weak self] _ in
+                                           style: .default) { _ in
                 message.fileMessageData?.requestFileDownload()
-                                            
-                self?.fileAvailabilityObserver = MessageKeyPathObserver(message: message,
-                                                                        keypath: \.fileAvailabilityChanged)
         }
         
         alertController.addAction(downloadAction)

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageAction.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageAction.swift
@@ -178,7 +178,6 @@ extension ConversationContentViewController {
                                                                         keypath: \.fileAvailabilityChanged)
         }
         
-        
         alertController.addAction(downloadAction)
         present(alertController, animated: true)
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
@@ -55,6 +55,7 @@ final class ConversationContentViewController: UIViewController, PopoverPresente
     let session: ZMUserSessionInterface
     var connectionViewController: UserConnectionViewController?
     var digitalSignatureToken: Any?
+    var fileAvailabilityObserver: MessageKeyPathObserver?
     var isDigitalSignatureVerificationShown: Bool = false
     
     private var mediaPlaybackManager: MediaPlaybackManager?

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
@@ -55,7 +55,6 @@ final class ConversationContentViewController: UIViewController, PopoverPresente
     let session: ZMUserSessionInterface
     var connectionViewController: UserConnectionViewController?
     var digitalSignatureToken: Any?
-    var fileAvailabilityObserver: MessageKeyPathObserver?
     var isDigitalSignatureVerificationShown: Bool = false
     
     private var mediaPlaybackManager: MediaPlaybackManager?


### PR DESCRIPTION
## What's new in this PR?

To digital sign a PDF it is necessary that it is already downloaded. When the PDF is not downloaded the client shows and alert and when the user tap on "download" the PDF will be downloaded.