### PR TITLE
[Fix] Unable to re-record an audio message

### DIFF
--- a/Wire-iOS Tests/AudioRecordKeyboardViewControllerTests.swift
+++ b/Wire-iOS Tests/AudioRecordKeyboardViewControllerTests.swift
@@ -181,7 +181,7 @@ final class AudioRecordKeyboardViewControllerTests: XCTestCase {
         // then
         XCTAssertEqual(self.sut.state, AudioRecordKeyboardViewController.State.ready)
         XCTAssertEqual(self.mockDelegate.didStartRecordingHitCount, 1)
-
+        XCTAssertEqual(self.audioRecorder.deleteRecordingHitCount, 1)
     }
 
     func testThatItCallsErrorDelegateCallback() {

--- a/Wire-iOS Tests/AudioRecordKeyboardViewControllerTests.swift
+++ b/Wire-iOS Tests/AudioRecordKeyboardViewControllerTests.swift
@@ -199,4 +199,5 @@ final class AudioRecordKeyboardViewControllerTests: XCTestCase {
         XCTAssertEqual(self.mockDelegate.didStartRecordingHitCount, 1)
         XCTAssertEqual(self.mockDelegate.didCancelHitCount, 1)
     }
+
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
@@ -339,6 +339,7 @@ final class AudioRecordKeyboardViewController: UIViewController, AudioRecordBase
         
         switch state {
         case .ready:
+            recorder.deleteRecording()
             self.closeEffectsPicker(animated: false)
             self.recordTapGestureRecognizer.isEnabled = true
             updateTimeLabel(0)

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
@@ -339,7 +339,6 @@ final class AudioRecordKeyboardViewController: UIViewController, AudioRecordBase
         
         switch state {
         case .ready:
-            recorder.deleteRecording()
             self.closeEffectsPicker(animated: false)
             self.recordTapGestureRecognizer.isEnabled = true
             updateTimeLabel(0)
@@ -453,6 +452,7 @@ final class AudioRecordKeyboardViewController: UIViewController, AudioRecordBase
     }
     
     @objc func redoButtonPressed(_ button: UIButton?) {
+        recorder.deleteRecording()
         self.state = .ready
     }
     

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecorder.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecorder.swift
@@ -232,9 +232,12 @@ public final class AudioRecorder: NSObject, AudioRecorderType {
     
     public func deleteRecording() {
         currentDuration = 0
+
         if let filePath = audioRecorder?.url.path, FileManager.default.fileExists(atPath: filePath) {
             audioRecorder?.deleteRecording()
         }
+
+        state = .initializing
     }
     
     fileprivate func setupDisplayLink() {


### PR DESCRIPTION
## What's new in this PR?

### Issues

After discarding a recorded audio message, it is impossible to start a new recording.

### Causes

When tapping the "redo" button, the audio record keyboard state transitions to `ready`, but the underlying audio recorder state is not reset and remains `stopped`. When tapping record again, the recording does not begin because state is not `initializing`.

### Solutions

When transition to the `ready` state, delete the existing recording and reset the recorder state to `initializing`.

### Notes

Jira: https://wearezeta.atlassian.net/browse/ZIOS-13748
Fixes: https://github.com/wireapp/wire-ios/issues/4567
