### PR TITLE
[Feature]: AppStateController Refactoring

### DIFF
--- a/Wire-iOS Tests/AppLock/AppLockPresenterTests.swift
+++ b/Wire-iOS Tests/AppLock/AppLockPresenterTests.swift
@@ -425,7 +425,7 @@ final class AppLockPresenterTests: XCTestCase {
         assert(contentsDimmed: false, reauthVisibile: false)
         
         //when
-        sut.appStateDidTransition(notification(for: AppState.blacklisted(jailbroken: true)))
+        sut.appStateDidTransition(notification(for: AppState.jailbroken))
         //then
         assert(contentsDimmed: false, reauthVisibile: false)
     }

--- a/Wire-iOS Tests/AppStateControllerTests.swift
+++ b/Wire-iOS Tests/AppStateControllerTests.swift
@@ -26,7 +26,6 @@ final class AppStateControllerTests: XCTestCase {
     override func setUp() {
         super.setUp()
         sut = AppStateController()
-        sut.isRunningSelfUnitTest = true
 
         if let accounts = SessionManager.shared?.accountManager.accounts {
             for account in accounts {
@@ -36,7 +35,6 @@ final class AppStateControllerTests: XCTestCase {
     }
 
     override func tearDown() {
-
         sut = nil
         super.tearDown()
     }
@@ -48,7 +46,6 @@ final class AppStateControllerTests: XCTestCase {
         let error = NSError(code: ZMUserSessionErrorCode.accessTokenExpired, userInfo: nil)
 
         // WHEN
-
         // When first time running the app, account is nil and error code is accessTokenExpired
         sut.sessinManagerObeserver.sessionManagerDidFailToLogin(account: nil, error: error)
 
@@ -84,7 +81,6 @@ final class AppStateControllerTests: XCTestCase {
         sut.sessinManagerObeserver.sessionManagerWillLogout(error: error, userSessionCanBeTornDown: {})
 
         // THEN
-
         // It should display the login screen in AppRootViewController
         XCTAssertEqual(SessionManager.shared?.accountManager.accounts.count, 1)
         XCTAssertEqual(sut.appState, .unauthenticated(error: error))
@@ -103,7 +99,6 @@ final class AppStateControllerTests: XCTestCase {
         sut.sessinManagerObeserver.sessionManagerDidFailToLogin(account: accountUnauthenticated, error: error)
 
         // THEN
-
         // It should display the login screen in AppRootViewController
         XCTAssertGreaterThanOrEqual((SessionManager.shared?.accountManager.accounts.count)!, 0)
         XCTAssertEqual(sut.appState, .unauthenticated(error: error))

--- a/Wire-iOS Tests/AppStateControllerTests.swift
+++ b/Wire-iOS Tests/AppStateControllerTests.swift
@@ -27,7 +27,6 @@ final class AppStateControllerTests: XCTestCase {
         super.setUp()
         sut = AppStateController()
         sut.isRunningSelfUnitTest = true
-        sut.applicationDidBecomeActive()
 
         if let accounts = SessionManager.shared?.accountManager.accounts {
             for account in accounts {
@@ -51,14 +50,11 @@ final class AppStateControllerTests: XCTestCase {
         // WHEN
 
         // When first time running the app, account is nil and error code is accessTokenExpired
-        sut.sessionManagerDidFailToLogin(account: nil, error: error)
+        sut.sessinManagerObeserver.sessionManagerDidFailToLogin(account: nil, error: error)
 
         // THEN
-        let newAppState = sut.calculateAppState()
-
-        // It should display the landing screen in AppRootViewController
         XCTAssertEqual(SessionManager.shared?.accountManager.accounts.count, 0)
-        XCTAssertEqual(newAppState, .unauthenticated(error: nil))
+        XCTAssertEqual(sut.appState, .unauthenticated(error: nil))
     }
 
     func testThatErrorIsAssignedWhenTheAccountManagerHasSomeAccounts() {
@@ -69,14 +65,12 @@ final class AppStateControllerTests: XCTestCase {
         SessionManager.shared?.accountManager.addAndSelect(account)
 
         // WHEN
-        sut.sessionManagerDidFailToLogin(account: nil, error: error)
+        sut.sessinManagerObeserver.sessionManagerDidFailToLogin(account: nil, error: error)
 
         // THEN
-        let newAppState = sut.calculateAppState()
-
         // It should display the login screen in AppRootViewController
         XCTAssertEqual(SessionManager.shared?.accountManager.accounts.count, 1)
-        XCTAssertEqual(newAppState, .unauthenticated(error: error))
+        XCTAssertEqual(sut.appState, .unauthenticated(error: error))
     }
 
     func testThatErrorAssignedWhenOtherDeivceRemovedCurrentlyAccount() {
@@ -87,14 +81,13 @@ final class AppStateControllerTests: XCTestCase {
         SessionManager.shared?.accountManager.addAndSelect(account)
 
         // WHEN
-        sut.sessionManagerWillLogout(error: error, userSessionCanBeTornDown: {})
+        sut.sessinManagerObeserver.sessionManagerWillLogout(error: error, userSessionCanBeTornDown: {})
 
         // THEN
-        let newAppState = sut.calculateAppState()
 
         // It should display the login screen in AppRootViewController
         XCTAssertEqual(SessionManager.shared?.accountManager.accounts.count, 1)
-        XCTAssertEqual(newAppState, .unauthenticated(error: error))
+        XCTAssertEqual(sut.appState, .unauthenticated(error: error))
     }
 
     func testThatErrorAssignedWhenSwitchingToUnauthenticatedAccount() {
@@ -107,13 +100,12 @@ final class AppStateControllerTests: XCTestCase {
         // WHEN
         let accountUnauthenticated = Account(userName: "Unauthenticated", userIdentifier: UUID())
         SessionManager.shared?.accountManager.addAndSelect(accountUnauthenticated)
-        sut.sessionManagerDidFailToLogin(account: accountUnauthenticated, error: error)
+        sut.sessinManagerObeserver.sessionManagerDidFailToLogin(account: accountUnauthenticated, error: error)
 
         // THEN
-        let newAppState = sut.calculateAppState()
 
         // It should display the login screen in AppRootViewController
         XCTAssertGreaterThanOrEqual((SessionManager.shared?.accountManager.accounts.count)!, 0)
-        XCTAssertEqual(newAppState, .unauthenticated(error: error))
+        XCTAssertEqual(sut.appState, .unauthenticated(error: error))
     }
 }

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -177,6 +177,7 @@
 		543E0C681E23A7C3000E2161 /* NotSignedInViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543E0C671E23A7C3000E2161 /* NotSignedInViewController.swift */; };
 		545BA2191E2D3C4900AA373E /* PostContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 545BA2181E2D3C4900AA373E /* PostContent.swift */; };
 		546B17642417A3D70091F4B3 /* CIContext+Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 546B17632417A3D70091F4B3 /* CIContext+Shared.swift */; };
+		5489E20E252C84BE0010461D /* AppStateSessionManagerObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5489E20D252C84BE0010461D /* AppStateSessionManagerObserver.swift */; };
 		549D55AC1DBE03990035EB66 /* Settings+Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 549D55AB1DBE03990035EB66 /* Settings+Logging.swift */; };
 		54AB765C1DB7AB77008D19C8 /* DeveloperOptionsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54AB765B1DB7AB77008D19C8 /* DeveloperOptionsController.swift */; };
 		54BB91E01E1FA6330039E91F /* WireShareEngine.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 54BB91DF1E1FA6330039E91F /* WireShareEngine.framework */; };
@@ -1772,6 +1773,7 @@
 		543E0C671E23A7C3000E2161 /* NotSignedInViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotSignedInViewController.swift; sourceTree = "<group>"; };
 		545BA2181E2D3C4900AA373E /* PostContent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostContent.swift; sourceTree = "<group>"; };
 		546B17632417A3D70091F4B3 /* CIContext+Shared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CIContext+Shared.swift"; sourceTree = "<group>"; };
+		5489E20D252C84BE0010461D /* AppStateSessionManagerObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateSessionManagerObserver.swift; sourceTree = "<group>"; };
 		549D55AB1DBE03990035EB66 /* Settings+Logging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Settings+Logging.swift"; sourceTree = "<group>"; };
 		54AA3C7B24E53E0100FE1F94 /* Security-Flags.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Security-Flags.xcconfig"; sourceTree = "<group>"; };
 		54AB765B1DB7AB77008D19C8 /* DeveloperOptionsController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeveloperOptionsController.swift; sourceTree = "<group>"; };
@@ -5143,6 +5145,7 @@
 				874B2C3C1BBA939000396047 /* WireBridgingHeader.h */,
 				162936BA1F470A9300D4F386 /* AppState.swift */,
 				162936BC1F470B4800D4F386 /* AppStateController.swift */,
+				5489E20D252C84BE0010461D /* AppStateSessionManagerObserver.swift */,
 				162936BE1F4714D200D4F386 /* AppRootViewController.swift */,
 				1610367020617BEC008AFDD0 /* AppRootViewController+Appearance.swift */,
 				161ACB2923F5982800ABFF33 /* AppRootViewController+URLActionDelegate.swift */,
@@ -7734,6 +7737,7 @@
 				EF7F8FC121B5761C00D7723C /* ConversationReadReceiptSettingChangedCellDescription.swift in Sources */,
 				5E8DA782211C3BF300360979 /* AuthenticationPhoneLoginErrorHandler.swift in Sources */,
 				EF3CBC0A2147D81800566295 /* ConversationListViewController+PushPermissions.swift in Sources */,
+				5489E20E252C84BE0010461D /* AppStateSessionManagerObserver.swift in Sources */,
 				F16427081FCC5BF800D2ABFC /* SetPasswordStepDescription.swift in Sources */,
 				5E8FFC0321ECC5CF0052DF03 /* AuthenticationFeatureProvider.swift in Sources */,
 				EF4C5D4E23391C7E0092CA38 /* ConversationListCell+ZMConversationObserver.swift in Sources */,

--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -180,7 +180,7 @@ final class AppRootViewController: UIViewController, SpinnerCapable {
             appVersion: appVersion!,
             mediaManager: mediaManager!,
             analytics: Analytics.shared,
-            delegate: appStateController,
+            delegate: appStateController.sessinManagerObeserver,
             showContentDelegate: self,
             application: UIApplication.shared,
             environment: BackendEnvironment.shared,
@@ -244,8 +244,10 @@ final class AppRootViewController: UIViewController, SpinnerCapable {
         resetAuthenticationCoordinatorIfNeeded(for: appState)
 
         switch appState {
-        case .blacklisted(jailbroken: let jailbroken):
-            viewController = BlockerViewController(context: jailbroken ? .jailbroken : .blacklist)
+        case .blacklisted:
+            viewController = BlockerViewController(context: .blacklist)
+        case .jailbroken:
+            viewController = BlockerViewController(context: .jailbroken)
         case .migrating:
             let launchImageViewController = LaunchImageViewController()
             launchImageViewController.showLoadingScreen()
@@ -334,14 +336,18 @@ final class AppRootViewController: UIViewController, SpinnerCapable {
         }
     }
 
-    func transition(to viewController: UIViewController, animated: Bool = true, completionHandler: (() -> Void)? = nil) {
+    func transition(to viewController: UIViewController,
+                    animated: Bool = true,
+                    completionHandler: (() -> Void)? = nil) {
 
         // If we have some modal view controllers presented in any of the (grand)children
         // of this controller they stay in memory and leak on iOS 10.
         dismissModalsFromAllChildren(of: visibleViewController)
         visibleViewController?.willMove(toParent: nil)
 
-        if let previousViewController = visibleViewController, animated {
+        if
+            let previousViewController = visibleViewController,
+            animated {
 
             addChild(viewController)
             transition(from: previousViewController,
@@ -583,7 +589,8 @@ extension AppRootViewController {
     fileprivate func presentAlertForDeletedAccount(_ reason: ZMAccountDeletedReason) {
         switch reason {
         case .sessionExpired:
-            presentAlertWithOKButton(title: "account_deleted_session_expired_alert.title".localized, message: "account_deleted_session_expired_alert.message".localized)
+            presentAlertWithOKButton(title: "account_deleted_session_expired_alert.title".localized,
+                                     message: "account_deleted_session_expired_alert.message".localized)
         default:
             break
             

--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -287,7 +287,7 @@ final class AppRootViewController: UIViewController, SpinnerCapable {
                 /// show the dialog only when lastAppState is .unauthenticated and the user is not a team member, i.e. the user not in a team login to a new device
                 clientViewController.needToShowDataUsagePermissionDialog = false
                 
-                if case .unauthenticated(_) = appStateController.lastAppState {
+                if case .unauthenticated(_) = appStateController.previousAppState {
                     if SelfUser.current.isTeamMember {
                         TrackingManager.shared.disableCrashSharing = true
                         TrackingManager.shared.disableAnalyticsSharing = false

--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -345,10 +345,8 @@ final class AppRootViewController: UIViewController, SpinnerCapable {
         dismissModalsFromAllChildren(of: visibleViewController)
         visibleViewController?.willMove(toParent: nil)
 
-        if
-            let previousViewController = visibleViewController,
+        if let previousViewController = visibleViewController,
             animated {
-
             addChild(viewController)
             transition(from: previousViewController,
                        to: viewController,

--- a/Wire-iOS/Sources/AppState.swift
+++ b/Wire-iOS/Sources/AppState.swift
@@ -19,12 +19,13 @@
 import Foundation
 import WireDataModel
 
-enum AppState : Equatable {
+enum AppState: Equatable {
     
     case headless
     case authenticated(completedRegistration: Bool, databaseIsLocked: Bool)
     case unauthenticated(error : NSError?)
-    case blacklisted(jailbroken: Bool)
+    case blacklisted
+    case jailbroken
     case migrating
     case loading(account: Account, from: Account?)
 }

--- a/Wire-iOS/Sources/AppStateController.swift
+++ b/Wire-iOS/Sources/AppStateController.swift
@@ -18,7 +18,6 @@
 
 import Foundation
 import WireSyncEngine
-//import WireSystem
 
 private let zmLog = ZMSLog(tag: "AppState")
 

--- a/Wire-iOS/Sources/AppStateController.swift
+++ b/Wire-iOS/Sources/AppStateController.swift
@@ -39,26 +39,10 @@ final class AppStateController : NSObject {
     
     // MARK - Private Set Property
     private(set) var sessinManagerObeserver = AppStateSessionManagerObserver()
+    private(set) var previousAppState: AppState = .headless
     private(set) var appState: AppState = .headless {
         willSet {
-            lastAppState = appState
-        }
-    }
-    private(set) var lastAppState: AppState = .headless
-    
-    // MARK - Test Property (??????)
-    private var isRunningTests = ProcessInfo.processInfo.isRunningTests {
-        didSet {
-            appState = !isRunningTests
-                ? .headless
-                : .unauthenticated(error: nil)
-        }
-    }
-    var isRunningSelfUnitTest = false {
-        didSet {
-            appState = isRunningSelfUnitTest
-                ? .headless
-                : .unauthenticated(error: nil)
+            previousAppState = appState
         }
     }
     
@@ -78,11 +62,10 @@ extension AppStateController: AppStateSessionManagerObserverDelegate {
     }
     
     // MARK - Private Helpers
-    
     private func transition(to appState: AppState,
                             completion: (() -> Void)? = nil) {
         self.appState = appState
-        if lastAppState != appState {
+        if previousAppState != appState {
             zmLog.debug("transitioning to app state: \(appState)")
             delegate?.appStateController(transitionedTo: appState) {
                 completion?()
@@ -100,7 +83,7 @@ extension AppStateController: AppStateSessionManagerObserverDelegate {
     }
 }
 
-// TO DO: Ask why AuthenticationCoordinatorDelegate implements AuthenticationStatusProvider. For the scope of knowing the appState it is not necessary. We could get rid off all the AuthenticationStatusProvider properties
+// TO DO: Ask why AuthenticationCoordinatorDelegate implements AuthenticationStatusProvider. For the scope of knowing the appState it is not necessary. We could get rid off all the AuthenticationStatusProvider properties.
 
 // MARK - AuthenticationCoordinatorDelegate
 

--- a/Wire-iOS/Sources/AppStateSessionManagerObserver.swift
+++ b/Wire-iOS/Sources/AppStateSessionManagerObserver.swift
@@ -1,0 +1,133 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireSyncEngine
+
+protocol AppStateSessionManagerObserverDelegate: class {
+    func sessionManagerObserver(_: AppStateSessionManagerObserver,
+                                willTransitionTo _: AppState,
+                                completion: (() -> Void)?)
+}
+
+class AppStateSessionManagerObserver: SessionManagerDelegate {
+    
+    // MARK - Public Property
+    weak var delegate: AppStateSessionManagerObserverDelegate?
+    
+    // MARK - Private Property
+    private var loadingAccount : Account?
+    private var databaseEncryptionObserverToken: Any? = nil
+    
+    func sessionManagerWillLogout(error: Error?,
+                                  userSessionCanBeTornDown: (() -> Void)?) {
+        databaseEncryptionObserverToken = nil
+        let appState: AppState = .unauthenticated(error: error as NSError?)
+        delegate?.sessionManagerObserver(self,
+                                         willTransitionTo: appState,
+                                         completion: userSessionCanBeTornDown)
+    }
+    
+    func sessionManagerDidFailToLogin(account: Account?, error: Error) {
+        let selectedAccount = SessionManager.shared?.accountManager.selectedAccount
+        var authenticationError: NSError?
+        // We only care about the error if it concerns the selected account, or the loading account.
+        if account != nil && (selectedAccount == account || loadingAccount == account) {
+            authenticationError = error as NSError
+        }
+        // When the account is nil, we care about the error if there are some accounts in accountManager
+        else if account == nil && SessionManager.shared?.accountManager.accounts.count > 0 {
+            authenticationError = error as NSError
+        }
+
+        loadingAccount = nil
+        let appState: AppState = .unauthenticated(error: authenticationError)
+        delegate?.sessionManagerObserver(self,
+                                         willTransitionTo: appState,
+                                         completion: nil)
+    }
+        
+    func sessionManagerDidBlacklistCurrentVersion() {
+        delegate?.sessionManagerObserver(self,
+                                         willTransitionTo: .blacklisted,
+                                         completion: nil)
+    }
+    
+    func sessionManagerDidBlacklistJailbrokenDevice() {
+        delegate?.sessionManagerObserver(self,
+                                         willTransitionTo: .jailbroken,
+                                         completion: nil)
+    }
+    
+    func sessionManagerWillMigrateLegacyAccount() {
+        delegate?.sessionManagerObserver(self,
+                                         willTransitionTo: .migrating,
+                                         completion: nil)
+    }
+    
+    func sessionManagerWillMigrateAccount(_ account: Account) {
+        guard account == loadingAccount else { return }
+        delegate?.sessionManagerObserver(self,
+                                         willTransitionTo: .migrating,
+                                         completion: nil)
+    }
+    
+    func sessionManagerWillOpenAccount(_ account: Account,
+                                       userSessionCanBeTornDown: @escaping () -> Void) {
+        databaseEncryptionObserverToken = nil
+        loadingAccount = account
+        let appState: AppState = .loading(account: account,
+                                          from: SessionManager.shared?.accountManager.selectedAccount)
+        delegate?.sessionManagerObserver(self,
+                                         willTransitionTo: appState,
+                                         completion: userSessionCanBeTornDown)
+    }
+    
+    func sessionManagerActivated(userSession: ZMUserSession) {
+        userSession.checkIfLoggedIn { [weak self] loggedIn in
+            guard
+                loggedIn,
+                let strongRef = self
+            else {
+                return
+            }
+            
+            self?.loadingAccount = nil
+            
+            // NOTE: we don't enter the unauthenticated appstate here if we are not logged in
+            //       because we will receive `sessionManagerDidLogout()` with an auth error
+            let appState: AppState = .authenticated(completedRegistration: false,
+                                                    databaseIsLocked: userSession.isDatabaseLocked)
+            strongRef.delegate?.sessionManagerObserver(strongRef,
+                                                       willTransitionTo: appState,
+                                                       completion: nil)
+        }
+        
+        databaseEncryptionObserverToken = userSession.registerDatabaseLockedHandler({ [weak self] isDatabaseLocked in
+            guard let strongRef = self else {
+                return
+            }
+            
+            let appState: AppState = .authenticated(completedRegistration: false,
+                                                    databaseIsLocked: isDatabaseLocked)
+            strongRef.delegate?.sessionManagerObserver(strongRef,
+                                                       willTransitionTo: appState,
+                                                       completion: nil)
+        })
+    }
+}


### PR DESCRIPTION
## What's new in this PR?

The context of this PR is the `App Launching Routing Refactoring`. The idea is separate it in smaller chunks that are easier to review. I thought that a reasonable starting point could be refactor the `AppState` and the way we calculate it in the `AppStateController`. 
Previously in the `AppStateController` you could have found a lot of variables used to calculate the current `AppState`. These variables were set in the `SessionManagerDelagate` methods and used in the `calculateAppState()` method to find the current appState. This approach is really verbose and it have been produced a lot of not necessary code. 
The idea behind this PR is set directly the appState in the `SessionManagerDelagate` call backs and get rid of all the variables used in the  `calculateAppState()` and of the method itself. 
Moreover to decouple the `AppStateController` from the `SessionManagerDelagate` callbacks (and make it lighter) I decided to create the  `AppStateSessionManagerObserver`. The scope of this class is to inform the `AppStateController` of the new `AppState`, in this manner the only dirty of the `AppStateController` will be transit (when necessary) from a state to another.

It seems to works fine but It would be nice if some of you at some point could do other manual test.

P.S: Any other idea is super well accepted
