### PR TITLE
[Feature] show self stream in floating tile when call has 2 participants

### DIFF
--- a/Wire-iOS Tests/Calling/VoiceChannelVideoStreamArrangmentTests.swift
+++ b/Wire-iOS Tests/Calling/VoiceChannelVideoStreamArrangmentTests.swift
@@ -155,7 +155,7 @@ class VoiceChannelVideoStreamArrangementTests: XCTestCase {
     // MARK - arrangeVideoStreams
     
     func videoStreamStub(userId: UUID = UUID(), clientId: String = UUID().transportString()) -> VideoStream {
-        let stream = Stream(streamId: AVSClient(userId: UUID(), clientId: clientId),
+        let stream = Stream(streamId: AVSClient(userId: userId, clientId: clientId),
                             participantName: nil,
                             microphoneState: .none,
                             videoState: .none)

--- a/Wire-iOS Tests/Calling/VoiceChannelVideoStreamArrangmentTests.swift
+++ b/Wire-iOS Tests/Calling/VoiceChannelVideoStreamArrangmentTests.swift
@@ -29,6 +29,10 @@ class VoiceChannelVideoStreamArrangementTests: XCTestCase {
     var remoteId2 = UUID()
     var remoteId3 = UUID()
     
+    var mockSelfUser: ZMUser!
+    var selfUserId = UUID()
+    var selfClientId = UUID().transportString()
+
     override func setUp() {
         super.setUp()
         let mockConversation = ((MockConversation.oneOnOneConversation() as Any) as! ZMConversation)
@@ -42,6 +46,16 @@ class VoiceChannelVideoStreamArrangementTests: XCTestCase {
         mockUser3 = MockUser.mockUsers()[2]
         mockUser3.remoteIdentifier = remoteId3
         mockUser3.name = "Cate"
+        
+        let userClient = MockUserClient()
+        userClient.remoteIdentifier = selfClientId
+
+        // Workaround to have the self user mock be of ZMUser type.
+        mockSelfUser = MockUser.mockUsers()[3]
+        MockUser.setMockSelf(mockSelfUser)
+        MockUser.mockSelf()?.remoteIdentifier = selfUserId
+        MockUser.mockSelf()?.clients = [userClient]
+        MockUser.mockSelf()?.isSelfUser = true
     }
     
     override func tearDown() {
@@ -140,8 +154,8 @@ class VoiceChannelVideoStreamArrangementTests: XCTestCase {
     
     // MARK - arrangeVideoStreams
     
-    func videoStreamStub() -> VideoStream {
-        let stream = Stream(streamId: AVSClient(userId: UUID(), clientId: UUID().transportString()),
+    func videoStreamStub(userId: UUID = UUID(), clientId: String = UUID().transportString()) -> VideoStream {
+        let stream = Stream(streamId: AVSClient(userId: UUID(), clientId: clientId),
                             participantName: nil,
                             microphoneState: .none,
                             videoState: .none)
@@ -149,12 +163,20 @@ class VoiceChannelVideoStreamArrangementTests: XCTestCase {
                            isPaused: false)
     }
     
-    func testThatItReturnsSelfPreviewAndParticipantInGrid_OneOnOneConversation() {
+    func setMockParticipants(with users: [ZMUser]) {
+        sut.mockParticipants = []
+        for user in users {
+            sut.mockParticipants.append(participantStub(for: user, videoEnabled: false))
+        }
+    }
+    
+    func testThatItReturnsSelfPreviewAndParticipantInGrid_WhenOnlyTwoParticipants() {
         // GIVEN
-        let participantVideoStreams = [videoStreamStub()]
-        let selfStream = videoStreamStub()
-        sut.conversation?.conversationType = .oneOnOne
+        setMockParticipants(with: [mockUser1, mockSelfUser])
         
+        let participantVideoStreams = [videoStreamStub()]
+        let selfStream = videoStreamStub(userId: selfUserId, clientId: selfClientId)
+
         // WHEN
         let videoStreamArrangement = sut.arrangeVideoStreams(for: selfStream, participantsStreams: participantVideoStreams)
         
@@ -162,31 +184,33 @@ class VoiceChannelVideoStreamArrangementTests: XCTestCase {
         XCTAssert(videoStreamArrangement.grid.elementsEqual(participantVideoStreams))
         XCTAssert(videoStreamArrangement.preview == selfStream)
     }
-    
-    func testThatItReturnsNilPreviewAndAllParticipantsInGrid_GroupConversation() {
+
+    func testThatItReturnsNilPreviewAndParticipantInGrid_WhenOnlyTwoParticipants_WithoutSelfStream() {
         // GIVEN
+        setMockParticipants(with: [mockUser1, mockSelfUser])
+
         let participantVideoStreams = [videoStreamStub()]
-        let selfStream = videoStreamStub()
-        sut.conversation?.conversationType = .group
-        
-        // WHEN
-        let videoStreamArrangement = sut.arrangeVideoStreams(for: selfStream, participantsStreams: participantVideoStreams)
-        
-        // THEN
-        XCTAssert(videoStreamArrangement.grid.elementsEqual([selfStream] + participantVideoStreams))
-        XCTAssert(videoStreamArrangement.preview == nil)
-    }
-    
-    func testThatItReturnsNilPreviewAndParticipantInGrid_WithoutSelfStream() {
-        // GIVEN
-        let participantVideoStreams = [videoStreamStub()]
-        sut.conversation?.conversationType = .oneOnOne
         
         // WHEN
         let videoStreamArrangement = sut.arrangeVideoStreams(for: nil, participantsStreams: participantVideoStreams)
         
         // THEN
         XCTAssert(videoStreamArrangement.grid.elementsEqual(participantVideoStreams))
+        XCTAssert(videoStreamArrangement.preview == nil)
+    }
+    
+    func testThatItReturnsNilPreviewAndAllParticipantsInGrid_WhenOverTwoParticipants() {
+        // GIVEN
+        setMockParticipants(with: [mockUser1, mockUser2, mockSelfUser])
+        
+        let participantVideoStreams = [videoStreamStub()]
+        let selfStream = videoStreamStub()
+        
+        // WHEN
+        let videoStreamArrangement = sut.arrangeVideoStreams(for: selfStream, participantsStreams: participantVideoStreams)
+        
+        // THEN
+        XCTAssert(videoStreamArrangement.grid.elementsEqual([selfStream] + participantVideoStreams))
         XCTAssert(videoStreamArrangement.preview == nil)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallInfoConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallInfoConfiguration.swift
@@ -258,10 +258,6 @@ fileprivate extension VoiceChannel {
             || isIncomingVideoCall                                   // This is an incoming video call
     }
     
-    var connectedParticipants: [CallParticipant] {
-        return participants.filter { $0.state.isConnected }
-    }
-
     func sortedConnectedParticipants() -> [CallParticipant] {
         return connectedParticipants.sorted { lhs, rhs in
             lhs.user.name?.lowercased() < rhs.user.name?.lowercased()
@@ -277,6 +273,9 @@ fileprivate extension VoiceChannel {
 }
 
 extension VoiceChannel {
+    var connectedParticipants: [CallParticipant] {
+        return participants.filter { $0.state.isConnected }
+    }
 
     var degradationState: CallDegradationState {
         switch state {

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/VideoConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/VideoConfiguration.swift
@@ -99,13 +99,17 @@ extension VoiceChannel {
             return (nil, streamsExcludingSelf)
         }
 
-        if conversation?.conversationType == ZMConversationType.oneOnOne && streamsExcludingSelf.count == 1 {
+        if callHasTwoParticipants && streamsExcludingSelf.count == 1 {
             return (selfStream, streamsExcludingSelf)
         } else {
             return (nil, [selfStream] + streamsExcludingSelf)
         }
     }
-
+    
+    private var callHasTwoParticipants: Bool {
+        return connectedParticipants.count == 2
+    }
+    
     var sortedActiveVideoStreams: [VideoStream] {
         return sortedParticipants.compactMap { participant in
             switch participant.state {


### PR DESCRIPTION
## What's new in this PR?

This is an update to show the self user video stream in the floating tile when a call has 2 participants **and** 2 active video streams. 

This was a feature restricted to 1:1 conversation that we now have on any kind of conversation as long as there are 2 participants in the call.