### PR TITLE
Fix Page scrolling to top after accepting one request

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Views/UpsideDownTableView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/UpsideDownTableView.swift
@@ -118,7 +118,9 @@ final class UpsideDownTableView: UITableView {
         super.scrollToNearestSelectedRow(at: inverseScrollPosition(scrollPosition), animated: animated)
     }
 
-    override func scrollToRow(at indexPath: IndexPath, at scrollPosition: UITableView.ScrollPosition, animated: Bool) {
+    override func scrollToRow(at indexPath: IndexPath,
+                              at scrollPosition: UITableView.ScrollPosition,
+                              animated: Bool) {
         super.scrollToRow(at: indexPath, at: inverseScrollPosition(scrollPosition), animated: animated)
     }
 

--- a/Wire-iOS/Sources/UserInterface/ConnectRequests/ConnectRequestsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConnectRequests/ConnectRequestsViewController.swift
@@ -18,7 +18,6 @@
 
 import Foundation
 import UIKit
-import WireDataModel
 import WireSyncEngine
 
 final class ConnectRequestsViewController: UIViewController, UITableViewDataSource, UITableViewDelegate {
@@ -137,7 +136,8 @@ final class ConnectRequestsViewController: UIViewController, UITableViewDataSour
         if connectionRequests.isEmpty {
             ZClientViewController.shared?.hideIncomingContactRequests()
         } else {
-            tableView.scrollToFirstRow(animated: animated)
+            // scroll to bottom to show the next request
+            tableView.setContentOffset(CGPoint(x: 0, y: CGFloat.greatestFiniteMagnitude), animated: animated)
         }
     }
     
@@ -166,11 +166,5 @@ extension ConnectRequestsViewController: ZMConversationListObserver {
 extension ConnectRequestsViewController: ZMUserObserver {
     func userDidChange(_ change: UserChangeInfo) {
         tableView.reloadData() //may need a slightly different approach, like enumerating through table cells of type FirstTimeTableViewCell and setting their bgColor property
-    }
-}
-
-extension UITableView {
-    func scrollToFirstRow(animated: Bool) {
-        scrollToRow(at: IndexPath(row: 0, section: 0), at: .bottom, animated: animated)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/ConnectRequests/ConnectRequestsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConnectRequests/ConnectRequestsViewController.swift
@@ -137,7 +137,7 @@ final class ConnectRequestsViewController: UIViewController, UITableViewDataSour
         if connectionRequests.isEmpty {
             ZClientViewController.shared?.hideIncomingContactRequests()
         } else {
-            tableView.scrollToFirststRow(animated: animated)
+            tableView.scrollToFirstRow(animated: animated)
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/ConnectRequests/ConnectRequestsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConnectRequests/ConnectRequestsViewController.swift
@@ -137,7 +137,7 @@ final class ConnectRequestsViewController: UIViewController, UITableViewDataSour
         if connectionRequests.isEmpty {
             ZClientViewController.shared?.hideIncomingContactRequests()
         } else {
-            tableView.scrollToLastRow(animated: animated)
+            tableView.scrollToFirststRow(animated: animated)
         }
     }
     
@@ -170,8 +170,7 @@ extension ConnectRequestsViewController: ZMUserObserver {
 }
 
 extension UITableView {
-    func scrollToLastRow(animated: Bool) {
-        let rowCount = numberOfRows(inSection: numberOfSections - 1)
-        scrollToRow(at: IndexPath(row: rowCount - 1, section: numberOfSections - 1), at: .bottom, animated: animated)
+    func scrollToFirstRow(animated: Bool) {
+        scrollToRow(at: IndexPath(row: 0, section: 0), at: .bottom, animated: animated)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/ConnectRequests/IncomingConnectionView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConnectRequests/IncomingConnectionView.swift
@@ -21,7 +21,7 @@ import Foundation
 import Cartography
 import WireSyncEngine
 
-public final class IncomingConnectionView: UIView {
+final class IncomingConnectionView: UIView {
 
     static private var correlationFormatter: AddressBookCorrelationFormatter = {
         return AddressBookCorrelationFormatter(
@@ -38,18 +38,18 @@ public final class IncomingConnectionView: UIView {
     private let acceptButton = Button(style: .full)
     private let ignoreButton = Button(style: .empty)
 
-    public var user: ZMUser {
+    var user: ZMUser {
         didSet {
             self.setupLabelText()
             self.userImageView.user = self.user
         }
     }
 
-    public typealias UserAction = (ZMUser) -> Void
-    public var onAccept: UserAction?
-    public var onIgnore: UserAction?
+    typealias UserAction = (ZMUser) -> Void
+    var onAccept: UserAction?
+    var onIgnore: UserAction?
 
-    public init(user: ZMUser) {
+    init(user: ZMUser) {
         self.user = user
         super.init(frame: .zero)
 
@@ -59,7 +59,7 @@ public final class IncomingConnectionView: UIView {
         self.createConstraints()
     }
 
-    required public init?(coder aDecoder: NSCoder) {
+    required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 

--- a/Wire-iOS/Sources/UserInterface/ConnectRequests/UserConnectionViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConnectRequests/UserConnectionViewController.swift
@@ -19,7 +19,6 @@
 
 import Foundation
 import UIKit
-import WireDataModel
 import WireSyncEngine
 
 enum IncomingConnectionAction: UInt {


### PR DESCRIPTION
## What's new in this PR?

### Issues

When multiple incoming requests in coming. The user would like to scroll to the next incoming request instead of the first one.

### Causes

~~In the `UpsideDownTableView`, the top and bottom are reversed.~~ The `scrollToRow` does not work as expected for unknown reasons.

### Solutions
~~Replace `UITableView.scrollToLastRow` with `scrollToFirstRow`.~~ Use `setContentOffset` instead. (tested and it works.)