### PR TITLE
remove objc support of StyleKitIcon

### DIFF
--- a/Scripts/update_stylekit/main.swift
+++ b/Scripts/update_stylekit/main.swift
@@ -33,7 +33,7 @@ import Foundation
 let template = """
 //
 // Wire
-// Copyright (C) 2019 Wire Swiss GmbH
+// Copyright (C) 2020 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -59,7 +59,6 @@ import UIKit
 * The list of icons that can be rendered from the style kit.
 */
 
-@objc(WRStyleKitIcon)
 public enum StyleKitIcon: Int {
 
     /// Represents the data necessary to render the icons.

--- a/Wire-iOS/Sources/UserInterface/Components/Views/UserImageView/BadgeUserImageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/UserImageView/BadgeUserImageView.swift
@@ -180,11 +180,11 @@ extension BadgeUserImageView {
         }
     }
 
-    @objc func setBadgeIcon(_ newValue: StyleKitIcon) {
+    func setBadgeIcon(_ newValue: StyleKitIcon) {
         badgeIcon = newValue
     }
 
-    @objc func removeBadgeIcon() {
+    func removeBadgeIcon() {
         badgeIcon = nil
     }
 


### PR DESCRIPTION
## What's new in this PR?

Remove `StyleKitIcon` support of objc in the generated code.