### PR TITLE
[Fix] user cell accessibility identifiers

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Views/IconImageView/IconImageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/IconImageView/IconImageView.swift
@@ -55,6 +55,8 @@ class IconImageView: UIImageView {
         // save size and color if needed
         set(size: size, color: color)
         
+        accessibilityIdentifier = style?.accesibilityIdentifier
+
         guard
             let style = style ?? self.style,
             let icon = style.icon
@@ -66,7 +68,6 @@ class IconImageView: UIImageView {
         isHidden = false
         let color = style.tintColor ?? self.color
         self.setIcon(icon, size: self.size, color: color)
-        self.setUpIconImageView(accessibilityIdentifier: style.accesibilityIdentifier)
         self.style = style
     }
     

--- a/Wire-iOS/Sources/UserInterface/Components/Views/IconImageView/IconImageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/IconImageView/IconImageView.swift
@@ -22,7 +22,7 @@ import WireCommonComponents
 protocol IconImageStyle {
     var icon: StyleKitIcon? { get }
     var tintColor: UIColor? { get }
-    var accesibilityIdentifier: String { get }
+    var accessibilityIdentifier: String { get }
     var accessibilityPrefix: String { get }
     var rawValue: String { get }
 }
@@ -32,7 +32,7 @@ extension IconImageStyle {
         return "img"
     }
     
-    var accesibilityIdentifier: String {
+    var accessibilityIdentifier: String {
         return "\(accessibilityPrefix).\(rawValue)"
     }
     
@@ -61,7 +61,7 @@ class IconImageView: UIImageView {
     
     override var accessibilityIdentifier: String? {
         get {
-            return style?.accesibilityIdentifier
+            return style?.accessibilityIdentifier
         }
         set {
             // no-op

--- a/Wire-iOS/Sources/UserInterface/Components/Views/IconImageView/IconImageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/IconImageView/IconImageView.swift
@@ -22,7 +22,7 @@ import WireCommonComponents
 protocol IconImageStyle {
     var icon: StyleKitIcon? { get }
     var tintColor: UIColor? { get }
-    var accesibilityIdentifier: String? { get }
+    var accesibilityIdentifier: String { get }
     var accessibilityPrefix: String { get }
     var rawValue: String { get }
 }
@@ -32,7 +32,7 @@ extension IconImageStyle {
         return "img"
     }
     
-    var accesibilityIdentifier: String? {
+    var accesibilityIdentifier: String {
         return "\(accessibilityPrefix).\(rawValue)"
     }
     

--- a/Wire-iOS/Sources/UserInterface/Components/Views/IconImageView/IconImageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/IconImageView/IconImageView.swift
@@ -59,13 +59,20 @@ class IconImageView: UIImageView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override var accessibilityIdentifier: String? {
+        get {
+            return style?.accesibilityIdentifier
+        }
+        set {
+            // no-op
+        }
+    }
+    
     func set(style: IconImageStyle? = nil,
              size: StyleKitIcon.Size? = nil,
              color: UIColor? = nil) {
         // save size and color if needed
         set(size: size, color: color)
-        
-        accessibilityIdentifier = style?.accesibilityIdentifier
 
         guard
             let style = style ?? self.style,

--- a/Wire-iOS/Sources/UserInterface/Components/Views/IconImageView/IconImageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/IconImageView/IconImageView.swift
@@ -24,7 +24,7 @@ protocol IconImageStyle {
     var tintColor: UIColor? { get }
     var accessibilityIdentifier: String { get }
     var accessibilityPrefix: String { get }
-    var rawValue: String { get }
+    var accessibilitySuffix: String { get }
 }
 
 extension IconImageStyle {
@@ -33,7 +33,7 @@ extension IconImageStyle {
     }
     
     var accessibilityIdentifier: String {
-        return "\(accessibilityPrefix).\(rawValue)"
+        return "\(accessibilityPrefix).\(accessibilitySuffix)"
     }
     
     var tintColor: UIColor? {

--- a/Wire-iOS/Sources/UserInterface/Components/Views/IconImageView/IconImageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/IconImageView/IconImageView.swift
@@ -22,6 +22,7 @@ import WireCommonComponents
 protocol IconImageStyle {
     var icon: StyleKitIcon? { get }
     var tintColor: UIColor? { get }
+    var accesibilityIdentifier: String? { get }
 }
 
 extension IconImageStyle {
@@ -65,6 +66,7 @@ class IconImageView: UIImageView {
         isHidden = false
         let color = style.tintColor ?? self.color
         self.setIcon(icon, size: self.size, color: color)
+        self.setUpIconImageView(accessibilityIdentifier: style.accesibilityIdentifier)
         self.style = style
     }
     

--- a/Wire-iOS/Sources/UserInterface/Components/Views/IconImageView/IconImageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/IconImageView/IconImageView.swift
@@ -23,9 +23,19 @@ protocol IconImageStyle {
     var icon: StyleKitIcon? { get }
     var tintColor: UIColor? { get }
     var accesibilityIdentifier: String? { get }
+    var accessibilityPrefix: String { get }
+    var rawValue: String { get }
 }
 
 extension IconImageStyle {
+    var accessibilityPrefix: String {
+        return "img"
+    }
+    
+    var accesibilityIdentifier: String? {
+        return "\(accessibilityPrefix).\(rawValue)"
+    }
+    
     var tintColor: UIColor? {
         return nil
     }

--- a/Wire-iOS/Sources/UserInterface/Components/Views/IconImageView/MicrophoneIconStyle.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/IconImageView/MicrophoneIconStyle.swift
@@ -46,13 +46,8 @@ enum MicrophoneIconStyle: String, IconImageStyle {
         }
     }
     
-    var accesibilityIdentifier: String? {
-        switch self {
-        case .hidden:
-            return nil
-        case .muted, .unmuted, .active:
-            return "img.microphone.\(rawValue)"
-        }
+    var accessibilityPrefix: String {
+        return "img.microphone"
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Components/Views/IconImageView/MicrophoneIconStyle.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/IconImageView/MicrophoneIconStyle.swift
@@ -49,6 +49,10 @@ enum MicrophoneIconStyle: String, IconImageStyle {
     var accessibilityPrefix: String {
         return "img.microphone"
     }
+
+    var accessibilitySuffix: String {
+        return rawValue
+    }
 }
 
 extension MicrophoneIconStyle {

--- a/Wire-iOS/Sources/UserInterface/Components/Views/IconImageView/MicrophoneIconStyle.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/IconImageView/MicrophoneIconStyle.swift
@@ -20,7 +20,7 @@ import Foundation
 import WireCommonComponents
 import WireSyncEngine
 
-enum MicrophoneIconStyle: IconImageStyle {
+enum MicrophoneIconStyle: String, IconImageStyle {
     case muted
     case unmuted
     case active
@@ -43,6 +43,15 @@ enum MicrophoneIconStyle: IconImageStyle {
             return .green
         default:
             return nil
+        }
+    }
+    
+    var accesibilityIdentifier: String? {
+        switch self {
+        case .hidden:
+            return nil
+        case .muted, .unmuted, .active:
+            return "img.microphone.\(rawValue)"
         }
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Components/Views/IconImageView/UserTypeIconStyle.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/IconImageView/UserTypeIconStyle.swift
@@ -35,6 +35,10 @@ enum UserTypeIconStyle: String, IconImageStyle {
             return .none
         }
     }
+
+    var accessibilitySuffix: String {
+        return rawValue
+    }
 }
 
 extension UserTypeIconStyle {

--- a/Wire-iOS/Sources/UserInterface/Components/Views/IconImageView/UserTypeIconStyle.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/IconImageView/UserTypeIconStyle.swift
@@ -20,7 +20,7 @@ import Foundation
 import WireCommonComponents
 import WireDataModel
 
-enum UserTypeIconStyle: IconImageStyle {
+enum UserTypeIconStyle: String, IconImageStyle {
     case guest
     case external
     case member
@@ -33,6 +33,15 @@ enum UserTypeIconStyle: IconImageStyle {
             return .externalPartner
         case .member:
             return .none
+        }
+    }
+    
+    var accesibilityIdentifier: String? {
+        switch self {
+        case .guest, .external:
+            return "img.\(rawValue)"
+        case .member:
+            return nil
         }
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Components/Views/IconImageView/UserTypeIconStyle.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/IconImageView/UserTypeIconStyle.swift
@@ -35,15 +35,6 @@ enum UserTypeIconStyle: String, IconImageStyle {
             return .none
         }
     }
-    
-    var accesibilityIdentifier: String? {
-        switch self {
-        case .guest, .external:
-            return "img.\(rawValue)"
-        case .member:
-            return nil
-        }
-    }
 }
 
 extension UserTypeIconStyle {

--- a/Wire-iOS/Sources/UserInterface/Components/Views/IconImageView/VideoIconStyle.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/IconImageView/VideoIconStyle.swift
@@ -35,6 +35,10 @@ enum VideoIconStyle: String, IconImageStyle {
             return .videoCall
         }
     }
+
+    var accessibilitySuffix: String {
+        return rawValue
+    }
 }
 
 extension VideoIconStyle {

--- a/Wire-iOS/Sources/UserInterface/Components/Views/IconImageView/VideoIconStyle.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/IconImageView/VideoIconStyle.swift
@@ -35,15 +35,6 @@ enum VideoIconStyle: String, IconImageStyle {
             return .videoCall
         }
     }
-    
-    var accesibilityIdentifier: String? {
-        switch self {
-        case .hidden:
-            return nil
-        case .video, .screenshare:
-            return "img.\(rawValue)"
-        }
-    }
 }
 
 extension VideoIconStyle {

--- a/Wire-iOS/Sources/UserInterface/Components/Views/IconImageView/VideoIconStyle.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/IconImageView/VideoIconStyle.swift
@@ -20,7 +20,7 @@ import Foundation
 import WireCommonComponents
 import WireSyncEngine
 
-enum VideoIconStyle: IconImageStyle {
+enum VideoIconStyle: String, IconImageStyle {
     case video
     case screenshare
     case hidden
@@ -33,6 +33,15 @@ enum VideoIconStyle: IconImageStyle {
             return .screenshare
         case .video:
             return .videoCall
+        }
+    }
+    
+    var accesibilityIdentifier: String? {
+        switch self {
+        case .hidden:
+            return nil
+        case .video, .screenshare:
+            return "img.\(rawValue)"
         }
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Components/Views/UserCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/UserCell.swift
@@ -101,9 +101,6 @@ class UserCell: SeparatorCollectionViewCell, SectionListCellType {
     override func setUp() {
         super.setUp()
 
-        videoIconView.setUpIconImageView(accessibilityIdentifier: "img.video")
-        userTypeIconView.setUpIconImageView(accessibilityIdentifier: "img.userType")
-        
         verifiedIconView.image = WireStyleKit.imageOfShieldverified
         verifiedIconView.setUpIconImageView(accessibilityIdentifier: "img.shield")
         

--- a/Wire-iOS/Sources/UserInterface/Components/Views/UserCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/UserCell.swift
@@ -101,6 +101,10 @@ class UserCell: SeparatorCollectionViewCell, SectionListCellType {
     override func setUp() {
         super.setUp()
 
+        userTypeIconView.setUpIconImageView()
+        microphoneIconView.setUpIconImageView()
+        videoIconView.setUpIconImageView()
+        
         verifiedIconView.image = WireStyleKit.imageOfShieldverified
         verifiedIconView.setUpIconImageView(accessibilityIdentifier: "img.shield")
         


### PR DESCRIPTION
## What's new in this PR?

https://wearezeta.atlassian.net/browse/ZIOS-13610

### Issues

Accessibility identifiers for `guest` and `external user` have been replaced by a single identifier `"img.userType"`, making the icons indistinguishable.

### Causes

`guest` and `external user` icons were two separate instances of `UIImageView` but have been replaced by a single instance of `IconImageView` causing it to have a single accessibility id 

### Solutions

add an `accessibilityIdentifier` property to `IconImageStyle` protocol and associate a different id per icon style
