### PR TITLE
Fix: Status bar is white on white when back from collection screen

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
@@ -299,7 +299,7 @@ final class CollectionsViewController: UIViewController {
 
     @objc
     fileprivate func closeButtonPressed(_ button: UIButton) {
-        self.onDismiss?(self)
+        onDismiss?(self)
     }
 
     @objc

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
@@ -159,28 +159,32 @@ extension ConversationViewController {
         startCallController.joinCall()
     }
 
-    @objc func onCollectionButtonPressed(_ sender: AnyObject!) {
+    @objc
+    private func onCollectionButtonPressed(_ sender: AnyObject!) {
         if self.collectionController == .none {
             let collections = CollectionsViewController(conversation: conversation)
             collections.delegate = self
 
             collections.onDismiss = { [weak self] _ in
 
-                guard let `self` = self, let collectionController = self.collectionController else {
+                guard let weakSelf = self else {
                     return
                 }
 
-                collectionController.dismiss(animated: true, completion: {
-                    })
+                weakSelf.collectionController?.dismiss(animated: true) {
+                    weakSelf.setNeedsStatusBarAppearanceUpdate()
+                }
             }
             self.collectionController = collections
         } else {
-            self.collectionController?.refetchCollection()
+            collectionController?.refetchCollection()
         }
 
         collectionController?.shouldTrackOnNextOpen = true
 
         let navigationController = KeyboardAvoidingViewController(viewController: self.collectionController!).wrapInNavigationController()
+
+        navigationController.presentationController?.delegate = ZClientViewController.shared
 
         ZClientViewController.shared?.present(navigationController, animated: true)
     }

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -17,9 +17,7 @@
 //
 
 
-import Foundation
 import UIKit
-import WireDataModel
 import WireSyncEngine
 import avs
 import WireCommonComponents
@@ -714,4 +712,10 @@ final class ZClientViewController: UIViewController {
         }
     }
 
+}
+
+extension ZClientViewController: UIAdaptivePresentationControllerDelegate {
+    func presentationControllerDidDismiss( _ presentationController: UIPresentationController) {
+        setNeedsStatusBarAppearanceUpdate()
+    }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

The status bar is white on white after dismissed collection screen.

### Causes

Same as https://github.com/wireapp/wire-ios/pull/4348

### Solutions

Same as https://github.com/wireapp/wire-ios/pull/4348