### PR TITLE
move scheme form xcconfig

### DIFF
--- a/Wire-iOS/Sources/Analytics/AnalyticsCountlyProvider.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsCountlyProvider.swift
@@ -61,7 +61,7 @@ final class AnalyticsCountlyProvider: AnalyticsProvider {
 
         let config: CountlyConfig = CountlyConfig()
         config.appKey = countlyAppKey
-        config.host = countlyHost
+        config.host = "https://" + countlyHost
         config.deviceID = CLYTemporaryDeviceID //TODO: wait for ID generation task done
         config.manualSessionHandling = true
 


### PR DESCRIPTION
## What's new in this PR?

Move the common URL scheme from xcconfig to the the code.