### PR TITLE
Fix: keyboard is shown over location picker after changing ephemeral timer

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Location/LocationSelectionViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Location/LocationSelectionViewController.swift
@@ -76,6 +76,8 @@ final class LocationSelectionViewController: UIViewController {
         if !userLocationAuthorized { mapView.restoreLocation(animated: true) }
         locationManager.requestWhenInUseAuthorization()
         updateUserLocation()
+        
+        endEditing()
     }
 
     override func viewWillDisappear(_ animated: Bool) {


### PR DESCRIPTION
## What's new in this PR?

Fix the similar issue as https://github.com/wireapp/wire-ios/pull/4362 when opening location screen