### PR TITLE
Fix: Do not use ZMUser.selfUser() when running CallInfoRootViewControllerTests

### DIFF
--- a/Wire-iOS Tests/CallInfoRootViewControllerSnapshotTests.swift
+++ b/Wire-iOS Tests/CallInfoRootViewControllerSnapshotTests.swift
@@ -40,7 +40,7 @@ final class CallInfoViewControllerSnapshotTests: XCTestCase, CoreDataFixtureTest
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        let sut = CallInfoViewController(configuration: fixture.oneToOneIncomingAudioRinging, user: coreDataFixture.selfUser)
+        let sut = CallInfoViewController(configuration: fixture.oneToOneIncomingAudioRinging, selfUser: coreDataFixture.selfUser)
 
         // then
         verifyAllIPhoneSizes(matching: sut)

--- a/Wire-iOS Tests/CallInfoRootViewControllerTests.swift
+++ b/Wire-iOS Tests/CallInfoRootViewControllerTests.swift
@@ -169,7 +169,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         verifyAllIPhoneSizes(matching: sut)
     }
 
-    func testGroupAudioConnecting() {///TODO: cpv?
+    func testGroupAudioConnecting() {
         // given
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
@@ -191,7 +191,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         verifyAllIPhoneSizes(matching: sut)
     }
 
-    func testGroupAudioEstablished_LargeGroup() {///TODO: cell?
+    func testGroupAudioEstablished_LargeGroup() {
         // given
         let fixture = CallInfoTestFixture(otherUser: otherUser, groupSize: .large)
 

--- a/Wire-iOS Tests/CallInfoRootViewControllerTests.swift
+++ b/Wire-iOS Tests/CallInfoRootViewControllerTests.swift
@@ -48,7 +48,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.oneToOneOutgoingAudioRinging, user: mockSelfUser)
+        sut = CallInfoRootViewController(configuration: fixture.oneToOneOutgoingAudioRinging, selfUser: mockSelfUser)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -59,7 +59,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.oneToOneAudioConnecting, user: mockSelfUser)
+        sut = CallInfoRootViewController(configuration: fixture.oneToOneAudioConnecting, selfUser: mockSelfUser)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -70,7 +70,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.oneToOneAudioEstablished, user: mockSelfUser)
+        sut = CallInfoRootViewController(configuration: fixture.oneToOneAudioEstablished, selfUser: mockSelfUser)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -81,7 +81,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.oneToOneAudioEstablishedCBR, user: mockSelfUser)
+        sut = CallInfoRootViewController(configuration: fixture.oneToOneAudioEstablishedCBR, selfUser: mockSelfUser)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -92,7 +92,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
         
         // when
-        sut = CallInfoRootViewController(configuration: fixture.oneToOneAudioEstablishedVBR, user: mockSelfUser)
+        sut = CallInfoRootViewController(configuration: fixture.oneToOneAudioEstablishedVBR, selfUser: mockSelfUser)
         
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -104,7 +104,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.oneToOneAudioEstablished, user: mockSelfUser)
+        sut = CallInfoRootViewController(configuration: fixture.oneToOneAudioEstablished, selfUser: mockSelfUser)
 
         // then
         _ = verifySnapshot(matching: sut, as: .image(on: SnapshotTesting.ViewImageConfig.iPhoneX))
@@ -115,7 +115,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.oneToOneAudioEstablishedPoorNetwork, user: mockSelfUser)
+        sut = CallInfoRootViewController(configuration: fixture.oneToOneAudioEstablishedPoorNetwork, selfUser: mockSelfUser)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -128,7 +128,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.oneToOneIncomingVideoRinging, user: mockSelfUser)
+        sut = CallInfoRootViewController(configuration: fixture.oneToOneIncomingVideoRinging, selfUser: mockSelfUser)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -139,7 +139,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.oneToOneVideoConnecting, user: mockSelfUser)
+        sut = CallInfoRootViewController(configuration: fixture.oneToOneVideoConnecting, selfUser: mockSelfUser)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -150,7 +150,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.oneToOneVideoEstablished, user: mockSelfUser)
+        sut = CallInfoRootViewController(configuration: fixture.oneToOneVideoEstablished, selfUser: mockSelfUser)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -163,18 +163,18 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.groupOutgoingAudioRinging, user: mockSelfUser)
+        sut = CallInfoRootViewController(configuration: fixture.groupOutgoingAudioRinging, selfUser: mockSelfUser)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
     }
 
-    func testGroupAudioConnecting() {
+    func testGroupAudioConnecting() {///TODO: cpv?
         // given
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.groupAudioConnecting, user: mockSelfUser)
+        sut = CallInfoRootViewController(configuration: fixture.groupAudioConnecting, selfUser: mockSelfUser)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -185,18 +185,18 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser, groupSize: .small)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.groupAudioEstablished, user: mockSelfUser)
+        sut = CallInfoRootViewController(configuration: fixture.groupAudioEstablished, selfUser: mockSelfUser)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
     }
 
-    func testGroupAudioEstablished_LargeGroup() {
+    func testGroupAudioEstablished_LargeGroup() {///TODO: cell?
         // given
         let fixture = CallInfoTestFixture(otherUser: otherUser, groupSize: .large)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.groupAudioEstablished, user: mockSelfUser)
+        sut = CallInfoRootViewController(configuration: fixture.groupAudioEstablished, selfUser: mockSelfUser)
 
         // then
         verify(matching: sut)
@@ -209,7 +209,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.groupIncomingVideoRinging, user: mockSelfUser)
+        sut = CallInfoRootViewController(configuration: fixture.groupIncomingVideoRinging, selfUser: mockSelfUser)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -220,7 +220,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.groupOutgoingVideoRinging, user: mockSelfUser)
+        sut = CallInfoRootViewController(configuration: fixture.groupOutgoingVideoRinging, selfUser: mockSelfUser)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -231,7 +231,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.groupVideoEstablished, user: mockSelfUser)
+        sut = CallInfoRootViewController(configuration: fixture.groupVideoEstablished, selfUser: mockSelfUser)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -242,7 +242,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.groupVideoEstablishedScreenSharing, user: mockSelfUser)
+        sut = CallInfoRootViewController(configuration: fixture.groupVideoEstablishedScreenSharing, selfUser: mockSelfUser)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -253,7 +253,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.groupVideoEstablishedPoorConnection, user: mockSelfUser)
+        sut = CallInfoRootViewController(configuration: fixture.groupVideoEstablishedPoorConnection, selfUser: mockSelfUser)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -264,7 +264,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.groupVideoEstablishedCBR, user: mockSelfUser)
+        sut = CallInfoRootViewController(configuration: fixture.groupVideoEstablishedCBR, selfUser: mockSelfUser)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -275,7 +275,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
         
         // when
-        sut = CallInfoRootViewController(configuration: fixture.groupVideoEstablishedVBR, user: mockSelfUser)
+        sut = CallInfoRootViewController(configuration: fixture.groupVideoEstablishedVBR, selfUser: mockSelfUser)
         
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -289,7 +289,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.groupVideoIncomingUndeterminedPermissions, user: mockSelfUser)
+        sut = CallInfoRootViewController(configuration: fixture.groupVideoIncomingUndeterminedPermissions, selfUser: mockSelfUser)
 
         //then
         verify(matching: sut)
@@ -300,7 +300,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.groupVideoIncomingDeniedPermissions, user: mockSelfUser)
+        sut = CallInfoRootViewController(configuration: fixture.groupVideoIncomingDeniedPermissions, selfUser: mockSelfUser)
 
         //then
         verify(matching: sut)

--- a/Wire-iOS Tests/CallInfoRootViewControllerTests.swift
+++ b/Wire-iOS Tests/CallInfoRootViewControllerTests.swift
@@ -24,16 +24,19 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
 
     var coreDataFixture: CoreDataFixture!
     var sut: CallInfoRootViewController!
+    var mockSelfUser: MockUserType!
 
     override func setUp() {
         super.setUp()
 
+        mockSelfUser = MockUserType.createSelfUser(name: "Bob")
         coreDataFixture = CoreDataFixture()
     }
 
     override func tearDown() {
         sut = nil
         coreDataFixture = nil
+        mockSelfUser = nil
 
         super.tearDown()
     }
@@ -45,7 +48,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.oneToOneOutgoingAudioRinging)
+        sut = CallInfoRootViewController(configuration: fixture.oneToOneOutgoingAudioRinging, user: mockSelfUser)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -56,7 +59,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.oneToOneAudioConnecting)
+        sut = CallInfoRootViewController(configuration: fixture.oneToOneAudioConnecting, user: mockSelfUser)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -67,7 +70,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.oneToOneAudioEstablished)
+        sut = CallInfoRootViewController(configuration: fixture.oneToOneAudioEstablished, user: mockSelfUser)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -78,7 +81,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.oneToOneAudioEstablishedCBR)
+        sut = CallInfoRootViewController(configuration: fixture.oneToOneAudioEstablishedCBR, user: mockSelfUser)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -89,7 +92,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
         
         // when
-        sut = CallInfoRootViewController(configuration: fixture.oneToOneAudioEstablishedVBR)
+        sut = CallInfoRootViewController(configuration: fixture.oneToOneAudioEstablishedVBR, user: mockSelfUser)
         
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -101,7 +104,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.oneToOneAudioEstablished)
+        sut = CallInfoRootViewController(configuration: fixture.oneToOneAudioEstablished, user: mockSelfUser)
 
         // then
         _ = verifySnapshot(matching: sut, as: .image(on: SnapshotTesting.ViewImageConfig.iPhoneX))
@@ -112,7 +115,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.oneToOneAudioEstablishedPoorNetwork)
+        sut = CallInfoRootViewController(configuration: fixture.oneToOneAudioEstablishedPoorNetwork, user: mockSelfUser)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -125,7 +128,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.oneToOneIncomingVideoRinging)
+        sut = CallInfoRootViewController(configuration: fixture.oneToOneIncomingVideoRinging, user: mockSelfUser)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -136,7 +139,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.oneToOneVideoConnecting)
+        sut = CallInfoRootViewController(configuration: fixture.oneToOneVideoConnecting, user: mockSelfUser)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -147,7 +150,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.oneToOneVideoEstablished)
+        sut = CallInfoRootViewController(configuration: fixture.oneToOneVideoEstablished, user: mockSelfUser)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -160,7 +163,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.groupOutgoingAudioRinging)
+        sut = CallInfoRootViewController(configuration: fixture.groupOutgoingAudioRinging, user: mockSelfUser)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -171,7 +174,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.groupAudioConnecting)
+        sut = CallInfoRootViewController(configuration: fixture.groupAudioConnecting, user: mockSelfUser)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -182,7 +185,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser, groupSize: .small)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.groupAudioEstablished)
+        sut = CallInfoRootViewController(configuration: fixture.groupAudioEstablished, user: mockSelfUser)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -193,7 +196,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser, groupSize: .large)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.groupAudioEstablished)
+        sut = CallInfoRootViewController(configuration: fixture.groupAudioEstablished, user: mockSelfUser)
 
         // then
         verify(matching: sut)
@@ -206,7 +209,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.groupIncomingVideoRinging)
+        sut = CallInfoRootViewController(configuration: fixture.groupIncomingVideoRinging, user: mockSelfUser)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -217,7 +220,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.groupOutgoingVideoRinging)
+        sut = CallInfoRootViewController(configuration: fixture.groupOutgoingVideoRinging, user: mockSelfUser)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -228,7 +231,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.groupVideoEstablished)
+        sut = CallInfoRootViewController(configuration: fixture.groupVideoEstablished, user: mockSelfUser)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -239,7 +242,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.groupVideoEstablishedScreenSharing)
+        sut = CallInfoRootViewController(configuration: fixture.groupVideoEstablishedScreenSharing, user: mockSelfUser)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -250,7 +253,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.groupVideoEstablishedPoorConnection)
+        sut = CallInfoRootViewController(configuration: fixture.groupVideoEstablishedPoorConnection, user: mockSelfUser)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -261,7 +264,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.groupVideoEstablishedCBR)
+        sut = CallInfoRootViewController(configuration: fixture.groupVideoEstablishedCBR, user: mockSelfUser)
 
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -272,7 +275,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
         
         // when
-        sut = CallInfoRootViewController(configuration: fixture.groupVideoEstablishedVBR)
+        sut = CallInfoRootViewController(configuration: fixture.groupVideoEstablishedVBR, user: mockSelfUser)
         
         // then
         verifyAllIPhoneSizes(matching: sut)
@@ -286,7 +289,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.groupVideoIncomingUndeterminedPermissions)
+        sut = CallInfoRootViewController(configuration: fixture.groupVideoIncomingUndeterminedPermissions, user: mockSelfUser)
 
         //then
         verify(matching: sut)
@@ -297,7 +300,7 @@ final class CallInfoRootViewControllerTests: XCTestCase, CoreDataFixtureTestHelp
         let fixture = CallInfoTestFixture(otherUser: otherUser)
 
         // when
-        sut = CallInfoRootViewController(configuration: fixture.groupVideoIncomingDeniedPermissions)
+        sut = CallInfoRootViewController(configuration: fixture.groupVideoIncomingDeniedPermissions, user: mockSelfUser)
 
         //then
         verify(matching: sut)

--- a/Wire-iOS Tests/CallParticipantsViewTests.swift
+++ b/Wire-iOS Tests/CallParticipantsViewTests.swift
@@ -50,7 +50,7 @@ class CallParticipantsViewTests: ZMSnapshotTestCase {
     
     func testCallParticipants_Overflowing_Light() {
         // When
-        sut = CallParticipantsViewController(participants: type(of: self).participants(count: 10), allowsScrolling: true)
+        sut = CallParticipantsViewController(participants: type(of: self).participants(count: 10), allowsScrolling: true, selfUser: ZMUser.selfUser())
         sut.view.frame = CGRect(x: 0, y: 0, width: 325, height: 336)
         sut.view.setNeedsLayout()
         sut.view.layoutIfNeeded()
@@ -61,7 +61,7 @@ class CallParticipantsViewTests: ZMSnapshotTestCase {
     
     func testCallParticipants_Overflowing_Dark() {
         // When
-        sut = CallParticipantsViewController(participants: type(of: self).participants(count: 10), allowsScrolling: true)
+        sut = CallParticipantsViewController(participants: type(of: self).participants(count: 10), allowsScrolling: true, selfUser: ZMUser.selfUser())
         sut.variant = .dark
         snapshotBackgroundColor = .black
         sut.view.frame = CGRect(x: 0, y: 0, width: 325, height: 336)
@@ -74,7 +74,7 @@ class CallParticipantsViewTests: ZMSnapshotTestCase {
     
     func testCallParticipants_Truncated_Light() {
         // When
-        sut = CallParticipantsViewController(participants: type(of: self).participants(count: 10), allowsScrolling: false)
+        sut = CallParticipantsViewController(participants: type(of: self).participants(count: 10), allowsScrolling: false, selfUser: ZMUser.selfUser())
         sut.view.frame = CGRect(x: 0, y: 0, width: 325, height: 336)
         
         // Then
@@ -83,7 +83,7 @@ class CallParticipantsViewTests: ZMSnapshotTestCase {
     
     func testCallParticipants_Truncated_Dark() {
         // When
-        sut = CallParticipantsViewController(participants: type(of: self).participants(count: 10), allowsScrolling: false)
+        sut = CallParticipantsViewController(participants: type(of: self).participants(count: 10), allowsScrolling: false, selfUser: ZMUser.selfUser())
         sut.variant = .dark
         snapshotBackgroundColor = .black
         sut.view.frame = CGRect(x: 0, y: 0, width: 325, height: 336)

--- a/Wire-iOS Tests/UserCellTests.swift
+++ b/Wire-iOS Tests/UserCellTests.swift
@@ -137,7 +137,7 @@ final class UserCellTests: ZMSnapshotTestCase {
         let user = MockUser.mockUsers()[0]
         verifyInAllColorSchemes(view: cell({ (cell) in
             let config = CallParticipantsCellConfiguration.callParticipant(user: HashBox(value: user), videoState: .started, microphoneState: .unmuted)
-            cell.configure(with: config, variant: .dark)
+            cell.configure(with: config, variant: .dark, selfUser: ZMUser.selfUser())
         }))
     }
     
@@ -145,7 +145,7 @@ final class UserCellTests: ZMSnapshotTestCase {
         let user = MockUser.mockUsers()[0]
         verifyInAllColorSchemes(view: cell({ (cell) in
             let config = CallParticipantsCellConfiguration.callParticipant(user: HashBox(value: user), videoState: .screenSharing, microphoneState: .unmuted)
-            cell.configure(with: config, variant: .dark)
+            cell.configure(with: config, variant: .dark, selfUser: ZMUser.selfUser())
         }))
     }
     

--- a/Wire-iOS Tests/UserCellTests.swift
+++ b/Wire-iOS Tests/UserCellTests.swift
@@ -153,7 +153,7 @@ final class UserCellTests: ZMSnapshotTestCase {
         let user = MockUser.mockUsers()[0]
         verifyInAllColorSchemes(view: cell({ (cell) in
             let config = CallParticipantsCellConfiguration.callParticipant(user: HashBox(value: user), videoState: .started, microphoneState: .unmuted)
-            cell.configure(with: config, variant: .dark, selfUser: ZMUser.selfUser())
+            cell.configure(with: config, variant: .dark, selfUser: MockUser.mockSelf())
         }))
     }
     
@@ -161,7 +161,7 @@ final class UserCellTests: ZMSnapshotTestCase {
         let user = MockUser.mockUsers()[0]
         verifyInAllColorSchemes(view: cell({ (cell) in
             let config = CallParticipantsCellConfiguration.callParticipant(user: HashBox(value: user), videoState: .screenSharing, microphoneState: .unmuted)
-            cell.configure(with: config, variant: .dark, selfUser: ZMUser.selfUser())
+            cell.configure(with: config, variant: .dark, selfUser: MockUser.mockSelf())
         }))
     }
     

--- a/Wire-iOS Tests/UserCellTests.swift
+++ b/Wire-iOS Tests/UserCellTests.swift
@@ -54,7 +54,9 @@ final class UserCellTests: ZMSnapshotTestCase {
         mockUser.teamRole = .partner
         
         verifyInAllColorSchemes(view: cell({ (cell) in
-            cell.configure(with: mockUser, conversation: conversation)
+            cell.configure(with: mockUser,
+                           selfUser: MockUser.mockSelf(),
+                           conversation: conversation)
         }))
     }
 
@@ -64,7 +66,9 @@ final class UserCellTests: ZMSnapshotTestCase {
         mockUser.isServiceUser = true
         
         verifyInAllColorSchemes(view: cell({ (cell) in
-            cell.configure(with: mockUser, conversation: conversation)
+            cell.configure(with: mockUser,
+                           selfUser: MockUser.mockSelf(),
+                           conversation: conversation)
         }))
     }
     
@@ -72,7 +76,9 @@ final class UserCellTests: ZMSnapshotTestCase {
         let user = MockUser.mockUsers()[0]
         
         verifyInAllColorSchemes(view: cell({ (cell) in
-            cell.configure(with: user, conversation: conversation)
+            cell.configure(with: user,
+                           selfUser: MockUser.mockSelf(),
+                           conversation: conversation)
         }))
     }
     
@@ -83,7 +89,9 @@ final class UserCellTests: ZMSnapshotTestCase {
         _ = mockUser.feature(withUserClients: 1)
         
         verifyInAllColorSchemes(view: cell({ (cell) in
-            cell.configure(with: mockUser, conversation: conversation)
+            cell.configure(with: mockUser,
+                           selfUser: MockUser.mockSelf(),
+                           conversation: conversation)
         }))
     }
     
@@ -94,7 +102,9 @@ final class UserCellTests: ZMSnapshotTestCase {
         mockUser.isGuestInConversation = true
         
         verifyInAllColorSchemes(view: cell({ (cell) in
-            cell.configure(with: mockUser, conversation: conversation)
+            cell.configure(with: mockUser,
+                           selfUser: MockUser.mockSelf(),
+                           conversation: conversation)
         }))
     }
     
@@ -106,7 +116,9 @@ final class UserCellTests: ZMSnapshotTestCase {
         mockUser.handle = nil
 
         verifyInAllColorSchemes(view: cell {
-            $0.configure(with: mockUser, conversation: conversation)
+            $0.configure(with: mockUser,
+                         selfUser: MockUser.mockSelf(),
+                         conversation: conversation)
         })
     }
     
@@ -120,7 +132,9 @@ final class UserCellTests: ZMSnapshotTestCase {
         _ = mockUser.feature(withUserClients: 1)
 
         verifyInAllColorSchemes(view: cell({ (cell) in
-            cell.configure(with: mockUser, conversation: conversation)
+            cell.configure(with: mockUser,
+                           selfUser: MockUser.mockSelf(),
+                           conversation: conversation)
         }))
     }
     
@@ -128,7 +142,9 @@ final class UserCellTests: ZMSnapshotTestCase {
         let user = MockUser.mockUsers()[10]
         
         verifyInAllColorSchemes(view: cell({ (cell) in
-            cell.configure(with: user, conversation: conversation)
+            cell.configure(with: user,
+                           selfUser: MockUser.mockSelf(),
+                           conversation: conversation)
         }))
     }
     

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallAccessoryViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallAccessoryViewController.swift
@@ -44,7 +44,7 @@ final class CallAccessoryViewController: UIViewController, CallParticipantsViewC
     }
 
     init(configuration: CallInfoViewControllerInput,
-         selfUser: UserType = ZMUser.selfUser()) {
+         selfUser: UserType) {
         self.configuration = configuration
         participantsViewController = CallParticipantsViewController(participants: configuration.accessoryType.participants,
                                                                     allowsScrolling: false,

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallAccessoryViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallAccessoryViewController.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import UIKit
+import WireDataModel
 
 protocol CallAccessoryViewControllerDelegate: class {
     func callAccessoryViewControllerDidSelectShowMore(viewController: CallAccessoryViewController)
@@ -42,9 +43,12 @@ final class CallAccessoryViewController: UIViewController, CallParticipantsViewC
         }
     }
 
-    init(configuration: CallInfoViewControllerInput) {
+    init(configuration: CallInfoViewControllerInput,
+         selfUser: UserType = ZMUser.selfUser()) {
         self.configuration = configuration
-        participantsViewController = CallParticipantsViewController(participants: configuration.accessoryType.participants, allowsScrolling: false)
+        participantsViewController = CallParticipantsViewController(participants: configuration.accessoryType.participants,
+                                                                    allowsScrolling: false,
+                                                                    selfUser: selfUser)
         super.init(nibName: nil, bundle: nil)
         participantsViewController.delegate = self
     }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoRootViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoRootViewController.swift
@@ -53,7 +53,7 @@ final class CallInfoRootViewController: UIViewController, UINavigationController
     }
     
     init(configuration: CallInfoViewControllerInput,
-         selfUser: UserType = ZMUser.selfUser()) {
+         selfUser: UserType) {
         self.configuration = configuration
         contentController = CallInfoViewController(configuration: configuration, selfUser: selfUser)
         contentNavigationController = contentController.wrapInNavigationController()

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoRootViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoRootViewController.swift
@@ -19,6 +19,7 @@
 import Foundation
 import UIKit
 import SafariServices
+import WireDataModel
 
 protocol CallInfoRootViewControllerDelegate: class {
     func infoRootViewController(_ viewController: CallInfoRootViewController, perform action: CallAction)
@@ -51,9 +52,10 @@ final class CallInfoRootViewController: UIViewController, UINavigationController
         }
     }
     
-    init(configuration: CallInfoViewControllerInput) {
+    init(configuration: CallInfoViewControllerInput,
+         user: UserType = ZMUser.selfUser()) {
         self.configuration = configuration
-        contentController = CallInfoViewController(configuration: configuration)
+        contentController = CallInfoViewController(configuration: configuration, user: user)
         contentNavigationController = contentController.wrapInNavigationController()
         callDegradationController = CallDegradationController()
         

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoRootViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoRootViewController.swift
@@ -53,9 +53,9 @@ final class CallInfoRootViewController: UIViewController, UINavigationController
     }
     
     init(configuration: CallInfoViewControllerInput,
-         user: UserType = ZMUser.selfUser()) {
+         selfUser: UserType = ZMUser.selfUser()) {
         self.configuration = configuration
-        contentController = CallInfoViewController(configuration: configuration, user: user)
+        contentController = CallInfoViewController(configuration: configuration, selfUser: selfUser)
         contentNavigationController = contentController.wrapInNavigationController()
         callDegradationController = CallDegradationController()
         

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoViewController.swift
@@ -75,12 +75,12 @@ final class CallInfoViewController: UIViewController, CallActionsViewDelegate, C
     }
 
     init(configuration: CallInfoViewControllerInput,
-         user: UserType = ZMUser.selfUser(),
+         selfUser: UserType = ZMUser.selfUser(),
          userSession: ZMUserSession? = ZMUserSession.shared()) {
         self.configuration = configuration
         statusViewController = CallStatusViewController(configuration: configuration)
-        accessoryViewController = CallAccessoryViewController(configuration: configuration)
-        backgroundViewController = BackgroundViewController(user: user, userSession: userSession)
+        accessoryViewController = CallAccessoryViewController(configuration: configuration, selfUser: selfUser)
+        backgroundViewController = BackgroundViewController(user: selfUser, userSession: userSession)
         super.init(nibName: nil, bundle: nil)
         accessoryViewController.delegate = self
         actionsView.delegate = self

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoViewController.swift
@@ -75,7 +75,7 @@ final class CallInfoViewController: UIViewController, CallActionsViewDelegate, C
     }
 
     init(configuration: CallInfoViewControllerInput,
-         selfUser: UserType = ZMUser.selfUser(),
+         selfUser: UserType,
          userSession: ZMUserSession? = ZMUserSession.shared()) {
         self.configuration = configuration
         statusViewController = CallStatusViewController(configuration: configuration)

--- a/Wire-iOS/Sources/UserInterface/Calling/CallParticipantsView/CallParticipantsView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallParticipantsView/CallParticipantsView.swift
@@ -22,7 +22,9 @@ import WireSyncEngine
 typealias CallParticipantsList = [CallParticipantsCellConfiguration]
 
 protocol CallParticipantsCellConfigurationConfigurable: Reusable {
-    func configure(with configuration: CallParticipantsCellConfiguration, variant: ColorSchemeVariant)
+    func configure(with configuration: CallParticipantsCellConfiguration,
+                   variant: ColorSchemeVariant,
+                   selfUser: UserType)
 }
 
 enum CallParticipantsCellConfiguration: Hashable {
@@ -52,7 +54,8 @@ enum CallParticipantsCellConfiguration: Hashable {
     }
 }
 
-class CallParticipantsView: UICollectionView, Themeable {
+final class CallParticipantsView: UICollectionView, Themeable {
+    let selfUser: UserType
     
     var rows = CallParticipantsList() {
         didSet {
@@ -71,13 +74,16 @@ class CallParticipantsView: UICollectionView, Themeable {
         reloadData()
     }
     
-    override init(frame: CGRect, collectionViewLayout: UICollectionViewLayout) {
-        super.init(frame: frame, collectionViewLayout: collectionViewLayout)
+    init(collectionViewLayout: UICollectionViewLayout, selfUser: UserType) {
+        self.selfUser = selfUser
+        super.init(frame: .zero, collectionViewLayout: collectionViewLayout)
+
         self.dataSource = self
         backgroundColor = .clear
         isOpaque = false
     }
-    
+        
+    @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -99,7 +105,9 @@ extension CallParticipantsView: UICollectionViewDataSource {
         let cell =  collectionView.dequeueReusableCell(withReuseIdentifier: cellConfiguration.cellType.reuseIdentifier, for: indexPath)
 
         if let configurableCell = cell as? CallParticipantsCellConfigurationConfigurable {
-            configurableCell.configure(with: cellConfiguration, variant: colorSchemeVariant)
+            configurableCell.configure(with: cellConfiguration,
+                                       variant: colorSchemeVariant,
+                                       selfUser: selfUser)
         }
         
         return cell
@@ -109,12 +117,14 @@ extension CallParticipantsView: UICollectionViewDataSource {
 
 extension UserCell: CallParticipantsCellConfigurationConfigurable {
     
-    func configure(with configuration: CallParticipantsCellConfiguration, variant: ColorSchemeVariant) {
+    func configure(with configuration: CallParticipantsCellConfiguration,
+                   variant: ColorSchemeVariant,
+                   selfUser: UserType) {
         guard case let .callParticipant(user, videoState, microphoneState) = configuration else { preconditionFailure() }
         colorSchemeVariant = variant
         contentBackgroundColor = .clear
         hidesSubtitle = true
-        configure(with: user.value)
+        configure(with: user.value, selfUser: selfUser)
         accessoryIconView.isHidden = true
         microphoneIconView.set(style: MicrophoneIconStyle(state: microphoneState))
         videoIconView.set(style: VideoIconStyle(state: videoState))

--- a/Wire-iOS/Sources/UserInterface/Calling/CallParticipantsView/CallParticipantsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallParticipantsView/CallParticipantsViewController.swift
@@ -48,7 +48,7 @@ final class CallParticipantsViewController: UIViewController, UICollectionViewDe
     
     init(participants: CallParticipantsList,
          allowsScrolling: Bool,
-         selfUser: UserType = ZMUser.selfUser()) {
+         selfUser: UserType) {
         self.participants = participants
         self.allowsScrolling = allowsScrolling
         self.selfUser = selfUser

--- a/Wire-iOS/Sources/UserInterface/Calling/CallParticipantsView/CallParticipantsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallParticipantsView/CallParticipantsViewController.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import UIKit
+import WireDataModel
 
 protocol CallParticipantsViewControllerDelegate: class {
     func callParticipantsViewControllerDidSelectShowMore(viewController: CallParticipantsViewController)
@@ -28,6 +29,7 @@ final class CallParticipantsViewController: UIViewController, UICollectionViewDe
     private let cellHeight: CGFloat = 56
     private var topConstraint: NSLayoutConstraint?
     weak var delegate: CallParticipantsViewControllerDelegate?
+    private let selfUser: UserType
     
     var participants: CallParticipantsList {
         didSet {
@@ -44,18 +46,25 @@ final class CallParticipantsViewController: UIViewController, UICollectionViewDe
         }
     }
     
-    init(participants: CallParticipantsList, allowsScrolling: Bool) {
+    init(participants: CallParticipantsList,
+         allowsScrolling: Bool,
+         selfUser: UserType = ZMUser.selfUser()) {
         self.participants = participants
         self.allowsScrolling = allowsScrolling
+        self.selfUser = selfUser
         super.init(nibName: nil, bundle: nil)
     }
     
-    convenience init(scrollableWithConfiguration configuration: CallInfoViewControllerInput) {
-        self.init(participants: configuration.accessoryType.participants, allowsScrolling: true)
+    convenience init(scrollableWithConfiguration configuration: CallInfoViewControllerInput,
+                     selfUser: UserType = ZMUser.selfUser()) {
+        self.init(participants: configuration.accessoryType.participants,
+                  allowsScrolling: true,
+                  selfUser: selfUser)
         variant = configuration.effectiveColorVariant
         view.backgroundColor = configuration.overlayBackgroundColor
     }
     
+    @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -83,7 +92,7 @@ final class CallParticipantsViewController: UIViewController, UICollectionViewDe
         collectionViewLayout.minimumInteritemSpacing = 12
         collectionViewLayout.minimumLineSpacing = 0
         
-        let collectionView = CallParticipantsView(frame: .zero, collectionViewLayout: collectionViewLayout)
+        let collectionView = CallParticipantsView(collectionViewLayout: collectionViewLayout, selfUser: selfUser)
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         collectionView.bounces = allowsScrolling
         collectionView.delegate = self

--- a/Wire-iOS/Sources/UserInterface/Calling/CallParticipantsView/ShowAllParticipantsCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallParticipantsView/ShowAllParticipantsCell.swift
@@ -104,7 +104,8 @@ class ShowAllParticipantsCell: UICollectionViewCell, SectionListCellType {
 }
 
 extension ShowAllParticipantsCell: CallParticipantsCellConfigurationConfigurable {
-    func configure(with configuration: CallParticipantsCellConfiguration, variant: ColorSchemeVariant) {
+    func configure(with configuration: CallParticipantsCellConfiguration, variant: ColorSchemeVariant,
+                   selfUser: UserType) {
         guard case let .showAll(totalCount: totalCount) = configuration else { preconditionFailure() }
         
         self.variant = variant

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -71,7 +71,7 @@ final class CallViewController: UIViewController {
         videoConfiguration = VideoConfiguration(voiceChannel: voiceChannel)
         callInfoConfiguration = CallInfoConfiguration(voiceChannel: voiceChannel, preferedVideoPlaceholderState: preferedVideoPlaceholderState, permissions: permissionsConfiguration, cameraType: cameraType, mediaManager: mediaManager, userEnabledCBR: CallViewController.userEnabledCBR)
 
-        callInfoRootViewController = CallInfoRootViewController(configuration: callInfoConfiguration)
+        callInfoRootViewController = CallInfoRootViewController(configuration: callInfoConfiguration, selfUser: ZMUser.selfUser())
         videoGridViewController = VideoGridViewController(configuration: videoConfiguration)
 
         super.init(nibName: nil, bundle: nil)

--- a/Wire-iOS/Sources/UserInterface/Components/Views/IconImageView/UserTypeIconStyle.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/IconImageView/UserTypeIconStyle.swift
@@ -42,13 +42,13 @@ enum UserTypeIconStyle: String, IconImageStyle {
 }
 
 extension UserTypeIconStyle {
-    init(conversation: ZMConversation?, user: UserType) {
+    init(conversation: ZMConversation?, user: UserType, selfUser: UserType = ZMUser.selfUser()) {
         if user.isExternalPartner {
             self = .external
         } else if let conversation = conversation {
             self = !user.isGuest(in: conversation) || user.isSelfUser ? .member : .guest
         } else {
-            self = !ZMUser.selfUser().isTeamMember
+            self = !selfUser.isTeamMember
                 || user.isTeamMember
                 || user.isServiceUser
                 ? .member

--- a/Wire-iOS/Sources/UserInterface/Components/Views/IconImageView/UserTypeIconStyle.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/IconImageView/UserTypeIconStyle.swift
@@ -42,7 +42,7 @@ enum UserTypeIconStyle: String, IconImageStyle {
 }
 
 extension UserTypeIconStyle {
-    init(conversation: ZMConversation?, user: UserType, selfUser: UserType = ZMUser.selfUser()) {
+    init(conversation: ZMConversation?, user: UserType, selfUser: UserType) {
         if user.isExternalPartner {
             self = .external
         } else if let conversation = conversation {

--- a/Wire-iOS/Sources/UserInterface/Components/Views/UserCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/UserCell.swift
@@ -199,12 +199,13 @@ class UserCell: SeparatorCollectionViewCell, SectionListCellType {
         updateTitleLabel()
     }
     
-    private func updateTitleLabel() {
-        guard let user = user else {
+    private func updateTitleLabel(selfUser: UserType? = nil) {
+        guard let user = user,
+              let selfUser = selfUser else {
             return
         }
         
-        var attributedTitle = user.nameIncludingAvailability(color: UIColor.from(scheme: .textForeground, variant: colorSchemeVariant))
+        var attributedTitle = user.nameIncludingAvailability(color: UIColor.from(scheme: .textForeground, variant: colorSchemeVariant), selfUser: selfUser)
         
         if user.isSelfUser, let title = attributedTitle {
             attributedTitle = title + "user_cell.title.you_suffix".localized
@@ -214,6 +215,7 @@ class UserCell: SeparatorCollectionViewCell, SectionListCellType {
     }
     
     func configure(with user: UserType,
+                   selfUser: UserType = ZMUser.selfUser(),
                    subtitle overrideSubtitle: NSAttributedString? = nil,
                    conversation: ZMConversation? = nil) {
         
@@ -227,9 +229,9 @@ class UserCell: SeparatorCollectionViewCell, SectionListCellType {
         self.user = user
 
         avatar.user = user
-        updateTitleLabel()
+        updateTitleLabel(selfUser: selfUser)
 
-        let style = UserTypeIconStyle(conversation: conversation, user: user)
+        let style = UserTypeIconStyle(conversation: conversation, user: user, selfUser: selfUser)
         userTypeIconView.set(style: style)
 
         verifiedIconView.isHidden = !user.isVerified
@@ -271,10 +273,10 @@ extension UserCell {
 
 extension UserType {
     
-    func nameIncludingAvailability(color: UIColor) -> NSAttributedString? {
-        if ZMUser.selfUser().isTeamMember {
+    func nameIncludingAvailability(color: UIColor, selfUser: UserType) -> NSAttributedString? {
+        if selfUser.isTeamMember {
             return AvailabilityStringBuilder.string(for: self, with: .list, color: color)
-        } else if let name = name{
+        } else if let name = name {
             return name && color
         }
 

--- a/Wire-iOS/Sources/UserInterface/Components/Views/UserCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/UserCell.swift
@@ -215,7 +215,7 @@ class UserCell: SeparatorCollectionViewCell, SectionListCellType {
     }
     
     func configure(with user: UserType,
-                   selfUser: UserType = ZMUser.selfUser(),
+                   selfUser: UserType,
                    subtitle overrideSubtitle: NSAttributedString? = nil,
                    conversation: ZMConversation? = nil) {
         

--- a/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsCell.swift
+++ b/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsCell.swift
@@ -222,7 +222,7 @@ class ContactsCell: UITableViewCell, SeparatorViewProtocol {
             return
         }
 
-        titleLabel.attributedText = user.nameIncludingAvailability(color: UIColor.from(scheme: .textForeground, variant: colorSchemeVariant))
+        titleLabel.attributedText = user.nameIncludingAvailability(color: UIColor.from(scheme: .textForeground, variant: colorSchemeVariant), selfUser: ZMUser.selfUser())
     }
 
     @objc func actionButtonPressed(sender: Any?) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Mentions/UserSearchResultsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Mentions/UserSearchResultsViewController.swift
@@ -267,7 +267,7 @@ extension UserSearchResultsViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let user = searchResults[indexPath.item]
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: UserCell.reuseIdentifier, for: indexPath) as! UserCell
-        cell.configure(with: user)
+        cell.configure(with: user, selfUser: ZMUser.selfUser())
         cell.showSeparator = false
         cell.avatarSpacing = conversationHorizontalMargins.left
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsContentViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsContentViewController.swift
@@ -257,7 +257,7 @@ extension MessageDetailsContentViewController: UICollectionViewDataSource, UICol
         let description = cells[indexPath.item]
         let cell = collectionView.dequeueReusableCell(ofType: UserCell.self, for: indexPath)
 
-        cell.configure(with: description.user, subtitle: description.attributedSubtitle, conversation: conversation)
+        cell.configure(with: description.user, selfUser: ZMUser.selfUser(), subtitle: description.attributedSubtitle, conversation: conversation)
         cell.showSeparator = indexPath.item != (cells.endIndex - 1)
         cell.subtitleLabel.accessibilityLabel = description.accessibleSubtitleLabel
         cell.subtitleLabel.accessibilityValue = description.accessibleSubtitleValue

--- a/Wire-iOS/Sources/UserInterface/ConversationList/BackgroundViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/BackgroundViewController.swift
@@ -48,7 +48,8 @@ final class BackgroundViewController: UIViewController {
     private func setupObservers(userSession: ZMUserSession?) {
         guard !ProcessInfo.processInfo.isRunningTests else { return }
 
-        if let userSession = userSession {
+        if !ProcessInfo.processInfo.isRunningTests,
+            let userSession = userSession {
             userObserverToken = UserChangeInfo.add(observer: self, for: user, in: userSession)
         }
         

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/ParticipantsSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/ParticipantsSectionController.swift
@@ -125,7 +125,7 @@ private struct ParticipantsSectionViewModel {
 extension UserCell: ParticipantsCellConfigurable {
     func configure(with rowType: ParticipantsRowType, conversation: ZMConversation, showSeparator: Bool) {
         guard case let .user(user) = rowType else { preconditionFailure() }
-        configure(with: user, conversation: conversation)
+        configure(with: user, selfUser: ZMUser.selfUser(), conversation: conversation)
         accessoryIconView.isHidden = user.isSelfUser
         accessibilityIdentifier = identifier
         self.showSeparator = showSeparator

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/ServicesSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/ServicesSectionController.swift
@@ -54,7 +54,7 @@ final class ServicesSectionController: GroupDetailsSectionController {
         let user = serviceUsers[indexPath.row]
         let cell = collectionView.dequeueReusableCell(ofType: UserCell.self, for: indexPath)
         
-        cell.configure(with: user, conversation: conversation)
+        cell.configure(with: user, selfUser: ZMUser.selfUser(), conversation: conversation)
         cell.showSeparator = (serviceUsers.count - 1) != indexPath.row
         cell.accessoryIconView.isHidden = false
         cell.accessibilityIdentifier = "participants.section.services.cell"

--- a/Wire-iOS/Sources/UserInterface/LegalHoldDetails/Sections/LegalHoldParticipantsSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/LegalHoldDetails/Sections/LegalHoldParticipantsSectionController.swift
@@ -84,7 +84,7 @@ class LegalHoldParticipantsSectionController: GroupDetailsSectionController {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: UserCell.reuseIdentifier, for: indexPath) as! UserCell
         let showSeparator = (viewModel.participants.count - 1) != indexPath.row
         
-        cell.configure(with: participant, conversation: conversation)
+        cell.configure(with: participant, selfUser: ZMUser.selfUser(), conversation: conversation)
         cell.accessoryIconView.isHidden = false
         cell.accessibilityIdentifier = "participants.section.participants.cell"
         cell.showSeparator = showSeparator

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/Contacts/ContactsSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/Contacts/ContactsSectionController.swift
@@ -65,7 +65,7 @@ class ContactsSectionController : SearchSectionController {
         let user = contacts[indexPath.row]
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: UserCell.zm_reuseIdentifier, for: indexPath) as! UserCell
         
-        cell.configure(with: user)
+        cell.configure(with: user, selfUser: ZMUser.selfUser())
         cell.showSeparator = (contacts.count - 1) != indexPath.row
         cell.checkmarkIconView.isHidden = !allowsSelection
         cell.accessoryIconView.isHidden = true

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/Services/SearchServicesSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/Services/SearchServicesSectionController.swift
@@ -81,7 +81,7 @@ final class SearchServicesSectionController: SearchSectionController {
             
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: UserCell.zm_reuseIdentifier, for: indexPath) as! UserCell
             
-            cell.configure(with: service)
+            cell.configure(with: service, selfUser: ZMUser.selfUser())
             cell.accessoryIconView.isHidden = false
             cell.showSeparator = (services.count - 1) != indexPath.row
             

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/Suggestions/DirectorySectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/Suggestions/DirectorySectionController.swift
@@ -54,7 +54,7 @@ final class DirectorySectionController: SearchSectionController {
         let user = suggestions[indexPath.row]
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: UserCell.zm_reuseIdentifier, for: indexPath) as! UserCell
         
-        cell.configure(with: user)
+        cell.configure(with: user, selfUser: ZMUser.selfUser())
         cell.showSeparator = (suggestions.count - 1) != indexPath.row
         cell.userTypeIconView.isHidden = true
         cell.accessoryIconView.isHidden = true

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Views/ProfileTitleView.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Views/ProfileTitleView.swift
@@ -67,7 +67,7 @@ final class ProfileTitleView: UIView {
     }
 
     func configure(with user: UserType, variant: ColorSchemeVariant) {
-        let attributedTitle = user.nameIncludingAvailability(color: UIColor.from(scheme: .textForeground, variant: variant))
+        let attributedTitle = user.nameIncludingAvailability(color: UIColor.from(scheme: .textForeground, variant: variant), selfUser: ZMUser.selfUser())
         titleLabel.attributedText = attributedTitle
         titleLabel.font = FontSpec(.normal, .medium).font!
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

When running `CallInfoRootViewControllerTests`, test crashes

### Causes

 `ZMUser.selfUser()` is called and can not released on Xcode 12.

### Solutions

Inject mock self user to `BackgroundViewController` and `UserCell`.