### PR TITLE
[Feature] maximise / minimise video stream on double tap

### DIFF
--- a/Wire-iOS Tests/VideoPreviewViewTests.swift
+++ b/Wire-iOS Tests/VideoPreviewViewTests.swift
@@ -31,14 +31,14 @@ class VideoPreviewViewTests: XCTestCase {
         super.tearDown()
     }
     
-    private func stream(muted: Bool) -> Wire.Stream {
+    private func stream(muted: Bool, videoState: VideoState = .started) -> Wire.Stream {
         let client = AVSClient(userId: UUID(), clientId: UUID().transportString())
 
         return Wire.Stream(
             streamId: client,
             participantName: "Bob",
             microphoneState: muted ? .muted : .unmuted,
-            videoState: .started
+            videoState: videoState
         )
     }
     
@@ -47,6 +47,33 @@ class VideoPreviewViewTests: XCTestCase {
         view.frame = CGRect(origin: CGPoint(x: 0, y: 0), size: XCTestCase.DeviceSizeIPhone5)
         view.backgroundColor = .graphite
         return view
+    }
+    
+    func testThatItShouldNotFill_WhenMaximized() {
+        // GIVEN
+        sut = createView(from: stream(muted: false), isCovered: false)
+        
+        // WHEN
+        sut.isMaximized = true
+        
+        // THEN
+        XCTAssertFalse(sut.shouldFill)
+    }
+    
+    func testThatItShouldFill_WhenSharingVideo_AndNotMaximized() {
+        // GIVEN / WHEN
+        sut = createView(from: stream(muted: false), isCovered: false)
+        
+        // THEN
+        XCTAssertTrue(sut.shouldFill)
+    }
+    
+    func testThatItShouldNotFill_WhenScreenSharing_AndNotMaximized() {
+        // GIVEN / WHEN
+        sut = createView(from: stream(muted: false, videoState: .screenSharing), isCovered: false)
+        
+        // THEN
+        XCTAssertFalse(sut.shouldFill)
     }
     
     func testDefaultState() {

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -108,11 +108,9 @@ final class CallViewController: UIViewController {
     }
 
     @objc func handleDoubleTap(_ sender: UITapGestureRecognizer) {
-
         guard !isOverlayVisible else { return }
 
-        let location = sender.location(in: self.view)
-        videoGridViewController.switchFillMode(location: location)
+        videoGridViewController.handleDoubleTap(gesture: sender)
     }
 
     deinit {

--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridViewController.swift
@@ -116,8 +116,9 @@ final class VideoGridViewController: UIViewController {
     }
 
     // MARK: - Public Interface
-
-    public func switchFillMode(location: CGPoint) {
+    
+    public func handleDoubleTap(gesture: UIGestureRecognizer) {
+        let location = gesture.location(in: gridView)
         toggleMaximized(view: streamView(at: location))
     }
     
@@ -282,15 +283,10 @@ final class VideoGridViewController: UIViewController {
     }
     
     private func streamView(at location: CGPoint) -> BaseVideoPreviewView? {
-        let displayedStreams = dataSource.compactMap { $0.stream }
-        
-        return viewCache.values.lazy
-            .compactMap { $0 as? BaseVideoPreviewView }
-            .first {
-                let isShown = displayedStreams.contains($0.stream)
-                let isAtLocation = self.view.convert($0.frame, from: $0.superview).contains(location)
-                return isShown && isAtLocation
+        guard let indexPath = gridView.indexPathForItem(at: location) else {
+            return nil
         }
+        return streamView(for: dataSource[indexPath.row].stream) as? BaseVideoPreviewView
     }
 
     private func stream(with streamId: AVSClient) -> Stream? {

--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridViewController.swift
@@ -127,7 +127,7 @@ final class VideoGridViewController: UIViewController {
         let stream = view?.stream
         
         maximizedView = isMaximized(stream: stream) ? nil : view
-        (view as? VideoPreviewView)?.shouldFill = !isMaximized(stream: stream)
+        (view as? VideoPreviewView)?.isMaximized = isMaximized(stream: stream)
         updateVideoGrid(with: videoStreams)
     }
     

--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridViewController.swift
@@ -33,10 +33,10 @@ final class VideoGridViewController: UIViewController {
     // MARK: - Private Properties
     
     private var videoStreams: [VideoStream] {
-        guard let videoStream = configuration.videoStreams.first(where: { $0.stream.streamId == maximizedStream?.streamId }) else {
-            return configuration.videoStreams
+        if let videoStream = configuration.videoStreams.first(where: { isMaximized(stream: $0.stream) }) {
+            return [videoStream]
         }
-        return [videoStream]
+        return configuration.videoStreams
     }
 
     private var dataSource: [VideoStream] = []

--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoPreviewView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoPreviewView.swift
@@ -36,7 +36,7 @@ final class VideoPreviewView: BaseVideoPreviewView {
         }
     }
     
-    private var shouldFill: Bool {
+    var shouldFill: Bool {
         return isMaximized ? false : videoKind.shouldFill
     }
 
@@ -55,6 +55,7 @@ final class VideoPreviewView: BaseVideoPreviewView {
     override init(stream: Stream, isCovered: Bool) {
         super.init(stream: stream, isCovered: isCovered)
         updateState()
+        updateVideoKind()
     }
     
     // MARK: - Setup
@@ -77,7 +78,7 @@ final class VideoPreviewView: BaseVideoPreviewView {
 
     override func streamDidChange() {
         super.streamDidChange()
-        videoKind = VideoKind(videoState: stream.videoState)
+        updateVideoKind()
     }
     
     // MARK: - Fill mode
@@ -87,6 +88,10 @@ final class VideoPreviewView: BaseVideoPreviewView {
             guard oldValue != videoKind else { return }
             updateFillMode()
         }
+    }
+
+    private func updateVideoKind() {
+        videoKind = VideoKind(videoState: stream.videoState)
     }
 
     private func updateFillMode() {

--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoPreviewView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoPreviewView.swift
@@ -30,10 +30,14 @@ final class VideoPreviewView: BaseVideoPreviewView {
         }
     }
 
-    var shouldFill: Bool = true {
+    var isMaximized: Bool = false {
         didSet {
             updateFillMode()
         }
+    }
+    
+    private var shouldFill: Bool {
+        return isMaximized ? false : videoKind.shouldFill
     }
 
     private var previewView: AVSVideoView?
@@ -81,7 +85,6 @@ final class VideoPreviewView: BaseVideoPreviewView {
     private var videoKind: VideoKind = .none {
         didSet {
             guard oldValue != videoKind else { return }
-            shouldFill = videoKind.shouldFill
             updateFillMode()
         }
     }
@@ -155,7 +158,7 @@ final class VideoPreviewView: BaseVideoPreviewView {
             insertSubview(preview, belowSubview: userDetailsView)
         }
         preview.fitInSuperview()
-        preview.shouldFill = videoKind.shouldFill
+        preview.shouldFill = shouldFill
         
         previewView = preview
     }


### PR DESCRIPTION
## What's new in this PR?

Maximise / minimise video stream on double tap.

### current behaviour

**given** we have a video grid containing one or more video tiles
**when** user double taps on a video tile
**then** the video tile's fill mode is toggled (either fills or fits the available space in the tile)

### new behaviour

**given** we have a video grid containing one or more video tiles
**when** user double taps on a video tile that is **not** maximised
**then** the video tile is maximised to **fit** the **video grid**

**given** we have a video grid containing one or more video tiles
**when** user double taps on a video tile that is maximised
**then** the video tile is minimised to allow all video tiles to be shown
