### PR TITLE
Fix: XCode11: endless spinner when sharing a text file from file app

### DIFF
--- a/Wire-iOS Share Extension/UnsentSendable.swift
+++ b/Wire-iOS Share Extension/UnsentSendable.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import UIKit
 import WireShareEngine
 import MobileCoreServices
@@ -44,13 +43,11 @@ protocol UnsentSendable {
     var error: UnsentSendableError? { get }
 }
 
-
 extension UnsentSendable {
     func prepare(completion: @escaping () -> Void) {
         precondition(needsPreparation, "Ensure this objects needs preparation, c.f. `needsPreparation`")
     }
 }
-
 
 class UnsentSendableBase {
 
@@ -90,13 +87,13 @@ class UnsentTextSendable: UnsentSendableBase, UnsentSendable {
             completion(message)
         }
     }
-    
+
     func prepare(completion: @escaping () -> Void) {
         precondition(needsPreparation, "Ensure this objects needs preparation, c.f. `needsPreparation`")
         needsPreparation = false
-        
+
         if let attachment = self.attachment, attachment.hasURL {
-            
+
             self.attachment?.fetchURL(completion: { (url) in
                 completion()
             })
@@ -124,53 +121,53 @@ final class UnsentImageSendable: UnsentSendableBase, UnsentSendable {
         needsPreparation = false
 
         let longestDimension: CGFloat = 1024
-        
+
         // note: this doesn't seem to have any effect, but perhaps it's an iOS bug that will be fixed...
         let options = [NSItemProviderPreferredImageSizeKey : NSValue(cgSize: CGSize(width: longestDimension, height: longestDimension))]
-        
+
         // app extensions have severely limited memory resources & risk termination if they are too greedy. In order to
         // minimize memory consumption we must downscale the images being shared. Standard image scaling methods that
         // rely on UIImage are too expensive (eg. 12MP image -> approx 48MB UIImage), so we make the system scale the images
         // for us ('free' of charge) by using the image URL & ImageIO library.
         //
-        
+
         attachment.loadItem(forTypeIdentifier: kUTTypeImage as String, options: options) { [weak self] (url, error) in
             error?.log(message: "Unable to load image from attachment")
-            
+
             //Tries to load the content from local URL...
-            
+
             if let cfUrl = (url as? URL) as CFURL?,
-               let imageSource = CGImageSourceCreateWithURL(cfUrl, nil) {
-                let options: [NSString : Any] = [
+                let imageSource = CGImageSourceCreateWithURL(cfUrl, nil) {
+                let options: [NSString: Any] = [
                     kCGImageSourceThumbnailMaxPixelSize: longestDimension,
                     kCGImageSourceCreateThumbnailFromImageAlways: true,
                     kCGImageSourceCreateThumbnailWithTransform: true
                 ]
-                
+
                 if let scaledImage = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, options as CFDictionary) {
                     self?.imageData = UIImage(cgImage: scaledImage).jpegData(compressionQuality: 0.9)
                 }
-                
+
                 completion()
-                
+
             } else {
-                
+
                 // if it fails, it will attach the content directly
-                
+
                 self?.attachment.loadItem(forTypeIdentifier: kUTTypeImage as String, options: options) { [weak self] (image, error) in
-                    
+
                     error?.log(message: "Unable to load image from attachment")
-                    
+
                     if let image = image as? UIImage {
                         self?.imageData = image.jpegData(compressionQuality: 0.9)
                     }
-                    
+
                     completion()
                 }
             }
-            
+
         }
-        
+
     }
 
     func send(completion: @escaping (Sendable?) -> Void) {
@@ -229,11 +226,11 @@ class UnsentFileSendable: UnsentSendableBase, UnsentSendable {
             completion(self.metadata.flatMap(self.conversation.appendFile))
         }
     }
-    
+
     private func prepareAsFileData(name: String?, completion: @escaping () -> Void) {
         self.prepareAsFile(name: name, typeIdentifier: kUTTypeData as String, completion: completion)
     }
-    
+
     private func prepareAsWalletPass(name: String?, completion: @escaping () -> Void) {
         self.prepareAsFile(name: nil, typeIdentifier: UnsentFileSendable.passkitUTI, completion: completion)
     }
@@ -250,7 +247,7 @@ class UnsentFileSendable: UnsentSendableBase, UnsentSendable {
                     error?.log(message: "Unable to prepare file attachment for sending")
                     return completion()
                 }
-                
+
                 // Generating PDF previews can be expensive. To avoid hitting the Share Extension's
                 // memory budget we should avoid to generate previews if the file is a PDF.
                 guard !UTTypeConformsTo(url.UTI() as CFString, kUTTypePDF) else {
@@ -258,30 +255,49 @@ class UnsentFileSendable: UnsentSendableBase, UnsentSendable {
                     completion()
                     return
                 }
-                
+
                 // Generate preview
                 FileMetaDataGenerator.metadataForFileAtURL(url, UTI: url.UTI(), name: name ?? url.lastPathComponent) { [weak self] metadata in
                     self?.metadata = metadata
                     completion()
                 }
             }
-            
+
             if let data = data as? Data {
 
-            self?.prepareForSending(withUTI: UTIString, name: name, data: data, completion: prepareColsure)
-        } else if let dataURL = data as? URL { ///TODO: url handling
-            ///TODO: url to data
+                self?.prepareForSending(withUTI: UTIString, name: name, data: data, completion: prepareColsure)
+            } else if let dataURL = data as? URL {
                 self?.prepareForSending(withUTI: UTIString, name: name, dataURL: dataURL, completion: prepareColsure)
             } else {
-                ///TODO: return
                 completion()
-
             }
         }
     }
 
-    /// Process data to the right format to be sent
-    private func prepareForSending(withUTI UTI: String, name: String?, dataURL: URL, completion: @escaping (URL?, Error?) -> Void) {
+    typealias SendingCompletion = (URL?, Error?) -> Void
+
+    private func convertVideoIfNeeded(UTI: String,
+                                      fileURL: URL,
+                                      completion: @escaping SendingCompletion) {
+        if UTTypeConformsTo(UTI as CFString, kUTTypeMovie) {
+            AVURLAsset.convertVideoToUploadFormat(at: fileURL) { (url, _, error) in
+                completion(url, error)
+            }
+        } else {
+            completion(fileURL, nil)
+        }
+    }
+
+    /// Process data URL to the right format to be sent
+    /// - Parameters:
+    ///   - UTI: UTI of the file to send
+    ///   - name: file name
+    ///   - dataURL: data URL
+    ///   - completion: completion handler
+    private func prepareForSending(withUTI UTI: String,
+                                   name: String?,
+                                   dataURL: URL,
+                                   completion: @escaping SendingCompletion) {
         guard let fileName = nameForFile(withUTI: UTI, name: name) else { return completion(nil, nil) }
 
         do {
@@ -296,20 +312,17 @@ class UnsentFileSendable: UnsentSendableBase, UnsentSendable {
                 return
             }
 
-            if UTTypeConformsTo(UTI as CFString, kUTTypeMovie) {
-                AVURLAsset.convertVideoToUploadFormat(at: tempFileURL) { (url, _, error) in
-                    completion(url, error)
-                }
-            } else {
-                completion(tempFileURL, nil)
-            }
+            convertVideoIfNeeded(UTI: UTI, fileURL: tempFileURL, completion: completion)
         } catch {
             return completion(nil, error)
         }
     }
 
     /// Process data to the right format to be sent
-    private func prepareForSending(withUTI UTI: String, name: String?, data: Data, completion: @escaping (URL?, Error?) -> Void) {
+    private func prepareForSending(withUTI UTI: String,
+                                   name: String?,
+                                   data: Data,
+                                   completion: @escaping (URL?, Error?) -> Void) {
         guard let fileName = nameForFile(withUTI: UTI, name: name) else { return completion(nil, nil) }
 
         let fileManager = FileManager.default
@@ -325,18 +338,11 @@ class UnsentFileSendable: UnsentSendableBase, UnsentSendable {
 
             try data.write(to: tempFileURL)
 
-            if UTTypeConformsTo(UTI as CFString, kUTTypeMovie) {
-                AVURLAsset.convertVideoToUploadFormat(at: tempFileURL) { (url, _, error) in
-                    completion(url, error)
-                }
-            } else {
-                completion(tempFileURL, nil)
-            }
+            convertVideoIfNeeded(UTI: UTI, fileURL: tempFileURL, completion: completion)
         } catch {
             return completion(nil, error)
         }
     }
-
 
     private func nameForFile(withUTI UTI: String, name: String?) -> String? {
         if let fileExtension = UTTypeCopyPreferredTagWithClass(UTI as CFString, kUTTagClassFilenameExtension)?.takeRetainedValue() as String? {

--- a/Wire-iOS Share Extension/UnsentSendable.swift
+++ b/Wire-iOS Share Extension/UnsentSendable.swift
@@ -239,10 +239,10 @@ class UnsentFileSendable: UnsentSendableBase, UnsentSendable {
         attachment.loadItem(forTypeIdentifier: typeIdentifier, options: [:]) { [weak self] (data, error) in
             guard let UTIString = self?.attachment.registeredTypeIdentifiers.first, error == nil else {
                 error?.log(message: "Unable to load file from attachment")
-                return completion() ///TODO: data is URL
+                return completion()
             }
 
-            let prepareColsure: (URL?, Error?) -> Void = { (url, error) in
+            let prepareColsure: SendingCompletion = { (url, error) in
                 guard let url = url, error == nil else {
                     error?.log(message: "Unable to prepare file attachment for sending")
                     return completion()
@@ -264,10 +264,15 @@ class UnsentFileSendable: UnsentSendableBase, UnsentSendable {
             }
 
             if let data = data as? Data {
-
-                self?.prepareForSending(withUTI: UTIString, name: name, data: data, completion: prepareColsure)
+                self?.prepareForSending(withUTI: UTIString,
+                                        name: name,
+                                        data: data,
+                                        completion: prepareColsure)
             } else if let dataURL = data as? URL {
-                self?.prepareForSending(withUTI: UTIString, name: name, dataURL: dataURL, completion: prepareColsure)
+                self?.prepareForSending(withUTI: UTIString,
+                                        name: name,
+                                        dataURL: dataURL,
+                                        completion: prepareColsure)
             } else {
                 completion()
             }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+ImagePicker.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+ImagePicker.swift
@@ -97,21 +97,14 @@ extension ConversationInputBarViewController {
         let videoTempURL = URL(fileURLWithPath: NSTemporaryDirectory(),
             isDirectory: true).appendingPathComponent(String.filenameForSelfUser()).appendingPathExtension(videoURL.pathExtension)
 
-        if FileManager.default.fileExists(atPath: videoTempURL.path) {
-            do {
-                try FileManager.default.removeItem(at: videoTempURL)
-            } catch let deleteError {
-                zmLog.error("Cannot delete old tmp video at \(videoTempURL): \(deleteError)")
-            }
-        }
 
         do {
-            try FileManager.default.copyItem(at: videoURL, to: videoTempURL)
+            try FileManager.default.removeTmpIfNeededAndCopy(fileURL: videoURL, tmpURL: videoTempURL)
         } catch let error {
             zmLog.error("Cannot copy video from \(videoURL) to \(videoTempURL): \(error)")
             return
         }
-
+        
         if picker.sourceType == UIImagePickerController.SourceType.camera && UIVideoAtPathIsCompatibleWithSavedPhotosAlbum(videoTempURL.path) {
             UISaveVideoAtPathToSavedPhotosAlbum(videoTempURL.path, self, #selector(video(_:didFinishSavingWithError:contextInfo:)), nil)
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+ImagePicker.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+ImagePicker.swift
@@ -97,14 +97,13 @@ extension ConversationInputBarViewController {
         let videoTempURL = URL(fileURLWithPath: NSTemporaryDirectory(),
             isDirectory: true).appendingPathComponent(String.filenameForSelfUser()).appendingPathExtension(videoURL.pathExtension)
 
-
         do {
             try FileManager.default.removeTmpIfNeededAndCopy(fileURL: videoURL, tmpURL: videoTempURL)
         } catch let error {
             zmLog.error("Cannot copy video from \(videoURL) to \(videoTempURL): \(error)")
             return
         }
-        
+
         if picker.sourceType == UIImagePickerController.SourceType.camera && UIVideoAtPathIsCompatibleWithSavedPhotosAlbum(videoTempURL.path) {
             UISaveVideoAtPathToSavedPhotosAlbum(videoTempURL.path, self, #selector(video(_:didFinishSavingWithError:contextInfo:)), nil)
         }

--- a/WireCommonComponents/AVAsset+VideoConvert.swift
+++ b/WireCommonComponents/AVAsset+VideoConvert.swift
@@ -116,8 +116,16 @@ extension AVURLAsset {
                         quality: String = defaultVideoQuality,
                         fileLengthLimit: Int64? = nil,
                         completion: @escaping ConvertVideoCompletion) {
-        let outputURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(filename)
         
+        let outputURL: URL
+        do {
+            try outputURL = FileManager.createTmpDirectory(fileName: filename)
+        } catch let error {
+            zmLog.error("Cannot createTmpDirectory with filename: \(filename). error: \(error)")
+            
+            return
+        }
+
         if FileManager.default.fileExists(atPath: outputURL.path) {
             do {
                 try FileManager.default.removeItem(at: outputURL)

--- a/WireCommonComponents/FileManager+TempDirectory.swift
+++ b/WireCommonComponents/FileManager+TempDirectory.swift
@@ -1,4 +1,3 @@
-
 // Wire
 // Copyright (C) 2020 Wire Swiss GmbH
 //
@@ -25,10 +24,10 @@ extension FileManager {
         if !fileManager.fileExists(atPath: tmp.absoluteString) {
             try fileManager.createDirectory(at: tmp, withIntermediateDirectories: true)
         }
-        
+
         return tmp
     }
-    
+
     public func removeTmpIfNeededAndCopy(fileURL: URL, tmpURL: URL) throws {
         if fileExists(atPath: tmpURL.path) {
                 try FileManager.default.removeItem(at: tmpURL)
@@ -38,4 +37,3 @@ extension FileManager {
 
     }
 }
-

--- a/WireCommonComponents/FileManager+TempDirectory.swift
+++ b/WireCommonComponents/FileManager+TempDirectory.swift
@@ -19,14 +19,23 @@
 import Foundation
 
 extension FileManager {
-    static public func createTmpDirectory() throws -> URL {
+    static public func createTmpDirectory(fileName: String? = nil) throws -> URL {
         let fileManager = FileManager.default
-        let tmp = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true).appendingPathComponent(UUID().uuidString) // temp subdir
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true).appendingPathComponent(fileName ?? UUID().uuidString) // temp subdir
         if !fileManager.fileExists(atPath: tmp.absoluteString) {
             try fileManager.createDirectory(at: tmp, withIntermediateDirectories: true)
         }
         
         return tmp
+    }
+    
+    public func removeTmpIfNeededAndCopy(fileURL: URL, tmpURL: URL) throws {
+        if fileExists(atPath: tmpURL.path) {
+                try FileManager.default.removeItem(at: tmpURL)
+        }
+
+        try copyItem(at: fileURL, to: tmpURL)
+
     }
 }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

When sharing a file from file app, only file name is sent but not the file.

### Causes

After update SDK, `NSItemProvider.loadItem` provides the URL of file instead of `Data`

### Solutions

Upload file instead of Data in for this case.