### PR TITLE
Fix: Xcode 11: status bar is white on white after dismissed the conversation detail screen

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation Options/UINavigationController+CloseButton.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/UINavigationController+CloseButton.swift
@@ -30,6 +30,9 @@ extension UINavigationController {
     
     @objc
     private func closeTapped() {
-        dismiss(animated: true) /// TODO: delegate
+        weak var presentingVC = presentingViewController
+        dismiss(animated: true) {
+            presentingVC?.setNeedsStatusBarAppearanceUpdate()
+        }
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation Options/UINavigationController+CloseButton.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/UINavigationController+CloseButton.swift
@@ -21,14 +21,15 @@ import UIKit
 
 extension UINavigationController {
     
-    @objc func closeItem() -> UIBarButtonItem {
+    func closeItem() -> UIBarButtonItem {
         let item = UIBarButtonItem(icon: .cross, target: self, action: #selector(closeTapped))
         item.accessibilityIdentifier = "close"
         item.accessibilityLabel = "general.close".localized
         return item
     }
     
-    @objc private func closeTapped() {
-        dismiss(animated: true)
+    @objc
+    private func closeTapped() {
+        dismiss(animated: true) /// TODO: delegate
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationRootViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationRootViewController.swift
@@ -16,10 +16,8 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
 import Cartography
 import UIKit
-import WireDataModel
 import WireSyncEngine
 
 // This class wraps the conversation content view controller in order to display the navigation bar on the top
@@ -127,12 +125,10 @@ final class ConversationRootViewController: UIViewController {
         return child
     }
 
-    @objc (scrollToMessage:)
     func scroll(to message: ZMConversationMessage) {
         conversationViewController?.scroll(to: message)
     }
 }
-
 
 extension ConversationRootViewController: NetworkStatusBarDelegate {
     var bottomMargin: CGFloat {

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+ParticipantsPopover.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+ParticipantsPopover.swift
@@ -20,17 +20,35 @@ import UIKit
 
 extension ConversationViewController: UIPopoverPresentationControllerDelegate {
 
-    @objc (createAndPresentParticipantsPopoverControllerWithRect:fromView:contentViewController:)
     func createAndPresentParticipantsPopoverController(with rect: CGRect,
                                                        from view: UIView,
                                                        contentViewController controller: UIViewController) {
 
         endEditing()
-        controller.modalPresentationStyle = .formSheet
+
+        controller.presentationController?.delegate = self
         present(controller, animated: true)
     }
+}
 
+extension ConversationViewController: UIAdaptivePresentationControllerDelegate {
+    func adaptivePresentationStyle(for controller: UIPresentationController) -> UIModalPresentationStyle {
+        if (controller.presentedViewController is AddParticipantsViewController) {
+            return .overFullScreen
+        }
+        
+        if #available(iOS 13, *) {
+            return .formSheet
+        } else {
+            return .fullScreen
+        }
+    }
 
+    func presentationControllerDidDismiss( _ presentationController: UIPresentationController) {
+        if #available(iOS 13, *) {
+            endEditing()
+        }
+    }
 }
 
 extension ConversationViewController: ViewControllerDismisser {

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+ParticipantsPopover.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+ParticipantsPopover.swift
@@ -45,9 +45,7 @@ extension ConversationViewController: UIAdaptivePresentationControllerDelegate {
     }
 
     func presentationControllerDidDismiss( _ presentationController: UIPresentationController) {
-        if #available(iOS 13, *) {
-            endEditing()
-        }
+        setNeedsStatusBarAppearanceUpdate()
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+ProfileViewControllerDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+ProfileViewControllerDelegate.swift
@@ -16,12 +16,9 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
-import WireDataModel
 import WireSyncEngine
 
 extension ConversationViewController {
-    @objc
     func createUserDetailViewController() -> UIViewController {
         guard let user = (conversation.firstActiveParticipantOtherThanSelf ?? conversation.connectedUser) else {
             fatal("no firstActiveParticipantOtherThanSelf!")            

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
@@ -16,8 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
-import WireDataModel
 import UIKit
 import WireSyncEngine
 import WireCommonComponents
@@ -349,15 +347,8 @@ final class ConversationViewController: UIViewController {
             dismiss(animated: true)
         }
     }
-    
-    // MARK: - UIPopoverPresentationControllerDelegate
-    func adaptivePresentationStyle(for controller: UIPresentationController) -> UIModalPresentationStyle {
-        if (controller.presentedViewController is AddParticipantsViewController) {
-            return .overFullScreen
-        }
-        return .fullScreen
-    }
 }
+
 //MARK: - InvisibleInputAccessoryViewDelegate
 
 extension ConversationViewController: InvisibleInputAccessoryViewDelegate {

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
@@ -18,7 +18,6 @@
 
 import UIKit
 import Cartography
-import WireDataModel
 import WireSyncEngine
 
 final class GroupDetailsViewController: UIViewController, ZMConversationObserver, GroupDetailsFooterViewDelegate {
@@ -45,8 +44,7 @@ final class GroupDetailsViewController: UIViewController, ZMConversationObserver
         return ColorScheme.default.statusBarStyle
     }
 
-    @objc
-    public init(conversation: ZMConversation) {
+    init(conversation: ZMConversation) {
         self.conversation = conversation
         collectionViewController = SectionCollectionViewController()
         


### PR DESCRIPTION
## What's new in this PR?

### Issues

Status bar is white on white after dismissed conversation detail screen.

### Causes

Unknown, status bar should be updated by the system.

### Solutions

Call `setNeedsStatusBarAppearanceUpdate` after the presented screen is dismissed.