### PR TITLE
[Fix] Ephemeral countdown not being visible to automation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
@@ -63,6 +63,7 @@ final class MessageToolboxView: UIView {
         let stack = UIStackView()
         stack.axis = .horizontal
         stack.spacing = 3
+        stack.isAccessibilityElement = false
         return stack
     }()
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

Only the `deliveryStatus` is visible for automation inside the message toolbox

### Causes

The delivery status and the ephemeral count are layed out using a stackview. Since the stack view is itself marked as being an accessibility element it will not expose its children and instead picks one (random) child element as its accessibility element.

### Solutions

Set `isAccessibilityElement = false` on the stack view so that all child  accessibility elements are exposed.