### PR TITLE
[Fix]: Links No Opened When Safari is NOT default browser on iOS 14

### DIFF
--- a/Wire-iOS/Wire-Info.plist
+++ b/Wire-iOS/Wire-Info.plist
@@ -86,6 +86,7 @@
 		<string>shtps</string>
 		<string>shtp</string>
 		<string>brave</string>
+		<string>https</string>
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>


### PR DESCRIPTION
## What's new in this PR?

### Issues

When the user tries to open an https links when the default browser is not safari the links is not opened.

### Causes

Error: "error: "This app is not allowed to query for scheme https"

iOS 14 bug: https://developer.apple.com/forums/thread/660241

### Solutions

Add https to the plist LSApplicationQueriesSchemes

### Dependencies

JIRA: https://wearezeta.atlassian.net/browse/ZIOS-13799