### PR TITLE
Fix: CompositeMessageCellTests with custom self user

### DIFF
--- a/Wire-iOS Tests/CollectionsViewControllerTests.swift
+++ b/Wire-iOS Tests/CollectionsViewControllerTests.swift
@@ -27,7 +27,7 @@ extension MockMessage {
     }
 }
 
-final class CollectionsViewControllerTests: XCTestCase, CoreDataFixtureTestHelper {
+final class CollectionsViewControllerTests: XCTestCase {
     
     var emptyCollection: AssetCollectionWrapper!
     var imageMessage: ZMConversationMessage!
@@ -48,15 +48,8 @@ final class CollectionsViewControllerTests: XCTestCase, CoreDataFixtureTestHelpe
     var deletedFileMessage: ZMConversationMessage!
     var deletedLinkMessage: ZMConversationMessage!
 
-    var coreDataFixture: CoreDataFixture!
-    
     override func setUp() {
         super.setUp()
-
-        coreDataFixture = CoreDataFixture()
-
-        MockUser.mockSelf()?.name = "Tarja Turunen"
-        MockUser.mockSelf()?.accentColorValue = .strongBlue
 
         let conversation = MockConversation() as Any as! ZMConversation
         let assetCollection = MockCollection.empty
@@ -102,7 +95,6 @@ final class CollectionsViewControllerTests: XCTestCase, CoreDataFixtureTestHelpe
         deletedFileMessage = nil
         deletedLinkMessage = nil
 
-        coreDataFixture = nil
         super.tearDown()
     }
     

--- a/Wire-iOS Tests/CollectionsViewControllerTests.swift
+++ b/Wire-iOS Tests/CollectionsViewControllerTests.swift
@@ -135,7 +135,7 @@ final class CollectionsViewControllerTests: XCTestCase {
 
     // MARK: - Expiration
 
-    func testImagesSectionWhenExpired() {
+    func testImagesSectionWhenExpired() {///TODO: bg color should be red, not blue
         let assetCollection = MockCollection(messages: [
             MockCollection.onlyImagesCategory: [expiredImageMessage],
             MockCollection.onlyVideosCategory: [videoMessage, expiredVideoMessage]])

--- a/Wire-iOS Tests/ConversationCell/CompositeMessageCellTests.swift
+++ b/Wire-iOS Tests/ConversationCell/CompositeMessageCellTests.swift
@@ -21,12 +21,23 @@ import XCTest
 final class CompositeMessageCellTests: ConversationCellSnapshotTestCase {
 
     typealias CellConfiguration = (MockMessage) -> Void
+    
+    var mockSelfUser: MockUserType!
 
     override func setUp() {
         super.setUp()
 
         // make sure the button's color is alarm red, not accent color
         coreDataFixture.accentColor = .strongBlue
+        
+        mockSelfUser = MockUserType.createSelfUser(name: "selfUser")
+        mockSelfUser.accentColorValue = .vividRed
+    }
+
+    override func tearDown() {
+        mockSelfUser = nil
+        
+        super.tearDown()
     }
 
     func testThatItRendersErrorMessage() {
@@ -37,14 +48,7 @@ final class CompositeMessageCellTests: ConversationCellSnapshotTestCase {
                                              createItem(title: "Giacomo Antonio Domenico Michele Secondo Maria Puccini & Giuseppe Fortunino Francesco Verdi", state:.unselected)]
 
         // when & then
-        let mockSelfUser = MockUserType.createSelfUser(name: "selfUser")
-        mockSelfUser.accentColorValue = .vividRed
-        
         let message = makeMessage(sender: mockSelfUser, items: items)
-        let sender = message.senderUser as! MockUserType
-        sender.name = "selfUser"
-        sender.accentColorValue = .vividRed
-        sender.initials = "S"
 
         verify(message: message,
                allWidths: false,
@@ -52,13 +56,13 @@ final class CompositeMessageCellTests: ConversationCellSnapshotTestCase {
     }
 
     func testThatItRendersButton() {
-        verify(message: makeMessage(),
+        verify(message: makeMessage(sender: mockSelfUser),
                snapshotBackgroundColor: UIColor.from(scheme: .contentBackground))
     }
 
     func testThatButtonStyleIsUpdatedAfterStateChange() {
         // given
-        let message = makeMessage() { config in
+        let message = makeMessage(sender: mockSelfUser) { config in
             // when
             let item = self.createItem(title: "J.S. Bach", state:.unselected)
             (config.compositeMessageData as? MockCompositeMessageData)?.items[1] = item
@@ -69,7 +73,7 @@ final class CompositeMessageCellTests: ConversationCellSnapshotTestCase {
     }
 
     // MARK: - Helpers
-
+    
     private func createItem(title: String, state: ButtonMessageState, isExpired: Bool = false) -> CompositeMessageItem {
         let mockButtonMessageData: MockButtonMessageData = MockButtonMessageData()
         mockButtonMessageData.state = state
@@ -96,8 +100,9 @@ final class CompositeMessageCellTests: ConversationCellSnapshotTestCase {
         return mockCompositeMessage
     }
 
-    private func makeMessage(_ config: CellConfiguration? = nil) -> MockMessage {
-        let mockCompositeMessage: MockMessage = MockMessageFactory.compositeMessage()
+    private func makeMessage(sender: UserType? = nil,
+                             _ config: CellConfiguration? = nil) -> MockMessage {
+        let mockCompositeMessage: MockMessage = MockMessageFactory.compositeMessage(sender: sender)
 
         let mockCompositeMessageData = MockCompositeMessageData()
         let textItem: CompositeMessageItem = .text(mockTextMessage.backingTextMessageData)

--- a/Wire-iOS Tests/ConversationCell/CompositeMessageCellTests.swift
+++ b/Wire-iOS Tests/ConversationCell/CompositeMessageCellTests.swift
@@ -24,6 +24,7 @@ final class CompositeMessageCellTests: ConversationCellSnapshotTestCase {
 
     override func setUp() {
         super.setUp()
+
         // make sure the button's color is alarm red, not accent color
         coreDataFixture.accentColor = .strongBlue
     }
@@ -36,7 +37,16 @@ final class CompositeMessageCellTests: ConversationCellSnapshotTestCase {
                                              createItem(title: "Giacomo Antonio Domenico Michele Secondo Maria Puccini & Giuseppe Fortunino Francesco Verdi", state:.unselected)]
 
         // when & then
-        verify(message: makeMessage(items: items),
+        let mockSelfUser = MockUserType.createSelfUser(name: "selfUser")
+        mockSelfUser.accentColorValue = .vividRed
+        
+        let message = makeMessage(sender: mockSelfUser, items: items)
+        let sender = message.senderUser as! MockUserType
+        sender.name = "selfUser"
+        sender.accentColorValue = .vividRed
+        sender.initials = "S"
+
+        verify(message: message,
                allWidths: false,
                snapshotBackgroundColor: UIColor.from(scheme: .contentBackground))
     }
@@ -70,10 +80,12 @@ final class CompositeMessageCellTests: ConversationCellSnapshotTestCase {
         return buttonItem
     }
 
-    fileprivate var mockTextMessage = MockMessageFactory.textMessage(withText: "# Question:\nWho is/are your most favourite musician(s)  ?")!
+    fileprivate lazy var mockTextMessage = MockMessageFactory.textMessage(withText: "# Question:\nWho is/are your most favourite musician(s)  ?")!
+
     
-    private func makeMessage(items: [CompositeMessageItem]) -> MockMessage {
-        let mockCompositeMessage: MockMessage = MockMessageFactory.compositeMessage
+    private func makeMessage(sender: UserType? = nil,
+                             items: [CompositeMessageItem]) -> MockMessage {
+        let mockCompositeMessage: MockMessage = MockMessageFactory.compositeMessage(sender: sender)
 
         let mockCompositeMessageData = MockCompositeMessageData()
         let textItem: CompositeMessageItem = .text(mockTextMessage.backingTextMessageData)
@@ -85,7 +97,7 @@ final class CompositeMessageCellTests: ConversationCellSnapshotTestCase {
     }
 
     private func makeMessage(_ config: CellConfiguration? = nil) -> MockMessage {
-        let mockCompositeMessage: MockMessage = MockMessageFactory.compositeMessage
+        let mockCompositeMessage: MockMessage = MockMessageFactory.compositeMessage()
 
         let mockCompositeMessageData = MockCompositeMessageData()
         let textItem: CompositeMessageItem = .text(mockTextMessage.backingTextMessageData)

--- a/Wire-iOS Tests/Mocks/MockMessage+Creation.swift
+++ b/Wire-iOS Tests/Mocks/MockMessage+Creation.swift
@@ -38,7 +38,9 @@ final class MockMessageFactory: NSObject {
         } else if let sender = sender {
             message.senderUser = sender
         } else {
-            message.senderUser = MockUserType.createSelfUser(name: "Alice")
+            let user = MockUserType.createSelfUser(name: "Tarja Turunen")
+            user.accentColorValue = .strongBlue
+            message.senderUser = user            
         }
         
         conversation?.activeParticipants = [message.senderUser as! MockUserType]

--- a/Wire-iOS Tests/Mocks/MockMessage+Creation.swift
+++ b/Wire-iOS Tests/Mocks/MockMessage+Creation.swift
@@ -23,9 +23,12 @@ import WireLinkPreview
 final class MockMessageFactory: NSObject {
 
     /// Create a template MockMessage with conversation, serverTimestamp, sender and activeParticipants set.
+    /// When sender is not provided, create a new self user and assign as sender of the return message
     ///
     /// - Returns: a MockMessage with default values
-    class func messageTemplate(sender: UserType? = nil) -> MockMessage {
+    class func messageTemplate(sender: UserType? = nil,
+                               defaultSelfUserName: String = "Tarja Turunen",
+                               defaultAccentColorValue: ZMAccentColor = .strongBlue) -> MockMessage {
         let message = MockMessage()
 
         let conversation = MockLoader.mockObjects(of: MockConversation.self, fromFile: "conversations-01.json")[0] as? MockConversation
@@ -38,8 +41,8 @@ final class MockMessageFactory: NSObject {
         } else if let sender = sender {
             message.senderUser = sender
         } else {
-            let user = MockUserType.createSelfUser(name: "Tarja Turunen")
-            user.accentColorValue = .strongBlue
+            let user = MockUserType.createSelfUser(name: defaultSelfUserName)
+            user.accentColorValue = defaultAccentColorValue
             message.senderUser = user            
         }
         

--- a/Wire-iOS Tests/Mocks/MockMessage+Creation.swift
+++ b/Wire-iOS Tests/Mocks/MockMessage+Creation.swift
@@ -20,15 +20,13 @@ import Foundation
 @testable import Wire
 import WireLinkPreview
 
-final class MockMessageFactory: NSObject {
+final class MockMessageFactory {
 
     /// Create a template MockMessage with conversation, serverTimestamp, sender and activeParticipants set.
     /// When sender is not provided, create a new self user and assign as sender of the return message
     ///
     /// - Returns: a MockMessage with default values
-    class func messageTemplate(sender: UserType? = nil,
-                               defaultSelfUserName: String = "Tarja Turunen",
-                               defaultAccentColorValue: ZMAccentColor = .strongBlue) -> MockMessage {
+    class func messageTemplate(sender: UserType? = nil) -> MockMessage {
         let message = MockMessage()
 
         let conversation = MockLoader.mockObjects(of: MockConversation.self, fromFile: "conversations-01.json")[0] as? MockConversation
@@ -41,8 +39,8 @@ final class MockMessageFactory: NSObject {
         } else if let sender = sender {
             message.senderUser = sender
         } else {
-            let user = MockUserType.createSelfUser(name: defaultSelfUserName)
-            user.accentColorValue = defaultAccentColorValue
+            let user = MockUserType.createSelfUser(name: "Tarja Turunen")
+            user.accentColorValue = .strongBlue
             message.senderUser = user            
         }
         
@@ -129,8 +127,8 @@ final class MockMessageFactory: NSObject {
         return message
     }
 
-    class var compositeMessage: MockMessage {
-        let message = MockMessageFactory.messageTemplate()
+    class func compositeMessage(sender: UserType? = nil) -> MockMessage {
+        let message = MockMessageFactory.messageTemplate(sender: sender)
         return message
     }
 

--- a/Wire-iOS/Sources/Helpers/syncengine/ZMUser+Additions.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMUser+Additions.swift
@@ -18,6 +18,11 @@
 
 import WireDataModel
 
+extension UserType {
+    var nameAccentColor: UIColor? {
+        return UIColor.nameColor(for: accentColorValue, variant: ColorScheme.default.variant)
+    }
+}
 
 extension ZMUser {
 
@@ -27,10 +32,6 @@ extension ZMUser {
         #else
         return hasTeam
         #endif
-    }
-
-    var nameAccentColor: UIColor? {
-        return UIColor.nameColor(for: accentColorValue, variant: ColorScheme.default.variant)
     }
 
     /// Blocks user if not already blocked and vice versa.

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionCellHeader.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionCellHeader.swift
@@ -23,23 +23,26 @@ import UIKit
 import WireDataModel
 
 final class CollectionCellHeader: UIView {
-    public var message: ZMConversationMessage? {
+    var message: ZMConversationMessage? {
         didSet {
-            guard let message = self.message, let serverTimestamp = message.serverTimestamp, let sender = message.sender else {
+            guard let message = message,
+                  let serverTimestamp = message.serverTimestamp,
+                  let sender = message.senderUser else {
                 return
             }
             
-            self.nameLabel.textColor = sender.nameAccentColor
-            self.nameLabel.text = sender.name
-            self.dateLabel.text = serverTimestamp.formattedDate
+            nameLabel.textColor = sender.nameAccentColor
+            
+            nameLabel.text = sender.name
+            dateLabel.text = serverTimestamp.formattedDate
         }
     }
     
-    public required init(coder: NSCoder) {
+    required init(coder: NSCoder) {
         fatal("init(coder: NSCoder) is not implemented")
     }
     
-    public override init(frame: CGRect) {
+    override init(frame: CGRect) {
         super.init(frame: frame)
         
         self.addSubview(self.nameLabel)
@@ -55,7 +58,7 @@ final class CollectionCellHeader: UIView {
         }
     }
     
-    public var nameLabel: UILabel = {
+    var nameLabel: UILabel = {
         let label = UILabel()
         label.accessibilityLabel = "sender name"
         label.font = .smallSemiboldFont
@@ -63,7 +66,7 @@ final class CollectionCellHeader: UIView {
         return label
     }()
 
-    public var dateLabel: UILabel = {
+    var dateLabel: UILabel = {
         let label = UILabel()
         label.accessibilityLabel = "sent on"
         label.font = .smallLightFont


### PR DESCRIPTION
## What's new in this PR?

After fix in https://github.com/wireapp/wire-ios/pull/4798, `CompositeMessageCellTests` no long get self user from `CoreDataFixture`, add the new parameter to allow creating a `MockMessage` with custom self user.