### PR TITLE
[Fix] Crash when creating new group conversation

### DIFF
--- a/Wire-iOS/Resources/fr.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/fr.lproj/Localizable.strings
@@ -732,7 +732,7 @@
 "participants.section.services" = "Services (%d)";
 "participants.section.settings" = "Options";
 "participants.footer.add_title" = "Ajouter des contacts";
-"participants.section.name.footer" = "Une conversation de groupe peut inclure jusqu'à %1$s contacts.";
+"participants.section.name.footer" = "Une conversation de groupe peut inclure jusqu'à %1$d contacts.";
 "participants.section.admins.footer" = "Il n'y a aucun administrateur.";
 "participants.section.members.footer" = "Il n'y a aucun participant.";
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

App (with a French localization) is crashing when creating a new group conversation.

### Causes

The argument placeholder type should be a number (not a string).

### Solutions
To fix the argument placeholder type.


### Dependencies

https://wearezeta.atlassian.net/browse/ZIOS-13850