### PR TITLE
[Fix] Call participant list not scrollable

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/CallParticipantsView/CallParticipantsView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallParticipantsView/CallParticipantsView.swift
@@ -68,12 +68,6 @@ class CallParticipantsView: UICollectionView, Themeable {
         }
     }
     
-    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
-        return subviews.any {
-            !$0.isHidden && $0.point(inside: convert(point, to: $0), with: event) && $0 is ShowAllParticipantsCell
-        }
-    }
-    
     func applyColorScheme(_ colorSchemeVariant: ColorSchemeVariant) {
         reloadData()
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

When viewing the full call participant list (after tapping the "show all" cell), it is not possible to scroll the list.

### Causes

`CallParticipantView` contains code that limits all touch events to the "show all" cell. This was introduced in https://github.com/wireapp/wire-ios/pull/2204/ but it's not clear why. In any case, because the full call participant list never contains the "show all" cell, the view was forwarding all of its touch events and therefore the internal scroll view gesture recognizers were not receiving these events.

### Solutions

Remove the code limiting touch events. 

After several manual tests, there doesn't seem to be any negative side effects. The interactive dismissal of the call UI works (vertical pan) and touching any of the user cells still results in the call info overlay being dismissed, revealing the video grid below.

