### PR TITLE
[Feature]: Right German Localization String for 'ping'

### DIFF
--- a/Wire-iOS/Resources/de.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/de.lproj/Localizable.strings
@@ -595,7 +595,7 @@
 "content.file.too_big" = "Sie können Dateien bis zu %@ senden";
 // Someone pinged
 "content.ping.text" = "%@ hat gepingt";
-"content.ping.text-you" = "%@ hast gepingt";
+"content.ping.text-you" = "%@ haben gepingt";
 
 // Current user pinged
 "content.ping.text.you" = "Sie";


### PR DESCRIPTION
## What's new in this PR?

Correct German Localization String for 'ping'.