### PR TITLE
[Fix] Like button not being exposed to automation

### DIFF
--- a/Wire-iOS/Sources/Components/Buttons/ButtonWithLargerHitArea.swift
+++ b/Wire-iOS/Sources/Components/Buttons/ButtonWithLargerHitArea.swift
@@ -18,7 +18,30 @@
 import UIKit
 
 class ButtonWithLargerHitArea: UIButton {
+    
+    // MARK: - Properties
+    
     var hitAreaPadding = CGSize.zero
+    
+    // MARK: - Init / Deinit
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setUp()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        
+        setUp()
+    }
+    
+    private func setUp() {
+        isAccessibilityElement = true
+    }
+    
+     // MARK: - Overridden methods
     
     override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
         if isHidden || alpha == 0 || !isUserInteractionEnabled || !isEnabled {


### PR DESCRIPTION
## What's new in this PR?

### Issues

The like button for a message is not visible in automation.

### Causes

Even though the Apple [documentation](https://developer.apple.com/documentation/uikit/uiaccessibilityelement/1619580-isaccessibilityelement) states that a UIButton will return true for `isAccessibilityElement`, this is not always the case. 

https://stackoverflow.com/questions/21144375/standard-uibutton-isaccessibilityelement-returns-no-by-default

### Solutions

Set `isAccessibilityElement` to  `true` in our button base class.