### PR TITLE
Tier1: Revert contacts title in startUI to "Contacts"

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -56,7 +56,7 @@
 "peoplepicker.header.conversations" = "Groups";
 "peoplepicker.header.team_conversations" = "%@ Groups";
 "peoplepicker.header.send_invitation" = "Invite";
-"peoplepicker.header.contacts" = "Recents";
+"peoplepicker.header.contacts" = "Contacts";
 "peoplepicker.header.contacts_personal" = "Personal Contacts";
 "peoplepicker.header.directory" = "Connect";
 


### PR DESCRIPTION
## What's new in this PR?

Undo section header title.