### PR TITLE
Moving debug actions to their own file

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -741,6 +741,7 @@
 		A936A37F23D202F600136469 /* InvisibleInputAccessoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A936A37E23D202F600136469 /* InvisibleInputAccessoryView.swift */; };
 		A937863423EB3BF00039987B /* CountryCodeTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A937863323EB3BF00039987B /* CountryCodeTableViewController.swift */; };
 		A937A5C323D5F0400080A507 /* ConversationInputBarViewControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A937A5C223D5F0400080A507 /* ConversationInputBarViewControllerDelegate.swift */; };
+		A93B528924FE98200061255E /* DebugActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A93B528824FE98200061255E /* DebugActions.swift */; };
 		A93E6104233B870300CEA65F /* ConversationListHeaderViewSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A93E6103233B870200CEA65F /* ConversationListHeaderViewSnapshotTests.swift */; };
 		A947673F23DF2414009C6AE9 /* UIViewController+isInsidePopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871BC21E1D34F8F800DF0793 /* UIViewController+isInsidePopover.swift */; };
 		A949418723E08AF6001B0373 /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A949418623E08AF6001B0373 /* Settings.swift */; };
@@ -2355,6 +2356,7 @@
 		A936A37E23D202F600136469 /* InvisibleInputAccessoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvisibleInputAccessoryView.swift; sourceTree = "<group>"; };
 		A937863323EB3BF00039987B /* CountryCodeTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountryCodeTableViewController.swift; sourceTree = "<group>"; };
 		A937A5C223D5F0400080A507 /* ConversationInputBarViewControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationInputBarViewControllerDelegate.swift; sourceTree = "<group>"; };
+		A93B528824FE98200061255E /* DebugActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugActions.swift; sourceTree = "<group>"; };
 		A93E6103233B870200CEA65F /* ConversationListHeaderViewSnapshotTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConversationListHeaderViewSnapshotTests.swift; sourceTree = "<group>"; };
 		A949418623E08AF6001B0373 /* Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings.swift; sourceTree = "<group>"; };
 		A949418823E09489001B0373 /* SplitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitViewController.swift; sourceTree = "<group>"; };
@@ -5450,6 +5452,7 @@
 				8751BA432069455E00DF8667 /* BackupViewController.swift */,
 				D5D65A10207509F300D7F3C3 /* BackupPasswordViewController.swift */,
 				EF2388852211A67900331C07 /* UserRight.swift */,
+				A93B528824FE98200061255E /* DebugActions.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -7513,6 +7516,7 @@
 				EF6E9FE623193478000B7785 /* UIViewControllerTransitioningDelegate+Present.swift in Sources */,
 				5E65A79E21303F97008BFCC0 /* AuthenticationCoordinator+UserChange.swift in Sources */,
 				BF52C1591CAEBD8D0037331F /* ArchivedNavigationBar.swift in Sources */,
+				A93B528924FE98200061255E /* DebugActions.swift in Sources */,
 				EF71BFD620EBCC5F00894A7C /* UIView+IPadPopover.swift in Sources */,
 				EFBCC917215548EE006AAB70 /* AVAudioSessionType.swift in Sources */,
 				87BEB03C1D3E44BA00DE9575 /* CameraKeyboardViewController.swift in Sources */,

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -1184,6 +1184,8 @@
 "self.settings.advanced.troubleshooting.submit_debug.title" = "Debug Report";
 "self.settings.advanced.debugging_tools.title" = "Debugging Tools";
 "self.settings.advanced.debugging_tools.first_unread_conversation.title" = "Find first unread conversation";
+"self.settings.advanced.debugging_tools.show_user_id.title" = "Show my user ID";
+"self.settings.advanced.debugging_tools.enter_debug_command.title" = "Enter debug command";
 "self.settings.advanced.troubleshooting.submit_debug.subtitle" = "This information helps Wire Support diagnose calling problems and improve the overall app experience.";
 "self.settings.advanced.reset_push_token.title" = "Reset Push Notifications Token";
 "self.settings.advanced.reset_push_token.subtitle" = "If you experience problems with push notifications, Wire Support may ask you to reset this token.";

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Advanced.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Advanced.swift
@@ -85,18 +85,25 @@ extension SettingsCellDescriptorFactory {
     }
     
     private var debuggingToolsSection: SettingsSectionDescriptor {
-        // Inner button
-        let findUnreadConversationButton = SettingsButtonCellDescriptor(
-            title: "self.settings.advanced.debugging_tools.first_unread_conversation.title".localized,
-            isDestructive: false,
-            selectAction: SettingsCellDescriptorFactory.findUnreadConversationContributingToBadgeCount
-        )
 
-        // Inner section
-        let findUnreadConversationSection = SettingsSectionDescriptor(
-            cellDescriptors:[findUnreadConversationButton]
-        )
-
+        let findUnreadConversationSection = SettingsSectionDescriptor(cellDescriptors:[
+            SettingsButtonCellDescriptor(
+                title: "self.settings.advanced.debugging_tools.first_unread_conversation.title".localized,
+                isDestructive: false,
+                selectAction: DebugActions.findUnreadConversationContributingToBadgeCount
+            ),
+            SettingsButtonCellDescriptor(
+                title: "self.settings.advanced.debugging_tools.show_user_id.title".localized,
+                isDestructive: false,
+                selectAction: DebugActions.showUserId
+            ),
+            SettingsButtonCellDescriptor(
+                title: "self.settings.advanced.debugging_tools.enter_debug_command.title".localized,
+                isDestructive: false,
+                selectAction: DebugActions.enterDebugCommand
+            )
+        ])
+        
         // Inner group
         let debuggingToolsGroup = SettingsGroupCellDescriptor(
             items: [findUnreadConversationSection],

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
@@ -177,32 +177,32 @@ class SettingsCellDescriptorFactory {
         
         let enableBatchCollections = SettingsPropertyToggleCellDescriptor(settingsProperty: self.settingsPropertyFactory.property(.enableBatchCollections))
         developerCellDescriptors.append(enableBatchCollections)
-        let sendBrokenMessageButton = SettingsButtonCellDescriptor(title: "Send broken message", isDestructive: true, selectAction: SettingsCellDescriptorFactory.sendBrokenMessage)
+        let sendBrokenMessageButton = SettingsButtonCellDescriptor(title: "Send broken message", isDestructive: true, selectAction: DebugActions.sendBrokenMessage)
         developerCellDescriptors.append(sendBrokenMessageButton)
-        let findUnreadBadgeConversationButton = SettingsButtonCellDescriptor(title: "First unread conversation (badge count)", isDestructive: false, selectAction: SettingsCellDescriptorFactory.findUnreadConversationContributingToBadgeCount)
+        let findUnreadBadgeConversationButton = SettingsButtonCellDescriptor(title: "First unread conversation (badge count)", isDestructive: false, selectAction: DebugActions.findUnreadConversationContributingToBadgeCount)
         developerCellDescriptors.append(findUnreadBadgeConversationButton)
-        let findUnreadBackArrowConversationButton = SettingsButtonCellDescriptor(title: "First unread conversation (back arrow count)", isDestructive: false, selectAction: SettingsCellDescriptorFactory.findUnreadConversationContributingToBackArrowDot)
+        let findUnreadBackArrowConversationButton = SettingsButtonCellDescriptor(title: "First unread conversation (back arrow count)", isDestructive: false, selectAction: DebugActions.findUnreadConversationContributingToBackArrowDot)
         developerCellDescriptors.append(findUnreadBackArrowConversationButton)
         let shareDatabase = SettingsShareDatabaseCellDescriptor()
         developerCellDescriptors.append(shareDatabase)
         let shareCryptobox = SettingsShareCryptoboxCellDescriptor()
         developerCellDescriptors.append(shareCryptobox)
-        let reloadUIButton = SettingsButtonCellDescriptor(title: "Reload user interface", isDestructive: false, selectAction: SettingsCellDescriptorFactory.reloadUserInterface)
+        let reloadUIButton = SettingsButtonCellDescriptor(title: "Reload user interface", isDestructive: false, selectAction: DebugActions.reloadUserInterface)
         developerCellDescriptors.append(reloadUIButton)
-        let recalculateBadgeCountButton = SettingsButtonCellDescriptor(title: "Re-calculate badge count", isDestructive: false, selectAction: SettingsCellDescriptorFactory.recalculateBadgeCount)
+        let recalculateBadgeCountButton = SettingsButtonCellDescriptor(title: "Re-calculate badge count", isDestructive: false, selectAction: DebugActions.recalculateBadgeCount)
         developerCellDescriptors.append(recalculateBadgeCountButton)
         let appendManyMessages = SettingsButtonCellDescriptor(title: "Append N messages to the top conv (not sending)", isDestructive: true) { _ in
             
-            self.requestNumber() { count in
-                self.appendMessagesInBatches(count: count)
+            DebugActions.askNumber(title: "Enter count of messages") { count in
+                DebugActions.appendMessagesInBatches(count: count)
             }
         }
         developerCellDescriptors.append(appendManyMessages)
         
         let spamWithMessages = SettingsButtonCellDescriptor(title: "Spam the top conv", isDestructive: true) { _ in
             
-            self.requestNumber() { count in
-                self.spamWithMessages(amount: count)
+            DebugActions.askNumber(title: "Enter count of messages") { count in
+                DebugActions.spamWithMessages(amount: count)
             }
         }
         developerCellDescriptors.append(spamWithMessages)
@@ -213,96 +213,18 @@ class SettingsCellDescriptorFactory {
         if !Analytics.shared().isOptedOut &&
             !TrackingManager.shared.disableCrashAndAnalyticsSharing {
 
-            let resetSurveyMuteButton = SettingsButtonCellDescriptor(title: "Reset call quality survey", isDestructive: false, selectAction: SettingsCellDescriptorFactory.resetCallQualitySurveyMuteFilter)
+            let resetSurveyMuteButton = SettingsButtonCellDescriptor(title: "Reset call quality survey", isDestructive: false, selectAction: DebugActions.resetCallQualitySurveyMuteFilter)
             developerCellDescriptors.append(resetSurveyMuteButton)
 
         }
         
-        let generateCrashButton = SettingsButtonCellDescriptor(title: "Generate test crash", isDestructive: false, selectAction: SettingsCellDescriptorFactory.generateTestCrash)
+        let generateCrashButton = SettingsButtonCellDescriptor(title: "Generate test crash", isDestructive: false, selectAction: DebugActions.generateTestCrash)
         developerCellDescriptors.append(generateCrashButton)
         
-        let triggerSlowSyncButton = SettingsButtonCellDescriptor(title: "Trigger slow sync", isDestructive: false, selectAction: SettingsCellDescriptorFactory.triggerSlowSync)
+        let triggerSlowSyncButton = SettingsButtonCellDescriptor(title: "Trigger slow sync", isDestructive: false, selectAction: DebugActions.triggerSlowSync)
         developerCellDescriptors.append(triggerSlowSyncButton)
 
         return SettingsGroupCellDescriptor(items: [SettingsSectionDescriptor(cellDescriptors:developerCellDescriptors)], title: title, icon: .robot)
-    }
-        
-    func requestNumber(_ callback: @escaping (Int)->()) {
-        guard let controllerToPresentOver = UIApplication.shared.topmostViewController(onlyFullScreen: false) else { return }
-
-        
-        let controller = UIAlertController(
-            title: "Enter count of messages",
-            message: nil,
-            preferredStyle: .alert
-        )
-        
-        let okAction = UIAlertAction(title: "general.ok".localized, style: .default) { [controller] _ in
-            callback(Int(controller.textFields?.first?.text ?? "0")!)
-        }
-        
-        controller.addTextField()
-        
-        controller.addAction(.cancel { })
-        controller.addAction(okAction)
-        controllerToPresentOver.present(controller, animated: true, completion: nil)
-    }
-    
-    func appendMessagesInBatches(count: Int) {
-        var left = count
-        let step = 10_000
-        
-        repeat {
-            let toAppendInThisStep = left < step ? left : step
-            
-            left = left - toAppendInThisStep
-            
-            appendMessages(count: toAppendInThisStep)
-        }
-        while(left > 0)
-    }
-    
-    func appendMessages(count: Int) {
-        let batchSize = 5_000
-        
-        var currentCount = count
-        
-        repeat {
-            let thisBatchCount = currentCount > batchSize ? batchSize : currentCount
-
-            appendMessagesToDatabase(count: thisBatchCount)
-            
-            currentCount = currentCount - thisBatchCount
-        }
-        while (currentCount > 0)
-    }
-    
-    func appendMessagesToDatabase(count: Int) {
-        let userSession = ZMUserSession.shared()!
-        let conversation = ZMConversationList.conversations(inUserSession: userSession).firstObject! as! ZMConversation
-        let conversationId = conversation.objectID
-        
-        let syncContext = userSession.syncManagedObjectContext
-        syncContext.performGroupedBlock {
-            let syncConversation = try! syncContext.existingObject(with: conversationId) as! ZMConversation
-            let messages: [ZMClientMessage] = (0...count).map { i in
-                let nonce = UUID()
-                let genericMessage = GenericMessage(content: Text(content: "Debugging message \(i): Append many messages to the top conversation; Append many messages to the top conversation;"), nonce: nonce)
-                let clientMessage = ZMClientMessage(nonce: nonce, managedObjectContext: syncContext)
-                do {
-                    clientMessage.add(try genericMessage.serializedData())
-                } catch {
-                }
-                clientMessage.sender = ZMUser.selfUser(in: syncContext)
-                
-                clientMessage.expire()
-                clientMessage.linkPreviewState = .done
-                
-                return clientMessage
-            }
-            syncConversation.mutableMessages.addObjects(from: messages)
-            userSession.syncManagedObjectContext.saveOrRollback()
-        }
     }
     
     func helpSection() -> SettingsCellDescriptorType {
@@ -396,158 +318,6 @@ class SettingsCellDescriptorFactory {
             let url = URL.wr_licenseInformation.appendingLocaleParameter
             return BrowserViewController(url: url)
         }, previewGenerator: .none)
-    }
-    
-    // MARK: Actions
-    
-    /// Check if there is any unread conversation, if there is, show an alert with the name and ID of the conversation
-    static func findUnreadConversationContributingToBadgeCount(_ type: SettingsCellDescriptorType) {
-        guard let userSession = ZMUserSession.shared() else { return }
-        let predicate = ZMConversation.predicateForConversationConsideredUnread()!
-        
-        guard let controller = UIApplication.shared.topmostViewController(onlyFullScreen: false) else { return }
-        let alert = UIAlertController(title: nil, message: "", preferredStyle: .alert)
-
-        let uiMOC = userSession.managedObjectContext
-        let fetchRequest = NSFetchRequest<ZMConversation>(entityName: ZMConversation.entityName())
-        let allConversations = uiMOC.fetchOrAssert(request: fetchRequest)
-        
-        if let convo = allConversations.first(where: { predicate.evaluate(with: $0) }) {
-            alert.message = ["Found an unread conversation:",
-                       "\(convo.displayName)",
-                        "<\(convo.remoteIdentifier?.uuidString ?? "n/a")>"
-                ].joined(separator: "\n")
-            alert.addAction(UIAlertAction(title: "Copy", style: .default, handler: { _ in
-                UIPasteboard.general.string = alert.message
-            }))
-
-        } else {
-            alert.message = "No unread conversation"
-        }
-        
-        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
-        controller.present(alert, animated: false)
-    }
-    
-    private static func recalculateBadgeCount(_ type: SettingsCellDescriptorType) {
-        guard let userSession = ZMUserSession.shared() else { return }
-        guard let controller = UIApplication.shared.topmostViewController(onlyFullScreen: false) else { return }
-        
-        var conversations: [ZMConversation]? = nil
-        userSession.syncManagedObjectContext.performGroupedBlock {
-            conversations = try? userSession.syncManagedObjectContext.fetch(NSFetchRequest<ZMConversation>(entityName: ZMConversation.entityName()))
-            conversations?.forEach({ _ = $0.estimatedUnreadCount })
-        }
-        userSession.syncManagedObjectContext.dispatchGroup.wait(forInterval: 5)
-        userSession.syncManagedObjectContext.performGroupedBlockAndWait {
-            conversations = nil
-            userSession.syncManagedObjectContext.saveOrRollback()
-        }
-        
-        let alertController = UIAlertController(title: "Updated", message: "Badge count  has been re-calculated", alertAction: .ok(style: .cancel))
-        controller.show(alertController, sender: nil)
-    }
-    
-    /// Check if there is any unread conversation, if there is, show an alert with the name and ID of the conversation
-    private static func findUnreadConversationContributingToBackArrowDot(_ type: SettingsCellDescriptorType) {
-        guard let userSession = ZMUserSession.shared() else { return }
-        let predicate = ZMConversation.predicateForConversationConsideredUnreadExcludingSilenced()!
-        
-        guard let controller = UIApplication.shared.topmostViewController(onlyFullScreen: false) else { return }
-        let alert = UIAlertController(title: nil, message: "", preferredStyle: .alert)
-        
-        if let convo = (ZMConversationList.conversations(inUserSession: userSession) as! [ZMConversation])
-            .first(where: predicate.evaluate)
-        {
-            alert.message = ["Found an unread conversation:",
-                             "\(convo.displayName)",
-                "<\(convo.remoteIdentifier?.uuidString ?? "n/a")>"
-                ].joined(separator: "\n")
-            alert.addAction(UIAlertAction(title: "Copy", style: .default, handler: { _ in
-                UIPasteboard.general.string = alert.message
-            }))
-            
-        } else {
-            alert.message = "No unread conversation"
-        }
-        
-        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
-        controller.present(alert, animated: false)
-    }
-    
-    /// Sends a message that will fail to decode on every other device, on the first conversation of the list
-    private static func sendBrokenMessage(_ type: SettingsCellDescriptorType) {
-        guard
-            let userSession = ZMUserSession.shared(),
-            let conversation = ZMConversationList.conversationsIncludingArchived(inUserSession: userSession).firstObject as? ZMConversation
-            else {
-                return
-        }
-        
-        var external = External()
-        if let otr = "broken_key".data(using: .utf8)  {
-             external.otrKey = otr
-        }
-        let genericMessage = GenericMessage(content: external)
-        
-        userSession.enqueue {
-            conversation.appendClientMessage(with: genericMessage, expires: false, hidden: false)
-        }
-    }
-    
-    /// Sends a number of messages to the top conversation in the list, in an asynchronous fashion
-    func spamWithMessages(amount: Int) {
-        guard
-            amount > 0,
-            let userSession = ZMUserSession.shared(),
-            let conversation = ZMConversationList.conversationsIncludingArchived(inUserSession: userSession).firstObject as? ZMConversation
-            else {
-                return
-        }
-        let nonce = UUID()
-        
-        func sendNext(count: Int) {
-            userSession.enqueue {
-                conversation.append(text: "Message #\(count+1), series \(nonce)")
-            }
-            guard count + 1 < amount else { return }
-            DispatchQueue.main.asyncAfter(
-                deadline: .now() + 0.4,
-                execute: { sendNext(count: count + 1) }
-            )
-        }
-        
-        sendNext(count: 0)
-    }
-    
-    private static func triggerSlowSync(_ type: SettingsCellDescriptorType) {
-        ZMUserSession.shared()?.syncManagedObjectContext.performGroupedBlock {
-            ZMUserSession.shared()?.requestSlowSync()
-        }
-    }
-    
-    private static func generateTestCrash(_ type: SettingsCellDescriptorType) {
-        MSCrashes.generateTestCrash()
-    }
-    
-    private static func reloadUserInterface(_ type: SettingsCellDescriptorType) {
-        guard let rootViewController = UIApplication.shared.keyWindow?.rootViewController as? AppRootViewController else {
-            return
-        }
-        
-        rootViewController.reload()
-    }
-
-    private static func resetCallQualitySurveyMuteFilter(_ type: SettingsCellDescriptorType) {
-        guard let controller = UIApplication.shared.topmostViewController(onlyFullScreen: false) else { return }
-
-        CallQualityController.resetSurveyMuteFilter()
-
-        let alert = UIAlertController(title: "Success",
-                                      message: "The call quality survey will be displayed after the next call.",
-                                      alertAction: .ok(style: .cancel))
-
-        controller.present(alert, animated: true)
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Settings/DebugActions.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DebugActions.swift
@@ -1,0 +1,292 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireSyncEngine
+import AppCenterCrashes
+
+
+class DebugActions {
+    
+    /// Shows an alert with the option to copy text to the clipboard
+    static func alert(
+        _ message: String,
+        title: String = "",
+        textToCopy: String? = nil)
+    {
+        guard let controller = UIApplication.shared.topmostViewController(onlyFullScreen: false) else { return }
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        if let textToCopy = textToCopy {
+            alert.addAction(UIAlertAction(title: "Copy", style: .default, handler: { _ in
+                UIPasteboard.general.string = textToCopy
+            }))
+        }
+        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+        controller.present(alert, animated: false)
+    }
+    
+    /// Check if there is any unread conversation, if there is, show an alert with the name and ID of the conversation
+    static func findUnreadConversationContributingToBadgeCount(_ type: SettingsCellDescriptorType) {
+        guard let userSession = ZMUserSession.shared() else { return }
+        let predicate = ZMConversation.predicateForConversationConsideredUnread()!
+        
+        let uiMOC = userSession.managedObjectContext
+        let fetchRequest = NSFetchRequest<ZMConversation>(entityName: ZMConversation.entityName())
+        let allConversations = uiMOC.fetchOrAssert(request: fetchRequest)
+        
+        if let convo = allConversations.first(where: { predicate.evaluate(with: $0) }) {
+            
+            let message = ["Found an unread conversation:",
+                       "\(convo.displayName)",
+                        "<\(convo.remoteIdentifier?.uuidString ?? "n/a")>"
+                ].joined(separator: "\n")
+            let textToCopy = convo.remoteIdentifier?.uuidString
+            alert(message, textToCopy: textToCopy)
+        } else {
+            alert("No unread conversation")
+        }
+    }
+    
+    /// Shows the user ID of the self user
+    static func showUserId(_ type: SettingsCellDescriptorType) {
+        guard let userSession = ZMUserSession.shared(),
+            let selfUser = (userSession.selfUser as? ZMUser)
+        else { return }
+        
+        alert(
+            selfUser.remoteIdentifier.uuidString,
+            title: "User Id",
+            textToCopy: selfUser.remoteIdentifier.uuidString
+        )
+    }
+    
+    /// Check if there is any unread conversation, if there is, show an alert with the name and ID of the conversation
+    static func findUnreadConversationContributingToBackArrowDot(_ type: SettingsCellDescriptorType) {
+        guard let userSession = ZMUserSession.shared() else { return }
+        let predicate = ZMConversation.predicateForConversationConsideredUnreadExcludingSilenced()!
+        
+        if let convo = (ZMConversationList.conversations(inUserSession: userSession) as! [ZMConversation])
+            .first(where: predicate.evaluate)
+        {
+            let message = ["Found an unread conversation:",
+                             "\(convo.displayName)",
+                "<\(convo.remoteIdentifier?.uuidString ?? "n/a")>"
+                ].joined(separator: "\n")
+            let textToCopy = convo.remoteIdentifier?.uuidString
+            alert(message, textToCopy: textToCopy)
+            
+        } else {
+            alert("No unread conversation")
+        }
+    }
+    
+    /// Sends a message that will fail to decode on every other device, on the first conversation of the list
+    static func sendBrokenMessage(_ type: SettingsCellDescriptorType) {
+        guard
+            let userSession = ZMUserSession.shared(),
+            let conversation = ZMConversationList.conversationsIncludingArchived(inUserSession: userSession).firstObject as? ZMConversation
+            else {
+                return
+        }
+        
+        var external = External()
+        if let otr = "broken_key".data(using: .utf8)  {
+             external.otrKey = otr
+        }
+        let genericMessage = GenericMessage(content: external)
+        
+        userSession.enqueue {
+            _ = conversation.appendClientMessage(with: genericMessage, expires: false, hidden: false)
+        }
+    }
+    
+    /// Sends a number of messages to the top conversation in the list, in an asynchronous fashion
+    static func spamWithMessages(amount: Int) {
+        guard
+            amount > 0,
+            let userSession = ZMUserSession.shared(),
+            let conversation = ZMConversationList.conversationsIncludingArchived(inUserSession: userSession).firstObject as? ZMConversation
+            else {
+                return
+        }
+        let nonce = UUID()
+        
+        func sendNext(count: Int) {
+            userSession.enqueue {
+                conversation.append(text: "Message #\(count+1), series \(nonce)")
+            }
+            guard count + 1 < amount else { return }
+            DispatchQueue.main.asyncAfter(
+                deadline: .now() + 0.4,
+                execute: { sendNext(count: count + 1) }
+            )
+        }
+        
+        sendNext(count: 0)
+    }
+    
+    static func triggerSlowSync(_ type: SettingsCellDescriptorType) {
+        ZMUserSession.shared()?.syncManagedObjectContext.performGroupedBlock {
+            ZMUserSession.shared()?.requestSlowSync()
+        }
+    }
+    
+    static func generateTestCrash(_ type: SettingsCellDescriptorType) {
+        MSCrashes.generateTestCrash()
+    }
+    
+    static func reloadUserInterface(_ type: SettingsCellDescriptorType) {
+        guard let rootViewController = UIApplication.shared.keyWindow?.rootViewController as? AppRootViewController else {
+            return
+        }
+        
+        rootViewController.reload()
+    }
+
+    static func resetCallQualitySurveyMuteFilter(_ type: SettingsCellDescriptorType) {
+        guard let controller = UIApplication.shared.topmostViewController(onlyFullScreen: false) else { return }
+
+        CallQualityController.resetSurveyMuteFilter()
+
+        let alert = UIAlertController(title: "Success",
+                                      message: "The call quality survey will be displayed after the next call.",
+                                      alertAction: .ok(style: .cancel))
+
+        controller.present(alert, animated: true)
+    }
+    
+    /// Accepts a debug command
+    static func enterDebugCommand(_ type: SettingsCellDescriptorType) {
+        askString(title: "Debug command") { _ in
+            alert("Command not recognized")
+        }
+    }
+    
+    static func appendMessagesToDatabase(count: Int) {
+        let userSession = ZMUserSession.shared()!
+        let conversation = ZMConversationList.conversations(inUserSession: userSession).firstObject! as! ZMConversation
+        let conversationId = conversation.objectID
+        
+        let syncContext = userSession.syncManagedObjectContext
+        syncContext.performGroupedBlock {
+            let syncConversation = try! syncContext.existingObject(with: conversationId) as! ZMConversation
+            let messages: [ZMClientMessage] = (0...count).map { i in
+                let nonce = UUID()
+                let genericMessage = GenericMessage(content: Text(content: "Debugging message \(i): Append many messages to the top conversation; Append many messages to the top conversation;"), nonce: nonce)
+                let clientMessage = ZMClientMessage(nonce: nonce, managedObjectContext: syncContext)
+                do {
+                    clientMessage.add(try genericMessage.serializedData())
+                } catch {
+                }
+                clientMessage.sender = ZMUser.selfUser(in: syncContext)
+                
+                clientMessage.expire()
+                clientMessage.linkPreviewState = .done
+                
+                return clientMessage
+            }
+            syncConversation.mutableMessages.addObjects(from: messages)
+            userSession.syncManagedObjectContext.saveOrRollback()
+        }
+    }
+    
+    static func recalculateBadgeCount(_ type: SettingsCellDescriptorType) {
+        guard let userSession = ZMUserSession.shared() else { return }
+        guard let controller = UIApplication.shared.topmostViewController(onlyFullScreen: false) else { return }
+        
+        var conversations: [ZMConversation]? = nil
+        userSession.syncManagedObjectContext.performGroupedBlock {
+            conversations = try? userSession.syncManagedObjectContext.fetch(NSFetchRequest<ZMConversation>(entityName: ZMConversation.entityName()))
+            conversations?.forEach({ _ = $0.estimatedUnreadCount })
+        }
+        userSession.syncManagedObjectContext.dispatchGroup.wait(forInterval: 5)
+        userSession.syncManagedObjectContext.performGroupedBlockAndWait {
+            conversations = nil
+            userSession.syncManagedObjectContext.saveOrRollback()
+        }
+        
+        let alertController = UIAlertController(title: "Updated", message: "Badge count  has been re-calculated", alertAction: .ok(style: .cancel))
+        controller.show(alertController, sender: nil)
+    }
+    
+    static func askNumber(
+        title: String,
+        _ callback: @escaping (Int)->())
+    {
+        askString(title: title) {
+            if let number = NumberFormatter().number(from: $0) {
+                callback(number.intValue)
+            } else {
+              alert("ERROR: not a number")
+            }
+        }
+    }
+    
+    static func askString(
+        title: String,
+        _ callback: @escaping (String)->())
+    {
+        guard let controllerToPresentOver = UIApplication.shared.topmostViewController(onlyFullScreen: false) else { return }
+
+        
+        let controller = UIAlertController(
+            title: title,
+            message: nil,
+            preferredStyle: .alert
+        )
+        
+        let okAction = UIAlertAction(title: "general.ok".localized, style: .default) { [controller] _ in
+            callback(controller.textFields?.first?.text ?? "")
+        }
+        
+        controller.addTextField()
+        
+        controller.addAction(.cancel { })
+        controller.addAction(okAction)
+        controllerToPresentOver.present(controller, animated: true, completion: nil)
+    }
+    
+    static func appendMessagesInBatches(count: Int) {
+        var left = count
+        let step = 10_000
+        
+        repeat {
+            let toAppendInThisStep = left < step ? left : step
+            
+            left = left - toAppendInThisStep
+            
+            appendMessages(count: toAppendInThisStep)
+        }
+        while(left > 0)
+    }
+    
+    static func appendMessages(count: Int) {
+        let batchSize = 5_000
+        
+        var currentCount = count
+        
+        repeat {
+            let thisBatchCount = currentCount > batchSize ? batchSize : currentCount
+
+            appendMessagesToDatabase(count: thisBatchCount)
+            
+            currentCount = currentCount - thisBatchCount
+        }
+        while (currentCount > 0)
+    }
+}

--- a/Wire-iOS/Sources/UserInterface/Settings/DebugActions.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DebugActions.swift
@@ -21,7 +21,7 @@ import WireSyncEngine
 import AppCenterCrashes
 
 
-class DebugActions {
+enum DebugActions {
     
     /// Shows an alert with the option to copy text to the clipboard
     static func alert(


### PR DESCRIPTION
## What's new in this PR?

As part of an investigation about decryption errors with the security team, I want to add more debugging capabilities to the app. In particular, we want to add a debug console to the app that will allow us to enter specific commands with parameters (such as the user ID or conversation ID that should be affected by that command).

This PR does some ground work, by adding more options to the troubleshooting public menu. As I was adding these menu items, I also noticed a lot of code related to (internal) debug options.

I thought it would be cleaner to have debug logic in its own file, instead of inside `SettingsCellDescriptorFactory`. I moved that code to its own file. In the process I removed some duplicated code (e.g. code for alerts) by refactoring to common functions.

I created this PR before I continue with the next steps that are needed for my investigation, so that changes are easier to track. I will open more PRs in the future.

### Main changes
- Moved debug menu actions to their own file `DebugActions` (I'm open to suggestions on naming or to where to put this file)
- Added placeholder debug menu item to enter debug commands
- Added debug menu item to print user ID