### PR TITLE
Fix: ProfileViewController monitors user name change

### DIFF
--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
 import UIKit
 import WireDataModel
 
@@ -124,7 +123,7 @@ final class ProfileViewController: UIViewController {
         usernameDetailsView.configure(with: userNameDetailViewModel)
         view.addSubview(usernameDetailsView)
         
-        profileTitleView.configure(with: viewModel.bareUser, variant: ColorScheme.default.variant)
+        updateTitleView()
         
         profileTitleView.translatesAutoresizingMaskIntoConstraints = false
         if #available(iOS 11, *) {
@@ -498,6 +497,10 @@ extension ProfileViewController: TabBarControllerDelegate {
 }
 
 extension ProfileViewController: ProfileViewControllerViewModelDelegate {
+    func updateTitleView() {
+        profileTitleView.configure(with: viewModel.bareUser, variant: ColorScheme.default.variant)
+    }
+    
     func updateShowVerifiedShield() {
         profileTitleView.showVerifiedShield = viewModel.shouldShowVerifiedShield && tabsController?.selectedIndex != ProfileViewControllerTabBarIndex.devices.rawValue
     }

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewControllerViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewControllerViewModel.swift
@@ -251,6 +251,10 @@ extension ProfileViewControllerViewModel: ZMUserObserver {
         if note.legalHoldStatusChanged {
             viewModelDelegate?.setupNavigationItems()
         }
+
+        if note.nameChanged {
+            viewModelDelegate?.updateTitleView()
+        }
     }
 }
 
@@ -264,5 +268,6 @@ protocol ProfileViewControllerViewModelDelegate: class {
     func updateShowVerifiedShield()
     func setupNavigationItems()
     func updateFooterViews()
+    func updateTitleView()
     func returnToPreviousScreen()
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

`ProfileViewController` title does not update when other user's name changes.


### Solutions

Update title when the user name changes.