### PR TITLE
[Feature] Hide App Lock setting when encryption at rest is enabled by default

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Options.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Options.swift
@@ -39,7 +39,7 @@ extension SettingsCellDescriptorFactory {
             externalAppsSection,
             popularDemandSendButtonSection,
             popularDemandDarkThemeSection,
-            appLockSection,
+            SecurityFlags.forceEncryptionAtRest.isEnabled ? nil : appLockSection,
             SecurityFlags.generateLinkPreviews.isEnabled ? linkPreviewSection : nil
         ].compactMap { $0 }
         


### PR DESCRIPTION
## What's new in this PR?

Hide App Lock setting when encryption at rest is enabled by default, since it's not possible to have both activated at the same time.