### PR TITLE
[Fix] Getting stuck with a spinner after removing a device during login

### DIFF
--- a/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
+++ b/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
@@ -173,7 +173,7 @@ extension AuthenticationCoordinator: AuthenticationStateControllerDelegate {
 // MARK: - Event Handling
 
 extension AuthenticationCoordinator: AuthenticationActioner, SessionManagerCreatedSessionObserver {
-
+    
     func sessionManagerCreated(userSession: ZMUserSession) {
         log.info("Session manager created session: \(userSession)")
         currentPostRegistrationFields().apply(sendPostRegistrationFields)
@@ -190,6 +190,10 @@ extension AuthenticationCoordinator: AuthenticationActioner, SessionManagerCreat
             PostLoginAuthenticationNotification.addObserver(self),
             sessionManager.addSessionManagerCreatedSessionObserver(self)
         ]
+        
+        if let userSession = SessionManager.shared?.activeUserSession {
+            initialSyncObserver = ZMUserSession.addInitialSyncCompletionObserver(self, userSession: userSession)
+        }
 
         registrationStatus.delegate = self
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

The app would get stuck with a spinner during login if you:

1. Login into an account with 7 devices 
2. When the it asks you to remove a device kill the app 
3. Launch the app again and resume the login flow 
4. It will ask you remove a device again and this time you actually remove a device

### Causes

When launching the app at step 3 we already have a UserSession at launch but it doesn't have a self client so we ask to user to remove a device so we can register a new device. This all works and the slow sync finishes but the UI never realises this because the initial sync observer is not registered in the `AuthenticationCoordinator`.

During the regular the login the initial sync observer is registered when `sessionManagerCreated(userSession: ZMUserSession)` is called but that doesn't happen in this case since the UserSession already exists.

### Solutions

Register the initial sync observer when the AuthenticationCoordinator is created if we already have a UserSession.