### PR TITLE
Fix: sometimes haptic touch not work on Conversation list cell

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/AvatarImageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/AvatarImageView.swift
@@ -196,7 +196,6 @@ class AvatarImageView: UIControl {
             initialsLabel.text = text
             imageView.isHidden = true
             initialsLabel.isHidden = false
-            print("imageView = \(imageView)")
 
         case .none:
             imageView.image = nil

--- a/Wire-iOS/Sources/UserInterface/Components/Views/SwipeMenuCollectionCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/SwipeMenuCollectionCell.swift
@@ -364,33 +364,45 @@ extension SwipeMenuCollectionCell: UIGestureRecognizerDelegate {
     }
 
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldBeRequiredToFailBy otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        if #available(iOS 13.0, *) {
+            return gestureRecognizer is UILongPressGestureRecognizer
+        }
+        
         // all other recognizers require this pan recognizer to fail
         return gestureRecognizer == revealDrawerGestureRecognizer
     }
 
-    // NOTE:
-    // In iOS 11, the force touch gesture recognizer used for peek & pop was blocking
-    // the pan gesture recognizer used for the swipeable cell. The fix to this problem
-    // however broke the correct behaviour for iOS 10 (namely, the pan gesture recognizer
-    // was now blocking the force touch recognizer). Although Apple documentation suggests
-    // getting the reference to the force recognizer and using delegate methods to create
-    // failure requirements, setting the delegate raised an exception (???). Here we
-    // simply apply the fix for iOS 11 and above.
-
-    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRequireFailureOf otherGestureRecognizer: UIGestureRecognizer) -> Bool {
-        // for iOS version >= 11
-        if UIDevice.current.systemVersion.compare("11", options: .numeric, range: nil, locale: .current) != .orderedAscending {
+    /// NOTE:
+    /// In iOS 11, the force touch gesture recognizer used for peek & pop was blocking
+    /// the pan gesture recognizer used for the swipeable cell. The fix to this problem
+    /// however broke the correct behaviour for iOS 10 (namely, the pan gesture recognizer
+    /// was now blocking the force touch recognizer). Although Apple documentation suggests
+    /// getting the reference to the force recognizer and using delegate methods to create
+    /// failure requirements, setting the delegate raised an exception (???). Here we
+    /// simply apply the fix for iOS 11 and above.
+    /// - Parameters:
+    ///   - gestureRecognizer: gestureRecognizer
+    ///   - otherGestureRecognizer: otherGestureRecognizer
+    /// - Returns: true if need to require failure of otherGestureRecognizer
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer,
+                           shouldRequireFailureOf otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        
+        if #available(iOS 13.0, *) {
+            return false
+        } else if #available(iOS 11.0, *) {
             // pan recognizer should not require failure of any other recognizer
             return !(gestureRecognizer is UIPanGestureRecognizer)
-        } else {
-            return !(gestureRecognizer is UIPanGestureRecognizer) || !(otherGestureRecognizer is UIPanGestureRecognizer)
         }
+
+        return !(gestureRecognizer is UIPanGestureRecognizer) || !(otherGestureRecognizer is UIPanGestureRecognizer)
     }
 
-    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer,
+                           shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
 
-        // iOS version >= 11
-        if UIDevice.current.systemVersion.compare("11", options: .numeric, range: nil, locale: .current) != .orderedAscending {
+        if #available(iOS 13.0, *) {
+            return true
+        } else if #available(iOS 11.0, *) {
             // pan recognizer should not recognize simultaneously with any other recognizer
             return !(gestureRecognizer is UIPanGestureRecognizer)
         }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
@@ -278,31 +278,28 @@ final class ConversationListContentController: UICollectionViewController {
     override func collectionView(_ collectionView: UICollectionView,
                                  contextMenuConfigurationForItemAt indexPath: IndexPath,
                                  point: CGPoint) -> UIContextMenuConfiguration? {
-        guard let conversation = self.listViewModel.item(for: indexPath) as? ZMConversation,
-            let previewViewController = conversationPreviewViewController(indexPath: indexPath) else { return nil }
+        guard let conversation = listViewModel.item(for: indexPath) as? ZMConversation,
+            let previewViewController = conversationPreviewViewController(indexPath: indexPath) else {
+                return nil                
+        }
 
         let previewProvider: UIContextMenuContentPreviewProvider = {
             return previewViewController
         }
 
         let actionProvider: UIContextMenuActionProvider = { _ in
-            return self.makeContextMenu(conversation: conversation, actionController: previewViewController.actionController)
+            let actions = conversation.listActions.map { action in
+                UIAction(title: action.title, image: nil) { _ in
+                    previewViewController.actionController.handleAction(action)
+                }
+            }
+
+            return UIMenu(title: conversation.displayName, children: actions)
         }
 
         return UIContextMenuConfiguration(identifier: indexPath as NSIndexPath,
                                           previewProvider: previewProvider,
                                           actionProvider: actionProvider)
-    }
-
-    @available(iOS 13.0, *)
-    private func makeContextMenu(conversation: ZMConversation, actionController: ConversationActionController) -> UIMenu {
-        let actions = conversation.listActions.map { action in
-            UIAction(title: action.title, image: nil) { _ in
-                actionController.handleAction(action)
-            }
-        }
-
-        return UIMenu(title: conversation.displayName, children: actions)
     }
 
     // MARK: - UICollectionViewDataSource

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
@@ -255,13 +255,6 @@ final class ConversationListContentController: UICollectionViewController {
         selectModelItem(conversationListItem)
     }
 
-    private func conversationPreviewViewController(indexPath: IndexPath) -> ConversationPreviewViewController? {
-        guard let conversation = listViewModel.item(for: indexPath) as? ZMConversation else { return nil }
-
-        return ConversationPreviewViewController(conversation: conversation, presentingViewController: self)
-
-    }
-
     // MARK: context menu
     @available(iOS 13.0, *)
     override func collectionView(_ collectionView: UICollectionView,
@@ -278,19 +271,20 @@ final class ConversationListContentController: UICollectionViewController {
     override func collectionView(_ collectionView: UICollectionView,
                                  contextMenuConfigurationForItemAt indexPath: IndexPath,
                                  point: CGPoint) -> UIContextMenuConfiguration? {
-        guard let conversation = listViewModel.item(for: indexPath) as? ZMConversation,
-            let previewViewController = conversationPreviewViewController(indexPath: indexPath) else {
+        guard let conversation = listViewModel.item(for: indexPath) as? ZMConversation else {
                 return nil                
         }
 
         let previewProvider: UIContextMenuContentPreviewProvider = {
-            return previewViewController
+            return ConversationPreviewViewController(conversation: conversation, presentingViewController: self)
         }
 
         let actionProvider: UIContextMenuActionProvider = { _ in
             let actions = conversation.listActions.map { action in
                 UIAction(title: action.title, image: nil) { _ in
-                    previewViewController.actionController.handleAction(action)
+                    let actionController = ConversationActionController(conversation: conversation, target: self)
+
+                    actionController.handleAction(action)
                 }
             }
 
@@ -451,9 +445,13 @@ extension ConversationListContentController: UIViewControllerPreviewingDelegate 
                 return nil
         }
 
+        guard let conversation = listViewModel.item(for: indexPath) as? ZMConversation else {
+            return nil
+        }
+
         previewingContext.sourceRect = layoutAttributes.frame
 
-        return conversationPreviewViewController(indexPath: indexPath)
+        return ConversationPreviewViewController(conversation: conversation, presentingViewController: self)
     }
 }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

Follow up of https://github.com/wireapp/wire-ios/pull/4376, sometimes long touch can not trigger preview

### Causes

The hack to fix 3D touch seems no longer works on iOS 13. The pan gesture of the conversation list cell cancels the long-press gesture.

### Solutions

Remove the hack of iOS11