### PR TITLE
clean up tests and do not set up observer when tests

### DIFF
--- a/Wire-iOS Tests/CallInfoRootViewControllerTests.swift
+++ b/Wire-iOS Tests/CallInfoRootViewControllerTests.swift
@@ -23,6 +23,7 @@ import SnapshotTesting
 final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelper {
 
     var coreDataFixture: CoreDataFixture!
+    var sut: CallInfoRootViewController!
 
     override func setUp() {
         super.setUp()
@@ -31,6 +32,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
     }
 
     override func tearDown() {
+        sut = nil
         coreDataFixture = nil
 
         super.tearDown()
@@ -43,7 +45,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        let sut = CallInfoRootViewController(configuration: fixture.oneToOneOutgoingAudioRinging)
+        sut = CallInfoRootViewController(configuration: fixture.oneToOneOutgoingAudioRinging)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -54,7 +56,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        let sut = CallInfoRootViewController(configuration: fixture.oneToOneAudioConnecting)
+        sut = CallInfoRootViewController(configuration: fixture.oneToOneAudioConnecting)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -65,7 +67,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        let sut = CallInfoRootViewController(configuration: fixture.oneToOneAudioEstablished)
+        sut = CallInfoRootViewController(configuration: fixture.oneToOneAudioEstablished)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -76,7 +78,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        let sut = CallInfoRootViewController(configuration: fixture.oneToOneAudioEstablishedCBR)
+        sut = CallInfoRootViewController(configuration: fixture.oneToOneAudioEstablishedCBR)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -87,7 +89,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
         
         // when
-        let sut = CallInfoRootViewController(configuration: fixture.oneToOneAudioEstablishedVBR)
+        sut = CallInfoRootViewController(configuration: fixture.oneToOneAudioEstablishedVBR)
         
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -99,7 +101,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        let sut = CallInfoRootViewController(configuration: fixture.oneToOneAudioEstablished)
+        sut = CallInfoRootViewController(configuration: fixture.oneToOneAudioEstablished)
 
         // then
         _ = verifySnapshot(matching: sut, as: .image(on: SnapshotTesting.ViewImageConfig.iPhoneX))
@@ -110,7 +112,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        let sut = CallInfoRootViewController(configuration: fixture.oneToOneAudioEstablishedPoorNetwork)
+        sut = CallInfoRootViewController(configuration: fixture.oneToOneAudioEstablishedPoorNetwork)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -123,7 +125,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        let sut = CallInfoRootViewController(configuration: fixture.oneToOneIncomingVideoRinging)
+        sut = CallInfoRootViewController(configuration: fixture.oneToOneIncomingVideoRinging)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -134,7 +136,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        let sut = CallInfoRootViewController(configuration: fixture.oneToOneVideoConnecting)
+        sut = CallInfoRootViewController(configuration: fixture.oneToOneVideoConnecting)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -145,7 +147,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        let sut = CallInfoRootViewController(configuration: fixture.oneToOneVideoEstablished)
+        sut = CallInfoRootViewController(configuration: fixture.oneToOneVideoEstablished)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -158,7 +160,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        let sut = CallInfoRootViewController(configuration: fixture.groupOutgoingAudioRinging)
+        sut = CallInfoRootViewController(configuration: fixture.groupOutgoingAudioRinging)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -169,7 +171,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        let sut = CallInfoRootViewController(configuration: fixture.groupAudioConnecting)
+        sut = CallInfoRootViewController(configuration: fixture.groupAudioConnecting)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -180,7 +182,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser, groupSize: .small)
 
         // when
-        let sut = CallInfoRootViewController(configuration: fixture.groupAudioEstablished)
+        sut = CallInfoRootViewController(configuration: fixture.groupAudioEstablished)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -191,7 +193,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser, groupSize: .large)
 
         // when
-        let sut = CallInfoRootViewController(configuration: fixture.groupAudioEstablished)
+        sut = CallInfoRootViewController(configuration: fixture.groupAudioEstablished)
 
         // then
         verify(matching: sut)
@@ -204,7 +206,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        let sut = CallInfoRootViewController(configuration: fixture.groupIncomingVideoRinging)
+        sut = CallInfoRootViewController(configuration: fixture.groupIncomingVideoRinging)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -215,7 +217,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        let sut = CallInfoRootViewController(configuration: fixture.groupOutgoingVideoRinging)
+        sut = CallInfoRootViewController(configuration: fixture.groupOutgoingVideoRinging)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -226,7 +228,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        let sut = CallInfoRootViewController(configuration: fixture.groupVideoEstablished)
+        sut = CallInfoRootViewController(configuration: fixture.groupVideoEstablished)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -237,7 +239,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        let sut = CallInfoRootViewController(configuration: fixture.groupVideoEstablishedScreenSharing)
+        sut = CallInfoRootViewController(configuration: fixture.groupVideoEstablishedScreenSharing)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -248,7 +250,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        let sut = CallInfoRootViewController(configuration: fixture.groupVideoEstablishedPoorConnection)
+        sut = CallInfoRootViewController(configuration: fixture.groupVideoEstablishedPoorConnection)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -259,7 +261,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        let sut = CallInfoRootViewController(configuration: fixture.groupVideoEstablishedCBR)
+        sut = CallInfoRootViewController(configuration: fixture.groupVideoEstablishedCBR)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -270,7 +272,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
         
         // when
-        let sut = CallInfoRootViewController(configuration: fixture.groupVideoEstablishedVBR)
+        sut = CallInfoRootViewController(configuration: fixture.groupVideoEstablishedVBR)
         
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -284,7 +286,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        let sut = CallInfoRootViewController(configuration: fixture.groupVideoIncomingUndeterminedPermissions)
+        sut = CallInfoRootViewController(configuration: fixture.groupVideoIncomingUndeterminedPermissions)
 
         //then
         verify(matching: sut)
@@ -295,7 +297,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        let sut = CallInfoRootViewController(configuration: fixture.groupVideoIncomingDeniedPermissions)
+        sut = CallInfoRootViewController(configuration: fixture.groupVideoIncomingDeniedPermissions)
 
         //then
         verify(matching: sut)

--- a/Wire-iOS Tests/ConversationInputBarViewController/ConversationInputBarViewControllerDelegateTests.swift
+++ b/Wire-iOS Tests/ConversationInputBarViewController/ConversationInputBarViewControllerDelegateTests.swift
@@ -22,6 +22,8 @@ import XCTest
 final class ConversationInputBarViewControllerDelegateTests: XCTestCase {
 
     var coreDataFixture: CoreDataFixture!
+    private var mockDelegate: MockDelegate!
+    var sut: ConversationInputBarViewController!
 
     override func setUp() {
         super.setUp()
@@ -30,16 +32,20 @@ final class ConversationInputBarViewControllerDelegateTests: XCTestCase {
 
     override func tearDown() {
         coreDataFixture = nil
+        mockDelegate = nil
+        sut = nil
+        
         super.tearDown()
     }
 
     func testThatDismissingQuoteUpdatesDraftAndNotifiesDelegate() {
         // Given
         let conversation = coreDataFixture.otherUserConversation!
-        let sut = ConversationInputBarViewController(conversation: conversation)
+        sut = ConversationInputBarViewController(conversation: conversation)
 
-        let delegate = MockDelegate()
-        sut.delegate = delegate
+        mockDelegate = MockDelegate()
+        
+        sut.delegate = mockDelegate
 
         let message = try! conversation.appendText(content: "Boo")
         conversation.draftMessage = DraftMessage(text: "Goo", mentions: [], quote: message as? ZMMessage)
@@ -50,8 +56,8 @@ final class ConversationInputBarViewControllerDelegateTests: XCTestCase {
         sut.removeReplyComposingView()
 
         // Then the delegate was called with the updated draft.
-        XCTAssertEqual(delegate.composedDrafts.count, 1)
-        XCTAssertEqual(delegate.composedDrafts[0], DraftMessage(text: "Goo", mentions: [], quote: nil))
+        XCTAssertEqual(mockDelegate.composedDrafts.count, 1)
+        XCTAssertEqual(mockDelegate.composedDrafts[0], DraftMessage(text: "Goo", mentions: [], quote: nil))
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Audio.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Audio.swift
@@ -28,7 +28,8 @@ import WireCommonComponents
 extension ConversationInputBarViewController {
 
     func setupCallStateObserver() {
-        if let userSession = ZMUserSession.shared() {
+        if !ProcessInfo.processInfo.isRunningTests,
+           let userSession = ZMUserSession.shared() {
             callStateObserverToken = WireCallCenterV3.addCallStateObserver(observer: self, userSession:userSession)
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Mentions.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Mentions.swift
@@ -98,6 +98,8 @@ extension ConversationInputBarViewController {
     }
 
     func registerForTextFieldSelectionChange() {
+        guard !ProcessInfo.processInfo.isRunningTests else { return }
+        
         textfieldObserverToken = inputBar.textView.observe(\MarkdownTextView.selectedTextRange, options: [.new]) { [weak self] (textView: MarkdownTextView, change: NSKeyValueObservedChange<UITextRange?>) -> Void in
             let newValue = change.newValue ?? nil
             self?.triggerMentionsIfNeeded(from: textView, with: newValue)

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
@@ -268,8 +268,10 @@ final class ConversationInputBarViewController: UIViewController,
 
         super.init(nibName: nil, bundle: nil)
 
-        conversationObserverToken = ConversationChangeInfo.add(observer:self, for: conversation)
-        typingObserverToken = conversation.addTypingObserver(self)
+        if !ProcessInfo.processInfo.isRunningTests {
+            conversationObserverToken = ConversationChangeInfo.add(observer:self, for: conversation)
+            typingObserverToken = conversation.addTypingObserver(self)
+        }
 
         setupNotificationCenter()
         setupInputLanguageObserver()
@@ -280,6 +282,14 @@ final class ConversationInputBarViewController: UIViewController,
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    deinit {
+        textfieldObserverToken = nil
+        conversationObserverToken = nil
+        typingObserverToken = nil
+        conversationObserverToken = nil
+        userObserverToken = nil
+    }///TODO: test crash
 
     // MARK: - view life cycle
 
@@ -308,13 +318,15 @@ final class ConversationInputBarViewController: UIViewController,
         gifButton.addTarget(self, action: #selector(giphyButtonPressed(_:)), for: .touchUpInside)
         locationButton.addTarget(self, action: #selector(locationButtonPressed(_:)), for: .touchUpInside)
 
-        if conversationObserverToken == nil {
-            conversationObserverToken = ConversationChangeInfo.add(observer:self, for: conversation)
-        }
+        if !ProcessInfo.processInfo.isRunningTests {
+            if conversationObserverToken == nil {
+                conversationObserverToken = ConversationChangeInfo.add(observer:self, for: conversation)
+            }
 
-        if let connectedUser = conversation.connectedUser,
-            let userSession = ZMUserSession.shared() {
-            userObserverToken = UserChangeInfo.add(observer:self, for: connectedUser, in: userSession)
+            if let connectedUser = conversation.connectedUser,
+                let userSession = ZMUserSession.shared() {
+                userObserverToken = UserChangeInfo.add(observer:self, for: connectedUser, in: userSession)
+            }
         }
 
         updateAccessoryViews()

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
@@ -289,7 +289,7 @@ final class ConversationInputBarViewController: UIViewController,
         typingObserverToken = nil
         conversationObserverToken = nil
         userObserverToken = nil
-    }///TODO: test crash
+    }
 
     // MARK: - view life cycle
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
@@ -318,17 +318,6 @@ final class ConversationInputBarViewController: UIViewController,
         gifButton.addTarget(self, action: #selector(giphyButtonPressed(_:)), for: .touchUpInside)
         locationButton.addTarget(self, action: #selector(locationButtonPressed(_:)), for: .touchUpInside)
 
-        if !ProcessInfo.processInfo.isRunningTests {
-            if conversationObserverToken == nil {
-                conversationObserverToken = ConversationChangeInfo.add(observer:self, for: conversation)
-            }
-
-            if let connectedUser = conversation.connectedUser,
-                let userSession = ZMUserSession.shared() {
-                userObserverToken = UserChangeInfo.add(observer:self, for: connectedUser, in: userSession)
-            }
-        }
-
         updateAccessoryViews()
         updateInputBarVisibility()
         updateTypingIndicator()
@@ -342,6 +331,23 @@ final class ConversationInputBarViewController: UIViewController,
         if #available(iOS 11.0, *) {
             let interaction = UIDropInteraction(delegate: self)
             inputBar.textView.addInteraction(interaction)
+        }
+        
+        setupObservers()
+    }
+    
+    private func setupObservers() {
+        guard !ProcessInfo.processInfo.isRunningTests else {
+            return
+        }
+        
+        if conversationObserverToken == nil {
+            conversationObserverToken = ConversationChangeInfo.add(observer:self, for: conversation)
+        }
+        
+        if let connectedUser = conversation.connectedUser,
+           let userSession = ZMUserSession.shared() {
+            userObserverToken = UserChangeInfo.add(observer:self, for: connectedUser, in: userSession)
         }
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
@@ -282,14 +282,6 @@ final class ConversationInputBarViewController: UIViewController,
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    deinit {
-        textfieldObserverToken = nil
-        conversationObserverToken = nil
-        typingObserverToken = nil
-        conversationObserverToken = nil
-        userObserverToken = nil
-    }
 
     // MARK: - view life cycle
 

--- a/Wire-iOS/Sources/UserInterface/ConversationList/BackgroundViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/BackgroundViewController.swift
@@ -62,10 +62,6 @@ final class BackgroundViewController: UIViewController {
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    deinit {
-        userObserverToken = nil
-    }
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Wire-iOS/Sources/UserInterface/ConversationList/BackgroundViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/BackgroundViewController.swift
@@ -30,7 +30,6 @@ final class BackgroundViewController: UIViewController {
     private var blurView = UIVisualEffectView(effect: UIBlurEffect(style: .dark))
     private var userObserverToken: NSObjectProtocol! = .none
     private let user: UserType
-    private let userSession: ZMUserSession?
     
     var darkMode: Bool = false {
         didSet {
@@ -38,21 +37,25 @@ final class BackgroundViewController: UIViewController {
         }
     }
     
-    init(user: UserType, userSession: ZMUserSession?) {
+    init(user: UserType,
+         userSession: ZMUserSession?) {
         self.user = user
-        self.userSession = userSession
         super.init(nibName: .none, bundle: .none)
         
-        if !ProcessInfo.processInfo.isRunningTests {
-            if let userSession = userSession {
-                userObserverToken = UserChangeInfo.add(observer: self, for: user, in: userSession)
-            }
-            
-            NotificationCenter.default.addObserver(self,
-                                                   selector: #selector(colorSchemeChanged),
-                                                   name: .SettingsColorSchemeChanged,
-                                                   object: nil)
+        setupObservers(userSession: userSession)
+    }
+    
+    private func setupObservers(userSession: ZMUserSession?) {
+        guard !ProcessInfo.processInfo.isRunningTests else { return }
+
+        if let userSession = userSession {
+            userObserverToken = UserChangeInfo.add(observer: self, for: user, in: userSession)
         }
+        
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(colorSchemeChanged),
+                                               name: .SettingsColorSchemeChanged,
+                                               object: nil)
     }
     
     @available(*, unavailable)


### PR DESCRIPTION
## What's new in this PR?

- Do not create unnecessary observers when testing
- Clean up observer tokens when deinit
- Clean up tests which do not release resources
- Clean up redundant checkers