### PR TITLE
[Fix] Network indicator not shown on conversation list

### DIFF
--- a/Wire-iOS Tests/NetworkStatusView/NetworkStatusViewControllerSnapshotTests.swift
+++ b/Wire-iOS Tests/NetworkStatusView/NetworkStatusViewControllerSnapshotTests.swift
@@ -52,12 +52,15 @@ final class NetworkStatusViewControllerSnapshotTests: ZMSnapshotTestCase {
         mockContentView = UIView()
         mockContentView.backgroundColor = .white
         mockContainerViewController.view.addSubview(mockContentView)
-
-        sut.createConstraintsInParentController(bottomView: mockContentView, controller: mockContainerViewController)
         
+        sut.view.translatesAutoresizingMaskIntoConstraints = false
         mockContentView.translatesAutoresizingMaskIntoConstraints = false
         
         NSLayoutConstraint.activate([
+            sut.view.topAnchor.constraint(equalTo: mockContainerViewController.safeTopAnchor),
+            sut.view.leadingAnchor.constraint(equalTo: mockContainerViewController.view.leadingAnchor),
+            sut.view.trailingAnchor.constraint(equalTo: mockContainerViewController.view.trailingAnchor),
+            sut.view.bottomAnchor.constraint(equalTo: mockContentView.topAnchor),
             mockContentView.leadingAnchor.constraint(equalTo: mockContainerViewController.view.leadingAnchor),
             mockContentView.trailingAnchor.constraint(equalTo: mockContainerViewController.view.trailingAnchor),
             mockContentView.bottomAnchor.constraint(equalTo: mockContainerViewController.safeBottomAnchor)

--- a/Wire-iOS/Sources/UserInterface/Components/NetworkStatus/NetworkStatusViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/NetworkStatus/NetworkStatusViewController.swift
@@ -111,16 +111,6 @@ final class NetworkStatusViewController : UIViewController {
         }
     }
 
-    func createConstraintsInParentController(bottomView: UIView, controller: UIViewController) {
-        constrain(bottomView, controller.view, view) { bottomView, containerView, networkStatusViewControllerView in
-            networkStatusViewControllerView.leading == containerView.leading
-            networkStatusViewControllerView.trailing == containerView.trailing
-            bottomView.top == networkStatusViewControllerView.bottom
-        }
-        
-        view.topAnchor.constraint(equalTo: controller.safeTopAnchor).isActive = true
-    }
-
     func showOfflineAlert() {
         let offlineAlert = UIAlertController(title: "system_status_bar.no_internet.title".localized,
                                                   message: "system_status_bar.no_internet.explanation".localized,

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationRootViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationRootViewController.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Cartography
 import UIKit
 import WireSyncEngine
 
@@ -86,24 +85,34 @@ final class ConversationRootViewController: UIViewController {
         self.addToSelf(navBarContainer)
         self.view.addSubview(self.contentView)
         self.addToSelf(networkStatusViewController)
-
-        networkStatusViewController.createConstraintsInParentController(bottomView: navBarContainer.view, controller: self)
-
-        constrain(navBarContainer.view, view, contentView, conversationViewController.view) {
-            navBarContainer, view, contentView, conversationViewControllerView in
-
-            navBarContainer.left == view.left
-            navBarContainer.right == view.right
-
-            contentView.left == view.left
-            contentView.right == view.right
-            contentView.top == navBarContainer.bottom
-
-            conversationViewControllerView.edges == contentView.edges
+        
+        [contentView,
+         conversationViewController.view,
+         networkStatusViewController.view
+        ].forEach() {
+            $0?.translatesAutoresizingMaskIntoConstraints = false
         }
         
-        contentView.bottomAnchor.constraint(equalTo: self.safeBottomAnchor).isActive = true
-        
+        NSLayoutConstraint.activate([
+            networkStatusViewController.view.topAnchor.constraint(equalTo: self.safeTopAnchor),
+            networkStatusViewController.view.leftAnchor.constraint(equalTo: view.leftAnchor),
+            networkStatusViewController.view.rightAnchor.constraint(equalTo: view.rightAnchor),
+            
+            navBarContainer.view.topAnchor.constraint(equalTo: networkStatusViewController.view.bottomAnchor),
+            navBarContainer.view.leftAnchor.constraint(equalTo: view.leftAnchor),
+            navBarContainer.view.rightAnchor.constraint(equalTo: view.rightAnchor),
+            
+            contentView.leftAnchor.constraint(equalTo: view.leftAnchor),
+            contentView.rightAnchor.constraint(equalTo: view.rightAnchor),
+            contentView.topAnchor.constraint(equalTo: navBarContainer.view.bottomAnchor),
+            contentView.bottomAnchor.constraint(equalTo: self.safeBottomAnchor),
+            
+            conversationViewController.view.topAnchor.constraint(equalTo: contentView.topAnchor),
+            conversationViewController.view.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            conversationViewController.view.leftAnchor.constraint(equalTo: contentView.leftAnchor),
+            conversationViewController.view.rightAnchor.constraint(equalTo: contentView.rightAnchor),
+        ])
+
         navBarContainer.navigationBar.pushItem(conversationViewController.navigationItem, animated: false)
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationRootViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationRootViewController.swift
@@ -89,9 +89,7 @@ final class ConversationRootViewController: UIViewController {
         [contentView,
          conversationViewController.view,
          networkStatusViewController.view
-        ].forEach() {
-            $0?.translatesAutoresizingMaskIntoConstraints = false
-        }
+        ].disableAutoresizingMaskTranslation()
         
         NSLayoutConstraint.activate([
             networkStatusViewController.view.topAnchor.constraint(equalTo: self.safeTopAnchor),
@@ -161,4 +159,3 @@ extension ZMConversation {
         }
     }
 }
-

--- a/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController.swift
@@ -245,7 +245,11 @@ final class ConversationListViewController: UIViewController {
             contentContainer.trailingAnchor.constraint(equalTo: view.safeTrailingAnchor),
             contentContainer.bottomAnchor.constraint(equalTo: safeBottomAnchor),
             
-            topBarView.topAnchor.constraint(equalTo: contentContainer.topAnchor),
+            networkStatusViewController.view.topAnchor.constraint(equalTo: contentContainer.topAnchor),
+            networkStatusViewController.view.leadingAnchor.constraint(equalTo: contentContainer.leadingAnchor),
+            networkStatusViewController.view.trailingAnchor.constraint(equalTo: contentContainer.trailingAnchor),
+            
+            topBarView.topAnchor.constraint(equalTo: networkStatusViewController.view.bottomAnchor),
             topBarView.leadingAnchor.constraint(equalTo: contentContainer.leadingAnchor),
             topBarView.trailingAnchor.constraint(equalTo: contentContainer.trailingAnchor),
             
@@ -266,11 +270,7 @@ final class ConversationListViewController: UIViewController {
             noConversationLabel.centerYAnchor.constraint(equalTo: contentContainer.centerYAnchor),
             noConversationLabel.widthAnchor.constraint(equalToConstant: 240),
         ]
-        
-        ///TODO: merge this method and activate the constraints in a batch
-        networkStatusViewController.createConstraintsInParentController(bottomView: topBarView,
-                                                                        controller: self)
-        
+                
         NSLayoutConstraint.activate(constraints)
     }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

Network indicator is not shown on the conversation list.

### Causes

Constraints are breaking for the height of the indicator.

`TopBar` is connected to `contentContainer` and the same time `networkStatusViewController.view` is connected the `contentContainer`and the `topBarView`. This leaves zero space for the network indicator to grow when needed.

### Solutions

Detach the `TopBar` from the `contentContainer` and only leave it connected to the bottom of the network indicator, so that the network indicator can push the `TopBar` down when needed.