### PR TITLE
[Fix]: Remove devices step during login includes temporary clients

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
@@ -111,7 +111,10 @@ final class ClientListViewController: UIViewController,
             self.variant = variant
         }
 
-        clientFilter = { $0 != selfClient && (showTemporary || $0.type != .temporary && showLegalHold || $0.type != .legalHold) }
+        clientFilter = {
+            $0 != selfClient && (showTemporary || $0.type != .temporary) && (showLegalHold || $0.type != .legalHold)
+        }
+
         clientSorter = {
             guard let leftDate = $0.activationDate, let rightDate = $1.activationDate else { return false }
             return leftDate.compare(rightDate) == .orderedDescending


### PR DESCRIPTION
## What's new in this PR?

### Issues

The temporary device(s) were shown in the remove device scree after the login.

### Causes

Wrong filter applied

### Solutions

Correct filter applied