### PR TITLE
[Fix] Removed unused ZMConversation in SenderCellComponent

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/UserImageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/UserImageView.swift
@@ -67,7 +67,7 @@ class UserImageView: AvatarImageView, ZMUserObserver {
     }
 
     /// The user to display the avatar of.
-    var user: UserType? {
+    weak var user: UserType? {
         didSet {
             updateUser()
         }
@@ -232,8 +232,8 @@ class UserImageView: AvatarImageView, ZMUserObserver {
 
         let defaultAvatar = Avatar.text(initials.localizedUppercase)
         setAvatar(defaultAvatar, user: user, animated: false)
-
-        if let userSession = userSession as? ZMUserSession {
+        if !ProcessInfo.processInfo.isRunningTests,
+           let userSession = userSession as? ZMUserSession {
             userObserverToken = UserChangeInfo.add(observer: self, for: user, in: userSession)
         }
 

--- a/Wire-iOS/Sources/UserInterface/Components/UserImageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/UserImageView.swift
@@ -67,7 +67,7 @@ class UserImageView: AvatarImageView, ZMUserObserver {
     }
 
     /// The user to display the avatar of.
-    unowned var user: UserType? {
+    var user: UserType? {
         didSet {
             updateUser()
         }

--- a/Wire-iOS/Sources/UserInterface/Components/UserImageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/UserImageView.swift
@@ -67,7 +67,7 @@ class UserImageView: AvatarImageView, ZMUserObserver {
     }
 
     /// The user to display the avatar of.
-    weak var user: UserType? {
+    unowned var user: UserType? {
         didSet {
             updateUser()
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/CellComponents/SenderCellComponent.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/CellComponents/SenderCellComponent.swift
@@ -112,7 +112,7 @@ final class SenderCellComponent: UIView {
             ])
     }
     
-    func configure(with user: UserType, conversation: ZMConversation?) {
+    func configure(with user: UserType) {
         avatar.user = user
         
         configureNameLabel(for: user)

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/CellComponents/SenderCellComponent.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/CellComponents/SenderCellComponent.swift
@@ -18,7 +18,6 @@
 
 import Foundation
 import UIKit
-import WireDataModel
 import WireSyncEngine
 import WireCommonComponents
 
@@ -48,15 +47,14 @@ private enum TextKind {
     }
 }
 
-class SenderCellComponent: UIView {
+final class SenderCellComponent: UIView {
     
     let avatarSpacer = UIView()
     let avatar = UserImageView()
     let authorLabel = UILabel()
     var stackView: UIStackView!
     var avatarSpacerWidthConstraint: NSLayoutConstraint?
-    var observerToken: Any? = nil
-    var conversation: ZMConversation? = nil
+    var observerToken: Any?
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -76,6 +74,7 @@ class SenderCellComponent: UIView {
         authorLabel.accessibilityIdentifier = "author.name"
         authorLabel.numberOfLines = 1
 
+        
         avatar.userSession = ZMUserSession.shared()
         avatar.initialsFont = .avatarInitial
         avatar.size = .badge
@@ -114,17 +113,17 @@ class SenderCellComponent: UIView {
     }
     
     func configure(with user: UserType, conversation: ZMConversation?) {
-        self.conversation = conversation
-        self.avatar.user = user
+        avatar.user = user
         
-        configureNameLabel(for: user, conversation: conversation)
+        configureNameLabel(for: user)
         
-        if let userSession = ZMUserSession.shared() {
+        if !ProcessInfo.processInfo.isRunningTests,
+           let userSession = ZMUserSession.shared() {
             observerToken = UserChangeInfo.add(observer: self, for: user, in: userSession)
         }
     }
     
-    func configureNameLabel(for user: UserType, conversation: ZMConversation?) {
+    private func configureNameLabel(for user: UserType) {
         let fullName =  user.name ?? ""
         
         var attributedString: NSAttributedString
@@ -167,7 +166,7 @@ extension SenderCellComponent: ZMUserObserver {
             return
         }
         
-        configureNameLabel(for: changeInfo.user, conversation: conversation)
+        configureNameLabel(for: changeInfo.user)
     }
     
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSenderMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSenderMessageCell.swift
@@ -51,7 +51,7 @@ class ConversationSenderMessageCell: UIView, ConversationMessageCell {
     }
 
     func configure(with object: Configuration, animated: Bool) {
-        senderView.configure(with: object.user, conversation: object.message.conversation)
+        senderView.configure(with: object.user)
         indicatorImageView.isHidden = object.indicatorIcon == nil
         indicatorImageView.image = object.indicatorIcon
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

When running tests, test crashes when dealloc `UserImageView` and `MockConversation`

### Causes

Unknown, but seems related to zombie object dealloc again.

### Solutions

Remove not used `conversation` property from `SenderCellComponent`
Do not observe User info in `UserImageView`
~~change `user` of `UserImageView` to unowned reference (when deinit, do not call `ZMUser`'s dealloc method since do not own it.)~~ (still not proved this solves the issue.)