### PR TITLE
Fix: SearchResultsViewController leaks after search screen is dismissed

### DIFF
--- a/Wire-iOS Tests/Search/SearchResultsViewControllerTests.swift
+++ b/Wire-iOS Tests/Search/SearchResultsViewControllerTests.swift
@@ -1,0 +1,40 @@
+
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+@testable import Wire
+
+final class SearchResultsViewControllerTests: XCTestCase {
+    weak var sut: SearchResultsViewController!
+    
+    func testThatSearchResultsViewControllerIsNotRetained() {
+        autoreleasepool {
+            // GIVEN
+            var searchResultsViewController: SearchResultsViewController! = SearchResultsViewController(userSelection: UserSelection(), isAddingParticipants: false, shouldIncludeGuests: true)
+            sut = searchResultsViewController
+            
+            // WHEN
+            searchResultsViewController.viewDidLoad()
+            
+            searchResultsViewController = nil
+        }
+        
+        // THEN
+        XCTAssertNil(sut)
+    }
+}

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -732,6 +732,7 @@
 		A9275F5F24221AD6007CB2BC /* TextTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9275F5E24221AD6007CB2BC /* TextTransform.swift */; };
 		A9275F6124223AB4007CB2BC /* DynamicsProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9275F6024223AB4007CB2BC /* DynamicsProxy.swift */; };
 		A9275F6324223FD3007CB2BC /* CGSize+Zoom.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9275F6224223FD2007CB2BC /* CGSize+Zoom.swift */; };
+		A92C443224EE9805006A4AB3 /* SearchResultsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A92C443124EE9805006A4AB3 /* SearchResultsViewControllerTests.swift */; };
 		A92CA24924323E2600A29896 /* Spinner.swift in Sources */ = {isa = PBXBuildFile; fileRef = A92CA24824323E2600A29896 /* Spinner.swift */; };
 		A92CB35723CDF6D100F12797 /* ConversationContentViewControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A92CB35623CDF6D100F12797 /* ConversationContentViewControllerDelegate.swift */; };
 		A92CB35923CDF97800F12797 /* ConversationViewController+ConversationContentViewControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A92CB35823CDF97800F12797 /* ConversationViewController+ConversationContentViewControllerDelegate.swift */; };
@@ -2343,6 +2344,7 @@
 		A9275F5E24221AD6007CB2BC /* TextTransform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextTransform.swift; sourceTree = "<group>"; };
 		A9275F6024223AB4007CB2BC /* DynamicsProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicsProxy.swift; sourceTree = "<group>"; };
 		A9275F6224223FD2007CB2BC /* CGSize+Zoom.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CGSize+Zoom.swift"; sourceTree = "<group>"; };
+		A92C443124EE9805006A4AB3 /* SearchResultsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultsViewControllerTests.swift; sourceTree = "<group>"; };
 		A92CA24824323E2600A29896 /* Spinner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Spinner.swift; sourceTree = "<group>"; };
 		A92CB35623CDF6D100F12797 /* ConversationContentViewControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationContentViewControllerDelegate.swift; sourceTree = "<group>"; };
 		A92CB35823CDF97800F12797 /* ConversationViewController+ConversationContentViewControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationViewController+ConversationContentViewControllerDelegate.swift"; sourceTree = "<group>"; };
@@ -5496,6 +5498,14 @@
 			path = ZipFile;
 			sourceTree = "<group>";
 		};
+		A92C443024EE97D6006A4AB3 /* Search */ = {
+			isa = PBXGroup;
+			children = (
+				A92C443124EE9805006A4AB3 /* SearchResultsViewControllerTests.swift */,
+			);
+			path = Search;
+			sourceTree = "<group>";
+		};
 		A93E6102233B870200CEA65F /* SectionHeader */ = {
 			isa = PBXGroup;
 			children = (
@@ -5575,6 +5585,7 @@
 		BACB88521AF7C48900DDCDB0 /* Wire-iOS Tests */ = {
 			isa = PBXGroup;
 			children = (
+				A92C443024EE97D6006A4AB3 /* Search */,
 				A90F3E06249B976200429BFE /* ContextMenu */,
 				A923F1C32428C562003F361F /* ZipFile */,
 				A918330B241922D700CBD0B7 /* Token */,
@@ -8277,6 +8288,7 @@
 				EF2A8DE9214A8B38002C9058 /* MockUser+Service.swift in Sources */,
 				8787BDD91BF374420096B1B5 /* SettingsPropertyTests.swift in Sources */,
 				EF1D80DD22275F8F00BCA8D3 /* MockUser+MockUserArray.swift in Sources */,
+				A92C443224EE9805006A4AB3 /* SearchResultsViewControllerTests.swift in Sources */,
 				D5943440203DCECA006AA0C0 /* ConversationOptionsViewControllerTests.swift in Sources */,
 				EF05948422DF07240079B8E1 /* XCTestCase+AccentColor.swift in Sources */,
 				EF17B0D0223A6692006252A8 /* MediaPreviewViewSnapshotTests.swift in Sources */,

--- a/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
@@ -233,9 +233,9 @@ final class AddParticipantsViewController: UIViewController {
         addChild(searchResultsViewController)
         view.addSubview(searchResultsViewController.view)
         searchResultsViewController.didMove(toParent: self)
-        searchResultsViewController.searchResultsView?.emptyResultView = emptyResultView
-        searchResultsViewController.searchResultsView?.backgroundColor = UIColor.from(scheme: .contentBackground, variant: self.variant)
-        searchResultsViewController.searchResultsView?.collectionView.accessibilityIdentifier = "add_participants.list"
+        searchResultsViewController.searchResultsView.emptyResultView = emptyResultView
+        searchResultsViewController.searchResultsView.backgroundColor = UIColor.from(scheme: .contentBackground, variant: self.variant)
+        searchResultsViewController.searchResultsView.collectionView.accessibilityIdentifier = "add_participants.list"
         
         view.backgroundColor = UIColor.from(scheme: .contentBackground, variant: self.variant)
         view.addSubview(confirmButton)
@@ -302,7 +302,7 @@ final class AddParticipantsViewController: UIViewController {
         // Update confirm button visibility & collection view content inset
         confirmButton.isHidden = userSelection.users.isEmpty || !viewModel.showsConfirmButton
         let bottomInset = confirmButton.isHidden ? bottomMargin : confirmButtonHeight + 16 + bottomMargin
-        searchResultsViewController.searchResultsView?.collectionView.contentInset.bottom = bottomInset
+        searchResultsViewController.searchResultsView.collectionView.contentInset.bottom = bottomInset
         
         updateTitle()
         

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/Contacts/ContactsSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/Contacts/ContactsSectionController.swift
@@ -28,7 +28,7 @@ class ContactsSectionController : SearchSectionController {
         }
     }
     var allowsSelection: Bool = false
-    weak var delegate: SearchSectionControllerDelegate? = nil
+    weak var delegate: SearchSectionControllerDelegate?
     weak var collectionView: UICollectionView? = nil
     
     deinit {

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/GroupConversations/GroupConversationSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/GroupConversations/GroupConversationSectionController.swift
@@ -24,7 +24,7 @@ final class GroupConversationsSectionController: SearchSectionController {
     
     var groupConversations: [ZMConversation] = []
     var title: String = ""
-    weak var delegate: SearchSectionControllerDelegate? = nil
+    weak var delegate: SearchSectionControllerDelegate?
     
     override var isHidden: Bool {
         return groupConversations.isEmpty

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/InviteTeamMember/InviteTeamMemberSection.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/InviteTeamMember/InviteTeamMemberSection.swift
@@ -24,7 +24,7 @@ protocol InviteTeamMemberSectionDelegate: class {
     func inviteSectionDidRequestTeamManagement()
 }
 
-class InviteTeamMemberSection: NSObject, CollectionViewSectionController {
+final class InviteTeamMemberSection: NSObject, CollectionViewSectionController {
     
     var team: Team?
     weak var delegate: InviteTeamMemberSectionDelegate?

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/Services/SearchServicesSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/Services/SearchServicesSectionController.swift
@@ -25,9 +25,9 @@ protocol SearchServicesSectionDelegate: SearchSectionControllerDelegate {
     func addServicesSectionDidRequestOpenServicesAdmin()
 }
 
-class SearchServicesSectionController: SearchSectionController {
+final class SearchServicesSectionController: SearchSectionController {
     
-    var delegate: SearchServicesSectionDelegate? = nil
+    weak var delegate: SearchServicesSectionDelegate? = nil
 
     var services: [ServiceUser] = []
 

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/Suggestions/DirectorySectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/Suggestions/DirectorySectionController.swift
@@ -21,10 +21,10 @@ import WireDataModel
 import UIKit
 import WireSyncEngine
 
-class DirectorySectionController: SearchSectionController {
+final class DirectorySectionController: SearchSectionController {
     
     var suggestions: [ZMSearchUser] = []
-    var delegate: SearchSectionControllerDelegate? = nil
+    weak var delegate: SearchSectionControllerDelegate?
     var token: AnyObject? = nil
     weak var collectionView: UICollectionView? = nil
     

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/TopPeopleLine/TopPeopleLineCollectionViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/TopPeopleLine/TopPeopleLineCollectionViewController.swift
@@ -19,7 +19,7 @@
 import Foundation
 import WireDataModel
 
-class TopPeopleLineCollectionViewController: NSObject {
+final class TopPeopleLineCollectionViewController: NSObject {
 
     var topPeople = [ZMConversation]()
 

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/TopPeopleLine/TopPeopleSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/TopPeopleLine/TopPeopleSectionController.swift
@@ -19,13 +19,13 @@
 import Foundation
 import WireSyncEngine
 
-final class TopPeopleSectionController : SearchSectionController {
+final class TopPeopleSectionController: SearchSectionController {
 
     fileprivate var innerCollectionView: UICollectionView!
     fileprivate let innerCollectionViewController = TopPeopleLineCollectionViewController()
     fileprivate let topConversationsDirectory: TopConversationsDirectory!
-    var token : Any? = nil
-    weak var delegate : SearchSectionControllerDelegate?
+    var token: Any?
+    weak var delegate: SearchSectionControllerDelegate?
 
     init(topConversationsDirectory: TopConversationsDirectory!) {
         self.topConversationsDirectory = topConversationsDirectory

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/TopPeopleLine/TopPeopleSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/TopPeopleLine/TopPeopleSectionController.swift
@@ -25,7 +25,7 @@ final class TopPeopleSectionController : SearchSectionController {
     fileprivate let innerCollectionViewController = TopPeopleLineCollectionViewController()
     fileprivate let topConversationsDirectory: TopConversationsDirectory!
     var token : Any? = nil
-    weak var delegate : SearchSectionControllerDelegate? = nil
+    weak var delegate : SearchSectionControllerDelegate?
 
     init(topConversationsDirectory: TopConversationsDirectory!) {
         self.topConversationsDirectory = topConversationsDirectory

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/TopPeopleLine/TopPeopleSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/TopPeopleLine/TopPeopleSectionController.swift
@@ -17,10 +17,9 @@
 //
 
 import Foundation
-import WireDataModel
 import WireSyncEngine
 
-class TopPeopleSectionController : SearchSectionController {
+final class TopPeopleSectionController : SearchSectionController {
 
     fileprivate var innerCollectionView: UICollectionView!
     fileprivate let innerCollectionViewController = TopPeopleLineCollectionViewController()

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
@@ -137,7 +137,14 @@ final class SearchResultsViewController: UIViewController {
     }()
     
 
-    var searchDirectory: SearchDirectory!
+    private lazy var searchDirectory: SearchDirectory! = {
+        guard let session = ZMUserSession.shared() else {
+            return nil
+        }
+        
+        return SearchDirectory(userSession: session)
+    }()
+    
     let userSelection: UserSelection
 
     let sectionController: SectionCollectionViewController
@@ -145,7 +152,16 @@ final class SearchResultsViewController: UIViewController {
     let teamMemberAndContactsSection: ContactsSectionController
     let directorySection = DirectorySectionController()
     let conversationsSection: GroupConversationsSectionController
-    let topPeopleSection: TopPeopleSectionController
+    
+    lazy var topPeopleSection: TopPeopleSectionController = {
+        if let session = ZMUserSession.shared() {
+            return TopPeopleSectionController(topConversationsDirectory: session.topConversationsDirectory)
+        } else {
+            return TopPeopleSectionController(topConversationsDirectory:nil)
+        }
+
+    }()
+    
     let servicesSection: SearchServicesSectionController
     let inviteTeamMemberSection: InviteTeamMemberSection
     let createGroupSection = CreateGroupSection()
@@ -194,12 +210,6 @@ final class SearchResultsViewController: UIViewController {
         servicesSection = SearchServicesSectionController(canSelfUserManageTeam: ZMUser.selfUser().canManageTeam)
         conversationsSection = GroupConversationsSectionController()
         conversationsSection.title = team != nil ? "peoplepicker.header.team_conversations".localized(args: teamName ?? "") : "peoplepicker.header.conversations".localized
-        if let session = ZMUserSession.shared() {
-            searchDirectory = SearchDirectory(userSession: session)
-            topPeopleSection = TopPeopleSectionController(topConversationsDirectory: session.topConversationsDirectory)
-        } else {
-            topPeopleSection = TopPeopleSectionController(topConversationsDirectory:nil)
-        }
         inviteTeamMemberSection = InviteTeamMemberSection(team: team)
 
         super.init(nibName: nil, bundle: nil)

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
@@ -19,7 +19,6 @@
 import Foundation
 import WireSyncEngine
 import UIKit
-import WireDataModel
 
 enum SearchGroup: Int {
     case people
@@ -180,7 +179,9 @@ final class SearchResultsViewController: UIViewController {
         searchDirectory?.tearDown()
     }
 
-    init(userSelection: UserSelection, isAddingParticipants: Bool = false, shouldIncludeGuests: Bool) {
+    init(userSelection: UserSelection,
+         isAddingParticipants: Bool = false,
+         shouldIncludeGuests: Bool) {
         self.userSelection = userSelection
         self.isAddingParticipants = isAddingParticipants
         self.mode = .list
@@ -211,6 +212,7 @@ final class SearchResultsViewController: UIViewController {
         inviteTeamMemberSection.delegate = self
     }
 
+    @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
@@ -27,7 +27,7 @@ enum SearchGroup: Int {
 }
 
 extension SearchGroup {
-    
+
     var accessible: Bool {
         switch self {
         case .people:
@@ -57,7 +57,7 @@ extension SearchGroup {
 }
 
 protocol SearchResultsViewControllerDelegate: class {
-    
+
     func searchResultsViewController(_ searchResultsViewController: SearchResultsViewController, didTapOnUser user: UserType, indexPath: IndexPath, section: SearchResultsViewControllerSection)
     func searchResultsViewController(_ searchResultsViewController: SearchResultsViewController, didDoubleTapOnUser user: UserType, indexPath: IndexPath)
     func searchResultsViewController(_ searchResultsViewController: SearchResultsViewController, didTapOnConversation conversation: ZMConversation)
@@ -65,18 +65,18 @@ protocol SearchResultsViewControllerDelegate: class {
     func searchResultsViewController(_ searchResultsViewController: SearchResultsViewController, wantsToPerformAction action: SearchResultsViewControllerAction)
 }
 
-public enum SearchResultsViewControllerAction : Int {
+enum SearchResultsViewControllerAction: Int {
     case createGroup
     case createGuestRoom
 }
 
-public enum SearchResultsViewControllerMode : Int {
+enum SearchResultsViewControllerMode: Int {
     case search
     case selection
     case list
 }
 
-public enum SearchResultsViewControllerSection : Int {
+enum SearchResultsViewControllerSection: Int {
     case unknown
     case topPeople
     case contacts
@@ -98,11 +98,9 @@ extension UIViewController {
             var candidate: UIViewController? = .none
             if let controller = current.navigationController {
                 candidate = controller
-            }
-            else if let controller = current.presentingViewController {
+            } else if let controller = current.presentingViewController {
                 candidate = controller
-            }
-            else if let controller = current.parent {
+            } else if let controller = current.parent {
                 candidate = controller
             }
             if let candidate = candidate {
@@ -119,8 +117,7 @@ extension UIViewController {
             if let arrowDirection = $0.popoverPresentationController?.arrowDirection,
                 arrowDirection != .unknown {
                 return true
-            }
-            else {
+            } else {
                 return false
             }
         }
@@ -132,19 +129,18 @@ final class SearchResultsViewController: UIViewController {
     lazy var searchResultsView: SearchResultsView = {
         let view = SearchResultsView()
         view.parentViewController = self
-        
+
         return view
     }()
-    
 
     private lazy var searchDirectory: SearchDirectory! = {
         guard let session = ZMUserSession.shared() else {
             return nil
         }
-        
+
         return SearchDirectory(userSession: session)
     }()
-    
+
     let userSelection: UserSelection
 
     let sectionController: SectionCollectionViewController = SectionCollectionViewController()
@@ -152,16 +148,16 @@ final class SearchResultsViewController: UIViewController {
     let teamMemberAndContactsSection: ContactsSectionController = ContactsSectionController()
     let directorySection = DirectorySectionController()
     let conversationsSection: GroupConversationsSectionController = GroupConversationsSectionController()
-    
+
     lazy var topPeopleSection: TopPeopleSectionController = {
         return TopPeopleSectionController(topConversationsDirectory: ZMUserSession.shared()?.topConversationsDirectory)
     }()
-    
+
     let servicesSection: SearchServicesSectionController
     let inviteTeamMemberSection: InviteTeamMemberSection
     let createGroupSection = CreateGroupSection()
 
-    var pendingSearchTask: SearchTask? = nil
+    var pendingSearchTask: SearchTask?
     var isAddingParticipants: Bool
     var searchGroup: SearchGroup = .people {
         didSet {
@@ -169,10 +165,10 @@ final class SearchResultsViewController: UIViewController {
         }
     }
 
-    var filterConversation: ZMConversation? = nil
+    var filterConversation: ZMConversation?
     let shouldIncludeGuests: Bool
 
-    weak var delegate: SearchResultsViewControllerDelegate? = nil
+    weak var delegate: SearchResultsViewControllerDelegate?
 
     var mode: SearchResultsViewControllerMode = .search {
         didSet {
@@ -293,7 +289,7 @@ final class SearchResultsViewController: UIViewController {
     }
 
     func updateVisibleSections() {
-        var sections : [CollectionViewSectionController]
+        var sections: [CollectionViewSectionController]
         let team = ZMUser.selfUser().team
 
         switch(self.searchGroup, isAddingParticipants) {
@@ -338,7 +334,7 @@ final class SearchResultsViewController: UIViewController {
 
         var contacts = searchResult.contacts
         var teamContacts = searchResult.teamMembers
-        
+
         if let filteredParticpants = filterConversation?.localParticipants {
             contacts = contacts.filter({
                 guard let user = $0.user else {
@@ -364,8 +360,7 @@ final class SearchResultsViewController: UIViewController {
 
                 return name0.compare(name1) == .orderedAscending
             }
-        }
-        else {
+        } else {
             teamMemberAndContactsSection.contacts = teamContacts
         }
 
@@ -396,16 +391,14 @@ final class SearchResultsViewController: UIViewController {
 
 }
 
-extension SearchResultsViewController : SearchSectionControllerDelegate {
+extension SearchResultsViewController: SearchSectionControllerDelegate {
 
     func searchSectionController(_ searchSectionController: CollectionViewSectionController, didSelectUser user: UserType, at indexPath: IndexPath) {
         if let user = user as? ZMUser {
             delegate?.searchResultsViewController(self, didTapOnUser: user, indexPath: indexPath, section: sectionFor(controller: searchSectionController))
-        }
-        else if let service = user as? ServiceUser, service.isServiceUser {
+        } else if let service = user as? ServiceUser, service.isServiceUser {
             delegate?.searchResultsViewController(self, didTapOnSeviceUser: service)
-        }
-        else if let searchUser = user as? ZMSearchUser {
+        } else if let searchUser = user as? ZMSearchUser {
             delegate?.searchResultsViewController(self, didTapOnUser: searchUser, indexPath: indexPath, section: sectionFor(controller: searchSectionController))
         }
     }
@@ -426,13 +419,13 @@ extension SearchResultsViewController : SearchSectionControllerDelegate {
 
 }
 
-extension SearchResultsViewController : InviteTeamMemberSectionDelegate {
+extension SearchResultsViewController: InviteTeamMemberSectionDelegate {
     func inviteSectionDidRequestTeamManagement() {
         URL.manageTeam(source: .onboarding).openInApp(above: self)
     }
 }
 
-extension SearchResultsViewController : SearchServicesSectionDelegate {
+extension SearchResultsViewController: SearchServicesSectionDelegate {
     func addServicesSectionDidRequestOpenServicesAdmin() {
         URL.manageTeam(source: .settings).openInApp(above: self)
     }

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
@@ -154,12 +154,7 @@ final class SearchResultsViewController: UIViewController {
     let conversationsSection: GroupConversationsSectionController
     
     lazy var topPeopleSection: TopPeopleSectionController = {
-        if let session = ZMUserSession.shared() {
-            return TopPeopleSectionController(topConversationsDirectory: session.topConversationsDirectory)
-        } else {
-            return TopPeopleSectionController(topConversationsDirectory:nil)
-        }
-
+        return TopPeopleSectionController(topConversationsDirectory: ZMUserSession.shared()?.topConversationsDirectory)
     }()
     
     let servicesSection: SearchServicesSectionController

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
@@ -127,9 +127,16 @@ extension UIViewController {
     }
 }
 
-class SearchResultsViewController : UIViewController {
+final class SearchResultsViewController: UIViewController {
 
-    var searchResultsView: SearchResultsView?
+    lazy var searchResultsView: SearchResultsView = {
+        let view = SearchResultsView()
+        view.parentViewController = self
+        
+        return view
+    }()
+    
+
     var searchDirectory: SearchDirectory!
     let userSelection: UserSelection
 
@@ -212,8 +219,6 @@ class SearchResultsViewController : UIViewController {
     }
 
     override func loadView() {
-        searchResultsView  = SearchResultsView()
-        searchResultsView?.parentViewController = self
         view = searchResultsView
     }
 
@@ -226,11 +231,11 @@ class SearchResultsViewController : UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        sectionController.collectionView = searchResultsView?.collectionView
+        sectionController.collectionView = searchResultsView.collectionView
 
         updateVisibleSections()
 
-        searchResultsView?.emptyResultContainer.isHidden = !isResultEmpty
+        searchResultsView.emptyResultContainer.isHidden = !isResultEmpty
     }
 
     @objc
@@ -242,7 +247,7 @@ class SearchResultsViewController : UIViewController {
     private func performSearch(query: String, options: SearchOptions) {
 
         pendingSearchTask?.cancel()
-        searchResultsView?.emptyResultContainer.isHidden = true
+        searchResultsView.emptyResultContainer.isHidden = true
 
         var options = options
         options.updateForSelfUserTeamRole(selfUser: ZMUser.selfUser())
@@ -274,7 +279,7 @@ class SearchResultsViewController : UIViewController {
 
     var isResultEmpty: Bool = true {
         didSet {
-            searchResultsView?.emptyResultContainer.isHidden = !isResultEmpty
+            searchResultsView.emptyResultContainer.isHidden = !isResultEmpty
         }
     }
 

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
@@ -147,11 +147,11 @@ final class SearchResultsViewController: UIViewController {
     
     let userSelection: UserSelection
 
-    let sectionController: SectionCollectionViewController
-    let contactsSection: ContactsSectionController
-    let teamMemberAndContactsSection: ContactsSectionController
+    let sectionController: SectionCollectionViewController = SectionCollectionViewController()
+    let contactsSection: ContactsSectionController = ContactsSectionController()
+    let teamMemberAndContactsSection: ContactsSectionController = ContactsSectionController()
     let directorySection = DirectorySectionController()
-    let conversationsSection: GroupConversationsSectionController
+    let conversationsSection: GroupConversationsSectionController = GroupConversationsSectionController()
     
     lazy var topPeopleSection: TopPeopleSectionController = {
         return TopPeopleSectionController(topConversationsDirectory: ZMUserSession.shared()?.topConversationsDirectory)
@@ -193,17 +193,13 @@ final class SearchResultsViewController: UIViewController {
         let team = ZMUser.selfUser().team
         let teamName = team?.name
 
-        sectionController = SectionCollectionViewController()
-        contactsSection = ContactsSectionController()
         contactsSection.selection = userSelection
         contactsSection.title = "peoplepicker.header.contacts_personal".localized
         contactsSection.allowsSelection = isAddingParticipants
-        teamMemberAndContactsSection = ContactsSectionController()
         teamMemberAndContactsSection.allowsSelection = isAddingParticipants
         teamMemberAndContactsSection.selection = userSelection
         teamMemberAndContactsSection.title = "peoplepicker.header.contacts".localized
         servicesSection = SearchServicesSectionController(canSelfUserManageTeam: ZMUser.selfUser().canManageTeam)
-        conversationsSection = GroupConversationsSectionController()
         conversationsSection.title = team != nil ? "peoplepicker.header.team_conversations".localized(args: teamName ?? "") : "peoplepicker.header.conversations".localized
         inviteTeamMemberSection = InviteTeamMemberSection(team: team)
 

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+SearchResults.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+SearchResults.swift
@@ -29,13 +29,13 @@ extension StartUIViewController {
         _ = searchHeaderViewController.tokenField.resignFirstResponder()
 
         guard let indexPath = indexPath,
-            let cell = searchResultsViewController.searchResultsView?.collectionView.cellForItem(at: indexPath) else { return }
+            let cell = searchResultsViewController.searchResultsView.collectionView.cellForItem(at: indexPath) else { return }
 
 
         profilePresenter.presentProfileViewController(for: bareUser, in: self, from: view.convert(cell.bounds, from: cell), onDismiss: {
-            if self.isIPadRegular(),
-                let indexPaths = self.searchResultsViewController.searchResultsView?.collectionView.indexPathsForVisibleItems {
-                self.searchResultsViewController.searchResultsView?.collectionView.reloadItems(at: indexPaths)
+            if self.isIPadRegular() {
+                let indexPaths = self.searchResultsViewController.searchResultsView.collectionView.indexPathsForVisibleItems
+                self.searchResultsViewController.searchResultsView.collectionView.reloadItems(at: indexPaths)
             } else if self.profilePresenter.keyboardPersistedAfterOpeningProfile {
                     _ = self.searchHeaderViewController.tokenField.becomeFirstResponder()
                     self.profilePresenter.keyboardPersistedAfterOpeningProfile = false

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.swift
@@ -69,10 +69,6 @@ final class StartUIViewController: UIViewController, SpinnerCapable {
         setupViews()
     }
     
-    deinit {
-        
-    }
-
     var searchHeader: SearchHeaderViewController {
         return self.searchHeaderViewController
     }

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.swift
@@ -30,7 +30,7 @@ final class StartUIViewController: UIViewController, SpinnerCapable {
     
     let searchHeaderViewController: SearchHeaderViewController = SearchHeaderViewController(userSelection: UserSelection(), variant: .dark)
     
-    let groupSelector: SearchGroupSelector
+    let groupSelector: SearchGroupSelector = SearchGroupSelector(style: .dark)
     
     let searchResultsViewController: SearchResultsViewController = {
         let viewController = SearchResultsViewController(userSelection: UserSelection(), isAddingParticipants: false, shouldIncludeGuests: true)
@@ -62,8 +62,6 @@ final class StartUIViewController: UIViewController, SpinnerCapable {
     /// - Parameter addressBookHelperType: a class type conforms AddressBookHelperProtocol
     init(addressBookHelperType: AddressBookHelperProtocol.Type = AddressBookHelper.self) {
         self.addressBookHelperType = addressBookHelperType
-        
-        groupSelector = SearchGroupSelector(style: .dark)
         
         super.init(nibName: nil, bundle: nil)
         

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.swift
@@ -118,8 +118,8 @@ final class StartUIViewController: UIViewController, SpinnerCapable {
         emptyResultView.delegate = self
         
         searchResultsViewController.mode = .list
-        searchResultsViewController.searchResultsView?.emptyResultView = self.emptyResultView
-        searchResultsViewController.searchResultsView?.collectionView.accessibilityIdentifier = "search.list"
+        searchResultsViewController.searchResultsView.emptyResultView = self.emptyResultView
+        searchResultsViewController.searchResultsView.collectionView.accessibilityIdentifier = "search.list"
 
 
         if let team = (selfUser as? ZMUser)?.team {
@@ -151,8 +151,8 @@ final class StartUIViewController: UIViewController, SpinnerCapable {
         
         searchResults.delegate = self
         addToSelf(searchResults)
-        searchResults.searchResultsView?.emptyResultView = emptyResultView
-        searchResults.searchResultsView?.collectionView.accessibilityIdentifier = "search.list"
+        searchResults.searchResultsView.emptyResultView = emptyResultView
+        searchResults.searchResultsView.collectionView.accessibilityIdentifier = "search.list"
         
         quickActionsBar.inviteButton.addTarget(self, action: #selector(inviteMoreButtonTapped(_:)), for: .touchUpInside)
         
@@ -181,9 +181,9 @@ final class StartUIViewController: UIViewController, SpinnerCapable {
     
     func updateActionBar() {
         if !searchHeader.query.isEmpty || (selfUser as? ZMUser)?.hasTeam == true {
-            searchResults.searchResultsView?.accessoryView = nil
+            searchResults.searchResultsView.accessoryView = nil
         } else {
-            searchResults.searchResultsView?.accessoryView = quickActionsBar
+            searchResults.searchResultsView.accessoryView = quickActionsBar
         }
         
         view.setNeedsLayout()

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.swift
@@ -27,7 +27,6 @@ final class StartUIViewController: UIViewController, SpinnerCapable {
     static let InitiallyShowsKeyboardConversationThreshold = 10
     
     weak var delegate: StartUIDelegate?
-    //TODO:    let selfUser: UserType
     
     let searchHeaderViewController: SearchHeaderViewController = SearchHeaderViewController(userSelection: UserSelection(), variant: .dark)
     
@@ -54,28 +53,28 @@ final class StartUIViewController: UIViewController, SpinnerCapable {
     private var emptyResultView: EmptySearchResultsView!
     
     @available(*, unavailable)
-    required public init?(coder aDecoder: NSCoder) {
+    required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
     /// init method for injecting mock addressBookHelper
     ///
     /// - Parameter addressBookHelperType: a class type conforms AddressBookHelperProtocol
-    init(addressBookHelperType: AddressBookHelperProtocol.Type = AddressBookHelper.self/*,
-         selfUser: UserType = ZMUser.selfUser()*/) {
-//        self.selfUser = selfUser
+    init(addressBookHelperType: AddressBookHelperProtocol.Type = AddressBookHelper.self) {
         self.addressBookHelperType = addressBookHelperType
         
-        groupSelector = SearchGroupSelector(style: .dark/*, selfUser: selfUser*/)
-//        emptyResultView = EmptySearchResultsView(variant: .dark, isSelfUserAdmin: selfUser.canManageTeam)
+        groupSelector = SearchGroupSelector(style: .dark)
         
         super.init(nibName: nil, bundle: nil)
         
         configGroupSelector()
         setupViews()
     }
+    
+    deinit {
+        
+    }
 
-    ///TODO: tmp
     var searchHeader: SearchHeaderViewController {
         return self.searchHeaderViewController
     }
@@ -191,7 +190,7 @@ final class StartUIViewController: UIViewController, SpinnerCapable {
     }
     
     @objc
-    func onDismissPressed() {
+    private func onDismissPressed() {
         _ = searchHeader.tokenField.resignFirstResponder()
         navigationController?.dismiss(animated: true)
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

`SearchResultsViewController` and its children leak every time when the search screen is dismissed. 

### Causes

`SearchServicesSectionController` and `DirectorySectionController` are keeping a strong reference to `SearchResultsViewController`.

### Solutions

Add `weak` keyword to prevent cyclic reference.
Clean up the code for better readibility. 