### PR TITLE
[Fix] Badge items on conversation message shows "Cut" and "Paste"

### DIFF
--- a/Wire-iOS Tests/ConversationMessageActionControllerTests.swift
+++ b/Wire-iOS Tests/ConversationMessageActionControllerTests.swift
@@ -110,5 +110,22 @@ final class ConversationMessageActionControllerTests: XCTestCase, CoreDataFixtur
         XCTAssertFalse(supportsReply)
 
     }
+    
+    // MARK: - Copy
+
+    func testThatItShowsCopyItemForTextMessage() {
+        // GIVEN
+         let message = MockMessageFactory.textMessage(withText: "Text")!
+        message.sender = otherUser
+        message.conversation = otherUserConversation
+        
+        
+        // WHEN
+        let actionController = ConversationMessageActionController(responder: nil, message: message, context: .content, view: UIView())
+        let supportsCopy = actionController.canPerformAction(#selector(ConversationMessageActionController.copyMessage))
+        
+        // THEN
+        XCTAssertTrue(supportsCopy)
+    }
 
 }

--- a/Wire-iOS/Sources/UserInterface/Components/Views/MarkdownTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/MarkdownTextView.swift
@@ -63,15 +63,15 @@ final class MarkdownTextView: NextResponderTextView {
     override func canPerformAction(_ action: Selector,
                                    withSender sender: Any?) -> Bool {
         switch action {
-        case #selector(UIResponderStandardEditActions.paste(_:)) where !SecurityFlags.clipboard.isEnabled,
-             #selector(UIResponderStandardEditActions.cut(_:)) where !SecurityFlags.clipboard.isEnabled,
-             #selector(UIResponderStandardEditActions.copy(_:)) where !SecurityFlags.clipboard.isEnabled:
-             return SecurityFlags.clipboard.isEnabled
+        case #selector(UIResponderStandardEditActions.paste(_:)),
+             #selector(UIResponderStandardEditActions.cut(_:)),
+             #selector(UIResponderStandardEditActions.copy(_:)):
+            guard SecurityFlags.clipboard.isEnabled else { return false }
+            fallthrough
         default:
             return super.canPerformAction(action, withSender: sender)
         }
     }
-    
     
     func setText(_ newText: String, withMentions mentions: [Mention]) {
         let mutable = NSMutableAttributedString(string: newText, attributes: currentAttributes)

--- a/Wire-iOS/Sources/UserInterface/Components/Views/MarkdownTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/MarkdownTextView.swift
@@ -63,9 +63,9 @@ final class MarkdownTextView: NextResponderTextView {
     override func canPerformAction(_ action: Selector,
                                    withSender sender: Any?) -> Bool {
         switch action {
-        case #selector(UIResponderStandardEditActions.paste(_:)),
-             #selector(UIResponderStandardEditActions.cut(_:)),
-             #selector(UIResponderStandardEditActions.copy(_:)):
+        case #selector(UIResponderStandardEditActions.paste(_:)) where !SecurityFlags.clipboard.isEnabled,
+             #selector(UIResponderStandardEditActions.cut(_:)) where !SecurityFlags.clipboard.isEnabled,
+             #selector(UIResponderStandardEditActions.copy(_:)) where !SecurityFlags.clipboard.isEnabled:
              return SecurityFlags.clipboard.isEnabled
         default:
             return super.canPerformAction(action, withSender: sender)


### PR DESCRIPTION
## What's new in this PR?

### Issues
Badge items on conversation message shows `"Cut"` and `"Paste"` actions.
**Actual result**
the badge items show:` Cut Copy Paste Copy Reply > Edit Delete Share Like`

**Expected result**
the badge items show: `Copy Reply Edit Delete Share Like`
### Solutions
To hide `"Cut", "Paste" and "Copy"` actions only if the SecurityFlags.clipboard is disabled.


### Dependencies

https://wearezeta.atlassian.net/browse/ZIOS-13695