### PR TITLE
[Feature] Linear onboarding - automatic SSO login for fixed SSO BE

### DIFF
--- a/Wire-iOS/Sources/Authentication/Coordinator/Coordinator+Delegates/AuthenticationCoordinator+CompanyLogin.swift
+++ b/Wire-iOS/Sources/Authentication/Coordinator/Coordinator+Delegates/AuthenticationCoordinator+CompanyLogin.swift
@@ -41,8 +41,4 @@ extension AuthenticationCoordinator: CompanyLoginControllerDelegate {
     func controllerDidCancelCompanyLoginFlow(_ controller: CompanyLoginController) {
         cancelCompanyLogin()
     }
-
-    func controllerDidUpdateBackendEnvironment(_ controller: CompanyLoginController) {
-        stateController.transition(to: .landingScreen, mode: .reset)
-    }
 }

--- a/Wire-iOS/Sources/UserInterface/Company Login/CompanyLoginController.swift
+++ b/Wire-iOS/Sources/UserInterface/Company Login/CompanyLoginController.swift
@@ -249,13 +249,14 @@ extension CompanyLoginController {
 extension CompanyLoginController {
     
     /// Fetches SSO code and starts flow automatically if code is returned on completion
-    /// Otherwise, falls back on prompting user for SSO code
-    func startAutomaticSSOFlow() {
+    /// - Parameter promptOnError: Prompt the user for SSO code if there is an error fetching code
+    func startAutomaticSSOFlow(promptOnError: Bool = true) {
         delegate?.controller(self, showLoadingView: true)
         SessionManager.shared?.activeUnauthenticatedSession.fetchSSOSettings { [weak self] result in
             guard let `self` = self else { return }
             self.delegate?.controller(self, showLoadingView: false)
             guard let ssoCode = result.value?.ssoCode else {
+                guard promptOnError else { return }
                 return self.displayCompanyLoginPrompt(ssoOnly: true)
             }
             self.attemptLoginWithSSOCode(ssoCode)
@@ -298,7 +299,7 @@ extension CompanyLoginController {
                 return
             }
             BackendEnvironment.shared = backendEnvironment
-            self.startAutomaticSSOFlow()
+            self.startAutomaticSSOFlow(promptOnError: false)
         }
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Company Login/CompanyLoginController.swift
+++ b/Wire-iOS/Sources/UserInterface/Company Login/CompanyLoginController.swift
@@ -37,10 +37,6 @@ protocol CompanyLoginControllerDelegate: class {
 
     /// Called when the company login controller cancels the company login flow.
     func controllerDidCancelCompanyLoginFlow(_ controller: CompanyLoginController)
-
-    /// Called when the company login controller updated to a different backend environment.
-    /// It will need the delegate to present the landing screen
-    func controllerDidUpdateBackendEnvironment(_ controller: CompanyLoginController)
 }
 
 ///
@@ -302,7 +298,7 @@ extension CompanyLoginController {
                 return
             }
             BackendEnvironment.shared = backendEnvironment
-            self.delegate?.controllerDidUpdateBackendEnvironment(self)
+            self.startAutomaticSSOFlow()
         }
     }
 }


### PR DESCRIPTION
## What's new in this PR?

https://wearezeta.atlassian.net/browse/ZIOS-13118

For custom backends with a fixed SSO code,
Instead of presenting the Enterprise Login landing page after the backend switch,
We need to open the SSO flow automatically.
