### PR TITLE
Fix: iOS 13: screen does not rotate when viewing image full screen and rotating iPhone

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/RotationAwareNavigationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/RotationAwareNavigationController.swift
@@ -68,4 +68,16 @@ final class RotationAwareNavigationController: UINavigationController, PopoverPr
         super.pushViewController(viewController, animated: animated)
     }
     
+    // MARK: - status bar
+    override var childForStatusBarStyle: UIViewController? {
+        return topViewController
+    }
+    
+    override var childForStatusBarHidden: UIViewController? {
+        return topViewController
+    }
+
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return ColorScheme.default.statusBarStyle
+    }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/MessagePresenter.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/MessagePresenter.swift
@@ -184,6 +184,8 @@ final class MessagePresenter: NSObject {
     func openImageMessage(_ message: ZMConversationMessage, actionResponder delegate: MessageActionResponder) {
         let imageViewController = viewController(forImageMessage: message, actionResponder: delegate)
         if let imageViewController = imageViewController {
+            // to allow image rotation, present the image viewer in full screen style
+            imageViewController.modalPresentationStyle = .fullScreen
             modalTargetController?.present(imageViewController, animated: true)
         }
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Image view can not be roatated.

### Causes

The new card style does not roatates, due to parent screen can not be roatated.

### Solutions

Present image viewer in full screen style.