### PR TITLE
Reduce the build time on CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,10 @@ steps:
   displayName: "Setup environment"
 
 - script: |
-    fastlane build
+    fastlane build build_number:0 \
+                     build_type:Development \
+                     configuration:Debug \
+                     for_simulator:true
   displayName: "Build"
 
 - task: PublishBuildArtifacts@1

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -51,10 +51,7 @@ platform :ios do
             xcversion(version: xcode_version)
         end
 
-        build_number = options[:build_number]
-        if build_number.nil? 
-            build_number = "0"
-        end
+        build = Build.new(options: options)
 
         run_tests(
             scheme: "Wire-iOS",
@@ -66,7 +63,7 @@ platform :ios do
             buildlog_path: "build",
             output_directory: "build",
             output_types: "junit",
-            xcargs: "BUILD_NUMBER=#{build_number}"
+            xcargs: "BUILD_NUMBER=#{build.build_number}"
         )
     end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -62,12 +62,11 @@ platform :ios do
             configuration: "Debug",
             build_for_testing: true,
             sdk:"iphonesimulator",
-            code_coverage: true,
             derived_data_path: "DerivedData",
             buildlog_path: "build",
             output_directory: "build",
             output_types: "junit",
-            # xcargs: "BUILD_NUMBER=#{build_number}"
+            xcargs: "BUILD_NUMBER=#{build_number}"
         )
     end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -51,8 +51,14 @@ platform :ios do
             xcversion(version: xcode_version)
         end
 
+        build_number = options[:build_number]
+        if build_number.nil? 
+            build_number = "0"
+        end
+
         run_tests(
             scheme: "Wire-iOS",
+            skip_detect_devices: true,
             configuration: "Debug",
             build_for_testing: true,
             devices: "iPhone 8",
@@ -61,7 +67,8 @@ platform :ios do
             derived_data_path: "DerivedData",
             buildlog_path: "build",
             output_directory: "build",
-            output_types: "junit"
+            output_types: "junit",
+            xcargs: "BUILD_NUMBER=#{build_number}"
         )
     end
 
@@ -82,6 +89,7 @@ platform :ios do
 
         run_tests(
             scheme: "Wire-iOS",
+            skip_detect_devices: true,
             configuration: "Debug",
             test_without_building: true,
             sdk:"iphonesimulator",
@@ -107,7 +115,7 @@ platform :ios do
         if build.for_simulator
             Dir.chdir("..") do
                 # Build the app for simulator
-                sh "xcodebuild -scheme 'Wire-iOS' -configuration 'Debug' -sdk 'iphonesimulator' -derivedDataPath DerivedData -quiet clean build BUILD_NUMBER=#{build.build_number}"
+                sh "xcodebuild -scheme 'Wire-iOS' -configuration 'Debug' -sdk 'iphonesimulator' -derivedDataPath DerivedData -quiet build BUILD_NUMBER=#{build.build_number}"
 
                 # make a "fake" .ipa package that QA will use for installing to simulator
                 sh "mkdir -p debug/Payload"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -61,14 +61,13 @@ platform :ios do
             skip_detect_devices: true,
             configuration: "Debug",
             build_for_testing: true,
-            devices: "iPhone 8",
             sdk:"iphonesimulator",
             code_coverage: true,
             derived_data_path: "DerivedData",
             buildlog_path: "build",
             output_directory: "build",
             output_types: "junit",
-            xcargs: "BUILD_NUMBER=#{build_number}"
+            # xcargs: "BUILD_NUMBER=#{build_number}"
         )
     end
 


### PR DESCRIPTION
## What's new in this PR?

The PR reduces the CI step `QA: build for simulator` with the following adjustments:
-  do not clean the project when building again for QA testing
-  add build number when `build for test` (i.e. build product is same as the `QA: build for simulator` step)
- add `skip_detect_devices` for both steps
- remove unnecessary `devices` & `code_coverage` options.