### PR TITLE
[Feature]: Feature Flag Create Restore Backup

### DIFF
--- a/Wire-iOS/Sources/Authentication/Interface/Descriptions/ScreenDescriptions/Login/BackupRestoreStepDescription.swift
+++ b/Wire-iOS/Sources/Authentication/Interface/Descriptions/ScreenDescriptions/Login/BackupRestoreStepDescription.swift
@@ -62,6 +62,10 @@ class BackupRestoreStepDescription: AuthenticationStepDescription {
             subtext = "registration.no_history.logged_out.subtitle".localized
         }
 
+        guard SecurityFlags.backup.isEnabled else {
+            secondaryView = nil
+            return
+        }
         secondaryView = BackupRestoreStepDescriptionSecondaryView()
     }
 

--- a/Wire-iOS/Sources/Helpers/Bundle+SecurityFlags.swift
+++ b/Wire-iOS/Sources/Helpers/Bundle+SecurityFlags.swift
@@ -29,6 +29,7 @@ enum SecurityFlags {
     case customBackend
     case shareExtension
     case cameraRoll
+    case backup
     
     var bundleKey: String {
         switch self {
@@ -52,6 +53,8 @@ enum SecurityFlags {
             return "ShareExtensionEnabled"
         case .cameraRoll:
             return "CameraRollEnabled"
+        case .backup:
+            return "BackupEnabled"
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
@@ -53,7 +53,9 @@ extension SettingsCellDescriptorFactory {
             sections.append(personalInformationSection())
         #endif
         
-        sections.append(conversationsSection())
+        if SecurityFlags.backup.isEnabled {
+            sections.append(conversationsSection())
+        }
         
         if let user = ZMUser.selfUser(), !user.usesCompanyLogin {
             sections.append(actionsSection())

--- a/Wire-iOS/Wire-Info.plist
+++ b/Wire-iOS/Wire-Info.plist
@@ -204,5 +204,7 @@
 	<string>${SHARE_EXTENSION_ENABLED}</string>
 	<key>CameraRollEnabled</key>
 	<string>${CAMERA_ROLL_ENABLED}</string>
+	<key>BackupEnabled</key>
+	<string>${BACKUP_ENABLED}</string>
 </dict>
 </plist>


### PR DESCRIPTION
## What's new in this PR?

For the BK build and BSI client we need to disable the creation and restoring of backup to avoid having an app with an invalid state.

### Solutions

Added a Security Flag to hide/show the 'create backup' button and the 'restore backup' button

### Dependencies

JIRA: https://wearezeta.atlassian.net/browse/ZIOS-13723


