### PR TITLE
[Chore] Downgrade AVS to 6.0.47

### DIFF
--- a/avs-versions
+++ b/avs-versions
@@ -17,4 +17,4 @@
 # along with this program. If not, see http://www.gnu.org/licenses/.
 #
 
-export APPSTORE_AVS_VERSION=6.1.12
+export APPSTORE_AVS_VERSION=6.0.47


### PR DESCRIPTION
## What's new in this PR?

AVS was bumped to a `6.1.12` on the `release/3.63` branch, but we need to have `6.0.47` on `develop`. The release branch was merged back to develop with https://github.com/wireapp/wire-ios/pull/4481, so this PR is to correct the AVS version.
