### PR TITLE
Fix: personal account user should not be able to create a invitation link

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCell.swift
@@ -354,8 +354,8 @@ final class ConversationSystemMessageCellDescription {
             
             /// only display invite user cell for team members
             if SelfUser.current.isTeamMember,
-               selfCanAddUsers(conversation: conversation),
-               isOpenGroup(conversation: conversation) {
+               conversation.selfCanAddUsers,
+               conversation.isOpenGroup {
                 cells.append(AnyConversationMessageCellDescription(GuestsAllowedCellDescription()))
             }
             
@@ -368,15 +368,16 @@ final class ConversationSystemMessageCellDescription {
 
         return []
     }
-    
-    private static func isOpenGroup(conversation: ZMConversation) -> Bool {
-        return conversation.conversationType == .group && conversation.allowGuests
+}
+
+private extension ZMConversation {
+    var isOpenGroup: Bool {
+        return conversationType == .group && allowGuests
     }
 
-    private static func selfCanAddUsers(conversation: ZMConversation) -> Bool {
-        return ZMUser.selfUser()?.canAddUser(to: conversation) ?? false
+    var selfCanAddUsers: Bool {
+        return SelfUser.current.canAddUser(to: self)
     }
-
 }
 
 // MARK: - Descriptions

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCell.swift
@@ -352,10 +352,10 @@ final class ConversationSystemMessageCellDescription {
             let startedConversationCell = ConversationStartedSystemMessageCellDescription(message: message, data: systemMessageData)
             cells.append(AnyConversationMessageCellDescription(startedConversationCell))
             
-            let isOpenGroup = conversation.conversationType == .group && conversation.allowGuests
-            let selfCanAddUsers = ZMUser.selfUser()?.canAddUser(to: conversation) ?? false
-            
-            if selfCanAddUsers && isOpenGroup {
+            /// only display invite user cell for team members
+            if SelfUser.current.isTeamMember,
+               selfCanAddUsers(conversation: conversation),
+               isOpenGroup(conversation: conversation) {
                 cells.append(AnyConversationMessageCellDescription(GuestsAllowedCellDescription()))
             }
             
@@ -367,6 +367,14 @@ final class ConversationSystemMessageCellDescription {
         }
 
         return []
+    }
+    
+    private static func isOpenGroup(conversation: ZMConversation) -> Bool {
+        return conversation.conversationType == .group && conversation.allowGuests
+    }
+
+    private static func selfCanAddUsers(conversation: ZMConversation) -> Bool {
+        return ZMUser.selfUser()?.canAddUser(to: conversation) ?? false
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/GroupOptionsSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/GroupOptionsSectionController.swift
@@ -35,13 +35,9 @@ final class GroupOptionsSectionController: GroupDetailsSectionController {
         
         func accessible(in conversation: ZMConversation, by user: UserType) -> Bool {
             switch self {
-            case .notifications:
-                return user.canModifyNotificationSettings(in: conversation)
-            case .guests:
-                return SelfUser.current.isTeamMember &&
-                       user.canModifyAccessControlSettings(in: conversation)
-            case .timeout:
-                return user.canModifyEphemeralSettings(in: conversation)
+            case .notifications: return user.canModifyNotificationSettings(in: conversation)
+            case .guests:        return user.canModifyAccessControlSettings(in: conversation)
+            case .timeout:       return user.canModifyEphemeralSettings(in: conversation) 
             }
         }
         

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/GroupOptionsSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/GroupOptionsSectionController.swift
@@ -35,9 +35,13 @@ final class GroupOptionsSectionController: GroupDetailsSectionController {
         
         func accessible(in conversation: ZMConversation, by user: UserType) -> Bool {
             switch self {
-            case .notifications: return user.canModifyNotificationSettings(in: conversation)
-            case .guests:        return user.canModifyAccessControlSettings(in: conversation)
-            case .timeout:       return user.canModifyEphemeralSettings(in: conversation) 
+            case .notifications:
+                return user.canModifyNotificationSettings(in: conversation)
+            case .guests:
+                return SelfUser.current.isTeamMember &&
+                       user.canModifyAccessControlSettings(in: conversation)
+            case .timeout:
+                return user.canModifyEphemeralSettings(in: conversation)
             }
         }
         

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/ReceiptOptionsSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/ReceiptOptionsSectionController.swift
@@ -18,7 +18,6 @@
 
 import Foundation
 import UIKit
-import WireDataModel
 import WireSyncEngine
 
 final class ReceiptOptionsSectionController: GroupDetailsSectionController {


### PR DESCRIPTION
## What's new in this PR?

### Issues

The "invite people" button is shown when a personal account user created a new conversation. Click the button and he/she can see the guest option screen which is not permitted.

### Causes

`GuestsAllowedCellDescription` is created without checking the current user is a team member or not.

### Solutions

Do not create `GuestsAllowedCellDescription` if the user is not a team member.