### PR TITLE
clean up SelfUser.provider when deinit

### DIFF
--- a/Wire-iOS Tests/ConversationMessageCell/ConversationImageMessageTests.swift
+++ b/Wire-iOS Tests/ConversationMessageCell/ConversationImageMessageTests.swift
@@ -16,13 +16,8 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
-
 import XCTest
 @testable import Wire
-
-
-import XCTest
 
 final class ConversationImageMessageTests: ConversationCellSnapshotTestCase {
 

--- a/Wire-iOS Tests/SettingsTableViewControllerSnapshotTests.swift
+++ b/Wire-iOS Tests/SettingsTableViewControllerSnapshotTests.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2019 Wire Swiss GmbH
+// Copyright (C) 2020 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/Wire-iOS Tests/SettingsTableViewControllerSnapshotTests.swift
+++ b/Wire-iOS Tests/SettingsTableViewControllerSnapshotTests.swift
@@ -48,12 +48,12 @@ final class SettingsTableViewControllerSnapshotTests: XCTestCase {
 	}
 
     func testForSettingGroup() {
-        let group = settingsCellDescriptorFactory.settingsGroup()
+        let group = settingsCellDescriptorFactory.settingsGroup(isTeamMember: coreDataFixture.selfUser.isTeamMember)
         verify(group: group)
     }
 
     func testForAccountGroup() {
-        let group = settingsCellDescriptorFactory.accountGroup()
+        let group = settingsCellDescriptorFactory.accountGroup(isTeamMember: coreDataFixture.selfUser.isTeamMember)
         verify(group: group)
     }
 

--- a/Wire-iOS Tests/SettingsTableViewControllerSnapshotTests.swift
+++ b/Wire-iOS Tests/SettingsTableViewControllerSnapshotTests.swift
@@ -60,7 +60,7 @@ final class SettingsTableViewControllerSnapshotTests: XCTestCase {
     func testForAccountGroupWithDisabledEditing() {
 		MockUserRight.isPermitted = false
 
-		let group = settingsCellDescriptorFactory.accountGroup()
+        let group = settingsCellDescriptorFactory.accountGroup(isTeamMember: coreDataFixture.selfUser.isTeamMember)
         verify(group: group)
     }
 

--- a/Wire-iOS Tests/SwiftSnapshotTesting/CoreDataFixture.swift
+++ b/Wire-iOS Tests/SwiftSnapshotTesting/CoreDataFixture.swift
@@ -166,6 +166,7 @@ final class CoreDataFixture {
     }
 
     deinit {
+        SelfUser.provider = nil
         selfUser = nil
         otherUser = nil
         otherUserConversation = nil

--- a/Wire-iOS/Sources/Analytics/Analytics.swift
+++ b/Wire-iOS/Sources/Analytics/Analytics.swift
@@ -48,9 +48,8 @@ final class Analytics: NSObject {
     @objc
     private func userSessionDidBecomeAvailable(_ note: Notification?) {
         callingTracker = AnalyticsCallingTracker(analytics: self)
-        if SelfUser.provider != nil {
-            selfUser = SelfUser.current
-        }
+        selfUser = SelfUser.provider?.selfUser
+
         decryptionFailedObserver = AnalyticsDecryptionFailedObserver(analytics: self)
     }
 

--- a/Wire-iOS/Sources/Analytics/Analytics.swift
+++ b/Wire-iOS/Sources/Analytics/Analytics.swift
@@ -48,7 +48,9 @@ final class Analytics: NSObject {
     @objc
     private func userSessionDidBecomeAvailable(_ note: Notification?) {
         callingTracker = AnalyticsCallingTracker(analytics: self)
-        selfUser = SelfUser.current
+        if SelfUser.provider != nil {
+            selfUser = SelfUser.current
+        }
         decryptionFailedObserver = AnalyticsDecryptionFailedObserver(analytics: self)
     }
 

--- a/Wire-iOS/Sources/Analytics/TrackingManager.swift
+++ b/Wire-iOS/Sources/Analytics/TrackingManager.swift
@@ -48,7 +48,7 @@ final class TrackingManager: NSObject, TrackingInterface {
 
     var disableAnalyticsSharing: Bool {
         set {
-            Analytics.shared.isOptedOut = newValue
+            Analytics.shared?.isOptedOut = newValue
             AVSFlowManager.getInstance()?.setEnableMetrics(!newValue)
             ExtensionSettings.shared.disableAnalyticsSharing = newValue
         }

--- a/Wire-iOS/Sources/Managers/ColorSchemeController.swift
+++ b/Wire-iOS/Sources/Managers/ColorSchemeController.swift
@@ -27,14 +27,16 @@ extension NSNotification {
     static let colorSchemeControllerDidApplyColorSchemeChange = Notification.Name.colorSchemeControllerDidApplyColorSchemeChange
 }
 
-class ColorSchemeController: NSObject {
+final class ColorSchemeController: NSObject {
 
     var userObserverToken: Any?
 
     override init() {
         super.init()
 
-        if let session = ZMUserSession.shared() {
+        // When SelfUser.provider is nil, e.g. running tests, do not set up UserChangeInfo observer
+        if let session = ZMUserSession.shared(),
+           SelfUser.provider != nil {
             userObserverToken = UserChangeInfo.add(observer:self, for: SelfUser.current, in: session)
         }
 

--- a/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
@@ -75,7 +75,7 @@ final class SelfProfileViewController: UIViewController {
         // Create the settings hierarchy
         let settingsPropertyFactory = SettingsPropertyFactory(userSession: userSession, selfUser: selfUser)
 		let settingsCellDescriptorFactory = SettingsCellDescriptorFactory(settingsPropertyFactory: settingsPropertyFactory, userRightInterfaceType: userRightInterfaceType)
-		let rootGroup = settingsCellDescriptorFactory.rootGroup()
+        let rootGroup = settingsCellDescriptorFactory.rootGroup(isTeamMember: selfUser.isTeamMember)
         settingsController = rootGroup.generateViewController()! as! SettingsTableViewController
         profileHeaderViewController = ProfileHeaderViewController(user: selfUser, viewer: selfUser, options: selfUser.isTeamMember ? [.allowEditingAvailability] : [.hideAvailability])
 

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
@@ -35,7 +35,7 @@ extension ZMUser {
 
 extension SettingsCellDescriptorFactory {
 
-    func accountGroup() -> SettingsCellDescriptorType {
+    func accountGroup(isTeamMember: Bool) -> SettingsCellDescriptorType {
         var sections: [SettingsSectionDescriptorType] = [infoSection()]
 
         if userRightInterfaceType.selfUserIsPermitted(to: .editAccentColor) &&
@@ -50,7 +50,7 @@ extension SettingsCellDescriptorFactory {
         }
 
         #if !DATA_COLLECTION_DISABLED
-            sections.append(personalInformationSection())
+        sections.append(personalInformationSection(isTeamMember: isTeamMember))
         #endif
         
         if SecurityFlags.backup.isEnabled {
@@ -113,9 +113,9 @@ extension SettingsCellDescriptorFactory {
         )
     }
 
-    func personalInformationSection() -> SettingsSectionDescriptorType {
+    func personalInformationSection(isTeamMember: Bool) -> SettingsSectionDescriptorType {
         return SettingsSectionDescriptor(
-            cellDescriptors: [dateUsagePermissionsElement()],
+            cellDescriptors: [dateUsagePermissionsElement(isTeamMember: isTeamMember)],
             header: "self.settings.account_personal_information_group.title".localized
         )
     }
@@ -303,8 +303,8 @@ extension SettingsCellDescriptorFactory {
         )
     }
 
-    func dateUsagePermissionsElement() -> SettingsCellDescriptorType {
-        return dataUsagePermissionsGroup()
+    func dateUsagePermissionsElement(isTeamMember: Bool) -> SettingsCellDescriptorType {
+        return dataUsagePermissionsGroup(isTeamMember: isTeamMember)
     }
 
     func resetPasswordElement() -> SettingsCellDescriptorType {

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+DataUsagePermissions.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+DataUsagePermissions.swift
@@ -19,7 +19,7 @@
 import Foundation
 
 extension SettingsCellDescriptorFactory {
-    func dataUsagePermissionsGroup(isTeamMember: Bool = SelfUser.current.isTeamMember) -> SettingsCellDescriptorType { //TODO: test
+    func dataUsagePermissionsGroup(isTeamMember: Bool) -> SettingsCellDescriptorType {
         
         let sendCrashData = SettingsPropertyToggleCellDescriptor(settingsProperty: settingsPropertyFactory.property(.disableCrashSharing), inverse: true)
         let sendCrashDataSection = SettingsSectionDescriptor(cellDescriptors: [sendCrashData], footer: "self.settings.privacy_crash_menu.description.title".localized)

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
@@ -35,14 +35,14 @@ class SettingsCellDescriptorFactory {
         self.userRightInterfaceType = userRightInterfaceType
     }
     
-    func rootGroup() -> SettingsControllerGeneratorType & SettingsInternalGroupCellDescriptorType {
+    func rootGroup(isTeamMember: Bool) -> SettingsControllerGeneratorType & SettingsInternalGroupCellDescriptorType {
         var rootElements: [SettingsCellDescriptorType] = []
         
         if ZMUser.selfUser().canManageTeam {
             rootElements.append(self.manageTeamCell())
         }
         
-        rootElements.append(self.settingsGroup())
+        rootElements.append(settingsGroup(isTeamMember: isTeamMember))
         #if MULTIPLE_ACCOUNTS_DISABLED
             // We skip "add account" cell
         #else
@@ -97,8 +97,13 @@ class SettingsCellDescriptorFactory {
                                                     accessoryViewMode: .alwaysHide)
     }
     
-    func settingsGroup() -> SettingsControllerGeneratorType & SettingsInternalGroupCellDescriptorType {
-        var topLevelElements = [self.accountGroup(), self.devicesCell(), self.optionsGroup, self.advancedGroup, self.helpSection(), self.aboutSection()]
+    func settingsGroup(isTeamMember: Bool) -> SettingsControllerGeneratorType & SettingsInternalGroupCellDescriptorType {
+        var topLevelElements = [accountGroup(isTeamMember: isTeamMember),
+                                devicesCell(),
+                                optionsGroup,
+                                advancedGroup,
+                                helpSection(),
+                                aboutSection()]
         
         if Bundle.developerModeEnabled {
             topLevelElements.append(self.developerGroup())


### PR DESCRIPTION
## What's new in this PR?

### Issues

When testing with Xcode 12.2, the test crashes when setting `SelfUser.provider` to nil.

### Causes

`EXC_BAD_ACCESS` occurs when running the test.
It seems like `SelfUser.provider` is corrupted after accessing second time.

### Solutions

When `CoreDataFixture` deinit, clean `SelfUser.provider`. (It may had side effect to other tests, which may assume `SelfUser.provider` is set)
Refactor `SettingsCellDescriptorFactory.dataUsagePermissionsGroup()` to prevent getting default parameter argument from  `SelfUser.current`

### Discussion
Should we protect `SelfUser.provider` in a queue, to prevent racing condition?