### PR TITLE
fix: testThatItIdentifiesJPEG fails on Xcode 12

### DIFF
--- a/Wire-iOS Tests/Data_ImageTypeTests.swift
+++ b/Wire-iOS Tests/Data_ImageTypeTests.swift
@@ -19,18 +19,19 @@
 import XCTest
 @testable import Wire
 
-///TODO: test failed with XCode11, may be due to image is not copied?
-///TODO: move to utilities
-
 final class Data_ImageTypeTests: XCTestCase {
 
-    func testThatItIdentifiesJPEG() {
+    var sut: Data!
+    
+    override func tearDown() {
+        sut = nil
 
+        super.tearDown()
+    }
+    
+    func testThatItIdentifiesJPEG() {
         // given
-        guard let sut = #imageLiteral(resourceName: "wire-logo-shield").jpegData(compressionQuality: 1.0) else {
-            XCTFail()
-            return
-        }
+        sut = dataInTestBundleNamed("unsplash_pano.jpg")
 
         // then
         XCTAssert(sut.isJPEG)
@@ -39,10 +40,7 @@ final class Data_ImageTypeTests: XCTestCase {
     func testThatItDoesNotIdentifyJPEG() {
 
         // given
-        guard let sut = #imageLiteral(resourceName: "wire-logo-shield").pngData() else {
-            XCTFail()
-            return
-        }
+        sut = dataInTestBundleNamed("identicon.png")
 
         // then
         XCTAssertFalse(sut.isJPEG)

--- a/Wire-iOS/Sources/Helpers/NSData+ImageType.swift
+++ b/Wire-iOS/Sources/Helpers/NSData+ImageType.swift
@@ -16,12 +16,11 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-///TODO: move to utilities
 import Foundation
 
 extension Data {
     var isJPEG: Bool {
-        let array = self.withUnsafeBytes { (unsafeRawBufferPointer: UnsafeRawBufferPointer) in
+        let array = withUnsafeBytes { (unsafeRawBufferPointer: UnsafeRawBufferPointer) in
             [UInt8](UnsafeBufferPointer(start: unsafeRawBufferPointer.bindMemory(to: UInt8.self).baseAddress!, count: 3))
         }
         let JPEGHeader: [UInt8] = [0xFF, 0xD8, 0xFF]


### PR DESCRIPTION
## What's new in this PR?

### Issues

On Xcode 12, testThatItIdentifiesJPEG fails

### Causes

image is not loaded with `#imageLiteral(resourceName: "wire-logo-shield")`

### Solutions

Load the jpg data with `dataInTestBundleNamed`