### PR TITLE
[Chore] Add logging to describe value of BackendEnvironment.shared

### DIFF
--- a/Wire-iOS/Sources/AppRootViewController.swift
+++ b/Wire-iOS/Sources/AppRootViewController.swift
@@ -172,6 +172,8 @@ final class AppRootViewController: UIViewController, SpinnerCapable {
         let jailbreakDetector = JailbreakDetector()
         configuration.blacklistDownloadInterval = Settings.shared.blacklistDownloadInterval
 
+        Logging.backendEnvironment.debug("Shared backend environment is: \(BackendEnvironment.shared.title)")
+
         SessionManager.clearPreviousBackups()
 
         SessionManager.create(

--- a/Wire-iOS/Sources/Components/Settings+Logging.swift
+++ b/Wire-iOS/Sources/Components/Settings+Logging.swift
@@ -43,7 +43,7 @@ extension Settings {
     
     /// Loads from user default the list of logs that are enabled
     func loadEnabledLogs() {
-        var tagsToEnable: Set<String> = ["AVS", "Network", "SessionManager", "Conversations", "calling", "link previews", "event-processing", "SyncStatus", "OperationStatus", "Push", "Crypto", "cryptobox"]
+        var tagsToEnable: Set<String> = ["AVS", "Network", "SessionManager", "Conversations", "calling", "link previews", "event-processing", "SyncStatus", "OperationStatus", "Push", "Crypto", "cryptobox", "backend-environment"]
 
         if let savedTags = UserDefaults.shared().object(forKey: enabledLogsKey) as? Array<String> {
             tagsToEnable = Set(savedTags)

--- a/Wire-iOS/Sources/Helpers/Logging.swift
+++ b/Wire-iOS/Sources/Helpers/Logging.swift
@@ -22,5 +22,6 @@ import WireSystem
 enum Logging {
 
     static let messageProcessing = ZMSLog(tag: "messageProcessing")
+    static let backendEnvironment = ZMSLog(tag: "backend-environment")
 
 }

--- a/WireCommonComponents/BackendEnvironment+Shared.swift
+++ b/WireCommonComponents/BackendEnvironment+Shared.swift
@@ -19,6 +19,8 @@
 import Foundation
 import WireTransport
 
+private let zmsLog = ZMSLog(tag: "backend-environment")
+
 extension BackendEnvironment {
     
     public static let backendSwitchNotification = Notification.Name("backendEnvironmentSwitchNotification")
@@ -37,6 +39,7 @@ extension BackendEnvironment {
             AutomationHelper.sharedHelper.disableBackendTypeOverride()
             shared.save(in: .applicationGroup)
             NotificationCenter.default.post(name: backendSwitchNotification, object: shared)
+            zmsLog.debug("Shared backend environment did change to: \(shared.title)")
         }
     }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

We are trying to debug some issues regarding custom backends, and while we do have logging when the backend is switched, we do not know which backend environment is being used when the app is launched.


### Solutions

Add some logs when to describe the value of `BackendEnvironment.shared` when the app launches and whenever the value changes.

Additionally, include the backend environment log tag as enabled by default.

