### PR TITLE
change Analytics.share to optional

### DIFF
--- a/Wire-iOS/Sources/Analytics/Analytics.swift
+++ b/Wire-iOS/Sources/Analytics/Analytics.swift
@@ -30,7 +30,7 @@ final class Analytics: NSObject {
     private var decryptionFailedObserver: AnalyticsDecryptionFailedObserver?
     private var userObserverToken: Any?
 
-    static var shared: Analytics!
+    static var shared: Analytics?
 
     required init(optedOut: Bool) {
         zmLog.info("Analytics initWithOptedOut: \(optedOut)")

--- a/Wire-iOS/Sources/Analytics/Events/Analytics+Guests.swift
+++ b/Wire-iOS/Sources/Analytics/Events/Analytics+Guests.swift
@@ -48,6 +48,6 @@ extension Analytics {
 
 extension Event {
     func track() {
-        Analytics.shared.tag(self)
+        Analytics.shared?.tag(self)
     }
 }

--- a/Wire-iOS/Sources/AppRootRouter.swift
+++ b/Wire-iOS/Sources/AppRootRouter.swift
@@ -100,7 +100,7 @@ public class AppRootRouter: NSObject {
     
     public func start(launchOptions: LaunchOptions) {
         transition(to: .headless, completion: {
-            Analytics.shared.tagEvent("app.open")
+            Analytics.shared?.tagEvent("app.open")
         })
         createAndStartSessionManager(launchOptions: launchOptions)
     }
@@ -337,11 +337,11 @@ extension AppRootRouter {
     }
     
     private func setupAnalyticsSharing() {
-        Analytics.shared.selfUser = SelfUser.current
+        Analytics.shared?.selfUser = SelfUser.current
         
         guard
             appStateCalculator.wasUnauthenticated,
-            Analytics.shared.selfUser?.isTeamMember ?? false
+            Analytics.shared?.selfUser?.isTeamMember ?? false
         else {
             return
         }

--- a/Wire-iOS/Sources/Authentication/Interface/Team Invites/TeamMemberInviteViewController.swift
+++ b/Wire-iOS/Sources/Authentication/Interface/Team Invites/TeamMemberInviteViewController.swift
@@ -133,7 +133,7 @@ final class TeamMemberInviteViewController: AuthenticationStepViewController {
         }
         
         guard let userSession = ZMUserSession.shared() else { return }
-        Analytics.shared.tag(TeamInviteEvent.sentInvite(.teamCreation))
+        Analytics.shared?.tag(TeamInviteEvent.sentInvite(.teamCreation))
         footerTextFieldView.isLoading = true
         
         ZMUser.selfUser().team?.invite(email: email, in: userSession) { [weak self] result in
@@ -171,7 +171,7 @@ final class TeamMemberInviteViewController: AuthenticationStepViewController {
     @objc private func didTapContinueButton(_ sender: Button) {
         let inviteResult = invitationsCount == 0 ? Analytics.InviteResult.none : Analytics.InviteResult.invited(invitesCount: invitationsCount)
 
-        Analytics.shared.tagTeamFinishedInviteStep(with: inviteResult)
+        Analytics.shared?.tagTeamFinishedInviteStep(with: inviteResult)
         authenticationCoordinator?.teamInviteViewControllerDidFinish(self)
     }
 

--- a/Wire-iOS/Sources/Components/Settings/SettingsProperty.swift
+++ b/Wire-iOS/Sources/Components/Settings/SettingsProperty.swift
@@ -143,7 +143,7 @@ class SettingsUserDefaultsProperty : SettingsProperty {
     }
 
     func trackNewValue() {
-        Analytics.shared.tagSettingsChanged(for: self.propertyName, to: self.value())
+        Analytics.shared?.tagSettingsChanged(for: self.propertyName, to: self.value())
     }
     
     let propertyName : SettingsPropertyName
@@ -177,7 +177,7 @@ final class SettingsBlockProperty : SettingsProperty {
     }
     
     func trackNewValue() {
-        Analytics.shared.tagSettingsChanged(for: self.propertyName, to: self.value())
+        Analytics.shared?.tagSettingsChanged(for: self.propertyName, to: self.value())
     }
     
     fileprivate let getAction : GetAction

--- a/Wire-iOS/Sources/Helpers/syncengine/Conversation+Participants.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/Conversation+Participants.swift
@@ -64,7 +64,7 @@ extension ZMConversation {
             switch result {
             case .success:
                 if let serviceUser = user as? ServiceUser, user.isServiceUser {
-                    Analytics.shared.tagDidRemoveService(serviceUser)
+                    Analytics.shared?.tagDidRemoveService(serviceUser)
                 }
             case .failure(let error):
                 self.showAlertForRemoval(for: error)

--- a/Wire-iOS/Sources/Helpers/syncengine/ZMConversation+Calling.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMConversation+Calling.swift
@@ -63,7 +63,7 @@ extension ZMConversation {
                 let joined = self.voiceChannel?.join(video: video, userSession: userSession) ?? false
                 
                 if joined {
-                    Analytics.shared.tagMediaActionCompleted(video ? .videoCall : .audioCall, inConversation: self)
+                    Analytics.shared?.tagMediaActionCompleted(video ? .videoCall : .audioCall, inConversation: self)
                 }
             } else {
                 self.voiceChannel?.leave(userSession: userSession, completion: nil)

--- a/Wire-iOS/Sources/UserInterface/Calling/CallQualityController/CallQualityController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallQualityController/CallQualityController.swift
@@ -104,12 +104,12 @@ class CallQualityController: NSObject {
         let callDuration = callEndDate.timeIntervalSince(callStartDate)
 
         guard callDuration >= miminumSignificantCallDuration else {
-            Analytics.shared.tagCallQualityReview(.notDisplayed(reason: .callTooShort, duration: Int(callDuration)))
+            Analytics.shared?.tagCallQualityReview(.notDisplayed(reason: .callTooShort, duration: Int(callDuration)))
             return
         }
 
         guard self.canRequestSurvey(at: callEndDate) else {
-            Analytics.shared.tagCallQualityReview(.notDisplayed(reason: .muted, duration: Int(callDuration)))
+            Analytics.shared?.tagCallQualityReview(.notDisplayed(reason: .muted, duration: Int(callDuration)))
             return
         }
 
@@ -161,12 +161,12 @@ extension CallQualityController : CallQualityViewControllerDelegate {
         })
         
         CallQualityController.updateLastSurveyDate(Date())
-        Analytics.shared.tagCallQualityReview(.answered(score: score, duration: controller.callDuration))
+        Analytics.shared?.tagCallQualityReview(.answered(score: score, duration: controller.callDuration))
     }
 
     func callQualityControllerDidFinishWithoutScore(_ controller: CallQualityViewController) {
         CallQualityController.updateLastSurveyDate(Date())
-        Analytics.shared.tagCallQualityReview(.dismissed(duration: controller.callDuration))
+        Analytics.shared?.tagCallQualityReview(.dismissed(duration: controller.callDuration))
         router?.dismissCallQualitySurvey(completion: nil)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+CanvasViewControllerDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+CanvasViewControllerDelegate.swift
@@ -31,7 +31,7 @@ extension ConversationContentViewController: CanvasViewControllerDelegate {
                         Logging.messageProcessing.warn("Failed to append image message from canvas. Reason: \(error.localizedDescription)")
                     }
                 }, completionHandler: {
-                    Analytics.shared.tagMediaActionCompleted(.photo, inConversation: self.conversation)
+                    Analytics.shared?.tagMediaActionCompleted(.photo, inConversation: self.conversation)
                 })
             }
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageAction.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageAction.swift
@@ -124,7 +124,7 @@ extension ConversationContentViewController {
                     willSelectRow(at: indexPath, tableView: tableView)
                 }
 
-                Analytics.shared.tagLiked(in: conversation)
+                Analytics.shared?.tagLiked(in: conversation)
             } else {
                 // Select if necessary to prevent message from collapsing
                 if !(selectedMessage == message) && !Message.hasReactions(message) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarSendController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarSendController.swift
@@ -41,7 +41,7 @@ final class ConversationInputBarSendController: NSObject {
             }
         }, completionHandler: {
                 completionHandler?()
-            Analytics.shared.tagMediaActionCompleted(.photo, inConversation: self.conversation)
+            Analytics.shared?.tagMediaActionCompleted(.photo, inConversation: self.conversation)
         })
     }
     
@@ -58,7 +58,7 @@ final class ConversationInputBarSendController: NSObject {
                 Logging.messageProcessing.warn("Failed to append text message. Reason: \(error.localizedDescription)")
             }
         }, completionHandler: {
-            Analytics.shared.tagMediaActionCompleted(.text, inConversation: self.conversation)
+            Analytics.shared?.tagMediaActionCompleted(.text, inConversation: self.conversation)
             
         })
     }
@@ -75,8 +75,8 @@ final class ConversationInputBarSendController: NSObject {
                 Logging.messageProcessing.warn("Failed to append text message with image data. Reason: \(error.localizedDescription)")
             }
         }, completionHandler: {
-            Analytics.shared.tagMediaActionCompleted(.photo, inConversation: self.conversation)
-            Analytics.shared.tagMediaActionCompleted(.text, inConversation: self.conversation)
+            Analytics.shared?.tagMediaActionCompleted(.photo, inConversation: self.conversation)
+            Analytics.shared?.tagMediaActionCompleted(.text, inConversation: self.conversation)
         })
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Files.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Files.swift
@@ -156,7 +156,7 @@ extension ConversationInputBarViewController {
                         }
                     }
 
-                    Analytics.shared.tagMediaActionCompleted(conversationMediaAction, inConversation: weakSelf.conversation)
+                    Analytics.shared?.tagMediaActionCompleted(conversationMediaAction, inConversation: weakSelf.conversation)
                 } catch {
                     Logging.messageProcessing.warn("Failed to append file. Reason: \(error.localizedDescription)")
                 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Location.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Location.swift
@@ -46,7 +46,7 @@ extension ConversationInputBarViewController: LocationSelectionViewControllerDel
         ZMUserSession.shared()?.enqueue {
             do {
                 try self.conversation.appendLocation(with: locationData)
-                Analytics.shared.tagMediaActionCompleted(.location, inConversation: self.conversation)
+                Analytics.shared?.tagMediaActionCompleted(.location, inConversation: self.conversation)
             } catch {
                 Logging.messageProcessing.warn("Failed to append location message. Reason: \(error.localizedDescription)")
             }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
@@ -531,7 +531,7 @@ final class ConversationInputBarViewController: UIViewController,
         ZMUserSession.shared()?.enqueue({
             do {
                 try self.conversation.appendKnock()
-                Analytics.shared.tagMediaActionCompleted(.ping, inConversation: self.conversation)
+                Analytics.shared?.tagMediaActionCompleted(.ping, inConversation: self.conversation)
 
                 AVSMediaManager.sharedInstance().playKnockSound()
                 self.notificationFeedbackGenerator.notificationOccurred(.success)

--- a/Wire-iOS/Sources/UserInterface/Services/ServiceDetailViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Services/ServiceDetailViewController.swift
@@ -195,7 +195,7 @@ final class ServiceDetailViewController: UIViewController {
                     
                     switch result {
                     case .success:
-                        Analytics.shared.tag(ServiceAddedEvent(service: serviceUser, conversation: conversation, context: .startUI))
+                        Analytics.shared?.tag(ServiceAddedEvent(service: serviceUser, conversation: conversation, context: .startUI))
                         completion?(.success(conversation: conversation))
                     case .failure(let error):
                         completion?(.failure(error: (error as? AddBotError) ?? AddBotError.general))
@@ -209,7 +209,7 @@ final class ServiceDetailViewController: UIViewController {
                 } else {
                     serviceUser.createConversation(in: userSession, completionHandler: { (result) in
                         if case let .success(conversation) = result {
-                            Analytics.shared.tag(ServiceAddedEvent(service: serviceUser, conversation: conversation, context: .startUI))
+                            Analytics.shared?.tag(ServiceAddedEvent(service: serviceUser, conversation: conversation, context: .startUI))
                         }
                         
                         switch result {

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
@@ -214,7 +214,7 @@ class SettingsCellDescriptorFactory {
         let showStatistics = SettingsExternalScreenCellDescriptor(title: "Show database statistics", isDestructive: false, presentationStyle: .navigation, presentationAction: {  DatabaseStatisticsController() })
         developerCellDescriptors.append(showStatistics)
 
-        if !Analytics.shared.isOptedOut &&
+        if false == Analytics.shared?.isOptedOut &&
             !TrackingManager.shared.disableAnalyticsSharing {
 
             let resetSurveyMuteButton = SettingsButtonCellDescriptor(title: "Reset call quality survey", isDestructive: false, selectAction: DebugActions.resetCallQualitySurveyMuteFilter)


### PR DESCRIPTION
## What's new in this PR?

### Issues

When testing `SettingsTableViewControllerSnapshotTests.testForSettingGroup` solely, app crashes.

### Causes

`Analytics.share` is nil in this case.

### Solutions

Since we would not set up Analytics for testing, change the `share` to optional.