### PR TITLE
[Feature]: Analytics Tracking Alert Logic

### DIFF
--- a/Wire-iOS/Sources/Analytics/Events/Analytics+Settings.swift
+++ b/Wire-iOS/Sources/Analytics/Events/Analytics+Settings.swift
@@ -27,8 +27,10 @@ private let settingsChangeEventPropertyValue = "new_value"
 extension Analytics {
     
     func tagSettingsChanged(for propertyName: SettingsPropertyName, to value: SettingsPropertyValue) {
-        guard let value = value.value(),
-                propertyName != SettingsPropertyName.disableAnalyticsSharing else {
+        guard
+            let value = value.value(),
+            propertyName != SettingsPropertyName.disableAnalyticsSharing
+        else {
             return
         }
         let attributes = [settingsChangeEventPropertyName: propertyName,

--- a/Wire-iOS/Sources/Analytics/Events/Analytics+Settings.swift
+++ b/Wire-iOS/Sources/Analytics/Events/Analytics+Settings.swift
@@ -27,10 +27,8 @@ private let settingsChangeEventPropertyValue = "new_value"
 extension Analytics {
     
     func tagSettingsChanged(for propertyName: SettingsPropertyName, to value: SettingsPropertyValue) {
-        guard
-            let value = value.value(),
-            propertyName != SettingsPropertyName.disableAnalyticsSharing
-        else {
+        guard let value = value.value(),
+                propertyName != SettingsPropertyName.disableAnalyticsSharing else {
             return
         }
         let attributes = [settingsChangeEventPropertyName: propertyName,

--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -285,13 +285,13 @@ final class AppRootViewController: UIViewController, SpinnerCapable {
                 /// show the dialog only when lastAppState is .unauthenticated and the user is not a team member, i.e. the user not in a team login to a new device
                 clientViewController.needToShowDataUsagePermissionDialog = false
                 
-                if case .unauthenticated(_) = appStateController.lastAppState,
-                    SelfUser.current.isTeamMember {
-                    TrackingManager.shared.disableCrashSharing = false
-                    TrackingManager.shared.disableAnalyticsSharing = false
-                } else if case .unauthenticated(_) = appStateController.lastAppState,
-                    !SelfUser.current.isTeamMember {
-                    clientViewController.needToShowDataUsagePermissionDialog = true
+                if case .unauthenticated(_) = appStateController.lastAppState {
+                    if SelfUser.current.isTeamMember {
+                      TrackingManager.shared.disableCrashSharing = true
+                      TrackingManager.shared.disableAnalyticsSharing = true
+                    } else {
+                      clientViewController.needToShowDataUsagePermissionDialog = true
+                    }
                 }
 
                 Analytics.shared.selfUser = SelfUser.current

--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -282,9 +282,15 @@ final class AppRootViewController: UIViewController, SpinnerCapable {
                                                                  selfUser: ZMUser.selfUser())
                 clientViewController.isComingFromRegistration = completedRegistration
 
-                /// show the dialog only when lastAppState is .unauthenticated, i.e. the user login to a new device
+                /// show the dialog only when lastAppState is .unauthenticated and the user is not a team member, i.e. the user not in a team login to a new device
                 clientViewController.needToShowDataUsagePermissionDialog = false
-                if case .unauthenticated(_) = appStateController.lastAppState {
+                
+                if case .unauthenticated(_) = appStateController.lastAppState,
+                    SelfUser.current.isTeamMember {
+                    TrackingManager.shared.disableCrashSharing = false
+                    TrackingManager.shared.disableAnalyticsSharing = false
+                } else if case .unauthenticated(_) = appStateController.lastAppState,
+                    !SelfUser.current.isTeamMember {
                     clientViewController.needToShowDataUsagePermissionDialog = true
                 }
 

--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -287,8 +287,8 @@ final class AppRootViewController: UIViewController, SpinnerCapable {
                 
                 if case .unauthenticated(_) = appStateController.lastAppState {
                     if SelfUser.current.isTeamMember {
-                      TrackingManager.shared.disableCrashSharing = true
-                      TrackingManager.shared.disableAnalyticsSharing = true
+                        TrackingManager.shared.disableCrashSharing = true
+                        TrackingManager.shared.disableAnalyticsSharing = false
                     } else {
                       clientViewController.needToShowDataUsagePermissionDialog = true
                     }


### PR DESCRIPTION
## What's new in this PR?

With this PR we are going to modify the way the app displays the "Help us make wire better" alert considering the user type. The new logic will be the following

- show the alert just for a user that is not a team member.
- disable by default the tracking setting for a user that is not a team member.

### Dependencies

JIRA: https://wearezeta.atlassian.net/browse/ZIOS-13755
