### PR TITLE
Add developer setting to send many messages at once, for debugging purposes

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
@@ -252,6 +252,14 @@ class SettingsCellDescriptorFactory {
             }
         }
         developerCellDescriptors.append(appendManyMessages)
+        
+        let spamWithMessages = SettingsButtonCellDescriptor(title: "Spam the top conv", isDestructive: true) { _ in
+            
+            self.requestNumber() { count in
+                self.spamWithMessages(amount: count)
+            }
+        }
+        developerCellDescriptors.append(spamWithMessages)
 
         let showStatistics = SettingsExternalScreenCellDescriptor(title: "Show database statistics", isDestructive: false, presentationStyle: .navigation, presentationAction: {  DatabaseStatisticsController() })
         developerCellDescriptors.append(showStatistics)
@@ -546,6 +554,23 @@ class SettingsCellDescriptorFactory {
         
         userSession.enqueue {
             conversation.appendClientMessage(with: genericMessage, expires: false, hidden: false)
+        }
+    }
+    
+    /// Sends a message that will fail to decode on every other device, on the first conversation of the list
+    func spamWithMessages(amount: Int) {
+        guard
+            let userSession = ZMUserSession.shared(),
+            let conversation = ZMConversationList.conversationsIncludingArchived(inUserSession: userSession).firstObject as? ZMConversation
+            else {
+                return
+        }
+        let nonce = UUID()
+        
+        userSession.enqueue {
+            (0...amount).forEach { i in
+                conversation.append(text: "This is message number \(i), serie \(nonce)")
+            }
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
@@ -557,7 +557,7 @@ class SettingsCellDescriptorFactory {
         }
     }
     
-    /// Sends a message that will fail to decode on every other device, on the first conversation of the list
+    /// Sends a number of messages to the top conversation in the list, in an asynchronous fashion
     func spamWithMessages(amount: Int) {
         guard
             amount > 0,
@@ -612,5 +612,4 @@ class SettingsCellDescriptorFactory {
         controller.present(alert, animated: true)
     }
 }
-
 


### PR DESCRIPTION

## What's new in this PR?

I am investigating possible causes for decryption errors when exchanging messages. I added this setting to automate sending messages back and forth between two devices to see if I can reproduce the problem. I am committing this because I believe this to be useful debugging tool that might come in handy at some other time.