### PR TITLE
[Fix] name & mic view missing after video preview creation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/BaseVideoPreviewView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/BaseVideoPreviewView.swift
@@ -42,10 +42,17 @@ class BaseVideoPreviewView: UIView, AVSIdentifierProvider {
         }
     }
     
+    private var isCovered: Bool
+    
+    private var userDetailsAlpha: CGFloat {
+        return isCovered ? 0 : 1
+    }
+    
     let userDetailsView = VideoParticipantDetailsView()
     
-    init(stream: Stream) {
+    init(stream: Stream, isCovered: Bool) {
         self.stream = stream
+        self.isCovered = isCovered
         
         super.init(frame: .zero)
 
@@ -68,6 +75,7 @@ class BaseVideoPreviewView: UIView, AVSIdentifierProvider {
     func updateUserDetails() {
         userDetailsView.name = stream.participantName
         userDetailsView.microphoneIconStyle = MicrophoneIconStyle(state: stream.microphoneState)
+        userDetailsView.alpha = userDetailsAlpha
     }
     
     func setupViews() {
@@ -89,12 +97,13 @@ class BaseVideoPreviewView: UIView, AVSIdentifierProvider {
         guard let isCovered = notification?.userInfo?[VideoGridViewController.isCoveredKey] as? Bool else {
             return
         }
+        self.isCovered = isCovered
         UIView.animate(
             withDuration: 0.2,
             delay: 0,
             options: [.curveEaseInOut, .beginFromCurrentState],
             animations: {
-                self.userDetailsView.alpha = isCovered ? 0.0 : 1.0
+                self.userDetailsView.alpha = self.userDetailsAlpha
         })
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridViewController.swift
@@ -170,7 +170,7 @@ final class VideoGridViewController: UIViewController {
         if let view = viewCache[selfStreamId] as? SelfVideoPreviewView {
             view.stream = selfStream
         } else {
-            viewCache[selfStreamId] = SelfVideoPreviewView(stream: selfStream)
+            viewCache[selfStreamId] = SelfVideoPreviewView(stream: selfStream, isCovered: isCovered)
         }
     }
 
@@ -314,7 +314,7 @@ extension VideoGridViewController: UICollectionViewDataSource {
         if let streamView = viewCache[streamId] {
             return streamView
         } else {
-            let view = VideoPreviewView(stream: videoStream.stream)
+            let view = VideoPreviewView(stream: videoStream.stream, isCovered: isCovered)
             viewCache[streamId] = view
             return view
         }

--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoPreviewView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoPreviewView.swift
@@ -42,8 +42,9 @@ final class VideoPreviewView: BaseVideoPreviewView {
     private var userHasSetFillMode: Bool = false
     private var snapshotView: UIView?
     
-    override init(stream: Stream) {
-        super.init(stream: stream)
+    // MARK: - Initialization
+    override init(stream: Stream, isCovered: Bool) {
+        super.init(stream: stream, isCovered: isCovered)
         updateState()
     }
     


### PR DESCRIPTION
## What's new in this PR?

https://wearezeta.atlassian.net/browse/ZIOS-13707

### Issues

The name and microphone view is missing from the video tile when it appears in the grid.
It only shows up after being covered, then uncovered, by the call info overlay.

### Causes

The view's alpha is set to `0` during setup

### Solutions

The view's alpha should be set according to the visibility of the video grid
