### PR TITLE
fix: Input field does not preserve text

### DIFF
--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -91,7 +91,12 @@ final class AppRootViewController: UIViewController, SpinnerCapable {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
-        if #available(iOS 12.0, *) {
+
+        if #available(iOS 12.0, *) {            
+            if UIApplication.shared.applicationState == .background {
+                return
+            }
+
             if previousTraitCollection?.userInterfaceStyle != traitCollection.userInterfaceStyle {
                 NotificationCenter.default.post(name: .SettingsColorSchemeChanged, object: nil)
             }

--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -91,12 +91,15 @@ final class AppRootViewController: UIViewController, SpinnerCapable {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
-
-        if #available(iOS 12.0, *) {            
+        // Do not refresh for iOS 13+ when the app is in background.
+        // Go to home screen may trigger `traitCollectionDidChange` twice.
+        if #available(iOS 13.0, *) {
             if UIApplication.shared.applicationState == .background {
                 return
             }
+        }
 
+        if #available(iOS 12.0, *) {
             if previousTraitCollection?.userInterfaceStyle != traitCollection.userInterfaceStyle {
                 NotificationCenter.default.post(name: .SettingsColorSchemeChanged, object: nil)
             }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarEditView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarEditView.swift
@@ -45,13 +45,13 @@ final class InputBarEditView: UIView {
     
     weak var delegate: InputBarEditViewDelegate?
     
-    public init() {
+    init() {
         super.init(frame: .zero)
         configureViews()
         createConstraints()
     }
     
-    required public init?(coder aDecoder: NSCoder) {
+    required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

Input field does not preserve text after the app goes to background.

### Causes

After updated to iOS 13 SDK, the `traitCollectionDidChange` is called twice when the app is going to the background (e.g. from `.light` to `.dark` and then from `.dark` to `.light`.) and triggers `.SettingsColorSchemeChanged` twice, which recreates the input field and loading the old preserved text before the app saved the current input bar text.

### Solutions

Do not triggers `.SettingsColorSchemeChanged` when the app going to the background.

### Discussion
Instead of recreating the whole view controls stack, we should use the new adaptive color in the future.