### PR TITLE
[Feature] Unlock database with app lock screen

### DIFF
--- a/Wire-iOS Share Extension/ShareExtensionViewController.swift
+++ b/Wire-iOS Share Extension/ShareExtensionViewController.swift
@@ -500,7 +500,7 @@ final class ShareExtensionViewController: SLComposeServiceViewController {
         
         let scenario: AppLock.AuthenticationScenario =
             .screenLock(requireBiometrics: AppLock.rules.useBiometricsOrAccountPassword,
-                        grantAccessIfNoPasscodeIsSet: !AppLock.rules.forceAppLock)
+                        grantAccessIfPolicyCannotBeEvaluated: !AppLock.rules.forceAppLock)
         
         AppLock.evaluateAuthentication(scenario: scenario,
                                        description: "share_extension.privacy_security.lock_app.description".localized)

--- a/Wire-iOS Share Extension/ShareExtensionViewController.swift
+++ b/Wire-iOS Share Extension/ShareExtensionViewController.swift
@@ -496,7 +496,15 @@ final class ShareExtensionViewController: SLComposeServiceViewController {
             return
         }
         
-        AppLock.evaluateAuthentication(description: "share_extension.privacy_security.lock_app.description".localized) { [weak self] (result) in
+        // TODO jacob handle database lock scenario
+        
+        let scenario: AppLock.AuthenticationScenario =
+            .screenLock(requireBiometrics: AppLock.rules.useBiometricsOrAccountPassword,
+                        grantAccessIfNoPasscodeIsSet: !AppLock.rules.forceAppLock)
+        
+        AppLock.evaluateAuthentication(scenario: scenario,
+                                       description: "share_extension.privacy_security.lock_app.description".localized)
+        { [weak self] (result, _) in
             DispatchQueue.main.async {
                 if case .granted = result {
                     self?.localAuthenticationStatus = .granted

--- a/Wire-iOS Tests/AppLock/AppLockPresenterTests.swift
+++ b/Wire-iOS Tests/AppLock/AppLockPresenterTests.swift
@@ -371,7 +371,7 @@ final class AppLockPresenterTests: XCTestCase {
     
     func testThatAppStateDidTransitionNotifiesInteractorWithState() {
         //given
-        let appState = AppState.authenticated(completedRegistration: true)
+        let appState = AppState.authenticated(completedRegistration: true, databaseIsLocked: false)
         //when
         sut.appStateDidTransition(notification(for: appState))
         //then
@@ -381,7 +381,7 @@ final class AppLockPresenterTests: XCTestCase {
     
     func testThatAppStateDidTransitionToAuthenticatedAsksIfApplockIsNeeded() {
         //given
-        let appState = AppState.authenticated(completedRegistration: true)
+        let appState = AppState.authenticated(completedRegistration: true, databaseIsLocked: false)
         //when
         sut.appStateDidTransition(notification(for: appState))
         //then

--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -270,7 +270,7 @@ final class AppRootViewController: UIViewController, SpinnerCapable {
 
             viewController = navigationController
 
-        case .authenticated(completedRegistration: let completedRegistration):
+        case .authenticated(completedRegistration: let completedRegistration, databaseIsLocked: _):
             UIColor.setAccentOverride(.undefined)
             mainWindow.tintColor = UIColor.accent()
             executeAuthenticatedBlocks()
@@ -403,7 +403,7 @@ final class AppRootViewController: UIViewController, SpinnerCapable {
     }
 
     func performWhenAuthenticated(_ block : @escaping () -> Void) {
-        if appStateController.appState == .authenticated(completedRegistration: false) {
+        if case .authenticated = appStateController.appState {
             block()
         } else {
             authenticatedBlocks.append(block)

--- a/Wire-iOS/Sources/AppState.swift
+++ b/Wire-iOS/Sources/AppState.swift
@@ -22,7 +22,7 @@ import WireDataModel
 enum AppState : Equatable {
     
     case headless
-    case authenticated(completedRegistration: Bool)
+    case authenticated(completedRegistration: Bool, databaseIsLocked: Bool)
     case unauthenticated(error : NSError?)
     case blacklisted(jailbroken: Bool)
     case migrating

--- a/Wire-iOS/Sources/AppStateController.swift
+++ b/Wire-iOS/Sources/AppStateController.swift
@@ -215,7 +215,7 @@ extension AppStateController : SessionManagerDelegate {
         }
         
         databaseEncryptionObserverToken = userSession.registerDatabaseLockedHandler({ [weak self] (isDatabaseLocked) in
-            self?.isDatabaseLocked = false
+            self?.isDatabaseLocked = isDatabaseLocked
             self?.updateAppState()
         })
     }

--- a/Wire-iOS/Sources/AppStateController.swift
+++ b/Wire-iOS/Sources/AppStateController.swift
@@ -49,6 +49,7 @@ final class AppStateController : NSObject {
     private(set) var lastAppState : AppState = .headless
     weak var delegate : AppStateControllerDelegate? = nil
     
+    fileprivate var isDatabaseLocked = false
     fileprivate var isBlacklisted = false
     fileprivate var isJailbroken = false
     fileprivate var hasEnteredForeground = false
@@ -57,6 +58,7 @@ final class AppStateController : NSObject {
     fileprivate var authenticationError : NSError?
     fileprivate var isRunningTests = ProcessInfo.processInfo.isRunningTests
     var isRunningSelfUnitTest = false
+    var databaseEncryptionObserverToken: Any? = nil
 
     /// The state of authentication.
     fileprivate(set) var authenticationState: AuthenticationState = .undetermined
@@ -97,7 +99,7 @@ final class AppStateController : NSObject {
 
         switch authenticationState {
         case .loggedIn(let addedAccount):
-            return .authenticated(completedRegistration: addedAccount)
+            return .authenticated(completedRegistration: addedAccount, databaseIsLocked: isDatabaseLocked)
         case .loggedOut:
             return .unauthenticated(error: authenticationError)
         case .undetermined:
@@ -144,6 +146,7 @@ extension AppStateController : SessionManagerDelegate {
     func sessionManagerWillLogout(error: Error?, userSessionCanBeTornDown: (() -> Void)?) {
         authenticationError = error as NSError?
         authenticationState = .loggedOut
+        databaseEncryptionObserverToken = nil
 
         updateAppState {
             userSessionCanBeTornDown?()
@@ -190,6 +193,7 @@ extension AppStateController : SessionManagerDelegate {
     }
     
     func sessionManagerWillOpenAccount(_ account: Account, userSessionCanBeTornDown: @escaping () -> Void) {
+        databaseEncryptionObserverToken = nil
         loadingAccount = account
         updateAppState { 
             userSessionCanBeTornDown()
@@ -203,11 +207,17 @@ extension AppStateController : SessionManagerDelegate {
             // NOTE: we don't enter the unauthenticated state here if we are not logged in
             //       because we will receive `sessionManagerDidLogout()` with an auth error
 
+            self?.isDatabaseLocked = userSession.isDatabaseLocked
             self?.authenticationState = .loggedIn(addedAccount: false)
             self?.loadingAccount = nil
             self?.isMigrating = false
             self?.updateAppState()
         }
+        
+        databaseEncryptionObserverToken = userSession.registerDatabaseLockedHandler({ [weak self] (isDatabaseLocked) in
+            self?.isDatabaseLocked = false
+            self?.updateAppState()
+        })
     }
     
 }

--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockInteractor.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockInteractor.swift
@@ -101,7 +101,7 @@ extension AppLockInteractor {
             return .databaseLock
         } else {
             return .screenLock(requireBiometrics: AppLock.rules.useBiometricsOrAccountPassword,
-                               grantAccessIfNoPasscodeIsSet: !AppLock.rules.forceAppLock)
+                               grantAccessIfPolicyCannotBeEvaluated: !AppLock.rules.forceAppLock)
         }
     }
     

--- a/WireCommonComponents/AppLock.swift
+++ b/WireCommonComponents/AppLock.swift
@@ -68,11 +68,7 @@ public class AppLock {
             case .screenLock(requireBiometrics: let requireBiometrics, grantAccessIfNoPasscodeIsSet: _):
                 return requireBiometrics ? .deviceOwnerAuthenticationWithBiometrics : .deviceOwnerAuthentication
             case .databaseLock:
-                #if targetEnvironment(simulator)
-                    return .deviceOwnerAuthentication
-                #else
-                    return .deviceOwnerAuthenticationWithBiometrics
-                #endif
+                return .deviceOwnerAuthentication
                 
             }
         }

--- a/WireCommonComponents/AppLock.swift
+++ b/WireCommonComponents/AppLock.swift
@@ -58,41 +58,77 @@ public class AppLock {
         /// Biometrics failed and account password is needed instead of device PIN
         case needAccountPassword
     }
+    
+    public enum AuthenticationScenario {
+        case screenLock(requireBiometrics: Bool, grantAccessIfNoPasscodeIsSet: Bool)
+        case databaseLock
+        
+        var policy: LAPolicy {
+            switch self {
+            case .screenLock(requireBiometrics: let requireBiometrics, grantAccessIfNoPasscodeIsSet: _):
+                return requireBiometrics ? .deviceOwnerAuthenticationWithBiometrics : .deviceOwnerAuthentication
+            case .databaseLock:
+                #if targetEnvironment(simulator)
+                    return .deviceOwnerAuthentication
+                #else
+                    return .deviceOwnerAuthenticationWithBiometrics
+                #endif
+                
+            }
+        }
+        
+        var supportsUserFallback: Bool {
+            if case .screenLock(requireBiometrics: true, grantAccessIfNoPasscodeIsSet: _) = self {
+                return true
+            }
+            
+            return false
+        }
+        
+        var grantAccessIfNoPasscodeIsSet: Bool {
+            if case .screenLock(requireBiometrics: _, grantAccessIfNoPasscodeIsSet: true) = self {
+                return true
+            }
+            
+            return false
+        }
+                
+    }
 
     /// a weak reference to LAContext, it should be nil when evaluatePolicy is done.
     public static weak var weakLAContext: LAContext? = nil // TODO jacob make private again
     
     // Creates a new LAContext and evaluates the authentication settings of the user.
-    public class func evaluateAuthentication(description: String, with callback: @escaping (AuthenticationResult) -> Void) {
+    public class func evaluateAuthentication(scenario: AuthenticationScenario,
+                                             description: String,
+                                             with callback: @escaping (AuthenticationResult, LAContext) -> Void) {
         guard AppLock.weakLAContext == nil else { return }
 
-        let useBiometricsOrAccountPassword = rules.useBiometricsOrAccountPassword
         let context: LAContext = LAContext()
         var error: NSError?
 
         AppLock.weakLAContext = context
         
-        let policy: LAPolicy = useBiometricsOrAccountPassword ? LAPolicy.deviceOwnerAuthenticationWithBiometrics : LAPolicy.deviceOwnerAuthentication
-        let canEvaluatePolicy = context.canEvaluatePolicy(policy, error: &error)
-        
-        if useBiometricsOrAccountPassword && (BiometricsState.biometricsChanged(in: context) || !canEvaluatePolicy) {
-            callback(.needAccountPassword)
+        let canEvaluatePolicy = context.canEvaluatePolicy(scenario.policy, error: &error)
+                
+        if scenario.supportsUserFallback && (BiometricsState.biometricsChanged(in: context)) || !canEvaluatePolicy {
+            callback(.needAccountPassword, context)
             return
         }
 
         if canEvaluatePolicy {
-            context.evaluatePolicy(policy, localizedReason: description, reply: { (success, error) -> Void in
+            context.evaluatePolicy(scenario.policy, localizedReason: description, reply: { (success, error) -> Void in
                 var authResult: AuthenticationResult = success ? .granted : .denied
             
-                if useBiometricsOrAccountPassword, let laError = error as? LAError, laError.code == .userFallback {
+                if scenario.supportsUserFallback, let laError = error as? LAError, laError.code == .userFallback {
                     authResult = .needAccountPassword
                 }
                 
-                callback(authResult)
+                callback(authResult, context)
             })
         } else {
             // If there's no passcode set automatically grant access unless app lock is a requirement to run the app
-            callback(rules.forceAppLock ? .unavailable : .granted)
+            callback(scenario.grantAccessIfNoPasscodeIsSet ? .granted : .unavailable, context)
             zmLog.error("Local authentication error: \(String(describing: error?.localizedDescription))")
         }
     }

--- a/WireCommonComponents/AppLock.swift
+++ b/WireCommonComponents/AppLock.swift
@@ -107,7 +107,7 @@ public class AppLock {
         
         let canEvaluatePolicy = context.canEvaluatePolicy(scenario.policy, error: &error)
                 
-        if scenario.supportsUserFallback && (BiometricsState.biometricsChanged(in: context)) || !canEvaluatePolicy {
+        if scenario.supportsUserFallback && (BiometricsState.biometricsChanged(in: context) || !canEvaluatePolicy) {
             callback(.needAccountPassword, context)
             return
         }

--- a/WireCommonComponents/AppLock.swift
+++ b/WireCommonComponents/AppLock.swift
@@ -123,7 +123,9 @@ public class AppLock {
                 callback(authResult, context)
             })
         } else {
-            // If there's no passcode set automatically grant access unless app lock is a requirement to run the app
+            // If the policy can't be evaluated automatically grant access unless app lock
+            // is a requirement to run the app. This will for example allow a user to access
+            // the app if he/she has disabled his/her passcode.
             callback(scenario.grantAccessIfPolicyCannotBeEvaluated ? .granted : .unavailable, context)
             zmLog.error("Local authentication error: \(String(describing: error?.localizedDescription))")
         }

--- a/WireCommonComponents/AppLock.swift
+++ b/WireCommonComponents/AppLock.swift
@@ -60,7 +60,7 @@ public class AppLock {
     }
 
     /// a weak reference to LAContext, it should be nil when evaluatePolicy is done.
-    private static weak var weakLAContext: LAContext? = nil
+    public static weak var weakLAContext: LAContext? = nil // TODO jacob make private again
     
     // Creates a new LAContext and evaluates the authentication settings of the user.
     public class func evaluateAuthentication(description: String, with callback: @escaping (AuthenticationResult) -> Void) {

--- a/WireCommonComponents/AppLock.swift
+++ b/WireCommonComponents/AppLock.swift
@@ -60,12 +60,12 @@ public class AppLock {
     }
     
     public enum AuthenticationScenario {
-        case screenLock(requireBiometrics: Bool, grantAccessIfNoPasscodeIsSet: Bool)
+        case screenLock(requireBiometrics: Bool, grantAccessIfPolicyCannotBeEvaluated: Bool)
         case databaseLock
         
         var policy: LAPolicy {
             switch self {
-            case .screenLock(requireBiometrics: let requireBiometrics, grantAccessIfNoPasscodeIsSet: _):
+            case .screenLock(requireBiometrics: let requireBiometrics, grantAccessIfPolicyCannotBeEvaluated: _):
                 return requireBiometrics ? .deviceOwnerAuthenticationWithBiometrics : .deviceOwnerAuthentication
             case .databaseLock:
                 return .deviceOwnerAuthentication
@@ -74,15 +74,15 @@ public class AppLock {
         }
         
         var supportsUserFallback: Bool {
-            if case .screenLock(requireBiometrics: true, grantAccessIfNoPasscodeIsSet: _) = self {
+            if case .screenLock(requireBiometrics: true, grantAccessIfPolicyCannotBeEvaluated: _) = self {
                 return true
             }
             
             return false
         }
         
-        var grantAccessIfNoPasscodeIsSet: Bool {
-            if case .screenLock(requireBiometrics: _, grantAccessIfNoPasscodeIsSet: true) = self {
+        var grantAccessIfPolicyCannotBeEvaluated: Bool {
+            if case .screenLock(requireBiometrics: _, grantAccessIfPolicyCannotBeEvaluated: true) = self {
                 return true
             }
             
@@ -124,7 +124,7 @@ public class AppLock {
             })
         } else {
             // If there's no passcode set automatically grant access unless app lock is a requirement to run the app
-            callback(scenario.grantAccessIfNoPasscodeIsSet ? .granted : .unavailable, context)
+            callback(scenario.grantAccessIfPolicyCannotBeEvaluated ? .granted : .unavailable, context)
             zmLog.error("Local authentication error: \(String(describing: error?.localizedDescription))")
         }
     }


### PR DESCRIPTION
## What's new in this PR?

When the database is locked we need to unlock it using biometrics or the passcode and we need to disable any fallbacks which requests that the user to enter his/her password since we can't use it to unlock the database.

* Introduce `AuthenticationScenario` which encapsulates the rules which apply when are unlocking the app.
* Add `isDatabaseLocked `parameter to the `.authenticated` `AppState` to signal that the database is locked.

