### PR TITLE
Context menu for ConversationLocationMessageCell

### DIFF
--- a/Wire-iOS Tests/ArticleViewTests.swift
+++ b/Wire-iOS Tests/ArticleViewTests.swift
@@ -157,10 +157,10 @@ final class ArticleViewTests: XCTestCase {
         sut.delegate = mockArticleViewDelegate
 
         // WHEN
-        let menu = sut.makeContextMenu(title: "test", view: sut)
+        let menu = sut.delegate?.makeContextMenu(title: "test", view: sut)
 
         // THEN
-        let children = menu.children
+        let children = menu!.children
         XCTAssertEqual(children.count, 1)
         XCTAssertEqual(children.first?.title, "Delete")
     }

--- a/Wire-iOS Tests/ArticleViewTests.swift
+++ b/Wire-iOS Tests/ArticleViewTests.swift
@@ -51,7 +51,7 @@ final class MockConversationMessageCellDelegate: ConversationMessageCellDelegate
     }
 }
 
-final class MockArticleViewDelegate: ArticleViewDelegate {
+final class MockArticleViewDelegate: ArticleViewDelegate, ContextMenuDelegate {
     func articleViewWantsToOpenURL(_ articleView: ArticleView, url: URL) {
         // no-op
     }
@@ -157,7 +157,7 @@ final class ArticleViewTests: XCTestCase {
         sut.delegate = mockArticleViewDelegate
 
         // WHEN
-        let menu = sut.makeContextMenu(title: "test")
+        let menu = sut.makeContextMenu(title: "test", view: sut)
 
         // THEN
         let children = menu.children

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -774,6 +774,7 @@
 		A990059C23F196170089CDEB /* AnimatedListMenuViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A990059A23F195A70089CDEB /* AnimatedListMenuViewTests.swift */; };
 		A993719123F7461600881564 /* UIView+ExtendedBlockAnimations.swift in Sources */ = {isa = PBXBuildFile; fileRef = A993719023F7461600881564 /* UIView+ExtendedBlockAnimations.swift */; };
 		A9AC63E123FC4A2D00016ABC /* AVURLAsset+conversionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9AC63E023FC4A2D00016ABC /* AVURLAsset+conversionTests.swift */; };
+		A9BA580D2497994D005B806B /* ContextMenuDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9BA580C2497994D005B806B /* ContextMenuDelegate.swift */; };
 		A9C3223F23EB200F00E17311 /* CountryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C3223E23EB200E00E17311 /* CountryCell.swift */; };
 		A9C3224023EB217A00E17311 /* CountryCodeResultsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2126CE1FB9DFE300625A9B /* CountryCodeResultsTableViewController.swift */; };
 		A9C33DFE23D0704F0069C8BB /* MediaPlaybackManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C33DFD23D0704F0069C8BB /* MediaPlaybackManager.swift */; };
@@ -2353,6 +2354,7 @@
 		A993719023F7461600881564 /* UIView+ExtendedBlockAnimations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+ExtendedBlockAnimations.swift"; sourceTree = "<group>"; };
 		A9AC63E023FC4A2D00016ABC /* AVURLAsset+conversionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVURLAsset+conversionTests.swift"; sourceTree = "<group>"; };
 		A9B02231209B6E4E00DF25D8 /* AppCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCenter.swift; sourceTree = "<group>"; };
+		A9BA580C2497994D005B806B /* ContextMenuDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuDelegate.swift; sourceTree = "<group>"; };
 		A9C3223E23EB200E00E17311 /* CountryCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CountryCell.swift; sourceTree = "<group>"; };
 		A9C33DFD23D0704F0069C8BB /* MediaPlaybackManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPlaybackManager.swift; sourceTree = "<group>"; };
 		A9C33DFF23D078B80069C8BB /* ConversationListItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationListItemView.swift; sourceTree = "<group>"; };
@@ -5201,6 +5203,7 @@
 				87F18BCE1E02F63700C69D9B /* MessagePresenter.swift */,
 				EF33204B21496A0D0079E832 /* AVPlayerViewController+StatusBarAndNotification.swift */,
 				87AAE4221E43234A00E1D13A /* MessagePresenter+ConversationImages.swift */,
+				A9BA580C2497994D005B806B /* ContextMenuDelegate.swift */,
 			);
 			path = Content;
 			sourceTree = "<group>";
@@ -7735,6 +7738,7 @@
 				5E35F7802183131400D3F4FE /* ConversationLinkAttachmentCell.swift in Sources */,
 				1687C0FC2151435F003099DD /* ZClientViewController+ShowContentDelegate.swift in Sources */,
 				F1B5EAC72029AB9A0081D402 /* SimpleTextField.swift in Sources */,
+				A9BA580D2497994D005B806B /* ContextMenuDelegate.swift in Sources */,
 				EE948F1923E17778000A663E /* ContactsDataSource.swift in Sources */,
 				16E2A0A61F6BF233005F4DB1 /* ZMConversation+Calling.swift in Sources */,
 				BFCF31DD1DA52ECE0039B3DC /* KeyboardHeight.swift in Sources */,

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationLocationMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationLocationMessageCell.swift
@@ -199,15 +199,8 @@ extension ConversationLocationMessageCell: UIContextMenuInteractionDelegate {
         return UIContextMenuConfiguration(identifier: message.objectIdentifier as NSCopying,
                                           previewProvider: previewProvider,
                                           actionProvider: { _ in
-                                            return self.makeContextMenu()
+                                            return self.makeContextMenu(title: "", view: self)
         })
-    }
-
-    @available(iOS 13.0, *)
-    func makeContextMenu() -> UIMenu {
-        let actions = actionController(view: self)?.allMessageMenuElements() ?? []
-
-        return UIMenu(title: "", children: actions)
     }
 
     @available(iOS 13.0, *)

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationLocationMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationLocationMessageCell.swift
@@ -20,7 +20,7 @@ import UIKit
 import MapKit
 import WireDataModel
 
-final class ConversationLocationMessageCell: UIView, ConversationMessageCell {
+final class ConversationLocationMessageCell: UIView, ConversationMessageCell, ContextMenuDelegate {
 
     struct Configuration {
         let location: LocationMessageData
@@ -206,7 +206,7 @@ extension ConversationLocationMessageCell: UIContextMenuInteractionDelegate {
     @available(iOS 13.0, *)
     func makeContextMenu() -> UIMenu {
         ///TODO: ask adapter?
-        delegate?.
+//        delegate?.perform(action: <#T##MessageAction#>, for: <#T##ZMConversationMessage!#>, view: <#T##UIView#>)
 //    let actions = actionController?.allMessageMenuElements() ?? []
 
         return UIMenu(title: "", children: [] /*actions*/)

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationLocationMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationLocationMessageCell.swift
@@ -205,10 +205,11 @@ extension ConversationLocationMessageCell: UIContextMenuInteractionDelegate {
 
     @available(iOS 13.0, *)
     func makeContextMenu() -> UIMenu {
-        //        let actions = actionController?.allMessageMenuElements() ?? []
+        ///TODO: ask adapter?
+        delegate?.
+//    let actions = actionController?.allMessageMenuElements() ?? []
 
-        ///TODO: tap to open map app
-        return UIMenu(title: "", children: [])
+        return UIMenu(title: "", children: [] /*actions*/)
     }
 
     @available(iOS 13.0, *)

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationLocationMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationLocationMessageCell.swift
@@ -58,9 +58,11 @@ final class ConversationLocationMessageCell: UIView, ConversationMessageCell {
         super.init(frame: frame)
         configureViews()
         createConstraints()
+        
+        ///TODO: preview this or containerView??
     }
 
-    required public init?(coder aDecoder: NSCoder) {
+    required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationLocationMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationLocationMessageCell.swift
@@ -205,11 +205,9 @@ extension ConversationLocationMessageCell: UIContextMenuInteractionDelegate {
 
     @available(iOS 13.0, *)
     func makeContextMenu() -> UIMenu {
-        ///TODO: ask adapter?
-//        delegate?.perform(action: <#T##MessageAction#>, for: <#T##ZMConversationMessage!#>, view: <#T##UIView#>)
-//    let actions = actionController?.allMessageMenuElements() ?? []
+        let actions = actionController(view: self)?.allMessageMenuElements() ?? []
 
-        return UIMenu(title: "", children: [] /*actions*/)
+        return UIMenu(title: "", children: actions)
     }
 
     @available(iOS 13.0, *)

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationLinkPreviewArticleCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationLinkPreviewArticleCell.swift
@@ -19,7 +19,7 @@
 import UIKit
 import WireDataModel
 
-final class ConversationLinkPreviewArticleCell: UIView, ConversationMessageCell {
+final class ConversationLinkPreviewArticleCell: UIView, ConversationMessageCell, ContextMenuDelegate {
 
     struct Configuration {
         let textMessageData: ZMTextMessageData

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageActionController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageActionController.swift
@@ -57,13 +57,6 @@ final class ConversationMessageActionController {
         return allPerformableMessageAction.compactMap { messageAction in
             guard let title = messageAction.title else { return nil }
 
-            let iconImage: UIImage?
-            if let icon = messageAction.icon {
-                iconImage = UIImage.imageForIcon(icon, size: StyleKitIcon.Size.tiny.rawValue, color: .label)
-            } else {
-                iconImage = nil
-            }
-
             let handler: UIActionHandler = { _ in
                 responder?.perform(action: messageAction,
                                    for: message,
@@ -71,7 +64,7 @@ final class ConversationMessageActionController {
             }
 
             return UIAction(title: title,
-                            image: iconImage,
+                            image: nil,
                             handler: handler)
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageActionController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageActionController.swift
@@ -47,9 +47,7 @@ final class ConversationMessageActionController {
         return MessageAction.allCases
             .filter(canPerformAction)
     }
-
-    // MARK: - iOS 13+ context menu
-
+    
     @available(iOS 13.0, *)
     func allMessageMenuElements() -> [UIAction] {
         weak var responder = self.responder

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageActionController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageActionController.swift
@@ -47,7 +47,7 @@ final class ConversationMessageActionController {
         return MessageAction.allCases
             .filter(canPerformAction)
     }
-    
+
     @available(iOS 13.0, *)
     func allMessageMenuElements() -> [UIAction] {
         weak var responder = self.responder
@@ -63,7 +63,7 @@ final class ConversationMessageActionController {
             } else {
                 iconImage = nil
             }
-            
+
             let handler: UIActionHandler = { _ in
                 responder?.perform(action: messageAction,
                                    for: message,
@@ -77,7 +77,7 @@ final class ConversationMessageActionController {
     }
 
     // MARK: - UI menu
-    
+
     static var allMessageActions: [UIMenuItem] {
         return MessageAction.allCases.compactMap {
             guard let selector = $0.selector,
@@ -142,7 +142,7 @@ final class ConversationMessageActionController {
     var previewActionItems: [UIPreviewAction] {
         return allPerformableMessageAction.compactMap { messageAction in
             guard let title = messageAction.title else { return nil }
-            
+
             return UIPreviewAction(title: title,
                                    style: .default) { [weak self] _, _ in
                                     self?.perform(action: messageAction)

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
@@ -192,8 +192,8 @@ extension ConversationMessageCellDescription {
 
     func makeCell(for tableView: UITableView, at indexPath: IndexPath) -> UITableViewCell {
         let cell =  tableView.dequeueConversationCell(with: self, for: indexPath)
-        cell.cellView.delegate = self.delegate
-        cell.cellView.message = self.message
+        cell.cellView.delegate = delegate
+        cell.cellView.message = message
         cell.accessibilityCustomActions = actionController?.makeAccessibilityActions()
         return cell
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/MessageAction.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/MessageAction.swift
@@ -105,8 +105,7 @@ enum MessageAction: CaseIterable {
         case .unlike:
             return .liked
         case .resend:
-            // no icon for resend
-            return nil
+            return .redo
         case .showInConversation:
             return .eye
         case .present:

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ArticleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ArticleView.swift
@@ -23,8 +23,6 @@ import WireDataModel
 
 protocol ArticleViewDelegate: class {
     func articleViewWantsToOpenURL(_ articleView: ArticleView, url: URL)
-    var delegate: ConversationMessageCellDelegate? { get }
-    var message: ZMConversationMessage? { get }
 }
 
 final class ArticleView: UIView {
@@ -52,20 +50,7 @@ final class ArticleView: UIView {
     private let obfuscationView = ObfuscationView(icon: .link)
     private let ephemeralColor = UIColor.accent()
     private var imageHeightConstraint: NSLayoutConstraint!
-    weak var delegate: ArticleViewDelegate?
-
-    // MARK: - for context menu action items
-    private var actionController: ConversationMessageActionController? {
-        guard let message = delegate?.message,
-              let messageActionResponder = delegate?.delegate else {
-                return nil
-        }
-
-        return ConversationMessageActionController(responder: messageActionResponder,
-                                                   message: message,
-                                                   context: .content,
-                                                   view: self)
-    }
+    weak var delegate: (ArticleViewDelegate & ContextMenuDelegate)?
 
     init(withImagePlaceholder imagePlaceholder: Bool) {
         super.init(frame: .zero)
@@ -252,7 +237,7 @@ extension ArticleView: UIContextMenuInteractionDelegate {
     }
 
     func makeContextMenu(title: String) -> UIMenu {
-        let actions = actionController?.allMessageMenuElements() ?? []
+        let actions = delegate?.actionController(view: self)?.allMessageMenuElements() ?? []
 
         return UIMenu(title: title, children: actions)
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ArticleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ArticleView.swift
@@ -232,14 +232,8 @@ extension ArticleView: UIContextMenuInteractionDelegate {
         return UIContextMenuConfiguration(identifier: nil,
                                           previewProvider: previewProvider,
                                           actionProvider: { _ in
-                                            return self.makeContextMenu(title: linkPreview.originalURLString)
+                                            return self.delegate?.makeContextMenu(title: linkPreview.originalURLString, view: self)
         })
-    }
-
-    func makeContextMenu(title: String) -> UIMenu {
-        let actions = delegate?.actionController(view: self)?.allMessageMenuElements() ?? []
-
-        return UIMenu(title: title, children: actions)
     }
 
     func contextMenuInteraction(_ interaction: UIContextMenuInteraction,

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ContextMenuDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ContextMenuDelegate.swift
@@ -23,11 +23,20 @@ protocol ContextMenuDelegate: class {
     var delegate: ConversationMessageCellDelegate? { get }
     var message: ZMConversationMessage? { get }
     
-    func actionController(view: UIView) -> ConversationMessageActionController?
+//    func actionController(view: UIView) -> ConversationMessageActionController?
+    @available(iOS 13.0, *)
+    func makeContextMenu(title: String, view: UIView) -> UIMenu
 }
 
 extension ContextMenuDelegate {
-    func actionController(view: UIView) -> ConversationMessageActionController? {
+    @available(iOS 13.0, *)
+    func makeContextMenu(title: String, view: UIView) -> UIMenu {
+        let actions = actionController(view: view)?.allMessageMenuElements() ?? []
+
+        return UIMenu(title: title, children: actions)
+    }
+    
+    private func actionController(view: UIView) -> ConversationMessageActionController? {
         guard let message = message else {
             return nil
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ContextMenuDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ContextMenuDelegate.swift
@@ -16,7 +16,8 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
+import UIKit
+import WireDataModel
 
 protocol ContextMenuDelegate: class {
     var delegate: ConversationMessageCellDelegate? { get }
@@ -26,19 +27,15 @@ protocol ContextMenuDelegate: class {
 }
 
 extension ContextMenuDelegate {
-    // MARK: - for context menu action items
     func actionController(view: UIView) -> ConversationMessageActionController? {
-//    private func actionController: ConversationMessageActionController? {
-        guard let message = message //,
-//              let messageActionResponder = delegate?.delegate
-        else {
-                return nil
+        guard let message = message else {
+            return nil
         }
-
+        
         return ConversationMessageActionController(responder: delegate,
                                                    message: message,
                                                    context: .content,
                                                    view: view)
     }
-
+    
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ContextMenuDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ContextMenuDelegate.swift
@@ -1,4 +1,3 @@
-
 // Wire
 // Copyright (C) 2020 Wire Swiss GmbH
 //
@@ -22,8 +21,7 @@ import WireDataModel
 protocol ContextMenuDelegate: class {
     var delegate: ConversationMessageCellDelegate? { get }
     var message: ZMConversationMessage? { get }
-    
-//    func actionController(view: UIView) -> ConversationMessageActionController?
+
     @available(iOS 13.0, *)
     func makeContextMenu(title: String, view: UIView) -> UIMenu
 }
@@ -35,16 +33,16 @@ extension ContextMenuDelegate {
 
         return UIMenu(title: title, children: actions)
     }
-    
+
     private func actionController(view: UIView) -> ConversationMessageActionController? {
         guard let message = message else {
             return nil
         }
-        
+
         return ConversationMessageActionController(responder: delegate,
                                                    message: message,
                                                    context: .content,
                                                    view: view)
     }
-    
+
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ContextMenuDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ContextMenuDelegate.swift
@@ -1,0 +1,44 @@
+
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+protocol ContextMenuDelegate: class {
+    var delegate: ConversationMessageCellDelegate? { get }
+    var message: ZMConversationMessage? { get }
+    
+    func actionController(view: UIView) -> ConversationMessageActionController?
+}
+
+extension ContextMenuDelegate {
+    // MARK: - for context menu action items
+    func actionController(view: UIView) -> ConversationMessageActionController? {
+//    private func actionController: ConversationMessageActionController? {
+        guard let message = message //,
+//              let messageActionResponder = delegate?.delegate
+        else {
+                return nil
+        }
+
+        return ConversationMessageActionController(responder: delegate,
+                                                   message: message,
+                                                   context: .content,
+                                                   view: view)
+    }
+
+}

--- a/WireCommonComponents/Icons/UIImage+StyleKit.swift
+++ b/WireCommonComponents/Icons/UIImage+StyleKit.swift
@@ -52,7 +52,9 @@ extension UIImage {
      * - returns: The image to use in the specified configuration.
      */
 
-    public static func imageForIcon(_ icon: StyleKitIcon, size: CGFloat, color: UIColor) -> UIImage {
+    public static func imageForIcon(_ icon: StyleKitIcon,
+                                    size: CGFloat,
+                                    color: UIColor) -> UIImage {
         return icon.makeImage(size: .custom(size), color: color)
     }
 


### PR DESCRIPTION
## What's new in this PR?

Add Context menu preview support to `ConversationLocationMessageCell` to show the mapview preview of a location message.

### Snapshot
<img src="https://user-images.githubusercontent.com/11852044/84658061-92c85d00-af15-11ea-922f-985e15f4ccda.png" height="500">
