### PR TITLE
[Chore] add accessibility identifier to beta toggle

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Options.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Options.swift
@@ -144,8 +144,11 @@ extension SettingsCellDescriptorFactory {
     }
     
     private var conferenceCallingSection: SettingsSectionDescriptor {
-        let betaToggle = SettingsPropertyToggleCellDescriptor(settingsProperty: settingsPropertyFactory.property(.enableConferenceCallingBeta))
-        
+        let betaToggle = SettingsPropertyToggleCellDescriptor(
+            settingsProperty: settingsPropertyFactory.property(.enableConferenceCallingBeta),
+            identifier: "Beta Toggle"
+        )
+
         return SettingsSectionDescriptor(
             cellDescriptors: [betaToggle],
             header: "self.settings.advanced.conference_calling.title".localized,


### PR DESCRIPTION
## What's new in this PR?

https://wearezeta.atlassian.net/browse/ZIOS-13648

- Add accessibility id to beta toggle

### Note

The `SettingsPropertyToggleCellDescriptor` class sets the toggle `accessibilityLabel` instead of the `accessibilityIdentifier`