### PR TITLE
Fix: remove unnecessary unboxing in ProfileViewControllerViewModel

### DIFF
--- a/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsContentController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsContentController.swift
@@ -289,10 +289,8 @@ final class ProfileDetailsContentController: NSObject,
             $0.name == (self.isAdminState ? ZMConversation.defaultAdminRoleName : ZMConversation.defaultMemberRoleName)
         }
         
-        guard
-            let role = newParticipantRole,
-            let session = ZMUserSession.shared(),
-            let user = (user as? ZMUser) ?? (user as? ZMSearchUser)?.user
+        guard let role = newParticipantRole,
+              let session = ZMUserSession.shared()
             else { return }
         
         conversation?.updateRole(of: user, to: role, session: session) { (result) in

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewControllerViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewControllerViewModel.swift
@@ -16,9 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
-import WireDataModel
-import WireSystem
 import WireSyncEngine
 
 private let zmLog = ZMSLog(tag: "ProfileViewControllerViewModel")
@@ -68,7 +65,7 @@ final class ProfileViewControllerViewModel: NSObject {
     }
     
     var fullUser: ZMUser? {
-        return (bareUser as? ZMUser) ?? (bareUser as? ZMSearchUser)?.user
+        return bareUser as? ZMUser
     }
 
     var hasLegalHoldItem: Bool {


### PR DESCRIPTION
## What's new in this PR?

Remove unnecessary unboxing of `bareUser` in `ProfileViewControllerViewModel`.