### PR TITLE
[Fix] Test containing out of bounds exception

### DIFF
--- a/Wire-iOS Tests/AccessoryTextField/LinkInteractionTextViewTests.swift
+++ b/Wire-iOS Tests/AccessoryTextField/LinkInteractionTextViewTests.swift
@@ -84,7 +84,7 @@ final class LinkInteractionTextViewTests: XCTestCase {
 
         let markdownId: Markdown = [.bold, .italic, .link]
         let attrs: [NSAttributedString.Key: Any] = [.markdownID: markdownId, .link: url]
-        sut.attributedText = NSAttributedString(string: "click me!", attributes: attrs)
+        sut.attributedText = NSAttributedString(string: str, attributes: attrs)
 
         // WHEN
         let shouldOpenURL = sut.delegate!.textView!(sut, shouldInteractWith: url, in: NSMakeRange(0, str.count), interaction: .invokeDefaultAction)


### PR DESCRIPTION
## What's new in this PR?

### Issues

A test was failing due to an out of bounds exception.

### Causes

I made some changes to the test when writing it but decided to undo those changes. Unfortunately I didn't undo far enough and the test was committed incorrectly. The out of bounds exception occurs because of an incorrect test string.

### Solutions

Use the correct test string.

