### PR TITLE
Fix: do not force cast MockUser to ZMUser for device target

### DIFF
--- a/Wire-iOS/Sources/Helpers/syncengine/ZMUser+Self.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMUser+Self.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2019 Wire Swiss GmbH
+// Copyright (C) 2020 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -17,9 +17,9 @@
 //
 
 import Foundation
-import WireDataModel
 import WireSyncEngine
 
+#if targetEnvironment(simulator)
 typealias EditableUser = ZMUser & ZMEditableUser
 
 protocol SelfUserProviderUI {
@@ -31,7 +31,6 @@ extension ZMUser {
     /// Return self's User object
     ///
     /// - Returns: a ZMUser<ZMEditableUser> object for app target, or a MockUser object for test.
-    @objc
     static func selfUser() -> EditableUser! {
 
         if let mockUserClass = NSClassFromString("MockUser") as? SelfUserProviderUI.Type {
@@ -43,3 +42,16 @@ extension ZMUser {
         }
     }
 }
+#else
+extension ZMUser {
+
+    /// Return self's User object
+    ///
+    /// - Returns: a ZMUser object for app target
+    static func selfUser() -> ZMUser! {
+        guard let session = ZMUserSession.shared() else { return nil }
+
+        return ZMUser.selfUser(inUserSession: session)
+    }
+}
+#endif


### PR DESCRIPTION
## What's new in this PR?

### Issues

When archive the project for release, Xcode 11 fails due to `While emitting IR SIL function "@$s4Wire36ConversationListTopBarViewControllerC014createSettingsfG0So06UIViewG0CyFTf4d_n".`

### Causes

It is related to casting `MockUser` to unrelated class `ZMUser`.

### Solutions

Cast in Simulator target only.