### PR TITLE
[Refactor] provide default implementation of ApplicationStateObserving protocol

### DIFF
--- a/Wire-iOS/Sources/Analytics/AnalyticsCountlyProvider.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsCountlyProvider.swift
@@ -268,11 +268,6 @@ extension AnalyticsCountlyProvider: ApplicationStateObserving {
         guard isRecording else { return }
         endSession()
     }
-
-    func applicationWillEnterForeground() {
-        // No op
-    }
-
 }
 
 // MARK: - Helpers

--- a/Wire-iOS/Sources/AppStateCalculator.swift
+++ b/Wire-iOS/Sources/AppStateCalculator.swift
@@ -105,10 +105,6 @@ extension AppStateCalculator: ApplicationStateObserving {
         hasEnteredForeground = true
         transition(to: pendingAppState ?? appState)
     }
-    
-    func applicationDidEnterBackground() { }
-    
-    func applicationWillEnterForeground() { }
 }
 
 // MARK: - SessionManagerDelegate

--- a/Wire-iOS/Sources/NotificationObserver.swift
+++ b/Wire-iOS/Sources/NotificationObserver.swift
@@ -31,6 +31,10 @@ protocol ApplicationStateObserving: ObserverTokenStore {
 }
 
 extension ApplicationStateObserving {
+    func applicationDidBecomeActive() {}
+    func applicationDidEnterBackground() {}
+    func applicationWillEnterForeground() {}
+    
     func setupApplicationNotifications() {
         addObserverToken(NotificationCenter.default.addObserver(forName: UIApplication.didEnterBackgroundNotification,
                                                                 object: nil,


### PR DESCRIPTION
## What's new in this PR?

- Provide default implementation of ApplicationStateObserving protocol in order to reduce boilerplate in classes implementing it