### PR TITLE
[Fix] Trigger team refresh immediately in account screen

### DIFF
--- a/Wire-iOS Tests/SelfProfileViewControllerTests.swift
+++ b/Wire-iOS Tests/SelfProfileViewControllerTests.swift
@@ -52,7 +52,7 @@ final class SelfProfileViewControllerTests: ZMSnapshotTestCase {
 
     private func createSut(userName: String, teamMember: Bool = true) {
         selfUser = MockUserType.createSelfUser(name: userName, inTeam: teamMember ? UUID() : nil)
-        sut = SelfProfileViewController(selfUser: selfUser, userRightInterfaceType: MockUserRight.self)
+        sut = SelfProfileViewController(selfUser: selfUser, userRightInterfaceType: MockUserRight.self, userSession:f MockZMUserSession())
         sut.view.backgroundColor = .black
     }
 }

--- a/Wire-iOS Tests/SelfProfileViewControllerTests.swift
+++ b/Wire-iOS Tests/SelfProfileViewControllerTests.swift
@@ -52,7 +52,7 @@ final class SelfProfileViewControllerTests: ZMSnapshotTestCase {
 
     private func createSut(userName: String, teamMember: Bool = true) {
         selfUser = MockUserType.createSelfUser(name: userName, inTeam: teamMember ? UUID() : nil)
-        sut = SelfProfileViewController(selfUser: selfUser, userRightInterfaceType: MockUserRight.self, userSession:f MockZMUserSession())
+        sut = SelfProfileViewController(selfUser: selfUser, userRightInterfaceType: MockUserRight.self, userSession: MockZMUserSession())
         sut.view.backgroundColor = .black
     }
 }

--- a/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
@@ -61,11 +61,14 @@ final class SelfProfileViewController: UIViewController {
      * - parameter userRightInterfaceType: The type of object to determine the user permissions.
      */
 
-    init(selfUser: SettingsSelfUser, userRightInterfaceType: UserRightInterface.Type = UserRight.self) {
+    init(selfUser: SettingsSelfUser,
+         userRightInterfaceType: UserRightInterface.Type = UserRight.self,
+         userSession: UserSessionSwiftInterface? = ZMUserSession.shared()) {
+        
         self.selfUser = selfUser
 
         // Create the settings hierarchy
-        let settingsPropertyFactory = SettingsPropertyFactory(userSession: SessionManager.shared?.activeUserSession, selfUser: selfUser)
+        let settingsPropertyFactory = SettingsPropertyFactory(userSession: userSession, selfUser: selfUser)
 		let settingsCellDescriptorFactory = SettingsCellDescriptorFactory(settingsPropertyFactory: settingsPropertyFactory, userRightInterfaceType: userRightInterfaceType)
 		let rootGroup = settingsCellDescriptorFactory.rootGroup()
         settingsController = rootGroup.generateViewController()! as! SettingsTableViewController
@@ -79,7 +82,7 @@ final class SelfProfileViewController: UIViewController {
         settingsPropertyFactory.delegate = self
 
         if selfUser.isTeamMember {
-            ZMUserSession.shared()?.enqueue {
+            userSession?.enqueue {
                 selfUser.refreshTeamData()
             }
         }

--- a/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
@@ -79,10 +79,9 @@ final class SelfProfileViewController: UIViewController {
         settingsPropertyFactory.delegate = self
 
         if selfUser.isTeamMember {
-            selfUser.refreshTeamData()
-
-            // Trigger the refresh immediately.
-            SessionManager.shared?.activeUserSession?.managedObjectContext.saveOrRollback()
+            ZMUserSession.shared()?.enqueue {
+                selfUser.refreshTeamData()
+            }
         }
     }
 

--- a/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
@@ -80,6 +80,9 @@ final class SelfProfileViewController: UIViewController {
 
         if selfUser.isTeamMember {
             selfUser.refreshTeamData()
+
+            // Trigger the refresh immediately.
+            SessionManager.shared?.activeUserSession?.managedObjectContext.saveOrRollback()
         }
     }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

If the team metadata has changed remotely and the user opens the account screen, they do not see the refreshed data until the dismiss the screen and reopen it.

### Causes

When the account screen is presented, the team is marked as needing to be refreshed. However the refresh won't be triggered until the managed object context is saved, which is probably happening when the screen is dismissed. Therefore opening the screen a second time will show the new metadata.

### Solutions

Trigger the refresh immediately.

