### PR TITLE
[Fix] Call Routing Refactoring: Avoid to open the Call topOverlay when it is shown

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/CallController/ActiveCallRouter.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallController/ActiveCallRouter.swift
@@ -49,6 +49,7 @@ class ActiveCallRouter: NSObject {
     
     private var isActiveCallShown = false
     private var isCallQualityShown = false
+    private var isCallTopOverlayShown = false
     private var scheduledPostCallAction: (() -> Void)?
     
     private var zClientViewController: ZClientViewController? {
@@ -111,13 +112,16 @@ extension ActiveCallRouter: ActiveCallRouterProtocol {
     
     // MARK: - CallTopOverlay
     func showCallTopOverlay(for conversation: ZMConversation) {
+        guard !isCallTopOverlayShown else { return }
         let callTopOverlayController = CallTopOverlayController(conversation: conversation)
         callTopOverlayController.delegate = self
         zClientViewController?.setTopOverlay(to: callTopOverlayController)
+        isCallTopOverlayShown = true
     }
     
     func hideCallTopOverlay() {
         zClientViewController?.setTopOverlay(to: nil)
+        isCallTopOverlayShown = false
     }
     
     // MARK: - Alerts


### PR DESCRIPTION
## What's new in this PR?

### Issues

When the app tries to open the Call TopOverlay when it was already opened a crash occurred

### Causes

Something was going wrong in the view hierarchy 

### Solutions

Avoid to show the TopOverlay when it is already shown
