### PR TITLE
disable cross resolve when opening emoji/sketch screen 

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/ConfirmAssetViewController/ConfirmAssetViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/ConfirmAssetViewController/ConfirmAssetViewController.swift
@@ -200,6 +200,11 @@ final class ConfirmAssetViewController: UIViewController {
         canvasViewController.select(editMode: editMode, animated: false)
 
         let navigationController = canvasViewController.wrapInNavigationController()
+        
+        if #available(iOS 13.0, *) {
+        } else {
+            navigationController.modalTransitionStyle = .crossDissolve
+        }
 
         present(navigationController, animated: true)
     }

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/ConfirmAssetViewController/ConfirmAssetViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/ConfirmAssetViewController/ConfirmAssetViewController.swift
@@ -200,7 +200,6 @@ final class ConfirmAssetViewController: UIViewController {
         canvasViewController.select(editMode: editMode, animated: false)
 
         let navigationController = canvasViewController.wrapInNavigationController()
-        navigationController.modalTransitionStyle = .crossDissolve
 
         present(navigationController, animated: true)
     }


### PR DESCRIPTION
## What's new in this PR?

Disable `crossDissolve`  modalTransitionStyle which does not fit iOS 13 card modal animation.