### PR TITLE
Call window blocks touches to conversation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -17,7 +17,6 @@
 //
 
 import UIKit
-import AVFoundation
 import WireSyncEngine
 import avs
 
@@ -93,7 +92,8 @@ final class CallViewController: UIViewController {
         singleTapRecognizer.require(toFail: doubleTapRecognizer)
     }
 
-    @objc func handleSingleTap(_ sender: UITapGestureRecognizer) {
+    @objc
+    private func handleSingleTap(_ sender: UITapGestureRecognizer) {
 
         guard canHideOverlay else { return }
 

--- a/Wire-iOS/Sources/UserInterface/Helpers/InteractiveModalTransition.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/InteractiveModalTransition.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
 import Cartography
 import UIKit
 
@@ -121,7 +120,8 @@ final fileprivate class ModalInteractionController: UIPercentDrivenInteractiveTr
         viewController.view.addGestureRecognizer(UIPanGestureRecognizer(target: self, action: #selector(didPan)))
     }
     
-    @objc private func didPan(_ sender: UIPanGestureRecognizer) {
+    @objc
+    private func didPan(_ sender: UIPanGestureRecognizer) {
         let translation = sender.translation(in: sender.view!.superview!)
         var progress = (translation.y / presentationViewController.viewController.view.bounds.height)
         progress = CGFloat(fminf(fmaxf(Float(progress), 0.0), 1.0))
@@ -129,7 +129,11 @@ final fileprivate class ModalInteractionController: UIPercentDrivenInteractiveTr
         switch sender.state {
         case .began:
             interactionInProgress = true
-            presentationViewController.dismiss(animated: true, completion: nil)
+            
+            weak var window = presentationViewController.view.window
+            presentationViewController.dismiss(animated: true) { ///TODO:
+                window?.isHidden = true
+            }
         case .changed:
             shouldCompleteTransition = progress > 0.2
             update(progress)
@@ -198,7 +202,8 @@ final class ModalPresentationViewController: UIViewController, UIViewControllerT
         }
     }
     
-    @objc private func didTapDimView(_ sender: UITapGestureRecognizer) {
+    @objc
+    private func didTapDimView(_ sender: UITapGestureRecognizer) {
         dismiss(animated: true, completion: nil)
     }
     

--- a/Wire-iOS/Sources/UserInterface/Helpers/InteractiveModalTransition.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/InteractiveModalTransition.swift
@@ -131,7 +131,7 @@ final private class ModalInteractionController: UIPercentDrivenInteractiveTransi
             interactionInProgress = true
 
             weak var window = presentationViewController.view.window
-            presentationViewController.dismiss(animated: true) { ///TODO:
+            presentationViewController.dismiss(animated: true) {
                 window?.isHidden = true
             }
         case .changed:

--- a/Wire-iOS/Sources/UserInterface/Helpers/InteractiveModalTransition.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/InteractiveModalTransition.swift
@@ -25,39 +25,39 @@ struct ModalPresentationConfiguration {
 }
 
 fileprivate extension UIViewControllerContextTransitioning {
-    func complete(_ success: Bool) -> Void {
+    func complete(_ success: Bool) {
         completeTransition(!transitionWasCancelled)
     }
 }
 
 final private class ModalPresentationTransition: NSObject, UIViewControllerAnimatedTransitioning {
-    
+
     private let configuration: ModalPresentationConfiguration
-    
+
     init(configuration: ModalPresentationConfiguration) {
         self.configuration = configuration
         super.init()
     }
-    
+
     func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
         return configuration.duration
     }
-    
+
     func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
         guard let toVC = transitionContext.viewController(forKey: .to) as? ModalPresentationViewController else { preconditionFailure("No ModalPresentationViewController") }
-        
+
         transitionContext.containerView.addSubview(toVC.view)
         toVC.view.layoutIfNeeded()
-        
+
         let animations = { [configuration] in
             toVC.dimView.backgroundColor = .init(white: 0, alpha: configuration.alpha)
             toVC.viewController.view.transform  = .identity
         }
-        
+
         if !transitionContext.isAnimated {
             return transitionContext.complete(true)
         }
-        
+
         toVC.viewController.view.transform = CGAffineTransform(translationX: 0, y: toVC.viewController.view.bounds.height)
         UIView.animate(
             withDuration: transitionDuration(using: transitionContext),
@@ -67,37 +67,37 @@ final private class ModalPresentationTransition: NSObject, UIViewControllerAnima
             completion: transitionContext.complete
         )
     }
-    
+
 }
 
 final private class ModalDismissalTransition: NSObject, UIViewControllerAnimatedTransitioning {
-    
+
     private let configuration: ModalPresentationConfiguration
-    
+
     init(configuration: ModalPresentationConfiguration) {
         self.configuration = configuration
         super.init()
     }
-    
+
     func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
         return configuration.duration
     }
-    
+
     func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
         guard let fromVC = transitionContext.viewController(forKey: .from) as? ModalPresentationViewController else { preconditionFailure("No ModalPresentationViewController") }
         guard let toVC = transitionContext.viewController(forKey: .to) else { preconditionFailure("No view controller to present") }
-        
+
         let animations = {
             toVC.view.transform  = .identity
             fromVC.viewController.view.transform = CGAffineTransform(translationX: 0, y: fromVC.viewController.view.bounds.height)
             fromVC.dimView.backgroundColor = .clear
         }
-        
+
         if !transitionContext.isAnimated {
             animations()
             return transitionContext.complete(true)
         }
-        
+
         UIView.animate(
             withDuration: transitionDuration(using: transitionContext),
             delay: transitionContext.isInteractive ? configuration.duration : 0,
@@ -106,30 +106,30 @@ final private class ModalDismissalTransition: NSObject, UIViewControllerAnimated
             completion: transitionContext.complete
         )
     }
-    
+
 }
 
-final fileprivate class ModalInteractionController: UIPercentDrivenInteractiveTransition {
-    
+final private class ModalInteractionController: UIPercentDrivenInteractiveTransition {
+
     var interactionInProgress = false
     private var shouldCompleteTransition = false
     private weak var presentationViewController: ModalPresentationViewController!
-    
+
     func setupWith(viewController: ModalPresentationViewController) {
         presentationViewController = viewController
         viewController.view.addGestureRecognizer(UIPanGestureRecognizer(target: self, action: #selector(didPan)))
     }
-    
+
     @objc
     private func didPan(_ sender: UIPanGestureRecognizer) {
         let translation = sender.translation(in: sender.view!.superview!)
         var progress = (translation.y / presentationViewController.viewController.view.bounds.height)
         progress = CGFloat(fminf(fmaxf(Float(progress), 0.0), 1.0))
-        
+
         switch sender.state {
         case .began:
             interactionInProgress = true
-            
+
             weak var window = presentationViewController.view.window
             presentationViewController.dismiss(animated: true) { ///TODO:
                 window?.isHidden = true
@@ -146,17 +146,17 @@ final fileprivate class ModalInteractionController: UIPercentDrivenInteractiveTr
         default: break
         }
     }
-    
+
 }
 
 final class ModalPresentationViewController: UIViewController, UIViewControllerTransitioningDelegate {
 
     fileprivate unowned let viewController: UIViewController
     fileprivate let dimView = UIView()
-    
+
     private let interactionController = ModalInteractionController()
     private let configuration: ModalPresentationConfiguration
-    
+
     init(viewController: UIViewController, configuration: ModalPresentationConfiguration = .init(alpha: 0.3, duration: 0.3)) {
         self.viewController = viewController
         self.configuration = configuration
@@ -165,16 +165,16 @@ final class ModalPresentationViewController: UIViewController, UIViewControllerT
         createConstraints()
         modalPresentationCapturesStatusBarAppearance = true
     }
-    
+
     @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     override var childForStatusBarStyle: UIViewController? {
         return viewController
     }
-    
+
     override var childForStatusBarHidden: UIViewController? {
         return viewController
     }
@@ -194,29 +194,29 @@ final class ModalPresentationViewController: UIViewController, UIViewControllerT
         view.addSubview(viewController.view)
         viewController.didMove(toParent: self)
     }
-    
+
     private func createConstraints() {
         constrain(view, viewController.view, dimView) { view, childViewControllerView, dimView in
             childViewControllerView.edges == view.edges
             dimView.edges == view.edges
         }
     }
-    
+
     @objc
     private func didTapDimView(_ sender: UITapGestureRecognizer) {
         dismiss(animated: true, completion: nil)
     }
-    
+
     func animationController(forPresented presented: UIViewController, presenting: UIViewController, source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
         return ModalPresentationTransition(configuration: configuration)
     }
-    
+
     func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
         return ModalDismissalTransition(configuration: configuration)
     }
-    
+
     func interactionControllerForDismissal(using animator: UIViewControllerAnimatedTransitioning) -> UIViewControllerInteractiveTransitioning? {
         return interactionController.interactionInProgress ? interactionController : nil
     }
-    
+
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

After dismiss a call screen by panning, the UI does not response to touches.

### Causes

same as https://github.com/wireapp/wire-ios/pull/4339

### Solutions

hide window when dismissal is done.