### PR TITLE
[Feature]: (ATS) Disabled the app establish HTTP connections

### DIFF
--- a/Wire-iOS/Wire-Info.plist
+++ b/Wire-iOS/Wire-Info.plist
@@ -115,10 +115,18 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-	</dict>
+     <dict>
+       <key>NSAllowsArbitraryLoads</key>
+       <false/>
+       <key>NSExceptionDomains</key>
+       <dict>
+        <key>*</key>
+       <dict>
+           <key>NSExceptionAllowsInsecureHTTPLoads</key>
+           <false/>
+       </dict>
+     </dict>
+    </dict>
 	<key>NSCameraUsageDescription</key>
 	<string>Allow Wire to access your camera so you can place video calls and send photos.</string>
 	<key>NSContactsUsageDescription</key>


### PR DESCRIPTION
## What's new in this PR?

Due security reason we should disabled the app might establish HTTP connections. 

Consequences:
1) SSO via plain HTTP will not work anymore
2) Not displaying anymore link previews for non-https
