### PR TITLE
[Feature]: Security Flag Photo Album Access

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Sketchpad/CanvasViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Sketchpad/CanvasViewController.swift
@@ -139,6 +139,7 @@ final class CanvasViewController: UIViewController, UINavigationControllerDelega
         photoButton.addTarget(self, action: #selector(pickImage), for: .touchUpInside)
         photoButton.hitAreaPadding = hitAreaPadding
         photoButton.accessibilityIdentifier = "photoButton"
+        photoButton.isHidden = !SecurityFlags.cameraRoll.isEnabled
         
         emojiButton.setIcon(.emoji, size: .tiny, for: .normal)
         emojiButton.addTarget(self, action: #selector(openEmojiKeyboard), for: .touchUpInside)


### PR DESCRIPTION
## What's new in this PR?

For BSI we won't to allow the user accessing to the camera roll or photo album. Currently from the sketch view is that possible tapping the button on the bottom left corner. Do avoid this we decided to hide that button
