### PR TITLE
Fix: collection screen - search bar is covered by navi bar after popped from image viewer

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionsView.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionsView.swift
@@ -105,7 +105,7 @@ final class CollectionsView: UIView {
         
         constrain(self, searchViewController.searchBar, self.collectionView, self.noResultsView) { selfView, searchBar, collectionView, noResultsView in
             
-            searchBar.top == selfView.top ///TODO: safe top
+            searchBar.top == selfView.top
             searchBar.leading == selfView.leading
             searchBar.trailing == selfView.trailing
             searchBar.height == 56

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionsView.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionsView.swift
@@ -100,12 +100,12 @@ final class CollectionsView: UIView {
     }
     
     func constrainViews(searchViewController: TextSearchViewController) {
-        self.addSubview(searchViewController.resultsView)
-        self.addSubview(searchViewController.searchBar)
+        addSubview(searchViewController.resultsView)
+        addSubview(searchViewController.searchBar)
         
         constrain(self, searchViewController.searchBar, self.collectionView, self.noResultsView) { selfView, searchBar, collectionView, noResultsView in
             
-            searchBar.top == selfView.top
+            searchBar.top == selfView.top ///TODO: safe top
             searchBar.leading == selfView.leading
             searchBar.trailing == selfView.trailing
             searchBar.height == 56

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionsView.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionsView.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
 import Cartography
 import UIKit
@@ -25,19 +24,19 @@ final class CollectionsView: UIView {
     var collectionViewLayout: CollectionViewLeftAlignedFlowLayout!
     var collectionView: UICollectionView!
     let noResultsView = NoResultsView()
-    
+
     static let useAutolayout = false
-    
+
     var noItemsInLibrary: Bool = false {
         didSet {
             self.noResultsView.isHidden = !self.noItemsInLibrary
         }
     }
-    
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         backgroundColor = .from(scheme: .contentBackground)
-        
+
         self.recreateLayout()
         self.collectionView = UICollectionView(frame: CGRect.zero, collectionViewLayout: self.collectionViewLayout)
 
@@ -56,14 +55,14 @@ final class CollectionsView: UIView {
         self.collectionView.isScrollEnabled = true
         self.collectionView.backgroundColor = UIColor.clear
         self.addSubview(self.collectionView)
-   
+
         self.noResultsView.label.accessibilityLabel = "no items"
         self.noResultsView.label.text = "collections.section.no_items".localized(uppercased: true)
         self.noResultsView.icon = .library
         self.noResultsView.isHidden = true
         self.addSubview(self.noResultsView)
     }
-    
+
     private func recreateLayout() {
         let layout = CollectionViewLeftAlignedFlowLayout()
         layout.scrollDirection = .vertical
@@ -73,14 +72,14 @@ final class CollectionsView: UIView {
         if CollectionsView.useAutolayout {
             layout.estimatedItemSize = CGSize(width: 64, height: 64)
         }
-        
+
         self.collectionViewLayout = layout
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     static func closeButton() -> IconButton {
         let button = IconButton(style: .default)
         button.setIcon(.cross, size: .tiny, for: .normal)
@@ -89,7 +88,7 @@ final class CollectionsView: UIView {
         button.imageEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: -24)
         return button
     }
-    
+
     static func backButton() -> IconButton {
         let button = IconButton(style: .default)
         button.setIcon(.backArrow, size: .tiny, for: .normal)
@@ -98,20 +97,20 @@ final class CollectionsView: UIView {
         button.accessibilityIdentifier = "back"
         return button
     }
-    
+
     func constrainViews(searchViewController: TextSearchViewController) {
         addSubview(searchViewController.resultsView)
         addSubview(searchViewController.searchBar)
-        
+
         constrain(self, searchViewController.searchBar, self.collectionView, self.noResultsView) { selfView, searchBar, collectionView, noResultsView in
-            
+
             searchBar.top == selfView.top
             searchBar.leading == selfView.leading
             searchBar.trailing == selfView.trailing
             searchBar.height == 56
-            
+
             collectionView.top == searchBar.bottom
-            
+
             collectionView.leading == selfView.leading
             collectionView.trailing == selfView.trailing
             collectionView.bottom == selfView.bottom
@@ -123,10 +122,10 @@ final class CollectionsView: UIView {
             noResultsView.leading >= selfView.leading + 24
             noResultsView.trailing <= selfView.trailing - 24
         }
-        
+
         constrain(self.collectionView, searchViewController.resultsView) { collectionView, resultsView in
             resultsView.edges == collectionView.edges
         }
     }
-    
+
 }

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Cartography
 import UIKit
 import WireSyncEngine
@@ -26,7 +25,7 @@ protocol CollectionsViewControllerDelegate: class {
 }
 
 final class CollectionsViewController: UIViewController {
-    var onDismiss: ((CollectionsViewController)->())?
+    var onDismiss: ((CollectionsViewController)->Void)?
     let sections: CollectionsSectionSet
     weak var delegate: CollectionsViewControllerDelegate?
     var isShowingSearchResults: Bool {
@@ -38,63 +37,63 @@ final class CollectionsViewController: UIViewController {
     }
 
     var shouldTrackOnNextOpen = false
-    
+
     var currentTextSearchQuery: [String] {
         guard let textSearchController = self.textSearchController else {
             return []
         }
-        
+
         return textSearchController.searchQuery?.components(separatedBy: .whitespacesAndNewlines) ?? []
     }
-    
+
     fileprivate var contentView: CollectionsView! {
         return self.view as? CollectionsView
     }
     fileprivate let messagePresenter = MessagePresenter()
     fileprivate weak var selectedMessage: ZMConversationMessage? = .none
-    
+
     fileprivate var imageMessages: [ZMConversationMessage] = []
     fileprivate var videoMessages: [ZMConversationMessage] = []
     fileprivate var linkMessages: [ZMConversationMessage] = []
     fileprivate var fileAndAudioMessages: [ZMConversationMessage] = []
-    
+
     fileprivate var collection: AssetCollectionWrapper!
 
     fileprivate var lastLayoutSize: CGSize = .zero
     fileprivate var deletionDialogPresenter: DeletionDialogPresenter?
-    
+
     fileprivate var fetchingDone: Bool = false {
         didSet {
             if self.isViewLoaded {
                 self.updateNoElementsState()
                 self.contentView.collectionView.reloadData()
             }
-            
+
             trackOpeningIfNeeded()
         }
     }
-    
+
     fileprivate var inOverviewMode: Bool {
         return self.sections == .all
     }
-    
+
     fileprivate var textSearchController: TextSearchViewController!
-    
+
     convenience init(conversation: ZMConversation) {
         let matchImages = CategoryMatch(including: .image, excluding: .GIF)
         let matchFiles = CategoryMatch(including: .file, excluding: .video)
         let matchVideo = CategoryMatch(including: .video, excluding: .none)
         let matchLink = CategoryMatch(including: .linkPreview, excluding: .none)
-        
+
         let holder = AssetCollectionWrapper(conversation: conversation, matchingCategories: [matchImages, matchFiles, matchVideo, matchLink])
-        
+
         self.init(collection: holder)
     }
-    
+
     init(collection: AssetCollectionWrapper, sections: CollectionsSectionSet = .all, messages: [ZMConversationMessage] = [], fetchingDone: Bool = false) {
         self.collection = collection
         self.sections = sections
-        
+
         switch(sections) {
         case CollectionsSectionSet.images:
             self.imageMessages = messages
@@ -106,22 +105,22 @@ final class CollectionsViewController: UIViewController {
             self.linkMessages = messages
         default: break
         }
-        
+
         self.fetchingDone = fetchingDone
-        
+
         super.init(nibName: .none, bundle: .none)
         self.collection.assetCollectionDelegate.add(self)
         self.deletionDialogPresenter = DeletionDialogPresenter(sourceViewController: self)
     }
-    
+
     deinit {
         self.collection.assetCollectionDelegate.remove(self)
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     func refetchCollection() {
         self.collection.assetCollectionDelegate.remove(self)
         self.imageMessages = []
@@ -132,54 +131,52 @@ final class CollectionsViewController: UIViewController {
         self.collection.assetCollectionDelegate.add(self)
         self.contentView.collectionView.reloadData()
     }
-    
+
     override func loadView() {
         view = CollectionsView()
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         self.textSearchController = TextSearchViewController(conversation: collection.conversation)
         self.textSearchController.delegate = self
         self.contentView.constrainViews(searchViewController: textSearchController)
-        
+
         self.messagePresenter.targetViewController = self
         self.messagePresenter.modalTargetController = self
 
         self.contentView.collectionView.delegate = self
         self.contentView.collectionView.dataSource = self
         self.contentView.collectionView.prefetchDataSource = self
-        
+
         self.updateNoElementsState()
     }
-    
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         setupNavigationItem()
         flushLayout()
-        
+
         navigationController?.interactivePopGestureRecognizer?.isEnabled = true
         navigationController?.interactivePopGestureRecognizer?.delegate = self
 
         ///Prevent content overlaps navi bar
         navigationController?.navigationBar.isTranslucent = false
     }
-    
+
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         self.textSearchController.teardown()
     }
 
-
-    // MARK:- device orientation
-
+    // MARK: - device orientation
 
     /// Notice: for iPad with iOS9 in landscape mode, horizontalSizeClass is .unspecified (.regular in iOS11).
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return wr_supportedInterfaceOrientations
     }
-    
+
     override var shouldAutorotate: Bool {
         switch (self.traitCollection.horizontalSizeClass) {
         case .compact:
@@ -189,7 +186,7 @@ final class CollectionsViewController: UIViewController {
         }
     }
 
-    override var preferredInterfaceOrientationForPresentation : UIInterfaceOrientation {
+    override var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
         return .portrait
     }
 
@@ -198,10 +195,10 @@ final class CollectionsViewController: UIViewController {
             guard let cell = cell as? CollectionCell else {
                 continue
             }
-            
+
             cell.flushCachedSize()
         }
-        
+
         self.contentView.collectionViewLayout.invalidateLayout()
         self.contentView.collectionViewLayout.finalizeCollectionViewUpdates()
     }
@@ -225,12 +222,12 @@ final class CollectionsViewController: UIViewController {
             }
         }
     }
-    
+
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         if self.lastLayoutSize != self.view.bounds.size {
             self.lastLayoutSize = self.view.bounds.size
-            
+
             DispatchQueue.main.async {
                 self.flushLayout()
                 self.reloadData()
@@ -247,52 +244,52 @@ final class CollectionsViewController: UIViewController {
         guard let _ = self.view.window else {
             return
         }
-        
+
         coordinator.animate(alongsideTransition: { _ in
             self.flushLayout()
         }) { _ in
             self.reloadData()
         }
     }
-    
+
     override var prefersStatusBarHidden: Bool {
         return false
     }
-    
-    override var preferredStatusBarStyle : UIStatusBarStyle {
+
+    override var preferredStatusBarStyle: UIStatusBarStyle {
         return ColorScheme.default.variant == .dark ? .lightContent : .default
     }
-    
+
     fileprivate func updateNoElementsState() {
         self.contentView.noItemsInLibrary = self.fetchingDone && self.inOverviewMode && self.totalNumberOfElements() == 0
     }
-    
+
     private func setupNavigationItem() {
-        
+
         // The label must be inset from the top due to navigation bar title alignment
         let titleViewWrapper = UIView()
         let titleView = ConversationTitleView(conversation: self.collection.conversation, interactive: false)
         titleViewWrapper.addSubview(titleView)
-        
+
         constrain(titleView, titleViewWrapper) { titleView, titleViewWrapper in
             titleView.top == titleViewWrapper.top + 4
             titleView.left == titleViewWrapper.left
             titleView.right == titleViewWrapper.right
             titleView.bottom == titleViewWrapper.bottom
         }
-        
+
         titleViewWrapper.setNeedsLayout()
         titleViewWrapper.layoutIfNeeded()
-        
+
         let size = titleViewWrapper.systemLayoutSizeFitting(CGSize(width: 320, height: 44))
         titleViewWrapper.frame = CGRect(x: 0, y: 0, width: size.width, height: size.height)
-        
+
         self.navigationItem.titleView = titleViewWrapper
-        
+
         let button = CollectionsView.closeButton()
         button.addTarget(self, action: #selector(CollectionsViewController.closeButtonPressed(_:)), for: .touchUpInside)
         self.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: button)
-        
+
         if !self.inOverviewMode && self.navigationController?.viewControllers.count > 1 {
             let backButton = CollectionsView.backButton()
             backButton.addTarget(self, action: #selector(CollectionsViewController.backButtonPressed(_:)), for: .touchUpInside)
@@ -304,7 +301,7 @@ final class CollectionsViewController: UIViewController {
     fileprivate func closeButtonPressed(_ button: UIButton) {
         self.onDismiss?(self)
     }
-    
+
     @objc
     fileprivate func backButtonPressed(_ button: UIButton) {
         _ = self.navigationController?.popViewController(animated: true)
@@ -312,41 +309,41 @@ final class CollectionsViewController: UIViewController {
 }
 
 extension CollectionsViewController: AssetCollectionDelegate {
-    func assetCollectionDidFetch(collection: ZMCollection, messages: [CategoryMatch : [ZMConversationMessage]], hasMore: Bool) {
-        
+    func assetCollectionDidFetch(collection: ZMCollection, messages: [CategoryMatch: [ZMConversationMessage]], hasMore: Bool) {
+
         for messageCategory in messages {
             let conversationMessages = messageCategory.value
-            
+
             if messageCategory.key.including.contains(.image) {
                 self.imageMessages.append(contentsOf: conversationMessages)
             }
-            
+
             if messageCategory.key.including.contains(.file) {
                 self.fileAndAudioMessages.append(contentsOf: conversationMessages)
             }
-            
+
             if messageCategory.key.including.contains(.linkPreview) {
                 self.linkMessages.append(contentsOf: conversationMessages)
             }
-            
+
             if messageCategory.key.including.contains(.video) {
                 self.videoMessages.append(contentsOf: conversationMessages)
             }
         }
-        
+
         if self.isViewLoaded {
             self.updateNoElementsState()
             self.contentView.collectionView.reloadData()
         }
     }
-    
+
     func assetCollectionDidFinishFetching(collection: ZMCollection, result: AssetFetchResult) {
         self.fetchingDone = true
     }
 }
 
 extension CollectionsViewController: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
-    
+
     fileprivate func elements(for section: CollectionsSectionSet) -> [ZMConversationMessage] {
         switch(section) {
         case CollectionsSectionSet.images:
@@ -360,193 +357,192 @@ extension CollectionsViewController: UICollectionViewDelegate, UICollectionViewD
         default: fatal("Unknown section")
         }
     }
-    
+
     fileprivate func numberOfElements(for section: CollectionsSectionSet) -> Int {
         switch(section) {
         case CollectionsSectionSet.images:
             let max = self.inOverviewMode ? self.maxOverviewElementsInGrid(in: section) : Int.max
             return min(self.imageMessages.count, max)
-        
+
         case CollectionsSectionSet.filesAndAudio:
             let max = self.inOverviewMode ? self.maxOverviewElementsInTable : Int.max
             return min(self.fileAndAudioMessages.count, max)
-            
+
         case CollectionsSectionSet.videos:
             let max = self.inOverviewMode ? self.maxOverviewElementsInGrid(in: section) : Int.max
             return min(self.videoMessages.count, max)
-            
+
         case CollectionsSectionSet.links:
             let max = self.inOverviewMode ? self.maxOverviewElementsInTable : Int.max
             return min(self.linkMessages.count, max)
-            
+
         case CollectionsSectionSet.loading:
             return 1
-            
+
         default: fatal("Unknown section")
         }
     }
-    
+
     fileprivate func totalNumberOfElements() -> Int {
         // Empty collection contains one element (loading cell)
         return CollectionsSectionSet.visible.map { self.numberOfElements(for: $0) }.reduce(0, +) - 1
     }
-    
+
     fileprivate func moreElementsToSee(in section: CollectionsSectionSet) -> Bool {
         return self.elements(for: section).count > self.numberOfElements(for: section)
     }
-    
+
     fileprivate func message(for indexPath: IndexPath) -> ZMConversationMessage {
         guard let section = CollectionsSectionSet(index: UInt(indexPath.section)) else {
             fatal("Unknown section")
         }
-        
+
         return self.elements(for: section)[indexPath.row]
     }
-    
+
     fileprivate func gridElementSize(in section: CollectionsSectionSet) -> CGSize {
         let sectionHorizontalInset = self.horizontalInset(in: section)
 
         let size = (self.contentView.collectionView.bounds.size.width - sectionHorizontalInset) / CGFloat(self.elementsPerLine(in: section))
-        
+
         return CGSize(width: size - 1, height: size - 1)
     }
-    
+
     fileprivate func elementsPerLine(in section: CollectionsSectionSet) -> Int {
         var count: Int = 1
         let sectionHorizontalInset = self.horizontalInset(in: section)
-        
+
         repeat {
             count += 1
         } while ((self.contentView.collectionView.bounds.size.width - sectionHorizontalInset) / CGFloat(count) > CollectionImageCell.maxCellSize)
-        
+
         return count
     }
-    
+
     fileprivate func maxOverviewElementsInGrid(in section: CollectionsSectionSet) -> Int {
         return self.elementsPerLine(in: section) * 2 // 2 lines of elements
     }
-    
+
     fileprivate var maxOverviewElementsInTable: Int {
         return 3
     }
-    
+
     fileprivate func sizeForCell(at indexPath: IndexPath) -> (CGFloat?, CGFloat?) {
         guard let section = CollectionsSectionSet(index: UInt(indexPath.section)) else {
             fatal("Unknown section")
         }
-        
+
         let gridElementSize = self.gridElementSize(in: section)
-        
+
         var desiredWidth: CGFloat?
         var desiredHeight: CGFloat?
-        
+
         switch(section) {
         case CollectionsSectionSet.images, CollectionsSectionSet.videos:
             desiredWidth = gridElementSize.width
             desiredHeight = gridElementSize.height
-            
+
         case CollectionsSectionSet.filesAndAudio:
             desiredWidth = self.contentView.collectionView.bounds.size.width - self.horizontalInset(in: section)
             if !CollectionsView.useAutolayout {
                 desiredHeight = 96
             }
-        
+
         case CollectionsSectionSet.links:
             desiredWidth = self.contentView.collectionView.bounds.size.width - self.horizontalInset(in: section)
             if !CollectionsView.useAutolayout {
                 desiredHeight = 98
             }
-            
+
         case CollectionsSectionSet.loading:
             desiredWidth = self.contentView.collectionView.bounds.size.width - self.horizontalInset(in: section)
             if !CollectionsView.useAutolayout {
                 desiredHeight = self.fetchingDone ? 24 : 88
             }
-            
+
         default: fatal("Unknown section")
         }
 
         return (desiredWidth, desiredHeight)
     }
-    
+
     fileprivate func horizontalInset(in section: CollectionsSectionSet) -> CGFloat {
         let insets = self.sectionInsets(in: section)
         return insets.left + insets.right
     }
-    
+
     fileprivate func sectionInsets(in section: CollectionsSectionSet) -> UIEdgeInsets {
         if section == CollectionsSectionSet.loading {
             return UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
         }
-        
+
         return self.elements(for: section).count > 0 ? UIEdgeInsets(top: 0, left: 16, bottom: 8, right: 16) : .zero
     }
 
     // MARK: - Data Source
-    
+
     func numberOfSections(in collectionView: UICollectionView) -> Int {
         return CollectionsSectionSet.visible.count
     }
-    
+
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         guard let section = CollectionsSectionSet(index: UInt(section)) else {
             fatal("Unknown section")
         }
-        
+
         return self.numberOfElements(for: section)
     }
-    
+
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         let (width, height) = self.sizeForCell(at: indexPath)
         return CGSize(width: width ?? 0, height: height ?? 0)
     }
-    
+
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let section = CollectionsSectionSet(index: UInt(indexPath.section)) else {
             fatal("Unknown section")
         }
-        
+
         let resultCell: CollectionCell
-        
+
         switch(section) {
         case CollectionsSectionSet.images:
             resultCell = collectionView.dequeueReusableCell(withReuseIdentifier: CollectionImageCell.reuseIdentifier, for: indexPath) as! CollectionImageCell
-            
+
         case CollectionsSectionSet.filesAndAudio:
             if self.message(for: indexPath).fileMessageData?.isAudio == true {
                 resultCell = collectionView.dequeueReusableCell(withReuseIdentifier: CollectionAudioCell.reuseIdentifier, for: indexPath) as! CollectionAudioCell
-            }
-            else {
+            } else {
                 resultCell = collectionView.dequeueReusableCell(withReuseIdentifier: CollectionFileCell.reuseIdentifier, for: indexPath) as! CollectionFileCell
             }
-            
+
         case CollectionsSectionSet.videos:
             resultCell = collectionView.dequeueReusableCell(withReuseIdentifier: CollectionVideoCell.reuseIdentifier, for: indexPath) as! CollectionVideoCell
-    
+
         case CollectionsSectionSet.links:
             resultCell = collectionView.dequeueReusableCell(withReuseIdentifier: CollectionLinkCell.reuseIdentifier, for: indexPath) as! CollectionLinkCell
-            
+
         case CollectionsSectionSet.loading:
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CollectionLoadingCell.reuseIdentifier, for: indexPath) as! CollectionLoadingCell
             cell.collapsed = self.fetchingDone
             cell.containerWidth = collectionView.bounds.size.width - self.horizontalInset(in: section)
             return cell
-        
+
         default: fatal("Unknown section")
         }
-        
+
         let message = self.message(for: indexPath)
         resultCell.message = message
         resultCell.delegate = self
         resultCell.messageChangeDelegate = self
-        
+
         if CollectionsView.useAutolayout {
             let (width, height) = self.sizeForCell(at: indexPath)
-            
+
             resultCell.desiredWidth = width
             resultCell.desiredHeight = height
         }
-        
+
         return resultCell
     }
 
@@ -554,7 +550,7 @@ extension CollectionsViewController: UICollectionViewDelegate, UICollectionViewD
         guard let section = CollectionsSectionSet(index: UInt(indexPath.section)) else {
             fatal("Unknown section")
         }
-        
+
         switch (kind) {
         case UICollectionView.elementKindSectionHeader:
             let header = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: CollectionHeaderView.reuseIdentifier, for: indexPath) as! CollectionHeaderView
@@ -603,21 +599,21 @@ extension CollectionsViewController: UICollectionViewDelegate, UICollectionViewD
     }
 
     // MARK: - Delegate
-    
+
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard let section = CollectionsSectionSet(index: UInt(indexPath.section)) else {
             fatal("Unknown section for indexPath = \(indexPath)")
         }
-        
+
         if section == .loading {
             return
         }
-        
+
         let message = self.message(for: indexPath)
 
         perform(.present, for: message, source: nil)
     }
-    
+
 }
 
 extension CollectionsViewController: UICollectionViewDataSourcePrefetching {
@@ -626,7 +622,7 @@ extension CollectionsViewController: UICollectionViewDataSourcePrefetching {
             guard let section = CollectionsSectionSet(index: UInt(indexPath.section)) else {
                 fatal("Unknown section")
             }
-        
+
             guard section != .loading else {
                 continue
             }
@@ -648,7 +644,7 @@ extension CollectionsViewController: CollectionCellMessageChangeDelegate {
               message.isFile || message.isVideo || message.isAudio else {
             return
         }
-        
+
         self.messagePresenter.openFileMessage(message, targetView: cell)
     }
 }
@@ -659,8 +655,7 @@ extension CollectionsViewController: UIGestureRecognizerDelegate {
     func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
         if self.navigationController?.interactivePopGestureRecognizer == gestureRecognizer {
             return self.navigationController?.viewControllers.count > 1
-        }
-        else {
+        } else {
             return true
         }
     }
@@ -701,16 +696,16 @@ extension CollectionsViewController: CollectionCellDelegate {
 
         case .present:
             self.selectedMessage = message
-            
+
             if message.isImage {
                 let imagesController = ConversationImagesViewController(collection: self.collection, initialMessage: message)
-                
+
                 let backButton = CollectionsView.backButton()
                 backButton.addTarget(self, action: #selector(CollectionsViewController.backButtonPressed(_:)), for: .touchUpInside)
-                
+
                 let closeButton = CollectionsView.closeButton()
                 closeButton.addTarget(self, action: #selector(CollectionsViewController.closeButtonPressed(_:)), for: .touchUpInside)
-                
+
                 imagesController.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: backButton)
                 imagesController.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: closeButton)
                 imagesController.swipeToDismiss = false

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
@@ -17,9 +17,7 @@
 //
 
 
-import Foundation
 import Cartography
-import WireDataModel
 import UIKit
 import WireSyncEngine
 

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
@@ -26,10 +26,10 @@ protocol CollectionsViewControllerDelegate: class {
 }
 
 final class CollectionsViewController: UIViewController {
-    public var onDismiss: ((CollectionsViewController)->())?
-    public let sections: CollectionsSectionSet
+    var onDismiss: ((CollectionsViewController)->())?
+    let sections: CollectionsSectionSet
     weak var delegate: CollectionsViewControllerDelegate?
-    public var isShowingSearchResults: Bool {
+    var isShowingSearchResults: Bool {
         guard let textSearchController = self.textSearchController,
               let resultsView = textSearchController.resultsView else {
             return false
@@ -37,9 +37,9 @@ final class CollectionsViewController: UIViewController {
         return !resultsView.isHidden
     }
 
-    public var shouldTrackOnNextOpen = false
+    var shouldTrackOnNextOpen = false
     
-    public var currentTextSearchQuery: [String] {
+    var currentTextSearchQuery: [String] {
         guard let textSearchController = self.textSearchController else {
             return []
         }
@@ -118,11 +118,11 @@ final class CollectionsViewController: UIViewController {
         self.collection.assetCollectionDelegate.remove(self)
     }
     
-    required public init?(coder aDecoder: NSCoder) {
+    required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
-    public func refetchCollection() {
+    func refetchCollection() {
         self.collection.assetCollectionDelegate.remove(self)
         self.imageMessages = []
         self.videoMessages = []
@@ -133,16 +133,16 @@ final class CollectionsViewController: UIViewController {
         self.contentView.collectionView.reloadData()
     }
     
-    override public func loadView() {
-        self.view = CollectionsView()
+    override func loadView() {
+        view = CollectionsView()
     }
     
-    override public func viewDidLoad() {
+    override func viewDidLoad() {
         super.viewDidLoad()
         
-        self.textSearchController = TextSearchViewController(conversation: self.collection.conversation)
+        self.textSearchController = TextSearchViewController(conversation: collection.conversation)
         self.textSearchController.delegate = self
-        self.contentView.constrainViews(searchViewController: self.textSearchController)
+        self.contentView.constrainViews(searchViewController: textSearchController)
         
         self.messagePresenter.targetViewController = self
         self.messagePresenter.modalTargetController = self
@@ -154,16 +154,19 @@ final class CollectionsViewController: UIViewController {
         self.updateNoElementsState()
     }
     
-    override public func viewWillAppear(_ animated: Bool) {
+    override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        self.setupNavigationItem()
-        self.flushLayout()
+        setupNavigationItem()
+        flushLayout()
         
-        self.navigationController?.interactivePopGestureRecognizer?.isEnabled = true
-        self.navigationController?.interactivePopGestureRecognizer?.delegate = self
+        navigationController?.interactivePopGestureRecognizer?.isEnabled = true
+        navigationController?.interactivePopGestureRecognizer?.delegate = self
+
+        ///Prevent content overlaps navi bar
+        navigationController?.navigationBar.isTranslucent = false
     }
     
-    override public func viewWillDisappear(_ animated: Bool) {
+    override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         self.textSearchController.teardown()
     }
@@ -173,11 +176,11 @@ final class CollectionsViewController: UIViewController {
 
 
     /// Notice: for iPad with iOS9 in landscape mode, horizontalSizeClass is .unspecified (.regular in iOS11).
-    override public var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return wr_supportedInterfaceOrientations
     }
     
-    override public var shouldAutorotate: Bool {
+    override var shouldAutorotate: Bool {
         switch (self.traitCollection.horizontalSizeClass) {
         case .compact:
             return false
@@ -186,7 +189,7 @@ final class CollectionsViewController: UIViewController {
         }
     }
 
-    override public var preferredInterfaceOrientationForPresentation : UIInterfaceOrientation {
+    override var preferredInterfaceOrientationForPresentation : UIInterfaceOrientation {
         return .portrait
     }
 
@@ -223,7 +226,7 @@ final class CollectionsViewController: UIViewController {
         }
     }
     
-    override public func viewDidLayoutSubviews() {
+    override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         if self.lastLayoutSize != self.view.bounds.size {
             self.lastLayoutSize = self.view.bounds.size
@@ -235,12 +238,12 @@ final class CollectionsViewController: UIViewController {
         }
     }
 
-    public override func viewDidAppear(_ animated: Bool) {
+    override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         trackOpeningIfNeeded()
     }
 
-    override public func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         guard let _ = self.view.window else {
             return
         }
@@ -252,11 +255,11 @@ final class CollectionsViewController: UIViewController {
         }
     }
     
-    override public var prefersStatusBarHidden: Bool {
+    override var prefersStatusBarHidden: Bool {
         return false
     }
     
-    public override var preferredStatusBarStyle : UIStatusBarStyle {
+    override var preferredStatusBarStyle : UIStatusBarStyle {
         return ColorScheme.default.variant == .dark ? .lightContent : .default
     }
     
@@ -297,17 +300,19 @@ final class CollectionsViewController: UIViewController {
         }
     }
 
-    @objc func closeButtonPressed(_ button: UIButton) {
+    @objc
+    fileprivate func closeButtonPressed(_ button: UIButton) {
         self.onDismiss?(self)
     }
     
-    @objc func backButtonPressed(_ button: UIButton) {
+    @objc
+    fileprivate func backButtonPressed(_ button: UIButton) {
         _ = self.navigationController?.popViewController(animated: true)
     }
 }
 
 extension CollectionsViewController: AssetCollectionDelegate {
-    public func assetCollectionDidFetch(collection: ZMCollection, messages: [CategoryMatch : [ZMConversationMessage]], hasMore: Bool) {
+    func assetCollectionDidFetch(collection: ZMCollection, messages: [CategoryMatch : [ZMConversationMessage]], hasMore: Bool) {
         
         for messageCategory in messages {
             let conversationMessages = messageCategory.value
@@ -335,7 +340,7 @@ extension CollectionsViewController: AssetCollectionDelegate {
         }
     }
     
-    public func assetCollectionDidFinishFetching(collection: ZMCollection, result: AssetFetchResult) {
+    func assetCollectionDidFinishFetching(collection: ZMCollection, result: AssetFetchResult) {
         self.fetchingDone = true
     }
 }
@@ -479,11 +484,11 @@ extension CollectionsViewController: UICollectionViewDelegate, UICollectionViewD
 
     // MARK: - Data Source
     
-    public func numberOfSections(in collectionView: UICollectionView) -> Int {
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
         return CollectionsSectionSet.visible.count
     }
     
-    public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         guard let section = CollectionsSectionSet(index: UInt(section)) else {
             fatal("Unknown section")
         }
@@ -491,12 +496,12 @@ extension CollectionsViewController: UICollectionViewDelegate, UICollectionViewD
         return self.numberOfElements(for: section)
     }
     
-    public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         let (width, height) = self.sizeForCell(at: indexPath)
         return CGSize(width: width ?? 0, height: height ?? 0)
     }
     
-    public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let section = CollectionsSectionSet(index: UInt(indexPath.section)) else {
             fatal("Unknown section")
         }
@@ -545,7 +550,7 @@ extension CollectionsViewController: UICollectionViewDelegate, UICollectionViewD
         return resultCell
     }
 
-    public func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+    func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
         guard let section = CollectionsSectionSet(index: UInt(indexPath.section)) else {
             fatal("Unknown section")
         }
@@ -575,7 +580,7 @@ extension CollectionsViewController: UICollectionViewDelegate, UICollectionViewD
 
     // MARK: - Layout
 
-    public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
         guard let section = CollectionsSectionSet(index: UInt(section)) else {
             fatal("Unknown section")
         }
@@ -586,11 +591,11 @@ extension CollectionsViewController: UICollectionViewDelegate, UICollectionViewD
         return self.elements(for: section).count > 0 ? CGSize(width: collectionView.bounds.size.width, height: 48) : .zero
     }
 
-    public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForFooterInSection section: Int) -> CGSize {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForFooterInSection section: Int) -> CGSize {
         return .zero
     }
 
-    public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
         guard let section = CollectionsSectionSet(index: UInt(section)) else {
             fatal("Unknown section")
         }
@@ -599,7 +604,7 @@ extension CollectionsViewController: UICollectionViewDelegate, UICollectionViewD
 
     // MARK: - Delegate
     
-    public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard let section = CollectionsSectionSet(index: UInt(indexPath.section)) else {
             fatal("Unknown section for indexPath = \(indexPath)")
         }
@@ -616,7 +621,7 @@ extension CollectionsViewController: UICollectionViewDelegate, UICollectionViewD
 }
 
 extension CollectionsViewController: UICollectionViewDataSourcePrefetching {
-    public func collectionView(_ collectionView: UICollectionView, prefetchItemsAt indexPaths: [IndexPath]) {
+    func collectionView(_ collectionView: UICollectionView, prefetchItemsAt indexPaths: [IndexPath]) {
         for indexPath in indexPaths {
             guard let section = CollectionsSectionSet(index: UInt(indexPath.section)) else {
                 fatal("Unknown section")
@@ -651,7 +656,7 @@ extension CollectionsViewController: CollectionCellMessageChangeDelegate {
 // MARK: - Gestures
 
 extension CollectionsViewController: UIGestureRecognizerDelegate {
-    public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
         if self.navigationController?.interactivePopGestureRecognizer == gestureRecognizer {
             return self.navigationController?.viewControllers.count > 1
         }
@@ -663,7 +668,7 @@ extension CollectionsViewController: UIGestureRecognizerDelegate {
 
 // MARK: - Actions
 extension CollectionsViewController: MessageActionResponder {
-    public func perform(action: MessageAction, for message: ZMConversationMessage!, view: UIView) {
+    func perform(action: MessageAction, for message: ZMConversationMessage!, view: UIView) {
         perform(action, for: message, source: view as? CollectionCell)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Collections/TextSearch/TextSearchViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/TextSearch/TextSearchViewController.swift
@@ -18,7 +18,6 @@
 
 import Foundation
 import WireSyncEngine
-import WireDataModel
 import Cartography
 
 final class TextSearchViewController: NSObject {
@@ -71,7 +70,8 @@ final class TextSearchViewController: NSObject {
         self.perform(searchSelector, with: .none, afterDelay: 0.2)
     }
     
-    @objc fileprivate func search() {
+    @objc
+    fileprivate func search() {
         let searchSelector = #selector(TextSearchViewController.search)
         NSObject.cancelPreviousPerformRequests(withTarget: self, selector: searchSelector, object: .none)
         textSearchQuery?.cancel()
@@ -105,7 +105,8 @@ final class TextSearchViewController: NSObject {
         resultsView.tableView.reloadData()
     }
 
-    @objc fileprivate func showLoadingSpinner() {
+    @objc
+    fileprivate func showLoadingSpinner() {
         searchBar.isLoading = true
     }
 

--- a/Wire-iOS/Sources/UserInterface/Collections/TextSearch/TextSearchViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/TextSearch/TextSearchViewController.swift
@@ -23,7 +23,7 @@ import Cartography
 final class TextSearchViewController: NSObject {
     public var resultsView: TextSearchResultsView!
     public var searchBar: TextSearchInputView!
-    
+
     weak var delegate: MessageActionResponder? = .none
     public let conversation: ZMConversation
     public var searchQuery: String? {
@@ -31,7 +31,7 @@ final class TextSearchViewController: NSObject {
     }
 
     fileprivate var textSearchQuery: TextSearchQuery?
-    
+
     fileprivate var results: [ZMConversationMessage] = [] {
         didSet {
             reloadResults()
@@ -39,13 +39,13 @@ final class TextSearchViewController: NSObject {
     }
 
     fileprivate var searchStartedDate: Date?
-    
+
     init(conversation: ZMConversation) {
         self.conversation = conversation
         super.init()
         self.loadViews()
     }
-    
+
     private func loadViews() {
         self.resultsView = TextSearchResultsView()
         self.resultsView.isHidden = results.count == 0
@@ -54,7 +54,7 @@ final class TextSearchViewController: NSObject {
 
         self.resultsView.tableView.delegate = self
         self.resultsView.tableView.dataSource = self
-        
+
         self.searchBar = TextSearchInputView()
         self.searchBar.delegate = self
         self.searchBar.placeholderString = "collections.search.field.placeholder".localized(uppercased: true)
@@ -63,13 +63,13 @@ final class TextSearchViewController: NSObject {
     public func teardown() {
         textSearchQuery?.cancel()
     }
-    
+
     fileprivate func scheduleSearch() {
         let searchSelector = #selector(TextSearchViewController.search)
         NSObject.cancelPreviousPerformRequests(withTarget: self, selector: searchSelector, object: .none)
         self.perform(searchSelector, with: .none, afterDelay: 0.2)
     }
-    
+
     @objc
     fileprivate func search() {
         let searchSelector = #selector(TextSearchViewController.search)
@@ -151,13 +151,13 @@ extension TextSearchViewController: UITableViewDelegate, UITableViewDataSource {
     public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return self.results.count
     }
-    
+
     public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: TextSearchResultCell.reuseIdentifier) as! TextSearchResultCell
         cell.configure(with: self.results[indexPath.row], queries: self.searchQuery?.components(separatedBy: .whitespacesAndNewlines) ?? [])
         return cell
     }
-    
+
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         delegate?.perform(action: .showInConversation, for: self.results[indexPath.row], view: tableView)
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
@@ -180,6 +180,7 @@ extension ConversationViewController {
 
         collectionController?.shouldTrackOnNextOpen = true
 
+        
         let navigationController = KeyboardAvoidingViewController(viewController: self.collectionController!).wrapInNavigationController()
 
         ZClientViewController.shared?.present(navigationController, animated: true)

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
@@ -26,7 +26,7 @@ extension ConversationViewController {
     func addCallStateObserver() -> Any? {
         return conversation.voiceChannel?.addCallStateObserver(self)
     }
-    
+
     var audioCallButton: UIBarButtonItem {
         let button = UIBarButtonItem(icon: .phone, target: self, action: #selector(ConversationViewController.voiceCallItemTapped(_:)))
         button.accessibilityIdentifier = "audioCallBarButton"
@@ -64,7 +64,7 @@ extension ConversationViewController {
         let arrowIcon: StyleKitIcon = view.isRightToLeft
             ? (hasUnreadInOtherConversations ? .forwardArrowWithDot : .forwardArrow)
             : (hasUnreadInOtherConversations ? .backArrowWithDot : .backArrow)
-        
+
         let icon: StyleKitIcon = (self.parent?.wr_splitViewController?.layoutSize == .compact) ? arrowIcon : .hamburger
         let action = #selector(ConversationViewController.onBackButtonPressed(_:))
         let button = UIBarButtonItem(icon: icon, target: self, action: action)
@@ -75,7 +75,7 @@ extension ConversationViewController {
             button.tintColor = UIColor.accent()
             button.accessibilityValue = "conversation_list.voiceover.unread_messages.hint".localized
         }
-        
+
         return button
     }
 
@@ -85,11 +85,11 @@ extension ConversationViewController {
         let button = UIBarButtonItem(icon: showingSearchResults ? .activeSearch : .search, target: self, action: action)
         button.accessibilityIdentifier = "collection"
         button.accessibilityLabel = "conversation.action.search".localized
-        
+
         if showingSearchResults {
             button.tintColor = UIColor.accent()
         }
-        
+
         return button
     }
 
@@ -180,7 +180,6 @@ extension ConversationViewController {
 
         collectionController?.shouldTrackOnNextOpen = true
 
-        
         let navigationController = KeyboardAvoidingViewController(viewController: self.collectionController!).wrapInNavigationController()
 
         ZClientViewController.shared?.present(navigationController, animated: true)
@@ -264,14 +263,14 @@ extension ZMConversation {
 }
 
 extension CallState {
-    
+
     var canJoinCall: Bool {
         switch self {
         case .incoming: return true
         default: return false
         }
     }
-    
+
     var isCallOngoing: Bool {
         switch self {
         case .none, .incoming: return false


### PR DESCRIPTION
## What's new in this PR?

### Issues

When popped to Collection Screen, the search bar is covered by navigation bar.

### Causes

Seems like a autolayout issue.

### Solutions

Set `navigationController?.navigationBar.isTranslucent = false` in `viewWillAppear` (The collection view does not go under navigation bar)