### PR TITLE
Fix: MessageToolboxViewTests

### DIFF
--- a/Wire-iOS Tests/ConversationCell/LocationMessageCellTests.swift
+++ b/Wire-iOS Tests/ConversationCell/LocationMessageCellTests.swift
@@ -23,6 +23,15 @@ final class LocationMessageCellTests: ConversationCellSnapshotTestCase {
 
     typealias CellConfiguration = (MockMessage) -> Void
 
+    var sut: ImageMessageView!
+    
+    override func setUp() {
+        super.setUp()
+        
+        mockSelfUser.name = "selfUser"
+        mockSelfUser.accentColorValue = .vividRed
+    }
+    
     /// Disabled since the MKMApView makes the test flaky (The map view is black when running on local machine)
     func disabled_testThatItRendersLocationCellWithAddressCorrect() {
         // This is experimental as the MKMapView might break the snapshot tests,
@@ -37,15 +46,15 @@ final class LocationMessageCellTests: ConversationCellSnapshotTestCase {
     }
 
     func testThatItRendersLocationCellObfuscated() {
-        verify(message: makeMessage {
+        verify(message: makeMessage() {
             $0.isObfuscated = true
         })
     }
 
     // MARK: - Helpers
 
-    func makeMessage(_ config: CellConfiguration? = nil) -> MockMessage {
-        let locationMessage = MockMessageFactory.locationMessage()!
+    private func makeMessage(_ config: CellConfiguration? = nil) -> MockMessage {
+        let locationMessage = MockMessageFactory.locationMessage(sender: mockSelfUser)!
         locationMessage.backingLocationMessageData?.name = "Berlin, Germany"
 
         config?(locationMessage)

--- a/Wire-iOS Tests/ConversationMessageCell/ConversationVideoMessageCellTests.swift
+++ b/Wire-iOS Tests/ConversationMessageCell/ConversationVideoMessageCellTests.swift
@@ -22,15 +22,25 @@ import XCTest
 
 final class ConversationVideoMessageCellTests: ConversationCellSnapshotTestCase {
 
+    var message: MockMessage!
+    
+    override func setUp() {
+        super.setUp()
+        
+        message = MockMessageFactory.videoMessage(sender: mockSelfUser,
+                                                  previewImage: image(inTestBundleNamed: "unsplash_matterhorn.jpg"))!
+    }
+    
     override func tearDown() {
+        message = nil
         MediaAssetCache.defaultImageCache.cache.removeAllObjects()
+        
         super.tearDown()
     }
 
     // MARK : Uploaded (File not downloaded)
     
     func testUploadedCell_fromThisDevice() {
-        let message = MockMessageFactory.videoMessage(previewImage: image(inTestBundleNamed: "unsplash_matterhorn.jpg"))!
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.fileURL = Bundle.main.bundleURL
         
@@ -38,8 +48,7 @@ final class ConversationVideoMessageCellTests: ConversationCellSnapshotTestCase 
     }
     
     func testUploadedCell_fromOtherUser() {
-        let message = MockMessageFactory.videoMessage(previewImage: image(inTestBundleNamed: "unsplash_matterhorn.jpg"))!
-        message.sender = MockUser.mockUsers().first!
+        message.senderUser = SwiftMockLoader.mockUsers().first!
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.fileURL = nil
         
@@ -48,7 +57,7 @@ final class ConversationVideoMessageCellTests: ConversationCellSnapshotTestCase 
     
     func testUploadedCell_fromOtherUser_withoutPreview() {
         let message = MockMessageFactory.videoMessage()!
-        message.sender = MockUser.mockUsers().first!
+        message.senderUser = SwiftMockLoader.mockUsers().first!
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.fileURL = nil
         
@@ -56,7 +65,6 @@ final class ConversationVideoMessageCellTests: ConversationCellSnapshotTestCase 
     }
     
     func testUploadedCell_fromThisDevice_bigFileSize() {
-        let message = MockMessageFactory.videoMessage(previewImage: image(inTestBundleNamed: "unsplash_matterhorn.jpg"))!
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.fileURL = Bundle.main.bundleURL
         (message.backingFileMessageData as! MockFileMessageData).size = UInt64(1024 * 1024 * 25)
@@ -68,7 +76,6 @@ final class ConversationVideoMessageCellTests: ConversationCellSnapshotTestCase 
     // MARK : Uploading
     
     func testUploadingCell_fromThisDevice() {
-        let message = MockMessageFactory.videoMessage(previewImage: image(inTestBundleNamed: "unsplash_matterhorn.jpg"))!
         message.backingFileMessageData.transferState = .uploading
         message.backingFileMessageData.progress = 0.75
         message.backingFileMessageData.fileURL = Bundle.main.bundleURL
@@ -78,7 +85,7 @@ final class ConversationVideoMessageCellTests: ConversationCellSnapshotTestCase 
     
     func testUploadingCell_fromOtherUser_withoutPreview() {
         let message = MockMessageFactory.videoMessage()!
-        message.sender = MockUser.mockUsers().first!
+        message.senderUser = SwiftMockLoader.mockUsers().first!
         message.backingFileMessageData.transferState = .uploading
         message.backingFileMessageData.fileURL = nil
         
@@ -86,8 +93,7 @@ final class ConversationVideoMessageCellTests: ConversationCellSnapshotTestCase 
     }
     
     func testUploadingCell_fromOtherUser() {
-        let message = MockMessageFactory.videoMessage(previewImage: image(inTestBundleNamed: "unsplash_matterhorn.jpg"))!
-        message.sender = MockUser.mockUsers().first!
+        message.senderUser = SwiftMockLoader.mockUsers().first!
         message.backingFileMessageData.transferState = .uploading
         message.backingFileMessageData.fileURL = nil
         
@@ -97,7 +103,6 @@ final class ConversationVideoMessageCellTests: ConversationCellSnapshotTestCase 
     // MARK : Downloading
     
     func testDownloadingCell_fromThisDevice() {
-        let message = MockMessageFactory.videoMessage(previewImage: image(inTestBundleNamed: "unsplash_matterhorn.jpg"))!
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.downloadState = .downloading
         message.backingFileMessageData.progress = 0.75
@@ -107,8 +112,7 @@ final class ConversationVideoMessageCellTests: ConversationCellSnapshotTestCase 
     }
     
     func testDownloadingCell_fromOtherUser() {
-        let message = MockMessageFactory.videoMessage(previewImage: image(inTestBundleNamed: "unsplash_matterhorn.jpg"))!
-        message.sender = MockUser.mockUsers().first!
+        message.senderUser = SwiftMockLoader.mockUsers().first!
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.downloadState = .downloading
         message.backingFileMessageData.fileURL = nil
@@ -119,7 +123,6 @@ final class ConversationVideoMessageCellTests: ConversationCellSnapshotTestCase 
     // MARK : Downloaded
     
     func testDownloadedCell_fromThisDevice() {
-        let message = MockMessageFactory.videoMessage(previewImage: image(inTestBundleNamed: "unsplash_matterhorn.jpg"))!
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.downloadState = .downloaded
         message.backingFileMessageData.fileURL = Bundle.main.bundleURL
@@ -128,8 +131,7 @@ final class ConversationVideoMessageCellTests: ConversationCellSnapshotTestCase 
     }
     
     func testDownloadedCell_fromOtherUser() {
-        let message = MockMessageFactory.videoMessage(previewImage: image(inTestBundleNamed: "unsplash_matterhorn.jpg"))!
-        message.sender = MockUser.mockUsers().first!
+        message.senderUser = SwiftMockLoader.mockUsers().first!
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.downloadState = .downloaded
         message.backingFileMessageData.fileURL = nil
@@ -140,7 +142,6 @@ final class ConversationVideoMessageCellTests: ConversationCellSnapshotTestCase 
     // MARK : Download Failed
     
     func testFailedDownloadCell_fromThisDevice() {
-        let message = MockMessageFactory.videoMessage(previewImage: image(inTestBundleNamed: "unsplash_matterhorn.jpg"))!
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.downloadState = .remote
         message.backingFileMessageData.fileURL = Bundle.main.bundleURL
@@ -149,8 +150,7 @@ final class ConversationVideoMessageCellTests: ConversationCellSnapshotTestCase 
     }
     
     func testFailedDownloadCell_fromOtherUser() {
-        let message = MockMessageFactory.videoMessage(previewImage: image(inTestBundleNamed: "unsplash_matterhorn.jpg"))!
-        message.sender = MockUser.mockUsers().first!
+        message.senderUser = SwiftMockLoader.mockUsers().first!
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.downloadState = .remote
         message.backingFileMessageData.fileURL = nil
@@ -161,7 +161,6 @@ final class ConversationVideoMessageCellTests: ConversationCellSnapshotTestCase 
     // MARK : Upload Failed
     
     func testFailedUploadCell_fromThisDevice() {
-        let message = MockMessageFactory.videoMessage(previewImage: image(inTestBundleNamed: "unsplash_matterhorn.jpg"))!
         message.backingFileMessageData.transferState = .uploadingFailed
         message.backingFileMessageData.fileURL = Bundle.main.bundleURL
         
@@ -169,8 +168,7 @@ final class ConversationVideoMessageCellTests: ConversationCellSnapshotTestCase 
     }
     
     func testFailedUploadCell_fromOtherUser() {
-        let message = MockMessageFactory.videoMessage(previewImage: image(inTestBundleNamed: "unsplash_matterhorn.jpg"))!
-        message.sender = MockUser.mockUsers().first!
+        message.senderUser = SwiftMockLoader.mockUsers().first!
         message.backingFileMessageData.transferState = .uploadingFailed
         message.backingFileMessageData.fileURL = nil
         
@@ -180,7 +178,6 @@ final class ConversationVideoMessageCellTests: ConversationCellSnapshotTestCase 
     // MARK : Upload Cancelled
     
     func testCancelledUploadCell_fromThisDevice() {
-        let message = MockMessageFactory.videoMessage(previewImage: image(inTestBundleNamed: "unsplash_matterhorn.jpg"))!
         message.backingFileMessageData.transferState = .uploadingCancelled
         message.backingFileMessageData.fileURL = Bundle.main.bundleURL
         
@@ -188,8 +185,7 @@ final class ConversationVideoMessageCellTests: ConversationCellSnapshotTestCase 
     }
     
     func testCancelledUploadCell_fromOtherUser() {
-        let message = MockMessageFactory.videoMessage(previewImage: image(inTestBundleNamed: "unsplash_matterhorn.jpg"))!
-        message.sender = MockUser.mockUsers().first!
+        message.senderUser = SwiftMockLoader.mockUsers().first!
         message.backingFileMessageData.transferState = .uploadingCancelled
         message.backingFileMessageData.fileURL = nil
         
@@ -199,7 +195,6 @@ final class ConversationVideoMessageCellTests: ConversationCellSnapshotTestCase 
     // MARK: No Duration
     
     func testDownloadedCell_fromThisDevice_NoDuration() {
-        let message = MockMessageFactory.videoMessage(previewImage: image(inTestBundleNamed: "unsplash_matterhorn.jpg"))!
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.downloadState = .downloaded
         message.backingFileMessageData.fileURL = Bundle.main.bundleURL
@@ -211,7 +206,6 @@ final class ConversationVideoMessageCellTests: ConversationCellSnapshotTestCase 
     // MARK : Obfuscated
     
     func testObfuscatedFileTransferCell() {
-        let message = MockMessageFactory.videoMessage(previewImage: image(inTestBundleNamed: "unsplash_matterhorn.jpg"))!
         message.isObfuscated = true
         message.backingFileMessageData.transferState = .uploaded
         message.backingFileMessageData.fileURL = Bundle.main.bundleURL

--- a/Wire-iOS Tests/ImageMessageViewTests.swift
+++ b/Wire-iOS Tests/ImageMessageViewTests.swift
@@ -35,9 +35,9 @@ final class ImageMessageViewTests: XCTestCase {
 
     override func tearDown() {
         sut = nil
+        mockSelfUser = nil
         super.tearDown()
     }
-
 
     func testThatItRendersSmallImage() {
         // GIVEN & WHEN

--- a/Wire-iOS Tests/ImageMessageViewTests.swift
+++ b/Wire-iOS Tests/ImageMessageViewTests.swift
@@ -21,9 +21,14 @@ import XCTest
 
 final class ImageMessageViewTests: XCTestCase {
     var sut: ImageMessageView!
+    var mockSelfUser: MockUserType!
 
     override func setUp() {
         super.setUp()
+
+        mockSelfUser = MockUserType.createSelfUser(name: "Tarja Turunen")
+        mockSelfUser.accentColorValue = .vividRed
+
         sut = ImageMessageView()
         sut.widthAnchor.constraint(equalToConstant: 320).isActive = true
     }
@@ -36,28 +41,31 @@ final class ImageMessageViewTests: XCTestCase {
 
     func testThatItRendersSmallImage() {
         // GIVEN & WHEN
-        sut.message = MockMessageFactory.imageMessage(with: self.image(inTestBundleNamed: "unsplash_small.jpg"))
+        sut.message = MockMessageFactory.imageMessage(sender: mockSelfUser,
+                                                      with: image(inTestBundleNamed: "unsplash_small.jpg"))
         // THEN
         verify(matching: sut)
     }
     
     func testThatItRendersPortraitImage() {
         // GIVEN & WHEN
-        sut.message = MockMessageFactory.imageMessage(with: self.image(inTestBundleNamed: "unsplash_burger.jpg"))
+        sut.message = MockMessageFactory.imageMessage(sender: mockSelfUser,
+                                                      with: image(inTestBundleNamed: "unsplash_burger.jpg"))
         // THEN
         verify(matching: sut)
     }
     
     func testThatItRendersLandscapeImage() {
         // GIVEN & WHEN
-        sut.message = MockMessageFactory.imageMessage(with: self.image(inTestBundleNamed: "unsplash_matterhorn.jpg"))
+        sut.message = MockMessageFactory.imageMessage(sender: mockSelfUser,
+                                                      with: image(inTestBundleNamed: "unsplash_matterhorn.jpg"))
         // THEN
         verify(matching: sut)
     }
     
     func testThatItShowsLoadingIndicator() {
         // GIVEN & WHEN
-        sut.message = MockMessageFactory.pendingImageMessage()
+        sut.message = MockMessageFactory.pendingImageMessage(sender: mockSelfUser)
         // THEN
         verify(matching: sut)
     }

--- a/Wire-iOS Tests/MessageDetails/MessageDetailsActionTests.swift
+++ b/Wire-iOS Tests/MessageDetails/MessageDetailsActionTests.swift
@@ -65,7 +65,7 @@ class MessageDetailsActionTests: CoreDataSnapshotTestCase {
 
     func testThatDetailsAreAvailableInTeamGroup_WithoutReceipts_OtherUserMessage() {
         withGroupMessage(belongsToTeam: true, teamGroup: true) { message in
-            message.sender = self.otherUser
+            message.senderUser = self.otherUser
             XCTAssertTrue(message.areMessageDetailsAvailable)
             XCTAssertFalse(message.areReadReceiptsDetailsAvailable)
         }

--- a/Wire-iOS Tests/Mocks/MockMessage+Creation.swift
+++ b/Wire-iOS Tests/Mocks/MockMessage+Creation.swift
@@ -56,7 +56,7 @@ final class MockMessageFactory {
         return message
     }
 
-    class func imageMessage(with image: UIImage?) -> MockMessage? {
+    class func imageMessage(sender: UserType? = nil, with image: UIImage?) -> MockMessage? {
         let imageData = MockImageMessageData()
         if let image = image, let data = image.imageData {
             imageData.mockImageData = data
@@ -66,24 +66,24 @@ final class MockMessageFactory {
             imageData.isDownloaded = false
         }
 
-        let message: MockMessage? = self.imageMessage()
+        let message: MockMessage? = imageMessage(sender: sender)
         message?.imageMessageData = imageData
 
         return message
     }
 
-    class func imageMessage() -> MockMessage? {
-        let message: MockMessage? = MockMessageFactory.messageTemplate()
+    class func imageMessage(sender: UserType? = nil) -> MockMessage? {
+        let message: MockMessage? = MockMessageFactory.messageTemplate(sender: sender)
 
         message?.imageMessageData = MockImageMessageData()
 
         return message
     }
 
-    class func pendingImageMessage() -> MockMessage? {
+    class func pendingImageMessage(sender: UserType? = nil) -> MockMessage? {
         let imageData = MockImageMessageData()
 
-        let message: MockMessage? = self.imageMessage()
+        let message: MockMessage? = imageMessage(sender: sender)
         message?.imageMessageData = imageData
 
         return message

--- a/Wire-iOS Tests/Mocks/MockMessage+Creation.swift
+++ b/Wire-iOS Tests/Mocks/MockMessage+Creation.swift
@@ -132,8 +132,9 @@ final class MockMessageFactory {
         return message
     }
 
-    class func videoMessage(previewImage: UIImage? = nil) -> MockMessage? {
-        let message: MockMessage? = self.fileTransferMessage()
+    class func videoMessage(sender: UserType? = nil,
+                            previewImage: UIImage? = nil) -> MockMessage? {
+        let message: MockMessage? = fileTransferMessage(sender: sender)
         message?.backingFileMessageData.mimeType = "video/mp4"
         message?.backingFileMessageData.filename = "vacation.mp4"
         message?.backingFileMessageData.previewData = previewImage?.jpegData(compressionQuality: 0.9)

--- a/Wire-iOS Tests/Mocks/MockMessage+Creation.swift
+++ b/Wire-iOS Tests/Mocks/MockMessage+Creation.swift
@@ -120,8 +120,8 @@ final class MockMessageFactory {
         return message
     }
 
-    class func locationMessage() -> MockMessage? {
-        let message = MockMessageFactory.messageTemplate()
+    class func locationMessage(sender: MockUserType? = nil) -> MockMessage? {
+        let message = MockMessageFactory.messageTemplate(sender: sender)
 
         message.backingLocationMessageData = MockLocationMessageData()
         return message

--- a/Wire-iOS/Sources/Managers/SoundEventListener.swift
+++ b/Wire-iOS/Sources/Managers/SoundEventListener.swift
@@ -17,13 +17,12 @@
 //
 
 import Foundation
-import WireDataModel
 import WireSyncEngine
 import avs
 
 extension ZMConversationMessage {
     var isSentBySelfUser: Bool {
-        return self.sender?.isSelfUser ?? false
+        return senderUser?.isSelfUser ?? false
     }
     
     var isRecentMessage: Bool {

--- a/Wire-iOS/Sources/UserInterface/Components/ImageMessageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/ImageMessageView.swift
@@ -55,9 +55,9 @@ final class ImageMessageView: UIView {
     var message: ZMConversationMessage? {
         didSet {
             if let message = self.message {
-                self.user = message.sender
+                user = message.senderUser
                 
-                self.updateForImage()
+                updateForImage()
             }
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxDataSource.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxDataSource.swift
@@ -99,7 +99,7 @@ class MessageToolboxDataSource {
     func updateContent(forceShowTimestamp: Bool, widthConstraint: CGFloat) -> SlideDirection? {
         // Compute the state
         let likers = message.likers()
-        let isSentBySelfUser = message.sender?.isSelfUser == true
+        let isSentBySelfUser = message.senderUser?.isSelfUser == true
         let failedToSend = message.deliveryState == .failedToSend && isSentBySelfUser
         let showTimestamp = forceShowTimestamp || likers.isEmpty
         let previousContent = self.content
@@ -227,7 +227,7 @@ class MessageToolboxDataSource {
 
     /// Returns the status for the sender of the message.
     fileprivate func selfStatus(for message: ZMConversationMessage) -> NSAttributedString? {
-        guard let sender = message.sender,
+        guard let sender = message.senderUser,
             sender.isSelfUser else { return nil }
 
         var deliveryStateString: String

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
@@ -155,7 +155,7 @@ final class MessageToolboxView: UIView {
         addGestureRecognizer(tapGestureRecogniser)
     }
 
-    required public init?(coder aDecoder: NSCoder) {
+    required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     


### PR DESCRIPTION
## What's new in this PR?

Fix failed `MessageToolboxViewTests` tests after `mesage.sender` is update to `mesage.senderUser`