### PR TITLE
[Fix] Accessibility hierarchy not updating

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationMessageToolboxCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationMessageToolboxCell.swift
@@ -21,9 +21,16 @@ import WireDataModel
 
 final class ConversationMessageToolboxCell: UIView, ConversationMessageCell, MessageToolboxViewDelegate {
 
-    struct Configuration {
+    struct Configuration: Equatable {
         let message: ZMConversationMessage
         let selected: Bool
+        let deliveryState: ZMDeliveryState
+        
+        static func == (lhs: ConversationMessageToolboxCell.Configuration, rhs: ConversationMessageToolboxCell.Configuration) -> Bool {
+            return lhs.deliveryState == rhs.deliveryState &&
+                   lhs.message == rhs.message &&
+                   lhs.selected == rhs.selected
+        }
     }
 
     let toolboxView = MessageToolboxView()
@@ -109,7 +116,7 @@ class ConversationMessageToolboxCellDescription: ConversationMessageCellDescript
 
     init(message: ZMConversationMessage, selected: Bool) {
         self.message = message
-        self.configuration = View.Configuration(message: message, selected: selected)
+        self.configuration = View.Configuration(message: message, selected: selected, deliveryState: message.deliveryState)
     }
     
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

When sending a message the accessibility hierarchy is not updated to reflect the views state after it's been delivered.

### Causes

We update the cell outside a table view update block which seems to not trigger the accessibility hierarchy to update. See: https://github.com/wireapp/wire-ios/blob/32038b8f3d975cc652c8214b43e5f0cfe521f391/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift#L132

### Solutions

Make the cell's configuration adopt `Equatable` and add the delivery state as a field. This will cause the cell to be reloaded using [reloadRows](https://developer.apple.com/documentation/uikit/uitableview/1614935-reloadrows) since DifferenceKit will now know that cell has been updated.
### Notes

Would be nicer to re-factor the `MessageToolBox` to not rely on having `ZMConversationMessage` in the configuration but that's a bigger re-factoring outside the scope of this bug fix.
