### PR TITLE
[Fix] video button disabled message

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -424,6 +424,7 @@
 		634497D924A492140000131D /* VideoParticipantDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634497D824A492140000131D /* VideoParticipantDetailView.swift */; };
 		634497DB24A49BF80000131D /* BaseVideoPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634497DA24A49BF70000131D /* BaseVideoPreviewView.swift */; };
 		63495DB423EB2D7B002A7C59 /* AutomationHelper+BackendEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63495DB323EB2D7B002A7C59 /* AutomationHelper+BackendEnvironment.swift */; };
+		63589AA124DAA398008FEC8F /* UIAlertController+Permissions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63589AA024DAA398008FEC8F /* UIAlertController+Permissions.swift */; };
 		6363EC9B23D7622F00E74F67 /* NSMutableAttributedString+CompanyLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6363EC9A23D7622F00E74F67 /* NSMutableAttributedString+CompanyLogin.swift */; };
 		636AD79A23A916CB004A3050 /* AppLockPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636AD79923A916CB004A3050 /* AppLockPresenter.swift */; };
 		636AD79C23A91A57004A3050 /* AppLockInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636AD79B23A91A57004A3050 /* AppLockInteractor.swift */; };
@@ -1978,6 +1979,7 @@
 		634497D824A492140000131D /* VideoParticipantDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoParticipantDetailView.swift; sourceTree = "<group>"; };
 		634497DA24A49BF70000131D /* BaseVideoPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseVideoPreviewView.swift; sourceTree = "<group>"; };
 		63495DB323EB2D7B002A7C59 /* AutomationHelper+BackendEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AutomationHelper+BackendEnvironment.swift"; sourceTree = "<group>"; };
+		63589AA024DAA398008FEC8F /* UIAlertController+Permissions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertController+Permissions.swift"; sourceTree = "<group>"; };
 		6363EC9A23D7622F00E74F67 /* NSMutableAttributedString+CompanyLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMutableAttributedString+CompanyLogin.swift"; sourceTree = "<group>"; };
 		636AD79923A916CB004A3050 /* AppLockPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockPresenter.swift; sourceTree = "<group>"; };
 		636AD79B23A91A57004A3050 /* AppLockInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockInteractor.swift; sourceTree = "<group>"; };
@@ -5072,6 +5074,7 @@
 				7C4918A01F8BB1A20038AF4B /* UIScreen+SafeArea.swift */,
 				BF8ECC2C1E570A920015177D /* UIActivityViewController+FileSaving.swift */,
 				1693D9661CEDB26200D1F13C /* UIApplication+Permissions.swift */,
+				63589AA024DAA398008FEC8F /* UIAlertController+Permissions.swift */,
 				871BC0251D34F5D200DF0793 /* EmoticonSubstitutionConfiguration.swift */,
 				EF1FDC7F21DE47AB00C9CEB1 /* NSString+EmoticonSubstitution.swift */,
 				EFB97F6F22EF45D50092A620 /* UIImage+ImageUtilities.swift */,
@@ -7753,6 +7756,7 @@
 				A97BC011241EA2660069E145 /* NSAttributedString+EnumerateAttachment.swift in Sources */,
 				63F65EFD2469967600534A69 /* AuthenticationCoordinator+PreBackendSwitch.swift in Sources */,
 				5EE73BF1212319BB0032986D /* RegistrationIncrementalUserDataChangeHandler.swift in Sources */,
+				63589AA124DAA398008FEC8F /* UIAlertController+Permissions.swift in Sources */,
 				5EFCB3BF21AAD46C00E892D9 /* Message+Pasteboard.swift in Sources */,
 				F15650E721DD14B600210504 /* String+Transform.swift in Sources */,
 				BF52C1571CAEB9E10037331F /* ArchivedListViewController.swift in Sources */,

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -27,6 +27,7 @@
 "general.edit" = "Edit";
 "general.done" = "Done";
 "general.confirm" = "OK";
+"general.later" = "Later";
 "general.skip" = "Not Now";
 "general.accept" = "Accept";
 "general.decline" = "No, thanks";
@@ -363,7 +364,7 @@
 "image.edit_image" = "Edit image";
 
 // Camera access
-"camera_access.denied" = "Wire needs access to the Camera.";
+"camera_access.denied" = "Wire needs access to the camera";
 "video_call.camera_access.denied" = "Wire doesn’t have access to the camera";
 "camera_access.denied.instruction" = "";
 "camera_access.denied.open_settings" = "Enable it in Wire Settings";
@@ -651,9 +652,9 @@
 "voice.alert.call_in_progress.message" = "You can have only one active call at a time";
 "voice.alert.call_in_progress.confirm" = "OK";
 
-"voice.alert.microphone_warning.title" = "Wire needs access to the Microphone.";
+"voice.alert.microphone_warning.title" = "Wire needs access to the microphone";
 
-"voice.alert.camera_warning.title" = "Wire needs access to the Camera.";
+"voice.alert.camera_warning.title" = "Wire needs access to the camera";
 
 "voice.top_overlay.tap_to_return" = "Tap to return to call";
 "voice.top_overlay.accessibility_title" = "Ongoing call";

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -674,9 +674,6 @@
 
 "call.video.paused" = "Video paused";
 
-"call.video.too_many.alert.title" = "Too many people for Video";
-"call.video.too_many.alert.message" = "Video calls only work in groups of 4 or less.";
-
 "call.degraded.alert.title" = "New Device";
 "call.degraded.alert.message.self" = "You started using a new device.";
 "call.degraded.alert.message.user" = "%@ started using a new device.";

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -675,6 +675,9 @@
 
 "call.video.paused" = "Video paused";
 
+"call.video.too_many.alert.title" = "Too many people for Video";
+"call.video.too_many.alert.message" = "Video calls only work in groups of 4 or less.";
+
 "call.degraded.alert.title" = "New Device";
 "call.degraded.alert.message.self" = "You started using a new device.";
 "call.degraded.alert.message.user" = "%@ started using a new device.";

--- a/Wire-iOS/Sources/Helpers/UIAlertController+Permissions.swift
+++ b/Wire-iOS/Sources/Helpers/UIAlertController+Permissions.swift
@@ -1,0 +1,59 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import UIKit
+import WireCommonComponents
+
+extension UIAlertController {
+    class func cameraPermissionAlert(with completion: AlertActionHandler? = nil) -> UIAlertController {
+        let alert = UIAlertController(
+            title: "voice.alert.camera_warning.title".localized,
+            message: "NSCameraUsageDescription".infoPlistLocalized,
+            preferredStyle: .alert
+        )
+        
+        alert.addAction(.actionLater(with: completion))
+        alert.addAction(.actionSettings(with: completion))
+        
+        return alert
+    }
+}
+
+extension UIAlertAction {
+    class func actionLater(with completion: AlertActionHandler?) -> UIAlertAction {
+        return UIAlertAction(
+            title: "general.later".localized,
+            style: .cancel,
+            handler: { action in
+                completion?(action)
+        })
+    }
+    
+    class func actionSettings(with completion: AlertActionHandler?) -> UIAlertAction {
+        return UIAlertAction(
+            title: "general.open_settings".localized,
+            style: .default,
+            handler: { action in
+                if let url = URL(string: UIApplication.openSettingsURLString) {
+                    UIApplication.shared.open(url, options: [:])
+                }
+                completion?(action)
+        })
+    }
+}

--- a/Wire-iOS/Sources/Helpers/UIApplication+Permissions.swift
+++ b/Wire-iOS/Sources/Helpers/UIApplication+Permissions.swift
@@ -16,7 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
+import WireCommonComponents
 import UIKit
 import Photos
 
@@ -48,7 +48,7 @@ extension UIApplication {
         UIApplication.wr_requestVideoAccess({ granted in
             DispatchQueue.main.async(execute: {
                 if !granted {
-                    self.wr_warnAboutCameraPermission(withCompletion: {
+                    self.wr_warnAboutCameraPermission(withCompletion: { _ in
                         grantedHandler(granted)
                     })
                 } else {
@@ -86,40 +86,11 @@ extension UIApplication {
         })
     }
     
-    class func cameraPermissionAlert(with completion: @escaping () -> ()) -> UIAlertController {
-        let alert = UIAlertController(
-            title: "voice.alert.camera_warning.title".localized,
-            message: "NSCameraUsageDescription".infoPlistLocalized,
-            preferredStyle: .alert
-        )
-        
-        let actionLater = UIAlertAction(
-            title: "general.later".localized,
-            style: .cancel,
-            handler: { _ in
-                completion()
-        })
-        alert.addAction(actionLater)
-        
-        let actionSettings = UIAlertAction(
-            title: "general.open_settings".localized,
-            style: .default,
-            handler: { _ in
-                if let url = URL(string: UIApplication.openSettingsURLString) {
-                    UIApplication.shared.open(url, options: [:])
-                }
-                completion()
-        })
-        alert.addAction(actionSettings)
-        
-        return alert
-    }
-    
-    private class func wr_warnAboutCameraPermission(withCompletion completion: @escaping () -> ()) {
+    private class func wr_warnAboutCameraPermission(withCompletion completion: AlertActionHandler?) {
         let currentResponder = UIResponder.currentFirst
         (currentResponder as? UIView)?.endEditing(true)
         
-        let alert = cameraPermissionAlert(with: completion)
+        let alert = UIAlertController.cameraPermissionAlert(with: completion)
         
         AppDelegate.shared.window?.rootViewController?.present(alert, animated: true)
     }

--- a/Wire-iOS/Sources/Helpers/UIApplication+Permissions.swift
+++ b/Wire-iOS/Sources/Helpers/UIApplication+Permissions.swift
@@ -87,25 +87,32 @@ extension UIApplication {
     }
     
     class func cameraPermissionAlert(with completion: @escaping () -> ()) -> UIAlertController {
-        let noVideoAlert = UIAlertController.alertWithOKButton(
+        let alert = UIAlertController(
             title: "voice.alert.camera_warning.title".localized,
             message: "NSCameraUsageDescription".infoPlistLocalized,
-            okActionHandler: { action in
+            preferredStyle: .alert
+        )
+        
+        let actionLater = UIAlertAction(
+            title: "general.later".localized,
+            style: .cancel,
+            handler: { _ in
                 completion()
         })
+        alert.addAction(actionLater)
         
         let actionSettings = UIAlertAction(
             title: "general.open_settings".localized,
             style: .default,
-            handler: { action in
+            handler: { _ in
                 if let url = URL(string: UIApplication.openSettingsURLString) {
                     UIApplication.shared.open(url, options: [:])
                 }
                 completion()
         })
+        alert.addAction(actionSettings)
         
-        noVideoAlert.addAction(actionSettings)
-        return noVideoAlert
+        return alert
     }
     
     private class func wr_warnAboutCameraPermission(withCompletion completion: @escaping () -> ()) {

--- a/Wire-iOS/Sources/Helpers/UIApplication+Permissions.swift
+++ b/Wire-iOS/Sources/Helpers/UIApplication+Permissions.swift
@@ -86,28 +86,35 @@ extension UIApplication {
         })
     }
     
+    class func cameraPermissionAlert(with completion: @escaping () -> ()) -> UIAlertController {
+        let noVideoAlert = UIAlertController.alertWithOKButton(
+            title: "voice.alert.camera_warning.title".localized,
+            message: "NSCameraUsageDescription".infoPlistLocalized,
+            okActionHandler: { action in
+                completion()
+        })
+        
+        let actionSettings = UIAlertAction(
+            title: "general.open_settings".localized,
+            style: .default,
+            handler: { action in
+                if let url = URL(string: UIApplication.openSettingsURLString) {
+                    UIApplication.shared.open(url, options: [:])
+                }
+                completion()
+        })
+        
+        noVideoAlert.addAction(actionSettings)
+        return noVideoAlert
+    }
+    
     private class func wr_warnAboutCameraPermission(withCompletion completion: @escaping () -> ()) {
         let currentResponder = UIResponder.currentFirst
         (currentResponder as? UIView)?.endEditing(true)
         
-        let noVideoAlert = UIAlertController.alertWithOKButton(title: "voice.alert.camera_warning.title".localized,
-                                                               message: "NSCameraUsageDescription".infoPlistLocalized,
-                                                               okActionHandler: { action in
-                                                                completion()
-        })
+        let alert = cameraPermissionAlert(with: completion)
         
-        let actionSettings = UIAlertAction(title: "general.open_settings".localized,
-                                           style: .default,
-                                           handler: { action in
-                                            if let url = URL(string: UIApplication.openSettingsURLString) {
-                                                UIApplication.shared.open(url, options: [:])
-                                            }
-                                            completion()
-        })
-        
-        noVideoAlert.addAction(actionSettings)
-        
-        AppDelegate.shared.window?.rootViewController?.present(noVideoAlert, animated: true)
+        AppDelegate.shared.window?.rootViewController?.present(alert, animated: true)
     }
     
     private class func wr_warnAboutMicrophonePermission() {

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallInfoConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallInfoConfiguration.swift
@@ -253,7 +253,7 @@ fileprivate extension VoiceChannel {
             return true
         }
         
-        guard conversation.localParticipants.count <= ZMConversation.legacyGroupVideoParticipantLimit else {
+        guard !isLegacyGroupVideoParticipantLimitReached else {
             return false
         }
 
@@ -288,5 +288,11 @@ fileprivate extension VoiceChannel {
         default: return false
         }
     }
-    
+}
+
+extension VoiceChannel {
+    var isLegacyGroupVideoParticipantLimitReached: Bool {
+        guard let conversation = conversation else { return false }
+        return conversation.localParticipants.count > ZMConversation.legacyGroupVideoParticipantLimit
+    }
 }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -234,12 +234,12 @@ final class CallViewController: UIViewController {
     }
 
     fileprivate func alertVideoUnavailable() {
-        if voiceChannel.videoState == .stopped, voiceChannel.conversation?.localParticipants.count > 4 {
-            let alert = UIAlertController.alertWithOKButton(title: "call.video.too_many.alert.title".localized,
-                                                            message: "call.video.too_many.alert.message".localized)
-
-            present(alert, animated: true)
-        }
+        guard
+            voiceChannel.videoState == .stopped,
+            !callInfoConfiguration.permissions.canAcceptVideoCalls
+        else { return }
+        
+        present(UIApplication.cameraPermissionAlert(with: {}), animated: true)
     }
 
     fileprivate func toggleVideoState() {

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -239,7 +239,7 @@ final class CallViewController: UIViewController {
             !callInfoConfiguration.permissions.canAcceptVideoCalls
         else { return }
         
-        present(UIApplication.cameraPermissionAlert(with: {}), animated: true)
+        present(UIAlertController.cameraPermissionAlert(), animated: true)
     }
 
     fileprivate func toggleVideoState() {

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -234,14 +234,30 @@ final class CallViewController: UIViewController {
     }
 
     fileprivate func alertVideoUnavailable() {
-        guard
-            voiceChannel.videoState == .stopped,
-            !callInfoConfiguration.permissions.canAcceptVideoCalls
-        else { return }
-        
-        present(UIAlertController.cameraPermissionAlert(), animated: true)
+        guard voiceChannel.videoState == .stopped else { return }
+ 
+        if !callInfoConfiguration.permissions.canAcceptVideoCalls {
+            present(UIAlertController.cameraPermissionAlert(), animated: true)
+        } else {
+            presentLegacyAlertIfNeeded()
+        }
     }
 
+    private func presentLegacyAlertIfNeeded() {
+        guard
+            !voiceChannel.isConferenceCall,
+            voiceChannel.isLegacyGroupVideoParticipantLimitReached
+        else {
+            return
+        }
+        let alert = UIAlertController.alertWithOKButton(
+            title: "call.video.too_many.alert.title".localized,
+            message: "call.video.too_many.alert.message".localized
+        )
+
+        present(alert, animated: true)
+    }
+    
     fileprivate func toggleVideoState() {
         if !permissions.canAcceptVideoCalls {
             permissions.requestOrWarnAboutVideoPermission { _ in


### PR DESCRIPTION
## What's new in this PR?

- Changed alert displayed when user taps video button in a call & video permissions are not granted. Now displays the correct message and actions instead of the incorrect alert ("Too many people for Video")

- Small refactor of the camera permission alert