### PR TITLE
Fix: disable emoji input when the passcode is revealed

### DIFF
--- a/Wire-iOS/Sources/Authentication/Interface/Views/AccessoryTextField.swift
+++ b/Wire-iOS/Sources/Authentication/Interface/Views/AccessoryTextField.swift
@@ -243,6 +243,7 @@ final class AccessoryTextField: UITextField, TextContainer, Themeable {
             keyboardType = .asciiCapable
             textContentType = nil
         case .passcode(let isNew):
+            keyboardType = .asciiCapable
             isSecureTextEntry = true
             accessibilityIdentifier = "PasscodeField"
             autocapitalizationType = .none


### PR DESCRIPTION
## What's new in this PR?

Set the keyboard type to `.asciiCapable` to prevent the user input a emoji to the passcode field