### PR TITLE
Fix: ConversationAudioMessageCellTests with injected self user

### DIFF
--- a/Wire-iOS Tests/ConversationCell/CompositeMessageCellTests.swift
+++ b/Wire-iOS Tests/ConversationCell/CompositeMessageCellTests.swift
@@ -22,22 +22,12 @@ final class CompositeMessageCellTests: ConversationCellSnapshotTestCase {
 
     typealias CellConfiguration = (MockMessage) -> Void
     
-    var mockSelfUser: MockUserType!
-
     override func setUp() {
         super.setUp()
 
         // make sure the button's color is alarm red, not accent color
         coreDataFixture.accentColor = .strongBlue
         
-        mockSelfUser = MockUserType.createSelfUser(name: "selfUser")
-        mockSelfUser.accentColorValue = .vividRed
-    }
-
-    override func tearDown() {
-        mockSelfUser = nil
-        
-        super.tearDown()
     }
 
     func testThatItRendersErrorMessage() {

--- a/Wire-iOS Tests/ConversationMessageCell/ConversationAudioMessageCellTests.swift
+++ b/Wire-iOS Tests/ConversationMessageCell/ConversationAudioMessageCellTests.swift
@@ -22,15 +22,24 @@ import XCTest
 
 final class ConversationAudioMessageCellTests: ConversationCellSnapshotTestCase {
     
+    var message: MockMessage!
+
+    override func setUp() {
+        super.setUp()
+        
+        message = MockMessageFactory.audioMessage(sender: mockSelfUser)!
+    }
+
     override func tearDown() {
+        message = nil
         MediaAssetCache.defaultImageCache.cache.removeAllObjects()
+        
         super.tearDown()
     }
 
     // MARK : Uploaded (File not downloaded)
     
     func testUploadedCell_fromThisDevice() {
-        let message = MockMessageFactory.audioMessage()!
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.fileURL = Bundle.main.bundleURL
         
@@ -38,8 +47,7 @@ final class ConversationAudioMessageCellTests: ConversationCellSnapshotTestCase 
     }
     
     func testUploadedCell_fromOtherUser() {
-        let message = MockMessageFactory.audioMessage()!
-        message.sender = MockUser.mockUsers().first!
+        message.senderUser = SwiftMockLoader.mockUsers().first!
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.fileURL = nil
         
@@ -47,8 +55,7 @@ final class ConversationAudioMessageCellTests: ConversationCellSnapshotTestCase 
     }
     
     func testUploadedCell_fromOtherUser_withoutPreview() {
-        let message = MockMessageFactory.audioMessage()!
-        message.sender = MockUser.mockUsers().first!
+        message.senderUser = SwiftMockLoader.mockUsers().first!
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.fileURL = nil
         message.backingFileMessageData.previewData = nil
@@ -57,17 +64,16 @@ final class ConversationAudioMessageCellTests: ConversationCellSnapshotTestCase 
     }
     
     func testUploadedCell_fromOtherUser_withPreview() {
-        let message = MockMessageFactory.audioMessage()!
-        message.sender = MockUser.mockUsers().first!
+        message.senderUser = SwiftMockLoader.mockUsers().first!
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.fileURL = nil
         message.backingFileMessageData.normalizedLoudness = [0.25, 0.5, 1]
         
+        UIColor.setAccentOverride(.strongBlue)
         verify(message: message)
     }
     
     func testUploadedCell_fromThisDevice_bigFileSize() {
-        let message = MockMessageFactory.audioMessage()!
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.fileURL = nil
         (message.backingFileMessageData as!  MockFileMessageData).size = UInt64(1024 * 1024 * 25)
@@ -79,7 +85,6 @@ final class ConversationAudioMessageCellTests: ConversationCellSnapshotTestCase 
     // MARK : Uploading
     
     func testUploadingCell_fromThisDevice() {
-        let message = MockMessageFactory.audioMessage()!
         message.backingFileMessageData.transferState = .uploading
         message.backingFileMessageData.progress = 0.75
         message.backingFileMessageData.fileURL = Bundle.main.bundleURL
@@ -88,8 +93,7 @@ final class ConversationAudioMessageCellTests: ConversationCellSnapshotTestCase 
     }
         
     func testUploadingCell_fromOtherUser() {
-        let message = MockMessageFactory.audioMessage()!
-        message.sender = MockUser.mockUsers().first!
+        message.senderUser = SwiftMockLoader.mockUsers().first!
         message.backingFileMessageData.transferState = .uploading
         message.backingFileMessageData.fileURL = nil
         
@@ -99,7 +103,6 @@ final class ConversationAudioMessageCellTests: ConversationCellSnapshotTestCase 
     // MARK : Downloading
     
     func testDownloadingCell_fromThisDevice() {
-        let message = MockMessageFactory.audioMessage()!
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.downloadState = .downloading
         message.backingFileMessageData.progress = 0.75
@@ -109,8 +112,7 @@ final class ConversationAudioMessageCellTests: ConversationCellSnapshotTestCase 
     }
     
     func testDownloadingCell_fromOtherUser() {
-        let message = MockMessageFactory.audioMessage()!
-        message.sender = MockUser.mockUsers().first!
+        message.senderUser = SwiftMockLoader.mockUsers().first!
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.downloadState = .downloading
         message.backingFileMessageData.progress = 0.75
@@ -122,7 +124,6 @@ final class ConversationAudioMessageCellTests: ConversationCellSnapshotTestCase 
     // MARK : Downloaded
     
     func testDownloadedCell_fromThisDevice() {
-        let message = MockMessageFactory.audioMessage()!
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.downloadState = .downloaded
         message.backingFileMessageData.fileURL = Bundle.main.bundleURL
@@ -131,8 +132,7 @@ final class ConversationAudioMessageCellTests: ConversationCellSnapshotTestCase 
     }
     
     func testDownloadedCell_fromOtherUser() {
-        let message = MockMessageFactory.audioMessage()!
-        message.sender = MockUser.mockUsers().first!
+        message.senderUser = SwiftMockLoader.mockUsers().first!
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.downloadState = .downloaded
         message.backingFileMessageData.fileURL = nil
@@ -143,7 +143,6 @@ final class ConversationAudioMessageCellTests: ConversationCellSnapshotTestCase 
     // MARK : Download Failed
     
     func testFailedDownloadCell_fromThisDevice() {
-        let message = MockMessageFactory.audioMessage()!
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.downloadState = .remote
         message.backingFileMessageData.fileURL = Bundle.main.bundleURL
@@ -152,8 +151,7 @@ final class ConversationAudioMessageCellTests: ConversationCellSnapshotTestCase 
     }
     
     func testFailedDownloadCell_fromOtherUser() {
-        let message = MockMessageFactory.audioMessage()!
-        message.sender = MockUser.mockUsers().first!
+        message.senderUser = SwiftMockLoader.mockUsers().first!
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.downloadState = .remote
         message.backingFileMessageData.fileURL = nil
@@ -164,7 +162,6 @@ final class ConversationAudioMessageCellTests: ConversationCellSnapshotTestCase 
     // MARK : Upload Failed
     
     func testFailedUploadCell_fromThisDevice() {
-        let message = MockMessageFactory.audioMessage()!
         message.backingFileMessageData.transferState = .uploadingFailed
         message.backingFileMessageData.fileURL = Bundle.main.bundleURL
         
@@ -172,8 +169,7 @@ final class ConversationAudioMessageCellTests: ConversationCellSnapshotTestCase 
     }
     
     func testFailedUploadCell_fromOtherUser() {
-        let message = MockMessageFactory.audioMessage()!
-        message.sender = MockUser.mockUsers().first!
+        message.senderUser = SwiftMockLoader.mockUsers().first!
         message.backingFileMessageData.transferState = .uploadingFailed
         message.backingFileMessageData.fileURL = nil
         
@@ -183,7 +179,6 @@ final class ConversationAudioMessageCellTests: ConversationCellSnapshotTestCase 
     // MARK : Upload Cancelled
     
     func testCancelledUploadCell_fromThisDevice() {
-        let message = MockMessageFactory.audioMessage()!
         message.backingFileMessageData.transferState = .uploadingCancelled
         message.backingFileMessageData.fileURL = Bundle.main.bundleURL
         
@@ -191,8 +186,7 @@ final class ConversationAudioMessageCellTests: ConversationCellSnapshotTestCase 
     }
     
     func testCancelledUploadCell_fromOtherUser() {
-        let message = MockMessageFactory.audioMessage()!
-        message.sender = MockUser.mockUsers().first!
+        message.senderUser = SwiftMockLoader.mockUsers().first!
         message.backingFileMessageData.transferState = .uploadingCancelled
         message.backingFileMessageData.fileURL = nil
         
@@ -202,7 +196,6 @@ final class ConversationAudioMessageCellTests: ConversationCellSnapshotTestCase 
     // MARK: No Duration
     
     func testDownloadedCell_fromThisDevice_NoDuration() {
-        let message = MockMessageFactory.audioMessage()!
         message.backingFileMessageData.fileURL = Bundle.main.bundleURL
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.downloadState = .downloaded
@@ -214,7 +207,6 @@ final class ConversationAudioMessageCellTests: ConversationCellSnapshotTestCase 
     // MARK : Obfuscated
     
     func testObfuscatedFileTransferCell() {
-        let message = MockMessageFactory.audioMessage()!
         message.isObfuscated = true
         message.backingFileMessageData.fileURL = Bundle.main.bundleURL
         message.backingFileMessageData.transferState = .uploaded

--- a/Wire-iOS Tests/ConversationMessageCell/ConversationCellSnapshotTestCase.swift
+++ b/Wire-iOS Tests/ConversationMessageCell/ConversationCellSnapshotTestCase.swift
@@ -27,6 +27,8 @@ import SnapshotTesting
 class ConversationCellSnapshotTestCase: XCTestCase, CoreDataFixtureTestHelper {
     var coreDataFixture: CoreDataFixture!
     
+    var mockSelfUser: MockUserType!
+
     fileprivate static let defaultContext = ConversationMessageContext(isSameSenderAsPrevious: false,
                                                                        isTimeIntervalSinceLastMessageSignificant: false,
                                                                        isFirstMessageOfTheDay: false,
@@ -45,6 +47,7 @@ class ConversationCellSnapshotTestCase: XCTestCase, CoreDataFixtureTestHelper {
         }
     }
     
+    
     override class func tearDown() {
         ColorScheme.default.variant = .light
     }
@@ -55,10 +58,14 @@ class ConversationCellSnapshotTestCase: XCTestCase, CoreDataFixtureTestHelper {
         
         ColorScheme.default.variant = .light
         
+        mockSelfUser = MockUserType.createSelfUser(name: "selfUser")
+        mockSelfUser.accentColorValue = .vividRed
     }
-    
+
     override func tearDown() {
         coreDataFixture = nil
+        mockSelfUser = nil
+
         super.tearDown()
     }
     

--- a/Wire-iOS Tests/ConversationMessageCell/ConversationFileMessageCellTests.swift
+++ b/Wire-iOS Tests/ConversationMessageCell/ConversationFileMessageCellTests.swift
@@ -22,13 +22,22 @@ import XCTest
 
 final class ConversationFileMessageTests: ConversationCellSnapshotTestCase {
 
+    var message: MockMessage!
+    
+    override func setUp() {
+        super.setUp()
+        
+        message = MockMessageFactory.fileTransferMessage(sender: mockSelfUser)!
+    }
+    
     override func tearDown() {
+        message = nil
         MediaAssetCache.defaultImageCache.cache.removeAllObjects()
+        
         super.tearDown()
     }
 
     func testUploadedCell_fromThisDevice() {
-        let message = MockMessageFactory.fileTransferMessage()!
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.fileURL = Bundle.main.bundleURL
 
@@ -36,7 +45,6 @@ final class ConversationFileMessageTests: ConversationCellSnapshotTestCase {
     }
 
     func testUploadedCell_fromOtherDevice() {
-        let message = MockMessageFactory.fileTransferMessage()!
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.fileURL = nil
 
@@ -44,8 +52,7 @@ final class ConversationFileMessageTests: ConversationCellSnapshotTestCase {
     }
 
     func testUploadedCell_fromOtherUser() {
-        let message = MockMessageFactory.fileTransferMessage()!
-        message.sender = MockUser.mockUsers().first!
+        message.senderUser = SwiftMockLoader.mockUsers().first!
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.fileURL = nil
 
@@ -53,8 +60,7 @@ final class ConversationFileMessageTests: ConversationCellSnapshotTestCase {
     }
 
     func testUploadedCell_fromThisDevice_longFileName() {
-        let message = MockMessageFactory.fileTransferMessage()!
-        message.sender = MockUser.mockUsers().first!
+        message.senderUser = SwiftMockLoader.mockUsers().first!
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.fileURL = Bundle.main.bundleURL
         message.backingFileMessageData.filename = "Etiam lacus elit, tempor at blandit sit amet, faucibus in erat. Mauris faucibus scelerisque mattis.pdf"
@@ -63,7 +69,6 @@ final class ConversationFileMessageTests: ConversationCellSnapshotTestCase {
     }
 
     func testUploadedCell_fromThisDevice_bigFileSize() {
-        let message = MockMessageFactory.fileTransferMessage()!
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.fileURL = nil
         (message.backingFileMessageData as! MockFileMessageData).size = UInt64(1024 * 1024 * 25)
@@ -72,7 +77,6 @@ final class ConversationFileMessageTests: ConversationCellSnapshotTestCase {
     }
 
     func testUploadingCell_fromThisDevice() {
-        let message = MockMessageFactory.fileTransferMessage()!
         message.backingFileMessageData.transferState = .uploading
         message.backingFileMessageData.fileURL = Bundle.main.bundleURL
 
@@ -80,7 +84,6 @@ final class ConversationFileMessageTests: ConversationCellSnapshotTestCase {
     }
 
     func testUploadingCell_fromOtherDevice() {
-        let message = MockMessageFactory.fileTransferMessage()!
         message.backingFileMessageData.transferState = .uploading
         message.backingFileMessageData.fileURL = nil
 
@@ -88,8 +91,7 @@ final class ConversationFileMessageTests: ConversationCellSnapshotTestCase {
     }
 
     func testUploadingCell_fromOtherUser() {
-        let message = MockMessageFactory.fileTransferMessage()!
-        message.sender = MockUser.mockUsers()?.first!
+        message.senderUser = SwiftMockLoader.mockUsers().first!
         message.backingFileMessageData.transferState = .uploading
         message.backingFileMessageData.fileURL = nil
 
@@ -97,7 +99,6 @@ final class ConversationFileMessageTests: ConversationCellSnapshotTestCase {
     }
 
     func testDownloadingCell_fromThisDevice() {
-        let message = MockMessageFactory.fileTransferMessage()!
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.downloadState = .downloading
         message.backingFileMessageData.progress = 0.75
@@ -107,7 +108,6 @@ final class ConversationFileMessageTests: ConversationCellSnapshotTestCase {
     }
 
     func testDownloadingCell_fromOtherDevice() {
-        let message = MockMessageFactory.fileTransferMessage()!
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.downloadState = .downloading
         message.backingFileMessageData.progress = 0.75
@@ -117,8 +117,7 @@ final class ConversationFileMessageTests: ConversationCellSnapshotTestCase {
     }
 
     func testDownloadingCell_fromOtherUser() {
-        let message = MockMessageFactory.fileTransferMessage()!
-        message.sender = MockUser.mockUsers()?.first!
+        message.senderUser = SwiftMockLoader.mockUsers().first!
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.downloadState = .downloading
         message.backingFileMessageData.progress = 0.75
@@ -128,7 +127,6 @@ final class ConversationFileMessageTests: ConversationCellSnapshotTestCase {
     }
 
     func testDownloadedCell_fromThisDevice() {
-        let message = MockMessageFactory.fileTransferMessage()!
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.downloadState = .downloaded
         message.backingFileMessageData.fileURL = Bundle.main.bundleURL
@@ -137,7 +135,6 @@ final class ConversationFileMessageTests: ConversationCellSnapshotTestCase {
     }
 
     func testDownloadedCell_fromOtherDevice() {
-        let message = MockMessageFactory.fileTransferMessage()!
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.downloadState = .downloaded
         message.backingFileMessageData.fileURL = nil
@@ -146,8 +143,7 @@ final class ConversationFileMessageTests: ConversationCellSnapshotTestCase {
     }
 
     func testDownloadedCell_fromOtherUser() {
-        let message = MockMessageFactory.fileTransferMessage()!
-        message.sender = MockUser.mockUsers()?.first!
+        message.senderUser = SwiftMockLoader.mockUsers().first!
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.downloadState = .downloaded
         message.backingFileMessageData.fileURL = nil
@@ -166,7 +162,6 @@ final class ConversationFileMessageTests: ConversationCellSnapshotTestCase {
     }
 
     func testFailedDownloadCell_fromThisDevice() {
-        let message = MockMessageFactory.fileTransferMessage()!
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.downloadState = .remote
         message.backingFileMessageData.fileURL = Bundle.main.bundleURL
@@ -175,7 +170,6 @@ final class ConversationFileMessageTests: ConversationCellSnapshotTestCase {
     }
 
     func testFailedDownloadCell_fromOtherDevice() {
-        let message = MockMessageFactory.fileTransferMessage()!
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.downloadState = .remote
         message.backingFileMessageData.fileURL = nil
@@ -184,8 +178,7 @@ final class ConversationFileMessageTests: ConversationCellSnapshotTestCase {
     }
 
     func testFailedDownloadCell_fromOtherUser() {
-        let message = MockMessageFactory.fileTransferMessage()!
-        message.sender = MockUser.mockUsers()?.first!
+        message.senderUser = SwiftMockLoader.mockUsers().first!
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.downloadState = .remote
         message.backingFileMessageData.fileURL = nil
@@ -194,7 +187,6 @@ final class ConversationFileMessageTests: ConversationCellSnapshotTestCase {
     }
 
     func testFailedUploadCell_fromThisDevice() {
-        let message = MockMessageFactory.fileTransferMessage()!
         message.backingFileMessageData.transferState = .uploadingFailed
         message.backingFileMessageData.fileURL = Bundle.main.bundleURL
 
@@ -202,7 +194,6 @@ final class ConversationFileMessageTests: ConversationCellSnapshotTestCase {
     }
 
     func testFailedUploadCell_fromOtherDevice() {
-        let message = MockMessageFactory.fileTransferMessage()!
         message.backingFileMessageData.transferState = .uploadingFailed
         message.backingFileMessageData.fileURL = nil
 
@@ -210,8 +201,7 @@ final class ConversationFileMessageTests: ConversationCellSnapshotTestCase {
     }
 
     func testFailedUploadCell_fromOtherUser() {
-        let message = MockMessageFactory.fileTransferMessage()!
-        message.sender = MockUser.mockUsers()?.first!
+        message.senderUser = SwiftMockLoader.mockUsers().first!
         message.backingFileMessageData.transferState = .uploadingFailed
         message.backingFileMessageData.fileURL = nil
 
@@ -221,7 +211,6 @@ final class ConversationFileMessageTests: ConversationCellSnapshotTestCase {
     // MARK : Upload Cancelled
 
     func testCancelledUploadCell_fromThisDevice() {
-        let message = MockMessageFactory.fileTransferMessage()!
         message.backingFileMessageData.transferState = .uploadingCancelled
         message.backingFileMessageData.fileURL = Bundle.main.bundleURL
 
@@ -231,7 +220,6 @@ final class ConversationFileMessageTests: ConversationCellSnapshotTestCase {
     // MARK : Obfuscated
 
     func testObfuscatedFileTransferCell() {
-        let message = MockMessageFactory.fileTransferMessage()!
         message.isObfuscated = true
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.fileURL = Bundle.main.bundleURL

--- a/Wire-iOS Tests/ConversationMessageCell/ConversationTextMessageTests.swift
+++ b/Wire-iOS Tests/ConversationMessageCell/ConversationTextMessageTests.swift
@@ -22,10 +22,24 @@ import WireLinkPreview
 
 final class ConversationTextMessageTests: ConversationCellSnapshotTestCase {
 
+    var mockOtherUser: MockUserType!
+    
+    override func setUp() {
+        super.setUp()
+        
+        mockOtherUser = MockUserType.createConnectedUser(name: "Bruno")
+    }
+    
+    override func tearDown() {
+        mockOtherUser = nil
+        
+        super.tearDown()
+    }
+    
     func testPlainText() {
         // GIVEN
         let message = MockMessageFactory.textMessage(withText: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. ")!
-        message.sender = otherUser
+        message.senderUser = mockOtherUser
         
         // THEN
         verify(message: message)
@@ -43,7 +57,7 @@ final class ConversationTextMessageTests: ConversationCellSnapshotTestCase {
         }
         let article = ArticleMetadata(protocolBuffer: linkPreview)
         let message = MockMessageFactory.textMessage(withText: "http://www.example.com")!
-        message.sender = otherUser
+        message.senderUser = mockOtherUser
         message.backingTextMessageData.backingLinkPreview = article
         
         // THEN
@@ -62,7 +76,7 @@ final class ConversationTextMessageTests: ConversationCellSnapshotTestCase {
         }
         let article = ArticleMetadata(protocolBuffer: linkPreview)
         let message = MockMessageFactory.textMessage(withText: "What do you think about this http://www.example.com")!
-        message.sender = otherUser
+        message.senderUser = mockOtherUser
         message.backingTextMessageData.backingLinkPreview = article
         
         // THEN
@@ -75,7 +89,7 @@ final class ConversationTextMessageTests: ConversationCellSnapshotTestCase {
         let quote = try! conversation.appendText(content: "Who is responsible for this!")
         (quote as? ZMMessage)?.serverTimestamp = Date.distantPast
         let message = MockMessageFactory.textMessage(withText: "I am")!
-        message.sender = otherUser
+        message.senderUser = mockOtherUser
         message.backingTextMessageData.hasQuote = true
         message.backingTextMessageData.quote = (quote as Any as! ZMMessage)
         
@@ -98,7 +112,7 @@ final class ConversationTextMessageTests: ConversationCellSnapshotTestCase {
         let quote = try! conversation.appendText(content: "Who is responsible for this!")
         (quote as? ZMMessage)?.serverTimestamp = Date.distantPast
         let message = MockMessageFactory.textMessage(withText: "I am http://www.example.com")!
-        message.sender = otherUser
+        message.senderUser = mockOtherUser
         message.backingTextMessageData.backingLinkPreview = article
         message.backingTextMessageData.hasQuote = true
         message.backingTextMessageData.quote = (quote as Any as! ZMMessage)
@@ -110,7 +124,7 @@ final class ConversationTextMessageTests: ConversationCellSnapshotTestCase {
     func testMediaPreviewAttachment() {
         // GIVEN
         let message = MockMessageFactory.textMessage(withText: "https://www.youtube.com/watch?v=l7aqpSTa234")!
-        message.sender = otherUser
+        message.senderUser = mockOtherUser
         message.linkAttachments = [
             LinkAttachment(type: .youTubeVideo, title: "Lagar mat med Fernando Di Luca",
                            permalink: URL(string: "https://www.youtube.com/watch?v=l7aqpSTa234")!,
@@ -124,7 +138,7 @@ final class ConversationTextMessageTests: ConversationCellSnapshotTestCase {
     func testSoundCloudMediaPreviewAttachment() {
         // GIVEN
         let message = MockMessageFactory.textMessage(withText: "https://soundcloud.com/bridgitmendler/bridgit-mendler-atlantis-feat-kaiydo")!
-        message.sender = otherUser
+        message.senderUser = mockOtherUser
         message.linkAttachments = [
             LinkAttachment(type: .soundCloudTrack, title: "Bridgit Mendler - Atlantis feat. Kaiydo",
                            permalink: URL(string: "https://soundcloud.com/bridgitmendler/bridgit-mendler-atlantis-feat-kaiydo")!,
@@ -138,7 +152,7 @@ final class ConversationTextMessageTests: ConversationCellSnapshotTestCase {
     func testSoundCloudSetMediaPreviewAttachment() {
         // GIVEN
         let message = MockMessageFactory.textMessage(withText: "https://soundcloud.com/playback/sets/2019-artists-to-watch")!
-        message.sender = otherUser
+        message.senderUser = mockOtherUser
         message.linkAttachments = [
             LinkAttachment(type: .soundCloudPlaylist, title: "Artists To Watch 2019",
                            permalink: URL(string: "https://soundcloud.com/playback/sets/2019-artists-to-watch")!,
@@ -161,7 +175,7 @@ final class ConversationTextMessageTests: ConversationCellSnapshotTestCase {
         }
         let article = ArticleMetadata(protocolBuffer: linkPreview)
         let message = MockMessageFactory.textMessage(withText: "Look at this! https://www.youtube.com/watch?v=l7aqpSTa234")!
-        message.sender = otherUser
+        message.senderUser = mockOtherUser
         message.backingTextMessageData.backingLinkPreview = article
         message.linkAttachments = [
             LinkAttachment(type: .youTubeVideo, title: "Lagar mat med Fernando Di Luca",

--- a/Wire-iOS Tests/Mocks/MockMessage+Creation.swift
+++ b/Wire-iOS Tests/Mocks/MockMessage+Creation.swift
@@ -49,8 +49,8 @@ final class MockMessageFactory {
         return message
     }
 
-    class func fileTransferMessage() -> MockMessage? {
-        let message: MockMessage? = MockMessageFactory.messageTemplate()
+    class func fileTransferMessage(sender: UserType? = nil) -> MockMessage? {
+        let message: MockMessage? = MockMessageFactory.messageTemplate(sender: sender)
 
         message?.backingFileMessageData = MockFileMessageData()
         return message
@@ -140,8 +140,8 @@ final class MockMessageFactory {
         return message
     }
 
-    class func audioMessage() -> MockMessage? {
-        let message: MockMessage? = self.fileTransferMessage()
+    class func audioMessage(sender: UserType? = nil) -> MockMessage? {
+        let message: MockMessage? = fileTransferMessage(sender: sender)
         message?.backingFileMessageData.mimeType = "audio/x-m4a"
         return message
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
@@ -217,9 +217,9 @@ final class AudioMessageView: UIView, TransferView {
 
         var visibleViews = [self.playButton, self.timeLabel]
 
-        if (fileMessageData.normalizedLoudness?.count ?? 0 > 0) {
+        if (fileMessageData.normalizedLoudness?.isEmpty == false) {
             waveformProgressView.samples = fileMessageData.normalizedLoudness ?? []
-            if let accentColor = fileMessage.sender?.accentColor {
+            if let accentColor = fileMessage.senderUser?.accentColor {
                 waveformProgressView.barColor = accentColor
                 waveformProgressView.highlightedBarColor = UIColor.gray
             }


### PR DESCRIPTION
## What's new in this PR?

After fix in #4798 & https://github.com/wireapp/wire-ios/pull/4801, `ConversationAudioMessageCellTests` no long get self user from CoreDataFixture, add the new parameter to allow creating a MockMessage(audioMessage) with the custom self user.