### PR TITLE
[Fix] Keyboard covers video preview screen

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
@@ -90,6 +90,7 @@ extension ConversationInputBarViewController: CameraKeyboardViewControllerDelega
             let confirmVideoViewController = ConfirmAssetViewController(context: context)
             confirmVideoViewController.previewTitle = self.conversation.displayName.localizedUppercase
 
+            endEditing()
             present(confirmVideoViewController, animated: true)
         }
     }


### PR DESCRIPTION
## What's new in this PR?

This is a follow up for https://github.com/wireapp/wire-ios/pull/4332

### Issues

When selecting a video from the keyboard, the video preview is shown but the text keyboard overlaps it.

### Causes

Not entirely sure.

### Solutions

Call `endEditing()` as the other PR does.

