### PR TITLE
fix: move close button logic inside PasscodeSetupViewController

### DIFF
--- a/Wire-iOS Tests/AppLock/AppLockPresenterTests.swift
+++ b/Wire-iOS Tests/AppLock/AppLockPresenterTests.swift
@@ -90,7 +90,7 @@ private final class AppLockInteractorMock: AppLockInteractorInput {
 }
 
 final class AppLockPresenterTests: XCTestCase {
-    var sut: AppLockPresenter!
+    private var sut: AppLockPresenter!
     private var userInterface: AppLockUserInterfaceMock!
     private var appLockInteractor: AppLockInteractorMock!
     

--- a/Wire-iOS/Sources/Authentication/Coordinator/Coordinator+Delegates/AuthenticationCoordinator+PasscodeSetup.swift
+++ b/Wire-iOS/Sources/Authentication/Coordinator/Coordinator+Delegates/AuthenticationCoordinator+PasscodeSetup.swift
@@ -18,6 +18,9 @@
 import Foundation
 
 extension AuthenticationCoordinator: PasscodeSetupViewControllerDelegate {
+    func passcodeSetupControllerDidDismissed(_ viewController: PasscodeSetupViewController) {
+        //no-op
+    }
 
     func passcodeSetupControllerDidFinish(_ viewController: PasscodeSetupViewController) {
         eventResponderChain.handleEvent(ofType: .passcodeSetupCompleted)

--- a/Wire-iOS/Sources/Authentication/Coordinator/Coordinator+Delegates/AuthenticationCoordinator+PasscodeSetup.swift
+++ b/Wire-iOS/Sources/Authentication/Coordinator/Coordinator+Delegates/AuthenticationCoordinator+PasscodeSetup.swift
@@ -18,7 +18,7 @@
 import Foundation
 
 extension AuthenticationCoordinator: PasscodeSetupViewControllerDelegate {
-    func passcodeSetupControllerDidDismissed(_ viewController: PasscodeSetupViewController) {
+    func passcodeSetupControllerWasDismissed(_ viewController: PasscodeSetupViewController) {
         //no-op
     }
 

--- a/Wire-iOS/Sources/UserInterface/Overlay/CustomAppLock/Setup/PasscodeSetupPresenter.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/CustomAppLock/Setup/PasscodeSetupPresenter.swift
@@ -22,7 +22,7 @@ final class PasscodeSetupPresenter {
     private var interactorInput: PasscodeSetupInteractorInput
 
     private var passcodeValidationResult: PasscodeValidationResult?
-    
+
     var isPasscodeValid: Bool {
         switch passcodeValidationResult {
         case .accepted:
@@ -31,7 +31,7 @@ final class PasscodeSetupPresenter {
             return false
         }
     }
-    
+
     convenience init(userInterface: PasscodeSetupUserInterface) {
         let interactor = PasscodeSetupInteractor()
         self.init(userInterface: userInterface, interactorInput: interactor)
@@ -47,7 +47,7 @@ final class PasscodeSetupPresenter {
     func validate(error: TextFieldValidator.ValidationError?) {
         interactorInput.validate(error: error)
     }
-    
+
     func storePasscode(passcode: String, callback: ResultHandler?) {
         do {
             try interactorInput.storePasscode(passcode: passcode)
@@ -69,7 +69,7 @@ extension PasscodeSetupPresenter: PasscodeSetupInteractorOutput {
 
     func passcodeValidated(result: PasscodeValidationResult) {
         passcodeValidationResult = result
-        
+
         switch result {
         case .accepted:
             userInterface?.createButtonEnabled = true

--- a/Wire-iOS/Sources/UserInterface/Overlay/CustomAppLock/Setup/PasscodeSetupViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/CustomAppLock/Setup/PasscodeSetupViewController.swift
@@ -28,14 +28,14 @@ extension PasscodeSetupViewController: AuthenticationCoordinatedViewController {
     func executeErrorFeedbackAction(_ feedbackAction: AuthenticationErrorFeedbackAction) {
         //no-op
     }
-    
+
     func displayError(_ error: Error) {
         //no-op
     }
 }
 
 final class PasscodeSetupViewController: UIViewController {
-    
+
     weak var passcodeSetupViewControllerDelegate: PasscodeSetupViewControllerDelegate?
 
     // MARK: AuthenticationCoordinatedViewController
@@ -64,9 +64,9 @@ final class PasscodeSetupViewController: UIViewController {
         let textField = AccessoryTextField.createPasscodeTextField(kind: .passcode(isNew: true), delegate: self)
         textField.placeholder = "create_passcode.textfield.placeholder".localized
         textField.delegate = self
-        
+
         textField.addTarget(self, action: #selector(textFieldDidChange(textField:)), for: .editingChanged)
-        
+
         return textField
     }()
 
@@ -78,19 +78,19 @@ final class PasscodeSetupViewController: UIViewController {
     }()
 
     private let useCompactLayout: Bool
-        
+
     private lazy var infoLabel: UILabel = {
         let label = UILabel()
         label.configMultipleLineLabel()
         label.textAlignment = .center
 
         let textColor = UIColor.from(scheme: .textForeground, variant: variant)
-        
+
         let regularFont: UIFont
         let heightFont: UIFont
         let lineHeight: CGFloat
 
-        if useCompactLayout  {
+        if useCompactLayout {
             regularFont = FontSpec(.small, .regular).font!
             heightFont = FontSpec(.small, .bold).font!
             lineHeight = 14
@@ -99,7 +99,7 @@ final class PasscodeSetupViewController: UIViewController {
             heightFont = FontSpec(.normal, .bold).font!
             lineHeight = 20
         }
-        
+
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.minimumLineHeight = lineHeight
         paragraphStyle.maximumLineHeight = lineHeight
@@ -138,7 +138,6 @@ final class PasscodeSetupViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    
     /// init with parameters
     /// - Parameters:
     ///   - callback: callback for storing passcode result.
@@ -149,7 +148,7 @@ final class PasscodeSetupViewController: UIViewController {
                   useCompactLayout: Bool? = nil) {
         self.callback = callback
         self.variant = variant ?? ColorScheme.default.variant
-        
+
         self.useCompactLayout = useCompactLayout ??
                                 (AppDelegate.shared.window!.frame.height <= CGFloat.iPhone4Inch.height)
 
@@ -241,59 +240,58 @@ final class PasscodeSetupViewController: UIViewController {
     private func storePasscode() {
         guard let passcode = passcodeTextField.text else { return }
         presenter.storePasscode(passcode: passcode, callback: callback)
-        
+
         authenticationCoordinator?.passcodeSetupControllerDidFinish(self)
         dismiss(animated: true)
     }
-    
+
     @objc
     private func textFieldDidChange(textField: UITextField) {
         passcodeTextField.returnKeyType = presenter.isPasscodeValid ? .done : .default
         passcodeTextField.reloadInputViews()
     }
-    
+
     @objc
     private func onCreateCodeButtonPressed(sender: AnyObject?) {
         storePasscode()
     }
 
     // MARK: - keyboard avoiding
-    
+
     static func createKeyboardAvoidingFullScreenView(callback: ResultHandler?,
                                                      variant: ColorSchemeVariant? = nil) -> KeyboardAvoidingAuthenticationCoordinatedViewController {
         let passcodeSetupViewController = PasscodeSetupViewController(callback: callback,
                                                                       variant: variant)
-        
+
         let keyboardAvoidingViewController = KeyboardAvoidingAuthenticationCoordinatedViewController(viewController: passcodeSetupViewController)
-        
+
         keyboardAvoidingViewController.modalPresentationStyle = .fullScreen
 
         return keyboardAvoidingViewController
     }
-    
-    
-    //MARK: - close button
-    
+
+    // MARK: - close button
+
     lazy var closeItem: UIBarButtonItem = {
         let closeItem = UIBarButtonItem.createCloseItem()
         closeItem.tintColor = .white
-        
+
         closeItem.target = self
         closeItem.action = #selector(PasscodeSetupViewController.closeTapped)
-        
+
         return closeItem
     }()
-    
+
     @objc
     private func closeTapped() {
         dismiss(animated: true)
 
         appLockSetupViewControllerDismissed()
     }
-    
+
     private func appLockSetupViewControllerDismissed() {
         callback?(false)
-        
+
         passcodeSetupViewControllerDelegate?.passcodeSetupControllerWasDismissed(self)
     }
 }
@@ -305,7 +303,7 @@ extension PasscodeSetupViewController: UITextFieldDelegate {
         guard presenter.isPasscodeValid else {
             return false
         }
-        
+
         storePasscode()
         return true
     }
@@ -353,7 +351,7 @@ extension PasscodeSetupViewController: UIAdaptivePresentationControllerDelegate 
     func presentationControllerWillDismiss(_ presentationController: UIPresentationController) {
         appLockSetupViewControllerDismissed()
     }
-    
+
     func adaptivePresentationStyle(for controller: UIPresentationController) -> UIModalPresentationStyle {
         // more space for iPhone 4-inch to prevent keyboard hides the create passcode button
         if view.frame.size.height <= CGFloat.iPhone4Inch.height {
@@ -366,5 +364,5 @@ extension PasscodeSetupViewController: UIAdaptivePresentationControllerDelegate 
             }
         }
     }
-    
+
 }

--- a/Wire-iOS/Sources/UserInterface/Overlay/CustomAppLock/Setup/PasscodeSetupViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/CustomAppLock/Setup/PasscodeSetupViewController.swift
@@ -294,7 +294,7 @@ final class PasscodeSetupViewController: UIViewController {
     private func appLockSetupViewControllerDismissed() {
         callback?(false)
         
-        passcodeSetupViewControllerDelegate?.passcodeSetupControllerDidDismissed(self)
+        passcodeSetupViewControllerDelegate?.passcodeSetupControllerWasDismissed(self)
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Overlay/CustomAppLock/Setup/PasscodeSetupViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/CustomAppLock/Setup/PasscodeSetupViewController.swift
@@ -270,6 +270,35 @@ final class PasscodeSetupViewController: UIViewController {
 
         return keyboardAvoidingViewController
     }
+    
+    
+    //MARK: - close button
+    
+    lazy var closeItem: UIBarButtonItem = {
+        let closeItem = UIBarButtonItem.createCloseItem()
+        closeItem.tintColor = .white
+        
+        closeItem.target = self
+        closeItem.action = #selector(PasscodeSetupViewController.closeTapped)
+        
+        return closeItem
+    }()
+    
+    @objc
+    private func closeTapped() {
+        dismiss(animated: true)
+
+        appLockSetupViewControllerDismissed()
+    }
+    
+    private func appLockSetupViewControllerDismissed() {
+        callback?(false)
+        
+        passcodeSetupViewControllerDelegate?.passcodeSetupControllerDidDismissed(self)
+        
+        // refresh options applock switch
+//        (topViewController as? SettingsTableViewController)?.refreshData()
+    }
 }
 
 // MARK: - UITextFieldDelegate
@@ -319,4 +348,26 @@ extension PasscodeSetupViewController: PasscodeSetupUserInterface {
             createButton.isEnabled = newValue
         }
     }
+}
+
+// MARK: - UIAdaptivePresentationControllerDelegate
+extension PasscodeSetupViewController: UIAdaptivePresentationControllerDelegate {
+    @available(iOS 13.0, *)
+    func presentationControllerWillDismiss(_ presentationController: UIPresentationController) {
+        appLockSetupViewControllerDismissed()
+    }
+    
+    func adaptivePresentationStyle(for controller: UIPresentationController) -> UIModalPresentationStyle {
+        // more space for iPhone 4-inch to prevent keyboard hides the create passcode button
+        if view.frame.size.height <= CGFloat.iPhone4Inch.height {
+            return .fullScreen
+        } else {
+            if #available(iOS 13.0, *) {
+                return .automatic
+            } else {
+                return .none
+            }
+        }
+    }
+    
 }

--- a/Wire-iOS/Sources/UserInterface/Overlay/CustomAppLock/Setup/PasscodeSetupViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/CustomAppLock/Setup/PasscodeSetupViewController.swift
@@ -295,9 +295,6 @@ final class PasscodeSetupViewController: UIViewController {
         callback?(false)
         
         passcodeSetupViewControllerDelegate?.passcodeSetupControllerDidDismissed(self)
-        
-        // refresh options applock switch
-//        (topViewController as? SettingsTableViewController)?.refreshData()
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Overlay/CustomAppLock/Setup/PasscodeSetupViewControllerDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/CustomAppLock/Setup/PasscodeSetupViewControllerDelegate.swift
@@ -18,7 +18,6 @@
 import Foundation
 
 protocol PasscodeSetupViewControllerDelegate: class {
-    func passcodeSetupControllerDidFinish(_ viewController: PasscodeSetupViewController)
-    
+    func passcodeSetupControllerDidFinish(_ viewController: PasscodeSetupViewController)    
     func passcodeSetupControllerWasDismissed(_ viewController: PasscodeSetupViewController)
 }

--- a/Wire-iOS/Sources/UserInterface/Overlay/CustomAppLock/Setup/PasscodeSetupViewControllerDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/CustomAppLock/Setup/PasscodeSetupViewControllerDelegate.swift
@@ -20,5 +20,5 @@ import Foundation
 protocol PasscodeSetupViewControllerDelegate: class {
     func passcodeSetupControllerDidFinish(_ viewController: PasscodeSetupViewController)
     
-    func passcodeSetupControllerDidDismissed(_ viewController: PasscodeSetupViewController)
+    func passcodeSetupControllerWasDismissed(_ viewController: PasscodeSetupViewController)
 }

--- a/Wire-iOS/Sources/UserInterface/Overlay/CustomAppLock/Setup/PasscodeSetupViewControllerDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/CustomAppLock/Setup/PasscodeSetupViewControllerDelegate.swift
@@ -19,4 +19,6 @@ import Foundation
 
 protocol PasscodeSetupViewControllerDelegate: class {
     func passcodeSetupControllerDidFinish(_ viewController: PasscodeSetupViewController)
+    
+    func passcodeSetupControllerDidDismissed(_ viewController: PasscodeSetupViewController)
 }

--- a/Wire-iOS/Sources/UserInterface/Overlay/CustomAppLock/Setup/PasscodeSetupViewControllerDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/CustomAppLock/Setup/PasscodeSetupViewControllerDelegate.swift
@@ -18,6 +18,6 @@
 import Foundation
 
 protocol PasscodeSetupViewControllerDelegate: class {
-    func passcodeSetupControllerDidFinish(_ viewController: PasscodeSetupViewController)    
+    func passcodeSetupControllerDidFinish(_ viewController: PasscodeSetupViewController)
     func passcodeSetupControllerWasDismissed(_ viewController: PasscodeSetupViewController)
 }

--- a/Wire-iOS/Sources/UserInterface/Overlay/CustomAppLock/WipeDatabaseViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/CustomAppLock/WipeDatabaseViewController.swift
@@ -104,7 +104,6 @@ final class WipeDatabaseViewController: UIViewController {
             
             self?.deleteAccounts()
             Keychain.deletePasscode()
-            ///TODO: reset passcode setting to false?
             
             self?.displayWipeCompletionScreen()
 

--- a/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
@@ -42,7 +42,6 @@ final class SelfProfileViewController: UIViewController {
     private let profileHeaderViewController: ProfileHeaderViewController
 
     // MARK: - AppLock
-    private weak var appLockSetupViewController: UIViewController?
     private var callback: ResultHandler?
 
     // MARK: - Configuration
@@ -221,10 +220,7 @@ extension SelfProfileViewController: SettingsPropertyFactoryDelegate {
             let closeItem = passcodeSetupViewController.closeItem
 
             keyboardAvoidingViewController.navigationItem.leftBarButtonItem = closeItem
-            
-            
-            appLockSetupViewController = wrappedViewController
-            
+                        
             wrappedViewController.presentationController?.delegate = passcodeSetupViewController
             
             UIApplication.shared.topmostViewController()?.present(wrappedViewController, animated: true)

--- a/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
@@ -236,7 +236,7 @@ extension SelfProfileViewController: PasscodeSetupViewControllerDelegate {
         //no-op
     }
     
-    func passcodeSetupControllerDidDismissed(_ viewController: PasscodeSetupViewController) {
+    func passcodeSetupControllerWasDismissed(_ viewController: PasscodeSetupViewController) {
         // refresh options applock switch
         (topViewController as? SettingsTableViewController)?.refreshData()
     }


### PR DESCRIPTION
## What's new in this PR?
Fix for https://github.com/wireapp/wire-ios/pull/4495#discussion_r483714903
Move logic of close button to `PasscodeSetupViewController`