### PR TITLE
Press keyboard return key to create passcode

### DIFF
--- a/Wire-iOS/Sources/Authentication/Interface/Views/AccessoryTextField.swift
+++ b/Wire-iOS/Sources/Authentication/Interface/Views/AccessoryTextField.swift
@@ -214,7 +214,7 @@ final class AccessoryTextField: UITextField, TextContainer, Themeable {
     }
 
     private func setupTextFieldProperties() {
-        self.returnKeyType = .next
+        returnKeyType = .next
 
         switch kind {
         case .email:
@@ -246,7 +246,7 @@ final class AccessoryTextField: UITextField, TextContainer, Themeable {
             isSecureTextEntry = true
             accessibilityIdentifier = "PasscodeField"
             autocapitalizationType = .none
-            returnKeyType = .done
+            returnKeyType = .default
             if #available(iOS 12, *) {
                 textContentType = .newPassword
                 passwordRules = textFieldValidator.passwordRules

--- a/Wire-iOS/Sources/Authentication/Interface/Views/AccessoryTextField.swift
+++ b/Wire-iOS/Sources/Authentication/Interface/Views/AccessoryTextField.swift
@@ -246,6 +246,7 @@ final class AccessoryTextField: UITextField, TextContainer, Themeable {
             isSecureTextEntry = true
             accessibilityIdentifier = "PasscodeField"
             autocapitalizationType = .none
+            returnKeyType = .done
             if #available(iOS 12, *) {
                 textContentType = .newPassword
                 passwordRules = textFieldValidator.passwordRules

--- a/Wire-iOS/Sources/UserInterface/Overlay/CustomAppLock/Setup/PasscodeSetupPresenter.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/CustomAppLock/Setup/PasscodeSetupPresenter.swift
@@ -21,6 +21,17 @@ final class PasscodeSetupPresenter {
     private weak var userInterface: PasscodeSetupUserInterface?
     private var interactorInput: PasscodeSetupInteractorInput
 
+    private var passcodeValidationResult: PasscodeValidationResult?
+    
+    var isPasscodeValid: Bool {
+        switch passcodeValidationResult {
+        case .accepted:
+            return true
+        default:
+            return false
+        }
+    }
+    
     convenience init(userInterface: PasscodeSetupUserInterface) {
         let interactor = PasscodeSetupInteractor()
         self.init(userInterface: userInterface, interactorInput: interactor)
@@ -57,6 +68,8 @@ extension PasscodeSetupPresenter: PasscodeSetupInteractorOutput {
     }
 
     func passcodeValidated(result: PasscodeValidationResult) {
+        passcodeValidationResult = result
+        
         switch result {
         case .accepted:
             userInterface?.createButtonEnabled = true

--- a/Wire-iOS/Sources/UserInterface/Overlay/CustomAppLock/Setup/PasscodeSetupViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/CustomAppLock/Setup/PasscodeSetupViewController.swift
@@ -51,6 +51,8 @@ final class PasscodeSetupViewController: UIViewController {
         textField.placeholder = "create_passcode.textfield.placeholder".localized
         textField.delegate = self
         
+        textField.addTarget(self, action: #selector(textFieldDidChange(textField:)), for: .editingChanged)
+        
         return textField
     }()
 
@@ -196,6 +198,12 @@ final class PasscodeSetupViewController: UIViewController {
         guard let passcode = passcodeTextField.text else { return }
         presenter.storePasscode(passcode: passcode, callback: callback)
         dismiss(animated: true)
+    }
+    
+    @objc
+    private func textFieldDidChange(textField: UITextField) {
+        passcodeTextField.returnKeyType = presenter.isPasscodeValid ? .done : .default
+        passcodeTextField.reloadInputViews()
     }
     
     @objc

--- a/Wire-iOS/Sources/UserInterface/Overlay/CustomAppLock/Setup/PasscodeSetupViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/CustomAppLock/Setup/PasscodeSetupViewController.swift
@@ -46,7 +46,6 @@ final class PasscodeSetupViewController: UIViewController {
     }()
 
     lazy var passcodeTextField: AccessoryTextField = {
-
         let textField = AccessoryTextField.createPasscodeTextField(kind: .passcode(isNew: true), delegate: self)
         textField.placeholder = "create_passcode.textfield.placeholder".localized
         textField.delegate = self

--- a/Wire-iOS/Sources/UserInterface/Overlay/CustomAppLock/Setup/PasscodeSetupViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/CustomAppLock/Setup/PasscodeSetupViewController.swift
@@ -49,7 +49,8 @@ final class PasscodeSetupViewController: UIViewController {
 
         let textField = AccessoryTextField.createPasscodeTextField(kind: .passcode(isNew: true), delegate: self)
         textField.placeholder = "create_passcode.textfield.placeholder".localized
-
+        textField.delegate = self
+        
         return textField
     }()
 
@@ -191,13 +192,30 @@ final class PasscodeSetupViewController: UIViewController {
         ])
     }
 
-    @objc
-    func onCreateCodeButtonPressed(sender: AnyObject?) {
+    private func storePasscode() {
         guard let passcode = passcodeTextField.text else { return }
         presenter.storePasscode(passcode: passcode, callback: callback)
         dismiss(animated: true)
     }
+    
+    @objc
+    private func onCreateCodeButtonPressed(sender: AnyObject?) {
+        storePasscode()
+    }
 
+}
+
+// MARK: - UITextFieldDelegate
+
+extension PasscodeSetupViewController: UITextFieldDelegate {
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        guard presenter.isPasscodeValid else {
+            return false
+        }
+        
+        storePasscode()
+        return true
+    }
 }
 
 // MARK: - AccessoryTextFieldDelegate


### PR DESCRIPTION
## What's new in this PR?

Allow the user to press the return key on the keyboard to create passcode.
When the passcode is valid, update the keyboard return key type to `done`