### PR TITLE
[Feature]: Notification Observing Centralisation 

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -172,6 +172,7 @@
 		1EFB23DC1ACEDE5400244571 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = 1EFB23DE1ACEDE5400244571 /* Localizable.stringsdict */; };
 		5407B8C31A643CCE009090C6 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5407B8C21A643CCE009090C6 /* UIKit.framework */; };
 		542CDF4024B32E2100DF0B39 /* HandleChangeStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 542CDF3F24B32E2100DF0B39 /* HandleChangeStateTests.swift */; };
+		543DF685252DD7F0001F6EA6 /* ApplicationStateObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543DF684252DD7F0001F6EA6 /* ApplicationStateObserver.swift */; };
 		543E0C641E2394F4000E2161 /* ConversationSelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543E0C611E2394E7000E2161 /* ConversationSelectionViewController.swift */; };
 		543E0C661E23A72F000E2161 /* SendingProgressViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543E0C651E23A72F000E2161 /* SendingProgressViewController.swift */; };
 		543E0C681E23A7C3000E2161 /* NotSignedInViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543E0C671E23A7C3000E2161 /* NotSignedInViewController.swift */; };
@@ -1767,6 +1768,7 @@
 		1EFB23DD1ACEDE5400244571 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = Base; path = Base.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		5407B8C21A643CCE009090C6 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		542CDF3F24B32E2100DF0B39 /* HandleChangeStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandleChangeStateTests.swift; sourceTree = "<group>"; };
+		543DF684252DD7F0001F6EA6 /* ApplicationStateObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApplicationStateObserver.swift; sourceTree = "<group>"; };
 		543E0C611E2394E7000E2161 /* ConversationSelectionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConversationSelectionViewController.swift; sourceTree = "<group>"; };
 		543E0C651E23A72F000E2161 /* SendingProgressViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SendingProgressViewController.swift; sourceTree = "<group>"; };
 		543E0C671E23A7C3000E2161 /* NotSignedInViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotSignedInViewController.swift; sourceTree = "<group>"; };
@@ -5146,6 +5148,7 @@
 				162936BE1F4714D200D4F386 /* AppRootViewController.swift */,
 				1610367020617BEC008AFDD0 /* AppRootViewController+Appearance.swift */,
 				161ACB2923F5982800ABFF33 /* AppRootViewController+URLActionDelegate.swift */,
+				543DF684252DD7F0001F6EA6 /* ApplicationStateObserver.swift */,
 				8751A6CA1FF6573D00804A58 /* QuickActionsManager.swift */,
 			);
 			name = Sources;
@@ -7344,6 +7347,7 @@
 				871BC35F1D34F94200DF0793 /* SettingsProperty.swift in Sources */,
 				5E65A7B121345314008BFCC0 /* TeamEmailVerificationCodeAvailableEventHandler.swift in Sources */,
 				87D56DF81E003D9300DFF722 /* CollectionsView.swift in Sources */,
+				543DF685252DD7F0001F6EA6 /* ApplicationStateObserver.swift in Sources */,
 				BFAF4CB91CEDE82400780537 /* NumberHelper.swift in Sources */,
 				5EFE9BFF21246483007932A6 /* RegistrationFinalErrorHandler.swift in Sources */,
 				8701221C20F7923E001E6342 /* Analytics+LinearGroupCreation.swift in Sources */,

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -172,7 +172,7 @@
 		1EFB23DC1ACEDE5400244571 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = 1EFB23DE1ACEDE5400244571 /* Localizable.stringsdict */; };
 		5407B8C31A643CCE009090C6 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5407B8C21A643CCE009090C6 /* UIKit.framework */; };
 		542CDF4024B32E2100DF0B39 /* HandleChangeStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 542CDF3F24B32E2100DF0B39 /* HandleChangeStateTests.swift */; };
-		543DF685252DD7F0001F6EA6 /* ApplicationStateObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543DF684252DD7F0001F6EA6 /* ApplicationStateObserver.swift */; };
+		543DF685252DD7F0001F6EA6 /* NotificationObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543DF684252DD7F0001F6EA6 /* NotificationObserver.swift */; };
 		543E0C641E2394F4000E2161 /* ConversationSelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543E0C611E2394E7000E2161 /* ConversationSelectionViewController.swift */; };
 		543E0C661E23A72F000E2161 /* SendingProgressViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543E0C651E23A72F000E2161 /* SendingProgressViewController.swift */; };
 		543E0C681E23A7C3000E2161 /* NotSignedInViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543E0C671E23A7C3000E2161 /* NotSignedInViewController.swift */; };
@@ -1768,7 +1768,7 @@
 		1EFB23DD1ACEDE5400244571 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = Base; path = Base.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		5407B8C21A643CCE009090C6 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		542CDF3F24B32E2100DF0B39 /* HandleChangeStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandleChangeStateTests.swift; sourceTree = "<group>"; };
-		543DF684252DD7F0001F6EA6 /* ApplicationStateObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApplicationStateObserver.swift; sourceTree = "<group>"; };
+		543DF684252DD7F0001F6EA6 /* NotificationObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationObserver.swift; sourceTree = "<group>"; };
 		543E0C611E2394E7000E2161 /* ConversationSelectionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConversationSelectionViewController.swift; sourceTree = "<group>"; };
 		543E0C651E23A72F000E2161 /* SendingProgressViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SendingProgressViewController.swift; sourceTree = "<group>"; };
 		543E0C671E23A7C3000E2161 /* NotSignedInViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotSignedInViewController.swift; sourceTree = "<group>"; };
@@ -5148,7 +5148,7 @@
 				162936BE1F4714D200D4F386 /* AppRootViewController.swift */,
 				1610367020617BEC008AFDD0 /* AppRootViewController+Appearance.swift */,
 				161ACB2923F5982800ABFF33 /* AppRootViewController+URLActionDelegate.swift */,
-				543DF684252DD7F0001F6EA6 /* ApplicationStateObserver.swift */,
+				543DF684252DD7F0001F6EA6 /* NotificationObserver.swift */,
 				8751A6CA1FF6573D00804A58 /* QuickActionsManager.swift */,
 			);
 			name = Sources;
@@ -7347,7 +7347,7 @@
 				871BC35F1D34F94200DF0793 /* SettingsProperty.swift in Sources */,
 				5E65A7B121345314008BFCC0 /* TeamEmailVerificationCodeAvailableEventHandler.swift in Sources */,
 				87D56DF81E003D9300DFF722 /* CollectionsView.swift in Sources */,
-				543DF685252DD7F0001F6EA6 /* ApplicationStateObserver.swift in Sources */,
+				543DF685252DD7F0001F6EA6 /* NotificationObserver.swift in Sources */,
 				BFAF4CB91CEDE82400780537 /* NumberHelper.swift in Sources */,
 				5EFE9BFF21246483007932A6 /* RegistrationFinalErrorHandler.swift in Sources */,
 				8701221C20F7923E001E6342 /* Analytics+LinearGroupCreation.swift in Sources */,

--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -153,10 +153,6 @@ final class AppRootViewController: UIViewController, SpinnerCapable {
         fatalError("init(coder:) has not been implemented")
     }
     
-    deinit {
-        removeAllObserverTokens()
-    }
-    
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
@@ -528,10 +524,6 @@ extension AppRootViewController: ForegroundNotificationResponder {
 extension AppRootViewController: ApplicationStateObserving {
     func addObserverToken(_ token: NSObjectProtocol) {
         observerTokens.append(token)
-    }
-    
-    func removeAllObserverTokens() {
-        observerTokens.removeAll()
     }
     
     func applicationDidBecomeActive() {

--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -144,8 +144,7 @@ final class AppRootViewController: UIViewController, SpinnerCapable {
 
         setupApplicationNotifications()
         setupContentSizeCategoryNotifications()
-        
-        NotificationCenter.default.addObserver(self, selector: #selector(onUserGrantedAudioPermissions), name: Notification.Name.UserGrantedAudioPermissions, object: nil)
+        setupAudioPermissionsNotifications()
         
         enqueueTransition(to: appStateController.appState)
     }
@@ -525,9 +524,8 @@ extension AppRootViewController: ForegroundNotificationResponder {
     }
 }
 
-// MARK: - ApplicationStateObserving && ContentSizeCategoryObserving
-
-extension AppRootViewController: ApplicationStateObserving, ContentSizeCategoryObserving {
+// MARK: - ApplicationStateObserving
+extension AppRootViewController: ApplicationStateObserving {
     func addObserverToken(_ token: NSObjectProtocol) {
         observerTokens.append(token)
     }
@@ -549,7 +547,10 @@ extension AppRootViewController: ApplicationStateObserving, ContentSizeCategoryO
     func applicationWillEnterForeground() {
         updateOverlayWindowFrame()
     }
-    
+}
+
+// MARK: - ContentSizeCategoryObserving
+extension AppRootViewController: ContentSizeCategoryObserving {
     func contentSizeCategoryDidChange() {
         NSAttributedString.invalidateParagraphStyle()
         NSAttributedString.invalidateMarkdownStyle()
@@ -558,6 +559,14 @@ extension AppRootViewController: ApplicationStateObserving, ContentSizeCategoryO
         type(of: self).configureAppearance()
     }
 }
+
+// MARK: - AudioPermissionsObserving
+extension AppRootViewController: AudioPermissionsObserving {
+    func userDidGrantAudioPermissions() {
+        sessionManager?.updateCallNotificationStyleFromSettings()
+    }
+}
+
 
 // MARK: - Session Manager Observer
 
@@ -598,15 +607,6 @@ extension AppRootViewController {
         }
     }
     
-}
-
-// MARK: - Audio Permissions granted
-
-extension AppRootViewController {
-
-    @objc func onUserGrantedAudioPermissions() {
-        sessionManager?.updateCallNotificationStyleFromSettings()
-    }
 }
 
 // MARK: - Ask user if they want want switch account if there's an ongoing call

--- a/Wire-iOS/Sources/ApplicationStateObserver.swift
+++ b/Wire-iOS/Sources/ApplicationStateObserver.swift
@@ -1,0 +1,69 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import UIKit
+
+protocol ObserverTokenStore: AnyObject {
+    func addObserverToken(_ token: NSObjectProtocol)
+}
+
+protocol ApplicationStateObserving: ObserverTokenStore {
+    func applicationDidBecomeActive()
+    func applicationDidEnterBackground()
+    func applicationWillEnterForeground()
+}
+
+extension ApplicationStateObserving {
+    func setupApplicationNotifications() {
+        addObserverToken(NotificationCenter.default.addObserver(forName: UIApplication.didEnterBackgroundNotification,
+                                                                object: nil,
+                                                                queue: nil) { [weak self] _ in
+            guard let observer = self else { return }
+            observer.applicationDidEnterBackground()
+        })
+        
+        addObserverToken(NotificationCenter.default.addObserver(forName: UIApplication.didBecomeActiveNotification,
+                                                                object: nil,
+                                                                queue: nil) { [weak self] _ in
+            guard let observer = self else { return }
+            observer.applicationDidBecomeActive()
+        })
+
+        addObserverToken(NotificationCenter.default.addObserver(forName: UIApplication.willEnterForegroundNotification,
+                                                                object: nil,
+                                                                queue: nil) { [weak self] _ in
+            guard let observer = self else { return }
+            observer.applicationWillEnterForeground()
+        })
+    }
+}
+
+protocol ContentSizeCategoryObserving: ObserverTokenStore {
+    func contentSizeCategoryDidChange()
+}
+
+extension ContentSizeCategoryObserving {
+    func setupContentSizeCategoryNotifications() {
+        addObserverToken(NotificationCenter.default.addObserver(forName: UIContentSizeCategory.didChangeNotification,
+                                                                object: nil,
+                                                                queue: nil) { [weak self] _ in
+            guard let observer = self else { return }
+            observer.contentSizeCategoryDidChange()
+        })
+    }
+}

--- a/Wire-iOS/Sources/Helpers/UIApplication+Permissions.swift
+++ b/Wire-iOS/Sources/Helpers/UIApplication+Permissions.swift
@@ -20,10 +20,6 @@ import WireCommonComponents
 import UIKit
 import Photos
 
-extension Notification.Name {
-    static let UserGrantedAudioPermissions = Notification.Name("UserGrantedAudioPermissionsNotification")
-}
-
 extension UIApplication {
     
     class func wr_requestOrWarnAboutMicrophoneAccess(_ grantedHandler: @escaping (_ granted: Bool) -> Void) {

--- a/Wire-iOS/Sources/NotificationObserver.swift
+++ b/Wire-iOS/Sources/NotificationObserver.swift
@@ -18,10 +18,12 @@
 
 import UIKit
 
+// MARK: - ObserverTokenStore
 protocol ObserverTokenStore: AnyObject {
     func addObserverToken(_ token: NSObjectProtocol)
 }
 
+// MARK: - ApplicationStateObserving
 protocol ApplicationStateObserving: ObserverTokenStore {
     func applicationDidBecomeActive()
     func applicationDidEnterBackground()
@@ -53,6 +55,7 @@ extension ApplicationStateObserving {
     }
 }
 
+// MARK: - ContentSizeCategoryObserving
 protocol ContentSizeCategoryObserving: ObserverTokenStore {
     func contentSizeCategoryDidChange()
 }
@@ -64,6 +67,27 @@ extension ContentSizeCategoryObserving {
                                                                 queue: nil) { [weak self] _ in
             guard let observer = self else { return }
             observer.contentSizeCategoryDidChange()
+        })
+    }
+}
+
+// MARK: - AudioPermissionsObserving
+
+extension Notification.Name {
+    static let UserGrantedAudioPermissions = Notification.Name("UserGrantedAudioPermissionsNotification")
+}
+
+protocol AudioPermissionsObserving: ObserverTokenStore {
+    func userDidGrantAudioPermissions()
+}
+
+extension AudioPermissionsObserving {
+    func setupAudioPermissionsNotifications() {
+        addObserverToken(NotificationCenter.default.addObserver(forName: Notification.Name.UserGrantedAudioPermissions,
+                                                                object: nil,
+                                                                queue: nil) { [weak self] _ in
+            guard let observer = self else { return }
+            observer.userDidGrantAudioPermissions()
         })
     }
 }

--- a/Wire-iOS/Sources/NotificationObserver.swift
+++ b/Wire-iOS/Sources/NotificationObserver.swift
@@ -72,7 +72,6 @@ extension ContentSizeCategoryObserving {
 }
 
 // MARK: - AudioPermissionsObserving
-
 extension Notification.Name {
     static let UserGrantedAudioPermissions = Notification.Name("UserGrantedAudioPermissionsNotification")
 }


### PR DESCRIPTION
## What's new in this PR?

This PR represent an idea how to centralise observing notification without having them spread everywhere in the UI project.  Here I put just few of the notifications just to show you the solution and get some feedback from you. It would not be difficult extend the `NotificationObserver` class to all the other notifications in the project and implement the observing protocols where we need.

IMHO some to the main advantages of this approach are:
- Avoid spreading NotificationCenter.default.addObserver method all around the UI project.
- Since they are centralised it would be much easier debug when we are waiting for a certain notification.
- Cause it is protocol oriented we don't have different naming of the call back for a certain notification.
- It is easy to apply all around the project


