### PR TITLE
[Chore] update thumbnail view accessibility id

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/Thumbnail/PinnableThumbnailViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/Thumbnail/PinnableThumbnailViewController.swift
@@ -20,12 +20,7 @@ import UIKit
 
 final class PinnableThumbnailViewController: UIViewController {
 
-    private let thumbnailView: RoundedView = {
-        let view = RoundedView()
-        view.accessibilityIdentifier = "ThumbnailView"
-        return view
-    }()
-
+    private let thumbnailView = RoundedView()
     private let thumbnailContainerView = UIView()
     private(set) var contentView: OrientableView?
 
@@ -51,11 +46,13 @@ final class PinnableThumbnailViewController: UIViewController {
     func removeCurrentThumbnailContentView() {
         contentView?.removeFromSuperview()
         contentView = nil
+        thumbnailView.accessibilityIdentifier = nil
     }
 
     func setThumbnailContentView(_ contentView: OrientableView, contentSize: CGSize) {
         removeCurrentThumbnailContentView()
         thumbnailView.addSubview(contentView)
+        thumbnailView.accessibilityIdentifier = "ThumbnailView"
         self.contentView = contentView
 
         self.thumbnailContentSize = contentSize


### PR DESCRIPTION
## What's new in this PR?

In order to simplify the implementation of QA automation, we're adding the thumbnail view accessibility identifier only when it is populated with a content view.