### PR TITLE
[Fix] Emojis rendering inside code blocks

### DIFF
--- a/Wire-iOS Tests/Message+FormattingTests.swift
+++ b/Wire-iOS Tests/Message+FormattingTests.swift
@@ -220,4 +220,15 @@ class Message_FormattingTests: XCTestCase {
         // then
         XCTAssertEqual(formattedText.attributes(at: mention.range.location + 1, effectiveRange: nil)[.link] as! URL, mention.link)
     }
+    
+    func testThatEmojiAreNotRenderedInsideCodeBlock() {
+        // given
+        let textMessageData = createTextMessageData(withMessageTemplate: "`:(`")
+        
+        // when
+        let formattedText = NSAttributedString.format(message: textMessageData, isObfuscated: false)
+        
+        // then
+        XCTAssertEqual(formattedText.string, ":(")
+    }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/NSAttributedString+MessageFormatting.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/NSAttributedString+MessageFormatting.swift
@@ -163,7 +163,8 @@ extension NSAttributedString {
         let links = markdownText.links()
         let linkAttachmentRanges = links.compactMap { Range<Int>($0.range) }
         let mentionRanges = mentionTextObjects.compactMap{ $0.range(in: markdownText.string as String)}
-        markdownText.replaceEmoticons(excluding: linkAttachmentRanges + mentionRanges)
+        let codeBlockRanges =  markdownText.ranges(of: .code).compactMap { Range<Int>($0) }
+        markdownText.replaceEmoticons(excluding: linkAttachmentRanges + mentionRanges + codeBlockRanges)
 
         markdownText.removeTrailingWhitespace()
         markdownText.changeFontSizeIfMessageContainsOnlyEmoticons()


### PR DESCRIPTION
## What's new in this PR?

### Issues
`:(` is displayed as an emoticon.

### Solutions
Do not replace emoticons in code blocks.
