### PR TITLE
ConnectRequestsViewController: do not setup observers when testing

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConnectRequests/ConnectRequestsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConnectRequests/ConnectRequestsViewController.swift
@@ -38,7 +38,8 @@ final class ConnectRequestsViewController: UIViewController, UITableViewDataSour
         tableView.delegate = self
         tableView.dataSource = self
         
-        if let userSession = ZMUserSession.shared() {
+        if !ProcessInfo.processInfo.isRunningTests,
+           let userSession = ZMUserSession.shared() {
             let pendingConnectionsList = ZMConversationList.pendingConnectionConversations(inUserSession: userSession)
             
             pendingConnectionsListObserverToken = ConversationListChangeInfo.add(observer: self,


### PR DESCRIPTION
## What's new in this PR?

Do not set up observers when testing which may cause a crash when destructing `ConnectRequestsViewController`