### PR TITLE
Fix: show passcode setup screen when login or unlock

### DIFF
--- a/Wire-iOS Tests/AppLock/AppLockPresenterTests.swift
+++ b/Wire-iOS Tests/AppLock/AppLockPresenterTests.swift
@@ -34,6 +34,10 @@ private final class AppLockUserInterfaceMock: AppLockUserInterface {
         callback(passwordInput)
     }
     
+    func presentCreatePasscodeScreen(callback: ResultHandler?) {
+        // no-op
+    }
+    
     var spinnerAnimating: Bool?
     func setSpinner(animating: Bool) {
         spinnerAnimating = animating

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -721,6 +721,7 @@
 		A90E4AC12381E6D700468F31 /* UIControlState+ExpandState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A90E4AC02381E6D600468F31 /* UIControlState+ExpandState.swift */; };
 		A90E4AC42381EFCD00468F31 /* Button.swift in Sources */ = {isa = PBXBuildFile; fileRef = A90E4AC32381EFCD00468F31 /* Button.swift */; };
 		A90F3E08249B978400429BFE /* MessageActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A90F3E07249B978400429BFE /* MessageActionTests.swift */; };
+		A9148C6D24EC26AE003458E6 /* AppLock+PasscodeExistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9148C6C24EC26AE003458E6 /* AppLock+PasscodeExistence.swift */; };
 		A9150DB523D1B6B900844185 /* Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9150DB423D1B6B800844185 /* Analytics.swift */; };
 		A918330D241922EB00CBD0B7 /* TokenTextAttachmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A918330C241922EB00CBD0B7 /* TokenTextAttachmentTests.swift */; };
 		A918330F2419272E00CBD0B7 /* TokenSeparatorAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = A918330E2419272E00CBD0B7 /* TokenSeparatorAttachment.swift */; };
@@ -2358,6 +2359,7 @@
 		A90E4AC02381E6D600468F31 /* UIControlState+ExpandState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UIControlState+ExpandState.swift"; path = "Wire-iOS/UIControlState+ExpandState.swift"; sourceTree = SOURCE_ROOT; };
 		A90E4AC32381EFCD00468F31 /* Button.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Button.swift; sourceTree = "<group>"; };
 		A90F3E07249B978400429BFE /* MessageActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageActionTests.swift; sourceTree = "<group>"; };
+		A9148C6C24EC26AE003458E6 /* AppLock+PasscodeExistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppLock+PasscodeExistence.swift"; sourceTree = "<group>"; };
 		A9150DB423D1B6B800844185 /* Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Analytics.swift; sourceTree = "<group>"; };
 		A918330C241922EB00CBD0B7 /* TokenTextAttachmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenTextAttachmentTests.swift; sourceTree = "<group>"; };
 		A918330E2419272E00CBD0B7 /* TokenSeparatorAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenSeparatorAttachment.swift; sourceTree = "<group>"; };
@@ -5114,6 +5116,7 @@
 		8FC85126199245760008B66B /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				A9148C6B24EC2685003458E6 /* AppLock */,
 				EF39BD31233E41AA00F02DDB /* FileDirectory */,
 				CE8E4FB61DF17BBE0009F437 /* TextTransform */,
 				8F5A3E9919AE2C9E00D0E9DA /* sound */,
@@ -5537,6 +5540,14 @@
 				A90F3E07249B978400429BFE /* MessageActionTests.swift */,
 			);
 			path = ContextMenu;
+			sourceTree = "<group>";
+		};
+		A9148C6B24EC2685003458E6 /* AppLock */ = {
+			isa = PBXGroup;
+			children = (
+				A9148C6C24EC26AE003458E6 /* AppLock+PasscodeExistence.swift */,
+			);
+			path = AppLock;
 			sourceTree = "<group>";
 		};
 		A918330B241922D700CBD0B7 /* Token */ = {
@@ -8117,6 +8128,7 @@
 				879649002046EE5E00F46B4B /* BarController.swift in Sources */,
 				EEE81E9623E0521300A1D035 /* TopPeopleLineCollectionViewControllerDelegate.swift in Sources */,
 				1639A85D2265FC8800868AB9 /* UIAlertController+Availability.swift in Sources */,
+				A9148C6D24EC26AE003458E6 /* AppLock+PasscodeExistence.swift in Sources */,
 				BFE57B4B1D52335A00CB0806 /* ConversationPreviewViewController.swift in Sources */,
 				5E628021221ED0A60039A8AB /* ProfileActionsFactory.swift in Sources */,
 				D5677158202B496700308448 /* CreateGroupSection.swift in Sources */,

--- a/Wire-iOS/Sources/Authentication/AuthenticationFlowStep.swift
+++ b/Wire-iOS/Sources/Authentication/AuthenticationFlowStep.swift
@@ -85,22 +85,6 @@ indirect enum AuthenticationFlowStep: Equatable {
 
     // MARK: - Properties
 
-    /// Whether the step can be unwinded.
-//    var allowsUnwind: Bool {
-//        switch self {
-//        case .landingScreen: return false
-//        case .passcodeSetup:
-//            return false
-//        case .clientManagement: return false
-//        case .noHistory: return false
-//        case .addEmailAndPassword: return false
-//        case .incrementalUserCreation: return false
-//        case .teamCreation(let teamState): return teamState.allowsUnwind
-//        case .switchBackend: return false
-//        default: return true
-//        }
-//    }
-
     /// Whether the authentication steps generates a user interface.
     var needsInterface: Bool {
         switch self {

--- a/Wire-iOS/Sources/Authentication/AuthenticationFlowStep.swift
+++ b/Wire-iOS/Sources/Authentication/AuthenticationFlowStep.swift
@@ -87,19 +87,20 @@ indirect enum AuthenticationFlowStep: Equatable {
     // MARK: - Properties
 
     /// Whether the step can be unwinded.
-    var allowsUnwind: Bool {
-        switch self {
-        case .landingScreen: return false
-        case .passcodeSetup: return false
-        case .clientManagement: return false
-        case .noHistory: return false
-        case .addEmailAndPassword: return false
-        case .incrementalUserCreation: return false
-        case .teamCreation(let teamState): return teamState.allowsUnwind
-        case .switchBackend: return false
-        default: return true
-        }
-    }
+//    var allowsUnwind: Bool {
+//        switch self {
+//        case .landingScreen: return false
+//        case .passcodeSetup:
+//            return false
+//        case .clientManagement: return false
+//        case .noHistory: return false
+//        case .addEmailAndPassword: return false
+//        case .incrementalUserCreation: return false
+//        case .teamCreation(let teamState): return teamState.allowsUnwind
+//        case .switchBackend: return false
+//        default: return true
+//        }
+//    }
 
     /// Whether the authentication steps generates a user interface.
     var needsInterface: Bool {

--- a/Wire-iOS/Sources/Authentication/AuthenticationFlowStep.swift
+++ b/Wire-iOS/Sources/Authentication/AuthenticationFlowStep.swift
@@ -17,7 +17,6 @@
 //
 
 import Foundation
-import WireDataModel
 import WireSyncEngine
 
 /**

--- a/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
+++ b/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
@@ -335,8 +335,6 @@ extension AuthenticationCoordinator: AuthenticationActioner, SessionManagerCreat
 
             case .addEmailAndPassword(let newCredentials):
                 setEmailCredentialsForCurrentUser(newCredentials)
-            case .startPasscodeSetup:
-                startPasscodeSetup()
             }
         }
     }
@@ -525,12 +523,6 @@ extension AuthenticationCoordinator {
         presenter?.isLoadingViewVisible = true
         stateController.transition(to: .activateCredentials(credentials, user: user, code: code))
         registrationStatus.checkActivationCode(credentials: credentials, code: code)
-    }
-
-    // MARK: - passcode
-
-    private func startPasscodeSetup() {
-        stateController.transition(to: .passcodeSetup)
     }
 
     // MARK: - Linear Registration

--- a/Wire-iOS/Sources/Authentication/Event Handlers/AuthenticationCoordinatorAction.swift
+++ b/Wire-iOS/Sources/Authentication/Event Handlers/AuthenticationCoordinatorAction.swift
@@ -32,7 +32,6 @@ enum AuthenticationCoordinatorAction {
     case presentAlert(AuthenticationCoordinatorAlert)
     case presentErrorAlert(AuthenticationCoordinatorErrorAlert)
     case completeBackupStep
-    case startPasscodeSetup
     case completeLoginFlow
     case completeRegistrationFlow
     case startPostLoginFlow

--- a/Wire-iOS/Sources/Authentication/Event Handlers/Initial Sync/AuthenticationInitialSyncEventHandler.swift
+++ b/Wire-iOS/Sources/Authentication/Event Handlers/Initial Sync/AuthenticationInitialSyncEventHandler.swift
@@ -63,10 +63,3 @@ final class AuthenticationInitialSyncEventHandler: NSObject, AuthenticationEvent
     }
 
 }
-
-extension AppLock {
-    static var isCustomPassCodeNotSet: Bool {
-        return AppLock.rules.useCustomCodeInsteadOfAccountPassword &&
-            Keychain.fetchPasscode() == nil
-    }
-}

--- a/Wire-iOS/Sources/Authentication/Event Handlers/Initial Sync/AuthenticationInitialSyncEventHandler.swift
+++ b/Wire-iOS/Sources/Authentication/Event Handlers/Initial Sync/AuthenticationInitialSyncEventHandler.swift
@@ -53,9 +53,8 @@ final class AuthenticationInitialSyncEventHandler: NSObject, AuthenticationEvent
             if AppLock.rules.useCustomCodeInsteadOfAccountPassword &&
                Keychain.fetchPasscode() == nil &&
                (AppLock.rules.forceAppLock ||
-                AppLock.isActive)
-                {
-                actions.append(.startPasscodeSetup)
+                AppLock.isActive) {
+                actions.append(.transition(.passcodeSetup, mode: .reset))
             } else {
                 actions.append(postAction)
             }

--- a/Wire-iOS/Sources/Authentication/Event Handlers/Initial Sync/AuthenticationInitialSyncEventHandler.swift
+++ b/Wire-iOS/Sources/Authentication/Event Handlers/Initial Sync/AuthenticationInitialSyncEventHandler.swift
@@ -50,7 +50,7 @@ final class AuthenticationInitialSyncEventHandler: NSObject, AuthenticationEvent
             actions.append(.transition(nextStep, mode: .reset))
         } else {
             // append passcode step if new registered or first time login but passcode is not store.(Upgrade from pervious version)
-            if AppLock.isCustomPassCodeNotSet &&
+            if AppLock.isCustomPasscodeNotSet &&
                (AppLock.rules.forceAppLock ||
                 AppLock.isActive) {
                 actions.append(.transition(.passcodeSetup, mode: .reset))

--- a/Wire-iOS/Sources/Authentication/Event Handlers/Initial Sync/AuthenticationInitialSyncEventHandler.swift
+++ b/Wire-iOS/Sources/Authentication/Event Handlers/Initial Sync/AuthenticationInitialSyncEventHandler.swift
@@ -50,8 +50,7 @@ final class AuthenticationInitialSyncEventHandler: NSObject, AuthenticationEvent
             actions.append(.transition(nextStep, mode: .reset))
         } else {
             // append passcode step if new registered or first time login but passcode is not store.(Upgrade from pervious version)
-            if AppLock.rules.useCustomCodeInsteadOfAccountPassword &&
-               Keychain.fetchPasscode() == nil &&
+            if AppLock.isCustomPassCodeNotSet &&
                (AppLock.rules.forceAppLock ||
                 AppLock.isActive) {
                 actions.append(.transition(.passcodeSetup, mode: .reset))
@@ -63,4 +62,11 @@ final class AuthenticationInitialSyncEventHandler: NSObject, AuthenticationEvent
         return actions
     }
 
+}
+
+extension AppLock {
+    static var isCustomPassCodeNotSet: Bool {
+        return AppLock.rules.useCustomCodeInsteadOfAccountPassword &&
+            Keychain.fetchPasscode() == nil
+    }
 }

--- a/Wire-iOS/Sources/Authentication/Event Handlers/Initial Sync/AuthenticationInitialSyncEventHandler.swift
+++ b/Wire-iOS/Sources/Authentication/Event Handlers/Initial Sync/AuthenticationInitialSyncEventHandler.swift
@@ -51,8 +51,10 @@ final class AuthenticationInitialSyncEventHandler: NSObject, AuthenticationEvent
         } else {
             // append passcode step if new registered or first time login but passcode is not store.(Upgrade from pervious version)
             if AppLock.rules.useCustomCodeInsteadOfAccountPassword &&
-               AppLock.isActive &&
-               Keychain.fetchPasscode() == nil {
+               Keychain.fetchPasscode() == nil &&
+               (AppLock.rules.forceAppLock ||
+                AppLock.isActive)
+                {
                 actions.append(.startPasscodeSetup)
             } else {
                 actions.append(postAction)

--- a/Wire-iOS/Sources/Authentication/Interface/Views/AccessoryTextField.swift
+++ b/Wire-iOS/Sources/Authentication/Interface/Views/AccessoryTextField.swift
@@ -242,11 +242,11 @@ final class AccessoryTextField: UITextField, TextContainer, Themeable {
         case .unknown:
             keyboardType = .asciiCapable
             textContentType = nil
-        case .passcode:
+        case .passcode(let isNew):
             isSecureTextEntry = true
             accessibilityIdentifier = "PasscodeField"
             autocapitalizationType = .none
-            returnKeyType = .default
+            returnKeyType = isNew ? .default : .continue
             if #available(iOS 12, *) {
                 textContentType = .newPassword
                 passwordRules = textFieldValidator.passwordRules

--- a/Wire-iOS/Sources/Authentication/TeamCreationState.swift
+++ b/Wire-iOS/Sources/Authentication/TeamCreationState.swift
@@ -44,15 +44,6 @@ enum TeamCreationState: Equatable {
         default: return true
         }
     }
-
-    /// Whether it's possible to exit this step and .
-//    var allowsUnwind: Bool {
-//        switch self {
-//        case .setFullName: return false
-//        case .inviteMembers: return false
-//        default: return true
-//        }
-//    }
 }
 
 // MARK: - State transitions

--- a/Wire-iOS/Sources/Authentication/TeamCreationState.swift
+++ b/Wire-iOS/Sources/Authentication/TeamCreationState.swift
@@ -46,13 +46,13 @@ enum TeamCreationState: Equatable {
     }
 
     /// Whether it's possible to exit this step and .
-    var allowsUnwind: Bool {
-        switch self {
-        case .setFullName: return false
-        case .inviteMembers: return false
-        default: return true
-        }
-    }
+//    var allowsUnwind: Bool {
+//        switch self {
+//        case .setFullName: return false
+//        case .inviteMembers: return false
+//        default: return true
+//        }
+//    }
 }
 
 // MARK: - State transitions

--- a/Wire-iOS/Sources/Helpers/AppLock/AppLock+PasscodeExistence.swift
+++ b/Wire-iOS/Sources/Helpers/AppLock/AppLock+PasscodeExistence.swift
@@ -21,7 +21,7 @@ import WireCommonComponents
 import WireUtilities
 
 extension AppLock {
-    static var isCustomPassCodeNotSet: Bool {
+    static var isCustomPasscodeNotSet: Bool {
         return AppLock.rules.useCustomCodeInsteadOfAccountPassword &&
                Keychain.fetchPasscode() == nil
     }

--- a/Wire-iOS/Sources/Helpers/AppLock/AppLock+PasscodeExistence.swift
+++ b/Wire-iOS/Sources/Helpers/AppLock/AppLock+PasscodeExistence.swift
@@ -1,0 +1,28 @@
+
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireCommonComponents
+import WireUtilities
+
+extension AppLock {
+    static var isCustomPassCodeNotSet: Bool {
+        return AppLock.rules.useCustomCodeInsteadOfAccountPassword &&
+               Keychain.fetchPasscode() == nil
+    }
+}

--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockPresenter.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockPresenter.swift
@@ -37,7 +37,7 @@ protocol AppLockUserInterface: class {
     
     
     /// Present create passcode screen (when the user first time use the app after updating from a version not support passcode)
-    func presentCreatePasscodeScreen()
+    func presentCreatePasscodeScreen(callback: ResultHandler?)
     
     func setSpinner(animating: Bool)
     func setContents(dimmed: Bool)
@@ -156,8 +156,11 @@ extension AppLockPresenter: AppLockInteractorOutput {
 
         if case .needAccountPassword = result {
             // When upgrade form a version not support custom passcode, ask the user to create a new passcode
+            //        Keychain.deletePasscode()
             if AppLock.isCustomPassCodeNotSet {
-                userInterface?.presentCreatePasscodeScreen()
+                userInterface?.presentCreatePasscodeScreen(callback: { _ in
+                    self.setContents(dimmed: true, withReauth: true)
+                })
             } else {
                 requestAccountPassword(with: AuthenticationMessageKey.accountPassword)
             }
@@ -171,7 +174,7 @@ extension AppLockPresenter: AppLockInteractorOutput {
     func passwordVerified(with result: VerifyPasswordResult?) {
         userInterface?.setSpinner(animating: false)
         guard let result = result else {
-            self.setContents(dimmed: true, withReauth: true)
+            setContents(dimmed: true, withReauth: true)
             return
         }
         let authNeeded = appLockInteractorInput.isAuthenticationNeeded

--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockPresenter.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockPresenter.swift
@@ -156,9 +156,9 @@ extension AppLockPresenter: AppLockInteractorOutput {
 
         if case .needAccountPassword = result {
             // When upgrade form a version not support custom passcode, ask the user to create a new passcode
-            //        Keychain.deletePasscode()
             if AppLock.isCustomPassCodeNotSet {
                 userInterface?.presentCreatePasscodeScreen(callback: { _ in
+                    // user need to enter the newly created passcode after creation
                     self.setContents(dimmed: true, withReauth: true)
                 })
             } else {

--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockPresenter.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockPresenter.swift
@@ -156,7 +156,7 @@ extension AppLockPresenter: AppLockInteractorOutput {
 
         if case .needAccountPassword = result {
             // When upgrade form a version not support custom passcode, ask the user to create a new passcode
-            if AppLock.isCustomPassCodeNotSet {
+            if AppLock.isCustomPasscodeNotSet {
                 userInterface?.presentCreatePasscodeScreen(callback: { _ in
                     // user need to enter the newly created passcode after creation
                     self.setContents(dimmed: true, withReauth: true)

--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
@@ -137,9 +137,9 @@ extension AppLockViewController: AppLockUserInterface {
         }
     }
     
-    func presentCreatePasscodeScreen() {
-        let passcodeSetupViewController = PasscodeSetupViewController(callback: nil, //TODO: callback,
-            variant: .dark)
+    func presentCreatePasscodeScreen(callback: ResultHandler?) {
+        let passcodeSetupViewController = PasscodeSetupViewController(callback: callback,
+                                                                      variant: .dark)
         
         let keyboardAvoidingViewController = KeyboardAvoidingViewController(viewController: passcodeSetupViewController)
         

--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockViewController.swift
@@ -136,6 +136,17 @@ extension AppLockViewController: AppLockUserInterface {
             presentRequestPasswordController(message: message, callback: callback)
         }
     }
+    
+    func presentCreatePasscodeScreen() {
+        let passcodeSetupViewController = PasscodeSetupViewController(callback: nil, //TODO: callback,
+            variant: .dark)
+        
+        let keyboardAvoidingViewController = KeyboardAvoidingViewController(viewController: passcodeSetupViewController)
+        
+        keyboardAvoidingViewController.modalPresentationStyle = .fullScreen
+        
+        present(keyboardAvoidingViewController, animated: false)
+    }
 
     func setSpinner(animating: Bool) {
         if animating {

--- a/Wire-iOS/Sources/UserInterface/Overlay/CustomAppLock/Unlock/UnlockViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/CustomAppLock/Unlock/UnlockViewController.swift
@@ -58,6 +58,7 @@ final class UnlockViewController: UIViewController {
     lazy var accessoryTextField: AccessoryTextField = {
         let textField = AccessoryTextField.createPasscodeTextField(kind: .passcode(isNew: false), delegate: self)
         textField.placeholder = "unlock.textfield.placeholder".localized
+        textField.delegate = self
 
         return textField
     }()
@@ -189,11 +190,17 @@ final class UnlockViewController: UIViewController {
         navigationController?.pushViewController(WipeDatabaseViewController(), animated: true)
     }
 
+    @discardableResult
+    private func unlock() -> Bool {
+        guard let passcode = accessoryTextField.text else { return false }
+        
+        presenter.unlock(passcode: passcode, callback: callback)
+        return true
+    }
+    
     @objc
     private func onUnlockButtonPressed(sender: AnyObject?) {
-        guard let passcode = accessoryTextField.text else { return }
-
-        presenter.unlock(passcode: passcode, callback: callback)
+        unlock()
     }
     
     func showWrongPasscodeMessage() {
@@ -222,5 +229,13 @@ extension UnlockViewController: TextFieldValidationDelegate {
     func validationUpdated(sender: UITextField, error: TextFieldValidator.ValidationError?) {
         unlockButton.isEnabled = error == nil
         errorLabel.text = " "
+    }
+}
+
+// MARK: - UITextFieldDelegate
+
+extension UnlockViewController: UITextFieldDelegate {
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        return unlock()
     }
 }


### PR DESCRIPTION
## What's new in this PR?

Clean up unused `allowsUnwind`.
Fix the back button is shown on passcode screen issue by changing the action to `.transition(.passcodeSetup, mode: .reset)`
Unlock screen - support tap keyboard return button to unlock

Tested cases:

When force app lock is true:
- registration on new device - show set up passcode screen
- login second acct on the same device - set up passcode screen not shown
- logout second acct - unlock screen is shown
- logout first acct - unlock screen is not shown
- login second acct on the again same device- set up passcode screen not shown (since passcode is still stored )
- (When the user upgrade from a version not support custom passcode) start the app after upgrade - show set up passcode screen, when the code is created, show the unlock screen

When force app lock is false:
- login with an acct - set up passcode screen not shown
- go to setting -> enable app lock - show set up passcode screen
- register a new acct - set up passcode screen not shown

