### PR TITLE
do setup sctipts steps in parallel

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -42,27 +42,29 @@ XCODE_VERSION=( ${version//./ } )
 
 # SETUP
 echo "ℹ️  Carthage bootstrap. This might take a while..."
-carthage bootstrap --platform ios
+carthage bootstrap --platform ios &
 echo ""
 
 echo "ℹ️  Downloading AVS library..."
-./Scripts/download-avs.sh
+./Scripts/download-avs.sh &
 echo ""
 
 echo "ℹ️  Downloading additional assets..."
-./Scripts/download-assets.sh "$@"
-echo ""
-
-echo "ℹ️  Doing additional postprocessing..."
-./Scripts/postprocess.sh
+./Scripts/download-assets.sh "$@" &
 echo ""
 
 echo "ℹ️  [CodeGen] Update StyleKit Icons..."
-swift run --package-path Scripts/updateStylekit
+swift run --package-path Scripts/updateStylekit &
 echo ""
 
 echo "ℹ️  Update Licenses File..."
-swift run --package-path ./Scripts/updateLicenses
+swift run --package-path ./Scripts/updateLicenses &
+echo ""
+
+wait
+
+echo "ℹ️  Doing additional postprocessing..."
+./Scripts/postprocess.sh
 echo ""
 
 echo "✅  Wire project was set up, you can now open Wire-iOS.xcodeproj"


### PR DESCRIPTION
## What's new in this PR?

Improve the speed of running `setup.sh` by running unrelated steps in parallel. Tested the running time can be reduced by 40%.