### PR TITLE
[Fix] Frozen frame after re-enabling video

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridViewController.swift
@@ -217,6 +217,7 @@ final class VideoGridViewController: UIViewController {
         let currentStreamsIds = configuration.allStreamIds
 
         for deletedStreamId in existingStreamsIds.subtracting(currentStreamsIds) {
+            viewCache[deletedStreamId]?.removeFromSuperview()
             viewCache.removeValue(forKey: deletedStreamId)
         }
     }


### PR DESCRIPTION
## What's new in this PR?

https://wearezeta.atlassian.net/browse/ZIOS-13689

### Issues

Self video freezes after toggling video off then on

### Causes

Instance A of `SelfVideoPreviewView` is deallocated after Instance B is added as subview of `GridCell`
Causing `stopCapture()` of A to be called after `startCapture()` of B
Since the capturer on avs side is the same instance, it causes the video capture to stop for B

### Solutions

Make sure to deallocate instance A before starting video capture on instance B

### Note

might need to change the base branch
