### PR TITLE
[Fix] Crash opening 1:1 conversation in tier 1 team

### DIFF
--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewControllerViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewControllerViewModel.swift
@@ -123,12 +123,15 @@ final class ProfileViewControllerViewModel: NSObject {
             zmLog.error("No user to open conversation with")
             return
         }
-        var conversation: ZMConversation! = nil
+        var conversation: ZMConversation? = nil
         
         ZMUserSession.shared()?.enqueue({
             conversation = fullUser.oneToOneConversation
         }, completionHandler: {
-            self.delegate?.profileViewController(self.viewModelDelegate as? ProfileViewController, wantsToNavigateTo: conversation)
+            guard let conversation = conversation else { return }
+            
+            self.delegate?.profileViewController(self.viewModelDelegate as? ProfileViewController,
+                                                 wantsToNavigateTo: conversation)
         })
     }
     

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewControllerViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewControllerViewModel.swift
@@ -258,6 +258,10 @@ extension ProfileViewControllerViewModel: ZMUserObserver {
         if note.nameChanged {
             viewModelDelegate?.updateTitleView()
         }
+        
+        if note.user.isAccountDeleted {
+            viewModelDelegate?.updateFooterViews()
+        }
     }
 }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

The app would crash if you tried to open the 1:1 conversation of deleted user in a tier 1 team.

### Causes

The user is no longer a member of the team after the he/she been deleted which causes `ZMUser.oneToOneConversation` to return `nil`. This was resulting in a crash because we where force unwrapping the conversation.

### Solutions

1. Guard against conversation being nil
2. Hide the "open conversation" button if we discover that a user is deleted.

### Notes

JIRA: https://wearezeta.atlassian.net/browse/ZIOS-13343