### PR TITLE
[Fix] poll button spinner

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
@@ -138,6 +138,7 @@ final class ConversationContentViewController: UIViewController, PopoverPresente
     private func applicationDidBecomeActive(_ notification: Notification) {
         dataSource.resetSectionControllers()
         tableView.reloadData()
+        dataSource.loadMessages()
     }
     
     override func viewDidAppear(_ animated: Bool) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
@@ -138,7 +138,6 @@ final class ConversationContentViewController: UIViewController, PopoverPresente
     private func applicationDidBecomeActive(_ notification: Notification) {
         dataSource.resetSectionControllers()
         tableView.reloadData()
-        dataSource.loadMessages()
     }
     
     override func viewDidAppear(_ animated: Bool) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
@@ -64,6 +64,7 @@ final class ConversationTableViewDataSource: NSObject {
     
     @objc func resetSectionControllers() {
         sectionControllers = [:]
+        calculateSections()
     }
     
     public var actionControllers: [String: ConversationMessageActionController] = [:]
@@ -106,6 +107,7 @@ final class ConversationTableViewDataSource: NSObject {
     ///
     /// - Parameter forceRecalculate: true if force recreate cell with context check
     /// - Returns: arraySection of cell desctiptions
+    @discardableResult
     func calculateSections(forceRecalculate: Bool = false) -> [ArraySection<String, AnyConversationMessageCellDescription>] {
         return messages.enumerated().map { tuple in
             let sectionIdentifier = tuple.element.objectIdentifier


### PR DESCRIPTION
## What's new in this PR?

### Issues

GIVEN There is a poll message
WHEN The app becomes active (after being in background)
THEN Spinner doesn't show on selected buttons
AND User needs to navigate back and forth to the conversation to refresh buttons statuses

### Causes

The main conversation controller (`ConversationContentViewController`) reacts to `applicationDidBecomeActive` notification by calling `dataSource.resetSectionControllers()`.

Resetting the section controllers causes the `ConversationMessageSectionController` to be deallocated. Which in turn prevents observation of the `ButtonState` of our buttons. Thus, when a button is selected and its state changes, we don't notice and can't update the UI.

### Solutions

According to a conversation with @typfel:
Originally, the logic in `applicationDidBecomeActive` is to reload everything after coming back from the background, since otherwise we might display out of date data.

At first glance, calling `tableView.reloadData()` should reinstantiate the section controllers.
However, it doesn't work. Instead, calling ` dataSource.loadMessages()` in `applicationDidBecomeActive` does.


