### PR TITLE
add tests for upgrade form old version without custom app lock

### DIFF
--- a/Wire-iOS Tests/AppLock/AppLockPresenterTests.swift
+++ b/Wire-iOS Tests/AppLock/AppLockPresenterTests.swift
@@ -442,7 +442,7 @@ final class AppLockPresenterTests: XCTestCase {
         
     }
 
-    func testThatAppLockDoesNotShowIfIsCustomPasscodeNotSet() {
+    func testThatAppLockDoesNotShowIfIsCustomPasscodIsSet() {
         //GIVEN
         appLockInteractor.isCustomPasscodeNotSet = false
         

--- a/Wire-iOS Tests/AppLock/AppLockPresenterTests.swift
+++ b/Wire-iOS Tests/AppLock/AppLockPresenterTests.swift
@@ -28,6 +28,8 @@ private final class AppLockUserInterfaceMock: AppLockUserInterface {
     
     var passwordInput: String?
     var requestPasswordMessage: String?
+    var presentCreatePasscodeScreenCalled: Bool = false
+    
     func presentUnlockScreen(with message: String,
                              callback: @escaping RequestPasswordController.Callback) {
         requestPasswordMessage = message
@@ -35,7 +37,7 @@ private final class AppLockUserInterfaceMock: AppLockUserInterface {
     }
     
     func presentCreatePasscodeScreen(callback: ResultHandler?) {
-        // no-op
+        presentCreatePasscodeScreenCalled = true
     }
     
     var spinnerAnimating: Bool?
@@ -55,6 +57,7 @@ private final class AppLockUserInterfaceMock: AppLockUserInterface {
 }
 
 private final class AppLockInteractorMock: AppLockInteractorInput {
+    var isCustomPasscodeNotSet: Bool = false
     var _isAuthenticationNeeded: Bool = false
     var didCallIsAuthenticationNeeded: Bool = false
     var isAuthenticationNeeded: Bool {
@@ -424,6 +427,31 @@ final class AppLockPresenterTests: XCTestCase {
         sut.appStateDidTransition(notification(for: AppState.blacklisted(jailbroken: true)))
         //then
         assert(contentsDimmed: false, reauthVisibile: false)
+    }
+    
+    //MARK: - custom app lock
+    func testThatUpdateFromAnOldVersionToNewVersionSupportAppLockShowsCreatePasscodeScreen() {
+        //GIVEN
+        appLockInteractor.isCustomPasscodeNotSet = true
+        
+        //WHEN
+        sut.authenticationEvaluated(with: .needAccountPassword)
+
+        //THEN
+        XCTAssert( userInterface.presentCreatePasscodeScreenCalled)
+        
+    }
+
+    func testThatAppLockDoesNotShowIfIsCustomPasscodeNotSet() {
+        //GIVEN
+        appLockInteractor.isCustomPasscodeNotSet = false
+        
+        //WHEN
+        sut.authenticationEvaluated(with: .needAccountPassword)
+        
+        //THEN
+        XCTAssertFalse( userInterface.presentCreatePasscodeScreenCalled)
+        
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockInteractor.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockInteractor.swift
@@ -22,6 +22,7 @@ import WireCommonComponents
 import WireSyncEngine
 
 protocol AppLockInteractorInput: class {
+    var isCustomPasscodeNotSet: Bool { get }
     var isAuthenticationNeeded: Bool { get }
     func evaluateAuthentication(description: String)
     func verify(password: String)
@@ -53,6 +54,10 @@ final class AppLockInteractor {
 
 // MARK: - Interface
 extension AppLockInteractor: AppLockInteractorInput {
+    var isCustomPasscodeNotSet: Bool {
+        return AppLock.isCustomPasscodeNotSet
+    }
+    
     var isAuthenticationNeeded: Bool {
         let screenLockIsActive = appLock.isActive && isLockTimeoutReached && isAppStateAuthenticated
         

--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockPresenter.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockPresenter.swift
@@ -156,7 +156,7 @@ extension AppLockPresenter: AppLockInteractorOutput {
 
         if case .needAccountPassword = result {
             // When upgrade form a version not support custom passcode, ask the user to create a new passcode
-            if AppLock.isCustomPasscodeNotSet {
+            if appLockInteractorInput.isCustomPasscodeNotSet {
                 userInterface?.presentCreatePasscodeScreen(callback: { _ in
                     // user need to enter the newly created passcode after creation
                     self.setContents(dimmed: true, withReauth: true)


### PR DESCRIPTION
## What's new in this PR?

fix for https://github.com/wireapp/wire-ios/pull/4495#discussion_r483703698

Create tests for showing create passcode screen or not when app lock screen is shown.