### PR TITLE
[Chore] Accessibility: replace hashed client id by participant name

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/BaseVideoPreviewView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/BaseVideoPreviewView.swift
@@ -141,9 +141,9 @@ class BaseVideoPreviewView: OrientableView, AVSIdentifierProvider {
     // MARK: - Accessibility for automation
     override var accessibilityIdentifier: String? {
         get {
-            let clientId = stream.streamId.clientId.readableHash
+            let name = stream.participantName ?? ""
             let state = isMaximized ? "maximized" : "minimized"
-            return "VideoView.\(clientId).\(state)"
+            return "VideoView.\(name).\(state)"
         }
         set {}
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

QA Automation can't match the video tiles with their test users

### Causes

QA doesn't have access to users client ids

### Solutions

Use user's name in accessibility identifier instead of hashed client id
