### PR TITLE
[Feature] Expose sharing cryptobox under the debugging tools

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
@@ -277,7 +277,11 @@ class SettingsCellDescriptorFactory {
         let title = "self.settings.advanced.debugging_tools.title".localized
         
         let findUnreadConversationButton = SettingsButtonCellDescriptor(title: "self.settings.advanced.debugging_tools.first_unread_conversation.title".localized, isDestructive: false, selectAction: SettingsCellDescriptorFactory.findUnreadConversationContributingToBadgeCount)
-        let debuggingToolsGroup = SettingsGroupCellDescriptor(items: [SettingsSectionDescriptor(cellDescriptors:[findUnreadConversationButton,])], title: title)
+        let shareCryptobox = SettingsShareCryptoboxCellDescriptor()
+        let debuggingToolsGroup = SettingsGroupCellDescriptor(items:
+            [SettingsSectionDescriptor(cellDescriptors:[
+                findUnreadConversationButton,
+                shareCryptobox])], title: title)
         return SettingsSectionDescriptor(cellDescriptors: [debuggingToolsGroup], header: .none, footer: .none)
     }
     


### PR DESCRIPTION
## What's new in this PR?

Add the ability to export the cryptobox under option debugging tools.