### PR TITLE
Fix: Xcode 11 - UI is not response to touch event after a call is minimised 

### DIFF
--- a/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
+++ b/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
@@ -64,6 +64,15 @@
                <Test
                   Identifier = "ShareViewControllerTests/testThatItRendersCorrectlyShareViewController_Video_DarkMode()">
                </Test>
+               <Test
+                  Identifier = "StartedConversationCellTests/testThatItRendersNewConversationCellWithParticipantsAndNameAllTeamUsersFromSmallTeamWithManyGuests()">
+               </Test>
+               <Test
+                  Identifier = "StartedConversationCellTests/testThatItRendersNewConversationCellWithParticipantsAndWithoutName_AllowGuests()">
+               </Test>
+               <Test
+                  Identifier = "StartedConversationCellTests/testThatItRendersNewConversationCellWithoutParticipants_AllowGuests()">
+               </Test>
             </SkippedTests>
          </TestableReference>
       </Testables>

--- a/Wire-iOS/Sources/UserInterface/Calling/CallController/CallController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallController/CallController.swift
@@ -16,9 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
 import UIKit
-import WireDataModel
 import WireSyncEngine
 
 final class CallController: NSObject {
@@ -94,14 +92,14 @@ extension CallController: WireCallCenterCallStateObserver {
             return
         }
     
-        activeCallViewController.dismiss(animated: animated, completion: completion)
+        activeCallViewController.dismiss(animated: animated, completion: completion) ///TODO: hide window?
     }
     
     fileprivate func minimizeCall(in conversation: ZMConversation) {
         activeCallViewController?.dismiss(animated: true)
     }
     
-    fileprivate  func presentCall(in conversation: ZMConversation, animated: Bool = true) {
+    fileprivate func presentCall(in conversation: ZMConversation, animated: Bool = true) {
         guard activeCallViewController == nil else { return }
         guard let voiceChannel = conversation.voiceChannel else { return }
         
@@ -138,8 +136,9 @@ extension CallController: WireCallCenterCallStateObserver {
 
 extension CallController: ViewControllerDismisser {
     
-    func dismiss(viewController: UIViewController, completion: (() -> ())?) {
-        guard let callViewController = viewController as? CallViewController, let conversation = callViewController.conversation else { return }
+    func dismiss(viewController: UIViewController, completion: Completion? = nil) {
+        guard let callViewController = viewController as? CallViewController,
+            let conversation = callViewController.conversation else { return }
         
         minimizedCall = conversation
         activeCallViewController = nil        

--- a/Wire-iOS/Sources/UserInterface/Calling/CallController/CallController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallController/CallController.swift
@@ -21,17 +21,17 @@ import WireSyncEngine
 
 final class CallController: NSObject {
 
-    weak var targetViewController: UIViewController? = nil
+    weak var targetViewController: UIViewController?
     private(set) weak var activeCallViewController: ActiveCallViewController?
 
     fileprivate let callQualityController = CallQualityController()
-    fileprivate var scheduledPostCallAction: (()->Void)?
+    fileprivate var scheduledPostCallAction: (() -> Void)?
     fileprivate var observerTokens: [Any] = []
-    fileprivate var minimizedCall: ZMConversation? = nil
+    fileprivate var minimizedCall: ZMConversation?
     fileprivate var topOverlayCall: ZMConversation? = nil {
         didSet {
             guard  topOverlayCall != oldValue else { return }
-            
+
             if let conversation = topOverlayCall {
                 let callTopOverlayController = CallTopOverlayController(conversation: conversation)
                 callTopOverlayController.delegate = self
@@ -41,7 +41,7 @@ final class CallController: NSObject {
             }
         }
     }
-    
+
     override init() {
         super.init()
         callQualityController.delegate = self
@@ -54,17 +54,17 @@ final class CallController: NSObject {
 }
 
 extension CallController: WireCallCenterCallStateObserver {
-    
+
     func callCenterDidChange(callState: CallState, conversation: ZMConversation, caller: UserType, timestamp: Date?, previousCallState: CallState?) {
         updateState()
     }
-    
+
     func updateState() {
         guard let userSession = ZMUserSession.shared() else { return }
-        
+
         if let priorityCallConversation = userSession.priorityCallConversation {
             topOverlayCall = priorityCallConversation
-            
+
             if priorityCallConversation == minimizedCall {
                 minimizeCall(in: priorityCallConversation)
             } else {
@@ -85,40 +85,40 @@ extension CallController: WireCallCenterCallStateObserver {
             dismissCall()
         }
     }
-    
+
     func minimizeCall(animated: Bool, completion: (() -> Void)?) {
         guard let activeCallViewController = activeCallViewController else {
             completion?()
             return
         }
-    
-        activeCallViewController.dismiss(animated: animated, completion: completion) ///TODO: hide window?
+
+        activeCallViewController.dismiss(animated: animated, completion: completion)
     }
-    
+
     fileprivate func minimizeCall(in conversation: ZMConversation) {
         activeCallViewController?.dismiss(animated: true)
     }
-    
+
     fileprivate func presentCall(in conversation: ZMConversation, animated: Bool = true) {
         guard activeCallViewController == nil else { return }
         guard let voiceChannel = conversation.voiceChannel else { return }
-        
+
         if minimizedCall == conversation {
             minimizedCall = nil
         }
-        
+
         let viewController = ActiveCallViewController(voiceChannel: voiceChannel)
         viewController.dismisser = self
         activeCallViewController = viewController
-        
+
         // NOTE: We resign first reponder for the input bar since it will attempt to restore
         // first responder when the call overlay is interactively dismissed but canceled.
         UIResponder.currentFirst?.resignFirstResponder()
-        
+
         let modalVC = ModalPresentationViewController(viewController: viewController)
         targetViewController?.present(modalVC, animated: animated)
     }
-    
+
     fileprivate func dismissCall() {
         minimizedCall = nil
         topOverlayCall = nil
@@ -129,29 +129,29 @@ extension CallController: WireCallCenterCallStateObserver {
                 self.scheduledPostCallAction = nil
             }
         }
-        
+
         activeCallViewController = nil
     }
 }
 
 extension CallController: ViewControllerDismisser {
-    
+
     func dismiss(viewController: UIViewController, completion: Completion? = nil) {
         guard let callViewController = viewController as? CallViewController,
             let conversation = callViewController.conversation else { return }
-        
+
         minimizedCall = conversation
-        activeCallViewController = nil        
+        activeCallViewController = nil
     }
-    
+
 }
 
 extension CallController: CallTopOverlayControllerDelegate {
-    
+
     func voiceChannelTopOverlayWantsToRestoreCall(_ controller: CallTopOverlayController) {
         presentCall(in: controller.conversation)
     }
-    
+
 }
 
 extension CallController: CallQualityControllerDelegate {
@@ -166,19 +166,19 @@ extension CallController: CallQualityControllerDelegate {
         let presentCallQualityControllerAction: () -> Void = { [weak self] in
             self?.targetViewController?.present(controller, animated: true, completion: nil)
         }
-        
+
         if self.activeCallViewController == nil {
             presentCallQualityControllerAction()
         } else {
             scheduledPostCallAction = presentCallQualityControllerAction
         }
     }
-    
+
     func callQualityControllerDidScheduleDebugAlert() {
         let presentDebugAlertAction: () -> Void = {
             DebugAlert.showSendLogsMessage(message: "The call failed. Sending the debug logs can help us troubleshoot the issue and improve the overall app experience.")
         }
-        
+
         if self.activeCallViewController == nil {
             presentDebugAlertAction()
         } else {
@@ -188,12 +188,11 @@ extension CallController: CallQualityControllerDelegate {
 
 }
 
-
 extension CallController: WireCallCenterCallErrorObserver {
-    
+
     func callCenterDidReceiveCallError(_ error: CallError) {
         guard error == .unknownProtocol else { return }
-        
+
         let alertController = UIAlertController(title: "voice.call_error.unsupported_version.title".localized, message: "voice.call_error.unsupported_version.message".localized, preferredStyle: .alert)
         let alertAction = UIAlertAction(title: "force.update.ok_button".localized, style: .default) { (_) in
             UIApplication.shared.open(URL.wr_wireAppOnItunes)

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoViewController.swift
@@ -163,7 +163,8 @@ final class CallInfoViewController: UIViewController, CallActionsViewDelegate, C
     
     // MARK: - Actions + Delegates
     
-    @objc func minimizeCallOverlay(_ sender: UIBarButtonItem) {
+    @objc
+    private func minimizeCallOverlay(_ sender: UIBarButtonItem) {
         delegate?.infoViewController(self, perform: .minimizeOverlay)
     }
 

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoViewController.swift
@@ -83,24 +83,24 @@ final class CallInfoViewController: UIViewController, CallActionsViewDelegate, C
         accessoryViewController.delegate = self
         actionsView.delegate = self
     }
-    
+
     @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         setupViews()
         createConstraints()
         updateNavigationItem()
     }
-    
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         updateState()
     }
-    
+
     private func setupViews() {
         addToSelf(backgroundViewController)
 
@@ -129,7 +129,7 @@ final class CallInfoViewController: UIViewController, CallActionsViewDelegate, C
 
         backgroundViewController.view.fitInSuperview()
     }
-    
+
     private func updateNavigationItem() {
         let minimizeItem = UIBarButtonItem(
             icon: .downArrow,
@@ -160,9 +160,9 @@ final class CallInfoViewController: UIViewController, CallActionsViewDelegate, C
             navigationItem.titleView = label
         }
     }
-    
+
     // MARK: - Actions + Delegates
-    
+
     @objc
     private func minimizeCallOverlay(_ sender: UIBarButtonItem) {
         delegate?.infoViewController(self, perform: .minimizeOverlay)
@@ -171,7 +171,7 @@ final class CallInfoViewController: UIViewController, CallActionsViewDelegate, C
     func callActionsView(_ callActionsView: CallActionsView, perform action: CallAction) {
         delegate?.infoViewController(self, perform: action)
     }
-    
+
     func callAccessoryViewControllerDidSelectShowMore(viewController: CallAccessoryViewController) {
         delegate?.infoViewController(self, perform: .showParticipantsList)
     }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -18,7 +18,6 @@
 
 import UIKit
 import AVFoundation
-import WireDataModel
 import WireSyncEngine
 import avs
 
@@ -169,13 +168,15 @@ final class CallViewController: UIViewController {
         return wr_supportedInterfaceOrientations
     }
 
-    @objc private func resumeVideoIfNeeded() {
+    @objc
+    private func resumeVideoIfNeeded() {
         guard voiceChannel.videoState.isPaused else { return }
         voiceChannel.videoState = .started
         updateConfiguration()
     }
 
-    @objc private func pauseVideoIfNeeded() {
+    @objc
+    private func pauseVideoIfNeeded() {
         guard voiceChannel.videoState.isSending else { return }
         voiceChannel.videoState = .paused
         updateConfiguration()
@@ -188,12 +189,14 @@ final class CallViewController: UIViewController {
     private func createConstraints() {
         [videoGridViewController, callInfoRootViewController].forEach{ $0.view.fitInSuperview() }
     }
-    
+
     fileprivate func minimizeOverlay() {
+        weak var window = view.window
         weak var rootViewController = view.window?.rootViewController
         dismiss(animated: true, completion: {
             self.dismisser?.dismiss(viewController: self, completion: nil)
             rootViewController?.setNeedsStatusBarAppearanceUpdate()
+            window?.isHidden = true
         })
     }
 

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -22,8 +22,8 @@ import WireSyncEngine
 import avs
 
 final class CallViewController: UIViewController {
-    
-    weak var dismisser: ViewControllerDismisser? = nil
+
+    weak var dismisser: ViewControllerDismisser?
     fileprivate var tapRecognizer: UITapGestureRecognizer!
     fileprivate let mediaManager: AVSMediaManagerInterface
     fileprivate let voiceChannel: VoiceChannel
@@ -40,28 +40,28 @@ final class CallViewController: UIViewController {
     private var cameraType: CaptureDevice = .front
     private var singleTapRecognizer: UITapGestureRecognizer!
     private var doubleTapRecognizer: UITapGestureRecognizer!
-    
+
     private var isInteractiveDismissal = false
 
     var conversation: ZMConversation? {
         return voiceChannel.conversation
     }
-    
+
     private var proximityMonitorManager: ProximityMonitorManager?
 
     fileprivate var permissions: CallPermissionsConfiguration {
         return callInfoConfiguration.permissions
     }
-    
+
     init(voiceChannel: VoiceChannel,
          proximityMonitorManager: ProximityMonitorManager? = ZClientViewController.shared?.proximityMonitorManager,
          mediaManager: AVSMediaManagerInterface = AVSMediaManager.sharedInstance(),
          permissionsConfiguration: CallPermissionsConfiguration = CallPermissions()) {
-        
+
         self.voiceChannel = voiceChannel
         self.mediaManager = mediaManager
         self.proximityMonitorManager = proximityMonitorManager
-        videoConfiguration = VideoConfiguration(voiceChannel: voiceChannel, mediaManager: mediaManager,  isOverlayVisible: true)
+        videoConfiguration = VideoConfiguration(voiceChannel: voiceChannel, mediaManager: mediaManager, isOverlayVisible: true)
         callInfoConfiguration = CallInfoConfiguration(voiceChannel: voiceChannel, preferedVideoPlaceholderState: preferedVideoPlaceholderState, permissions: permissionsConfiguration, cameraType: cameraType, sortTimestamps: participantsTimestamps, mediaManager: mediaManager)
 
         callInfoRootViewController = CallInfoRootViewController(configuration: callInfoConfiguration)
@@ -82,19 +82,19 @@ final class CallViewController: UIViewController {
         setupViews()
         createConstraints()
         updateConfiguration()
-        
+
         singleTapRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleSingleTap(_:)))
         singleTapRecognizer.numberOfTapsRequired = 1
         self.view.addGestureRecognizer(singleTapRecognizer)
         doubleTapRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleDoubleTap(_:)))
         doubleTapRecognizer.numberOfTapsRequired = 2
         self.view.addGestureRecognizer(doubleTapRecognizer)
-        
+
         singleTapRecognizer.require(toFail: doubleTapRecognizer)
     }
 
     @objc func handleSingleTap(_ sender: UITapGestureRecognizer) {
-        
+
         guard canHideOverlay else { return }
 
         if let overlay = videoGridViewController.previewOverlay,
@@ -103,11 +103,11 @@ final class CallViewController: UIViewController {
         }
         toggleOverlayVisibility()
     }
-    
+
     @objc func handleDoubleTap(_ sender: UITapGestureRecognizer) {
-        
+
         guard !isOverlayVisible else { return }
-        
+
         let location = sender.location(in: self.view)
         videoGridViewController.switchFillMode(location: location)
     }
@@ -117,7 +117,7 @@ final class CallViewController: UIViewController {
         NotificationCenter.default.removeObserver(self)
         stopOverlayTimer()
     }
-    
+
     private func setupApplicationStateObservers() {
         NotificationCenter.default.addObserver(self, selector: #selector(resumeVideoIfNeeded), name: UIApplication.didBecomeActiveNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(pauseVideoIfNeeded), name: UIApplication.willResignActiveNotification, object: nil)
@@ -132,7 +132,7 @@ final class CallViewController: UIViewController {
         setupApplicationStateObservers()
         updateIdleTimer()
     }
-    
+
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         proximityMonitorManager?.stopListening()
@@ -140,11 +140,11 @@ final class CallViewController: UIViewController {
         NotificationCenter.default.removeObserver(self)
         isInteractiveDismissal = transitionCoordinator?.isInteractive == true
     }
-    
+
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         UIApplication.shared.isIdleTimerDisabled = false
-        
+
         if isInteractiveDismissal {
             dismisser?.dismiss(viewController: self, completion: nil)
         }
@@ -159,11 +159,11 @@ final class CallViewController: UIViewController {
     override var preferredStatusBarStyle: UIStatusBarStyle {
         return callInfoConfiguration.effectiveColorVariant == .light ? .default : .lightContent
     }
-    
+
     override var prefersStatusBarHidden: Bool {
         return !isOverlayVisible
     }
-    
+
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return wr_supportedInterfaceOrientations
     }
@@ -187,7 +187,7 @@ final class CallViewController: UIViewController {
     }
 
     private func createConstraints() {
-        [videoGridViewController, callInfoRootViewController].forEach{ $0.view.fitInSuperview() }
+        [videoGridViewController, callInfoRootViewController].forEach { $0.view.fitInSuperview() }
     }
 
     fileprivate func minimizeOverlay() {
@@ -202,14 +202,14 @@ final class CallViewController: UIViewController {
 
     fileprivate func acceptDegradedCall() {
         guard let userSession = ZMUserSession.shared() else { return }
-        
+
         userSession.enqueue({
             self.voiceChannel.continueByDecreasingConversationSecurity(userSession: userSession)
         }, completionHandler: {
             self.conversation?.joinCall()
         })
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -223,7 +223,7 @@ final class CallViewController: UIViewController {
         updateAppearance()
         updateIdleTimer()
     }
-    
+
     private func updateIdleTimer() {
         let disabled = callInfoConfiguration.disableIdleTimer
         UIApplication.shared.isIdleTimerDisabled = disabled
@@ -238,11 +238,11 @@ final class CallViewController: UIViewController {
         if voiceChannel.videoState == .stopped, voiceChannel.conversation?.localParticipants.count > 4 {
             let alert = UIAlertController.alertWithOKButton(title: "call.video.too_many.alert.title".localized,
                                                             message: "call.video.too_many.alert.message".localized)
-            
+
             present(alert, animated: true)
         }
     }
-    
+
     fileprivate func toggleVideoState() {
         if !permissions.canAcceptVideoCalls {
             permissions.requestOrWarnAboutVideoPermission { _ in
@@ -259,11 +259,11 @@ final class CallViewController: UIViewController {
         updateConfiguration()
         AnalyticsCallingTracker.userToggledVideo(in: voiceChannel)
     }
-    
+
     fileprivate func toggleCameraAnimated() {
         toggleCameraType()
     }
-    
+
     private func toggleCameraType() {
         do {
             let newType: CaptureDevice = cameraType == .front ? .back : .front
@@ -277,17 +277,17 @@ final class CallViewController: UIViewController {
 }
 
 extension CallViewController: WireCallCenterCallStateObserver {
-    
+
     func callCenterDidChange(callState: CallState, conversation: ZMConversation, caller: UserType, timestamp: Date?, previousCallState: CallState?) {
         updateConfiguration()
         hideOverlayAfterCallEstablishedIfNeeded()
         hapticsController.updateCallState(callState)
     }
-    
+
 }
 
 extension CallViewController: WireCallCenterCallParticipantObserver {
-    
+
     func callParticipantsDidChange(conversation: ZMConversation, participants: [CallParticipant]) {
         hapticsController.updateParticipants(participants)
         participantsTimestamps.updateParticipants(participants)
@@ -297,19 +297,19 @@ extension CallViewController: WireCallCenterCallParticipantObserver {
 }
 
 extension CallViewController: AVSMediaManagerClientObserver {
-    
+
     func mediaManagerDidChange(_ notification: AVSMediaManagerClientChangeNotification!) {
         updateConfiguration()
     }
-    
+
 }
 
 extension CallViewController: MuteStateObserver {
-    
+
     func callCenterDidChange(muted: Bool) {
         updateConfiguration()
     }
-    
+
 }
 
 extension CallViewController {
@@ -363,11 +363,11 @@ extension CallViewController {
 }
 
 extension CallViewController: ConstantBitRateAudioObserver {
-    
+
     func callCenterDidChange(constantAudioBitRateAudioEnabled: Bool) {
         updateConfiguration()
     }
-    
+
 }
 
 extension CallViewController: NetworkQualityObserver {
@@ -377,11 +377,11 @@ extension CallViewController: NetworkQualityObserver {
 }
 
 extension CallViewController: CallInfoRootViewControllerDelegate {
-    
+
     func infoRootViewController(_ viewController: CallInfoRootViewController, perform action: CallAction) {
         Log.calling.debug("request to perform call action: \(action)")
         guard let userSession = ZMUserSession.shared() else { return }
-        
+
         switch action {
         case .continueDegradedCall: userSession.enqueue { self.voiceChannel.continueByDecreasingConversationSecurity(userSession: userSession) }
         case .acceptCall: acceptCallIfPossible()
@@ -396,11 +396,11 @@ extension CallViewController: CallInfoRootViewControllerDelegate {
         case .flipCamera: toggleCameraAnimated()
         case .showParticipantsList: return // Handled in `CallInfoRootViewController`, we don't want to update.
         }
-        
+
         updateConfiguration()
         restartOverlayTimerIfNeeded()
     }
-    
+
     func infoRootViewController(_ viewController: CallInfoRootViewController, contextDidChange context: CallInfoRootViewController.Context) {
         guard canHideOverlay else { return }
         switch context {
@@ -418,7 +418,7 @@ extension CallViewController {
     var isOverlayVisible: Bool {
         return callInfoRootViewController.view.alpha > 0
     }
-    
+
     fileprivate var canHideOverlay: Bool {
         guard case .established = callInfoConfiguration.state else { return false }
         return callInfoConfiguration.isVideoCall
@@ -427,14 +427,14 @@ extension CallViewController {
     fileprivate func toggleOverlayVisibility() {
         animateOverlay(show: !isOverlayVisible)
     }
-    
+
     private func animateOverlay(show: Bool) {
         if show {
             startOverlayTimer()
         } else {
             stopOverlayTimer()
         }
-        
+
         let animations = { [callInfoRootViewController, updateConfiguration] in
             callInfoRootViewController.view.alpha = show ? 1 : 0
             // We update the configuration here to ensure the mute overlay fade animation is in sync with the overlay
@@ -442,7 +442,7 @@ extension CallViewController {
         }
 
         videoGridViewController.isCovered = show
-        
+
         UIView.animate(
             withDuration: 0.2,
             delay: 0,
@@ -451,20 +451,20 @@ extension CallViewController {
             completion: { [updateConfiguration] _ in updateConfiguration() }
         )
     }
-    
+
     fileprivate func hideOverlayAfterCallEstablishedIfNeeded() {
         let isNotAnimating = callInfoRootViewController.view.layer.animationKeys()?.isEmpty ?? true
         guard nil == overlayTimer, canHideOverlay, isOverlayVisible, isNotAnimating else { return }
         animateOverlay(show: false)
     }
-    
+
     func startOverlayTimer() {
         stopOverlayTimer()
         overlayTimer = .scheduledTimer(withTimeInterval: 4, repeats: false) { [weak self] _ in
             self?.animateOverlay(show: false)
         }
     }
-    
+
     fileprivate func updateOverlayAfterStateChanged() {
         if canHideOverlay {
             if overlayTimer == nil {
@@ -477,12 +477,12 @@ extension CallViewController {
             stopOverlayTimer()
         }
     }
-    
+
     fileprivate func restartOverlayTimerIfNeeded() {
         guard nil != overlayTimer, canHideOverlay else { return }
         startOverlayTimer()
     }
-    
+
     fileprivate func stopOverlayTimer() {
         overlayTimer?.invalidate()
         overlayTimer = nil
@@ -491,7 +491,7 @@ extension CallViewController {
 }
 
 extension CallViewController {
-    
+
     func proximityStateDidChange(_ raisedToEar: Bool) {
         guard voiceChannel.isVideoCall, voiceChannel.videoState != .stopped else { return }
         voiceChannel.videoState = raisedToEar ? .paused : .started

--- a/Wire-iOS/Sources/UserInterface/Helpers/ViewControllerDismisser.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/ViewControllerDismisser.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import UIKit
 
 protocol ViewControllerDismisser: class {

--- a/Wire-iOS/Sources/UserInterface/Helpers/ViewControllerDismisser.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/ViewControllerDismisser.swift
@@ -17,9 +17,8 @@
 //
 
 
-import Foundation
 import UIKit
 
 protocol ViewControllerDismisser: class {
-    func dismiss(viewController: UIViewController, completion: (()->())?)
+    func dismiss(viewController: UIViewController, completion: Completion?)
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

After a call screen is minimised, the conversation screen is not responsible to touch events.

### Causes

`CallWindow` is not hidden, and touch evert does not pass though that window.

### Solutions

Hide the window after dismissal