### PR TITLE
[Fix] Setup script failing on CI machines

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -69,8 +69,4 @@ echo "ℹ️ Update Licenses File..."
 swift run --package-path ./Scripts/updateLicenses
 echo ""
 
-echo "ℹ️  Installing template files..."
-./Scripts/install-templates.sh
-echo ""
-
 echo "✅  Wire project was set up, you can now open Wire-iOS.xcodeproj"


### PR DESCRIPTION
## What's new in this PR?

### Issues

The `setup.sh` script is failing on CI machines.

### Causes

The failure is caused by the recently added step to install the Viper template files in Xcode. On the CI machine we don't have permission to copy the files to the right location, so it fails.

### Solutions

Don't install the viper templates in the setup script.

