### PR TITLE
Fix: Share Extension: using share extension from Giphy results in endless spinner

### DIFF
--- a/Wire-iOS Share Extension/UnsentGifImageSendable.swift
+++ b/Wire-iOS Share Extension/UnsentGifImageSendable.swift
@@ -43,6 +43,8 @@ final class UnsentGifImageSendable: UnsentSendableBase, UnsentSendable {
             if let url = url as? URL,
                let data = try? Data(contentsOf: url) {
                 self?.gifImageData = data
+            } else if let data = url as? Data {
+                self?.gifImageData = data
             } else {
                 error?.log(message: "Invalid Gif data")
             }


### PR DESCRIPTION
## What's new in this PR?

Fix the similar issue as https://github.com/wireapp/wire-ios/pull/4353 for GIF files.