### PR TITLE
Fix: move hardcoded email address to configure json file

### DIFF
--- a/Scripts/download-assets.sh
+++ b/Scripts/download-assets.sh
@@ -78,7 +78,7 @@ else
         exit -1
     fi 
 
-    echo "✅ Cloning assets from ${REPO_URL} to path ${CONFIGURATION_LOCATION}"
+    echo "✅ Cloning assets from ${REPO_URL} (branch: ${BRANCH}) to path ${CONFIGURATION_LOCATION}"
     git clone --branch ${BRANCH} --depth 1 ${REPO_URL} ${CONFIGURATION_LOCATION}
 fi
 

--- a/Scripts/download-assets.sh
+++ b/Scripts/download-assets.sh
@@ -79,7 +79,7 @@ else
     fi 
 
     echo "✅ Cloning assets from ${REPO_URL} (branch: ${BRANCH}) to path ${CONFIGURATION_LOCATION}"
-    git clone --branch feature/email-json --depth 1 ${REPO_URL} ${CONFIGURATION_LOCATION}
+    git clone --branch ${BRANCH} --depth 1 ${REPO_URL} ${CONFIGURATION_LOCATION}
 fi
 
 if [ ! -z "${OVERRIDES_DIR}" ]; then

--- a/Scripts/download-assets.sh
+++ b/Scripts/download-assets.sh
@@ -79,7 +79,7 @@ else
     fi 
 
     echo "✅ Cloning assets from ${REPO_URL} (branch: ${BRANCH}) to path ${CONFIGURATION_LOCATION}"
-    git clone --branch ${BRANCH} --depth 1 ${REPO_URL} ${CONFIGURATION_LOCATION}
+    git clone --branch feature/email-json --depth 1 ${REPO_URL} ${CONFIGURATION_LOCATION}
 fi
 
 if [ ! -z "${OVERRIDES_DIR}" ]; then

--- a/Wire-iOS Tests/Bundle/URL+WireTests.swift
+++ b/Wire-iOS Tests/Bundle/URL+WireTests.swift
@@ -20,7 +20,7 @@ import XCTest
 import WireTransport
 @testable import Wire
 
-class URL_WireTests: XCTestCase {
+final class URL_WireTests: XCTestCase {
     
     var be: BackendEnvironment!
     
@@ -67,11 +67,4 @@ class URL_WireTests: XCTestCase {
         XCTAssertEqual(be.accountsURL, accountsURL)
         XCTAssertEqual(URL.wr_passwordReset, accountsURL.appendingPathComponent("forgot"))
     }
-    /*
-    func testThatTeamURLsAreLoadedCorrectly() {
-        let teamsURL = URL(string: "https://teams.wire.com")!
-        XCTAssertEqual(be.teamsURL, teamsURL)
-        XCTAssertEqual(URL.wr_manageTeam, teamsURL.appendingPathComponent("login?pk_campaign=client&pk_kwd=ios"))
-    }
-    */
 }

--- a/Wire-iOS Tests/Bundle/WireEmailTests.swift
+++ b/Wire-iOS Tests/Bundle/WireEmailTests.swift
@@ -1,4 +1,3 @@
-
 // Wire
 // Copyright (C) 2020 Wire Swiss GmbH
 //

--- a/Wire-iOS Tests/Bundle/WireEmailTests.swift
+++ b/Wire-iOS Tests/Bundle/WireEmailTests.swift
@@ -16,23 +16,11 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
+import XCTest
+@testable import Wire
 
-struct WireEmail: Codable {
-    let supportEmail: String
-    let callingSupportEmail: String    
-    
-    static var shared: WireEmail! = {
-        return WireEmail(for: "email", with: "json")
-    }()
-    
-    private init?(for resource: String, with fileExtension: String) {
-        do {
-            let fileURL = Bundle.fileURL(for: resource, with: fileExtension)!
-            self = try fileURL.decode(WireEmail.self)
-        } catch {
-            return nil
-        }
+final class WireEmailTests: XCTestCase {
+    func testThatCallingSupportEmailIsCorrect() {
+        XCTAssertEqual(WireEmail.shared.callingSupportEmail, "calling-ios@wire.com")
     }
-
 }

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -809,6 +809,7 @@
 		A9D19B16238441B500F6E14A /* ConversationViewController+ProfileViewControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D19B15238441B500F6E14A /* ConversationViewController+ProfileViewControllerDelegate.swift */; };
 		A9D19B182385245E00F6E14A /* ProfileViewControllerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D19B172385245E00F6E14A /* ProfileViewControllerViewModel.swift */; };
 		A9DA5084240FFD0900C2F886 /* ButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DA5083240FFD0900C2F886 /* ButtonTests.swift */; };
+		A9E674D524F508B70058FC72 /* WireEmail.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E674D424F508B70058FC72 /* WireEmail.swift */; };
 		A9EB722323C1581A00DA8240 /* ContactsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EB722223C1581A00DA8240 /* ContactsViewController.swift */; };
 		A9EB722523C3A47B00DA8240 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EB722423C3A47B00DA8240 /* AppDelegate.swift */; };
 		A9EB722823C3A9F600DA8240 /* ConversationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EB722723C3A9F600DA8240 /* ConversationViewController.swift */; };
@@ -2410,6 +2411,7 @@
 		A9D19B15238441B500F6E14A /* ConversationViewController+ProfileViewControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationViewController+ProfileViewControllerDelegate.swift"; sourceTree = "<group>"; };
 		A9D19B172385245E00F6E14A /* ProfileViewControllerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewControllerViewModel.swift; sourceTree = "<group>"; };
 		A9DA5083240FFD0900C2F886 /* ButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonTests.swift; sourceTree = "<group>"; };
+		A9E674D424F508B70058FC72 /* WireEmail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WireEmail.swift; sourceTree = "<group>"; };
 		A9EB722223C1581A00DA8240 /* ContactsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactsViewController.swift; sourceTree = "<group>"; };
 		A9EB722423C3A47B00DA8240 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A9EB722723C3A9F600DA8240 /* ConversationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationViewController.swift; sourceTree = "<group>"; };
@@ -5073,6 +5075,7 @@
 				16FB2F6B20C0389800582137 /* Dictionary+Merge.swift */,
 				D5189472204D543C00C095C1 /* InitialSyncObserver.swift */,
 				D5168F4C2010B61D00F8222A /* URL+Wire.swift */,
+				A9E674D424F508B70058FC72 /* WireEmail.swift */,
 				D5D65A0E2074CFBB00D7F3C3 /* AuthenticationType.swift */,
 				D5694B5120441EE900C84C8F /* UILabel+Convenience.swift */,
 				BF86E11A1C245BF9001D9430 /* UserClient+Fingerprint.swift */,
@@ -7674,6 +7677,7 @@
 				5E769C5421AD89A900785EB7 /* UIViewController+Dismiss.swift in Sources */,
 				5E35F733217F147A00D3F4FE /* ConversationMessageSectionController.swift in Sources */,
 				87797C0B1FF3C849009FC9A9 /* SearchServicesSectionController.swift in Sources */,
+				A9E674D524F508B70058FC72 /* WireEmail.swift in Sources */,
 				87BEB03E1D3E44DE00DE9575 /* CameraCell.swift in Sources */,
 				A9614EF823C38C810012A718 /* ConnectRequestsViewController.swift in Sources */,
 				A90E4ABF2381CD0200468F31 /* AccentColorChangeHandler.swift in Sources */,

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -810,6 +810,8 @@
 		A9D19B182385245E00F6E14A /* ProfileViewControllerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D19B172385245E00F6E14A /* ProfileViewControllerViewModel.swift */; };
 		A9DA5084240FFD0900C2F886 /* ButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DA5083240FFD0900C2F886 /* ButtonTests.swift */; };
 		A9E674D524F508B70058FC72 /* WireEmail.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E674D424F508B70058FC72 /* WireEmail.swift */; };
+		A9E674D724F514710058FC72 /* email.json in Resources */ = {isa = PBXBuildFile; fileRef = A9E674D624F514700058FC72 /* email.json */; };
+		A9E674DB24F51A5C0058FC72 /* WireEmailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E674D924F51A190058FC72 /* WireEmailTests.swift */; };
 		A9EB722323C1581A00DA8240 /* ContactsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EB722223C1581A00DA8240 /* ContactsViewController.swift */; };
 		A9EB722523C3A47B00DA8240 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EB722423C3A47B00DA8240 /* AppDelegate.swift */; };
 		A9EB722823C3A9F600DA8240 /* ConversationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EB722723C3A9F600DA8240 /* ConversationViewController.swift */; };
@@ -2412,6 +2414,8 @@
 		A9D19B172385245E00F6E14A /* ProfileViewControllerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewControllerViewModel.swift; sourceTree = "<group>"; };
 		A9DA5083240FFD0900C2F886 /* ButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonTests.swift; sourceTree = "<group>"; };
 		A9E674D424F508B70058FC72 /* WireEmail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WireEmail.swift; sourceTree = "<group>"; };
+		A9E674D624F514700058FC72 /* email.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = email.json; sourceTree = "<group>"; };
+		A9E674D924F51A190058FC72 /* WireEmailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WireEmailTests.swift; sourceTree = "<group>"; };
 		A9EB722223C1581A00DA8240 /* ContactsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactsViewController.swift; sourceTree = "<group>"; };
 		A9EB722423C3A47B00DA8240 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A9EB722723C3A9F600DA8240 /* ConversationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationViewController.swift; sourceTree = "<group>"; };
@@ -5577,6 +5581,15 @@
 			path = Button;
 			sourceTree = "<group>";
 		};
+		A9E674D824F519C60058FC72 /* Bundle */ = {
+			isa = PBXGroup;
+			children = (
+				7CCB8F7E229D67BD005BBC10 /* URL+WireTests.swift */,
+				A9E674D924F51A190058FC72 /* WireEmailTests.swift */,
+			);
+			path = Bundle;
+			sourceTree = "<group>";
+		};
 		A9E844F723730CC7001D1C47 /* Color */ = {
 			isa = PBXGroup;
 			children = (
@@ -5588,6 +5601,7 @@
 		BACB88521AF7C48900DDCDB0 /* Wire-iOS Tests */ = {
 			isa = PBXGroup;
 			children = (
+				A9E674D824F519C60058FC72 /* Bundle */,
 				A92C443024EE97D6006A4AB3 /* Search */,
 				A90F3E06249B976200429BFE /* ContextMenu */,
 				A923F1C32428C562003F361F /* ZipFile */,
@@ -5787,7 +5801,6 @@
 				EF2FEDC7228E9E42000883C8 /* UserImageViewContainerSnapshotTests.swift */,
 				EF4FFB3422830BD200B69851 /* String+WholeRangeTests.swift */,
 				EFDBA24622942FBB00874A15 /* UIAlertViewController+CompanyLoginTests.swift */,
-				7CCB8F7E229D67BD005BBC10 /* URL+WireTests.swift */,
 				EF23740F230D49EC006F53F3 /* NetworkConditionHelperTests.swift */,
 				EFFE1D3A230D63EA00389290 /* CountryTests.swift */,
 				EF3243522317F0060043F147 /* ZClientViewControllerTests.swift */,
@@ -6440,6 +6453,7 @@
 		F12C48952199CBB600F49548 /* Configuration */ = {
 			isa = PBXGroup;
 			children = (
+				A9E674D624F514700058FC72 /* email.json */,
 				EF2B0DD021CA8DF7003B2882 /* url.json */,
 				5E39FC5E225CBBD300C682B8 /* password_rules.json */,
 				161041B622D764C1001109D7 /* session_manager.json */,
@@ -6816,6 +6830,7 @@
 				5E39FC5F225CBBD400C682B8 /* password_rules.json in Resources */,
 				DB3E943A1B96EDBD00990482 /* LaunchScreen.xib in Resources */,
 				EF2B0DD121CA8EF1003B2882 /* url.json in Resources */,
+				A9E674D724F514710058FC72 /* email.json in Resources */,
 				1658D2051D3E742A00249609 /* ping_from_them.caf in Resources */,
 				848DE12B1A83D20000E154B1 /* emoticons.min.json in Resources */,
 				1660F2381FBC6E2E00A0EE54 /* silence.m4a in Resources */,
@@ -8147,6 +8162,7 @@
 				5E35F78D21870EDB00D3F4FE /* ConversationPingMessageTests.swift in Sources */,
 				EF2128EE2056D55400C1673B /* NetworkStatusViewControllerTests.swift in Sources */,
 				EFDBA24722942FBB00874A15 /* UIAlertViewController+CompanyLoginTests.swift in Sources */,
+				A9E674DB24F51A5C0058FC72 /* WireEmailTests.swift in Sources */,
 				EE75B774203C6F5300855099 /* MarkdownTextStorageTests.swift in Sources */,
 				EF19209D20C6E4F800E4B92D /* XCTestCase+DayFormatter.swift in Sources */,
 				A923F1C72428C71A003F361F /* ZipFileTests.swift in Sources */,

--- a/Wire-iOS/Sources/Developer/DebugAlert.swift
+++ b/Wire-iOS/Sources/Developer/DebugAlert.swift
@@ -132,7 +132,7 @@ final class DebugLogSender: NSObject, MFMailComposeViewControllerDelegate {
         let device = UIDevice.current.name
         let userDescription = "\(user?.name ?? "") [user: \(userID)] [device: \(device)]"
         let message = "Logs for: \(message)\n\n"
-        let mail = "\(shareWithAVS ? "calling-" : "")ios@wire.com"
+        let mail = shareWithAVS ? WireEmail.shared.callingSupportEmail : WireEmail.shared.supportEmail
         
         guard MFMailComposeViewController.canSendMail() else {
             DebugAlert.displayFallbackActivityController(logPaths: ZMSLog.pathsForExistingLogs, email: mail, from: controller)

--- a/Wire-iOS/Sources/Helpers/URL+String.swift
+++ b/Wire-iOS/Sources/Helpers/URL+String.swift
@@ -21,7 +21,7 @@ import WireSystem
 private let zmLog = ZMSLog(tag: "URL Helper")
 
 extension URL {
-    func decode<T>(_ type: T.Type) throws -> T where T : Decodable {
+    func decode<T>(_ type: T.Type) throws -> T where T: Decodable {
         let data: Data
         do {
             data = try Data(contentsOf: self)
@@ -29,9 +29,9 @@ extension URL {
             zmLog.error("Failed to load \(type) at path: \(self), error: \(error)")
             throw error
         }
-        
+
         let decoder = JSONDecoder()
-        
+
         do {
             return try decoder.decode(type, from: data)
         } catch {

--- a/Wire-iOS/Sources/Helpers/URL+String.swift
+++ b/Wire-iOS/Sources/Helpers/URL+String.swift
@@ -16,8 +16,30 @@
 //
 
 import Foundation
+import WireSystem
+
+private let zmLog = ZMSLog(tag: "URL Helper")
 
 extension URL {
+    func decode<T>(_ type: T.Type) throws -> T where T : Decodable {
+        let data: Data
+        do {
+            data = try Data(contentsOf: self)
+        } catch {
+            zmLog.error("Failed to load \(type) at path: \(self), error: \(error)")
+            throw error
+        }
+        
+        let decoder = JSONDecoder()
+        
+        do {
+            return try decoder.decode(type, from: data)
+        } catch {
+            zmLog.error("Failed to parse JSON at path: \(self), error: \(error)")
+            throw error
+        }
+    }
+
     var urlWithoutScheme: String {
         return stringWithoutPrefix("\(scheme ?? "")://")
     }

--- a/Wire-iOS/Sources/Helpers/URL+Wire.swift
+++ b/Wire-iOS/Sources/Helpers/URL+Wire.swift
@@ -33,38 +33,6 @@ enum TeamSource: Int {
     }
 }
 
-extension Bundle {
-    static func fileURL(for resource: String, with fileExtension: String) -> URL? {
-        guard let filePath = Bundle.main.url(forResource: resource, withExtension: fileExtension) else {
-            zmLog.error("Failed to get resource from bundle")
-            return nil
-        }
-        
-        return filePath
-    }
-}
-
-extension URL {
-    func decode<T>(_ type: T.Type) throws -> T where T : Decodable {
-        let data: Data
-        do {
-            data = try Data(contentsOf: self)
-        } catch {
-            zmLog.error("Failed to load \(type) at path: \(self), error: \(error)")
-            throw error
-        }
-        
-        let decoder = JSONDecoder()
-        
-        do {
-            return try decoder.decode(type, from: data)
-        } catch {
-            zmLog.error("Failed to parse JSON at path: \(self), error: \(error)")
-            throw error
-        }
-    }
-}
-
 struct WireUrl: Codable {
     let wireAppOnItunes: URL
     let support: URL

--- a/Wire-iOS/Sources/Helpers/WireEmail.swift
+++ b/Wire-iOS/Sources/Helpers/WireEmail.swift
@@ -1,0 +1,23 @@
+
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+struct WireEmail: Codable {
+    let supportEmail: String    
+}

--- a/Wire-iOS/Sources/Helpers/WireEmail.swift
+++ b/Wire-iOS/Sources/Helpers/WireEmail.swift
@@ -1,4 +1,3 @@
-
 // Wire
 // Copyright (C) 2020 Wire Swiss GmbH
 //
@@ -20,13 +19,13 @@ import Foundation
 
 struct WireEmail: Codable {
     let supportEmail: String
-    let callingSupportEmail: String    
-    
-    static var shared: WireEmail! = {
-        return WireEmail(for: "email", with: "json")
+    let callingSupportEmail: String
+
+    static var shared: WireEmail = {
+        return WireEmail(forResource: "email", withExtension: "json")!
     }()
-    
-    private init?(for resource: String, with fileExtension: String) {
+
+    private init?(forResource resource: String, withExtension fileExtension: String) {
         do {
             let fileURL = Bundle.fileURL(for: resource, with: fileExtension)!
             self = try fileURL.decode(WireEmail.self)

--- a/Wire-iOS/Sources/UserInterface/Helpers/Bundle+config.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/Bundle+config.swift
@@ -17,9 +17,21 @@
 //
 
 import Foundation
+import WireSystem
+
+private let zmLog = ZMSLog(tag: "Bundle")
 
 extension Bundle {    
     static var developerModeEnabled: Bool {
         return Bundle.appMainBundle.infoForKey("EnableDeveloperMenu") == "1"
+    }
+
+    static func fileURL(for resource: String, with fileExtension: String) -> URL? {
+        guard let filePath = Bundle.main.url(forResource: resource, withExtension: fileExtension) else {
+            zmLog.error("Failed to get \(resource).\(fileExtension) from bundle")
+            return nil
+        }
+        
+        return filePath
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Helpers/Bundle+config.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/Bundle+config.swift
@@ -1,4 +1,3 @@
-
 // Wire
 // Copyright (C) 2020 Wire Swiss GmbH
 //
@@ -21,7 +20,7 @@ import WireSystem
 
 private let zmLog = ZMSLog(tag: "Bundle")
 
-extension Bundle {    
+extension Bundle {
     static var developerModeEnabled: Bool {
         return Bundle.appMainBundle.infoForKey("EnableDeveloperMenu") == "1"
     }
@@ -31,7 +30,7 @@ extension Bundle {
             zmLog.error("Failed to get \(resource).\(fileExtension) from bundle")
             return nil
         }
-        
+
         return filePath
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Settings/SettingsTechnicalReportViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/SettingsTechnicalReportViewController.swift
@@ -60,7 +60,7 @@ final class SettingsTechnicalReportViewController: UITableViewController, MFMail
     }
     
     func sendReport(sourceView: UIView? = nil) {
-        let mailRecipient = "calling-ios@wire.com"
+        let mailRecipient = WireEmail.shared.callingSupportEmail
 
         guard MFMailComposeViewController.canSendMail() else {
             DebugAlert.displayFallbackActivityController(logPaths: ZMSLog.pathsForExistingLogs, email: mailRecipient, from: self, sourceView: sourceView)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -30,7 +30,7 @@ platform :ios do
 
             config_branch = options[:config_branch]
             if config_branch.nil? 
-                config_branch = "feature/email-json"
+                config_branch = "master"
             end
 
             build = Build.new(options: options)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -30,7 +30,7 @@ platform :ios do
 
             config_branch = options[:config_branch]
             if config_branch.nil? 
-                config_branch = "master"
+                config_branch = "feature/email-json"
             end
 
             build = Build.new(options: options)


### PR DESCRIPTION
## What's new in this PR?

Move the hardcoded email address in Swift code to `email.json` configure file.

### dependency
- [x] update config https://github.com/wireapp/wire-ios-build-configuration/pull/44