### PR TITLE
[Chore] Bump AVS to 6.2.11

### DIFF
--- a/avs-versions
+++ b/avs-versions
@@ -17,4 +17,4 @@
 # along with this program. If not, see http://www.gnu.org/licenses/.
 #
 
-export APPSTORE_AVS_VERSION=6.2.10
+export APPSTORE_AVS_VERSION=6.2.11


### PR DESCRIPTION
## What's new in this PR?

Bump AVS to 6.2.11, which has targeted messaging enabled.