### PR TITLE
[Fix] audio message can't be played sometimes

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
@@ -33,10 +33,10 @@ final class AudioMessageView: UIView, TransferView {
     private weak var mediaPlaybackManager: MediaPlaybackManager?
     
     var audioTrackPlayer: AudioTrackPlayer? {
-        let audioTrackPlayer = mediaPlaybackManager?.audioTrackPlayer
-
+        let mediaManager = mediaPlaybackManager ?? AppDelegate.shared.mediaPlaybackManager
+        let audioTrackPlayer = mediaManager?.audioTrackPlayer
         audioTrackPlayer?.audioTrackPlayerDelegate = self
-        return mediaPlaybackManager?.audioTrackPlayer
+        return audioTrackPlayer
     }
 
     private let downloadProgressView = CircularProgressView()
@@ -86,7 +86,7 @@ final class AudioMessageView: UIView, TransferView {
     private var isPausedForIncomingCall: Bool
 
     
-    init(mediaPlaybackManager: MediaPlaybackManager? = AppDelegate.shared.mediaPlaybackManager) {
+    init(mediaPlaybackManager: MediaPlaybackManager? = nil) {
         isPausedForIncomingCall = false
         self.mediaPlaybackManager = mediaPlaybackManager
 

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListAccessoryView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListAccessoryView.swift
@@ -32,6 +32,11 @@ final class ConversationListAccessoryView: UIView {
         }
     }
     
+    var activeMediaPlayer: MediaPlayer? {
+        let mediaManager = mediaPlaybackManager ?? AppDelegate.shared.mediaPlaybackManager
+        return mediaManager?.activeMediaPlayer
+    }
+    
     let mediaPlaybackManager: MediaPlaybackManager?
     
     let badgeView = RoundedBadge(view: UIView())
@@ -44,7 +49,7 @@ final class ConversationListAccessoryView: UIView {
     let defaultViewWidth: CGFloat = 28
     let activeCallWidth: CGFloat = 20
     
-    init(mediaPlaybackManager: MediaPlaybackManager?) {
+    init(mediaPlaybackManager: MediaPlaybackManager? = nil) {
         self.mediaPlaybackManager = mediaPlaybackManager
         super.init(frame: .zero)
         
@@ -130,7 +135,7 @@ final class ConversationListAccessoryView: UIView {
             accessibilityValue = "conversation_list.voiceover.status.missed_call".localized
             return iconView
         case .playingMedia:
-            if let mediaPlayer = self.mediaPlaybackManager?.activeMediaPlayer, mediaPlayer.state == .playing {
+            if let mediaPlayer = activeMediaPlayer, mediaPlayer.state == .playing {
                 iconView.setIcon(.pause, size: iconSize, color: .white)
                 accessibilityValue = "conversation_list.voiceover.status.pause_media".localized
             }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
@@ -26,7 +26,6 @@ private let CellReuseIdConversation = "CellId"
 final class ConversationListContentController: UICollectionViewController {
     weak var contentDelegate: ConversationListContentDelegate?
     let listViewModel: ConversationListViewModel = ConversationListViewModel()
-    private weak var mediaPlaybackManager: MediaPlaybackManager?
     private var focusOnNextSelection = false
     private var animateNextSelection = false
     private weak var scrollToMessageOnNextSelection: ZMConversationMessage?
@@ -82,8 +81,6 @@ final class ConversationListContentController: UICollectionViewController {
         token = NotificationCenter.default.addObserver(forName: .activeMediaPlayerChanged, object: nil, queue: .main) { [weak self] _ in
             self?.activeMediaPlayerChanged()
         }
-
-        mediaPlaybackManager = AppDelegate.shared.mediaPlaybackManager
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListItemView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListItemView.swift
@@ -43,7 +43,7 @@ final class ConversationListItemView: UIView {
     let titleField: UILabel = UILabel()
     let avatarView: ConversationAvatarView = ConversationAvatarView()
     lazy var rightAccessory: ConversationListAccessoryView = {
-        return ConversationListAccessoryView(mediaPlaybackManager: AppDelegate.shared.mediaPlaybackManager)
+        return ConversationListAccessoryView()
     }()
 
     var selected = false {

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -29,7 +29,7 @@ final class ZClientViewController: UIViewController {
     var needToShowDataUsagePermissionDialog = false
     let wireSplitViewController: SplitViewController = SplitViewController()
     
-    private(set) var mediaPlaybackManager: MediaPlaybackManager
+    private(set) var mediaPlaybackManager: MediaPlaybackManager?
     let conversationListViewController: ConversationListViewController
     var proximityMonitorManager: ProximityMonitorManager?
     var legalHoldDisclosureController: LegalHoldDisclosureController?

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -29,7 +29,7 @@ final class ZClientViewController: UIViewController {
     var needToShowDataUsagePermissionDialog = false
     let wireSplitViewController: SplitViewController = SplitViewController()
     
-    private(set) var mediaPlaybackManager: MediaPlaybackManager?
+    private(set) var mediaPlaybackManager: MediaPlaybackManager
     let conversationListViewController: ConversationListViewController
     var proximityMonitorManager: ProximityMonitorManager?
     var legalHoldDisclosureController: LegalHoldDisclosureController?


### PR DESCRIPTION
## What's new in this PR?

### Issues

Audio message can't be played sometimes

### Causes

Audio message which are visible when the app launches don't have the `mediaPlaybackManager` property set since they will try access it through the `AppDelegate` but it is not available until the RootViewController has finished the transition to `ZClientViewController`.

### Solutions

Fetch the `mediaPlaybackManager` later on first use.

### Notes

It would be nicer to get rid of the `mediaPlaybackManager` from the `AppDelegate` and do a proper dependency injection instead but that would require a large re-factoring and I don't want delay this bug fix.
