### PR TITLE
fix: app crash at ConversationTableViewDataSource.messages

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
@@ -51,41 +51,41 @@ extension ZMConversationMessage {
 }
 
 final class ConversationTableViewDataSource: NSObject {
-    public static let defaultBatchSize = 30 // Magic number: amount of messages per screen (upper bound).
+    static let defaultBatchSize = 30 // Magic number: amount of messages per screen (upper bound).
     
     private var fetchController: NSFetchedResultsController<ZMMessage>!
     private var lastFetchedObjectCount: Int = 0
     
-    public var registeredCells: [AnyClass] = []
-    public var sectionControllers: [String: ConversationMessageSectionController] = [:]
+    var registeredCells: [AnyClass] = []
+    var sectionControllers: [String: ConversationMessageSectionController] = [:]
 
-    @objc public private(set) var hasOlderMessagesToLoad = false
-    @objc public private(set) var hasNewerMessagesToLoad = false
+    private(set) var hasOlderMessagesToLoad = false
+    private(set) var hasNewerMessagesToLoad = false
     
-    @objc func resetSectionControllers() {
+    func resetSectionControllers() {
         sectionControllers = [:]
     }
     
-    public var actionControllers: [String: ConversationMessageActionController] = [:]
+    var actionControllers: [String: ConversationMessageActionController] = [:]
     
-    public let conversation: ZMConversation
-    public let tableView: UpsideDownTableView
+    let conversation: ZMConversation
+    let tableView: UpsideDownTableView
     
-    @objc public var firstUnreadMessage: ZMConversationMessage?
-    @objc public var selectedMessage: ZMConversationMessage? = nil
-    @objc public var editingMessage: ZMConversationMessage? = nil
+    var firstUnreadMessage: ZMConversationMessage?
+    var selectedMessage: ZMConversationMessage? = nil
+    var editingMessage: ZMConversationMessage? = nil
     
     weak var conversationCellDelegate: ConversationMessageCellDelegate? = nil
     weak var messageActionResponder: MessageActionResponder? = nil
     
-    @objc public var searchQueries: [String] = [] {
+    var searchQueries: [String] = [] {
         didSet {
             currentSections = calculateSections()
             tableView.reloadData()
         }
     }
     
-    @objc public var messages: [ZMConversationMessage] {
+    var messages: [ZMConversationMessage] {
         // NOTE: We limit the number of messages to the `lastFetchedObjectCount` since the
         // NSFetchResultsController will add objects to `fetchObjects` if they are modified after
         // the initial fetch, which results in unwanted table view updates. This is normally what
@@ -191,7 +191,7 @@ final class ConversationTableViewDataSource: NSObject {
         return sectionController
     }
     
-    @objc func sectionController(at sectionIndex: Int, in tableView: UITableView) -> ConversationMessageSectionController {
+    func sectionController(at sectionIndex: Int, in tableView: UITableView) -> ConversationMessageSectionController {
         let message = messages[sectionIndex]
         
         return sectionController(for: message, at: sectionIndex)
@@ -270,14 +270,14 @@ final class ConversationTableViewDataSource: NSObject {
         loadMessages(offset: newOffset, limit: currentLimit)
     }
     
-    @objc func indexOfMessage(_ message: ZMConversationMessage) -> Int {
+    func indexOfMessage(_ message: ZMConversationMessage) -> Int {
         guard let index = index(of: message) else {
             return NSNotFound
         }
         return index
     }
     
-    public func index(of message: ZMConversationMessage) -> Int? {
+    func index(of message: ZMConversationMessage) -> Int? {
         if let indexPath = fetchController.indexPath(forObject: message as! ZMMessage) {
             return indexPath.row
         }
@@ -381,18 +381,16 @@ extension ConversationTableViewDataSource: NSFetchedResultsControllerDelegate {
 
 extension ConversationTableViewDataSource: UITableViewDataSource {
     
-    public func numberOfSections(in tableView: UITableView) -> Int {
+    func numberOfSections(in tableView: UITableView) -> Int {
         return currentSections.count
     }
     
-    @objc
     func select(indexPath: IndexPath) {
         let sectionController = self.sectionController(at: indexPath.section, in: tableView)
         sectionController.didSelect()
         reloadSections(newSections: calculateSections(updating: sectionController))
     }
     
-    @objc
     func deselect(indexPath: IndexPath) {
         let sectionController = self.sectionController(at: indexPath.section, in: tableView)
         sectionController.didDeselect()
@@ -475,7 +473,7 @@ extension ConversationTableViewDataSource {
         return true
     }
     
-    public func context(for message: ZMConversationMessage,
+    func context(for message: ZMConversationMessage,
                         at index: Int,
                         firstUnreadMessage: ZMConversationMessage?,
                         searchQueries: [String]) -> ConversationMessageContext {


### PR DESCRIPTION
## What's new in this PR?

### Issues

App crash at getter `ConversationTableViewDataSource.messages`

### Causes

Unknown, but the stack trace stops at the objc getter first line.

### Solutions

Remove the @objc interfaces in `ConversationTableViewDataSource` to see this issue still occurs or not.