### PR TITLE
Fix: upload a video (via share extension) but it is stuck in this screen

### DIFF
--- a/Wire-iOS Share Extension/UnsentSendable.swift
+++ b/Wire-iOS Share Extension/UnsentSendable.swift
@@ -312,7 +312,8 @@ class UnsentFileSendable: UnsentSendableBase, UnsentSendable {
                                       fileURL: URL,
                                       completion: @escaping SendingCompletion) {
         if UTTypeConformsTo(UTI as CFString, kUTTypeMovie) {
-            AVURLAsset.convertVideoToUploadFormat(at: fileURL) { (url, _, error) in
+            AVURLAsset.convertVideoToUploadFormat(at: fileURL,
+                                                  fileLengthLimit: Int64(AccountManager.fileSizeLimitInBytes)) { (url, _, error) in
                 completion(url, error)
             }
         } else {

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -5658,6 +5658,55 @@
 			path = Cells;
 			sourceTree = "<group>";
 		};
+		A96E072525416F87001F7658 /* video */ = {
+			isa = PBXGroup;
+			children = (
+				EF2C9544214983BB000E4960 /* video.mp4 */,
+			);
+			name = video;
+			sourceTree = "<group>";
+		};
+		A96E072625417133001F7658 /* image */ = {
+			isa = PBXGroup;
+			children = (
+				EF640EB72111EAAC00C1D1F0 /* unsplash_matterhorn_very_small_size_40x20.jpg */,
+				EF8DD909211C840800E970F1 /* 20000x20000.gif */,
+				BFA13E1B1D4B77C600F0A91B /* unsplash_small.jpg */,
+				BFA13E171D4B509A00F0A91B /* unsplash_burger.jpg */,
+				7C37E3431FDE89510077B2E3 /* unsplash_matterhorn.jpg */,
+				7C374E481FDE7B8B00A43B9C /* unsplash_matterhorn_exact_size.jpg */,
+				7C374E471FDE7B8B00A43B9C /* unsplash_matterhorn_small_height.jpg */,
+				7C374E491FDE7B8C00A43B9C /* unsplash_matterhorn_small_size.jpg */,
+				7C374E4A1FDE7B8C00A43B9C /* unsplash_matterhorn_small_width.jpg */,
+				BFF9446D20F64B4100531BC3 /* unsplash_pano.jpg */,
+				BFF9446E20F64B4200531BC3 /* unsplash_square.jpg */,
+				BFF9446F20F64B4200531BC3 /* unsplash_vertical_pano.jpg */,
+				EF6E3C7F208A262B003F6752 /* not_animated.gif */,
+				EF6E3C792089F231003F6752 /* animated.gif */,
+				EF30524A2088927D00613C45 /* transparent.png */,
+			);
+			name = image;
+			sourceTree = "<group>";
+		};
+		A96E072725417154001F7658 /* pdf */ = {
+			isa = PBXGroup;
+			children = (
+				8735AE702036C88800DCE66E /* huge.pdf */,
+				87656FCE1FB5FEDC00D5286C /* 0x0.pdf */,
+			);
+			name = pdf;
+			sourceTree = "<group>";
+		};
+		A96E072825417173001F7658 /* others */ = {
+			isa = PBXGroup;
+			children = (
+				EF701A31223BE005007165E4 /* DummyComponentsVersions.plist */,
+				BFEA26581D410F9F000D0ED5 /* audio_sample.m4a */,
+				EF8DD916211E2BD200E970F1 /* sample.pkpass */,
+			);
+			name = others;
+			sourceTree = "<group>";
+		};
 		A96E802F24CB2A760010CD80 /* Setup */ = {
 			isa = PBXGroup;
 			children = (
@@ -6130,27 +6179,10 @@
 		BFAD3A1B1CD1078500F0FBED /* Resources */ = {
 			isa = PBXGroup;
 			children = (
-				EF701A31223BE005007165E4 /* DummyComponentsVersions.plist */,
-				EF2C9544214983BB000E4960 /* video.mp4 */,
-				BFF9446D20F64B4100531BC3 /* unsplash_pano.jpg */,
-				BFF9446E20F64B4200531BC3 /* unsplash_square.jpg */,
-				BFF9446F20F64B4200531BC3 /* unsplash_vertical_pano.jpg */,
-				EF6E3C7F208A262B003F6752 /* not_animated.gif */,
-				EF6E3C792089F231003F6752 /* animated.gif */,
-				EF30524A2088927D00613C45 /* transparent.png */,
-				BFEA26581D410F9F000D0ED5 /* audio_sample.m4a */,
-				BFA13E1B1D4B77C600F0A91B /* unsplash_small.jpg */,
-				BFA13E171D4B509A00F0A91B /* unsplash_burger.jpg */,
-				7C37E3431FDE89510077B2E3 /* unsplash_matterhorn.jpg */,
-				7C374E481FDE7B8B00A43B9C /* unsplash_matterhorn_exact_size.jpg */,
-				7C374E471FDE7B8B00A43B9C /* unsplash_matterhorn_small_height.jpg */,
-				7C374E491FDE7B8C00A43B9C /* unsplash_matterhorn_small_size.jpg */,
-				7C374E4A1FDE7B8C00A43B9C /* unsplash_matterhorn_small_width.jpg */,
-				EF640EB72111EAAC00C1D1F0 /* unsplash_matterhorn_very_small_size_40x20.jpg */,
-				8735AE702036C88800DCE66E /* huge.pdf */,
-				87656FCE1FB5FEDC00D5286C /* 0x0.pdf */,
-				EF8DD909211C840800E970F1 /* 20000x20000.gif */,
-				EF8DD916211E2BD200E970F1 /* sample.pkpass */,
+				A96E072825417173001F7658 /* others */,
+				A96E072725417154001F7658 /* pdf */,
+				A96E072625417133001F7658 /* image */,
+				A96E072525416F87001F7658 /* video */,
 			);
 			name = Resources;
 			sourceTree = "<group>";

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
@@ -318,7 +318,9 @@ class CameraKeyboardViewController: UIViewController, SpinnerCapable {
                 self.isLoadingViewVisible = true
             })
             
-            AVURLAsset.convertVideoToUploadFormat(at: url, fileLengthLimit: Int64(fileLengthLimit)) { resultURL, asset, error in
+            ///TODO: size check alert?
+            AVURLAsset.convertVideoToUploadFormat(at: url,
+                                                  fileLengthLimit: Int64(fileLengthLimit)) { resultURL, asset, error in
                 DispatchQueue.main.async(execute: {
                     self.isLoadingViewVisible = false
                 })

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
@@ -305,7 +305,7 @@ class CameraKeyboardViewController: UIViewController, SpinnerCapable {
     
     fileprivate func forwardSelectedVideoAsset(_ asset: PHAsset) {
         isLoadingViewVisible = true
-        guard let fileLengthLimit: UInt64 = ZMUserSession.shared()?.maxUploadFileSize else { return }
+        guard let fileLengthLimit: UInt64 = ZMUserSession.shared()?.maxUploadFileSize else { return } //TODO: SE?
         
         asset.getVideoURL { url in
             DispatchQueue.main.async(execute: {

--- a/WireCommonComponents/AVAsset+VideoConvert.swift
+++ b/WireCommonComponents/AVAsset+VideoConvert.swift
@@ -80,7 +80,7 @@ extension AVURLAsset {
     public static func convertVideoToUploadFormat(at url: URL,
                                                   quality: String = AVURLAsset.defaultVideoQuality,
                                                   deleteSourceFile: Bool = true,
-                                                  fileLengthLimit: Int64? = nil, ///TODO: nil?
+                                                  fileLengthLimit: Int64?,
                                                   completion: @escaping ConvertVideoCompletion ) {
         let filename = url.deletingPathExtension().lastPathComponent + ".mp4"
         let asset: AVURLAsset = AVURLAsset(url: url, options: nil)

--- a/WireCommonComponents/AVAsset+VideoConvert.swift
+++ b/WireCommonComponents/AVAsset+VideoConvert.swift
@@ -134,24 +134,28 @@ extension AVURLAsset {
         
         exportSession.timeRange = CMTimeRangeMake(start: .zero, duration: duration);
         
-        //TODO: get est. size here
-        let estimatedOutputFileLength = exportSession.estimatedOutputFileLength
-        //TODO: estimatedOutputFileLength = 0
-        
-        if estimatedOutputFileLength > fileLengthLimit {
-            let reducedQuality: String
-            if quality == AVAssetExportPresetHighestQuality {
+        // reduce quality if estimatedOutputFileLength is large then limitation.
+        var estimatedOutputFileLength = exportSession.estimatedOutputFileLength
+        var reducedQuality: String = quality
+
+        while let fileLengthLimit = fileLengthLimit,
+              estimatedOutputFileLength > fileLengthLimit,
+              reducedQuality != AVAssetExportPresetLowQuality {
+                
+            if reducedQuality == AVAssetExportPresetHighestQuality {
                 reducedQuality = AVAssetExportPresetMediumQuality
-            } else if quality == AVAssetExportPresetMediumQuality {
-                reducedQuality = AVAssetExportPresetLowQuality
             } else {
                 reducedQuality = AVAssetExportPresetLowQuality
             }
+                
             if let reducedExportSession = AVAssetExportSession(asset: self,
                                                                presetName: reducedQuality) {
             
             exportSession = reducedExportSession
+                
             }
+            
+            estimatedOutputFileLength = exportSession.estimatedOutputFileLength
         }
         
         if let fileLengthLimit = fileLengthLimit {


### PR DESCRIPTION
## What's new in this PR?

### Issues

When a user sharing a ~70MB .mov, it takes several minutes and the converted video is ~140MB.

### Causes

The converssion from .mov to .mp4 may increase the file size due to quality config

### Solutions

Calculate the estimated file size, if the size exceeded the account limit, reduce the export quality