### PR TITLE
[Feature] Feature Flag: Share extension Enabled 

### DIFF
--- a/Wire-iOS Share Extension/Info.plist
+++ b/Wire-iOS Share Extension/Info.plist
@@ -29,7 +29,9 @@
 		<key>NSExtensionAttributes</key>
 		<dict>
 			<key>NSExtensionActivationRule</key>
-			<string>
+            <string>
+                ${SHARE_EXTENSION_ENABLED} == 1
+                AND (
                 SUBQUERY(extensionItems, $extensionItem, SUBQUERY($extensionItem.attachments, $attachment, ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.plain-text").@count &gt;= 1).@count &gt;= 1
                 
                 OR SUBQUERY(extensionItems, $extensionItem, SUBQUERY($extensionItem.attachments, $attachment, SUBQUERY($attachment.registeredTypeIdentifiers, $uti, $uti UTI-CONFORMS-TO "public.url").@count &gt;= 1).@count &gt;= 1).@count &gt;= 1
@@ -40,7 +42,7 @@
                 
                 OR SUBQUERY(extensionItems,$extensionItem,SUBQUERY($extensionItem.attachments,$attachment,ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.apple.pkpass").@count == $extensionItem.attachments.@count AND $extensionItem.attachments.@count &lt;= 1).@count == 1
                 
-                OR SUBQUERY(extensionItems,$extensionItem,SUBQUERY($extensionItem.attachments,$attachment,ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.content").@count == $extensionItem.attachments.@count AND $extensionItem.attachments.@count &lt;= 1).@count == 1
+                OR SUBQUERY(extensionItems,$extensionItem,SUBQUERY($extensionItem.attachments,$attachment,ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.content").@count == $extensionItem.attachments.@count AND $extensionItem.attachments.@count &lt;= 1).@count == 1)
             </string>
 		</dict>
 		<key>NSExtensionMainStoryboard</key>

--- a/Wire-iOS/Sources/Helpers/Bundle+SecurityFlags.swift
+++ b/Wire-iOS/Sources/Helpers/Bundle+SecurityFlags.swift
@@ -28,6 +28,7 @@ enum SecurityFlags {
     case forceConstantBitRateCalls
     case openFilePreview
     case customBackend
+    case shareExtension
     
     var bundleKey: String {
         switch self {
@@ -49,6 +50,8 @@ enum SecurityFlags {
             return "OpenFilePreviewEnabled"
         case .customBackend:
             return "CustomBackendEnabled"
+        case .shareExtension:
+            return "ShareExtensionEnabled"
         }
     }
     

--- a/Wire-iOS/Wire-Info.plist
+++ b/Wire-iOS/Wire-Info.plist
@@ -202,5 +202,7 @@
 	<string>${OPEN_FILE_PREVIEW_ENABLED}</string>
 	<key>CustomBackendEnabled</key>
 	<string>${CUSTOM_BACKEND_ENABLED}</string>
+	<key>ShareExtensionEnabled</key>
+	<string>${SHARE_EXTENSION_ENABLED}</string>
 </dict>
 </plist>


### PR DESCRIPTION

## What's new in this PR?

### Issues
Disable share extension for the client.

### Solutions
Modify `NSExtensionActivationRules` in the `Info.plist` to be able to enable/disable the Share extension.


### Dependencies

https://wearezeta.atlassian.net/browse/ZIOS-13529