### PR TITLE
add test for non team member do not start Countly session

### DIFF
--- a/Wire-iOS Tests/Analytics/AnalyticsCountlyProviderTests.swift
+++ b/Wire-iOS Tests/Analytics/AnalyticsCountlyProviderTests.swift
@@ -67,7 +67,9 @@ final class AnalyticsCountlyProviderTests: XCTestCase, CoreDataFixtureTestHelper
 
             //GIVEN
             sut = Analytics(optedOut: false)
-            let analyticsCountlyProvider = AnalyticsCountlyProvider(countlyInstanceType: MockCountly.self)!
+            let analyticsCountlyProvider = AnalyticsCountlyProvider(countlyInstanceType: MockCountly.self ,
+                                                                    countlyAppKey: "dummy countlyAppKey"
+                )!
             sut.provider = analyticsCountlyProvider
 
             //WHEN

--- a/Wire-iOS Tests/Analytics/AnalyticsCountlyProviderTests.swift
+++ b/Wire-iOS Tests/Analytics/AnalyticsCountlyProviderTests.swift
@@ -17,20 +17,25 @@
 
 import Foundation
 import XCTest
+import Countly
 @testable import Wire
 
 final class AnalyticsCountlyProviderTests: XCTestCase, CoreDataFixtureTestHelper {
     var coreDataFixture: CoreDataFixture!
 
+    var sut: Analytics!
+    
     override func setUp() {
         super.setUp()
-
+        
         coreDataFixture = CoreDataFixture()
     }
 
     override func tearDown() {
+        sut = nil
         coreDataFixture = nil
-
+        MockCountly.reset()
+        
         super.tearDown()
     }
 
@@ -61,8 +66,7 @@ final class AnalyticsCountlyProviderTests: XCTestCase, CoreDataFixtureTestHelper
         coreDataFixture.teamTest {
 
             //GIVEN
-            let sut = Analytics(optedOut: false)
-            ///TODO: inject app key to prevent nil
+            sut = Analytics(optedOut: false)
             let analyticsCountlyProvider = AnalyticsCountlyProvider(countlyInstanceType: MockCountly.self)!
             sut.provider = analyticsCountlyProvider
 
@@ -75,24 +79,54 @@ final class AnalyticsCountlyProviderTests: XCTestCase, CoreDataFixtureTestHelper
             XCTAssertEqual(MockCountly.recordEventCount, 0)
 
             //WHEN
+            coreDataFixture.selfUser?.analyticsIdentifier = "dummy"
+
             sut.selfUser = coreDataFixture.selfUser
 
             //THEN
+            XCTAssertEqual(MockCountly.startCount, 1)
+
             XCTAssertEqual(analyticsCountlyProvider.storedEventsCount, 0)
             XCTAssertEqual(MockCountly.recordEventCount, 1)
+        }
+    }
+    
+    func testThatCountlyIsNotStartedForNonTeamMember() {
+        coreDataFixture.nonTeamTest {
+            //GIVEN
+            sut = Analytics(optedOut: false)
+            let analyticsCountlyProvider = AnalyticsCountlyProvider(countlyInstanceType: MockCountly.self)!
+            sut.provider = analyticsCountlyProvider
+
+            //WHEN
+            sut.selfUser = coreDataFixture.selfUser
+
+            //THEN
+            XCTAssertEqual(MockCountly.startCount, 0)
         }
     }
 }
 
 final class MockCountly: CountlyInstance {
     static var recordEventCount = 0
-    static let shared = MockCountly()
+    static var startCount = 0
 
-    func recordEvent(_ key: String, segmentation: [String: String]?) {
-        MockCountly.recordEventCount += 1
+    static let shared = MockCountly()
+    
+    static func reset() {
+        recordEventCount = 0
+        startCount = 0
     }
 
     static func sharedInstance() -> Self {
         return shared as! Self
+    }
+    
+    func recordEvent(_ key: String, segmentation: [String: String]?) {
+        MockCountly.recordEventCount += 1
+    }
+    
+    func start(with config: CountlyConfig) {
+        MockCountly.startCount += 1
     }
 }

--- a/Wire-iOS Tests/Analytics/AnalyticsCountlyProviderTests.swift
+++ b/Wire-iOS Tests/Analytics/AnalyticsCountlyProviderTests.swift
@@ -67,9 +67,8 @@ final class AnalyticsCountlyProviderTests: XCTestCase, CoreDataFixtureTestHelper
 
             //GIVEN
             sut = Analytics(optedOut: false)
-            let analyticsCountlyProvider = AnalyticsCountlyProvider(countlyInstanceType: MockCountly.self ,
-                                                                    countlyAppKey: "dummy countlyAppKey"
-                )!
+            let analyticsCountlyProvider = AnalyticsCountlyProvider(countlyInstanceType: MockCountly.self,
+                                                                    countlyAppKey: "dummy countlyAppKey")!
             sut.provider = analyticsCountlyProvider
 
             //WHEN

--- a/Wire-iOS/Sources/Analytics/AnalyticsCountlyProvider.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsCountlyProvider.swift
@@ -83,10 +83,12 @@ final class AnalyticsCountlyProvider: AnalyticsProvider {
     }
     
     var countlyInstanceType: CountlyInstance.Type
-    var countlyAppKey: String?
+    var countlyAppKey: String
 
     init?(countlyInstanceType: CountlyInstance.Type = Countly.self,
           countlyAppKey: String? = Bundle.countlyAppKey) {
+        guard let countlyAppKey = countlyAppKey else { return nil }
+        
         self.countlyAppKey = countlyAppKey
         self.countlyInstanceType = countlyInstanceType
         isOptedOut = false
@@ -110,9 +112,8 @@ final class AnalyticsCountlyProvider: AnalyticsProvider {
                 return false
         }
 
-        guard let countlyAppKey = countlyAppKey,
-            !countlyAppKey.isEmpty,
-            let countlyURL = BackendEnvironment.shared.countlyURL else {
+        guard !countlyAppKey.isEmpty,
+              let countlyURL = BackendEnvironment.shared.countlyURL else {
                 zmLog.error("AnalyticsCountlyProvider is not created. Bundle.countlyAppKey = \(String(describing: Bundle.countlyAppKey)), countlyURL = \(String(describing: BackendEnvironment.shared.countlyURL)). Please check COUNTLY_APP_KEY is set in .xcconfig file")
                 return false
         }

--- a/Wire-iOS/Sources/Analytics/AnalyticsCountlyProvider.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsCountlyProvider.swift
@@ -29,6 +29,8 @@ extension Int {
 
 protocol CountlyInstance {
     func recordEvent(_ key: String, segmentation: [String : String]?)
+    func start(with config: CountlyConfig)
+    
     static func sharedInstance() -> Self
 }
 
@@ -81,8 +83,11 @@ final class AnalyticsCountlyProvider: AnalyticsProvider {
     }
     
     var countlyInstanceType: CountlyInstance.Type
+    var countlyAppKey: String?
 
-    init?(countlyInstanceType: CountlyInstance.Type = Countly.self) {
+    init?(countlyInstanceType: CountlyInstance.Type = Countly.self,
+          countlyAppKey: String? = Bundle.countlyAppKey) {
+        self.countlyAppKey = countlyAppKey
         self.countlyInstanceType = countlyInstanceType
         isOptedOut = false
     }
@@ -99,22 +104,26 @@ final class AnalyticsCountlyProvider: AnalyticsProvider {
         // 1. self user is a team member
         // 2. analyticsIdentifier is generated
         // 3. Countly key and URL is read
-        guard let countlyAppKey = Bundle.countlyAppKey,
-            !countlyAppKey.isEmpty,
-            let countlyURL = BackendEnvironment.shared.countlyURL,
-            shouldTracksEvent,
+        
+        guard shouldTracksEvent,
             let analyticsIdentifier = (selfUser as? ZMUser)?.analyticsIdentifier else {
+                return false
+        }
+
+        guard let countlyAppKey = countlyAppKey,
+            !countlyAppKey.isEmpty,
+            let countlyURL = BackendEnvironment.shared.countlyURL else {
                 zmLog.error("AnalyticsCountlyProvider is not created. Bundle.countlyAppKey = \(String(describing: Bundle.countlyAppKey)), countlyURL = \(String(describing: BackendEnvironment.shared.countlyURL)). Please check COUNTLY_APP_KEY is set in .xcconfig file")
                 return false
         }
-        
+                
         let config: CountlyConfig = CountlyConfig()
         config.appKey = countlyAppKey
         config.host = countlyURL.absoluteString
         config.manualSessionHandling = true
         
         config.deviceID = analyticsIdentifier
-        Countly.sharedInstance().start(with: config)
+        countlyInstanceType.sharedInstance().start(with: config)
         // Changing Device ID after app started
         // ref: https://support.count.ly/hc/en-us/articles/360037753511-iOS-watchOS-tvOS-macOS#section-resetting-stored-device-id
         Countly.sharedInstance().setNewDeviceID(analyticsIdentifier, onServer:true)


### PR DESCRIPTION
## What's new in this PR?

Add a test to verify that non-team members do not start Countly session.