### PR TITLE
replace ZMConversation with InputBarConversationType

### DIFF
--- a/Wire-iOS Tests/ConnectRequestsViewControllerSnapshotTests.swift
+++ b/Wire-iOS Tests/ConnectRequestsViewControllerSnapshotTests.swift
@@ -21,7 +21,7 @@ import XCTest
 import SnapshotTesting
 import WireDataModel
 
-final class MockConnectionRequest: ConnectionRequest {
+final class MockConnectionRequest: ConnectedUserContainer {
     var connectedUserType: UserType?
 }
 

--- a/Wire-iOS Tests/ConversationInputBarViewController/ConversationInputBarViewControllerTests.swift
+++ b/Wire-iOS Tests/ConversationInputBarViewController/ConversationInputBarViewControllerTests.swift
@@ -22,26 +22,24 @@ import WireCommonComponents
 
 final class MockInputBarConversationType: InputBarConversationType {
     var typingUsers: [UserType] = []
-    
+
     var hasDraftMessage: Bool = false
-    
+
     var connectedUserType: UserType?
-    
+
     var draftMessage: DraftMessage?
-    
+
     var messageDestructionTimeoutValue: TimeInterval = 0
     var messageDestructionTimeout: MessageDestructionTimeout?
 
     var conversationType: ZMConversationType = .group
-    
-    var hasSyncedMessageDestructionTimeout: Bool = false
-    
+
     func setIsTyping(_ isTyping: Bool) {
         //no-op
     }
-    
+
     var isReadOnly: Bool = false
-    
+
     var displayName: String = ""
 }
 
@@ -52,7 +50,7 @@ final class ConversationInputBarViewControllerTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        
+
         UIColor.setAccentOverride(.vividRed)
 
         mockConversation = MockInputBarConversationType()
@@ -62,7 +60,7 @@ final class ConversationInputBarViewControllerTests: XCTestCase {
     override func tearDown() {
         sut = nil
         mockConversation = nil
-        
+
         super.tearDown()
     }
 
@@ -74,7 +72,7 @@ final class ConversationInputBarViewControllerTests: XCTestCase {
     }
 
     // MARK: - Typing indication
-    
+
     func testTypingIndicationIsShown() {
         // GIVEN & WHEN
         /// directly working with sut.typingIndicatorView to prevent triggering aniamtion
@@ -112,14 +110,14 @@ final class ConversationInputBarViewControllerTests: XCTestCase {
         mockConversation.messageDestructionTimeout = .local(MessageDestructionTimeoutValue(rawValue: timeInterval))
         mockConversation.messageDestructionTimeoutValue = timeInterval
     }
-    
+
     func testEphemeralTime10Second() {
         // GIVEN
 
         // WHEN
         sut.mode = .timeoutConfguration
         setMessageDestructionTimeout(timeInterval: 10)
-        
+
         sut.inputBar.setInputBarState(.writing(ephemeral: .message), animated: false)
 
         // THEN

--- a/Wire-iOS Tests/ConversationInputBarViewController/ConversationInputBarViewControllerTests.swift
+++ b/Wire-iOS Tests/ConversationInputBarViewController/ConversationInputBarViewControllerTests.swift
@@ -21,23 +21,20 @@ import XCTest
 
 final class ConversationInputBarViewControllerTests: XCTestCase {
 
-    var coreDataFixture: CoreDataFixture!
-
     var sut: ConversationInputBarViewController!
+    var mockConversation: MockConversation!
 
     override func setUp() {
         super.setUp()
-        coreDataFixture = CoreDataFixture()
-
-        sut = ConversationInputBarViewController(conversation: coreDataFixture.otherUserConversation)
-
-        sut.loadViewIfNeeded()
+        
+        mockConversation = MockConversation.oneOnOneConversation()
+        sut = ConversationInputBarViewController(conversation: mockConversation.convertToRegularConversation())
     }
 
     override func tearDown() {
         sut = nil
-
-        coreDataFixture = nil
+        mockConversation = nil
+        
         super.tearDown()
     }
 
@@ -54,7 +51,7 @@ extension ConversationInputBarViewControllerTests {
     func testTypingIndicationIsShown() {
         // GIVEN & WHEN
         /// directly working with sut.typingIndicatorView to prevent triggering aniamtion
-        sut.typingIndicatorView.typingUsers = [coreDataFixture.otherUser]
+        sut.typingIndicatorView.typingUsers = [MockUserType.createUser(name: "Alice")]
         sut.typingIndicatorView.setHidden(false, animated: false)
 
         // THEN
@@ -71,7 +68,7 @@ extension ConversationInputBarViewControllerTests {
         sut.mode = .timeoutConfguration
 
         // THEN
-        self.verifyInAllPhoneWidths(matching: sut.view)
+        verifyInAllPhoneWidths(matching: sut.view)
     }
 
     func testEphemeralTimeNone() {
@@ -79,23 +76,24 @@ extension ConversationInputBarViewControllerTests {
 
         // WHEN
         sut.mode = .timeoutConfguration
-        coreDataFixture.otherUserConversation.messageDestructionTimeout = .local(.none)
+        mockConversation.messageDestructionTimeout = .local(.none)
+        //TODO:     public var messageDestructionTimeout: WireDataModel.MessageDestructionTimeout?
 
         // THEN
-        self.verifyInAllPhoneWidths(matching: sut.view)
+        verifyInAllPhoneWidths(matching: sut.view)
     }
-
+/*
     func testEphemeralTime10Second() {
         // GIVEN
 
         // WHEN
         sut.mode = .timeoutConfguration
-        coreDataFixture.otherUserConversation.messageDestructionTimeout = .local(10)
+//        coreDataFixture.otherUserConversation.messageDestructionTimeout = .local(10)
 
         sut.inputBar.setInputBarState(.writing(ephemeral: .message), animated: false)
 
         // THEN
-        self.verifyInAllPhoneWidths(matching: sut.view)
+        verifyInAllPhoneWidths(matching: sut.view)
     }
 
     func testEphemeralTime5Minutes() {
@@ -103,12 +101,12 @@ extension ConversationInputBarViewControllerTests {
 
         // WHEN
         sut.mode = .timeoutConfguration
-        coreDataFixture.otherUserConversation.messageDestructionTimeout = .local(300)
+//        coreDataFixture.otherUserConversation.messageDestructionTimeout = .local(300)
 
         sut.inputBar.setInputBarState(.writing(ephemeral: .message), animated: false)
 
         // THEN
-        self.verifyInAllPhoneWidths(matching: sut.view)
+        verifyInAllPhoneWidths(matching: sut.view)
     }
 
     func testEphemeralTime2Hours() {
@@ -116,12 +114,12 @@ extension ConversationInputBarViewControllerTests {
 
         // WHEN
         sut.mode = .timeoutConfguration
-        coreDataFixture.otherUserConversation.messageDestructionTimeout = .local(7200)
+//        coreDataFixture.otherUserConversation.messageDestructionTimeout = .local(7200)
 
         sut.inputBar.setInputBarState(.writing(ephemeral: .message), animated: false)
 
         // THEN
-        self.verifyInAllPhoneWidths(matching: sut.view)
+        verifyInAllPhoneWidths(matching: sut.view)
     }
 
     func testEphemeralTime3Days() {
@@ -129,7 +127,7 @@ extension ConversationInputBarViewControllerTests {
 
         // WHEN
         sut.mode = .timeoutConfguration
-        coreDataFixture.otherUserConversation.messageDestructionTimeout = .local(259200)
+//        coreDataFixture.otherUserConversation.messageDestructionTimeout = .local(259200)
 
         sut.inputBar.setInputBarState(.writing(ephemeral: .message), animated: false)
 
@@ -142,7 +140,7 @@ extension ConversationInputBarViewControllerTests {
 
         // WHEN
         sut.mode = .timeoutConfguration
-        coreDataFixture.otherUserConversation.messageDestructionTimeout = .local(2419200)
+//        coreDataFixture.otherUserConversation.messageDestructionTimeout = .local(2419200)
 
         sut.inputBar.setInputBarState(.writing(ephemeral: .message), animated: false)
 
@@ -171,5 +169,5 @@ extension ConversationInputBarViewControllerTests {
         let alert: UIAlertController = sut.createDocUploadActionSheet()
 
         verify(matching: alert)
-    }
+    }*/
 }

--- a/Wire-iOS Tests/ConversationInputBarViewController/ConversationInputBarViewControllerTests.swift
+++ b/Wire-iOS Tests/ConversationInputBarViewController/ConversationInputBarViewControllerTests.swift
@@ -36,8 +36,6 @@ final class MockInputBarConversationType: InputBarConversationType {
     
     var hasSyncedMessageDestructionTimeout: Bool = false
     
-    var disabledTimeoutImage: UIImage?
-    
     func setIsTyping(_ isTyping: Bool) {
         //no-op
     }
@@ -45,8 +43,6 @@ final class MockInputBarConversationType: InputBarConversationType {
     var isReadOnly: Bool = false
     
     var displayName: String = ""
-    
-    
 }
 
 final class ConversationInputBarViewControllerTests: XCTestCase {
@@ -112,14 +108,18 @@ final class ConversationInputBarViewControllerTests: XCTestCase {
         verifyInAllPhoneWidths(matching: sut.view)
     }
 
+    private func setMessageDestructionTimeout(timeInterval: TimeInterval) {
+        mockConversation.messageDestructionTimeout = .local(MessageDestructionTimeoutValue(rawValue: timeInterval))
+        mockConversation.messageDestructionTimeoutValue = timeInterval
+    }
+    
     func testEphemeralTime10Second() {
         // GIVEN
 
         // WHEN
         sut.mode = .timeoutConfguration
-        mockConversation.messageDestructionTimeout = .local(10)
-        mockConversation.messageDestructionTimeoutValue = 10
-
+        setMessageDestructionTimeout(timeInterval: 10)
+        
         sut.inputBar.setInputBarState(.writing(ephemeral: .message), animated: false)
 
         // THEN
@@ -131,7 +131,7 @@ final class ConversationInputBarViewControllerTests: XCTestCase {
 
         // WHEN
         sut.mode = .timeoutConfguration
-        mockConversation.messageDestructionTimeout = .local(300)
+        setMessageDestructionTimeout(timeInterval: 300)
 
         sut.inputBar.setInputBarState(.writing(ephemeral: .message), animated: false)
 
@@ -144,7 +144,7 @@ final class ConversationInputBarViewControllerTests: XCTestCase {
 
         // WHEN
         sut.mode = .timeoutConfguration
-        mockConversation.messageDestructionTimeout = .local(7200)
+        setMessageDestructionTimeout(timeInterval: 7200)
 
         sut.inputBar.setInputBarState(.writing(ephemeral: .message), animated: false)
 
@@ -157,7 +157,7 @@ final class ConversationInputBarViewControllerTests: XCTestCase {
 
         // WHEN
         sut.mode = .timeoutConfguration
-        mockConversation.messageDestructionTimeout = .local(259200)
+        setMessageDestructionTimeout(timeInterval: 259200)
 
         sut.inputBar.setInputBarState(.writing(ephemeral: .message), animated: false)
 
@@ -170,7 +170,7 @@ final class ConversationInputBarViewControllerTests: XCTestCase {
 
         // WHEN
         sut.mode = .timeoutConfguration
-        mockConversation.messageDestructionTimeout = .local(2419200)
+        setMessageDestructionTimeout(timeInterval: 2419200)
 
         sut.inputBar.setInputBarState(.writing(ephemeral: .message), animated: false)
 
@@ -183,14 +183,14 @@ final class ConversationInputBarViewControllerTests: XCTestCase {
 
         // WHEN
         sut.mode = .timeoutConfguration
-        mockConversation.messageDestructionTimeout = .local(2419200)
+        setMessageDestructionTimeout(timeInterval: 2419200)
 
         sut.inputBar.setInputBarState(.writing(ephemeral: .message), animated: false)
         let shortText = "Lorem ipsum dolor"
         sut.inputBar.textView.text = shortText
 
         // THEN
-        self.verifyInAllPhoneWidths(matching: sut.view)
+        verifyInAllPhoneWidths(matching: sut.view)
     }
 
 // MARK: - file action sheet

--- a/Wire-iOS Tests/ConversationInputBarViewController/ConversationInputBarViewControllerTests.swift
+++ b/Wire-iOS Tests/ConversationInputBarViewController/ConversationInputBarViewControllerTests.swift
@@ -19,16 +19,47 @@
 import XCTest
 @testable import Wire
 
+final class MockInputBarConversationType: InputBarConversationType {
+    var typingUsers: [UserType] = []
+    
+    var hasDraftMessage: Bool = false
+    
+    var connectedUserType: UserType?
+    
+    var draftMessage: DraftMessage?
+    
+    var messageDestructionTimeoutValue: TimeInterval = 0
+    var messageDestructionTimeout: MessageDestructionTimeout?
+
+    var conversationType: ZMConversationType = .group
+    
+    var hasSyncedMessageDestructionTimeout: Bool = false
+    
+    var timeoutImage: UIImage?
+    
+    var disabledTimeoutImage: UIImage?
+    
+    func setIsTyping(_ isTyping: Bool) {
+        //no-op
+    }
+    
+    var isReadOnly: Bool = false
+    
+    var displayName: String = ""
+    
+    
+}
+
 final class ConversationInputBarViewControllerTests: XCTestCase {
 
     var sut: ConversationInputBarViewController!
-    var mockConversation: MockConversation!
+    var mockConversation: MockInputBarConversationType!
 
     override func setUp() {
         super.setUp()
         
-        mockConversation = MockConversation.oneOnOneConversation()
-        sut = ConversationInputBarViewController(conversation: mockConversation.convertToRegularConversation())
+        mockConversation = MockInputBarConversationType()
+        sut = ConversationInputBarViewController(conversation: mockConversation)
     }
 
     override func tearDown() {
@@ -44,23 +75,21 @@ final class ConversationInputBarViewControllerTests: XCTestCase {
                        widths: tabletWidths(), snapshotBackgroundColor: .white)
 
     }
-}
 
-// MARK: - Typing indication
-extension ConversationInputBarViewControllerTests {
+    // MARK: - Typing indication
+    
     func testTypingIndicationIsShown() {
         // GIVEN & WHEN
         /// directly working with sut.typingIndicatorView to prevent triggering aniamtion
-        sut.typingIndicatorView.typingUsers = [MockUserType.createUser(name: "Alice")]
+        sut.typingIndicatorView.typingUsers = [MockUserType.createUser(name: "Bruno")]
         sut.typingIndicatorView.setHidden(false, animated: false)
 
         // THEN
         verifyInAllPhoneWidths(matching: sut.view)
     }
-}
 
-// MARK: - Ephemeral indicator button
-extension ConversationInputBarViewControllerTests {
+    // MARK: - Ephemeral indicator button
+
     func testEphemeralIndicatorButton() {
         // GIVEN
 
@@ -77,18 +106,17 @@ extension ConversationInputBarViewControllerTests {
         // WHEN
         sut.mode = .timeoutConfguration
         mockConversation.messageDestructionTimeout = .local(.none)
-        //TODO:     public var messageDestructionTimeout: WireDataModel.MessageDestructionTimeout?
 
         // THEN
         verifyInAllPhoneWidths(matching: sut.view)
     }
-/*
+
     func testEphemeralTime10Second() {
         // GIVEN
 
         // WHEN
         sut.mode = .timeoutConfguration
-//        coreDataFixture.otherUserConversation.messageDestructionTimeout = .local(10)
+        mockConversation.messageDestructionTimeout = .local(10)
 
         sut.inputBar.setInputBarState(.writing(ephemeral: .message), animated: false)
 
@@ -101,7 +129,7 @@ extension ConversationInputBarViewControllerTests {
 
         // WHEN
         sut.mode = .timeoutConfguration
-//        coreDataFixture.otherUserConversation.messageDestructionTimeout = .local(300)
+        mockConversation.messageDestructionTimeout = .local(300)
 
         sut.inputBar.setInputBarState(.writing(ephemeral: .message), animated: false)
 
@@ -114,7 +142,7 @@ extension ConversationInputBarViewControllerTests {
 
         // WHEN
         sut.mode = .timeoutConfguration
-//        coreDataFixture.otherUserConversation.messageDestructionTimeout = .local(7200)
+        mockConversation.messageDestructionTimeout = .local(7200)
 
         sut.inputBar.setInputBarState(.writing(ephemeral: .message), animated: false)
 
@@ -127,7 +155,7 @@ extension ConversationInputBarViewControllerTests {
 
         // WHEN
         sut.mode = .timeoutConfguration
-//        coreDataFixture.otherUserConversation.messageDestructionTimeout = .local(259200)
+        mockConversation.messageDestructionTimeout = .local(259200)
 
         sut.inputBar.setInputBarState(.writing(ephemeral: .message), animated: false)
 
@@ -140,7 +168,7 @@ extension ConversationInputBarViewControllerTests {
 
         // WHEN
         sut.mode = .timeoutConfguration
-//        coreDataFixture.otherUserConversation.messageDestructionTimeout = .local(2419200)
+        mockConversation.messageDestructionTimeout = .local(2419200)
 
         sut.inputBar.setInputBarState(.writing(ephemeral: .message), animated: false)
 
@@ -153,7 +181,7 @@ extension ConversationInputBarViewControllerTests {
 
         // WHEN
         sut.mode = .timeoutConfguration
-        coreDataFixture.otherUserConversation.messageDestructionTimeout = .local(2419200)
+        mockConversation.messageDestructionTimeout = .local(2419200)
 
         sut.inputBar.setInputBarState(.writing(ephemeral: .message), animated: false)
         let shortText = "Lorem ipsum dolor"
@@ -169,5 +197,5 @@ extension ConversationInputBarViewControllerTests {
         let alert: UIAlertController = sut.createDocUploadActionSheet()
 
         verify(matching: alert)
-    }*/
+    }
 }

--- a/Wire-iOS Tests/ConversationInputBarViewController/ConversationInputBarViewControllerTests.swift
+++ b/Wire-iOS Tests/ConversationInputBarViewController/ConversationInputBarViewControllerTests.swift
@@ -18,6 +18,7 @@
 
 import XCTest
 @testable import Wire
+import WireCommonComponents
 
 final class MockInputBarConversationType: InputBarConversationType {
     var typingUsers: [UserType] = []
@@ -34,8 +35,6 @@ final class MockInputBarConversationType: InputBarConversationType {
     var conversationType: ZMConversationType = .group
     
     var hasSyncedMessageDestructionTimeout: Bool = false
-    
-    var timeoutImage: UIImage?
     
     var disabledTimeoutImage: UIImage?
     
@@ -58,6 +57,8 @@ final class ConversationInputBarViewControllerTests: XCTestCase {
     override func setUp() {
         super.setUp()
         
+        UIColor.setAccentOverride(.vividRed)
+
         mockConversation = MockInputBarConversationType()
         sut = ConversationInputBarViewController(conversation: mockConversation)
     }
@@ -117,6 +118,7 @@ final class ConversationInputBarViewControllerTests: XCTestCase {
         // WHEN
         sut.mode = .timeoutConfguration
         mockConversation.messageDestructionTimeout = .local(10)
+        mockConversation.messageDestructionTimeoutValue = 10
 
         sut.inputBar.setInputBarState(.writing(ephemeral: .message), animated: false)
 

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -816,6 +816,7 @@
 		A9859D6823FE955000DC3F36 /* LoadingSpinner.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9859D6723FE955000DC3F36 /* LoadingSpinner.swift */; };
 		A9859D6A23FEDD7400DC3F36 /* FullscreenImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9859D6923FEDD7400DC3F36 /* FullscreenImageViewController.swift */; };
 		A98CD44E24C74C9F00EAC484 /* UIColor+Const.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98CD44D24C74C9F00EAC484 /* UIColor+Const.swift */; };
+		A98CF97425A47295008818D8 /* InputBarConversationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98CF97325A47295008818D8 /* InputBarConversationType.swift */; };
 		A98ECDF1232A94DD006A57FD /* ConversationListViewControllerViewModelSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98ECDF0232A94DD006A57FD /* ConversationListViewControllerViewModelSnapshotTests.swift */; };
 		A98ECDF3232A9564006A57FD /* MockConversationListContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98ECDF2232A9564006A57FD /* MockConversationListContainer.swift */; };
 		A990059C23F196170089CDEB /* AnimatedListMenuViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A990059A23F195A70089CDEB /* AnimatedListMenuViewTests.swift */; };
@@ -2467,6 +2468,7 @@
 		A9859D6723FE955000DC3F36 /* LoadingSpinner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingSpinner.swift; sourceTree = "<group>"; };
 		A9859D6923FEDD7400DC3F36 /* FullscreenImageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullscreenImageViewController.swift; sourceTree = "<group>"; };
 		A98CD44D24C74C9F00EAC484 /* UIColor+Const.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Const.swift"; sourceTree = "<group>"; };
+		A98CF97325A47295008818D8 /* InputBarConversationType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputBarConversationType.swift; sourceTree = "<group>"; };
 		A98ECDF0232A94DD006A57FD /* ConversationListViewControllerViewModelSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationListViewControllerViewModelSnapshotTests.swift; sourceTree = "<group>"; };
 		A98ECDF2232A9564006A57FD /* MockConversationListContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockConversationListContainer.swift; sourceTree = "<group>"; };
 		A990059A23F195A70089CDEB /* AnimatedListMenuViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatedListMenuViewTests.swift; sourceTree = "<group>"; };
@@ -5429,6 +5431,7 @@
 		8FC851B3199245760008B66B /* InputBar */ = {
 			isa = PBXGroup;
 			children = (
+				A98CF97325A47295008818D8 /* InputBarConversationType.swift */,
 				A937A5C223D5F0400080A507 /* ConversationInputBarViewControllerDelegate.swift */,
 				A965F89D23DB3359005209E1 /* ConversationInputBarViewController.swift */,
 				EF95B053227C782D005A060A /* ConversationInputBarViewController+TypingIndicator.swift */,
@@ -7397,6 +7400,7 @@
 				5EFD914421C918E400080599 /* AuthenticationCodeVerificationInputHandler.swift in Sources */,
 				EF883F292151190900B440CC /* UserCellSubtitleProtocol.swift in Sources */,
 				EFDC36DB2257A8F300F916F3 /* CollectionViewContainerCell.swift in Sources */,
+				A98CF97425A47295008818D8 /* InputBarConversationType.swift in Sources */,
 				D518947B20504C6A00C095C1 /* LoadingIndicatorCell.swift in Sources */,
 				EF4795AD2077847E00334E32 /* ConversationInputBarViewController+UITextViewDelegate.swift in Sources */,
 				167961A9203F26E600B72ACC /* SectionHeader.swift in Sources */,

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -816,7 +816,7 @@
 		A9859D6823FE955000DC3F36 /* LoadingSpinner.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9859D6723FE955000DC3F36 /* LoadingSpinner.swift */; };
 		A9859D6A23FEDD7400DC3F36 /* FullscreenImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9859D6923FEDD7400DC3F36 /* FullscreenImageViewController.swift */; };
 		A98CD44E24C74C9F00EAC484 /* UIColor+Const.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98CD44D24C74C9F00EAC484 /* UIColor+Const.swift */; };
-		A98CF97425A47295008818D8 /* InputBarConversationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98CF97325A47295008818D8 /* InputBarConversationType.swift */; };
+		A98CF97425A47295008818D8 /* ConversationProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98CF97325A47295008818D8 /* ConversationProtocol.swift */; };
 		A98ECDF1232A94DD006A57FD /* ConversationListViewControllerViewModelSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98ECDF0232A94DD006A57FD /* ConversationListViewControllerViewModelSnapshotTests.swift */; };
 		A98ECDF3232A9564006A57FD /* MockConversationListContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98ECDF2232A9564006A57FD /* MockConversationListContainer.swift */; };
 		A990059C23F196170089CDEB /* AnimatedListMenuViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A990059A23F195A70089CDEB /* AnimatedListMenuViewTests.swift */; };
@@ -2468,7 +2468,7 @@
 		A9859D6723FE955000DC3F36 /* LoadingSpinner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingSpinner.swift; sourceTree = "<group>"; };
 		A9859D6923FEDD7400DC3F36 /* FullscreenImageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullscreenImageViewController.swift; sourceTree = "<group>"; };
 		A98CD44D24C74C9F00EAC484 /* UIColor+Const.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Const.swift"; sourceTree = "<group>"; };
-		A98CF97325A47295008818D8 /* InputBarConversationType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputBarConversationType.swift; sourceTree = "<group>"; };
+		A98CF97325A47295008818D8 /* ConversationProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationProtocol.swift; sourceTree = "<group>"; };
 		A98ECDF0232A94DD006A57FD /* ConversationListViewControllerViewModelSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationListViewControllerViewModelSnapshotTests.swift; sourceTree = "<group>"; };
 		A98ECDF2232A9564006A57FD /* MockConversationListContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockConversationListContainer.swift; sourceTree = "<group>"; };
 		A990059A23F195A70089CDEB /* AnimatedListMenuViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatedListMenuViewTests.swift; sourceTree = "<group>"; };
@@ -5353,6 +5353,7 @@
 		8FC8517F199245760008B66B /* Conversation */ = {
 			isa = PBXGroup;
 			children = (
+				A98CF97325A47295008818D8 /* ConversationProtocol.swift */,
 				7C25D7532149118D002E22BF /* Mentions */,
 				F10F46D02028857C00261449 /* Create */,
 				8FC85180199245760008B66B /* Content */,
@@ -5431,7 +5432,6 @@
 		8FC851B3199245760008B66B /* InputBar */ = {
 			isa = PBXGroup;
 			children = (
-				A98CF97325A47295008818D8 /* InputBarConversationType.swift */,
 				A937A5C223D5F0400080A507 /* ConversationInputBarViewControllerDelegate.swift */,
 				A965F89D23DB3359005209E1 /* ConversationInputBarViewController.swift */,
 				EF95B053227C782D005A060A /* ConversationInputBarViewController+TypingIndicator.swift */,
@@ -7400,7 +7400,7 @@
 				5EFD914421C918E400080599 /* AuthenticationCodeVerificationInputHandler.swift in Sources */,
 				EF883F292151190900B440CC /* UserCellSubtitleProtocol.swift in Sources */,
 				EFDC36DB2257A8F300F916F3 /* CollectionViewContainerCell.swift in Sources */,
-				A98CF97425A47295008818D8 /* InputBarConversationType.swift in Sources */,
+				A98CF97425A47295008818D8 /* ConversationProtocol.swift in Sources */,
 				D518947B20504C6A00C095C1 /* LoadingIndicatorCell.swift in Sources */,
 				EF4795AD2077847E00334E32 /* ConversationInputBarViewController+UITextViewDelegate.swift in Sources */,
 				167961A9203F26E600B72ACC /* SectionHeader.swift in Sources */,

--- a/Wire-iOS/Sources/UserInterface/ConnectRequests/ConnectRequestsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConnectRequests/ConnectRequestsViewController.swift
@@ -20,18 +20,8 @@ import Foundation
 import UIKit
 import WireSyncEngine
 
-protocol ConnectionRequest {
-    var connectedUserType: UserType? { get }
-}
-
-extension ZMConversation: ConnectionRequest {
-    var connectedUserType: UserType? {
-        return connectedUser
-    }
-}
-
 final class ConnectRequestsViewController: UIViewController, UITableViewDataSource, UITableViewDelegate {
-    var connectionRequests: [ConnectionRequest] = []
+    var connectionRequests: [ConnectedUserContainer] = []
     
     private var userObserverToken: Any?
     private var pendingConnectionsListObserverToken: Any?
@@ -57,7 +47,7 @@ final class ConnectRequestsViewController: UIViewController, UITableViewDataSour
             
             userObserverToken = UserChangeInfo.add(observer: self, for: userSession.selfUser, in: userSession)
             
-            connectionRequests = pendingConnectionsList as? [ConnectionRequest] ?? []
+            connectionRequests = pendingConnectionsList as? [ConnectedUserContainer] ?? []
         }
         
         reload()
@@ -155,7 +145,7 @@ final class ConnectRequestsViewController: UIViewController, UITableViewDataSour
         if let userSession = ZMUserSession.shared() {
             let pendingConnectionsList = ZMConversationList.pendingConnectionConversations(inUserSession: userSession)
             
-            connectionRequests = pendingConnectionsList as? [ConnectionRequest] ?? []
+            connectionRequests = pendingConnectionsList as? [ConnectedUserContainer] ?? []
         }
         
         tableView.reloadData()

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationProtocol.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationProtocol.swift
@@ -1,4 +1,3 @@
-
 // Wire
 // Copyright (C) 2021 Wire Swiss GmbH
 //
@@ -23,15 +22,14 @@ protocol InputBarConversation {
     var typingUsers: [UserType] { get }
     var hasDraftMessage: Bool { get }
     var draftMessage: DraftMessage? { get }
-    
+
     var messageDestructionTimeoutValue: TimeInterval { get }
     var messageDestructionTimeout: MessageDestructionTimeout? { get }
-    
+
     var conversationType: ZMConversationType { get }
-    var hasSyncedMessageDestructionTimeout: Bool { get }
-        
+
     func setIsTyping(_ isTyping: Bool)
-    
+
     var isReadOnly: Bool { get }
     var displayName: String { get }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationProtocol.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationProtocol.swift
@@ -19,10 +19,9 @@
 import Foundation
 import WireDataModel
 
-protocol InputBarConversationType {
+protocol InputBarConversation {
     var typingUsers: [UserType] { get }
     var hasDraftMessage: Bool { get }
-    var connectedUserType: UserType? { get } ///TODO: merge with ConnectionRequest protocol
     var draftMessage: DraftMessage? { get }
     
     var messageDestructionTimeoutValue: TimeInterval { get }
@@ -37,4 +36,16 @@ protocol InputBarConversationType {
     var displayName: String { get }
 }
 
-extension ZMConversation: InputBarConversationType {}
+protocol ConnectedUserContainer {
+    var connectedUserType: UserType? { get }
+}
+
+typealias InputBarConversationType = InputBarConversation & ConnectedUserContainer
+
+extension ZMConversation: ConnectedUserContainer {
+    var connectedUserType: UserType? {
+        return connectedUser
+    }
+}
+
+extension ZMConversation: InputBarConversation {}

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarButtonState.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarButtonState.swift
@@ -22,10 +22,10 @@ import WireDataModel
 private let disableEphemeralSending = false
 private let disableEphemeralSendingInGroups = false
 
-extension ZMConversation { ///TODO: abstract
+extension InputBarConversation {
     var hasSyncedMessageDestructionTimeout: Bool {
         switch messageDestructionTimeout {
-        case .synced(_)?:
+        case .synced?:
             return true
         default:
             return false

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarButtonState.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarButtonState.swift
@@ -22,7 +22,7 @@ import WireDataModel
 private let disableEphemeralSending = false
 private let disableEphemeralSendingInGroups = false
 
-extension ZMConversation {
+extension ZMConversation { ///TODO: abstract
     var hasSyncedMessageDestructionTimeout: Bool {
         switch messageDestructionTimeout {
         case .synced(_)?:

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Editing.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Editing.swift
@@ -45,11 +45,13 @@ extension ConversationInputBarViewController {
     
     @objc
     func endEditingMessageIfNeeded() {
-        guard let message = editingMessage else { return }
+        guard let message = editingMessage,
+              let conversation = conversation as? ZMConversation else { return }
+        
         delegate?.conversationInputBarViewControllerDidCancelEditing(message)
         editingMessage = nil
         ZMUserSession.shared()?.enqueue {
-            self.conversation.draftMessage = nil
+            conversation.draftMessage = nil
         }
         updateWritingState(animated: true)
         conversation.setIsTyping(false)

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Ephemeral.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Ephemeral.swift
@@ -96,8 +96,7 @@ extension ConversationInputBarViewController {
     }
 
     func updateEphemeralIndicatorButtonTitle(_ button: ButtonWithLargerHitArea) {
-        guard let conversation = conversation as? ZMConversation,
-              let timerValue = conversation.destructionTimeout else {
+        guard let timerValue = conversation.destructionTimeout else {
             button.setTitle("", for: .normal)
             return
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Ephemeral.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Ephemeral.swift
@@ -24,7 +24,7 @@ extension ConversationInputBarViewController {
 
     @discardableResult
     func createEphemeralKeyboardViewController() -> EphemeralKeyboardViewController {
-        let ephemeralKeyboardViewController = EphemeralKeyboardViewController(conversation: conversation)
+        let ephemeralKeyboardViewController = EphemeralKeyboardViewController(conversation: conversation as? ZMConversation)
         ephemeralKeyboardViewController.delegate = self
         
         self.ephemeralKeyboardViewController = ephemeralKeyboardViewController
@@ -96,7 +96,8 @@ extension ConversationInputBarViewController {
     }
 
     func updateEphemeralIndicatorButtonTitle(_ button: ButtonWithLargerHitArea) {
-        guard let timerValue = conversation.destructionTimeout else {
+        guard let conversation = conversation as? ZMConversation,
+              let timerValue = conversation.destructionTimeout else {
             button.setTitle("", for: .normal)
             return
         }
@@ -114,11 +115,13 @@ extension ConversationInputBarViewController: EphemeralKeyboardViewControllerDel
     }
 
     func ephemeralKeyboard(_ keyboard: EphemeralKeyboardViewController, didSelectMessageTimeout timeout: TimeInterval) {
+        guard let conversation = conversation as? ZMConversation else { return }
+        
         inputBar.setInputBarState(.writing(ephemeral: timeout != 0 ? .message : .none), animated: true)
         updateMarkdownButton()
 
         ZMUserSession.shared()?.enqueue {
-            self.conversation.messageDestructionTimeout = .local(MessageDestructionTimeoutValue(rawValue: timeout))
+            conversation.messageDestructionTimeout = .local(MessageDestructionTimeoutValue(rawValue: timeout))
             self.updateRightAccessoryView()
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Files.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Files.swift
@@ -109,6 +109,8 @@ extension ConversationInputBarViewController {
     ///
     /// - Parameter url: the URL of the file
     func uploadFile(at url: URL) {
+        guard let conversation = conversation as? ZMConversation else { return }
+
         guard let maxUploadFileSize = ZMUserSession.shared()?.maxUploadFileSize else { return }
 
         let completion: Completion = { [weak self] in
@@ -147,7 +149,7 @@ extension ConversationInputBarViewController {
                 var conversationMediaAction: ConversationMediaAction = .fileTransfer
 
                 do {
-                    let message = try weakSelf.conversation.appendFile(with: metadata)
+                    let message = try conversation.appendFile(with: metadata)
                     if let fileMessageData = message.fileMessageData {
                         if fileMessageData.isVideo {
                             conversationMediaAction = .videoMessage
@@ -156,7 +158,7 @@ extension ConversationInputBarViewController {
                         }
                     }
 
-                    Analytics.shared.tagMediaActionCompleted(conversationMediaAction, inConversation: weakSelf.conversation)
+                    Analytics.shared.tagMediaActionCompleted(conversationMediaAction, inConversation: conversation)
                 } catch {
                     Logging.messageProcessing.warn("Failed to append file. Reason: \(error.localizedDescription)")
                 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Language.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Language.swift
@@ -26,17 +26,21 @@ extension ConversationInputBarViewController {
 
     }
 
-    @objc func inputModeDidChange(_ notification: Notification?) {
+    @objc
+    func inputModeDidChange(_ notification: Notification?) {
+        guard let conversation = conversation as? ZMConversation else { return }
 
         guard let keyboardLanguage =  self.inputBar.textView.originalTextInputMode?.primaryLanguage else { return }
 
         ZMUserSession.shared()?.enqueue {
-            self.conversation.language = keyboardLanguage
+            conversation.language = keyboardLanguage
             self.setInputLanguage()
         }
     }
 
     func setInputLanguage() {
+        guard let conversation = conversation as? ZMConversation else { return }
+
         inputBar.textView.language = conversation.language
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Location.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Location.swift
@@ -42,11 +42,14 @@ extension ConversationInputBarViewController {
 }
 
 extension ConversationInputBarViewController: LocationSelectionViewControllerDelegate {
+    
     func locationSelectionViewController(_ viewController: LocationSelectionViewController, didSelectLocationWithData locationData: LocationData) {
+        guard let conversation = conversation as? ZMConversation else { return }
+
         ZMUserSession.shared()?.enqueue {
             do {
-                try self.conversation.appendLocation(with: locationData)
-                Analytics.shared.tagMediaActionCompleted(.location, inConversation: self.conversation)
+                try conversation.appendLocation(with: locationData)
+                Analytics.shared.tagMediaActionCompleted(.location, inConversation: conversation)
             } catch {
                 Logging.messageProcessing.warn("Failed to append location message. Reason: \(error.localizedDescription)")
             }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Mentions.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Mentions.swift
@@ -85,6 +85,8 @@ extension ConversationInputBarViewController {
     }
 
     func triggerMentionsIfNeeded(from textView: UITextView, with selection: UITextRange? = nil) {
+        guard let conversation = conversation as? ZMConversation else { return }
+
         if let position = MentionsHandler.cursorPosition(in: textView, range: selection) {
             mentionsHandler = MentionsHandler(text: textView.text, cursorPosition: position)
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+UITextViewDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+UITextViewDelegate.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import UIKit
+import WireDataModel
 
 // MARK: SplitViewController reveal
 
@@ -35,7 +36,9 @@ extension ConversationInputBarViewController {
 }
 
 extension ConversationInputBarViewController: UITextViewDelegate {
-    public func textViewDidChange(_ textView: UITextView) {
+    func textViewDidChange(_ textView: UITextView) {
+        guard let conversation = conversation as? ZMConversation else { return }
+
         // In case the conversation isDeleted
         if conversation.managedObjectContext == nil {
             return
@@ -47,7 +50,7 @@ extension ConversationInputBarViewController: UITextViewDelegate {
         updateRightAccessoryView()
     }
 
-    public func textView(_ textView: UITextView, shouldInteractWith textAttachment: NSTextAttachment, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
+    func textView(_ textView: UITextView, shouldInteractWith textAttachment: NSTextAttachment, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
         return textAttachment.image == nil
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
@@ -29,6 +29,26 @@ enum ConversationInputBarViewControllerMode {
     case timeoutConfguration
 }
 
+protocol InputBarConversationType {
+    var typingUsers: [UserType] { get }
+    var hasDraftMessage: Bool { get }
+    var connectedUserType: UserType? { get } ///TODO: merge with ConnectionRequest protocol
+    var draftMessage: DraftMessage? { get }
+    var messageDestructionTimeoutValue: TimeInterval { get }
+    var conversationType: ZMConversationType { get }
+    var hasSyncedMessageDestructionTimeout: Bool { get }
+    
+    var timeoutImage: UIImage? { get }
+    var disabledTimeoutImage: UIImage? { get }
+    
+    func setIsTyping(_ isTyping: Bool)
+    
+    var isReadOnly: Bool { get }
+    var displayName: String { get }
+}
+
+extension ZMConversation: InputBarConversationType {}
+
 final class ConversationInputBarViewController: UIViewController,
                                             UIPopoverPresentationControllerDelegate,
                                                 PopoverPresenter {
@@ -36,7 +56,7 @@ final class ConversationInputBarViewController: UIViewController,
     var presentedPopover: UIPopoverPresentationController?
     var popoverPointToView: UIView?
 
-    let conversation: ZMConversation
+    let conversation: InputBarConversationType
     weak var delegate: ConversationInputBarViewControllerDelegate?
 
     private(set) var inputController: UIViewController? {
@@ -263,12 +283,13 @@ final class ConversationInputBarViewController: UIViewController,
 
     /// init with a ZMConversation objcet
     /// - Parameter conversation: provide nil only for tests
-    init(conversation: ZMConversation) {
+    init(conversation: InputBarConversationType) {
         self.conversation = conversation
 
         super.init(nibName: nil, bundle: nil)
 
-        if !ProcessInfo.processInfo.isRunningTests {
+        if !ProcessInfo.processInfo.isRunningTests,
+           let conversation = conversation as? ZMConversation {
             conversationObserverToken = ConversationChangeInfo.add(observer:self, for: conversation)
             typingObserverToken = conversation.addTypingObserver(self)
         }
@@ -333,11 +354,12 @@ final class ConversationInputBarViewController: UIViewController,
             return
         }
         
-        if conversationObserverToken == nil {
+        if conversationObserverToken == nil,
+           let conversation = conversation as? ZMConversation {
             conversationObserverToken = ConversationChangeInfo.add(observer:self, for: conversation)
         }
         
-        if let connectedUser = conversation.connectedUser,
+        if let connectedUser = conversation.connectedUserType as? ZMUser,
            let userSession = ZMUserSession.shared() {
             userObserverToken = UserChangeInfo.add(observer:self, for: connectedUser, in: userSession)
         }
@@ -413,7 +435,13 @@ final class ConversationInputBarViewController: UIViewController,
 
         let trimmed = inputBar.textView.text.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
 
-        sendButtonState.update(textLength: trimmed.count, editing: nil != editingMessage, markingDown: inputBar.isMarkingDown, destructionTimeout: conversation.messageDestructionTimeoutValue, conversationType: conversation.conversationType, mode: mode, syncedMessageDestructionTimeout: conversation.hasSyncedMessageDestructionTimeout)
+        sendButtonState.update(textLength: trimmed.count,
+                               editing: nil != editingMessage,
+                               markingDown: inputBar.isMarkingDown,
+                               destructionTimeout: conversation.messageDestructionTimeoutValue,
+                               conversationType: conversation.conversationType,
+                               mode: mode,
+                               syncedMessageDestructionTimeout: conversation.hasSyncedMessageDestructionTimeout)
 
         sendButton.isHidden = sendButtonState.sendButtonHidden
         hourglassButton.isHidden = sendButtonState.hourglassButtonHidden
@@ -450,7 +478,7 @@ final class ConversationInputBarViewController: UIViewController,
     func updateAvailabilityPlaceholder() {
         guard ZMUser.selfUser().hasTeam,
             conversation.conversationType == .oneOnOne,
-            let connectedUser = conversation.connectedUser else {
+            let connectedUser = conversation.connectedUserType else {
                 return
         }
 
@@ -522,16 +550,18 @@ final class ConversationInputBarViewController: UIViewController,
     // MARK: - PingButton
 
     @objc
-    func pingButtonPressed(_ button: UIButton?) {
+    private func pingButtonPressed(_ button: UIButton?) {
         appendKnock()
     }
 
     private func appendKnock() {
+        guard let conversation = conversation as? ZMConversation else { return }
+        
         notificationFeedbackGenerator.prepare()
         ZMUserSession.shared()?.enqueue({
             do {
-                try self.conversation.appendKnock()
-                Analytics.shared.tagMediaActionCompleted(.ping, inConversation: self.conversation)
+                try conversation.appendKnock()
+                Analytics.shared.tagMediaActionCompleted(.ping, inConversation: conversation)
 
                 AVSMediaManager.sharedInstance().playKnockSound()
                 self.notificationFeedbackGenerator.notificationOccurred(.success)
@@ -558,7 +588,7 @@ final class ConversationInputBarViewController: UIViewController,
 
     @objc
     private func giphyButtonPressed(_ sender: Any?) {
-        guard !AppDelegate.isOffline else { return }
+        guard !AppDelegate.isOffline, let conversation = conversation as? ZMConversation else { return }
 
         let giphySearchViewController = GiphySearchViewController(searchTerm: "", conversation: conversation)
         giphySearchViewController.delegate = self

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
@@ -29,26 +29,6 @@ enum ConversationInputBarViewControllerMode {
     case timeoutConfguration
 }
 
-protocol InputBarConversationType {
-    var typingUsers: [UserType] { get }
-    var hasDraftMessage: Bool { get }
-    var connectedUserType: UserType? { get } ///TODO: merge with ConnectionRequest protocol
-    var draftMessage: DraftMessage? { get }
-    var messageDestructionTimeoutValue: TimeInterval { get }
-    var conversationType: ZMConversationType { get }
-    var hasSyncedMessageDestructionTimeout: Bool { get }
-    
-    var timeoutImage: UIImage? { get }
-    var disabledTimeoutImage: UIImage? { get }
-    
-    func setIsTyping(_ isTyping: Bool)
-    
-    var isReadOnly: Bool { get }
-    var displayName: String { get }
-}
-
-extension ZMConversation: InputBarConversationType {}
-
 final class ConversationInputBarViewController: UIViewController,
                                             UIPopoverPresentationControllerDelegate,
                                                 PopoverPresenter {
@@ -281,7 +261,7 @@ final class ConversationInputBarViewController: UIViewController,
 
     // MARK: - Input views handling
 
-    /// init with a ZMConversation objcet
+    /// init with a InputBarConversationType objcet
     /// - Parameter conversation: provide nil only for tests
     init(conversation: InputBarConversationType) {
         self.conversation = conversation

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/EphemeralKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/EphemeralKeyboardViewController.swift
@@ -31,7 +31,7 @@ protocol EphemeralKeyboardViewControllerDelegate: class {
     )
 }
 
-extension InputBarConversationType {
+extension InputBarConversation {
 
     var destructionTimeout: MessageDestructionTimeoutValue? {
         switch messageDestructionTimeout {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/EphemeralKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/EphemeralKeyboardViewController.swift
@@ -31,7 +31,7 @@ protocol EphemeralKeyboardViewControllerDelegate: class {
     )
 }
 
-public extension ZMConversation {
+extension ZMConversation { ///TODO: abstact
 
     var destructionTimeout: MessageDestructionTimeoutValue? {
         switch messageDestructionTimeout {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/EphemeralKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/EphemeralKeyboardViewController.swift
@@ -31,7 +31,7 @@ protocol EphemeralKeyboardViewControllerDelegate: class {
     )
 }
 
-extension ZMConversation { ///TODO: abstact
+extension InputBarConversationType {
 
     var destructionTimeout: MessageDestructionTimeoutValue? {
         switch messageDestructionTimeout {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarConversationType.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarConversationType.swift
@@ -1,0 +1,43 @@
+
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireDataModel
+
+protocol InputBarConversationType {
+    var typingUsers: [UserType] { get }
+    var hasDraftMessage: Bool { get }
+    var connectedUserType: UserType? { get } ///TODO: merge with ConnectionRequest protocol
+    var draftMessage: DraftMessage? { get }
+    
+    var messageDestructionTimeoutValue: TimeInterval { get }
+    var messageDestructionTimeout: MessageDestructionTimeout? { get }
+    
+    var conversationType: ZMConversationType { get }
+    var hasSyncedMessageDestructionTimeout: Bool { get }
+    
+    var timeoutImage: UIImage? { get }
+    var disabledTimeoutImage: UIImage? { get }
+    
+    func setIsTyping(_ isTyping: Bool)
+    
+    var isReadOnly: Bool { get }
+    var displayName: String { get }
+}
+
+extension ZMConversation: InputBarConversationType {}

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarConversationType.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarConversationType.swift
@@ -30,10 +30,7 @@ protocol InputBarConversationType {
     
     var conversationType: ZMConversationType { get }
     var hasSyncedMessageDestructionTimeout: Bool { get }
-    
-    var timeoutImage: UIImage? { get }
-    var disabledTimeoutImage: UIImage? { get }
-    
+        
     func setIsTyping(_ isTyping: Bool)
     
     var isReadOnly: Bool { get }


### PR DESCRIPTION
## What's new in this PR?

When testing `ConversationInputBarViewController` in `ConversationInputBarViewControllerTests`, we had to create `ZMConversation` and `ZMUser`. This PR creates a simpler interface `InputBarConversationType` for easier to mock a conversation to prevent creating ZMConversation.

### TODO
- [x] update other tests
- [x] merge with `ConnectionRequest` in https://github.com/wireapp/wire-ios/pull/4804 or seperate `InputBarConversationType` into 2 protocols
- [x] add more protocol methods to prevent guard and casting