### PR TITLE
Fix: switch off app lock does not saved in the perference

### DIFF
--- a/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
@@ -232,6 +232,7 @@ extension SelfProfileViewController: SettingsPropertyFactoryDelegate {
             UIApplication.shared.topmostViewController()?.present(wrappedViewController, animated: true)
         } else {
             Keychain.deletePasscode()
+            AppLock.isActive = false
         }
     }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

When switching off applock switch and go back to root setting page, app lock switch is still on.

### Causes

Applock setting is not set.

### Solutions

Set `AppLock.isActive = false` after deleted passcode.