### PR TITLE
inject self user in CallInfoViewController

### DIFF
--- a/Wire-iOS Tests/CallInfoRootViewControllerSnapshotTests.swift
+++ b/Wire-iOS Tests/CallInfoRootViewControllerSnapshotTests.swift
@@ -40,7 +40,7 @@ final class CallInfoViewControllerSnapshotTests: XCTestCase, CoreDataFixtureTest
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        let sut = CallInfoViewController(configuration: fixture.oneToOneIncomingAudioRinging)
+        let sut = CallInfoViewController(configuration: fixture.oneToOneIncomingAudioRinging, user: coreDataFixture.selfUser)
 
         // then
         verifyAllIPhoneSizes(matching: sut)

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoViewController.swift
@@ -74,11 +74,13 @@ final class CallInfoViewController: UIViewController, CallActionsViewDelegate, C
         }
     }
 
-    init(configuration: CallInfoViewControllerInput) {
+    init(configuration: CallInfoViewControllerInput,
+         user: UserType = ZMUser.selfUser(),
+         userSession: ZMUserSession? = ZMUserSession.shared()) {
         self.configuration = configuration
         statusViewController = CallStatusViewController(configuration: configuration)
         accessoryViewController = CallAccessoryViewController(configuration: configuration)
-        backgroundViewController = BackgroundViewController(user: ZMUser.selfUser(), userSession: ZMUserSession.shared())
+        backgroundViewController = BackgroundViewController(user: user, userSession: userSession)
         super.init(nibName: nil, bundle: nil)
         accessoryViewController.delegate = self
         actionsView.delegate = self

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -46,7 +46,7 @@ final class ZClientViewController: UIViewController {
     private var contentTopCompactConstraint: NSLayoutConstraint!
     // init value = false which set to true, set to false after data usage permission dialog is displayed
     var dataUsagePermissionDialogDisplayed = false
-    let backgroundViewController: BackgroundViewController = BackgroundViewController(user: ZMUser.selfUser(), userSession: ZMUserSession.shared())
+    let backgroundViewController: BackgroundViewController
 
     private let colorSchemeController: ColorSchemeController = ColorSchemeController()
     private var incomingApnsObserver: Any?
@@ -59,7 +59,9 @@ final class ZClientViewController: UIViewController {
     ///   - account: an Account object
     ///   - selfUser: a SelfUserType object
     required init(account: Account,
-                  selfUser: SelfUserType) {
+                  selfUser: SelfUserType,
+                  userSession: ZMUserSession? = ZMUserSession.shared()) {
+        backgroundViewController = BackgroundViewController(user: selfUser, userSession: userSession)
         conversationListViewController = ConversationListViewController(account: account, selfUser: selfUser)
         
         super.init(nibName:nil, bundle:nil)


### PR DESCRIPTION
## What's new in this PR?

### Issues

In some tests, `BackgroundViewController` uses `ZMUser.selfUser()` which is not as same as the mock user of the parent view controller

### Causes

In `CallInfoRootViewControllerSnapshotTests`, the self user injected into `CallInfoViewController` is different from the `user` in `BackgroundViewController`

### Solutions

Inject self user instead of using `ZMUser.selfUser()`