### PR TITLE
[Fix] Call overlay does not dismiss

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/CallController/CallController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallController/CallController.swift
@@ -119,10 +119,6 @@ extension CallController: WireCallCenterCallStateObserver {
 
         let modalVC = ModalPresentationViewController(viewController: viewController)
 
-        modalVC.dismissClosure = {
-            self.activeCallViewController = nil
-        }
-
         let callWindow: CallWindow? = targetViewController?.view.window as? CallWindow
         let presentClosure: Completion = {
             callWindow?.isHidden = false

--- a/Wire-iOS/Sources/UserInterface/Helpers/InteractiveModalTransition.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/InteractiveModalTransition.swift
@@ -157,8 +157,6 @@ final private class ModalInteractionController: UIPercentDrivenInteractiveTransi
 
 final class ModalPresentationViewController: UIViewController, UIViewControllerTransitioningDelegate {
 
-    var dismissClosure: Completion?
-
     fileprivate unowned let viewController: UIViewController
     fileprivate let dimView = UIView()
 
@@ -189,14 +187,6 @@ final class ModalPresentationViewController: UIViewController, UIViewControllerT
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return wr_supportedInterfaceOrientations
-    }
-
-    override func dismiss(animated flag: Bool,
-                          completion: Completion? = nil) {
-        super.dismiss(animated: flag) {
-            completion?()
-            self.dismissClosure?()
-        }
     }
 
     private func setupViews(with viewController: UIViewController) {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Sometimes the call overlay does not dismiss when hanging up the call. Additionally, some people are reporting a similar issue that the calling overlay no longer receives touch events and the app must be terminated.

### Causes

A dismiss closure in which `activeViewController` is set to `nil` is being called when the calling overlay is dismissed. However, it is also being called when the user interactively starts to dismiss the calling overlay but cancels the transition. This can also occur just by tapping the screen.

When this happens, the the app loses all references to `activeViewController` and so it can't be dismissed programatically. It is still retained by the system, because we are using custom transitioning objects to present and dismiss it. This means the calling overlay can still be dismissed by dragging the screen down, if the UI is responsive...

This bad state may also be the cause of the unresponsive UI in calls, but I am not certain. 

### Solutions

Remove the closure altogether. `activeViewController` is marked as a `weak` property, so it should be nullified when the system releases is after the interactive transition completes.

