### PR TITLE
Fix: refactor NSPredicate query to block in LicensesLoaderTests

### DIFF
--- a/Wire-iOS Tests/LicensesLoaderTests.swift
+++ b/Wire-iOS Tests/LicensesLoaderTests.swift
@@ -19,7 +19,7 @@
 import XCTest
 @testable import Wire
 
-class LicensesLoaderTests: XCTestCase {
+final class LicensesLoaderTests: XCTestCase {
 
     var memoryManager: NSObject!
     var loader: LicensesLoader!
@@ -81,10 +81,14 @@ class LicensesLoaderTests: XCTestCase {
         XCTAssertFalse(loader.cacheEmpty)
 
         // WHEN
-        let deletedCacheExpectation = expectation(for: NSPredicate(format: "cacheEmpty == YES"), evaluatedWith: loader) {
+        let predicate = NSPredicate(block: { any, _ in
+            return self.loader.cacheEmpty
+        })
+
+        let deletedCacheExpectation = expectation(for: predicate, evaluatedWith: loader) {
             return self.loader.cache == nil
         }
-
+        
         sendMemoryWarning()
         wait(for: [deletedCacheExpectation], timeout: 10)
 

--- a/Wire-iOS Tests/LicensesLoaderTests.swift
+++ b/Wire-iOS Tests/LicensesLoaderTests.swift
@@ -88,7 +88,7 @@ final class LicensesLoaderTests: XCTestCase {
         let deletedCacheExpectation = expectation(for: predicate, evaluatedWith: loader) {
             return self.loader.cache == nil
         }
-        
+
         sendMemoryWarning()
         wait(for: [deletedCacheExpectation], timeout: 10)
 

--- a/Wire-iOS/Sources/Components/LicensesLoader.swift
+++ b/Wire-iOS/Sources/Components/LicensesLoader.swift
@@ -33,7 +33,7 @@ final class LicensesLoader {
     private let sourceName = "Licenses.generated"
     private let sourceExtension = "plist"
 
-    private(set) var cache: [SettingsLicenseItem]? = nil
+    private(set) var cache: [SettingsLicenseItem]?
     private var memoryWarningToken: Any?
 
     // MARK: - Initialization

--- a/Wire-iOS/Sources/Components/LicensesLoader.swift
+++ b/Wire-iOS/Sources/Components/LicensesLoader.swift
@@ -25,7 +25,7 @@ import UIKit
  * This object is not thread safe and should only be used from the main thread.
  */
 
-final class LicensesLoader: NSObject {
+final class LicensesLoader {
 
     /// The shared loader.
     static let shared = LicensesLoader()
@@ -39,7 +39,6 @@ final class LicensesLoader: NSObject {
     // MARK: - Initialization
 
     init(memoryManager: Any? = nil) {
-        super.init()
         memoryWarningToken = NotificationCenter.default.addObserver(forName: UIApplication.didReceiveMemoryWarningNotification, object: memoryManager, queue: .main) { [weak self] _ in
             self?.cache = nil
         }
@@ -71,7 +70,7 @@ final class LicensesLoader: NSObject {
 
     // MARK: - Testing
 
-    @objc var cacheEmpty: Bool {
+    var cacheEmpty: Bool {
         return cache == nil
     }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

After removing objc/NSObject marks in `LicensesLoader`, `LicensesLoaderTests` fails.

### Causes

It can not meet the expectation query after the line `@objc var cacheEmpty` removed the `@objc` signature.

### Solutions

Refactor with `NSPredicate(block:)`