### PR TITLE
[Refactor] Use app lock controller to manage passcode

### DIFF
--- a/Wire-iOS Tests/AppLock/AppLockInteractorTests.swift
+++ b/Wire-iOS Tests/AppLock/AppLockInteractorTests.swift
@@ -89,6 +89,18 @@ final class AppLockMock: AppLockType {
     func persistBiometrics() {
         AppLockMock.didPersistBiometrics = true
     }
+
+    func storePasscode(_ passcode: String) throws {
+
+    }
+
+    func fetchPasscode() -> Data? {
+        return nil
+    }
+
+    func deletePasscode() throws {
+
+    }
 }
 
 final class AppLockInteractorTests: ZMSnapshotTestCase {

--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockInteractor.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockInteractor.swift
@@ -136,7 +136,7 @@ extension AppLockInteractor: AppLockInteractorInput {
         
         let result: VerifyPasswordResult
         
-        if let data: Data = Keychain.fetchPasscode() {
+        if let data = appLock?.fetchPasscode() {
             result = customPasscode == String(data: data, encoding: .utf8) ? .validated : .denied
         } else {
             result = .unknown

--- a/Wire-iOS/Sources/UserInterface/Overlay/CustomAppLock/Setup/PasscodeSetupInteractor.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/CustomAppLock/Setup/PasscodeSetupInteractor.swift
@@ -19,6 +19,7 @@ import Foundation
 import WireUtilities
 import WireCommonComponents
 import WireTransport
+import WireSyncEngine
 
 protocol PasscodeSetupInteractorInput: class {
     func validate(error: TextFieldValidator.ValidationError?)
@@ -40,10 +41,11 @@ final class PasscodeSetupInteractor {
 
 // MARK: - Interface
 extension PasscodeSetupInteractor: PasscodeSetupInteractorInput {
-    func storePasscode(passcode: String) throws {
-        guard let data = passcode.data(using: .utf8) else { return }
 
-        try Keychain.updateItem(PasscodeKeychainItem.passcode, value: data)
+    func storePasscode(passcode: String) throws {
+        // TODO: [John] Inject the app lock controller.
+        guard let appLock = ZMUserSession.shared()?.appLockController else { return }
+        try appLock.storePasscode(passcode)
     }
 
     private func passcodeError(from missingCharacterClasses: Set<WireUtilities.PasswordCharacterClass>) -> Set<PasscodeError> {

--- a/Wire-iOS/Sources/UserInterface/Overlay/CustomAppLock/WipeDatabase/WipeDatabaseInteractor.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/CustomAppLock/WipeDatabase/WipeDatabaseInteractor.swift
@@ -38,6 +38,8 @@ extension WipeDatabaseInteractor: WipeDatabaseInteractorInput {
     }
 
     func deletePasscode() {
-        Keychain.deletePasscode()
+        // TODO: [John] Inject the app lock controller.
+        guard let appLock = ZMUserSession.shared()?.appLockController else { return }
+        try? appLock.deletePasscode()
     }
 }

--- a/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
@@ -219,11 +219,10 @@ extension SelfProfileViewController: SettingsPropertyFactoryDelegate {
             callback(newValue)
             return
         }
-        
+
         guard newValue else {
-            Keychain.deletePasscode()
+            try? settingsPropertyFactory.userSession?.appLockController.deletePasscode()
             callback(newValue)
-            
             return
         }
         


### PR DESCRIPTION
## What's new in this PR?

In https://github.com/wireapp/wire-ios-data-model/pull/1096 direct access to the app lock passcode in the keychain has been prohibited. Instead, the app lock controller is responsible for storing, deleting, and updating the passcode. This PR integrates this API change.

### Dependencies

Needs releases with:

- [x] https://github.com/wireapp/wire-ios-data-model/pull/1096

### Notes

I've opted for simplicity by accessing the app lock controller though the shared user session. Ideally we should be injecting and instance of the app lock controller, however it's not a trivial task and I would address it in a separate PR.

