### PR TITLE
Fix: When system dark mode is enabled, conversation screen status is white on white

### DIFF
--- a/Wire-iOS/Sources/Authentication/Landing/LandingViewController.swift
+++ b/Wire-iOS/Sources/Authentication/Landing/LandingViewController.swift
@@ -256,7 +256,7 @@ final class LandingViewController: AuthenticationStepViewController {
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
-        return .default
+        return .compatibleDarkContent
     }
 
     func configure(with featureProvider: AuthenticationFeatureProvider) {

--- a/Wire-iOS/Sources/Helpers/ColorScheme+Helper.swift
+++ b/Wire-iOS/Sources/Helpers/ColorScheme+Helper.swift
@@ -19,16 +19,22 @@
 import Foundation
 import UIKit
 
+extension UIStatusBarStyle {
+    static var compatibleDarkContent: UIStatusBarStyle {
+        if #available(iOS 13.0, *) {
+            return .darkContent
+        }
+        
+        return .default
+    }
+}
+
 extension ColorScheme {
 
     var statusBarStyle: UIStatusBarStyle {
         switch variant {
         case .light:
-            if #available(iOS 13.0, *) {
-                return .darkContent
-            } else {
-                return .default
-            }
+            return .compatibleDarkContent
         case .dark:
             return .lightContent
         }

--- a/Wire-iOS/Sources/Helpers/ColorScheme+Helper.swift
+++ b/Wire-iOS/Sources/Helpers/ColorScheme+Helper.swift
@@ -22,7 +22,12 @@ import UIKit
 extension ColorScheme {
 
     var statusBarStyle: UIStatusBarStyle {
-        return variant == .light ? .default : .lightContent
+        switch variant {
+        case .light:
+            return .default
+        case .dark:
+            return .lightContent
+        }
     }
 
     func isCurrentAccentColor(_ accentColor: UIColor) -> Bool {

--- a/Wire-iOS/Sources/Helpers/ColorScheme+Helper.swift
+++ b/Wire-iOS/Sources/Helpers/ColorScheme+Helper.swift
@@ -24,7 +24,7 @@ extension UIStatusBarStyle {
         if #available(iOS 13.0, *) {
             return .darkContent
         }
-        
+
         return .default
     }
 }
@@ -43,5 +43,5 @@ extension ColorScheme {
     func isCurrentAccentColor(_ accentColor: UIColor) -> Bool {
         return self.accentColor == accentColor
     }
-    
+
 }

--- a/Wire-iOS/Sources/Helpers/ColorScheme+Helper.swift
+++ b/Wire-iOS/Sources/Helpers/ColorScheme+Helper.swift
@@ -24,7 +24,11 @@ extension ColorScheme {
     var statusBarStyle: UIStatusBarStyle {
         switch variant {
         case .light:
-            return .default
+            if #available(iOS 13.0, *) {
+                return .darkContent
+            } else {
+                return .default
+            }
         case .dark:
             return .lightContent
         }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -157,7 +157,7 @@ final class CallViewController: UIViewController {
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
-        return callInfoConfiguration.effectiveColorVariant == .light ? .default : .lightContent
+        return callInfoConfiguration.effectiveColorVariant == .light ? .compatibleDarkContent : .lightContent
     }
 
     override var prefersStatusBarHidden: Bool {

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
@@ -257,7 +257,7 @@ final class CollectionsViewController: UIViewController {
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
-        return ColorScheme.default.variant == .dark ? .lightContent : .default
+        return ColorScheme.default.statusBarStyle
     }
 
     fileprivate func updateNoElementsState() {

--- a/Wire-iOS/Sources/UserInterface/Components/Giphy/GiphyNavigationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Giphy/GiphyNavigationController.swift
@@ -18,10 +18,10 @@
 
 import UIKit
 
-class GiphyNavigationController: UINavigationController {
+final class GiphyNavigationController: UINavigationController {
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
-        return ColorScheme.default.variant == .dark ? .lightContent : .default
+       return ColorScheme.default.statusBarStyle
     }
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
@@ -164,8 +164,8 @@ final class ConversationCreationController: UIViewController {
         }
     }
 
-    override public var preferredStatusBarStyle: UIStatusBarStyle {
-        return colorSchemeVariant == .light ? .default : .lightContent
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return ColorScheme.default.statusBarStyle
     }
 
     override public func viewDidAppear(_ animated: Bool) {

--- a/Wire-iOS/Sources/UserInterface/Folders/FolderCreationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Folders/FolderCreationController.swift
@@ -79,7 +79,7 @@ final class FolderCreationController: UIViewController {
     }
     
     override public var preferredStatusBarStyle: UIStatusBarStyle {
-        return colorSchemeVariant == .light ? .default : .lightContent
+        return colorSchemeVariant == .light ? .compatibleDarkContent : .lightContent
     }
     
     override public func viewDidAppear(_ animated: Bool) {

--- a/Wire-iOS/Sources/UserInterface/Settings/AccentColorPickerController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/AccentColorPickerController.swift
@@ -122,9 +122,7 @@ class ColorPickerController: UIViewController {
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
-        get {
-            return .lightContent
-        }
+        return .lightContent
     }
     
     fileprivate class PickerCell: UITableViewCell {

--- a/Wire-iOS/Sources/UserInterface/SkeletonViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/SkeletonViewController.swift
@@ -319,9 +319,9 @@ final class SkeletonViewController: UIViewController {
     
     override var preferredStatusBarStyle: UIStatusBarStyle {
         if customSplitViewController.layoutSize == .compact {
-            return UIStatusBarStyle.lightContent
+            return .lightContent
         } else {
-            return UIStatusBarStyle.default
+            return .default
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/SkeletonViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/SkeletonViewController.swift
@@ -321,7 +321,7 @@ final class SkeletonViewController: UIViewController {
         if customSplitViewController.layoutSize == .compact {
             return .lightContent
         } else {
-            return .default
+            return .compatibleDarkContent
         }
     }
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

After updating to iOS 13 SDK, some screens has status bar with light content when changed to system dark mode.

### Causes

on iOS 13, `UIStatusBarStyle.default` can be either light or dark.

### Solutions

Replace `.default` with `.compatibleDarkContent`.