### PR TITLE
[Fix] Don't display floating video tile in group calls

### DIFF
--- a/Wire-iOS Tests/Calling/VoiceChannelVideoStreamArrangmentTests.swift
+++ b/Wire-iOS Tests/Calling/VoiceChannelVideoStreamArrangmentTests.swift
@@ -120,42 +120,44 @@ class VoiceChannelVideoStreamArrangementTests: XCTestCase {
                            isPaused: false)
     }
     
-    func testThatWithoutSelfStreamItReturnsNilPreviewAndParticipantsVideoStateGrid() {
-        // GIVEN
-        let participantVideoStreams = [videoStreamStub(), videoStreamStub()]
-        
-        // WHEN
-        let videoStreamArrangement = sut.arrangeVideoStreams(for: nil, participantsStreams: participantVideoStreams)
-
-        // THEN
-        XCTAssert(videoStreamArrangement.grid.elementsEqual(participantVideoStreams))
-        XCTAssert(videoStreamArrangement.preview == nil)
-    }
-    
-    func testThatWithSelfStreamAndOneParticipantItReturnsSelfStreamAsPreviewAndOtherParticipantsVideoStatesAsGrid() {
+    func testThatItReturnsSelfPreviewAndParticipantInGrid_OneOnOneConversation() {
         // GIVEN
         let participantVideoStreams = [videoStreamStub()]
         let selfStream = videoStreamStub()
+        sut.conversation?.conversationType = .oneOnOne
         
         // WHEN
         let videoStreamArrangement = sut.arrangeVideoStreams(for: selfStream, participantsStreams: participantVideoStreams)
-
+        
         // THEN
         XCTAssert(videoStreamArrangement.grid.elementsEqual(participantVideoStreams))
         XCTAssert(videoStreamArrangement.preview == selfStream)
     }
     
-    func testThatWithSelfStreamAndMultipleParticipantsItReturnsNilAsPreviewAndSelfStreamPlusOtherParticipantsVideoStatesAsGrid()  {
+    func testThatItReturnsNilPreviewAndAllParticipantsInGrid_GroupConversation() {
         // GIVEN
-        let participantVideoStreams = [videoStreamStub(), videoStreamStub()]
+        let participantVideoStreams = [videoStreamStub()]
         let selfStream = videoStreamStub()
-        let expectedStreams = [selfStream] + participantVideoStreams
-
+        sut.conversation?.conversationType = .group
+        
         // WHEN
         let videoStreamArrangement = sut.arrangeVideoStreams(for: selfStream, participantsStreams: participantVideoStreams)
-
+        
         // THEN
-        XCTAssert(videoStreamArrangement.grid.elementsEqual(expectedStreams))
+        XCTAssert(videoStreamArrangement.grid.elementsEqual([selfStream] + participantVideoStreams))
+        XCTAssert(videoStreamArrangement.preview == nil)
+    }
+    
+    func testThatItReturnsNilPreviewAndParticipantInGrid_WithoutSelfStream() {
+        // GIVEN
+        let participantVideoStreams = [videoStreamStub()]
+        sut.conversation?.conversationType = .oneOnOne
+        
+        // WHEN
+        let videoStreamArrangement = sut.arrangeVideoStreams(for: nil, participantsStreams: participantVideoStreams)
+        
+        // THEN
+        XCTAssert(videoStreamArrangement.grid.elementsEqual(participantVideoStreams))
         XCTAssert(videoStreamArrangement.preview == nil)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/VideoConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/VideoConfiguration.swift
@@ -80,7 +80,7 @@ extension VoiceChannel {
             return (nil, streamsExcludingSelf)
         }
 
-        if 1 == streamsExcludingSelf.count {
+        if conversation?.conversationType == ZMConversationType.oneOnOne {
             return (selfStream, streamsExcludingSelf)
         } else {
             return (nil, [selfStream] + streamsExcludingSelf)

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/VideoConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/VideoConfiguration.swift
@@ -80,7 +80,7 @@ extension VoiceChannel {
             return (nil, streamsExcludingSelf)
         }
 
-        if conversation?.conversationType == ZMConversationType.oneOnOne {
+        if conversation?.conversationType == ZMConversationType.oneOnOne && streamsExcludingSelf.count == 1 {
             return (selfStream, streamsExcludingSelf)
         } else {
             return (nil, [selfStream] + streamsExcludingSelf)

--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridConfiguration.swift
@@ -27,12 +27,20 @@ protocol VideoGridConfiguration {
 
 }
 
-// Workaround to make the protocol equatable, it might be possible to conform VideoGridConfiguration
-// to Equatable with Swift 4.1 and conditional conformances. Right now we would have to make
-// the `VideoGridViewController` generic to work around the `Self` requirement of
-// `Equatable` which we want to avoid.
+
 extension VideoGridConfiguration {
 
+    var allStreams: [VideoStream] {
+        guard let stream = floatingVideoStream else {
+            return videoStreams
+        }
+        return videoStreams + [stream]
+    }
+    
+    // Workaround to make the protocol equatable, it might be possible to conform VideoGridConfiguration
+    // to Equatable with Swift 4.1 and conditional conformances. Right now we would have to make
+    // the `VideoGridViewController` generic to work around the `Self` requirement of
+    // `Equatable` which we want to avoid.
     func isEqual(toConfiguration other: VideoGridConfiguration) -> Bool {
         return floatingVideoStream == other.floatingVideoStream &&
             videoStreams == other.videoStreams &&

--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridConfiguration.swift
@@ -30,11 +30,9 @@ protocol VideoGridConfiguration {
 
 extension VideoGridConfiguration {
 
-    var allStreams: [VideoStream] {
-        guard let stream = floatingVideoStream else {
-            return videoStreams
-        }
-        return videoStreams + [stream]
+    var allStreamIds: Set<AVSClient> {
+        let streamIds = (videoStreams + [floatingVideoStream]).compactMap { $0?.stream.streamId }
+        return Set(streamIds)
     }
     
     // Workaround to make the protocol equatable, it might be possible to conform VideoGridConfiguration

--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridViewController.swift
@@ -37,7 +37,6 @@ final class VideoGridViewController: UIViewController {
     private let thumbnailViewController = PinnableThumbnailViewController()
     private let networkConditionView = NetworkConditionIndicatorView()
     private let mediaManager: AVSMediaManagerInterface
-    private var selfPreviewView: SelfVideoPreviewView?
     private var viewCache = [AVSClient: UIView]()
 
     // MARK: - Properties
@@ -268,6 +267,13 @@ final class VideoGridViewController: UIViewController {
         return stream
     }
 
+    private var selfPreviewView: SelfVideoPreviewView? {
+        guard let selfStreamId = ZMUser.selfUser()?.selfStreamId else {
+            return nil
+        }
+        return viewCache[selfStreamId] as? SelfVideoPreviewView
+    }
+    
     private func videoConfigurationDescription() -> String {
         return """
         showing self preview: \(selfPreviewView != nil)

--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridViewController.swift
@@ -214,7 +214,7 @@ final class VideoGridViewController: UIViewController {
 
     private func pruneCache() {
         let existingStreamsIds = Set(viewCache.keys)
-        let currentStreamsIds = videoStreams.map(\.stream.streamId)
+        let currentStreamsIds = configuration.allStreams.map(\.stream.streamId)
 
         for deletedStreamId in existingStreamsIds.subtracting(currentStreamsIds) {
             viewCache.removeValue(forKey: deletedStreamId)

--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridViewController.swift
@@ -214,7 +214,7 @@ final class VideoGridViewController: UIViewController {
 
     private func pruneCache() {
         let existingStreamsIds = Set(viewCache.keys)
-        let currentStreamsIds = configuration.allStreams.map(\.stream.streamId)
+        let currentStreamsIds = configuration.allStreamIds
 
         for deletedStreamId in existingStreamsIds.subtracting(currentStreamsIds) {
             viewCache.removeValue(forKey: deletedStreamId)


### PR DESCRIPTION
## What's new in this PR?

https://wearezeta.atlassian.net/browse/ZIOS-13483

- Display floating video tile only in one to one calls (not in group conv/calls)
- Fixed issues with floating video (see below)

### Issues

1. Floating video never shows over the grid

2. Floating video freezes after first grid update

### Causes

1. Floating video relied on `selfPreviewView` property, which was never set

2. Floating video view was removed from cache on `updateState()`

### Solutions

1. Make `selfPreviewView` a computed property returning cached self preview

2. Remove views from cache based on all streams from video configuration (higher source of truth)

