### PR TITLE
wipe UnlockViewController in navi

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
@@ -94,7 +94,7 @@ final class AppLockViewController: UIViewController {
         if unlockViewController == nil {
             let viewController = UnlockViewController()
             
-            let keyboardAvoidingViewController = KeyboardAvoidingViewController(viewController: viewController)
+            let keyboardAvoidingViewController = KeyboardAvoidingViewController(viewController: viewController.wrapInNavigationController(navigationBarClass: TransparentNavigationBar.self))
             keyboardAvoidingViewController.modalPresentationStyle = .fullScreen
             present(keyboardAvoidingViewController, animated: false)
             


### PR DESCRIPTION
## What's new in this PR?

Wrap `unlockViewController` in navigation controller to allow pushing wipe database screen.