### PR TITLE
Fix: status bar not updated when back from iOS 13 card style presentaion

### DIFF
--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -35,17 +35,17 @@ final class AppRootViewController: UIViewController, SpinnerCapable {
 
     fileprivate(set) var sessionManager: SessionManager?
     fileprivate(set) var quickActionsManager: QuickActionsManager?
-    
+
     fileprivate var sessionManagerCreatedSessionObserverToken: Any?
     fileprivate var sessionManagerDestroyedSessionObserverToken: Any?
-    fileprivate var soundEventListeners = [UUID : SoundEventListener]()
+    fileprivate var soundEventListeners = [UUID: SoundEventListener]()
 
     fileprivate(set) var visibleViewController: UIViewController? {
         didSet {
             visibleViewController?.setNeedsStatusBarAppearanceUpdate()
         }
     }
-    
+
     fileprivate let appStateController: AppStateController
     fileprivate let fileBackupExcluder: FileBackupExcluder
     fileprivate var authenticatedBlocks : [() -> Void] = []

--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -33,14 +33,18 @@ final class AppRootViewController: UIViewController, SpinnerCapable {
     let callWindow: CallWindow
     let overlayWindow: NotificationWindow
 
-    public fileprivate(set) var sessionManager: SessionManager?
-    public fileprivate(set) var quickActionsManager: QuickActionsManager?
+    fileprivate(set) var sessionManager: SessionManager?
+    fileprivate(set) var quickActionsManager: QuickActionsManager?
     
     fileprivate var sessionManagerCreatedSessionObserverToken: Any?
     fileprivate var sessionManagerDestroyedSessionObserverToken: Any?
     fileprivate var soundEventListeners = [UUID : SoundEventListener]()
 
-    public fileprivate(set) var visibleViewController: UIViewController?
+    fileprivate(set) var visibleViewController: UIViewController? {
+        didSet {
+            visibleViewController?.setNeedsStatusBarAppearanceUpdate()
+        }
+    }
     
     fileprivate let appStateController: AppStateController
     fileprivate let fileBackupExcluder: FileBackupExcluder
@@ -75,7 +79,7 @@ final class AppRootViewController: UIViewController, SpinnerCapable {
         }
     }
 
-    override public func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
         
         mainWindow.frame.size = size
@@ -152,14 +156,14 @@ final class AppRootViewController: UIViewController, SpinnerCapable {
         fatalError("init(coder:) has not been implemented")
     }
     
-    public override func viewWillAppear(_ animated: Bool) {
+    override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         view.frame = mainWindow.bounds
     }
 
     
-    public func launch(with launchOptions: LaunchOptions) {
+    func launch(with launchOptions: LaunchOptions) {
         let bundle = Bundle.main
         let appVersion = bundle.infoDictionary?[kCFBundleVersionKey as String] as? String
         let mediaManager = AVSMediaManager.sharedInstance()
@@ -396,7 +400,7 @@ final class AppRootViewController: UIViewController, SpinnerCapable {
         type(of: self).configureAppearance()
     }
 
-    public func performWhenAuthenticated(_ block : @escaping () -> Void) {
+    func performWhenAuthenticated(_ block : @escaping () -> Void) {
         if appStateController.appState == .authenticated(completedRegistration: false) {
             block()
         } else {

--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -40,11 +40,7 @@ final class AppRootViewController: UIViewController, SpinnerCapable {
     fileprivate var sessionManagerDestroyedSessionObserverToken: Any?
     fileprivate var soundEventListeners = [UUID : SoundEventListener]()
 
-    public fileprivate(set) var visibleViewController: UIViewController? {
-        didSet {
-            visibleViewController?.setNeedsStatusBarAppearanceUpdate()
-        }
-    }
+    public fileprivate(set) var visibleViewController: UIViewController?
     
     fileprivate let appStateController: AppStateController
     fileprivate let fileBackupExcluder: FileBackupExcluder

--- a/Wire-iOS/Sources/Components/ShareViewController/ShareViewController.swift
+++ b/Wire-iOS/Sources/Components/ShareViewController/ShareViewController.swift
@@ -78,7 +78,7 @@ final class ShareViewController<D: ShareDestination & NSObjectProtocol, S: Share
         self.showPreview = showPreview
         self.allowsMultipleSelection = allowsMultipleSelection
         super.init(nibName: nil, bundle: nil)
-        self.transitioningDelegate = self
+        transitioningDelegate = self
         
         let messagePreviewAppearance = MessagePreviewView.appearance(whenContainedInInstancesOf: [ShareViewController.self])
         messagePreviewAppearance.colorSchemeVariant = .light
@@ -95,10 +95,11 @@ final class ShareViewController<D: ShareDestination & NSObjectProtocol, S: Share
                                                name: UIResponder.keyboardDidChangeFrameNotification,
                                                object: nil)
 
-        self.createViews()
-        self.createConstraints()
+        createViews()
+        createConstraints()
     }
     
+    @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -147,7 +148,7 @@ final class ShareViewController<D: ShareDestination & NSObjectProtocol, S: Share
     
     @objc
     func onCloseButtonPressed(sender: AnyObject?) {
-        self.onDismiss?(self, false)
+        onDismiss?(self, false)
     }
     
     @objc

--- a/Wire-iOS/Sources/UserInterface/Collections/ConversationImagesViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/ConversationImagesViewController.swift
@@ -130,8 +130,8 @@ final class ConversationImagesViewController: TintColorCorrectedViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        self.createPageController()
-        self.createControlsBar()
+        createPageController()
+        createControlsBar()
         view.addSubview(overlay)
         view.addSubview(separator)
 

--- a/Wire-iOS/Sources/UserInterface/Components/KeyboardAvoidingViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/KeyboardAvoidingViewController.swift
@@ -39,6 +39,7 @@ final class KeyboardAvoidingViewController: UIViewController {
                                                object: nil)
     }
     
+    @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation Options/UINavigationController+CloseButton.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/UINavigationController+CloseButton.swift
@@ -20,14 +20,14 @@ import Foundation
 import UIKit
 
 extension UINavigationController {
-    
+
     func closeItem() -> UIBarButtonItem {
         let item = UIBarButtonItem(icon: .cross, target: self, action: #selector(closeTapped))
         item.accessibilityIdentifier = "close"
         item.accessibilityLabel = "general.close".localized
         return item
     }
-    
+
     @objc
     private func closeTapped() {
         dismiss(animated: true)

--- a/Wire-iOS/Sources/UserInterface/Conversation Options/UINavigationController+CloseButton.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/UINavigationController+CloseButton.swift
@@ -30,9 +30,6 @@ extension UINavigationController {
     
     @objc
     private func closeTapped() {
-        weak var presentingVC = presentingViewController
-        dismiss(animated: true) {
-            presentingVC?.setNeedsStatusBarAppearanceUpdate()
-        }
+        dismiss(animated: true)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
@@ -173,9 +173,7 @@ extension ConversationContentViewController: UIAdaptivePresentationControllerDel
         shareViewController.onDismiss = { (shareController: ShareViewController<ZMConversation, ZMMessage>, _) -> Void in
             weak var presentingViewController = shareController.presentingViewController
 
-            presentingViewController?.dismiss(animated: true) {
-                presentingViewController?.setNeedsStatusBarAppearanceUpdate()
-            }
+            presentingViewController?.dismiss(animated: true)
         }
 
         (presenter ?? self).present(keyboardAvoiding, animated: true)

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
@@ -155,7 +155,7 @@ extension ConversationContentViewController: UIAdaptivePresentationControllerDel
         let keyboardAvoiding = KeyboardAvoidingViewController(viewController: shareViewController)
         keyboardAvoiding.disabledWhenInsidePopover = true
         keyboardAvoiding.preferredContentSize = CGSize.IPadPopover.preferredContentSize
-        keyboardAvoiding.modalPresentationStyle = .popover
+        keyboardAvoiding.modalPresentationCapturesStatusBarAppearance = true
 
         let presenter: PopoverPresenterViewController? = (presentedViewController ?? UIApplication.shared.keyWindow?.rootViewController) as? PopoverPresenterViewController
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/MessagePresenter+ConversationImages.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/MessagePresenter+ConversationImages.swift
@@ -22,7 +22,6 @@ import UIKit
 
 extension MessagePresenter {
 
-
     /// return a view controller for viewing image messge
     ///
     /// - Parameters:
@@ -33,7 +32,7 @@ extension MessagePresenter {
     func imagesViewController(for message: ZMConversationMessage,
                                     actionResponder: MessageActionResponder,
                                     isPreviewing: Bool) -> UIViewController {
-        
+
         guard let conversation = message.conversation else {
             fatal("Message has no conversation.")
         }
@@ -43,9 +42,9 @@ extension MessagePresenter {
         }
 
         let imagesCategoryMatch = CategoryMatch(including: .image, excluding: .none)
-        
+
         let collection = AssetCollectionWrapper(conversation: conversation, matchingCategories: [imagesCategoryMatch])
-        
+
         let imagesController = ConversationImagesViewController(collection: collection, initialMessage: message, inverse: true)
         imagesController.isPreviewing = isPreviewing
 
@@ -57,19 +56,17 @@ extension MessagePresenter {
             imagesController.preferredContentSize = preferredContentSize
         }
 
-        if (UIDevice.current.userInterfaceIdiom == .phone) {
-            imagesController.modalPresentationStyle = .fullScreen;
+        if UIDevice.current.userInterfaceIdiom == .phone {
+            imagesController.modalPresentationStyle = .fullScreen
             imagesController.snapshotBackgroundView = UIScreen.main.snapshotView(afterScreenUpdates: true)
         } else {
             imagesController.modalPresentationStyle = .overFullScreen
         }
         imagesController.modalTransitionStyle = .crossDissolve
 
-        
-
         let closeButton = CollectionsView.closeButton()
         closeButton.addTarget(self, action: #selector(MessagePresenter.closeImagesButtonPressed(_:)), for: .touchUpInside)
-        
+
         imagesController.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: closeButton)
         imagesController.messageActionDelegate = actionResponder
         imagesController.swipeToDismiss = true
@@ -83,7 +80,7 @@ extension MessagePresenter {
             return imagesController.wrapInNavigationController(navigationBarClass: UINavigationBar.self)
         }
     }
-    
+
     @objc
     private func closeImagesButtonPressed(_ sender: AnyObject!) {
         modalTargetController?.dismiss(animated: true)

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/MessagePresenter+ConversationImages.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/MessagePresenter+ConversationImages.swift
@@ -74,10 +74,7 @@ extension MessagePresenter {
         imagesController.messageActionDelegate = actionResponder
         imagesController.swipeToDismiss = true
         imagesController.dismissAction = { [weak self] completion in
-            guard let `self` = self else {
-                return
-            }
-            self.modalTargetController?.dismiss(animated: true, completion: completion)
+            self?.modalTargetController?.dismiss(animated: true, completion: completion)
         }
 
         if isPreviewing {
@@ -87,7 +84,8 @@ extension MessagePresenter {
         }
     }
     
-    @objc func closeImagesButtonPressed(_ sender: AnyObject!) {
-        modalTargetController?.dismiss(animated: true, completion: .none)
+    @objc
+    private func closeImagesButtonPressed(_ sender: AnyObject!) {
+        modalTargetController?.dismiss(animated: true)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
@@ -166,16 +166,13 @@ extension ConversationViewController {
             collections.delegate = self
 
             collections.onDismiss = { [weak self] _ in
-
                 guard let weakSelf = self else {
                     return
                 }
 
-                weakSelf.collectionController?.dismiss(animated: true) {
-                    weakSelf.setNeedsStatusBarAppearanceUpdate()
-                }
+                weakSelf.collectionController?.dismiss(animated: true)
             }
-            self.collectionController = collections
+            collectionController = collections
         } else {
             collectionController?.refetchCollection()
         }
@@ -183,8 +180,6 @@ extension ConversationViewController {
         collectionController?.shouldTrackOnNextOpen = true
 
         let navigationController = KeyboardAvoidingViewController(viewController: self.collectionController!).wrapInNavigationController()
-
-        navigationController.presentationController?.delegate = ZClientViewController.shared
 
         ZClientViewController.shared?.present(navigationController, animated: true)
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+ParticipantsPopover.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+ParticipantsPopover.swift
@@ -33,10 +33,10 @@ extension ConversationViewController: UIPopoverPresentationControllerDelegate {
 
 extension ConversationViewController: UIAdaptivePresentationControllerDelegate {
     func adaptivePresentationStyle(for controller: UIPresentationController) -> UIModalPresentationStyle {
-        if (controller.presentedViewController is AddParticipantsViewController) {
+        if controller.presentedViewController is AddParticipantsViewController {
             return .overFullScreen
         }
-        
+
         if #available(iOS 13, *) {
             return .formSheet
         } else {

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+ParticipantsPopover.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+ParticipantsPopover.swift
@@ -43,10 +43,6 @@ extension ConversationViewController: UIAdaptivePresentationControllerDelegate {
             return .fullScreen
         }
     }
-
-    func presentationControllerDidDismiss( _ presentationController: UIPresentationController) {
-        setNeedsStatusBarAppearanceUpdate()
-    }
 }
 
 extension ConversationViewController: ViewControllerDismisser {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsViewController.swift
@@ -19,7 +19,6 @@
 import UIKit
 import WireDataModel
 
-
 /**
  * A view controller wrapping the message details.
  */
@@ -135,7 +134,7 @@ final class MessageDetailsViewController: UIViewController, ModalTopBarDelegate 
     override var preferredStatusBarStyle: UIStatusBarStyle {
         return ColorScheme.default.statusBarStyle
     }
-    
+
     // MARK: - Configuration
 
     override func viewDidLoad() {
@@ -184,7 +183,7 @@ final class MessageDetailsViewController: UIViewController, ModalTopBarDelegate 
             container.view.topAnchor.constraint(equalTo: topBar.bottomAnchor),
             container.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             container.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            container.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            container.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
     }
 
@@ -219,13 +218,13 @@ final class MessageDetailsViewController: UIViewController, ModalTopBarDelegate 
     }
 
     func modelTopBarWantsToBeDismissed(_ topBar: ModalTopBar) {
-        dismiss(animated: true  )
+        dismiss(animated: true)
     }
 
     override var shouldAutorotate: Bool {
         return false
     }
-    
+
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return wr_supportedInterfaceOrientations
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsViewController.swift
@@ -214,12 +214,12 @@ final class MessageDetailsViewController: UIViewController, ModalTopBarDelegate 
     // MARK: - Top Bar
 
     override func accessibilityPerformEscape() -> Bool {
-        dismiss(animated: true, completion: nil)
+        dismiss(animated: true)
         return true
     }
 
     func modelTopBarWantsToBeDismissed(_ topBar: ModalTopBar) {
-        dismiss(animated: true, completion: nil)
+        dismiss(animated: true  )
     }
 
     override var shouldAutorotate: Bool {

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -714,9 +714,3 @@ final class ZClientViewController: UIViewController {
     }
 
 }
-
-extension ZClientViewController: UIAdaptivePresentationControllerDelegate {
-    func presentationControllerDidDismiss( _ presentationController: UIPresentationController) {
-        setNeedsStatusBarAppearanceUpdate()
-    }
-}

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -185,10 +185,15 @@ final class ZClientViewController: UIViewController {
     
     // MARK: Status bar
     private var child: UIViewController? {
-        if nil != topOverlayViewController {
-            return topOverlayViewController
-        } else if traitCollection.horizontalSizeClass == .compact {
-            return presentedViewController ?? wireSplitViewController
+        // for iOS 13, only child of this VC can be use for childForStatusBar
+        if #available(iOS 13.0, *) {
+            return topOverlayViewController ?? wireSplitViewController
+        } else {
+            if nil != topOverlayViewController {
+                return topOverlayViewController
+            } else if traitCollection.horizontalSizeClass == .compact {
+                return presentedViewController ?? wireSplitViewController
+            }
         }
         
         return nil

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -532,7 +532,7 @@ final class ZClientViewController: UIViewController {
                 viewController.view.fitInSuperview()
                 viewController.didMove(toParent: self)
                 topOverlayViewController = viewController
-                        updateSplitViewTopConstraint()
+                updateSplitViewTopConstraint()
             }
         } else if let previousViewController = topOverlayViewController {
             if animated {

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -37,11 +37,7 @@ final class ZClientViewController: UIViewController {
     var userObserverToken: Any?
     
     private let topOverlayContainer: UIView = UIView()
-    private var topOverlayViewController: UIViewController? {
-        didSet {
-            setNeedsStatusBarAppearanceUpdate()
-        }
-    }
+    private var topOverlayViewController: UIViewController? 
     private var contentTopRegularConstraint: NSLayoutConstraint!
     private var contentTopCompactConstraint: NSLayoutConstraint!
     // init value = false which set to true, set to false after data usage permission dialog is displayed

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -712,5 +712,4 @@ final class ZClientViewController: UIViewController {
             Analytics.shared().tag($0)
         }
     }
-
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

We have a lot of fixing regarding status bar not updated like this: https://github.com/wireapp/wire-ios/pull/4428

### Causes

After a discussion in 1-1 lab in WWDC, we found that we misused `override var childForStatusBarStyle: UIViewController?`.
We should only choose a child of the view controller, not a presented view controller

### Solutions

Only choose a child of the current view controller.
Clean up unnecessary `setNeedsStatusBarAppearanceUpdate` call.
It should fix all status bar issues on conversation screen.