### PR TITLE
Fix: missing Share extension gets stuck on sending

### DIFF
--- a/Wire-iOS Share Extension/PostContent.swift
+++ b/Wire-iOS Share Extension/PostContent.swift
@@ -77,8 +77,10 @@ final class PostContent {
         // conversation degradation and to tearDown the observer once done.
         sendController?.send {
             switch $0 {
-            case .done: conversationObserverToken.tearDown()
-            case .startingSending: allMessagesEnqueuedGroup.leave()
+            case .done:
+                conversationObserverToken.tearDown()
+            case .startingSending:
+                allMessagesEnqueuedGroup.leave()
             default: break
             }
 

--- a/Wire-iOS Share Extension/SendController.swift
+++ b/Wire-iOS Share Extension/SendController.swift
@@ -102,7 +102,9 @@ final class SendController {
         self.progress = progress
         
         let completion: SendableCompletion  = { [weak self] sendableResult in
-            guard let weakSelf = self else { return }
+            guard let weakSelf = self else {
+                return                
+            }
             
             switch sendableResult {
             case .success(let sendables):
@@ -115,6 +117,7 @@ final class SendController {
                 weakSelf.observer?.sentHandler = { [weak self] in
                     self?.cancelTimeout()
                     self?.sentAllSendables = true
+                    progress(.done)
                 }
             case .failure(let error):
                 progress(.error(error))
@@ -125,7 +128,9 @@ final class SendController {
             progress(.preparing)
             prepare(unsentSendables: unsentSendables) { [weak self] in
                 guard let `self` = self else { return }
-                guard !self.isCancelled else { return progress(.done) }
+                guard !self.isCancelled else {
+                    return progress(.done)                    
+                }
                 progress(.startingSending)
                 self.append(unsentSendables: self.unsentSendables, completion: completion)
             }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Share extension gets stuck on sending

### Causes

In https://github.com/wireapp/wire-ios/pull/4387, missing a line `progress(.done)`.

### Solutions

add the missing line of code.
