### PR TITLE
[Fix] make sorting of call participants case insensitive

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallInfoConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallInfoConfiguration.swift
@@ -272,7 +272,7 @@ fileprivate extension VoiceChannel {
 
     func sortedConnectedParticipants() -> [CallParticipant] {
         return connectedParticipants.sorted { lhs, rhs in
-            lhs.user.name < rhs.user.name
+            lhs.user.name?.lowercased() < rhs.user.name?.lowercased()
         }
     }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

- Call participants list in calling overlay were sorted in case sensitive fashion

### Solutions

- Sort call participants in case insensitive fashion using `.lowercased()` on participants names

