### PR TITLE
Fix: iPad - app crash when opening conversation list cell context menu

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ArchivedListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ArchivedListViewController.swift
@@ -185,7 +185,7 @@ extension ArchivedListViewController: ConversationListCellDelegate {
     func conversationListCellOverscrolled(_ cell: ConversationListCell) {
         guard let conversation = cell.conversation else { return }
 
-        actionController = ConversationActionController(conversation: conversation, target: self)
+        actionController = ConversationActionController(conversation: conversation, target: self, sourceView: cell)
         actionController?.presentMenu(from: cell, context: .list)
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationPreviewViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationPreviewViewController.swift
@@ -28,10 +28,12 @@ final class ConversationPreviewViewController: TintColorCorrectedViewController 
     fileprivate var contentViewController: ConversationContentViewController
 
     init(conversation: ZMConversation,
-         presentingViewController: UIViewController) {
+         presentingViewController: UIViewController,
+         sourceView: UIView?) {
         self.conversation = conversation
         actionController = ConversationActionController(conversation: conversation,
-                                                        target: presentingViewController)
+                                                        target: presentingViewController,
+                                                        sourceView: sourceView)
         
         contentViewController = ConversationContentViewController(conversation: conversation, mediaPlaybackManager: nil, session: ZMUserSession.shared()!)
         super.init(nibName: nil, bundle: nil)

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationPreviewViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationPreviewViewController.swift
@@ -27,9 +27,12 @@ final class ConversationPreviewViewController: TintColorCorrectedViewController 
     let actionController: ConversationActionController
     fileprivate var contentViewController: ConversationContentViewController
 
-    init(conversation: ZMConversation, presentingViewController: UIViewController) {
+    init(conversation: ZMConversation,
+         presentingViewController: UIViewController) {
         self.conversation = conversation
-        self.actionController = ConversationActionController(conversation: conversation, target: presentingViewController)
+        actionController = ConversationActionController(conversation: conversation,
+                                                        target: presentingViewController)
+        
         contentViewController = ConversationContentViewController(conversation: conversation, mediaPlaybackManager: nil, session: ZMUserSession.shared()!)
         super.init(nibName: nil, bundle: nil)
     }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/Container/ViewModel/ConversationListViewControllerViewModel+ConversationListContentDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/Container/ViewModel/ConversationListViewControllerViewModel+ConversationListContentDelegate.swift
@@ -44,7 +44,7 @@ extension ConversationListViewController.ViewModel {
     func showActionMenu(for conversation: ZMConversation!, from view: UIView!) {
         guard let viewController = viewController as? UIViewController else { return }
 
-        actionsController = ConversationActionController(conversation: conversation, target: viewController)
+        actionsController = ConversationActionController(conversation: conversation, target: viewController, sourceView: view)
         actionsController?.presentMenu(from: view, context: .list)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
@@ -23,7 +23,11 @@ import WireDataModel
 private let CellReuseIdConnectionRequests = "CellIdConnectionRequests"
 private let CellReuseIdConversation = "CellId"
 
-final class ConversationListContentController: UICollectionViewController {
+final class ConversationListContentController: UICollectionViewController, PopoverPresenter {
+    // PopoverPresenter
+    weak var presentedPopover: UIPopoverPresentationController?
+    weak var popoverPointToView: UIView?
+
     weak var contentDelegate: ConversationListContentDelegate?
     let listViewModel: ConversationListViewModel = ConversationListViewModel()
     private var focusOnNextSelection = false

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
@@ -277,13 +277,15 @@ final class ConversationListContentController: UICollectionViewController, Popov
         }
 
         let previewProvider: UIContextMenuContentPreviewProvider = {
-            return ConversationPreviewViewController(conversation: conversation, presentingViewController: self)
+            return ConversationPreviewViewController(conversation: conversation, presentingViewController: self, sourceView: collectionView.cellForItem(at: indexPath))
         }
 
         let actionProvider: UIContextMenuActionProvider = { _ in
             let actions = conversation.listActions.map { action in
                 UIAction(title: action.title, image: nil) { _ in
-                    let actionController = ConversationActionController(conversation: conversation, target: self)
+                    let actionController = ConversationActionController(conversation: conversation,
+                                                                        target: self,
+                                                                        sourceView: collectionView.cellForItem(at: indexPath))
 
                     actionController.handleAction(action)
                 }
@@ -452,7 +454,7 @@ extension ConversationListContentController: UIViewControllerPreviewingDelegate 
 
         previewingContext.sourceRect = layoutAttributes.frame
 
-        return ConversationPreviewViewController(conversation: conversation, presentingViewController: self)
+        return ConversationPreviewViewController(conversation: conversation, presentingViewController: self, sourceView: collectionView.cellForItem(at: indexPath))
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController.swift
@@ -34,7 +34,8 @@ final class ConversationActionController {
     var currentContext: PresentationContext?
     weak var alertController: UIAlertController?
     
-    init(conversation: ZMConversation, target: UIViewController) {
+    init(conversation: ZMConversation,
+         target: UIViewController) {
         self.conversation = conversation
         self.target = target
     }
@@ -97,8 +98,9 @@ final class ConversationActionController {
         case .silence(isSilenced: let isSilenced): self.enqueue {
             self.conversation.mutedMessageTypes = isSilenced ? .none : .all 
             }
-        case .leave: self.request(LeaveResult.self) { result in
-            self.handleLeaveResult(result, for: self.conversation)
+        case .leave:
+            request(LeaveResult.self) { result in
+                self.handleLeaveResult(result, for: self.conversation)
             }
         case .clearContent: self.requestClearContentResult(for: self.conversation) { result in
             self.handleClearContentResult(result, for: self.conversation)
@@ -151,7 +153,10 @@ final class ConversationActionController {
         currentContext.apply {
             prepare(viewController: controller, with: $0)
         }
-        target.present(controller, animated: true, completion: nil)
+        
+        controller.configPopover(pointToView: target.view, popoverPresenter: target as? PopoverPresenterViewController)
+
+        target.present(controller, animated: true)
     }
     
 }

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController.swift
@@ -31,13 +31,16 @@ final class ConversationActionController {
 
     private let conversation: ZMConversation
     unowned let target: UIViewController
+    weak var sourceView: UIView?
     var currentContext: PresentationContext?
     weak var alertController: UIAlertController?
     
     init(conversation: ZMConversation,
-         target: UIViewController) {
+         target: UIViewController,
+         sourceView: UIView? = nil) {
         self.conversation = conversation
         self.target = target
+        self.sourceView = sourceView
     }
 
     func presentMenu(from sourceView: UIView?, context: Context) {
@@ -154,7 +157,7 @@ final class ConversationActionController {
             prepare(viewController: controller, with: $0)
         }
         
-        controller.configPopover(pointToView: target.view, popoverPresenter: target as? PopoverPresenterViewController)
+        controller.configPopover(pointToView: sourceView ?? target.view, popoverPresenter: target as? PopoverPresenterViewController)
 
         target.present(controller, animated: true)
     }

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController.swift
@@ -37,7 +37,7 @@ final class ConversationActionController {
     
     init(conversation: ZMConversation,
          target: UIViewController,
-         sourceView: UIView? = nil) {
+         sourceView: UIView?) {
         self.conversation = conversation
         self.target = target
         self.sourceView = sourceView

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
@@ -205,7 +205,8 @@ final class GroupDetailsViewController: UIViewController, ZMConversationObserver
         }
     }
     
-    func footerView(_ view: GroupDetailsFooterView, shouldPerformAction action: GroupDetailsFooterView.Action) {
+    func footerView(_ view: GroupDetailsFooterView,
+                    shouldPerformAction action: GroupDetailsFooterView.Action) {
         switch action {
         case .invite:
             let addParticipantsViewController = AddParticipantsViewController(conversation: conversation)
@@ -213,7 +214,9 @@ final class GroupDetailsViewController: UIViewController, ZMConversationObserver
             navigationController.modalPresentationStyle = .currentContext
             present(navigationController, animated: true)
         case .more:
-            actionController = ConversationActionController(conversation: conversation, target: self)
+            actionController = ConversationActionController(conversation: conversation,
+                                                            target: self,
+                                                            sourceView: view)
             actionController?.presentMenu(from: view, context: .details)
         }
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

App crashes after deleting conversations with context menu.
https://github.com/wireapp/wire-ios/issues/4504

### Causes

The confirm alert is not setting the popover source rect.

### Solutions
Config the popover alert with `configPopover` method. This PR also fix similar cases which create action alert popover with `ConversationActionController`.
