### PR TITLE
[Fix] Presented call participant list not updated

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoRootViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoRootViewController.swift
@@ -35,6 +35,8 @@ final class CallInfoRootViewController: UIViewController, UINavigationController
     private let contentController: CallInfoViewController
     private let contentNavigationController: UINavigationController
     private let callDegradationController: CallDegradationController
+
+    private weak var participantsViewController: CallParticipantsViewController?
     
     var context: Context = .overview {
         didSet {
@@ -95,12 +97,20 @@ final class CallInfoRootViewController: UIViewController, UINavigationController
         UIView.animate(withDuration: 0.2) { [view, configuration] in
             view?.backgroundColor = configuration.overlayBackgroundColor
         }
+
+        updatePresentedParticipantsListIfNeeded()
     }
     
     private func presentParticipantsList() {
         context = .participants
         let participantsList = CallParticipantsViewController(scrollableWithConfiguration: configuration)
+        participantsViewController = participantsList
         contentNavigationController.pushViewController(participantsList, animated: true)
+    }
+
+    private func updatePresentedParticipantsListIfNeeded() {
+        guard case let .participantsList(participants) = configuration.accessoryType else { return }
+        participantsViewController?.participants = participants
     }
     
     // MARK: - Delegates


### PR DESCRIPTION
## What's new in this PR?

### Issues

During a call with many participants, the participant list may have a "show all" row at the bottom. Tapping on this button will present a scrollable participant list. If any participant leaves or joins, then change will not be visible on this screen until it is popped and represented.

### Causes

There are two `CallParticipantsViewController` instances, one is for the truncated version on the call overlay, and one is for the full screen scrollable list. Only the first instance is updated when the `CallInfoConfiguration` changes.

### Solutions

When the call configuration changes, also update the fullscreen participant list, if it exists.

