### PR TITLE
Wrong error message

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -428,7 +428,7 @@
 "digital_signature.alert.error" = "Unfortunately, your digital signature failed.";
 "digital_signature.alert.error.no_consent_url" = "Unfortunately, the signature form did not open. Please try again";
 "digital_signature.alert.error.no_signature" = "Unfortunately, your digital signature failed. Please try again";
-"digital_signature.alert.download_necessary" = "Please save and read the document before sign in";
+"digital_signature.alert.download_necessary" = "Please save and read the document before signing it";
 
 // New conversation participants added / removed / started system message
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

Digital Signature: Incorrect error message when document is not downloaded before signing.

### Causes

wrong text in the localisable string text.

### Solutions

right text in the localisable string text.