### PR TITLE
Fix: Xcode 11: confirm image screen not shown after tapped a photo on camera keyboard

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
@@ -185,10 +185,9 @@ extension ConversationInputBarViewController: CameraKeyboardViewControllerDelega
                                                                     })
 
         let confirmImageViewController = ConfirmAssetViewController(context: context)
-        confirmImageViewController.transitioningDelegate = FastTransitioningDelegate.sharedDelegate
         confirmImageViewController.previewTitle = self.conversation.displayName.localizedUppercase
 
-        UIApplication.shared.topmostViewController()?.present(confirmImageViewController, animated: true)
+        ZClientViewController.shared?.present(confirmImageViewController, animated: true)
     }
 
     private func executeWithCameraRollPermission(_ closure: @escaping (_ success: Bool) -> Void) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
@@ -16,12 +16,10 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-import Foundation
 import MobileCoreServices
 import Photos
 import FLAnimatedImage
 import UIKit
-import WireSystem
 import WireSyncEngine
 
 private let zmLog = ZMSLog(tag: "UI")
@@ -190,7 +188,7 @@ extension ConversationInputBarViewController: CameraKeyboardViewControllerDelega
         confirmImageViewController.transitioningDelegate = FastTransitioningDelegate.sharedDelegate
         confirmImageViewController.previewTitle = self.conversation.displayName.localizedUppercase
 
-        present(confirmImageViewController, animated: true)
+        UIApplication.shared.topmostViewController()?.present(confirmImageViewController, animated: true)
     }
 
     private func executeWithCameraRollPermission(_ closure: @escaping (_ success: Bool) -> Void) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
@@ -19,22 +19,9 @@
 import MobileCoreServices
 import Photos
 import FLAnimatedImage
-import UIKit
 import WireSyncEngine
 
 private let zmLog = ZMSLog(tag: "UI")
-
-final class FastTransitioningDelegate: NSObject, UIViewControllerTransitioningDelegate {
-    static let sharedDelegate = FastTransitioningDelegate()
-
-    func animationController(forPresented presented: UIViewController, presenting: UIViewController, source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
-        return VerticalTransition(offset: -180)
-    }
-
-    func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
-        return VerticalTransition(offset: 180)
-    }
-}
 
 final class StatusBarVideoEditorController: UIVideoEditorController {
     func adaptivePresentationStyle(for controller: UIPresentationController) -> UIModalPresentationStyle {
@@ -60,7 +47,6 @@ extension ConversationInputBarViewController: CameraKeyboardViewControllerDelega
         // Video can be longer than allowed to be uploaded. Then we need to add user the possibility to trim it.
         if duration > ZMUserSession.shared()!.maxVideoLength {
             let videoEditor = StatusBarVideoEditorController()
-            videoEditor.transitioningDelegate = FastTransitioningDelegate.sharedDelegate
             videoEditor.delegate = self
             videoEditor.videoMaximumDuration = ZMUserSession.shared()!.maxVideoLength
             videoEditor.videoPath = videoURL.path
@@ -102,11 +88,9 @@ extension ConversationInputBarViewController: CameraKeyboardViewControllerDelega
                                                                             }
                                                             })
             let confirmVideoViewController = ConfirmAssetViewController(context: context)
-            confirmVideoViewController.transitioningDelegate = FastTransitioningDelegate.sharedDelegate
             confirmVideoViewController.previewTitle = self.conversation.displayName.localizedUppercase
 
-            self.present(confirmVideoViewController, animated: true) {
-            }
+            present(confirmVideoViewController, animated: true)
         }
     }
 
@@ -187,7 +171,7 @@ extension ConversationInputBarViewController: CameraKeyboardViewControllerDelega
         let confirmImageViewController = ConfirmAssetViewController(context: context)
         confirmImageViewController.previewTitle = self.conversation.displayName.localizedUppercase
 
-        ZClientViewController.shared?.present(confirmImageViewController, animated: true)
+        present(confirmImageViewController, animated: true)
     }
 
     private func executeWithCameraRollPermission(_ closure: @escaping (_ success: Bool) -> Void) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+DragAndDrop.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+DragAndDrop.swift
@@ -48,7 +48,6 @@ extension ConversationInputBarViewController: UIDropInteractionDelegate {
                     )
 
                     let confirmImageViewController = ConfirmAssetViewController(context: context)
-                    confirmImageViewController.transitioningDelegate = FastTransitioningDelegate.sharedDelegate
                     confirmImageViewController.previewTitle = self.conversation.displayName.localizedUppercase
                     self.present(confirmImageViewController, animated: true) {
                             }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
@@ -15,11 +15,9 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
 import MobileCoreServices
 import Photos
 import UIKit
-import WireDataModel
 import WireSyncEngine
 import avs
 import AVFoundation
@@ -552,7 +550,7 @@ final class ConversationInputBarViewController: UIViewController,
     // MARK: - Giphy
 
     @objc
-    func giphyButtonPressed(_ sender: Any?) {
+    private func giphyButtonPressed(_ sender: Any?) {
         guard !AppDelegate.isOffline else { return }
 
         let giphySearchViewController = GiphySearchViewController(searchTerm: "", conversation: conversation)


### PR DESCRIPTION
## What's new in this PR?

### Issues

On Xcode 11, confirm image screen not shown after tapped a photo on camera keyboard.

### Causes

Unknown, but after removed `FastTransitioningDelegate` it works again.

### Solutions

Remove `FastTransitioningDelegate` completely to prevent similar cases.