### PR TITLE
[Fix] Make email and phone fields non-editable when re-authenticating

### DIFF
--- a/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationCredentialsViewController.swift
+++ b/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationCredentialsViewController.swift
@@ -59,6 +59,14 @@ final class AuthenticationCredentialsViewController: AuthenticationStepControlle
             return false
         }
     }
+    
+    var isReauthenticating: Bool {
+        if case .reauthentication? = flowType {
+            return true
+        } else {
+            return false
+        }
+    }
 
     private var emailFieldValidationError: TextFieldValidator.ValidationError? = .tooShort(kind: .email)
 
@@ -126,8 +134,10 @@ final class AuthenticationCredentialsViewController: AuthenticationStepControlle
         // Phone Number View
         phoneInputView.delegate = self
         phoneInputView.tintColor = .black
+        phoneInputView.allowEditingPrefilledValue = !isReauthenticating
 
         // Email Password Input View
+        emailPasswordInputField.allowEditingPrefilledValue = !isReauthenticating
         emailPasswordInputField.delegate = self
 
         // Email input view

--- a/Wire-iOS/Sources/Authentication/Interface/Views/PhoneNumberInputView.swift
+++ b/Wire-iOS/Sources/Authentication/Interface/Views/PhoneNumberInputView.swift
@@ -41,6 +41,13 @@ class PhoneNumberInputView: UIView, UITextFieldDelegate, TextFieldValidationDele
 
     /// The validation error for the current input.
     private(set) var validationError: TextFieldValidator.ValidationError? = .tooShort(kind: .phoneNumber)
+    
+    var hasPrefilledValue: Bool = false
+    var allowEditingPrefilledValue: Bool = true {
+        didSet {
+            updatePhoneNumberInputFieldIsEnabled()
+        }
+    }
 
     /// Whether to show the confirm button.
     var showConfirmButton: Bool = true {
@@ -239,11 +246,20 @@ class PhoneNumberInputView: UIView, UITextFieldDelegate, TextFieldValidationDele
         let selectedLabel = title.addingTrailingAttachment(selectedIcon, verticalOffset: 1) && selectedColor
         countryPickerButton.setAttributedTitle(selectedLabel, for: .highlighted)
     }
-
+    
     /// Sets the phone number to display.
     func setPhoneNumber(_ phoneNumber: PhoneNumber) {
+        hasPrefilledValue = true
         selectCountry(phoneNumber.country)
         textField.updateText(phoneNumber.numberWithoutCode)
+        updatePhoneNumberInputFieldIsEnabled()
+    }
+    
+    func updatePhoneNumberInputFieldIsEnabled() {
+        let allowEditing = !hasPrefilledValue || allowEditingPrefilledValue
+        textField.isEnabled = allowEditing
+        countryPickerButton.isEnabled = allowEditing
+        countryCodeInputView.isEnabled = allowEditing
     }
 
     // MARK: - Text Update

--- a/Wire-iOS/Sources/Authentication/Interface/Views/PhoneNumberInputView.swift
+++ b/Wire-iOS/Sources/Authentication/Interface/Views/PhoneNumberInputView.swift
@@ -48,6 +48,9 @@ class PhoneNumberInputView: UIView, UITextFieldDelegate, TextFieldValidationDele
             updatePhoneNumberInputFieldIsEnabled()
         }
     }
+    var allowEditing: Bool {
+        return !hasPrefilledValue || allowEditingPrefilledValue
+    }
 
     /// Whether to show the confirm button.
     var showConfirmButton: Bool = true {
@@ -63,7 +66,11 @@ class PhoneNumberInputView: UIView, UITextFieldDelegate, TextFieldValidationDele
 
     var text: String? {
         get { return textField.text }
-        set { textField.text = newValue }
+        set {
+            hasPrefilledValue = newValue != nil
+            textField.text = newValue
+            updatePhoneNumberInputFieldIsEnabled()
+        }
     }
 
     // MARK: - Views
@@ -256,8 +263,6 @@ class PhoneNumberInputView: UIView, UITextFieldDelegate, TextFieldValidationDele
     }
     
     func updatePhoneNumberInputFieldIsEnabled() {
-        let allowEditing = !hasPrefilledValue || allowEditingPrefilledValue
-        textField.isEnabled = allowEditing
         countryPickerButton.isEnabled = allowEditing
         countryCodeInputView.isEnabled = allowEditing
     }
@@ -266,7 +271,10 @@ class PhoneNumberInputView: UIView, UITextFieldDelegate, TextFieldValidationDele
 
     /// Returns whether the text should be updated.
     func shouldChangeCharacters(in range: NSRange, replacementString: String) -> Bool {
-        guard let replacementRange = Range(range, in: input) else {
+        guard
+            allowEditing,
+            let replacementRange = Range(range, in: input)
+        else {
             return false
         }
 

--- a/Wire-iOS/Sources/Authentication/Interface/Views/PhoneNumberInputView.swift
+++ b/Wire-iOS/Sources/Authentication/Interface/Views/PhoneNumberInputView.swift
@@ -264,7 +264,6 @@ class PhoneNumberInputView: UIView, UITextFieldDelegate, TextFieldValidationDele
     
     func updatePhoneNumberInputFieldIsEnabled() {
         countryPickerButton.isEnabled = allowEditing
-        countryCodeInputView.isEnabled = allowEditing
     }
 
     // MARK: - Text Update

--- a/Wire-iOS/Sources/UserInterface/Components/Views/EmailPasswordTextField.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/EmailPasswordTextField.swift
@@ -32,6 +32,11 @@ class EmailPasswordTextField: UIView, MagicTappable {
     let separatorContainer: ContentInsetView
 
     var hasPrefilledValue: Bool = false
+    var allowEditingPrefilledValue: Bool = true {
+        didSet {
+            updateEmailFieldisEnabled()
+        }
+    }
 
     weak var delegate: EmailPasswordTextFieldDelegate?
 
@@ -130,6 +135,11 @@ class EmailPasswordTextField: UIView, MagicTappable {
     func prefill(email: String?) {
         hasPrefilledValue = email != nil
         emailField.text = email
+        updateEmailFieldisEnabled()
+    }
+    
+    func updateEmailFieldisEnabled() {
+        emailField.isEnabled = !hasPrefilledValue || allowEditingPrefilledValue
     }
 
     // MARK: - Appearance


### PR DESCRIPTION
## What's new in this PR?

### Issues

When your session expires you are asked to login with your email / phone number fields pre-filled. It's possible to edit these fields but those edits are ignored when trying to login, which is confusing.

### Causes

Fields are editable but the email / phone number is not taken from the input field when submitting the login request.

### Solutions

Make input fields non-editable when re-authenticating.