### PR TITLE
Fix: disable auto fill passcode

### DIFF
--- a/Wire-iOS/Sources/Authentication/Interface/Views/AccessoryTextField.swift
+++ b/Wire-iOS/Sources/Authentication/Interface/Views/AccessoryTextField.swift
@@ -249,9 +249,17 @@ final class AccessoryTextField: UITextField, TextContainer, Themeable {
             autocapitalizationType = .none
             returnKeyType = isNew ? .default : .continue
             if #available(iOS 12, *) {
-                textContentType = isNew ? .newPassword : .password
+                if isNew {
+                    textContentType = .newPassword
+                } else {
+                    //Hack: disable auto fill passcode
+                    textContentType = .oneTimeCode
+                }
                 passwordRules = textFieldValidator.passwordRules
+            } else {
+                textContentType = .init(rawValue: "")
             }
+            
         }
     }
 


### PR DESCRIPTION
## What's new in this PR?
By default, when the user forgets his/her passcode code, the user can fill in the text field store passcode with touch id/face id and then screen lock passcode. 
Prevent the user auto fill passcode from keyboard accessory. A hack is applied by setting `textContentType = .oneTimeCode`.