### PR TITLE
[Fix] App lock setting is not disabled when app lock is forced

### DIFF
--- a/Wire-iOS/Sources/AppRootRouter.swift
+++ b/Wire-iOS/Sources/AppRootRouter.swift
@@ -475,7 +475,9 @@ extension AppRootRouter: AudioPermissionsObserving {
 extension AppRootRouter {
     //TODO: katerina we should do it in our slow sync
     private func updateTeamFeature() {
-        ZMUser.selfUser()?.team?.enqueueBackendRefresh(for: .appLock)
+        ZMUserSession.shared()?.perform {
+            ZMUser.selfUser()?.team?.enqueueBackendRefresh(for: .appLock)
+        }
     }
 }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

The app lock setting is not always disabled when the app lock is forced.

### Causes

A request to fetch the app lock config is enqueued when the app comes to the foreground. This request won't be triggered until the next managed object context save, so it was happening that the settings property cell was reading an outdated value.

### Solutions

Enqueue and **trigger** a fetch of the app lock config when the app comes to the foreground.

