### PR TITLE
fix: SelfProfileViewController observes team name update

### DIFF
--- a/Wire-iOS/Sources/UserInterface/SelfProfile/ProfileHeaderViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/ProfileHeaderViewController.swift
@@ -288,7 +288,7 @@ final class ProfileHeaderViewController: UIViewController, Themeable {
         }
     }
     
-    private func updateTeamLabel() {
+    func updateTeamLabel() {
         if let teamName = user.teamName, !options.contains(.hideTeamName) {
             teamNameLabel.text = teamName.localizedUppercase
             teamNameLabel.accessibilityValue = teamNameLabel.text

--- a/Wire-iOS/Sources/UserInterface/SelfProfile/ProfileHeaderViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/ProfileHeaderViewController.swift
@@ -16,9 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
 import UIKit
-import WireDataModel
 import WireSyncEngine
 
 final class ProfileHeaderViewController: UIViewController, Themeable {
@@ -115,6 +113,7 @@ final class ProfileHeaderViewController: UIViewController, Themeable {
     let externalIndicator = LabelIndicator(context: .external)
 
     private var tokens: [Any?] = []
+    private var teamObserver: NSObjectProtocol?
     
     /**
      * Creates a profile view for the specified user and options.
@@ -218,6 +217,10 @@ final class ProfileHeaderViewController: UIViewController, Themeable {
         applyOptions()
         
         availabilityTitleViewController.didMove(toParent: self)
+        
+        if let team = (user as? ZMUser)?.team {
+            teamObserver = TeamChangeInfo.add(observer: self, for: team)
+        }
     }
     
     private func configureConstraints() {
@@ -288,7 +291,7 @@ final class ProfileHeaderViewController: UIViewController, Themeable {
         }
     }
     
-    func updateTeamLabel() {
+    private func updateTeamLabel() {
         if let teamName = user.teamName, !options.contains(.hideTeamName) {
             teamNameLabel.text = teamName.localizedUppercase
             teamNameLabel.accessibilityValue = teamNameLabel.text
@@ -331,6 +334,14 @@ extension ProfileHeaderViewController: ZMUserObserver {
         
         if changeInfo.availabilityChanged {
             updateAvailabilityVisibility()
+        }
+    }
+}
+
+extension ProfileHeaderViewController: TeamObserver {
+    func teamDidChange(_ changeInfo: TeamChangeInfo) {
+        if changeInfo.nameChanged {
+            updateTeamLabel()
         }
     }
 }

--- a/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
@@ -39,8 +39,6 @@ final class SelfProfileViewController: UIViewController {
     private let profileContainerView = UIView()
     private let profileHeaderViewController: ProfileHeaderViewController
 
-    private var teamObserver: NSObjectProtocol?
-
     // MARK: - Configuration
 
     override var supportedInterfaceOrientations : UIInterfaceOrientationMask {
@@ -120,11 +118,7 @@ final class SelfProfileViewController: UIViewController {
 
         navigationItem.rightBarButtonItem = navigationController?.closeItem()
         configureAccountTitle()
-        createConstraints()
-        
-        if let team = ZMUser.selfUser()?.team {
-            teamObserver = TeamChangeInfo.add(observer: self, for: team)
-        }
+        createConstraints()        
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -201,12 +195,4 @@ extension SelfProfileViewController: SettingsPropertyFactoryDelegate {
         (navigationController?.topViewController as? SpinnerCapableViewController)?.isLoadingViewVisible = false
     }
 
-}
-
-extension SelfProfileViewController: TeamObserver {
-    func teamDidChange(_ changeInfo: TeamChangeInfo) {
-        if changeInfo.nameChanged {
-            profileHeaderViewController.updateTeamLabel()
-        }
-    }
 }

--- a/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
@@ -39,6 +39,8 @@ final class SelfProfileViewController: UIViewController {
     private let profileContainerView = UIView()
     private let profileHeaderViewController: ProfileHeaderViewController
 
+    private var teamObserver: NSObjectProtocol?
+
     // MARK: - Configuration
 
     override var supportedInterfaceOrientations : UIInterfaceOrientationMask {
@@ -119,6 +121,10 @@ final class SelfProfileViewController: UIViewController {
         navigationItem.rightBarButtonItem = navigationController?.closeItem()
         configureAccountTitle()
         createConstraints()
+        
+        if let team = ZMUser.selfUser()?.team {
+            teamObserver = TeamChangeInfo.add(observer: self, for: team)
+        }
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -195,4 +201,12 @@ extension SelfProfileViewController: SettingsPropertyFactoryDelegate {
         (navigationController?.topViewController as? SpinnerCapableViewController)?.isLoadingViewVisible = false
     }
 
+}
+
+extension SelfProfileViewController: TeamObserver {
+    func teamDidChange(_ changeInfo: TeamChangeInfo) {
+        if changeInfo.nameChanged {
+            profileHeaderViewController.updateTeamLabel()
+        }
+    }
 }

--- a/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
@@ -118,7 +118,7 @@ final class SelfProfileViewController: UIViewController {
 
         navigationItem.rightBarButtonItem = navigationController?.closeItem()
         configureAccountTitle()
-        createConstraints()        
+        createConstraints()
     }
     
     override func viewDidAppear(_ animated: Bool) {


### PR DESCRIPTION
## What's new in this PR?

Observes team name update in `SelfProfileViewController` and update the team name label text.