### PR TITLE
[Fix] message banners not being shown when enabled

### DIFF
--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -494,7 +494,8 @@ extension AppRootViewController: ShowContentDelegate {
 extension AppRootViewController: ForegroundNotificationResponder {
     func shouldPresentNotification(with userInfo: NotificationUserInfo) -> Bool {
         // user wants to see fg notifications
-        guard false == Settings.shared[.chatHeadsDisabled] else {
+        let chatHeadsDisabled: Bool = Settings.shared[.chatHeadsDisabled] ?? false
+        guard !chatHeadsDisabled else {
             return false
         }
         


### PR DESCRIPTION
## What's new in this PR?

### Issues

Message banners are not shown inside the app.

### Causes

The guard statement is incorrectly assuming that the optional value for `.chatHeadsDisabled` will evaluate to `true` if the value is `nil`. 

### Solutions

Unwrap the optional value and explicitly declare the default value.