### PR TITLE
saving Carthage downloading if cache exists

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -42,7 +42,7 @@ XCODE_VERSION=( ${version//./ } )
 
 # SETUP
 echo "ℹ️  Carthage bootstrap. This might take a while..."
-carthage bootstrap --platform ios
+carthage bootstrap --cache-builds --platform ios
 echo ""
 
 echo "ℹ️  Downloading AVS library..."


### PR DESCRIPTION
## What's new in this PR?

To saving downloading Carthage downloading on CI server everytime, apply `--cache-builds` to use local cache if exists.

### Note 
if `Carthage/Build` folder is deleted, the cache is gone and the machine has to download again.