### PR TITLE
create ConnectionRequest protocol for testing ConnectRequestsViewController

### DIFF
--- a/Wire-iOS Tests/ConnectRequestsViewControllerSnapshotTests.swift
+++ b/Wire-iOS Tests/ConnectRequestsViewControllerSnapshotTests.swift
@@ -20,25 +20,31 @@ import XCTest
 @testable import Wire
 import SnapshotTesting
 
-final class ConnectRequestsViewControllerSnapshotTests: XCTestCase, CoreDataFixtureTestHelper {
+final class MockCnnectionRequest: ConnectionRequest {
+    var connectedUser: UserType?
+}
+
+final class ConnectRequestsViewControllerSnapshotTests: XCTestCase {
     
     var sut: ConnectRequestsViewController!
-    var mockConversation: ZMConversation!
+    var mockConversation: MockConversation!
 
-    var coreDataFixture: CoreDataFixture!
-    
     override func setUp() {
         super.setUp()
 
-        coreDataFixture = CoreDataFixture()
+        UIColor.setAccentOverride(.vividRed)
 
         sut = ConnectRequestsViewController()
 
         sut.loadViewIfNeeded()
 
-        mockConversation = otherUserConversation
-
-        sut.connectionRequests = [mockConversation]
+        let mockCnnectionRequest = MockCnnectionRequest()
+        let mockUser = MockUserType.createSelfUser(name: "Bruno")
+        mockUser.accentColorValue = .brightOrange
+        mockUser.handle = "bruno"
+        mockCnnectionRequest.connectedUser = mockUser
+        
+        sut.connectionRequests = [mockCnnectionRequest]
         sut.reload()
 
         sut.view.frame = CGRect(origin: .zero, size: CGSize.iPhoneSize.iPhone4_7)
@@ -47,7 +53,6 @@ final class ConnectRequestsViewControllerSnapshotTests: XCTestCase, CoreDataFixt
     override func tearDown() {
         sut = nil
         mockConversation = nil
-        coreDataFixture = nil
 
         super.tearDown()
     }
@@ -56,18 +61,15 @@ final class ConnectRequestsViewControllerSnapshotTests: XCTestCase, CoreDataFixt
         verify(matching: sut)
     }
 
-    func testForTwoRequests() {
-        let otherUser = ZMUser.insertNewObject(in: coreDataFixture.uiMOC)
-        otherUser.remoteIdentifier = UUID()
-        otherUser.name = "Bill"
-        otherUser.setHandle("bill")
+    /*func testForTwoRequests() {
+        let otherUser = MockUserType.createUser(name: "Bill")
         otherUser.accentColorValue = .brightYellow
         
-        let requestConversation = ZMConversation.createOtherUserConversation(moc: coreDataFixture.uiMOC, otherUser: otherUser)
+        let requestConversation = MockConversation.oneOnOneConversation()
         
-        sut.connectionRequests = [requestConversation, mockConversation]
+        sut.connectionRequests = [requestConversation.convertToRegularConversation(), mockConversation.convertToRegularConversation()]
         sut.reload(animated: false)
         
         verify(matching: sut)
-    }
+    }*/
 }

--- a/Wire-iOS Tests/ConnectRequestsViewControllerSnapshotTests.swift
+++ b/Wire-iOS Tests/ConnectRequestsViewControllerSnapshotTests.swift
@@ -19,15 +19,16 @@
 import XCTest
 @testable import Wire
 import SnapshotTesting
+import WireDataModel
 
 final class MockCnnectionRequest: ConnectionRequest {
-    var connectedUser: UserType?
+    var connectedUserType: UserType?
 }
 
 final class ConnectRequestsViewControllerSnapshotTests: XCTestCase {
     
     var sut: ConnectRequestsViewController!
-    var mockConversation: MockConversation!
+    var mockConnectionRequest: MockCnnectionRequest!
 
     override func setUp() {
         super.setUp()
@@ -38,13 +39,13 @@ final class ConnectRequestsViewControllerSnapshotTests: XCTestCase {
 
         sut.loadViewIfNeeded()
 
-        let mockCnnectionRequest = MockCnnectionRequest()
+        mockConnectionRequest = MockCnnectionRequest()
         let mockUser = MockUserType.createSelfUser(name: "Bruno")
         mockUser.accentColorValue = .brightOrange
         mockUser.handle = "bruno"
-        mockCnnectionRequest.connectedUser = mockUser
+        mockConnectionRequest.connectedUserType = mockUser
         
-        sut.connectionRequests = [mockCnnectionRequest]
+        sut.connectionRequests = [mockConnectionRequest]
         sut.reload()
 
         sut.view.frame = CGRect(origin: .zero, size: CGSize.iPhoneSize.iPhone4_7)
@@ -52,7 +53,7 @@ final class ConnectRequestsViewControllerSnapshotTests: XCTestCase {
     
     override func tearDown() {
         sut = nil
-        mockConversation = nil
+        mockConnectionRequest = nil
 
         super.tearDown()
     }
@@ -61,15 +62,18 @@ final class ConnectRequestsViewControllerSnapshotTests: XCTestCase {
         verify(matching: sut)
     }
 
-    /*func testForTwoRequests() {
-        let otherUser = MockUserType.createUser(name: "Bill")
+    func testForTwoRequests() {
+        let otherUser = MockUserType.createConnectedUser(name: "Bill")
         otherUser.accentColorValue = .brightYellow
-        
-        let requestConversation = MockConversation.oneOnOneConversation()
-        
-        sut.connectionRequests = [requestConversation.convertToRegularConversation(), mockConversation.convertToRegularConversation()]
+        otherUser.handle = "bill"
+
+        let secondConnectionRequest = MockCnnectionRequest()
+        secondConnectionRequest.connectedUserType = otherUser
+
+
+        sut.connectionRequests = [secondConnectionRequest, mockConnectionRequest]
         sut.reload(animated: false)
         
         verify(matching: sut)
-    }*/
+    }
 }

--- a/Wire-iOS Tests/ConnectRequestsViewControllerSnapshotTests.swift
+++ b/Wire-iOS Tests/ConnectRequestsViewControllerSnapshotTests.swift
@@ -21,14 +21,14 @@ import XCTest
 import SnapshotTesting
 import WireDataModel
 
-final class MockCnnectionRequest: ConnectionRequest {
+final class MockConnectionRequest: ConnectionRequest {
     var connectedUserType: UserType?
 }
 
 final class ConnectRequestsViewControllerSnapshotTests: XCTestCase {
     
     var sut: ConnectRequestsViewController!
-    var mockConnectionRequest: MockCnnectionRequest!
+    var mockConnectionRequest: MockConnectionRequest!
 
     override func setUp() {
         super.setUp()
@@ -39,7 +39,7 @@ final class ConnectRequestsViewControllerSnapshotTests: XCTestCase {
 
         sut.loadViewIfNeeded()
 
-        mockConnectionRequest = MockCnnectionRequest()
+        mockConnectionRequest = MockConnectionRequest()
         let mockUser = MockUserType.createSelfUser(name: "Bruno")
         mockUser.accentColorValue = .brightOrange
         mockUser.handle = "bruno"
@@ -67,7 +67,7 @@ final class ConnectRequestsViewControllerSnapshotTests: XCTestCase {
         otherUser.accentColorValue = .brightYellow
         otherUser.handle = "bill"
 
-        let secondConnectionRequest = MockCnnectionRequest()
+        let secondConnectionRequest = MockConnectionRequest()
         secondConnectionRequest.connectedUserType = otherUser
 
 

--- a/Wire-iOS/Sources/UserInterface/ConnectRequests/ConnectRequestCell.swift
+++ b/Wire-iOS/Sources/UserInterface/ConnectRequests/ConnectRequestCell.swift
@@ -26,7 +26,7 @@ final class ConnectRequestCell: UITableViewCell {
 
     private var connectRequestViewController: IncomingConnectionViewController?
 
-    var user: ZMUser! {
+    var user: UserType! {
         didSet {
             guard let user = user else { return }
             

--- a/Wire-iOS/Sources/UserInterface/ConnectRequests/ConnectRequestsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConnectRequests/ConnectRequestsViewController.swift
@@ -20,8 +20,18 @@ import Foundation
 import UIKit
 import WireSyncEngine
 
+protocol ConnectionRequest {
+    var connectedUserType: UserType? { get }
+}
+
+extension ZMConversation: ConnectionRequest {
+    var connectedUserType: UserType? {
+        return connectedUser
+    }
+}
+
 final class ConnectRequestsViewController: UIViewController, UITableViewDataSource, UITableViewDelegate {
-    var connectionRequests: [ZMConversation] = []
+    var connectionRequests: [ConnectionRequest] = []
     
     private var userObserverToken: Any?
     private var pendingConnectionsListObserverToken: Any?
@@ -47,7 +57,7 @@ final class ConnectRequestsViewController: UIViewController, UITableViewDataSour
             
             userObserverToken = UserChangeInfo.add(observer: self, for: userSession.selfUser, in: userSession)
             
-            connectionRequests = pendingConnectionsList as? [ZMConversation] ?? []
+            connectionRequests = pendingConnectionsList as? [ConnectionRequest] ?? []
         }
         
         reload()
@@ -109,7 +119,7 @@ final class ConnectRequestsViewController: UIViewController, UITableViewDataSour
         /// get the user in reversed order, newer request is shown on top
         let request = connectionRequests[(connectionRequests.count - 1) - (indexPath.row)]
         
-        let user = request.connectedUser
+        let user = request.connectedUserType
         cell.user = user
         cell.selectionStyle = .none
         cell.separatorInset = .zero
@@ -145,7 +155,7 @@ final class ConnectRequestsViewController: UIViewController, UITableViewDataSour
         if let userSession = ZMUserSession.shared() {
             let pendingConnectionsList = ZMConversationList.pendingConnectionConversations(inUserSession: userSession)
             
-            connectionRequests = pendingConnectionsList as? [ZMConversation] ?? []
+            connectionRequests = pendingConnectionsList as? [ConnectionRequest] ?? []
         }
         
         tableView.reloadData()

--- a/Wire-iOS/Sources/UserInterface/ConnectRequests/IncomingConnectionView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConnectRequests/IncomingConnectionView.swift
@@ -88,7 +88,7 @@ final class IncomingConnectionView: UIView {
         let viewModel = UserNameDetailViewModel(
             user: user,
             fallbackName: "",
-            addressBookName: (user as? ZMUser)?.addressBookEntry?.cachedName ///TODO: add addressBookEntry to user type
+            addressBookName: (user as? ZMUser)?.addressBookEntry?.cachedName
         )
         
         usernameLabel.attributedText = viewModel.title

--- a/Wire-iOS/Sources/UserInterface/ConnectRequests/IncomingConnectionView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConnectRequests/IncomingConnectionView.swift
@@ -38,18 +38,18 @@ final class IncomingConnectionView: UIView {
     private let acceptButton = Button(style: .full)
     private let ignoreButton = Button(style: .empty)
 
-    var user: ZMUser {
+    var user: UserType {
         didSet {
             self.setupLabelText()
             self.userImageView.user = self.user
         }
     }
 
-    typealias UserAction = (ZMUser) -> Void
+    typealias UserAction = (UserType) -> Void
     var onAccept: UserAction?
     var onIgnore: UserAction?
 
-    init(user: ZMUser) {
+    init(user: UserType) {
         self.user = user
         super.init(frame: .zero)
 
@@ -88,7 +88,7 @@ final class IncomingConnectionView: UIView {
         let viewModel = UserNameDetailViewModel(
             user: user,
             fallbackName: "",
-            addressBookName: user.addressBookEntry?.cachedName
+            addressBookName: (user as? ZMUser)?.addressBookEntry?.cachedName ///TODO: add addressBookEntry to user type
         )
         
         usernameLabel.attributedText = viewModel.title

--- a/Wire-iOS/Sources/UserInterface/ConnectRequests/UserConnectionViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConnectRequests/UserConnectionViewController.swift
@@ -30,10 +30,10 @@ final class IncomingConnectionViewController: UIViewController {
     fileprivate var connectionView: IncomingConnectionView!
 
     let userSession: ZMUserSession?
-    let user: ZMUser
+    let user: UserType
     var onAction: ((IncomingConnectionAction) -> ())?
 
-    init(userSession: ZMUserSession?, user: ZMUser) {
+    init(userSession: ZMUserSession?, user: UserType) {
         self.userSession = userSession
         self.user = user
         super.init(nibName: .none, bundle: .none)
@@ -42,6 +42,7 @@ final class IncomingConnectionViewController: UIViewController {
         user.refreshData()
     }
 
+    @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -49,17 +50,17 @@ final class IncomingConnectionViewController: UIViewController {
     override func loadView() {
         connectionView = IncomingConnectionView(user: user)
         connectionView.onAccept = { [weak self] user in
-            guard let `self` = self else { return }
-            self.userSession?.perform {
-                self.user.accept()
+            guard let weakSelf = self else { return }
+            weakSelf.userSession?.perform {
+                (weakSelf.user as? ZMUser)?.accept()
             }
-            self.onAction?(.accept)
+            weakSelf.onAction?(.accept)
         }
         connectionView.onIgnore = { [weak self] user in
-            guard let `self` = self else { return }
-            self.userSession?.perform {
-                self.user.ignore()
-                self.onAction?(.ignore)
+            guard let weakSelf = self else { return }
+            weakSelf.userSession?.perform {
+                (weakSelf.user as? ZMUser)?.ignore()
+                weakSelf.onAction?(.ignore)
             }
         }
 


### PR DESCRIPTION
## What's new in this PR?

When testing `ConnectRequestsViewController` in `ConnectRequestsViewControllerSnapshotTests`, we had to create `ZMConversation` and `ZMUser` for assigning `connectedUser` (type: `ZMuser?`). This PR creates a simpler interface `ConnectionRequest` for easier to mock `connectedUser` with type `UserType?` and prevent creating `ZMConversation`.