### PR TITLE
[WIP] Feature: App Lock unlock screen

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Helpers/RequestPasswordController.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/RequestPasswordController.swift
@@ -26,6 +26,7 @@ final class RequestPasswordController {
         case removeDevice
         case logout
         case unlock(message: String)
+        case unlockWithCustomCode
     }
 
     var alertController: UIAlertController
@@ -39,8 +40,8 @@ final class RequestPasswordController {
 
         self.callback = callback
 
-        let okTitle: String = "general.ok".localized
-        let cancelTitle: String = "general.cancel".localized
+        var okTitle: String = "general.ok".localized
+        var cancelTitle: String = "general.cancel".localized
         let title: String
         let message: String
         let placeholder: String
@@ -62,6 +63,14 @@ final class RequestPasswordController {
             message = unlockMessage
             placeholder = "self.settings.account_details.log_out.alert.password".localized
             okActionStyle = .default
+        case .unlockWithCustomCode:
+            //TODO: text copy
+            title = "Application is locked due to inactivity"
+            message = "Please enter your Application lock password to Unlock the application"
+            placeholder = "Passphrase"
+            okActionStyle = .default
+            okTitle = "unlock"
+            cancelTitle = "Forgot lock password?"
         }
 
         alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)

--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockInteractor.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockInteractor.swift
@@ -25,6 +25,7 @@ protocol AppLockInteractorInput: class {
     var isAuthenticationNeeded: Bool { get }
     func evaluateAuthentication(description: String)
     func verify(password: String)
+    func verify(customPasscode: String)
     func appStateDidTransition(to newState: AppState)
 }
 
@@ -65,6 +66,16 @@ extension AppLockInteractor: AppLockInteractorInput {
         }
     }
     
+    func verify(customPasscode: String) {
+        // TODO: ALWAYS PASS NOW! check with custom pass code
+        let result: VerifyPasswordResult = .validated
+        
+        notifyPasswordVerified(with: result)
+        if case .validated = result {
+            appLock.persistBiometrics()
+        }
+    }
+
     func verify(password: String) {
         userSession?.verify(password: password) { [weak self] result in
             guard let `self` = self else { return }

--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockPresenter.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockPresenter.swift
@@ -109,13 +109,28 @@ extension AppLockPresenter {
         userInterface?.presentRequestPasswordController(with: message) { [weak self] password in
             guard let `self` = self else { return }
             self.dispatchQueue.async {
-                guard let password = password, !password.isEmpty else {
-                    self.authenticationState = .cancelled
-                    self.setContents(dimmed: true, withReauth: true)
-                    return
+                
+                if AppLock.rules.useCustomCodeInsteadOfAccountPassword {
+                    guard let password = password, !password.isEmpty else {
+                        self.authenticationState = .cancelled
+                        self.setContents(dimmed: true, withReauth: true)
+                        
+                        ///TODO: wipe go to forgot password screen
+                        return
+                    }
+                    self.userInterface?.setSpinner(animating: true)
+
+                    self.appLockInteractorInput.verify(customPasscode: password)
+                } else {
+                    guard let password = password, !password.isEmpty else {
+                        self.authenticationState = .cancelled
+                        self.setContents(dimmed: true, withReauth: true)
+                        return
+                    }
+                    self.userInterface?.setSpinner(animating: true)
+
+                    self.appLockInteractorInput.verify(password: password)
                 }
-                self.userInterface?.setSpinner(animating: true)
-                self.appLockInteractorInput.verify(password: password)
             }
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
@@ -19,6 +19,7 @@
 import Cartography
 import WireSyncEngine
 import UIKit
+import WireCommonComponents
 
 private let zmLog = ZMSLog(tag: "UI")
 
@@ -88,9 +89,18 @@ final class AppLockViewController: UIViewController {
 // MARK: - AppLockManagerDelegate
 extension AppLockViewController: AppLockUserInterface {
     func presentRequestPasswordController(with message: String, callback: @escaping RequestPasswordController.Callback) {
-        let passwordController = RequestPasswordController(context: .unlock(message: message.localized), callback: callback)
+        
+        let context: RequestPasswordController.RequestPasswordContext
+        
+        if AppLock.rules.useCustomCodeInsteadOfAccountPassword {
+            context = .unlockWithCustomCode
+        } else {
+            context = .unlock(message: message.localized)
+        }
+        
+        let passwordController = RequestPasswordController(context: context, callback: callback)
         self.passwordController = passwordController
-        self.present(passwordController.alertController, animated: true, completion: nil)
+        present(passwordController.alertController, animated: true)
     }
 
     func setSpinner(animating: Bool) {

--- a/WireCommonComponents/AppLock.swift
+++ b/WireCommonComponents/AppLock.swift
@@ -134,6 +134,7 @@ public class BiometricsState {
 
 public struct AppLockRules: Decodable {
     public let useBiometricsOrAccountPassword: Bool
+    public let useCustomCodeInsteadOfAccountPassword: Bool
     public let forceAppLock: Bool
     public let appLockTimeout: UInt
     


### PR DESCRIPTION

## What's new in this PR?

add `useCustomCodeInsteadOfAccountPassword` flag. When it is true(and `useBiometricsOrAccountPassword` is true), use custom code to unlock the app instead of account password.
Drafted a custom passcode alert.

<img src="https://user-images.githubusercontent.com/11852044/86949823-87043b00-c14f-11ea-9d6b-f4c92cd6adb4.png" height=500>

