### PR TITLE
Fix: XCode11: Keyboard appears after image confirmation screen presented

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
@@ -169,8 +169,9 @@ extension ConversationInputBarViewController: CameraKeyboardViewControllerDelega
                                                                     })
 
         let confirmImageViewController = ConfirmAssetViewController(context: context)
-        confirmImageViewController.previewTitle = self.conversation.displayName.localizedUppercase
+        confirmImageViewController.previewTitle = conversation.displayName.localizedUppercase
 
+        endEditing()
         present(confirmImageViewController, animated: true)
     }
 


### PR DESCRIPTION
## What's new in this PR?

Call `endEditing` before presenting `confirmImageViewController` to prevent keyboard overlaps the presented screen.