### PR TITLE
[Fix]: On iPad no Spinner and Network Alert is shown when logout

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/KeyboardAvoidingViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/KeyboardAvoidingViewController.swift
@@ -19,7 +19,10 @@
 import Foundation
 import UIKit
 
-class KeyboardAvoidingViewController: UIViewController {
+class KeyboardAvoidingViewController: UIViewController, SpinnerCapable {
+
+    //MARK: SpinnerCapable
+    var dismissSpinner: SpinnerCompletion?
     
     let viewController: UIViewController
     var disabledWhenInsidePopover: Bool = false

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsSignOutCellDescriptor.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsSignOutCellDescriptor.swift
@@ -40,7 +40,15 @@ final class SettingsSignOutCellDescriptor: SettingsExternalScreenCellDescriptor 
         guard let selfUser = ZMUser.selfUser() else { return }
     
         if selfUser.usesCompanyLogin || password != nil {
-            weak var topMostViewController: SpinnerCapableViewController? = UIApplication.shared.topmostViewController(onlyFullScreen: false) as? SpinnerCapableViewController
+            
+            weak var topMostViewController: SpinnerCapableViewController?
+            
+            if let topController = UIApplication.shared.topmostViewController(onlyFullScreen: false) as? KeyboardAvoidingViewController {
+                topMostViewController = topController.viewController as? SpinnerCapableViewController
+            } else {
+                topMostViewController = UIApplication.shared.topmostViewController(onlyFullScreen: false) as? SpinnerCapableViewController
+            }
+            
             topMostViewController?.isLoadingViewVisible = true
             ZMUserSession.shared()?.logout(credentials: ZMEmailCredentials(email: "", password: password ?? ""), { (result) in
                 topMostViewController?.isLoadingViewVisible = false

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsSignOutCellDescriptor.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsSignOutCellDescriptor.swift
@@ -40,15 +40,7 @@ final class SettingsSignOutCellDescriptor: SettingsExternalScreenCellDescriptor 
         guard let selfUser = ZMUser.selfUser() else { return }
     
         if selfUser.usesCompanyLogin || password != nil {
-            
-            weak var topMostViewController: SpinnerCapableViewController?
-            
-            if let topController = UIApplication.shared.topmostViewController(onlyFullScreen: false) as? KeyboardAvoidingViewController {
-                topMostViewController = topController.viewController as? SpinnerCapableViewController
-            } else {
-                topMostViewController = UIApplication.shared.topmostViewController(onlyFullScreen: false) as? SpinnerCapableViewController
-            }
-            
+            weak var topMostViewController: SpinnerCapableViewController? = UIApplication.shared.topmostViewController(onlyFullScreen: false) as? SpinnerCapableViewController
             topMostViewController?.isLoadingViewVisible = true
             ZMUserSession.shared()?.logout(credentials: ZMEmailCredentials(email: "", password: password ?? ""), { (result) in
                 topMostViewController?.isLoadingViewVisible = false


### PR DESCRIPTION
## What's new in this PR?

### Issues

on iPad when there is no connectivity and the user is logging out, after entering password and tapping OK dialog is closed, but nothing happens, no spinner is shown and no alert is shown.

### Causes

The `topMostViewController` (`KeyboardAvoidingViewController`) is not of type `SpinnerCapable`

### Solutions

`KeyboardAvoidingViewController` is now `SpinnerCapable`