### PR TITLE
[Fix] User details not visible when video paused

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoPreviewView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoPreviewView.swift
@@ -52,7 +52,7 @@ final class VideoPreviewView: BaseVideoPreviewView {
         
         [blurView, pausedLabel].forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false
-            addSubview($0)
+            insertSubview($0, belowSubview: userDetailsView)
         }
         pausedLabel.textAlignment = .center
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

When a call participant has a paused video tile, their user details view (microphone state and name label) are not visible.

### Causes

The blur view and "Video is paused" label are above the user details view.

### Solutions

Insert the blur view and label beneath the user details view.
