### PR TITLE
Fix: Call screen is not presented when call quality screen is dismissing

### DIFF
--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -19,7 +19,6 @@
 import Foundation
 import UIKit
 import SafariServices
-import WireDataModel
 import WireSyncEngine
 import avs
 import WireCommonComponents
@@ -29,9 +28,9 @@ var defaultFontScheme: FontScheme = FontScheme(contentSizeCategory: UIApplicatio
 final class AppRootViewController: UIViewController, SpinnerCapable {
     var dismissSpinner: SpinnerCompletion?
 
-    public let mainWindow: UIWindow
-    public let callWindow: CallWindow
-    public let overlayWindow: NotificationWindow
+    let mainWindow: UIWindow
+    let callWindow: CallWindow
+    let overlayWindow: NotificationWindow
 
     public fileprivate(set) var sessionManager: SessionManager?
     public fileprivate(set) var quickActionsManager: QuickActionsManager?

--- a/Wire-iOS/Sources/Helpers/Delay.swift
+++ b/Wire-iOS/Sources/Helpers/Delay.swift
@@ -19,7 +19,7 @@
 
 import Foundation
 
-func delay(_ delay:Double, closure:@escaping ()->()) {
+func delay(_ delay:Double, closure:@escaping Completion) {
     DispatchQueue.main.asyncAfter(
         deadline: DispatchTime.now() + Double(Int64(delay * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC), execute: closure)
 }

--- a/Wire-iOS/Sources/Helpers/Delay.swift
+++ b/Wire-iOS/Sources/Helpers/Delay.swift
@@ -16,10 +16,9 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import Foundation
 
-func delay(_ delay:Double, closure:@escaping Completion) {
+func delay(_ delay: Double, closure:@escaping Completion) {
     DispatchQueue.main.asyncAfter(
         deadline: DispatchTime.now() + Double(Int64(delay * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC), execute: closure)
 }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallController/CallController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallController/CallController.swift
@@ -22,12 +22,7 @@ import WireSyncEngine
 final class CallController: NSObject {
 
     weak var targetViewController: UIViewController?
-    private(set) weak var activeCallViewController: ActiveCallViewController? {
-        didSet {
-            print("activeCallViewController = \(activeCallViewController)")
-        }
-    }
-
+    private(set) weak var activeCallViewController: ActiveCallViewController?
     fileprivate let callQualityController = CallQualityController()
     fileprivate var scheduledPostCallAction: (() -> Void)?
     fileprivate var observerTokens: [Any] = []

--- a/Wire-iOS/Sources/UserInterface/Calling/CallController/CallController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallController/CallController.swift
@@ -24,11 +24,11 @@ final class CallController: NSObject {
     weak var targetViewController: UIViewController?
     private(set) weak var activeCallViewController: ActiveCallViewController? {
         didSet {
-            
+            print("activeCallViewController = \(activeCallViewController)")
         }
     }
 
-    fileprivate let callQualityController = CallQualityController()
+    fileprivate lazy var callQualityController = CallQualityController()
     fileprivate var scheduledPostCallAction: (() -> Void)?
     fileprivate var observerTokens: [Any] = []
     fileprivate var minimizedCall: ZMConversation?
@@ -104,7 +104,7 @@ extension CallController: WireCallCenterCallStateObserver {
     }
 
     fileprivate func presentCall(in conversation: ZMConversation, animated: Bool = true) {
-        guard activeCallViewController == nil else {
+        guard activeCallViewController == nil else { ///TODO: aVC is presented already?
             return
         }
         guard let voiceChannel = conversation.voiceChannel else { return }
@@ -122,7 +122,7 @@ extension CallController: WireCallCenterCallStateObserver {
         UIResponder.currentFirst?.resignFirstResponder()
 
         let modalVC = ModalPresentationViewController(viewController: viewController)
-        targetViewController?.present(modalVC, animated: animated)
+        targetViewController?.present(modalVC, animated: animated) ///TODO: dismiss call qa before present
     }
 
     fileprivate func dismissCall() {
@@ -163,7 +163,7 @@ extension CallController: CallQualityControllerDelegate {
 
     func dismissCurrentSurveyIfNeeded() {
         if let survey = targetViewController?.presentedViewController as? CallQualityViewController {
-            survey.dismiss(animated: true, completion: nil)
+            survey.dismiss(animated: true)
         }
     }
 

--- a/Wire-iOS/Sources/UserInterface/Calling/CallController/CallController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallController/CallController.swift
@@ -99,7 +99,7 @@ extension CallController: WireCallCenterCallStateObserver {
     }
 
     fileprivate func presentCall(in conversation: ZMConversation, animated: Bool = true) {
-        guard activeCallViewController == nil else { ///TODO: aVC is presented already?
+        guard activeCallViewController == nil else {
             return
         }
         guard let voiceChannel = conversation.voiceChannel else { return }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallController/CallController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallController/CallController.swift
@@ -22,7 +22,11 @@ import WireSyncEngine
 final class CallController: NSObject {
 
     weak var targetViewController: UIViewController?
-    private(set) weak var activeCallViewController: ActiveCallViewController?
+    private(set) weak var activeCallViewController: ActiveCallViewController? {
+        didSet {
+            
+        }
+    }
 
     fileprivate let callQualityController = CallQualityController()
     fileprivate var scheduledPostCallAction: (() -> Void)?
@@ -100,7 +104,9 @@ extension CallController: WireCallCenterCallStateObserver {
     }
 
     fileprivate func presentCall(in conversation: ZMConversation, animated: Bool = true) {
-        guard activeCallViewController == nil else { return }
+        guard activeCallViewController == nil else {
+            return
+        }
         guard let voiceChannel = conversation.voiceChannel else { return }
 
         if minimizedCall == conversation {
@@ -123,14 +129,13 @@ extension CallController: WireCallCenterCallStateObserver {
         minimizedCall = nil
         topOverlayCall = nil
 
-        activeCallViewController?.dismiss(animated: true) {
-            if let postCallAction = self.scheduledPostCallAction {
+        activeCallViewController?.dismiss(animated: true) { [weak self] in
+            if let postCallAction = self?.scheduledPostCallAction {
                 postCallAction()
-                self.scheduledPostCallAction = nil
+                self?.scheduledPostCallAction = nil
             }
+            self?.activeCallViewController = nil
         }
-
-        activeCallViewController = nil
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Calling/CallController/CallController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallController/CallController.swift
@@ -123,8 +123,7 @@ extension CallController: WireCallCenterCallStateObserver {
         }
 
         if targetViewController?.presentedViewController != nil {
-            ///HACK: Since CallQualityController is dismissing at the same time, delay to wait for the animation done.
-            delay(1, closure: presentClosure)
+            targetViewController?.presentedViewController?.dismiss(animated: true, completion: presentClosure)
         } else {
             presentClosure()
         }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallController/CallController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallController/CallController.swift
@@ -123,12 +123,15 @@ extension CallController: WireCallCenterCallStateObserver {
 
         let modalVC = ModalPresentationViewController(viewController: viewController)
         
-        if targetViewController?.presentedViewController != nil {
-        delay(1) {
-            self.targetViewController?.present(modalVC, animated: animated) ///TODO: dismiss call qa before present
+        let presentClosure: Completion = {
+            self.targetViewController?.present(modalVC, animated: animated)
         }
+        
+        if targetViewController?.presentedViewController != nil {
+            ///HACK: Since CallQualityController is dismissing at the same time, delay to wait for the animation done.
+            delay(1, closure: presentClosure)
         } else {
-            targetViewController?.present(modalVC, animated: animated)
+            presentClosure()
         }
     }
 

--- a/Wire-iOS/Sources/UserInterface/Calling/CallController/CallController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallController/CallController.swift
@@ -28,7 +28,7 @@ final class CallController: NSObject {
         }
     }
 
-    fileprivate lazy var callQualityController = CallQualityController()
+    fileprivate let callQualityController = CallQualityController()
     fileprivate var scheduledPostCallAction: (() -> Void)?
     fileprivate var observerTokens: [Any] = []
     fileprivate var minimizedCall: ZMConversation?
@@ -122,7 +122,14 @@ extension CallController: WireCallCenterCallStateObserver {
         UIResponder.currentFirst?.resignFirstResponder()
 
         let modalVC = ModalPresentationViewController(viewController: viewController)
-        targetViewController?.present(modalVC, animated: animated) ///TODO: dismiss call qa before present
+        
+        if targetViewController?.presentedViewController != nil {
+        delay(1) {
+            self.targetViewController?.present(modalVC, animated: animated) ///TODO: dismiss call qa before present
+        }
+        } else {
+            targetViewController?.present(modalVC, animated: animated)
+        }
     }
 
     fileprivate func dismissCall() {

--- a/Wire-iOS/Sources/UserInterface/Calling/CallController/CallController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallController/CallController.swift
@@ -117,11 +117,11 @@ extension CallController: WireCallCenterCallStateObserver {
         UIResponder.currentFirst?.resignFirstResponder()
 
         let modalVC = ModalPresentationViewController(viewController: viewController)
-        
+
         let presentClosure: Completion = {
             self.targetViewController?.present(modalVC, animated: animated)
         }
-        
+
         if targetViewController?.presentedViewController != nil {
             ///HACK: Since CallQualityController is dismissing at the same time, delay to wait for the animation done.
             delay(1, closure: presentClosure)

--- a/Wire-iOS/Sources/UserInterface/Calling/CallQualityController/CallQualityController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallQualityController/CallQualityController.swift
@@ -149,10 +149,9 @@ extension CallQualityController: WireCallCenterCallStateObserver {
             handleCallStart(in: conversation)
         case .terminating(let terminationReason):
             handleCallCompletion(in: conversation, reason: terminationReason, eventDate: eventDate)
-        case .incoming(_, let shouldRing, _):
-            if shouldRing {
-                delegate?.dismissCurrentSurveyIfNeeded()
-            }
+        case .incoming(_, _, _):
+            /// when call incoming, dismiss CallQuality VC in CallController.presentCall
+            break
         default:
             return
         }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallQualityController/CallQualityController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallQualityController/CallQualityController.swift
@@ -149,9 +149,13 @@ extension CallQualityController: WireCallCenterCallStateObserver {
             handleCallStart(in: conversation)
         case .terminating(let terminationReason):
             handleCallCompletion(in: conversation, reason: terminationReason, eventDate: eventDate)
-        case .incoming(_, _, _):
-            /// when call incoming, dismiss CallQuality VC in CallController.presentCall
-            break
+        case .incoming(_, let shouldRing, _):
+            if shouldRing {
+                /// when call incoming, dismiss CallQuality VC in CallController.presentCall
+                break
+            } else {
+                delegate?.dismissCurrentSurveyIfNeeded()
+            }
         default:
             return
         }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallQualityController/CallQualityController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallQualityController/CallQualityController.swift
@@ -149,13 +149,9 @@ extension CallQualityController: WireCallCenterCallStateObserver {
             handleCallStart(in: conversation)
         case .terminating(let terminationReason):
             handleCallCompletion(in: conversation, reason: terminationReason, eventDate: eventDate)
-        case .incoming(_, let shouldRing, _):
-            if shouldRing {
-                /// when call incoming, dismiss CallQuality VC in CallController.presentCall
-                break
-            } else {
-                delegate?.dismissCurrentSurveyIfNeeded()
-            }
+        case .incoming(_, _, _):
+            /// when call incoming, dismiss CallQuality VC in CallController.presentCall
+            break
         default:
             return
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

When a call quality screen is presented and a new incoming call is ringing, the call screen does not present, tap on the top bar does not open the call screen.

### Causes

The dismissal of the call quality screen and the presenting of the call screen starts at the same time and the later one fails to complete.

### Solutions

Delay the presenting of the call screen in this case.