### PR TITLE
Status bar is white on white when back from message detail screen

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+ConversationMessageCellDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+ConversationMessageCellDelegate.swift
@@ -81,6 +81,8 @@ extension ConversationContentViewController: ConversationMessageCellDelegate {
 
     func conversationMessageWantsToOpenMessageDetails(_ cell: UIView, messageDetailsViewController: MessageDetailsViewController) {
         parent?.present(messageDetailsViewController, animated: true)
+        
+        messageDetailsViewController.presentationController?.delegate = parent as? UIAdaptivePresentationControllerDelegate
     }
 
     func conversationMessageWantsToOpenGuestOptionsFromView(_ cell: UIView, sourceView: UIView) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+ConversationMessageCellDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+ConversationMessageCellDelegate.swift
@@ -80,9 +80,10 @@ extension ConversationContentViewController: ConversationMessageCellDelegate {
     }
 
     func conversationMessageWantsToOpenMessageDetails(_ cell: UIView, messageDetailsViewController: MessageDetailsViewController) {
-        parent?.present(messageDetailsViewController, animated: true)
+        let parent = self.parent
         
         messageDetailsViewController.presentationController?.delegate = parent as? UIAdaptivePresentationControllerDelegate
+        parent?.present(messageDetailsViewController, animated: true)
     }
 
     func conversationMessageWantsToOpenGuestOptionsFromView(_ cell: UIView, sourceView: UIView) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsViewController.swift
@@ -99,7 +99,7 @@ final class MessageDetailsViewController: UIViewController, ModalTopBarDelegate 
 
     init(message: ZMConversationMessage, preferredDisplayMode: MessageDetailsDisplayMode) {
         self.message = message
-        self.dataSource = MessageDetailsDataSource(message: message)
+        dataSource = MessageDetailsDataSource(message: message)
 
         // Setup the appropriate view controllers
         switch dataSource.displayMode {
@@ -128,6 +128,7 @@ final class MessageDetailsViewController: UIViewController, ModalTopBarDelegate 
         self.modalPresentationStyle = .formSheet
     }
 
+    @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -213,13 +214,20 @@ final class MessageDetailsViewController: UIViewController, ModalTopBarDelegate 
 
     // MARK: - Top Bar
 
+    private func dismiss() {
+        weak var presentingViewController = self.presentingViewController
+        dismiss(animated: true) {
+            presentingViewController?.setNeedsStatusBarAppearanceUpdate()
+        }
+    }
+    
     override func accessibilityPerformEscape() -> Bool {
-        dismiss(animated: true, completion: nil)
+        dismiss()
         return true
     }
 
     func modelTopBarWantsToBeDismissed(_ topBar: ModalTopBar) {
-        dismiss(animated: true, completion: nil)
+        dismiss()
     }
 
     override var shouldAutorotate: Bool {

--- a/Wire-iOS/Sources/UserInterface/Location/ModalTopBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Location/ModalTopBar.swift
@@ -159,7 +159,8 @@ final class ModalTopBar: UIView {
         subtitleLabel.setContentCompressionResistancePriority(UILayoutPriority(rawValue: 750), for: .horizontal)
     }
     
-    @objc fileprivate func dismissButtonTapped(_ sender: IconButton) {
+    @objc
+    fileprivate func dismissButtonTapped(_ sender: IconButton) {
         delegate?.modelTopBarWantsToBeDismissed(self)
     }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

When message detail screen is dismissed, status bar is white on white.

### Causes

same as https://github.com/wireapp/wire-ios/pull/4399

### Solutions

same as https://github.com/wireapp/wire-ios/pull/4399