### PR TITLE
Fix: Xcode 11: action sheet has dark text in iOS dark mode

### DIFF
--- a/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 import UIKit
-import WireDataModel
 import WireSyncEngine
 
 final class ConversationActionController {

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -474,7 +474,16 @@ final class ZClientViewController: UIViewController {
         GroupConversationCell.appearance(whenContainedInInstancesOf: [StartUIView.self]).contentBackgroundColor = .clear
         OpenServicesAdminCell.appearance(whenContainedInInstancesOf: [StartUIView.self]).colorSchemeVariant = .dark
         OpenServicesAdminCell.appearance(whenContainedInInstancesOf: [StartUIView.self]).contentBackgroundColor = .clear
-        UIView.appearance(whenContainedInInstancesOf: [UIAlertController.self]).tintColor = ColorScheme.default.color(named: .textForeground, variant: .light)
+        
+        
+        let labelColor: UIColor
+        if #available(iOS 13.0, *) {
+            labelColor = .label
+        } else {
+            labelColor = ColorScheme.default.color(named: .textForeground, variant: .light)
+        }
+
+        UIView.appearance(whenContainedInInstancesOf: [UIAlertController.self]).tintColor = labelColor
     }
 
     // MARK: - Setup methods


### PR DESCRIPTION
## What's new in this PR?

For iOS 13, uses `UIColor.label` which adapts system apperance for alert's tint(text) color.