### PR TITLE
Revert "[Chore] Bump AVS to 6.2.7 (#4474)"

### DIFF
--- a/avs-versions
+++ b/avs-versions
@@ -17,4 +17,4 @@
 # along with this program. If not, see http://www.gnu.org/licenses/.
 #
 
-export APPSTORE_AVS_VERSION=6.2.7
+export APPSTORE_AVS_VERSION=6.0.47


### PR DESCRIPTION
## What's new in this PR?

This reverts commit 7418d7564a08ac47ee1995ed5251c46847923d65. We are reverting because the web team encountered a blocker and is not able to push a new internal with the same AVS bump.