### PR TITLE
[Fix] Status bar white on white

### DIFF
--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -653,6 +653,11 @@ extension SessionManager {
 
 final class SpinnerCapableNavigationController: UINavigationController, SpinnerCapable {
     var dismissSpinner: SpinnerCompletion?
+
+    override var childForStatusBarStyle: UIViewController? {
+        return topViewController
+    }
+    
 }
 
 extension UIApplication {


### PR DESCRIPTION
## What's new in this PR?

### Issues

If the phone is on dark mode and the app respects this system setting, then all throughout the registration flow the status bar is white on white.

### Causes

The navigation controller containing the registration flow does not use the child status bar style.

### Solutions

Use the top view controller to determine the status bar style.