### PR TITLE
fix: crash - share extension crashes when search a name

### DIFF
--- a/Wire-iOS Share Extension/ConversationSelectionViewController.swift
+++ b/Wire-iOS Share Extension/ConversationSelectionViewController.swift
@@ -24,7 +24,7 @@ import WireShareEngine
 private let cellReuseIdentifier = "ConversationCell"
 
 
-class ConversationSelectionViewController : UITableViewController {
+final class ConversationSelectionViewController : UITableViewController {
     
     fileprivate var allConversations : [Conversation]
     fileprivate var visibleConversations : [Conversation]
@@ -89,9 +89,12 @@ class ConversationSelectionViewController : UITableViewController {
 extension ConversationSelectionViewController : UISearchResultsUpdating {
     func updateSearchResults(for searchController: UISearchController) {
         if let searchText = searchController.searchBar.text, !searchText.isEmpty {
-            let predicate = NSPredicate(format: "name CONTAINS[cd] %@", searchText)
             visibleConversations = allConversations.filter { conversation in
-                predicate.evaluate(with: conversation)
+                if let _ = conversation.name.range(of: searchText, options: .diacriticInsensitive) {
+                    return true
+                } else {
+                    return false
+                }
             }
         } else {
             visibleConversations = allConversations


### PR DESCRIPTION
## What's new in this PR?

### Issues

Share extension crash when searching a name.

### Causes

Unknown, but it does not occur in pervious and seems related to objc removal tasks.

### Solutions

To prevent using `NSPredicate` with non-objc protocol and String, use range search instead.