### PR TITLE
fix: remove warning when building extension and framework

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -8468,6 +8468,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = F1B24239219B2C9B00F7035C /* Share-Extension-Debug.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = NO;
 			};
 			name = Debug;
 		};
@@ -8475,6 +8476,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = F1B24238219B2C9B00F7035C /* Share-Extension-Release.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = NO;
 			};
 			name = Release;
 		};
@@ -8524,6 +8526,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = F156509721DCED3000210504 /* CommonComponents-Debug.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = NO;
 			};
 			name = Debug;
 		};
@@ -8531,6 +8534,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = F156509621DCED3000210504 /* CommonComponents-Release.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = NO;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
## What's new in this PR?

### Issues

Warning when build the app: `:-1: Linking against a dylib which is not safe for use in application extensions: /Users/bill/Documents/wire/wire-ios/Carthage/Build/iOS/PINCache.framework/PINCache`

### Causes


ref to: https://developer.apple.com/library/archive/documentation/General/Conceptual/ExtensibilityPG/ExtensionScenarios.html

"To configure an app extension target to use an embedded framework, set the target’s “Require Only App-Extension-Safe API” build setting to Yes. If you don’t, Xcode reminds you to do so by displaying the warning “linking against dylib not safe for use in application extensions”."

But actually WireCommonComponent and WireShareExtensions do not use `PINCache`, seems like and issue of Carthage, which includes the the framework to all targets.

### Solutions

Set `APPLICATION_EXTENSION_API_ONLY` to `NO` for WireCommonComponent and WireShareExtensions.