### PR TITLE
remove NotificationCenter.default.removeObserver in deinit

### DIFF
--- a/Wire-iOS/Sources/Managers/FileBackupExcluder.swift
+++ b/Wire-iOS/Sources/Managers/FileBackupExcluder.swift
@@ -31,10 +31,6 @@ final class FileBackupExcluder: BackupExcluder {
         (.libraryDirectory, ".")
     ]
     
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-    
     init() {
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(FileBackupExcluder.applicationWillEnterForeground(_:)),
@@ -49,11 +45,13 @@ final class FileBackupExcluder: BackupExcluder {
         self.excludeFilesFromBackup()
     }
     
-    @objc func applicationWillEnterForeground(_ sender: AnyObject!) {
+    @objc
+    private func applicationWillEnterForeground(_ sender: AnyObject!) {
         self.excludeFilesFromBackup()
     }
     
-    @objc func applicationWillResignActive(_ sender: AnyObject!) {
+    @objc
+    private func applicationWillResignActive(_ sender: AnyObject!) {
         self.excludeFilesFromBackup()
     }
     

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -117,7 +117,6 @@ final class CallViewController: UIViewController {
 
     deinit {
         AVSMediaManagerClientChangeNotification.remove(self)
-        NotificationCenter.default.removeObserver(self)
         stopOverlayTimer()
     }
 

--- a/Wire-iOS/Sources/UserInterface/Calling/Thumbnail/PinnableThumbnailViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/Thumbnail/PinnableThumbnailViewController.swift
@@ -76,10 +76,6 @@ final class PinnableThumbnailViewController: UIViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(orientationDidChange), name: UIDevice.orientationDidChangeNotification, object: nil)
     }
     
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 

--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/BaseVideoPreviewView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/BaseVideoPreviewView.swift
@@ -76,10 +76,6 @@ class BaseVideoPreviewView: OrientableView, AVSIdentifierProvider {
         fatalError("init(coder:) has not been implemented")
     }
     
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-    
     // MARK: - Handle Stream changes
     func streamDidChange() {
         updateUserDetails()

--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/GridCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/GridCell.swift
@@ -31,10 +31,6 @@ class GridCell: UICollectionViewCell {
         NotificationCenter.default.addObserver(self, selector: #selector(orientationDidChange), name: UIDevice.orientationDidChangeNotification, object: nil)
     }
     
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
     override func layoutSubviews() {
         super.layoutSubviews()
         streamView?.layoutForOrientation()

--- a/Wire-iOS/Sources/UserInterface/Components/NetworkStatus/NetworkStatusViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/NetworkStatus/NetworkStatusViewController.swift
@@ -73,7 +73,6 @@ final class NetworkStatusViewController : UIViewController {
 
     deinit {
         NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(applyPendingState), object: nil)
-        NotificationCenter.default.removeObserver(self)
     }
 
     override func loadView() {

--- a/Wire-iOS/Sources/UserInterface/Components/ThreeDotsLoadingView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/ThreeDotsLoadingView.swift
@@ -32,10 +32,6 @@ final class ThreeDotsLoadingView: UIView {
     let dot2 = UIView()
     let dot3 = UIView()
     
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
     override init(frame: CGRect) {
         super.init(frame: frame)
         

--- a/Wire-iOS/Sources/UserInterface/Components/Views/BreathLoadingBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/BreathLoadingBar.swift
@@ -80,10 +80,6 @@ final class BreathLoadingBar: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
     private func updateView() {
         switch state {
         case .online:

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraCell.swift
@@ -33,10 +33,6 @@ final class CameraCell: UICollectionViewCell {
 
     weak var delegate: CameraCellDelegate?
 
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
     override init(frame: CGRect) {
         let camera: SettingsCamera = Settings.shared[.preferredCamera] ?? .front
         cameraController = CameraController(camera: camera)

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
@@ -67,10 +67,6 @@ class CameraKeyboardViewController: UIViewController, SpinnerCapable {
     let splitLayoutObservable: SplitLayoutObservable
     weak var delegate: CameraKeyboardViewControllerDelegate?
     
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-    
     init(splitLayoutObservable: SplitLayoutObservable,
          imageManagerType: ImageManagerProtocol.Type = PHImageManager.self,
          permissions: PhotoPermissionsController = PhotoPermissionsControllerStrategy()) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
@@ -152,7 +152,6 @@ final class InputBar: UIView {
 
     fileprivate let buttonRowSeparator = UIView()
     fileprivate let constants = InputBarConstants()
-    fileprivate let notificationCenter = NotificationCenter.default
     
     fileprivate var leftAccessoryViewWidthConstraint: NSLayoutConstraint?
     
@@ -202,10 +201,6 @@ final class InputBar: UIView {
         textView.isScrollEnabled = true
     }
 
-    deinit {
-        notificationCenter.removeObserver(self)
-    }
-
     required init(buttons: [UIButton]) {
         buttonsView = InputBarButtonsView(buttons: buttons)
         secondaryButtonsView = InputBarSecondaryButtonsView(editBarView: editingView, markdownBarView: markdownView)
@@ -225,6 +220,8 @@ final class InputBar: UIView {
         setupViews()
         updateRightAccessoryStackViewLayoutMargins()
         createConstraints()
+        
+        let notificationCenter = NotificationCenter.default
         
         notificationCenter.addObserver(markdownView, selector: #selector(markdownView.textViewDidChangeActiveMarkdown), name: Notification.Name.MarkdownTextViewDidChangeActiveMarkdown, object: textView)
         notificationCenter.addObserver(self, selector: #selector(textViewTextDidChange), name: UITextView.textDidChangeNotification, object: textView)

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/TypingIndicatorView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/TypingIndicatorView.swift
@@ -34,10 +34,6 @@ final class AnimatedPenView : UIView {
         }
     }
     
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-    
     override init(frame: CGRect) {
         super.init(frame: frame)
         

--- a/Wire-iOS/Sources/UserInterface/ConversationList/BackgroundViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/BackgroundViewController.swift
@@ -40,10 +40,6 @@ final class BackgroundViewController: UIViewController {
         }
     }
     
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-    
     init(user: UserType, userSession: ZMUserSession?) {
         self.user = user
         self.userSession = userSession
@@ -59,10 +55,11 @@ final class BackgroundViewController: UIViewController {
                                                object: nil)
     }
     
-    public required init?(coder aDecoder: NSCoder) {
+    @available(*, unavailable)
+    required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         

--- a/Wire-iOS/Sources/UserInterface/Helpers/KeyboardBlockObserver.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/KeyboardBlockObserver.swift
@@ -59,7 +59,6 @@ final class KeyboardBlockObserver: NSObject {
     typealias ChangeBlock = (ChangeInfo) -> Void
     
     private let changeBlock: ChangeBlock
-    private let center = NotificationCenter.default
     
     init(block: @escaping ChangeBlock) {
         self.changeBlock = block
@@ -67,11 +66,9 @@ final class KeyboardBlockObserver: NSObject {
         registerKeyboardObservers()
     }
     
-    deinit {
-        center.removeObserver(self)
-    }
-    
     private func registerKeyboardObservers() {
+        let center = NotificationCenter.default
+
         center.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
         center.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
         center.addObserver(self, selector: #selector(keyboardWillChangeFrame), name: UIResponder.keyboardWillChangeFrameNotification, object: nil)

--- a/Wire-iOS/Sources/UserInterface/Settings/SettingsCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/SettingsCell.swift
@@ -352,10 +352,6 @@ final class SettingsValueCell: SettingsTableCell {
         }
     }
     
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-    
     // MARK: - Properties observing
     
     @objc func onPropertyChanged(_ notification: Notification) {

--- a/WireCommonComponents/CircularProgressView.swift
+++ b/WireCommonComponents/CircularProgressView.swift
@@ -22,10 +22,6 @@ import UIKit
 
 public class CircularProgressView: UIView {
     
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-    
     override init(frame: CGRect) {
         super.init(frame: frame)
         self.setup()


### PR DESCRIPTION
## What's new in this PR?

### Issues

On Xcode 12, test crashes when calling NotificationCenter.default.removeObserver in deinit

### Causes

Unknown, but it may be related to the racing condition issue when multiple tests release objects.

### Solutions
Remove the unnecessary NotificationCenter.default.removeObserver in deinit, which is not needed after iOS 9.
