### PR TITLE
[Fix] Apply carthage workaround for 'The file couldn’t be saved'

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -7243,7 +7243,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# to run locally, replace with $(BUILT_PRODUCTS_DIR)/WireSyncEngine.framework\n/usr/local/bin/carthage copy-frameworks\n";
+			shellScript = "# Workaround for for carthage \"The file couldn’t be saved.\" error\nrm -rf ${TMPDIR}/TemporaryItems/*carthage*\n# to run locally, replace with $(BUILT_PRODUCTS_DIR)/WireSyncEngine.framework\n/usr/local/bin/carthage copy-frameworks\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/setup.sh
+++ b/setup.sh
@@ -41,6 +41,10 @@ XCODE_VERSION=( ${version//./ } )
 [[ ${XCODE_VERSION[0]} -gt 11 || ( ${XCODE_VERSION[0]} -eq 11 && ${XCODE_VERSION[1]} -ge 4 ) ]] || die "Xcode version should be at least 11.4.0. The current version is ${XCODE_VERSION}"
 
 # SETUP
+
+# Workaround for for carthage "The file couldn’t be saved." error
+rm -rf ${TMPDIR}/TemporaryItems/*carthage*
+
 echo "ℹ️  Carthage bootstrap. This might take a while..."
 carthage bootstrap --cache-builds --platform ios
 echo ""


### PR DESCRIPTION
## What's new in this PR?

### Issues

CI fails to building with the following error during Carthage bootstrap:

```
*** Downloading appcenter-sdk-apple.framework binary at "3.3.1"
***  Skipped installing appcenter-sdk-apple.framework binary due to the error:
	"The file couldn’t be saved."
```

### Causes

Bug in Carthage: https://github.com/Carthage/Carthage/issues/3056

### Solutions

Apply workaround described in the issue.