### PR TITLE
Feature: iOS 13 UIContextMenu support of conversation list

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+PeekPop.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+PeekPop.swift
@@ -23,7 +23,6 @@ import WireDataModel
 
 private var lastPreviewURL: URL?
 
-///TODO: retire UIContextMenuInteraction
 extension ConversationContentViewController: UIViewControllerPreviewingDelegate {
 
     @available(iOS, introduced: 9.0, deprecated: 13.0, renamed: "UIContextMenuInteraction")

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+PeekPop.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+PeekPop.swift
@@ -81,26 +81,3 @@ extension ConversationContentViewController: UIViewControllerPreviewingDelegate 
     }
 
 }
-
-extension ConversationContentViewController: UIContextMenuInteractionDelegate {
-    @available(iOS 13.0, *)
-    func contextMenuInteraction(_ interaction: UIContextMenuInteraction, configurationForMenuAtLocation location: CGPoint) -> UIContextMenuConfiguration? {
-        return UIContextMenuConfiguration(identifier: nil, previewProvider: nil, actionProvider: { suggestedActions in
-            return self.makeContextMenu()
-               })
-    }
-    
-    
-    @available(iOS 13.0, *)
-    private func makeContextMenu() -> UIMenu {
-
-        // Create a UIAction for sharing
-        let share = UIAction(title: "Share Pupper", image: nil) { action in
-            // Show system share sheet
-        }
-
-        // Create and return a UIMenu with the share action
-        return UIMenu(title: "Main Menu", children: [share])
-    }
-
-}

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+PeekPop.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+PeekPop.swift
@@ -23,6 +23,7 @@ import WireDataModel
 
 private var lastPreviewURL: URL?
 
+///TODO: retire UIContextMenuInteraction
 extension ConversationContentViewController: UIViewControllerPreviewingDelegate {
 
     func previewingContext(_ previewingContext: UIViewControllerPreviewing, viewControllerForLocation location: CGPoint) -> UIViewController? {
@@ -75,6 +76,29 @@ extension ConversationContentViewController: UIViewControllerPreviewingDelegate 
         } else {
             self.messagePresenter.modalTargetController?.present(viewControllerToCommit, animated: true, completion: .none)
         }
+    }
+
+}
+
+extension ConversationContentViewController: UIContextMenuInteractionDelegate {
+    @available(iOS 13.0, *)
+    func contextMenuInteraction(_ interaction: UIContextMenuInteraction, configurationForMenuAtLocation location: CGPoint) -> UIContextMenuConfiguration? {
+        return UIContextMenuConfiguration(identifier: nil, previewProvider: nil, actionProvider: { suggestedActions in
+            return self.makeContextMenu()
+               })
+    }
+    
+    
+    @available(iOS 13.0, *)
+    private func makeContextMenu() -> UIMenu {
+
+        // Create a UIAction for sharing
+        let share = UIAction(title: "Share Pupper", image: nil) { action in
+            // Show system share sheet
+        }
+
+        // Create and return a UIMenu with the share action
+        return UIMenu(title: "Main Menu", children: [share])
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+PeekPop.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+PeekPop.swift
@@ -26,6 +26,7 @@ private var lastPreviewURL: URL?
 ///TODO: retire UIContextMenuInteraction
 extension ConversationContentViewController: UIViewControllerPreviewingDelegate {
 
+    @available(iOS, introduced: 9.0, deprecated: 13.0, renamed: "UIContextMenuInteraction")
     func previewingContext(_ previewingContext: UIViewControllerPreviewing, viewControllerForLocation location: CGPoint) -> UIViewController? {
 
         let cellLocation = view.convert(location, to: tableView)
@@ -56,6 +57,7 @@ extension ConversationContentViewController: UIViewControllerPreviewingDelegate 
         return controller
     }
 
+    @available(iOS, introduced: 9.0, deprecated: 13.0, renamed: "UIContextMenuInteraction")
     func previewingContext(_ previewingContext: UIViewControllerPreviewing, commit viewControllerToCommit: UIViewController) {
 
         // If the previewed item is an image, show the previously hidden controls.

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
@@ -144,8 +144,14 @@ final class ConversationContentViewController: UIViewController, PopoverPresente
         super.viewDidAppear(animated)
         updateVisibleMessagesWindow()
         
-        if traitCollection.forceTouchCapability == .available {
-            registerForPreviewing(with: self, sourceView: view)
+        
+        if #available(iOS 13, *) {
+            let interaction = UIContextMenuInteraction(delegate: self)
+            view.addInteraction(interaction) ///TODO: add to each cell
+        } else {
+            if traitCollection.forceTouchCapability == .available {
+                registerForPreviewing(with: self, sourceView: view)
+            }
         }
         
         UIAccessibility.post(notification: .screenChanged, argument: nil)

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
@@ -125,135 +125,133 @@ final class ConversationContentViewController: UIViewController, PopoverPresente
         tableView.separatorStyle = .none
         tableView.delaysContentTouches = false
         tableView.keyboardDismissMode = AutomationHelper.sharedHelper.disableInteractiveKeyboardDismissal ? .none : .interactive
-        
+
         tableView.backgroundColor = UIColor.from(scheme: .contentBackground)
         view.backgroundColor = UIColor.from(scheme: .contentBackground)
-        
+
         setupMentionsResultsView()
-        
+
         NotificationCenter.default.addObserver(self, selector: #selector(UIApplicationDelegate.applicationDidBecomeActive(_:)), name: UIApplication.didBecomeActiveNotification, object: nil)
     }
-    
+
     @objc
     private func applicationDidBecomeActive(_ notification: Notification) {
         dataSource.resetSectionControllers()
         tableView.reloadData()
     }
-    
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         updateVisibleMessagesWindow()
-        
-        
+
         if #available(iOS 13, *) {
-            let interaction = UIContextMenuInteraction(delegate: self)
-            view.addInteraction(interaction) ///TODO: add to each cell
+            // handle Context menu in table view delegate
         } else {
             if traitCollection.forceTouchCapability == .available {
                 registerForPreviewing(with: self, sourceView: view)
             }
         }
-        
+
         UIAccessibility.post(notification: .screenChanged, argument: nil)
         setNeedsStatusBarAppearanceUpdate()
     }
-    
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         onScreen = true
-        
+
         for cell in tableView.visibleCells {
             cell.willDisplayCell()
         }
-        
+
         messagePresenter.modalTargetController = parent
-        
+
         updateHeaderHeight()
-        
+
         setNeedsStatusBarAppearanceUpdate()
     }
-    
+
     override func viewWillDisappear(_ animated: Bool) {
         onScreen = false
         removeHighlightsAndMenu()
         super.viewWillDisappear(animated)
     }
-    
+
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        
+
         scrollToFirstUnreadMessageIfNeeded()
         updatePopover()
     }
-    
+
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return wr_supportedInterfaceOrientations
     }
-    
+
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator?) {
-        
+
         guard let coordinator = coordinator else { return }
-        
+
         super.viewWillTransition(to: size, with: coordinator)
-        
+
         coordinator.animate(alongsideTransition: nil) { _ in
             self.updatePopoverSourceRect()
         }
     }
-    
+
     func setupMentionsResultsView() {
         mentionsSearchResultsViewController.view.translatesAutoresizingMaskIntoConstraints = false
-        
+
         addChild(mentionsSearchResultsViewController)
         view.addSubview(mentionsSearchResultsViewController.view)
-        
+
         mentionsSearchResultsViewController.view.fitInSuperview()
     }
-    
+
     func scrollToFirstUnreadMessageIfNeeded() {
         if !hasDoneInitialLayout {
             hasDoneInitialLayout = true
             scroll(to: messageVisibleOnLoad)
         }
     }
-    
+
     override var shouldAutorotate: Bool {
         return true
     }
-    
+
     override func didReceiveMemoryWarning() {
         zmLog.warn("Received system memory warning.")
         super.didReceiveMemoryWarning()
     }
-    
+
     override var preferredStatusBarStyle: UIStatusBarStyle {
         return ColorScheme.default.statusBarStyle
     }
-    
+
     func setConversationHeaderView(_ headerView: UIView) {
         headerView.frame = headerViewFrame(view: headerView)
         tableView.tableHeaderView = headerView
     }
-    
+
     @discardableResult
     func willSelectRow(at indexPath: IndexPath, tableView: UITableView) -> IndexPath? {
         guard dataSource.messages.indices.contains(indexPath.section) == true else { return nil }
-        
+
         // If the menu is visible, hide it and do nothing
         if UIMenuController.shared.isMenuVisible {
             UIMenuController.shared.setMenuVisible(false, animated: true)
             return nil
         }
-        
+
         let message = dataSource.messages[indexPath.section] as? ZMMessage
-        
+
         if message == dataSource.selectedMessage {
-            
+
             // If this cell is already selected, deselect it.
             dataSource.selectedMessage = nil
             dataSource.deselect(indexPath: indexPath)
             tableView.deselectRow(at: indexPath, animated: true)
-            
+
             return nil
         } else {
             if let indexPathForSelectedRow = tableView.indexPathForSelectedRow {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationPreviewViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationPreviewViewController.swift
@@ -19,7 +19,6 @@
 import Foundation
 import Cartography
 import UIKit
-import WireDataModel
 import WireSyncEngine
 
 final class ConversationPreviewViewController: TintColorCorrectedViewController {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationPreviewViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationPreviewViewController.swift
@@ -63,10 +63,12 @@ final class ConversationPreviewViewController: TintColorCorrectedViewController 
 
     // MARK: Preview Actions
 
+    @available(iOS, introduced: 9.0, deprecated: 13.0, message: "UIViewControllerPreviewing is deprecated. Please use UIContextMenuInteraction.")
     override var previewActionItems: [UIPreviewActionItem] {
         return conversation.listActions.map(makePreviewAction)
     }
 
+    @available(iOS, introduced: 9.0, deprecated: 13.0, message: "UIViewControllerPreviewing is deprecated. Please use UIContextMenuInteraction.")
     private func makePreviewAction(for action: ZMConversation.Action) -> UIPreviewAction {
         return action.previewAction { [weak self] in
             guard let `self` = self else { return }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationPreviewViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationPreviewViewController.swift
@@ -24,7 +24,7 @@ import WireSyncEngine
 final class ConversationPreviewViewController: TintColorCorrectedViewController {
 
     let conversation: ZMConversation
-    fileprivate let actionController: ConversationActionController
+    let actionController: ConversationActionController
     fileprivate var contentViewController: ConversationContentViewController
 
     init(conversation: ZMConversation, presentingViewController: UIViewController) {

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListCell.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListCell.swift
@@ -17,7 +17,6 @@
 //
 
 import Foundation
-import WireDataModel
 import WireSyncEngine
 import avs
 
@@ -66,6 +65,11 @@ final class ConversationListCell: SwipeMenuCollectionCell,
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupConversationListCell()
+        
+        if #available(iOS 13.0, *) {
+            let interaction = UIContextMenuInteraction(delegate: self)
+            addInteraction(interaction)
+        }
     }
     
     deinit {
@@ -273,3 +277,27 @@ extension ConversationListCell: AVSMediaManagerClientObserver {
     }
 }
 
+// MARK: - UIContextMenuInteractionDelegate
+
+extension ConversationListCell: UIContextMenuInteractionDelegate {
+    @available(iOS 13.0, *)
+    func contextMenuInteraction(_ interaction: UIContextMenuInteraction, configurationForMenuAtLocation location: CGPoint) -> UIContextMenuConfiguration? {
+        return UIContextMenuConfiguration(identifier: nil, previewProvider: nil, actionProvider: { suggestedActions in
+            return self.makeContextMenu()
+               })
+    }
+    
+    
+    @available(iOS 13.0, *)
+    private func makeContextMenu() -> UIMenu {
+
+        // Create a UIAction for sharing
+        let share = UIAction(title: "Share Pupper", image: nil) { action in
+            // Show system share sheet
+        }
+
+        // Create and return a UIMenu with the share action
+        return UIMenu(title: "Main Menu", children: [share])
+    }
+
+}

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListCell.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListCell.swift
@@ -65,11 +65,6 @@ final class ConversationListCell: SwipeMenuCollectionCell,
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupConversationListCell()
-        
-        if #available(iOS 13.0, *) {
-            let interaction = UIContextMenuInteraction(delegate: self)
-            addInteraction(interaction)
-        }
     }
     
     deinit {
@@ -275,29 +270,4 @@ extension ConversationListCell: AVSMediaManagerClientObserver {
             }
         })
     }
-}
-
-// MARK: - UIContextMenuInteractionDelegate
-
-extension ConversationListCell: UIContextMenuInteractionDelegate {
-    @available(iOS 13.0, *)
-    func contextMenuInteraction(_ interaction: UIContextMenuInteraction, configurationForMenuAtLocation location: CGPoint) -> UIContextMenuConfiguration? {
-        return UIContextMenuConfiguration(identifier: nil, previewProvider: nil, actionProvider: { suggestedActions in
-            return self.makeContextMenu()
-               })
-    }
-    
-    
-    @available(iOS 13.0, *)
-    private func makeContextMenu() -> UIMenu {
-
-        // Create a UIAction for sharing
-        let share = UIAction(title: "Share Pupper", image: nil) { action in
-            // Show system share sheet
-        }
-
-        // Create and return a UIMenu with the share action
-        return UIMenu(title: "Main Menu", children: [share])
-    }
-
 }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
@@ -60,8 +60,11 @@ final class ConversationListContentController: UICollectionViewController {
 
         setupViews()
 
-        if traitCollection.forceTouchCapability == .available {
-            registerForPreviewing(with: self, sourceView: collectionView)
+        if #available(iOS 13, *) {
+        } else {
+            if traitCollection.forceTouchCapability == .available {
+                registerForPreviewing(with: self, sourceView: collectionView)
+            }
         }
     }
 

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
@@ -1,4 +1,3 @@
-
 // Wire
 // Copyright (C) 2019 Wire Swiss GmbH
 //
@@ -36,7 +35,7 @@ final class ConversationListContentController: UICollectionViewController {
     var startCallController: ConversationCallController?
     private let selectionFeedbackGenerator = UISelectionFeedbackGenerator()
     private var token: NSObjectProtocol?
-    
+
     init() {
         let flowLayout = BoundsAwareFlowLayout()
         flowLayout.minimumLineSpacing = 0
@@ -80,7 +79,6 @@ final class ConversationListContentController: UICollectionViewController {
 
         scrollToCurrentSelection(animated: false)
 
-    
         token = NotificationCenter.default.addObserver(forName: .activeMediaPlayerChanged, object: nil, queue: .main) { [weak self] _ in
             self?.activeMediaPlayerChanged()
         }
@@ -90,13 +88,13 @@ final class ConversationListContentController: UICollectionViewController {
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-       
+
         if let token = token {
             NotificationCenter.default.removeObserver(token)
             self.token = nil
         }
     }
-    
+
     private func activeMediaPlayerChanged() {
         DispatchQueue.main.async(execute: {
             for cell in self.collectionView.visibleCells {
@@ -141,10 +139,10 @@ final class ConversationListContentController: UICollectionViewController {
         switch kind {
         case UICollectionView.elementKindSectionHeader:
             let section = indexPath.section
-            
+
             if let header = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: ConversationListHeaderView.reuseIdentifier, for: indexPath) as? ConversationListHeaderView {
                 header.title = listViewModel.sectionHeaderTitle(sectionIndex: section)?.uppercased()
-                
+
                 header.folderBadge = listViewModel.folderBadge(at: section)
 
                 header.collapsed = listViewModel.collapsed(at: section)
@@ -152,7 +150,7 @@ final class ConversationListContentController: UICollectionViewController {
                 header.tapHandler = {[weak self] collapsed in
                     self?.listViewModel.setCollapsed(sectionIndex: section, collapsed: collapsed)
                 }
-                
+
                 return header
             } else {
                 fatal("Unknown supplementary view for \(kind)")
@@ -161,7 +159,6 @@ final class ConversationListContentController: UICollectionViewController {
             fatal("No supplementary view for \(kind)")
         }
     }
-
 
     private func registerSectionHeader() {
         collectionView?.register(ConversationListHeaderView.self, forSupplementaryViewOfKind:
@@ -218,20 +215,20 @@ final class ConversationListContentController: UICollectionViewController {
 
     func select(_ conversation: ZMConversation?, scrollTo message: ZMConversationMessage?, focusOnView focus: Bool, animated: Bool, completion: Completion?) -> Bool {
         focusOnNextSelection = focus
-        
+
         selectConversationCompletion = completion
         animateNextSelection = animated
         scrollToMessageOnNextSelection = message
-        
+
         // Tell the model to select the item
         return selectModelItem(conversation)
     }
-    
+
     @discardableResult
     func selectModelItem(_ itemToSelect: ConversationListItem?) -> Bool {
         return listViewModel.select(itemToSelect: itemToSelect)
     }
-    
+
     // MARK: - UICollectionViewDelegate
 
     override func collectionView(_ collectionView: UICollectionView, shouldHighlightItemAt indexPath: IndexPath) -> Bool {
@@ -246,14 +243,14 @@ final class ConversationListContentController: UICollectionViewController {
     override func collectionView(_ collectionView: UICollectionView,
                                  didSelectItemAt indexPath: IndexPath) {
         selectionFeedbackGenerator.selectionChanged()
-        
+
         let item = listViewModel.item(for: indexPath)
-        
+
         focusOnNextSelection = true
         animateNextSelection = true
         selectModelItem(item)
     }
-    
+
     @available(iOS 13.0, *)
     override func collectionView(_ collectionView: UICollectionView,
     contextMenuConfigurationForItemAt indexPath: IndexPath,
@@ -262,17 +259,17 @@ final class ConversationListContentController: UICollectionViewController {
 
         guard let previewViewController = conversationPreviewViewController(indexPath: indexPath) else { return nil}
         let previewProvider: UIContextMenuContentPreviewProvider = {
-            
+
             return previewViewController
         }
-        
+
         return UIContextMenuConfiguration(identifier: nil,
                                           previewProvider: previewProvider,
                                           actionProvider: { suggestedActions in
                                             return self.makeContextMenu(conversation: conversation, actionController: previewViewController.actionController)
            })
     }
-    
+
     @available(iOS 13.0, *)
     private func makeContextMenu(conversation: ZMConversation, actionController: ConversationActionController) -> UIMenu {
             let actions = conversation.listActions.map { action in
@@ -280,10 +277,10 @@ final class ConversationListContentController: UICollectionViewController {
                     actionController.handleAction(action)
                 }
             }
-    
+
             return UIMenu(title: conversation.displayName, children: actions)
         }
-    
+
     // MARK: - UICollectionViewDataSource
 
     override func numberOfSections(in collectionView: UICollectionView) -> Int {
@@ -293,7 +290,6 @@ final class ConversationListContentController: UICollectionViewController {
     override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return listViewModel.numberOfItems(inSection: section)
     }
-
 
     override func collectionView(_ cv: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let item = listViewModel.item(for: indexPath)
@@ -316,13 +312,12 @@ final class ConversationListContentController: UICollectionViewController {
 
         (cell as? SectionListCellType)?.sectionName = listViewModel.sectionCanonicalName(of: indexPath.section)
         (cell as? SectionListCellType)?.cellIdentifier = "conversation_list_cell"
-        
+
         cell.autoresizingMask = .flexibleWidth
 
         return cell
     }
 }
-
 
 extension ConversationListContentController: UICollectionViewDelegateFlowLayout {
     public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
@@ -385,7 +380,6 @@ extension ConversationListContentController: ConversationListViewModelDelegate {
         ensureCurrentSelection()
     }
 
-
     func listViewModelShouldBeReloaded() {
         reload()
     }
@@ -418,19 +412,19 @@ extension ConversationListContentController: ConversationListViewModelDelegate {
     }
 }
 
-//MARK: iOS 12- peek pop
+// MARK: iOS 12- peek pop
 extension ConversationListContentController: UIViewControllerPreviewingDelegate {
-    
+
     @available(iOS, introduced: 9.0, deprecated: 13.0, renamed: "UIContextMenuInteraction")
     func previewingContext(_ previewingContext: UIViewControllerPreviewing, commit viewControllerToCommit: UIViewController) {
-        
+
         guard let previewViewController = viewControllerToCommit as? ConversationPreviewViewController else { return }
-        
+
         focusOnNextSelection = true
         animateNextSelection = true
         selectModelItem(previewViewController.conversation)
     }
-    
+
     @available(iOS, introduced: 9.0, deprecated: 13.0, renamed: "UIContextMenuInteraction")
     func previewingContext(_ previewingContext: UIViewControllerPreviewing, viewControllerForLocation location: CGPoint) -> UIViewController? {
         guard let indexPath = collectionView.indexPathForItem(at: location),
@@ -438,12 +432,12 @@ extension ConversationListContentController: UIViewControllerPreviewingDelegate 
                else {
             return nil
         }
-        
+
         previewingContext.sourceRect = layoutAttributes.frame
-        
+
         return conversationPreviewViewController(indexPath: indexPath)
     }
-    
+
     private func conversationPreviewViewController(indexPath: IndexPath) -> ConversationPreviewViewController? {
         guard let conversation = listViewModel.item(for: indexPath) as? ZMConversation else { return nil }
 

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
@@ -278,19 +278,20 @@ final class ConversationListContentController: UICollectionViewController {
     override func collectionView(_ collectionView: UICollectionView,
     contextMenuConfigurationForItemAt indexPath: IndexPath,
     point: CGPoint) -> UIContextMenuConfiguration? {
-        guard let conversation = self.listViewModel.item(for: indexPath) as? ZMConversation else { return nil }
+        guard let conversation = self.listViewModel.item(for: indexPath) as? ZMConversation,
+              let previewViewController = conversationPreviewViewController(indexPath: indexPath) else { return nil }
 
-        guard let previewViewController = conversationPreviewViewController(indexPath: indexPath) else { return nil}
         let previewProvider: UIContextMenuContentPreviewProvider = {
-
             return previewViewController
         }
+        
+        let actionProvider: UIContextMenuActionProvider = { suggestedActions in
+                                                            return self.makeContextMenu(conversation: conversation, actionController: previewViewController.actionController)
+        }
 
-        return UIContextMenuConfiguration(identifier: nil,
+        return UIContextMenuConfiguration(identifier: indexPath as NSIndexPath,
                                           previewProvider: previewProvider,
-                                          actionProvider: { suggestedActions in
-                                            return self.makeContextMenu(conversation: conversation, actionController: previewViewController.actionController)
-           })
+                                          actionProvider: actionProvider)
     }
 
     @available(iOS 13.0, *)

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
@@ -61,6 +61,7 @@ final class ConversationListContentController: UICollectionViewController {
         setupViews()
 
         if #available(iOS 13, *) {
+            // handle Context menu in each cell
         } else {
             if traitCollection.forceTouchCapability == .available {
                 registerForPreviewing(with: self, sourceView: collectionView)
@@ -387,8 +388,11 @@ extension ConversationListContentController: ConversationListViewModelDelegate {
     }
 }
 
+//MARK: iOS 12- peek pop
 extension ConversationListContentController: UIViewControllerPreviewingDelegate {
-    public func previewingContext(_ previewingContext: UIViewControllerPreviewing, commit viewControllerToCommit: UIViewController) {
+    
+    @available(iOS, introduced: 9.0, deprecated: 13.0, renamed: "UIContextMenuInteraction")
+    func previewingContext(_ previewingContext: UIViewControllerPreviewing, commit viewControllerToCommit: UIViewController) {
         
         guard let previewViewController = viewControllerToCommit as? ConversationPreviewViewController else { return }
         
@@ -397,7 +401,8 @@ extension ConversationListContentController: UIViewControllerPreviewingDelegate 
         selectModelItem(previewViewController.conversation)
     }
     
-    public func previewingContext(_ previewingContext: UIViewControllerPreviewing, viewControllerForLocation location: CGPoint) -> UIViewController? {
+    @available(iOS, introduced: 9.0, deprecated: 13.0, renamed: "UIContextMenuInteraction")
+    func previewingContext(_ previewingContext: UIViewControllerPreviewing, viewControllerForLocation location: CGPoint) -> UIViewController? {
         guard let indexPath = collectionView.indexPathForItem(at: location),
               let layoutAttributes = collectionView.layoutAttributesForItem(at: indexPath),
               let conversation = listViewModel.item(for: indexPath) as? ZMConversation else {

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
@@ -189,7 +189,7 @@ final class ConversationListContentController: UICollectionViewController {
             // Check if indexPath is valid for the collection view
             collectionView.numberOfSections > selectedIndexPath.section,
             collectionView.numberOfItems(inSection: selectedIndexPath.section) > selectedIndexPath.item else {
-            return
+                return
         }
 
         if !collectionView.indexPathsForVisibleItems.contains(selectedIndexPath) {
@@ -246,7 +246,7 @@ final class ConversationListContentController: UICollectionViewController {
 
         openConversation(conversationListItem: listViewModel.item(for: indexPath))
     }
-    
+
     // MARK: preview
 
     private func openConversation(conversationListItem: ConversationListItem?) {
@@ -254,7 +254,7 @@ final class ConversationListContentController: UICollectionViewController {
         animateNextSelection = true
         selectModelItem(conversationListItem)
     }
-    
+
     private func conversationPreviewViewController(indexPath: IndexPath) -> ConversationPreviewViewController? {
         guard let conversation = listViewModel.item(for: indexPath) as? ZMConversation else { return nil }
 
@@ -265,28 +265,28 @@ final class ConversationListContentController: UICollectionViewController {
     // MARK: context menu
     @available(iOS 13.0, *)
     override func collectionView(_ collectionView: UICollectionView,
-    willPerformPreviewActionForMenuWith configuration: UIContextMenuConfiguration,
-                        animator: UIContextMenuInteractionCommitAnimating) {
+                                 willPerformPreviewActionForMenuWith configuration: UIContextMenuConfiguration,
+                                 animator: UIContextMenuInteractionCommitAnimating) {
         guard let destinationViewController = animator.previewViewController as? ConversationPreviewViewController else { return }
 
         animator.addAnimations { [weak self] in
             self?.openConversation(conversationListItem: destinationViewController.conversation)
         }
     }
-    
+
     @available(iOS 13.0, *)
     override func collectionView(_ collectionView: UICollectionView,
-    contextMenuConfigurationForItemAt indexPath: IndexPath,
-    point: CGPoint) -> UIContextMenuConfiguration? {
+                                 contextMenuConfigurationForItemAt indexPath: IndexPath,
+                                 point: CGPoint) -> UIContextMenuConfiguration? {
         guard let conversation = self.listViewModel.item(for: indexPath) as? ZMConversation,
-              let previewViewController = conversationPreviewViewController(indexPath: indexPath) else { return nil }
+            let previewViewController = conversationPreviewViewController(indexPath: indexPath) else { return nil }
 
         let previewProvider: UIContextMenuContentPreviewProvider = {
             return previewViewController
         }
-        
-        let actionProvider: UIContextMenuActionProvider = { suggestedActions in
-                                                            return self.makeContextMenu(conversation: conversation, actionController: previewViewController.actionController)
+
+        let actionProvider: UIContextMenuActionProvider = { _ in
+            return self.makeContextMenu(conversation: conversation, actionController: previewViewController.actionController)
         }
 
         return UIContextMenuConfiguration(identifier: indexPath as NSIndexPath,
@@ -296,14 +296,14 @@ final class ConversationListContentController: UICollectionViewController {
 
     @available(iOS 13.0, *)
     private func makeContextMenu(conversation: ZMConversation, actionController: ConversationActionController) -> UIMenu {
-            let actions = conversation.listActions.map { action in
-                UIAction(title: action.title, image: nil) { _ in
-                    actionController.handleAction(action)
-                }
+        let actions = conversation.listActions.map { action in
+            UIAction(title: action.title, image: nil) { _ in
+                actionController.handleAction(action)
             }
-
-            return UIMenu(title: conversation.displayName, children: actions)
         }
+
+        return UIMenu(title: conversation.displayName, children: actions)
+    }
 
     // MARK: - UICollectionViewDataSource
 
@@ -431,7 +431,7 @@ extension ConversationListContentController: ConversationListViewModelDelegate {
         using stagedChangeset: StagedChangeset<C>,
         interrupt: ((Changeset<C>) -> Bool)? = nil,
         setData: (C?) -> Void
-        ) {
+    ) {
         collectionView.reload(using: stagedChangeset, interrupt: interrupt, setData: setData)
     }
 }
@@ -449,9 +449,9 @@ extension ConversationListContentController: UIViewControllerPreviewingDelegate 
     @available(iOS, introduced: 9.0, deprecated: 13.0, renamed: "UIContextMenuInteraction")
     func previewingContext(_ previewingContext: UIViewControllerPreviewing, viewControllerForLocation location: CGPoint) -> UIViewController? {
         guard let indexPath = collectionView.indexPathForItem(at: location),
-              let layoutAttributes = collectionView.layoutAttributesForItem(at: indexPath)
-               else {
-            return nil
+            let layoutAttributes = collectionView.layoutAttributesForItem(at: indexPath)
+            else {
+                return nil
         }
 
         previewingContext.sourceRect = layoutAttributes.frame

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
@@ -258,9 +258,9 @@ final class ConversationListContentController: UICollectionViewController {
     override func collectionView(_ collectionView: UICollectionView,
     contextMenuConfigurationForItemAt indexPath: IndexPath,
     point: CGPoint) -> UIContextMenuConfiguration? {
-        
+        guard let conversation = self.listViewModel.item(for: indexPath) as? ZMConversation else { return nil }
+
         let previewProvider: UIContextMenuContentPreviewProvider = {
-            guard let conversation = self.listViewModel.item(for: indexPath) as? ZMConversation else { return nil }
             
             return self.conversationPreviewViewController(indexPath: indexPath)
         }
@@ -270,20 +270,20 @@ final class ConversationListContentController: UICollectionViewController {
                                           actionProvider: { suggestedActions in
 
                // "puppers" is the array backing the collection view
-               return self.makeContextMenu(/*for: self.puppers[indexPath.row]*/)
+                                            return self.makeContextMenu(conversation: conversation)
            })
     }
     
         @available(iOS 13.0, *)
-        private func makeContextMenu() -> UIMenu {
-            ///TODO: convo menu?
-            // Create a UIAction for sharing
-            let share = UIAction(title: "Share Pupper", image: nil) { action in
-                // Show system share sheet
+    private func makeContextMenu(conversation: ZMConversation) -> UIMenu {
+            let actions = conversation.listActions.map { action in
+                UIAction(title: action.title, image: nil) { action in
+                    // Show system share sheet
+                }
             }
     
             // Create and return a UIMenu with the share action
-            return UIMenu(title: "Main Menu", children: [share])
+            return UIMenu(title: conversation.displayName, children: actions)
         }
     
     // MARK: - UICollectionViewDataSource

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
@@ -260,29 +260,26 @@ final class ConversationListContentController: UICollectionViewController {
     point: CGPoint) -> UIContextMenuConfiguration? {
         guard let conversation = self.listViewModel.item(for: indexPath) as? ZMConversation else { return nil }
 
+        let previewViewController = conversationPreviewViewController(indexPath: indexPath)
         let previewProvider: UIContextMenuContentPreviewProvider = {
             
-            return self.conversationPreviewViewController(indexPath: indexPath)
+            return previewViewController
         }
         
         return UIContextMenuConfiguration(identifier: nil,
                                           previewProvider: previewProvider,
                                           actionProvider: { suggestedActions in
-
-               // "puppers" is the array backing the collection view
                                             return self.makeContextMenu(conversation: conversation)
            })
     }
     
-        @available(iOS 13.0, *)
+    @available(iOS 13.0, *)
     private func makeContextMenu(conversation: ZMConversation) -> UIMenu {
             let actions = conversation.listActions.map { action in
                 UIAction(title: action.title, image: nil) { action in
-                    // Show system share sheet
                 }
             }
     
-            // Create and return a UIMenu with the share action
             return UIMenu(title: conversation.displayName, children: actions)
         }
     

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
@@ -260,7 +260,7 @@ final class ConversationListContentController: UICollectionViewController {
     point: CGPoint) -> UIContextMenuConfiguration? {
         guard let conversation = self.listViewModel.item(for: indexPath) as? ZMConversation else { return nil }
 
-        let previewViewController = conversationPreviewViewController(indexPath: indexPath)
+        guard let previewViewController = conversationPreviewViewController(indexPath: indexPath) else { return nil}
         let previewProvider: UIContextMenuContentPreviewProvider = {
             
             return previewViewController
@@ -269,14 +269,15 @@ final class ConversationListContentController: UICollectionViewController {
         return UIContextMenuConfiguration(identifier: nil,
                                           previewProvider: previewProvider,
                                           actionProvider: { suggestedActions in
-                                            return self.makeContextMenu(conversation: conversation)
+                                            return self.makeContextMenu(conversation: conversation, actionController: previewViewController.actionController)
            })
     }
     
     @available(iOS 13.0, *)
-    private func makeContextMenu(conversation: ZMConversation) -> UIMenu {
+    private func makeContextMenu(conversation: ZMConversation, actionController: ConversationActionController) -> UIMenu {
             let actions = conversation.listActions.map { action in
-                UIAction(title: action.title, image: nil) { action in
+                UIAction(title: action.title, image: nil) { _ in
+                    actionController.handleAction(action)
                 }
             }
     

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
@@ -61,7 +61,7 @@ final class ConversationListContentController: UICollectionViewController {
         setupViews()
 
         if #available(iOS 13, *) {
-            // handle Context menu in each cell
+            // handle Context menu in collection view delegate
         } else {
             if traitCollection.forceTouchCapability == .available {
                 registerForPreviewing(with: self, sourceView: collectionView)
@@ -254,6 +254,38 @@ final class ConversationListContentController: UICollectionViewController {
         selectModelItem(item)
     }
     
+    @available(iOS 13.0, *)
+    override func collectionView(_ collectionView: UICollectionView,
+    contextMenuConfigurationForItemAt indexPath: IndexPath,
+    point: CGPoint) -> UIContextMenuConfiguration? {
+        
+        let previewProvider: UIContextMenuContentPreviewProvider = {
+            guard let conversation = self.listViewModel.item(for: indexPath) as? ZMConversation else { return nil }
+            
+            return self.conversationPreviewViewController(indexPath: indexPath)
+        }
+        
+        return UIContextMenuConfiguration(identifier: nil,
+                                          previewProvider: previewProvider,
+                                          actionProvider: { suggestedActions in
+
+               // "puppers" is the array backing the collection view
+               return self.makeContextMenu(/*for: self.puppers[indexPath.row]*/)
+           })
+    }
+    
+        @available(iOS 13.0, *)
+        private func makeContextMenu() -> UIMenu {
+            ///TODO: convo menu?
+            // Create a UIAction for sharing
+            let share = UIAction(title: "Share Pupper", image: nil) { action in
+                // Show system share sheet
+            }
+    
+            // Create and return a UIMenu with the share action
+            return UIMenu(title: "Main Menu", children: [share])
+        }
+    
     // MARK: - UICollectionViewDataSource
 
     override func numberOfSections(in collectionView: UICollectionView) -> Int {
@@ -404,14 +436,21 @@ extension ConversationListContentController: UIViewControllerPreviewingDelegate 
     @available(iOS, introduced: 9.0, deprecated: 13.0, renamed: "UIContextMenuInteraction")
     func previewingContext(_ previewingContext: UIViewControllerPreviewing, viewControllerForLocation location: CGPoint) -> UIViewController? {
         guard let indexPath = collectionView.indexPathForItem(at: location),
-              let layoutAttributes = collectionView.layoutAttributesForItem(at: indexPath),
-              let conversation = listViewModel.item(for: indexPath) as? ZMConversation else {
+              let layoutAttributes = collectionView.layoutAttributesForItem(at: indexPath)
+               else {
             return nil
         }
         
         previewingContext.sourceRect = layoutAttributes.frame
         
+        return conversationPreviewViewController(indexPath: indexPath)
+    }
+    
+    private func conversationPreviewViewController(indexPath: IndexPath) -> ConversationPreviewViewController? {
+        guard let conversation = listViewModel.item(for: indexPath) as? ZMConversation else { return nil }
+
         return ConversationPreviewViewController(conversation: conversation, presentingViewController: self)
+
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationAction.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationAction.swift
@@ -143,7 +143,7 @@ extension ZMConversation.Action {
         }
     }
     
-    fileprivate var title: String {
+    var title: String {
         switch self {
         case .removeFromFolder(let folder):
             return localizationKey.localized(args: folder)
@@ -175,6 +175,7 @@ extension ZMConversation.Action {
         return .init(title: title, style: isDestructive ? .destructive : .default) { _ in handler() }
     }
 
+    @available(iOS, introduced: 9.0, deprecated: 13.0, message: "UIViewControllerPreviewing is deprecated. Please use UIContextMenuInteraction.")
     func previewAction(handler: @escaping () -> Void) -> UIPreviewAction {
         return .init(title: title, style: isDestructive ? .destructive : .default, handler: { _, _ in handler() })
     }


### PR DESCRIPTION
## What's new in this PR?

After updating to iOS 13 SDK, old peek and pop feature does not work anymore since 3D touch is no longer triggers. Implement `UIMenu` to restore the preview feature of conversation list.