### PR TITLE
[Fix] Analytic sessions are not being updated

### DIFF
--- a/Wire-iOS Tests/Analytics/AnalyticsCountlyProviderTests.swift
+++ b/Wire-iOS Tests/Analytics/AnalyticsCountlyProviderTests.swift
@@ -72,11 +72,11 @@ final class AnalyticsCountlyProviderTests: XCTestCase, CoreDataFixtureTestHelper
             sut.provider = analyticsCountlyProvider
 
             //WHEN
-            XCTAssertEqual(analyticsCountlyProvider.storedEventsCount, 0)
+            XCTAssertEqual(analyticsCountlyProvider.storedEvents.count, 0)
             sut.tagEvent("app.open")
 
             //THEN
-            XCTAssertEqual(analyticsCountlyProvider.storedEventsCount, 1)
+            XCTAssertEqual(analyticsCountlyProvider.storedEvents.count, 1)
             XCTAssertEqual(MockCountly.recordEventCount, 0)
 
             //WHEN
@@ -85,7 +85,7 @@ final class AnalyticsCountlyProviderTests: XCTestCase, CoreDataFixtureTestHelper
             //THEN
             XCTAssertEqual(MockCountly.startCount, 1)
 
-            XCTAssertEqual(analyticsCountlyProvider.storedEventsCount, 0)
+            XCTAssertEqual(analyticsCountlyProvider.storedEvents.count, 0)
             XCTAssertEqual(MockCountly.recordEventCount, 1)
         }
     }

--- a/Wire-iOS Tests/Analytics/AnalyticsCountlyProviderTests.swift
+++ b/Wire-iOS Tests/Analytics/AnalyticsCountlyProviderTests.swift
@@ -72,11 +72,11 @@ final class AnalyticsCountlyProviderTests: XCTestCase, CoreDataFixtureTestHelper
             sut.provider = analyticsCountlyProvider
 
             //WHEN
-            XCTAssertEqual(analyticsCountlyProvider.storedEvents.count, 0)
+            XCTAssertEqual(analyticsCountlyProvider.pendingEvents.count, 0)
             sut.tagEvent("app.open")
 
             //THEN
-            XCTAssertEqual(analyticsCountlyProvider.storedEvents.count, 1)
+            XCTAssertEqual(analyticsCountlyProvider.pendingEvents.count, 1)
             XCTAssertEqual(MockCountly.recordEventCount, 0)
 
             //WHEN
@@ -85,7 +85,7 @@ final class AnalyticsCountlyProviderTests: XCTestCase, CoreDataFixtureTestHelper
             //THEN
             XCTAssertEqual(MockCountly.startCount, 1)
 
-            XCTAssertEqual(analyticsCountlyProvider.storedEvents.count, 0)
+            XCTAssertEqual(analyticsCountlyProvider.pendingEvents.count, 0)
             XCTAssertEqual(MockCountly.recordEventCount, 1)
         }
     }

--- a/Wire-iOS Tests/Analytics/AnalyticsCountlyProviderTests.swift
+++ b/Wire-iOS Tests/Analytics/AnalyticsCountlyProviderTests.swift
@@ -67,8 +67,12 @@ final class AnalyticsCountlyProviderTests: XCTestCase, CoreDataFixtureTestHelper
 
             //GIVEN
             sut = Analytics(optedOut: false)
-            let analyticsCountlyProvider = AnalyticsCountlyProvider(countlyInstanceType: MockCountly.self,
-                                                                    countlyAppKey: "dummy countlyAppKey")!
+            let analyticsCountlyProvider = AnalyticsCountlyProvider(
+                countlyInstanceType: MockCountly.self,
+                countlyAppKey: "dummy countlyAppKey",
+                serverURL: URL(string: "www.wire.com")!
+            )!
+
             sut.provider = analyticsCountlyProvider
 
             //WHEN
@@ -94,7 +98,13 @@ final class AnalyticsCountlyProviderTests: XCTestCase, CoreDataFixtureTestHelper
         coreDataFixture.nonTeamTest {
             //GIVEN
             sut = Analytics(optedOut: false)
-            let analyticsCountlyProvider = AnalyticsCountlyProvider(countlyInstanceType: MockCountly.self)!
+
+            let analyticsCountlyProvider = AnalyticsCountlyProvider(
+                countlyInstanceType: MockCountly.self,
+                countlyAppKey: "dummy countlyAppKey",
+                serverURL: URL(string: "www.wire.com")!
+            )!
+
             sut.provider = analyticsCountlyProvider
 
             //WHEN

--- a/Wire-iOS Tests/Analytics/AnalyticsTests.swift
+++ b/Wire-iOS Tests/Analytics/AnalyticsTests.swift
@@ -77,8 +77,13 @@ final class AnalyticsTests: XCTestCase {
         coreDataFixture.teamTest {
             // Given
             let sut = Analytics(optedOut: false)
-            let provider = AnalyticsCountlyProvider(countlyInstanceType: MockCountly.self,
-                                                    countlyAppKey: "dummy countlyAppKey")!
+
+            let provider = AnalyticsCountlyProvider(
+                countlyInstanceType: MockCountly.self,
+                countlyAppKey: "dummy countlyAppKey",
+                serverURL: URL(string: "www.wire.com")!
+            )!
+
             sut.provider = provider
 
             let selfUser = coreDataFixture.selfUser!

--- a/Wire-iOS/Sources/Analytics/AnalyticsCountlyProvider.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsCountlyProvider.swift
@@ -76,8 +76,10 @@ final class AnalyticsCountlyProvider: AnalyticsProvider {
 
     // MARK: - Life cycle
 
-    init?(countlyInstanceType: CountlyInstance.Type = Countly.self,
-          countlyAppKey: String? = Bundle.countlyAppKey) {
+    init?(
+        countlyInstanceType: CountlyInstance.Type = Countly.self,
+        countlyAppKey: String? = Bundle.countlyAppKey
+    ) {
         guard let countlyAppKey = countlyAppKey else { return nil }
         
         self.countlyAppKey = countlyAppKey

--- a/Wire-iOS/Sources/Analytics/AnalyticsCountlyProvider.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsCountlyProvider.swift
@@ -52,7 +52,7 @@ final class AnalyticsCountlyProvider: AnalyticsProvider {
     private var isRecording: Bool = false {
         didSet {
             guard isRecording != oldValue else { return }
-            
+
             if isRecording {
                 updateTimer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { _ in self.updateSession() }
             } else {
@@ -82,11 +82,8 @@ final class AnalyticsCountlyProvider: AnalyticsProvider {
 
     var selfUser: UserType? {
         didSet {
-            guard let user = selfUser as? ZMUser else {
-                endCountly()
-                return
-            }
-
+            endCountly()
+            guard let user = selfUser as? ZMUser else { return }
             startCountly(for: user)
         }
     }

--- a/Wire-iOS/Sources/Analytics/AnalyticsCountlyProvider.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsCountlyProvider.swift
@@ -51,6 +51,8 @@ final class AnalyticsCountlyProvider: AnalyticsProvider {
 
     private var isRecording: Bool = false {
         didSet {
+            guard isRecording != oldValue else { return }
+            
             if isRecording {
                 updateTimer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { _ in self.updateSession() }
             } else {

--- a/Wire-iOS/Sources/Analytics/AnalyticsCountlyProvider.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsCountlyProvider.swift
@@ -74,7 +74,7 @@ final class AnalyticsCountlyProvider: AnalyticsProvider {
             }
 
             if !sessionBegun {
-                beginSession()
+                startCountly()
             }
 
             updateUserProperties()
@@ -103,7 +103,7 @@ final class AnalyticsCountlyProvider: AnalyticsProvider {
         zmLog.info("AnalyticsCountlyProvider \(self) deallocated")
     }
 
-    private func beginSession() {
+    private func startCountly() {
         guard
             shouldTracksEvent,
             let selfUser = selfUser as? ZMUser,
@@ -121,20 +121,26 @@ final class AnalyticsCountlyProvider: AnalyticsProvider {
             zmLog.error("AnalyticsCountlyProvider is not created. Bundle.countlyAppKey = \(appKey), countlyURL = \(url). Please check COUNTLY_APP_KEY is set in .xcconfig file")
             return
         }
-                
+
         let config: CountlyConfig = CountlyConfig()
         config.appKey = countlyAppKey
         config.host = countlyURL.absoluteString
         config.manualSessionHandling = true
-        
+
         config.deviceID = analyticsIdentifier
         countlyInstanceType.sharedInstance().start(with: config)
 
         // Changing Device ID after app started
         // ref: https://support.count.ly/hc/en-us/articles/360037753511-iOS-watchOS-tvOS-macOS#section-resetting-stored-device-id
         Countly.sharedInstance().setNewDeviceID(analyticsIdentifier, onServer:true)
-        
+
         zmLog.info("AnalyticsCountlyProvider \(self) started")
+
+        beginSession()
+    }
+
+    private func beginSession() {
+        Countly.sharedInstance().beginSession()
         sessionBegun = true
     }
 

--- a/Wire-iOS/Sources/Analytics/AnalyticsCountlyProvider.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsCountlyProvider.swift
@@ -43,15 +43,12 @@ final class AnalyticsCountlyProvider: AnalyticsProvider {
     private(set) var storedEvents: [StoredEvent] = []
 
     var isOptedOut: Bool {
-        get {
-            return !isRecording
-        }
-
-        set {
-            newValue ? Countly.sharedInstance().endSession() :
-                       Countly.sharedInstance().beginSession()
-
-            isRecording = !isOptedOut
+        didSet {
+            if !isOptedOut {
+                endSession()
+            } else if let user = selfUser as? ZMUser {
+                startCountly(for: user)
+            }
         }
     }
 
@@ -84,7 +81,7 @@ final class AnalyticsCountlyProvider: AnalyticsProvider {
         
         self.countlyAppKey = countlyAppKey
         self.countlyInstanceType = countlyInstanceType
-        isOptedOut = false
+        isOptedOut = true
     }
 
     deinit {
@@ -94,7 +91,7 @@ final class AnalyticsCountlyProvider: AnalyticsProvider {
     // MARK: - Methods
 
     private func startCountly(for user: ZMUser) {
-        guard !isRecording else { return }
+        guard !isOptedOut && !isRecording else { return }
 
         guard
             shouldTracksEvent,

--- a/Wire-iOS/Sources/Analytics/AnalyticsCountlyProvider.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsCountlyProvider.swift
@@ -35,22 +35,23 @@ final class AnalyticsCountlyProvider: AnalyticsProvider {
 
     // MARK: - Properties
 
-    /// flag for recording session is begun
-    private var sessionBegun: Bool = false
+    /// Whether a recording session is in progress.
+
+    private var isRecording: Bool = false
 
     /// store the events before selfUser is assigned. Send them and clear after selfUser is set
     private(set) var storedEvents: [StoredEvent] = []
 
     var isOptedOut: Bool {
         get {
-            return !sessionBegun
+            return !isRecording
         }
 
         set {
             newValue ? Countly.sharedInstance().endSession() :
                        Countly.sharedInstance().beginSession()
 
-            sessionBegun = !isOptedOut
+            isRecording = !isOptedOut
         }
     }
 
@@ -93,7 +94,7 @@ final class AnalyticsCountlyProvider: AnalyticsProvider {
     // MARK: - Methods
 
     private func startCountly(for user: ZMUser) {
-        guard !sessionBegun else { return }
+        guard !isRecording else { return }
 
         guard
             shouldTracksEvent,
@@ -151,7 +152,7 @@ final class AnalyticsCountlyProvider: AnalyticsProvider {
 
     private func updateCountlyUser(with user: ZMUser) {
         guard
-            !sessionBegun,
+            !isRecording,
             let properties = userProperties(for: user)
         else {
             return
@@ -181,12 +182,12 @@ final class AnalyticsCountlyProvider: AnalyticsProvider {
 
     private func beginSession() {
         Countly.sharedInstance().beginSession()
-        sessionBegun = true
+        isRecording = true
     }
 
     private func endSession() {
         Countly.sharedInstance().endSession()
-        sessionBegun = false
+        isRecording = false
     }
 
     private var shouldTracksEvent: Bool {

--- a/Wire-iOS/Sources/Analytics/AnalyticsCountlyProvider.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsCountlyProvider.swift
@@ -94,7 +94,7 @@ final class AnalyticsCountlyProvider: AnalyticsProvider {
         zmLog.info("AnalyticsCountlyProvider \(self) deallocated")
     }
 
-    // MARK: - Methods
+    // MARK: - Session management
 
     private func startCountly(for user: ZMUser) {
         guard
@@ -127,12 +127,24 @@ final class AnalyticsCountlyProvider: AnalyticsProvider {
         tagPendingEvents()
     }
 
+    private func beginSession() {
+        Countly.sharedInstance().beginSession()
+        isRecording = true
+    }
+
+    private func endSession() {
+        Countly.sharedInstance().endSession()
+        isRecording = false
+    }
+
+    // MARK: - Countly user
+
     private func userProperties(for user: ZMUser) -> [String: Any]? {
         guard
             let team = user.team,
             let teamId = team.remoteIdentifier
-        else {
-            return nil
+            else {
+                return nil
         }
 
         return [
@@ -165,19 +177,11 @@ final class AnalyticsCountlyProvider: AnalyticsProvider {
         Countly.user().save()
     }
 
-    private func beginSession() {
-        Countly.sharedInstance().beginSession()
-        isRecording = true
-    }
-
-    private func endSession() {
-        Countly.sharedInstance().endSession()
-        isRecording = false
-    }
-
     private var shouldTracksEvent: Bool {
         return selfUser?.isTeamMember == true
     }
+
+    // MARK: - Tag events
 
     func tagEvent(_ event: String,
                   attributes: [String: Any]) {

--- a/Wire-iOS/Sources/Analytics/AnalyticsCountlyProvider.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsCountlyProvider.swift
@@ -41,9 +41,11 @@ final class AnalyticsCountlyProvider: AnalyticsProvider {
 
     /// The Countly application to which events will be sent.
 
-    var countlyAppKey: String
+    private let appKey: String
 
-    let serverURL: URL
+    /// The url of the server hosting the Countly application.
+
+    private let serverURL: URL
 
     /// Whether a recording session is in progress.
 
@@ -85,7 +87,7 @@ final class AnalyticsCountlyProvider: AnalyticsProvider {
         guard !countlyAppKey.isEmpty else { return nil }
         
         self.countlyInstanceType = countlyInstanceType
-        self.countlyAppKey = countlyAppKey
+        self.appKey = countlyAppKey
         self.serverURL = serverURL
         isOptedOut = false
     }
@@ -108,7 +110,7 @@ final class AnalyticsCountlyProvider: AnalyticsProvider {
         }
 
         let config: CountlyConfig = CountlyConfig()
-        config.appKey = countlyAppKey
+        config.appKey = appKey
         config.host = serverURL.absoluteString
         config.manualSessionHandling = true
         config.deviceID = analyticsIdentifier

--- a/Wire-iOS/Sources/Analytics/AnalyticsCountlyProvider.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsCountlyProvider.swift
@@ -145,8 +145,8 @@ final class AnalyticsCountlyProvider: AnalyticsProvider {
         guard
             let team = user.team,
             let teamId = team.remoteIdentifier
-            else {
-                return nil
+        else {
+            return nil
         }
 
         return [

--- a/Wire-iOS/Sources/Analytics/AnalyticsCountlyProvider.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsCountlyProvider.swift
@@ -35,6 +35,12 @@ final class AnalyticsCountlyProvider: AnalyticsProvider {
 
     // MARK: - Properties
 
+    var countlyInstanceType: CountlyInstance.Type
+
+    /// The Countly application to which events will be sent.
+
+    var countlyAppKey: String
+
     /// Whether a recording session is in progress.
 
     private var isRecording: Bool = false
@@ -69,9 +75,6 @@ final class AnalyticsCountlyProvider: AnalyticsProvider {
             storedEvents.removeAll()
         }
     }
-    
-    var countlyInstanceType: CountlyInstance.Type
-    var countlyAppKey: String
 
     // MARK: - Life cycle
 

--- a/Wire-iOS/Sources/Analytics/AnalyticsCountlyProvider.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsCountlyProvider.swift
@@ -77,6 +77,8 @@ final class AnalyticsCountlyProvider: AnalyticsProvider {
         }
     }
 
+    private var updateTimer: Timer?
+
     // MARK: - Life cycle
 
     init?(
@@ -132,11 +134,20 @@ final class AnalyticsCountlyProvider: AnalyticsProvider {
     private func beginSession() {
         Countly.sharedInstance().beginSession()
         isRecording = true
+        updateTimer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { _ in self.updateSession() }
+    }
+
+    private func updateSession() {
+        guard isRecording else { return }
+        Countly.sharedInstance().updateSession()
     }
 
     private func endSession() {
         Countly.sharedInstance().endSession()
         isRecording = false
+
+        updateTimer?.invalidate()
+        updateTimer = nil
     }
 
     // MARK: - Countly user

--- a/Wire-iOS/Sources/Analytics/AnalyticsCountlyProvider.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsCountlyProvider.swift
@@ -49,7 +49,16 @@ final class AnalyticsCountlyProvider: AnalyticsProvider {
 
     /// Whether a recording session is in progress.
 
-    private var isRecording: Bool = false
+    private var isRecording: Bool = false {
+        didSet {
+            if isRecording {
+                updateTimer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { _ in self.updateSession() }
+            } else {
+                updateTimer?.invalidate()
+                updateTimer = nil
+            }
+        }
+    }
 
     /// Whether the Countly instance has been configured and started.
 
@@ -146,7 +155,6 @@ final class AnalyticsCountlyProvider: AnalyticsProvider {
     private func beginSession() {
         Countly.sharedInstance().beginSession()
         isRecording = true
-        updateTimer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { _ in self.updateSession() }
     }
 
     private func updateSession() {
@@ -157,9 +165,6 @@ final class AnalyticsCountlyProvider: AnalyticsProvider {
     private func endSession() {
         Countly.sharedInstance().endSession()
         isRecording = false
-
-        updateTimer?.invalidate()
-        updateTimer = nil
     }
 
     // MARK: - Countly user

--- a/Wire-iOS/Sources/Analytics/AnalyticsProviderFactory.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsProviderFactory.swift
@@ -19,6 +19,7 @@
 import Foundation
 import WireSystem
 import WireCommonComponents
+import WireSyncEngine
 
 private let zmLog = ZMSLog(tag: "Analytics")
 
@@ -42,7 +43,16 @@ final class AnalyticsProviderFactory: NSObject {
             return AnalyticsConsoleProvider()
         } else if AutomationHelper.sharedHelper.useAnalytics {
             // Create & return valid provider, when available.
-            return AnalyticsCountlyProvider()
+            guard
+                let appKey = Bundle.countlyAppKey,
+                let url = BackendEnvironment.shared.countlyURL
+            else {
+                zmLog.error("Could not create Countly provider. Make sure COUNTLY_APP_KEY in .xcconfig is set and countlyURL exists in backend environment.")
+                return nil
+            }
+
+            return AnalyticsCountlyProvider(countlyAppKey: appKey, serverURL: url)
+
         } else {
             zmLog.info("Creating analyticsProvider: no provider")
             return nil

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
@@ -224,6 +224,9 @@ class SettingsCellDescriptorFactory {
         let triggerSlowSyncButton = SettingsButtonCellDescriptor(title: "Trigger slow sync", isDestructive: false, selectAction: DebugActions.triggerSlowSync)
         developerCellDescriptors.append(triggerSlowSyncButton)
 
+        let showAnalyticsIdentiferButton = SettingsButtonCellDescriptor(title: "What's my analytics id?", isDestructive: false, selectAction: DebugActions.showAnalyticsIdentifier)
+        developerCellDescriptors.append(showAnalyticsIdentiferButton)
+
         return SettingsGroupCellDescriptor(items: [SettingsSectionDescriptor(cellDescriptors:developerCellDescriptors)], title: title, icon: .robot)
     }
     

--- a/Wire-iOS/Sources/UserInterface/Settings/DebugActions.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DebugActions.swift
@@ -145,6 +145,25 @@ enum DebugActions {
             ZMUserSession.shared()?.requestSlowSync()
         }
     }
+
+    static func showAnalyticsIdentifier(_ type: SettingsCellDescriptorType) {
+        guard
+            let controller = UIApplication.shared.topmostViewController(onlyFullScreen: false),
+            let userSession = ZMUserSession.shared()
+        else {
+            return
+        }
+
+        let selfUser = ZMUser.selfUser(inUserSession: userSession)
+
+        let alert = UIAlertController(
+            title: "Analytics identifier",
+            message: "\(selfUser.analyticsIdentifier ?? "nil")",
+            alertAction: .ok(style: .cancel)
+        )
+
+        controller.present(alert, animated: true)
+    }
     
     static func generateTestCrash(_ type: SettingsCellDescriptorType) {
         MSCrashes.generateTestCrash()


### PR DESCRIPTION
## What's new in this PR?

### Issues

Countly integration is broken since 3.68. The majority of iOS users have zero sessions recorded and therefore are not showing any recorded events. Some users however do show recorded events and sessions. 

### Causes

Manual session handling is enabled, however the sessions were never being explicitly updated nor explicitly ended. As a result, Countly was recognizing users but never received any events or session information from those users. In some cases though events would be uploaded, but (I believe) this would only happen when the self user changes (due to an account switch).

### Solutions

Explicitly start, update and end the session. The lifetime of the session matches the default behavior of Countly (when manual session handling is disabled), which means sessions begin when the app is foregrounded, updated every 60 seconds, and ended when the app is backgrounded.

### Notes

There is substantial refactoring in this PR to make this work and it has been done under time pressure, so there is certainly a lot more that I would refactor to clean up and make it more robust and better tested. For now, however, manual testing has indicated that it is working as expected.