### PR TITLE
tag app open event after self user is set

### DIFF
--- a/Wire-iOS/Sources/Analytics/AnalyticsConsoleProvider.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsConsoleProvider.swift
@@ -64,7 +64,7 @@ extension AnalyticsConsoleProvider: AnalyticsProvider {
         }
     }
     
-    func tagEvent(_ event: String, attributes: [String : Any] = [:]) {
+    func tagEvent(_ event: String, attributes: [String : Any] = [:]) -> Bool {
         
         let printableAttributes = attributes
         
@@ -83,6 +83,8 @@ extension AnalyticsConsoleProvider: AnalyticsProvider {
         }
         
         print(loggingData: loggingDict)
+        
+        return true
     }
     
     func setSuperProperty(_ name: String, value: Any?) {

--- a/Wire-iOS/Sources/Analytics/AnalyticsProvider.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsProvider.swift
@@ -23,8 +23,13 @@ protocol AnalyticsProvider: class {
     var isOptedOut: Bool { get set }
     var selfUser: UserType? { get set }
 
+        
     /// Record an event with optional attributes.
-    func tagEvent(_ event: String, attributes: [String: Any])
+    /// - Parameters:
+    ///   - event: event to tag
+    ///   - attributes: event attributes
+    @discardableResult
+    func tagEvent(_ event: String, attributes: [String: Any]) -> Bool
 
     /// Set a custom dimension
     func setSuperProperty(_ name: String, value: Any?)


### PR DESCRIPTION
## What's new in this PR?

Tag for "app.open" event once after `selfUser` property of `AnalyticsProvider` is set (tagging requires user id, and it is assigned after `selfUser` is assigned when the user session is created).