### PR TITLE
Fix: iOS 10 app crash when MediaPlayerController is deinit

### DIFF
--- a/Wire-iOS/Sources/Components/AudioPlayer/MediaPlayerController.swift
+++ b/Wire-iOS/Sources/Components/AudioPlayer/MediaPlayerController.swift
@@ -42,7 +42,7 @@ final class MediaPlayerController: NSObject {
             self?.playerRateChanged()
         }
     }
-    
+
     deinit {
         playerRateObserver.invalidate()
     }

--- a/Wire-iOS/Sources/Components/AudioPlayer/MediaPlayerController.swift
+++ b/Wire-iOS/Sources/Components/AudioPlayer/MediaPlayerController.swift
@@ -25,20 +25,26 @@ import WireDataModel
 final class MediaPlayerController: NSObject {
 
     let message: ZMConversationMessage
-    var player: AVPlayer?
+    private let player: AVPlayer
     weak var delegate: MediaPlayerDelegate?
     fileprivate var playerRateObserver: NSKeyValueObservation!
 
-    init(player: AVPlayer, message: ZMConversationMessage, delegate: MediaPlayerDelegate) {
+    init(player: AVPlayer,
+         message: ZMConversationMessage,
+         delegate: MediaPlayerDelegate) {
         self.player = player
         self.message = message
         self.delegate = delegate
 
         super.init()
 
-        playerRateObserver = player.observe(\AVPlayer.rate) { [weak self] _, _ in
+        playerRateObserver = self.player.observe(\AVPlayer.rate) { [weak self] _, _ in
             self?.playerRateChanged()
         }
+    }
+    
+    deinit {
+        playerRateObserver.invalidate()
     }
 
     func tearDown() {
@@ -46,7 +52,7 @@ final class MediaPlayerController: NSObject {
     }
 
     private func playerRateChanged() {
-        if player?.rate > 0 {
+        if player.rate > 0 {
             delegate?.mediaPlayer(self, didChangeTo: MediaPlayerState.playing)
         } else {
             delegate?.mediaPlayer(self, didChangeTo: MediaPlayerState.paused)
@@ -65,7 +71,7 @@ extension MediaPlayerController: MediaPlayer {
     }
 
     var state: MediaPlayerState? {
-        if player?.rate > 0 {
+        if player.rate > 0 {
             return MediaPlayerState.playing
         } else {
             return MediaPlayerState.paused
@@ -73,14 +79,14 @@ extension MediaPlayerController: MediaPlayer {
     }
 
     func play() {
-        player?.play()
+        player.play()
     }
 
     func stop() {
-        player?.pause()
+        player.pause()
     }
 
     func pause() {
-        player?.pause()
+        player.pause()
     }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues
On iOS 10 devices, app crash for `An instance 0xxxx of class AVPlayer was deallocated while key value observers were still registered with it.`

### Causes

missing calling `invalidate` of the `NSKeyValueObservation`

### Solutions

Call `invalidate` in `deinit`