### PR TITLE
Fix: app crash when entered a number in country selection screen

### DIFF
--- a/Wire-iOS Tests/CountryCodeTableViewControllerTests.swift
+++ b/Wire-iOS Tests/CountryCodeTableViewControllerTests.swift
@@ -34,6 +34,16 @@ final class CountryCodeTableViewControllerTests: XCTestCase {
         super.tearDown()
     }
 
+    //MARK: - logic
+    func testForSearchForCountryE164CodeReturnsResult() {
+        // GIVEN & WHEN
+        let filteredResult = sut.filter(searchText: "49") as? [Country]
+        
+        //THEN
+        XCTAssertEqual(filteredResult?.first?.displayName, "Germany")
+    }
+
+    //MARK: - snapshot
     func testForWirestanAppearInFirstRow() {
         verify(matching: sut.wrapInNavigationController())
     }

--- a/Wire-iOS Tests/CountryCodeTableViewControllerTests.swift
+++ b/Wire-iOS Tests/CountryCodeTableViewControllerTests.swift
@@ -20,30 +20,30 @@ import XCTest
 @testable import Wire
 
 final class CountryCodeTableViewControllerTests: XCTestCase {
-    
+
     var sut: CountryCodeTableViewController!
-    
+
     override func setUp() {
         super.setUp()
         accentColor = .strongBlue
         sut = CountryCodeTableViewController()
     }
-    
+
     override func tearDown() {
         sut = nil
         super.tearDown()
     }
 
-    //MARK: - logic
+    // MARK: - logic
     func testForSearchForCountryE164CodeReturnsResult() {
         // GIVEN & WHEN
         let filteredResult = sut.filter(searchText: "49") as? [Country]
-        
+
         //THEN
         XCTAssertEqual(filteredResult?.first?.displayName, "Germany")
     }
 
-    //MARK: - snapshot
+    // MARK: - snapshot
     func testForWirestanAppearInFirstRow() {
         verify(matching: sut.wrapInNavigationController())
     }

--- a/Wire-iOS/Sources/Authentication/Helpers/CountryCode/Country.swift
+++ b/Wire-iOS/Sources/Authentication/Helpers/CountryCode/Country.swift
@@ -28,6 +28,8 @@ extension String {
 final class Country: NSObject {
     let iso: String
 
+    // this property has to be marked @objc for NSPredicate key
+    @objc
     let e164: UInt
 
     class var defaultCountry: Country {
@@ -128,6 +130,7 @@ final class Country: NSObject {
 
     #endif
 
+    // this property has to be marked @objc for NSPredicate key
     @objc
     var displayName: String {
         #if WIRESTAN

--- a/Wire-iOS/Sources/Authentication/Helpers/CountryCode/Country.swift
+++ b/Wire-iOS/Sources/Authentication/Helpers/CountryCode/Country.swift
@@ -105,7 +105,7 @@ final class Country: NSObject {
         countries.append(Country.countryWirestan)
         #endif
 
-        guard let countryCodeDict = Dictionary<String, AnyObject>.contentsOf(url: Bundle.main.url(forResource: "CountryCodes", withExtension: "plist")!),
+        guard let countryCodeDict = [String: AnyObject].contentsOf(url: Bundle.main.url(forResource: "CountryCodes", withExtension: "plist")!),
               let countryCodes = countryCodeDict["countryCodes"] as? [[String: Any]] else {
             return countries
         }
@@ -188,7 +188,7 @@ final class Country: NSObject {
 }
 
 extension Dictionary {
-    static func contentsOf(url: URL) -> Dictionary<String, AnyObject>? {
+    static func contentsOf(url: URL) -> [String: AnyObject]? {
         guard let data = try? Data(contentsOf: url),
               let plist = try? PropertyListSerialization.propertyList(from: data, options: .mutableContainers, format: nil) else {
                 return nil

--- a/Wire-iOS/Sources/Authentication/Helpers/CountryCode/CountryCodeTableViewController.swift
+++ b/Wire-iOS/Sources/Authentication/Helpers/CountryCode/CountryCodeTableViewController.swift
@@ -142,13 +142,13 @@ extension CountryCodeTableViewController: UISearchBarDelegate {
 
 ///TODO: test
 extension CountryCodeTableViewController: UISearchResultsUpdating {
-    
-    func filter(searchText: String?) -> Array<Any>? {
-        guard var searchResults: Array<Any> = (sections as NSArray).value(forKeyPath: "@unionOfArrays.self") as? Array<Any> else { return nil}
-        
+
+    func filter(searchText: String?) -> [Any]? {
+        guard var searchResults: [Any] = (sections as NSArray).value(forKeyPath: "@unionOfArrays.self") as? [Any] else { return nil}
+
         // Strip out all the leading and trailing spaces
         let strippedString = searchText?.trimmingCharacters(in: CharacterSet.whitespaces)
-        
+
         // Break up the search terms (separated by spaces)
         let searchItems: [String]
         if strippedString?.isEmpty == false {
@@ -156,40 +156,39 @@ extension CountryCodeTableViewController: UISearchResultsUpdating {
         } else {
             searchItems = []
         }
-        
+
         var searchItemPredicates: [NSPredicate] = []
         var numberPredicates: [NSPredicate] = []
         for searchString in searchItems {
             let displayNamePredicate = NSPredicate(format: "displayName CONTAINS[cd] %@", searchString)
             searchItemPredicates.append(displayNamePredicate)
-            
+
             let numberFormatter = NumberFormatter()
             numberFormatter.numberStyle = .none
-            
+
             if let targetNumber = numberFormatter.number(from: searchString) {
                 numberPredicates.append(NSPredicate(format: "e164 == %@", targetNumber))
             }
         }
-        
+
         let andPredicates: NSCompoundPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: searchItemPredicates)
-        
+
         let orPredicates = NSCompoundPredicate(orPredicateWithSubpredicates: numberPredicates)
         let finalPredicate = NSCompoundPredicate(orPredicateWithSubpredicates: [andPredicates, orPredicates])
-        
+
         searchResults = searchResults.filter {
             finalPredicate.evaluate(with: $0)
         }
 
         return searchResults
     }
-    
+
     func updateSearchResults(for searchController: UISearchController) {
         // Update the filtered array based on the search text
         let searchText = searchController.searchBar.text
 
         guard let searchResults = filter(searchText: searchText) else { return }
-        
-        
+
         // Hand over the filtered results to our search results table
         let tableController = self.searchController.searchResultsController as? CountryCodeResultsTableViewController
         tableController?.filteredCountries = searchResults as? [Country]

--- a/Wire-iOS/Sources/Authentication/Helpers/CountryCode/CountryCodeTableViewController.swift
+++ b/Wire-iOS/Sources/Authentication/Helpers/CountryCode/CountryCodeTableViewController.swift
@@ -140,15 +140,15 @@ extension CountryCodeTableViewController: UISearchBarDelegate {
 
 // MARK: - UISearchResultsUpdating
 
+///TODO: test
 extension CountryCodeTableViewController: UISearchResultsUpdating {
-    func updateSearchResults(for searchController: UISearchController) {
-        // Update the filtered array based on the search text
-        let searchText = searchController.searchBar.text
-        guard var searchResults: Array<Any> = (sections as NSArray).value(forKeyPath: "@unionOfArrays.self") as? Array<Any> else { return }
-
+    
+    func filter(searchText: String?) -> Array<Any>? {
+        guard var searchResults: Array<Any> = (sections as NSArray).value(forKeyPath: "@unionOfArrays.self") as? Array<Any> else { return nil}
+        
         // Strip out all the leading and trailing spaces
         let strippedString = searchText?.trimmingCharacters(in: CharacterSet.whitespaces)
-
+        
         // Break up the search terms (separated by spaces)
         let searchItems: [String]
         if strippedString?.isEmpty == false {
@@ -156,30 +156,40 @@ extension CountryCodeTableViewController: UISearchResultsUpdating {
         } else {
             searchItems = []
         }
-
+        
         var searchItemPredicates: [NSPredicate] = []
         var numberPredicates: [NSPredicate] = []
         for searchString in searchItems {
             let displayNamePredicate = NSPredicate(format: "displayName CONTAINS[cd] %@", searchString)
             searchItemPredicates.append(displayNamePredicate)
-
+            
             let numberFormatter = NumberFormatter()
             numberFormatter.numberStyle = .none
-
+            
             if let targetNumber = numberFormatter.number(from: searchString) {
                 numberPredicates.append(NSPredicate(format: "e164 == %@", targetNumber))
             }
         }
-
+        
         let andPredicates: NSCompoundPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: searchItemPredicates)
-
+        
         let orPredicates = NSCompoundPredicate(orPredicateWithSubpredicates: numberPredicates)
         let finalPredicate = NSCompoundPredicate(orPredicateWithSubpredicates: [andPredicates, orPredicates])
-
+        
         searchResults = searchResults.filter {
             finalPredicate.evaluate(with: $0)
         }
-            
+
+        return searchResults
+    }
+    
+    func updateSearchResults(for searchController: UISearchController) {
+        // Update the filtered array based on the search text
+        let searchText = searchController.searchBar.text
+
+        guard let searchResults = filter(searchText: searchText) else { return }
+        
+        
         // Hand over the filtered results to our search results table
         let tableController = self.searchController.searchResultsController as? CountryCodeResultsTableViewController
         tableController?.filteredCountries = searchResults as? [Country]

--- a/Wire-iOS/Sources/Authentication/Helpers/CountryCode/CountryCodeTableViewController.swift
+++ b/Wire-iOS/Sources/Authentication/Helpers/CountryCode/CountryCodeTableViewController.swift
@@ -144,7 +144,7 @@ extension CountryCodeTableViewController: UISearchResultsUpdating {
     func updateSearchResults(for searchController: UISearchController) {
         // Update the filtered array based on the search text
         let searchText = searchController.searchBar.text
-        guard var searchResults: Array = (sections as NSArray).value(forKeyPath: "@unionOfArrays.self") as? Array<Any> else { return }
+        guard var searchResults: Array<Any> = (sections as NSArray).value(forKeyPath: "@unionOfArrays.self") as? Array<Any> else { return }
 
         // Strip out all the leading and trailing spaces
         let strippedString = searchText?.trimmingCharacters(in: CharacterSet.whitespaces)

--- a/Wire-iOS/Sources/Authentication/Helpers/CountryCode/CountryCodeTableViewController.swift
+++ b/Wire-iOS/Sources/Authentication/Helpers/CountryCode/CountryCodeTableViewController.swift
@@ -144,7 +144,7 @@ extension CountryCodeTableViewController: UISearchResultsUpdating {
     func updateSearchResults(for searchController: UISearchController) {
         // Update the filtered array based on the search text
         let searchText = searchController.searchBar.text
-        guard var searchResults: NSArray = (sections as NSArray).value(forKeyPath: "@unionOfArrays.self") as? NSArray else { return }
+        guard var searchResults: Array = (sections as NSArray).value(forKeyPath: "@unionOfArrays.self") as? Array<Any> else { return }
 
         // Strip out all the leading and trailing spaces
         let strippedString = searchText?.trimmingCharacters(in: CharacterSet.whitespaces)
@@ -176,8 +176,10 @@ extension CountryCodeTableViewController: UISearchResultsUpdating {
         let orPredicates = NSCompoundPredicate(orPredicateWithSubpredicates: numberPredicates)
         let finalPredicate = NSCompoundPredicate(orPredicateWithSubpredicates: [andPredicates, orPredicates])
 
-        searchResults = searchResults.filtered(using: finalPredicate) as NSArray
-
+        searchResults = searchResults.filter {
+            finalPredicate.evaluate(with: $0)
+        }
+            
         // Hand over the filtered results to our search results table
         let tableController = self.searchController.searchResultsController as? CountryCodeResultsTableViewController
         tableController?.filteredCountries = searchResults as? [Country]


### PR DESCRIPTION
## What's new in this PR?

### Issues

In the country selection screen, app crashes after entered a number in the search field.

### Causes

`@objc` signature of `Country` class is removed in https://github.com/wireapp/wire-ios/pull/4255

### Solutions

Add `@objc` to member `e164`.
