### PR TITLE
[Chore] Clean up cancelPreviousPerformRequests

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
@@ -281,10 +281,6 @@ final class ConversationInputBarViewController: UIViewController,
         fatalError("init(coder:) has not been implemented")
     }
 
-    deinit {
-        NSObject.cancelPreviousPerformRequests(withTarget: self)
-    }
-
     // MARK: - view life cycle
 
     override func viewDidLoad() {
@@ -353,7 +349,6 @@ final class ConversationInputBarViewController: UIViewController,
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         endEditingMessageIfNeeded()
-        NSObject.cancelPreviousPerformRequests(withTarget: self)
     }
 
     override func viewDidLayoutSubviews() {


### PR DESCRIPTION
## What's new in this PR?

Cleanup up no long needed code which may crash when running tests with Xcode 12 at the line `NSObject.cancelPreviousPerformRequests(withTarget: self)`.