### PR TITLE
[Fix] Status bar in login flow is white on white

### DIFF
--- a/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationStepController.swift
+++ b/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationStepController.swift
@@ -46,6 +46,10 @@ class AuthenticationStepController: AuthenticationStepViewController {
 
     // MARK: - Views
 
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return .compatibleDarkContent
+    }
+
     private var contentStack: CustomSpacingStackView!
 
     private var headlineLabel: UILabel!


### PR DESCRIPTION
## What's new in this PR?

### Issues

The status bar in the login flow is white on white.

### Causes

No preferred style was set.

### Solutions

Set the preferred style.

