### PR TITLE
assign dummy Analytics to prevent crash when running SettingsTableViewControllerSnapshotTests.testForSettingGroup

### DIFF
--- a/Wire-iOS Tests/SettingsTableViewControllerSnapshotTests.swift
+++ b/Wire-iOS Tests/SettingsTableViewControllerSnapshotTests.swift
@@ -48,6 +48,8 @@ final class SettingsTableViewControllerSnapshotTests: XCTestCase {
 	}
 
     func testForSettingGroup() {
+        // prevent app crash when checking Analytics.shared.isOptout
+        Analytics.shared = Analytics(optedOut: true)
         let group = settingsCellDescriptorFactory.settingsGroup(isTeamMember: coreDataFixture.selfUser.isTeamMember)
         verify(group: group)
     }


### PR DESCRIPTION
## What's new in this PR?

rework of https://github.com/wireapp/wire-ios/pull/4787, assign a dummy Analytics singleton object to prevent crashes when force unwrapping  `Analytics.shared` 