### PR TITLE
[Feature] Security flag to force encryption at rest

### DIFF
--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -556,6 +556,10 @@ extension AppRootViewController: SessionManagerCreatedSessionObserver, SessionMa
                 soundEventListeners[accountId] = SoundEventListener(userSession: userSession)
             }
         }
+
+        if SecurityFlags.forceEncryptionAtRest.isEnabled && !userSession.encryptMessagesAtRest {
+            userSession.encryptMessagesAtRest = true
+        }
     }
 
     func sessionManagerCreated(unauthenticatedSession: UnauthenticatedSession) {

--- a/Wire-iOS/Sources/Helpers/Bundle+SecurityFlags.swift
+++ b/Wire-iOS/Sources/Helpers/Bundle+SecurityFlags.swift
@@ -60,7 +60,7 @@ enum SecurityFlags {
         case .backup:
             return "BackupEnabled"
         case .forceEncryptionAtRest:
-            return "ForceEncryptionAtRest"
+            return "ForceEncryptionAtRestEnabled"
         }
     }
     

--- a/Wire-iOS/Sources/Helpers/Bundle+SecurityFlags.swift
+++ b/Wire-iOS/Sources/Helpers/Bundle+SecurityFlags.swift
@@ -31,7 +31,7 @@ enum SecurityFlags {
     case cameraRoll
     case backup
 
-    /// Wether encryption at rest is enabled and can't be disabled.
+    /// Whether encryption at rest is enabled and can't be disabled.
     
     case forceEncryptionAtRest
     

--- a/Wire-iOS/Sources/Helpers/Bundle+SecurityFlags.swift
+++ b/Wire-iOS/Sources/Helpers/Bundle+SecurityFlags.swift
@@ -30,6 +30,10 @@ enum SecurityFlags {
     case shareExtension
     case cameraRoll
     case backup
+
+    /// Wether encryption at rest is enabled and can't be disabled.
+    
+    case forceEncryptionAtRest
     
     var bundleKey: String {
         switch self {
@@ -55,6 +59,8 @@ enum SecurityFlags {
             return "CameraRollEnabled"
         case .backup:
             return "BackupEnabled"
+        case .forceEncryptionAtRest:
+            return "ForceEncryptionAtRest"
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
@@ -45,7 +45,7 @@ extension SettingsCellDescriptorFactory {
 
         sections.append(privacySection())
 
-        if Bundle.developerModeEnabled {
+        if Bundle.developerModeEnabled && !SecurityFlags.forceEncryptionAtRest.isEnabled {
             sections.append(encryptionAtRestSection())
         }
 

--- a/Wire-iOS/Wire-Info.plist
+++ b/Wire-iOS/Wire-Info.plist
@@ -206,7 +206,7 @@
 	<string>${CAMERA_ROLL_ENABLED}</string>
 	<key>BackupEnabled</key>
 	<string>${BACKUP_ENABLED}</string>
-	<key>ForceEncryptionAtRest</key>
-	<string>$(FORCE_ENCRYPTION_AT_REST)</string>
+	<key>ForceEncryptionAtRestEnabled</key>
+	<string>$(FORCE_ENCRYPTION_AT_REST_ENABLED)</string>
 </dict>
 </plist>

--- a/Wire-iOS/Wire-Info.plist
+++ b/Wire-iOS/Wire-Info.plist
@@ -206,5 +206,7 @@
 	<string>${CAMERA_ROLL_ENABLED}</string>
 	<key>BackupEnabled</key>
 	<string>${BACKUP_ENABLED}</string>
+	<key>ForceEncryptionAtRest</key>
+	<string>$(FORCE_ENCRYPTION_AT_REST)</string>
 </dict>
 </plist>


### PR DESCRIPTION
## What's new in this PR?

Add a new security flag which allows forcing encryption at rest to be enabled. If the flag is enabled, then encryption at rest is enabled when the user session is created. Additionally, the option in the account settings is hidden to prevent the feature being disabled.


### Dependencies

Needs releases with:

- [x] https://github.com/wireapp/wire-ios-build-configuration/pull/43

