### PR TITLE
Fix: app crash when create a FLAnimatedImage with nil imageData

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.swift
@@ -316,8 +316,9 @@ final class FullscreenImageViewController: UIViewController {
 
             let mediaAsset: MediaAsset
 
-            if imageIsAnimatedGIF == true {
-                mediaAsset = FLAnimatedImage(animatedGIFData: imageData)
+            if imageIsAnimatedGIF == true,
+               let gifImageData = imageData {
+                mediaAsset = FLAnimatedImage(animatedGIFData: gifImageData)
             } else if let image = imageData.map(UIImage.init) as? UIImage {
                 mediaAsset = image
             } else {


### PR DESCRIPTION
## What's new in this PR?

Unwrap the data before creating `FLAnimatedImage `