### PR TITLE
Fix: add missing localization in Setting screen

### DIFF
--- a/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
+++ b/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
@@ -77,6 +77,9 @@
                   Identifier = "StartedConversationCellTests/testThatItRendersNewConversationCellWithParticipantsAndNameAllTeamUsersFromSmallTeamWithManyGuests()">
                </Test>
                <Test
+                  Identifier = "StartedConversationCellTests/testThatItRendersNewConversationCellWithParticipantsAndNameAllTeamUsersWithGuests()">
+               </Test>
+               <Test
                   Identifier = "StartedConversationCellTests/testThatItRendersNewConversationCellWithParticipantsAndWithoutName_AllowGuests()">
                </Test>
                <Test

--- a/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
+++ b/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
@@ -77,7 +77,7 @@
                   Identifier = "StartedConversationCellTests/testThatItRendersNewConversationCellWithParticipantsAndNameAllTeamUsersFromSmallTeamWithManyGuests()">
                </Test>
                <Test
-                  Identifier = "StartedConversationCellTests/testThatItRendersNewConversationCellWithParticipantsAndNameAllTeamUsersWithGuests()">
+                  Identifier = "StartedConversationCellTests/testThatItRendersNewConversationCellWithParticipantsAndName_AllowGuests()">
                </Test>
                <Test
                   Identifier = "StartedConversationCellTests/testThatItRendersNewConversationCellWithParticipantsAndWithoutName_AllowGuests()">

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/Cells/GroupDetailsNotificationOptionsCell.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/Cells/GroupDetailsNotificationOptionsCell.swift
@@ -25,7 +25,7 @@ final class GroupDetailsNotificationOptionsCell: GroupDetailsDisclosureOptionsCe
     override func setUp() {
         super.setUp()
         accessibilityIdentifier = "cell.groupdetails.notificationsoptions"
-        title = "group_details.notification_options_cell.title"
+        title = "group_details.notification_options_cell.title".localized
     }
     
     func configure(with conversation: ZMConversation) {

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/Cells/GroupDetailsNotificationOptionsCell.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/Cells/GroupDetailsNotificationOptionsCell.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
 import UIKit
 import WireDataModel
 import WireCommonComponents
@@ -26,7 +25,7 @@ final class GroupDetailsNotificationOptionsCell: GroupDetailsDisclosureOptionsCe
     override func setUp() {
         super.setUp()
         accessibilityIdentifier = "cell.groupdetails.notificationsoptions"
-        title = "Notifications"
+        title = "group_details.notification_options_cell.title"
     }
     
     func configure(with conversation: ZMConversation) {


### PR DESCRIPTION
## What's new in this PR?

Add missing localisation for "Notifications" cell title.