### PR TITLE
[Fix] Conversation not disappearing after deletion

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
@@ -424,6 +424,9 @@ extension ConversationViewController: ZMConversationObserver {
 extension ConversationViewController: ZMConversationListObserver {
     public func conversationListDidChange(_ changeInfo: ConversationListChangeInfo) {
         updateLeftNavigationBarItems()
+        if changeInfo.deletedObjects.contains(conversation) {
+            ZClientViewController.shared?.transitionToList(animated: true, completion: nil)
+        }
     }
     
     public func conversationInsideList(_ list: ZMConversationList, didChange changeInfo: ConversationChangeInfo) {


### PR DESCRIPTION
## What's new in this PR?

### Issues

GIVEN conversation is open on mobile
WHEN deleting a conversation from the webapp, 
THEN the conversation content is cleared 
BUT the conversation remains open
AND is only deleted after returning to conversation list

### Causes

That case was not covered. When observing a change in the conversation, no action related to deletion was taken.

### Solutions

Transition to the conversation list if the conversation was deleted