### PR TITLE
Add init with selfUser ConversationMessageCell protocol

### DIFF
--- a/Wire-iOS Tests/ConversationMessageCell/ConversationLinkAttachmentMessageCellTests.swift
+++ b/Wire-iOS Tests/ConversationMessageCell/ConversationLinkAttachmentMessageCellTests.swift
@@ -46,7 +46,7 @@ final class ConversationLinkAttachmentMessageCellTests: ConversationCellSnapshot
         let configuration = ConversationLinkAttachmentCell.Configuration(attachment: attachment, thumbnailResource: mockThumbnail)
 
         // WHEN
-        let cell = ConversationLinkAttachmentCell()
+        let cell = ConversationLinkAttachmentCell(selfUser: selfUser)
         cell.configure(with: configuration, animated: false)
         cell.frame.size = cell.systemLayoutSizeFitting(CGSize(width: 414, height: 0))
 
@@ -64,7 +64,7 @@ final class ConversationLinkAttachmentMessageCellTests: ConversationCellSnapshot
         let configuration = ConversationLinkAttachmentCell.Configuration(attachment: attachment, thumbnailResource: mockThumbnail)
 
         // WHEN
-        let cell = ConversationLinkAttachmentCell()
+        let cell = ConversationLinkAttachmentCell(selfUser: selfUser)
         cell.configure(with: configuration, animated: false)
         cell.frame.size = cell.systemLayoutSizeFitting(CGSize(width: 414, height: 0))
 
@@ -82,7 +82,7 @@ final class ConversationLinkAttachmentMessageCellTests: ConversationCellSnapshot
         let configuration = ConversationLinkAttachmentCell.Configuration(attachment: attachment, thumbnailResource: mockThumbnail)
 
         // WHEN
-        let cell = ConversationLinkAttachmentCell()
+        let cell = ConversationLinkAttachmentCell(selfUser: selfUser)
         cell.configure(with: configuration, animated: false)
         cell.frame.size = cell.systemLayoutSizeFitting(CGSize(width: 414, height: 0))
 

--- a/Wire-iOS Tests/ConversationMessageCell/MockCell.swift
+++ b/Wire-iOS Tests/ConversationMessageCell/MockCell.swift
@@ -19,7 +19,7 @@
 import UIKit
 @testable import Wire
 
-class MockCell: UIView, ConversationMessageCell {
+final class MockCell: UIView, ConversationMessageCell {
     struct Configuration {
         let backgroundColor: UIColor
     }
@@ -30,6 +30,15 @@ class MockCell: UIView, ConversationMessageCell {
     var isConfigured: Bool  = false
     var isSelected: Bool = false
 
+    init(selfUser: UserType) {
+        super.init(frame: .zero)
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     func configure(with object: Configuration, animated: Bool) {
         isConfigured = true
         backgroundColor = object.backgroundColor

--- a/Wire-iOS Tests/ConversationMessageCell/MockCell.swift
+++ b/Wire-iOS Tests/ConversationMessageCell/MockCell.swift
@@ -30,8 +30,8 @@ final class MockCell: UIView, ConversationMessageCell {
     var isConfigured: Bool  = false
     var isSelected: Bool = false
 
-    override init(selfUser: UserType) {
-        super.init(selfUser: selfUser)
+    init(selfUser: UserType) {
+        super.init(frame: .zero)
     }
     
     @available(*, unavailable)

--- a/Wire-iOS Tests/ConversationMessageCell/MockCell.swift
+++ b/Wire-iOS Tests/ConversationMessageCell/MockCell.swift
@@ -30,8 +30,8 @@ final class MockCell: UIView, ConversationMessageCell {
     var isConfigured: Bool  = false
     var isSelected: Bool = false
 
-    init(selfUser: UserType) {
-        super.init(frame: .zero)
+    override init(selfUser: UserType) {
+        super.init(selfUser: selfUser)
     }
     
     @available(*, unavailable)

--- a/Wire-iOS Tests/ConversationReplyCellTests.swift
+++ b/Wire-iOS Tests/ConversationReplyCellTests.swift
@@ -488,7 +488,7 @@ final class ConversationReplyCellTests: CoreDataSnapshotTestCase {
 
     private func makeCell(for message: ZMConversationMessage?) -> ConversationReplyCell {
         let cellDescription = ConversationReplyCellDescription(quotedMessage: message)
-        let cell = ConversationReplyCell()
+        let cell = ConversationReplyCell(selfUser: selfUser)
         cell.configure(with: cellDescription.configuration, animated: false)
         XCTAssertTrue(waitForGroupsToBeEmpty([MediaAssetCache.defaultImageCache.dispatchGroup]))
         return cell

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/BurstTimestampTableViewCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/BurstTimestampTableViewCell.swift
@@ -64,16 +64,15 @@ final class BurstTimestampSenderMessageCell: UIView, ConversationMessageCell {
     weak var delegate: ConversationMessageCellDelegate? = nil
     weak var message: ZMConversationMessage? = nil
     
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    init(selfUser: UserType) {
+        super.init(frame: .zero)
         configureSubviews()
         configureConstraints()
     }
 
+    @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
-        configureSubviews()
-        configureConstraints()
+        fatalError("init(coder:) has not been implemented")
     }
 
     private func configureSubviews() {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationGuestsAllowedCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationGuestsAllowedCell.swift
@@ -64,12 +64,13 @@ final class GuestsAllowedCell: UIView, ConversationMessageCell {
     let inviteButton = InviteButton()
     var isSelected: Bool = false
         
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    init(selfUser: UserType) {
+        super.init(frame: .zero)
         setupViews()
         createConstraints()
     }
     
+    @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationIconBasedCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationIconBasedCell.swift
@@ -66,16 +66,17 @@ class ConversationIconBasedCell: UIView {
         return -conversationHorizontalMargins.right * 2
     }
 
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    /// allow injection self user when testing a ConversationMessageCell
+    /// - Parameter selfUser: self user for configuration
+    init(selfUser: UserType) {
+        super.init(frame: .zero)
         configureSubviews()
         configureConstraints()
     }
 
+    @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
-        configureSubviews()
-        configureConstraints()
+        fatalError("init(coder:) has not been implemented")
     }
 
     func configureSubviews() {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationLegalHoldCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationLegalHoldCell.swift
@@ -31,16 +31,16 @@ final class ConversationLegalHoldSystemMessageCell: ConversationIconBasedCell, C
         var conversation: ZMConversation?
     }
     
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    init(selfUser: UserType) {
+        super.init(frame: .zero)
         setupView()
     }
     
+    @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
-        setupView()
+        fatalError("init(coder:) has not been implemented")
     }
-    
+
     func setupView() {
         lineView.isHidden = true
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationLegalHoldCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationLegalHoldCell.swift
@@ -31,14 +31,9 @@ final class ConversationLegalHoldSystemMessageCell: ConversationIconBasedCell, C
         var conversation: ZMConversation?
     }
     
-    init(selfUser: UserType) {
-        super.init(frame: .zero)
+    override init(selfUser: UserType) {
+        super.init(selfUser: selfUser)
         setupView()
-    }
-    
-    @available(*, unavailable)
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
     }
 
     func setupView() {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationMessageToolboxCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationMessageToolboxCell.swift
@@ -40,16 +40,15 @@ final class ConversationMessageToolboxCell: UIView, ConversationMessageCell, Mes
     var isSelected: Bool = false
     var observerToken: Any?
 
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    init(selfUser: UserType) {
+        super.init(frame: .zero)
         configureSubviews()
         configureConstraints()
     }
 
+    @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
-        configureSubviews()
-        configureConstraints()
+        fatalError("init(coder:) has not been implemented")
     }
 
     private func configureSubviews() {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSenderMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSenderMessageCell.swift
@@ -20,7 +20,7 @@ import UIKit
 import WireCommonComponents
 import WireDataModel
 
-class ConversationSenderMessageCell: UIView, ConversationMessageCell {
+final class ConversationSenderMessageCell: UIView, ConversationMessageCell {
 
     struct Configuration {
         let user: UserType
@@ -38,16 +38,15 @@ class ConversationSenderMessageCell: UIView, ConversationMessageCell {
 
     private var indicatorImageViewTrailing: NSLayoutConstraint!
 
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    init(selfUser: UserType) {
+        super.init(frame: .zero)
         configureSubviews()
         configureConstraints()
     }
 
+    @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
-        configureSubviews()
-        configureConstraints()
+        fatalError("init(coder:) has not been implemented")
     }
 
     func configure(with object: Configuration, animated: Bool) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCell.swift
@@ -18,12 +18,11 @@
 
 import UIKit
 import WireCommonComponents
-import WireDataModel
 import WireSyncEngine
 
 // MARK: - Cells
 
-class ConversationSystemMessageCell: ConversationIconBasedCell, ConversationMessageCell {
+final class ConversationSystemMessageCell: ConversationIconBasedCell, ConversationMessageCell {
 
     struct Configuration: Equatable {
         let icon: UIImage?
@@ -32,7 +31,15 @@ class ConversationSystemMessageCell: ConversationIconBasedCell, ConversationMess
     }
 
     // MARK: - Configuration
-
+    init(selfUser: UserType) {
+        super.init(frame: .zero)
+    }
+    
+    @available(*, unavailable)
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     func configure(with object: Configuration, animated: Bool) {
         lineView.isHidden = !object.showLine
         imageView.image = object.icon
@@ -41,7 +48,7 @@ class ConversationSystemMessageCell: ConversationIconBasedCell, ConversationMess
 
 }
 
-class ConversationStartedSystemMessageCell: ConversationIconBasedCell, ConversationMessageCell {
+final class ConversationStartedSystemMessageCell: ConversationIconBasedCell, ConversationMessageCell {
     
     struct Configuration {
         let title: NSAttributedString?
@@ -53,6 +60,15 @@ class ConversationStartedSystemMessageCell: ConversationIconBasedCell, Conversat
     private let titleLabel = UILabel()
     private var selectedUsers: [UserType] = []
     
+    init(selfUser: UserType) {
+        super.init(frame: .zero)
+    }
+    
+    @available(*, unavailable)
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     override func configureSubviews() {
         super.configureSubviews()
         
@@ -88,7 +104,7 @@ extension ConversationStartedSystemMessageCell {
 
 }
 
-class ParticipantsConversationSystemMessageCell: ConversationIconBasedCell, ConversationMessageCell {
+final class ParticipantsConversationSystemMessageCell: ConversationIconBasedCell, ConversationMessageCell {
     
     struct Configuration: Equatable {
         let icon: UIImage?
@@ -99,6 +115,15 @@ class ParticipantsConversationSystemMessageCell: ConversationIconBasedCell, Conv
     
     private let warningLabel = UILabel()
     
+    init(selfUser: UserType) {
+        super.init(frame: .zero)
+    }
+    
+    @available(*, unavailable)
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     override func configureSubviews() {
         super.configureSubviews()
         warningLabel.numberOfLines = 0
@@ -124,7 +149,7 @@ class ParticipantsConversationSystemMessageCell: ConversationIconBasedCell, Conv
     }
 }
 
-class LinkConversationSystemMessageCell: ConversationIconBasedCell, ConversationMessageCell {
+final class LinkConversationSystemMessageCell: ConversationIconBasedCell, ConversationMessageCell {
 
     struct Configuration {
         let icon: UIImage?
@@ -134,6 +159,15 @@ class LinkConversationSystemMessageCell: ConversationIconBasedCell, Conversation
     }
 
     var lastConfiguration: Configuration?
+
+    init(selfUser: UserType) {
+        super.init(frame: .zero)
+    }
+    
+    @available(*, unavailable)
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     // MARK: - Configuration
 
@@ -178,18 +212,16 @@ class NewDeviceSystemMessageCell: ConversationIconBasedCell, ConversationMessage
         var linkTarget: LinkTarget
     }
     
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        
-       setupView()
-    }
-    
-    required init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
-        
+    init(selfUser: UserType) {
+        super.init(frame: .zero)
         setupView()
     }
     
+    @available(*, unavailable)
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     func setupView() {
         lineView.isHidden = false
     }
@@ -206,7 +238,7 @@ class NewDeviceSystemMessageCell: ConversationIconBasedCell, ConversationMessage
 
 extension NewDeviceSystemMessageCell {
 
-    public override func textView(_ textView: UITextView, shouldInteractWith url: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
+    override func textView(_ textView: UITextView, shouldInteractWith url: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
 
         guard let linkTarget = linkTarget,
               url == type(of: self).userClientURL,
@@ -224,7 +256,7 @@ extension NewDeviceSystemMessageCell {
 
 }
 
-class ConversationRenamedSystemMessageCell: ConversationIconBasedCell, ConversationMessageCell {
+final class ConversationRenamedSystemMessageCell: ConversationIconBasedCell, ConversationMessageCell {
 
     struct Configuration {
         let attributedText: NSAttributedString
@@ -233,6 +265,15 @@ class ConversationRenamedSystemMessageCell: ConversationIconBasedCell, Conversat
 
     var nameLabelFont: UIFont? = .normalSemiboldFont
     private let nameLabel = UILabel()
+
+    init(selfUser: UserType) {
+        super.init(frame: .zero)
+    }
+    
+    @available(*, unavailable)
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     override func configureSubviews() {
         super.configureSubviews()

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCell.swift
@@ -31,14 +31,6 @@ final class ConversationSystemMessageCell: ConversationIconBasedCell, Conversati
     }
 
     // MARK: - Configuration
-    init(selfUser: UserType) {
-        super.init(frame: .zero)
-    }
-    
-    @available(*, unavailable)
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
     
     func configure(with object: Configuration, animated: Bool) {
         lineView.isHidden = !object.showLine
@@ -60,15 +52,6 @@ final class ConversationStartedSystemMessageCell: ConversationIconBasedCell, Con
     private let titleLabel = UILabel()
     private var selectedUsers: [UserType] = []
     
-    init(selfUser: UserType) {
-        super.init(frame: .zero)
-    }
-    
-    @available(*, unavailable)
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
     override func configureSubviews() {
         super.configureSubviews()
         
@@ -115,15 +98,6 @@ final class ParticipantsConversationSystemMessageCell: ConversationIconBasedCell
     
     private let warningLabel = UILabel()
     
-    init(selfUser: UserType) {
-        super.init(frame: .zero)
-    }
-    
-    @available(*, unavailable)
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
     override func configureSubviews() {
         super.configureSubviews()
         warningLabel.numberOfLines = 0
@@ -159,15 +133,6 @@ final class LinkConversationSystemMessageCell: ConversationIconBasedCell, Conver
     }
 
     var lastConfiguration: Configuration?
-
-    init(selfUser: UserType) {
-        super.init(frame: .zero)
-    }
-    
-    @available(*, unavailable)
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
 
     // MARK: - Configuration
 
@@ -212,16 +177,11 @@ final class NewDeviceSystemMessageCell: ConversationIconBasedCell, ConversationM
         var linkTarget: LinkTarget
     }
     
-    init(selfUser: UserType) {
-        super.init(frame: .zero)
+    override init(selfUser: UserType) {
+        super.init(selfUser: selfUser)
         setupView()
     }
     
-    @available(*, unavailable)
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
     func setupView() {
         lineView.isHidden = false
     }
@@ -265,15 +225,6 @@ final class ConversationRenamedSystemMessageCell: ConversationIconBasedCell, Con
 
     var nameLabelFont: UIFont? = .normalSemiboldFont
     private let nameLabel = UILabel()
-
-    init(selfUser: UserType) {
-        super.init(frame: .zero)
-    }
-    
-    @available(*, unavailable)
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
 
     override func configureSubviews() {
         super.configureSubviews()

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCell.swift
@@ -195,7 +195,7 @@ extension LinkConversationSystemMessageCell {
 }
 
 
-class NewDeviceSystemMessageCell: ConversationIconBasedCell, ConversationMessageCell {
+final class NewDeviceSystemMessageCell: ConversationIconBasedCell, ConversationMessageCell {
     
     static let userClientURL: URL = URL(string: "settings://user-client")!
     

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/UnknownMessageCellDescription.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/UnknownMessageCellDescription.swift
@@ -20,8 +20,8 @@ import Foundation
 import UIKit
 import WireDataModel
 
-extension CustomMessageView: ConversationMessageCell {
-
+extension CustomMessageView {
+    
     var selectionView: UIView? {
         return messageLabel
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Poll/ConversationButtonMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Poll/ConversationButtonMessageCell.swift
@@ -103,28 +103,20 @@ final class ConversationButtonMessageCell: UIView, ConversationMessageCell {
         let hasError: Bool
     }
 
-    convenience init() {
-        self.init(frame: .zero)
-    }
-
-    override init(frame: CGRect) {
+    init(selfUser: UserType) {
         super.init(frame: .zero)
-
+        
         configureViews()
         createConstraints()
-
+        
         button.addTarget(self, action: #selector(buttonTouched(sender:)), for: .touchUpInside)
     }
-
+    
     @objc
     private func buttonTouched(sender: Any) {
         buttonAction?()
     }
 
-    init(selfUser: UserType) {
-        super.init(frame: .zero)
-    }
-    
     @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Poll/ConversationButtonMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Poll/ConversationButtonMessageCell.swift
@@ -121,6 +121,10 @@ final class ConversationButtonMessageCell: UIView, ConversationMessageCell {
         buttonAction?()
     }
 
+    init(selfUser: UserType) {
+        super.init(frame: .zero)
+    }
+    
     @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationAudioMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationAudioMessageCell.swift
@@ -20,7 +20,7 @@ import Foundation
 import UIKit
 import WireDataModel
 
-class ConversationAudioMessageCell: RoundedView, ConversationMessageCell {
+final class ConversationAudioMessageCell: RoundedView, ConversationMessageCell {
     
     struct Configuration {
         let message: ZMConversationMessage
@@ -37,18 +37,17 @@ class ConversationAudioMessageCell: RoundedView, ConversationMessageCell {
     
     var isSelected: Bool = false
     
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    init(selfUser: UserType) {
+        super.init(frame: .zero)
         configureSubviews()
         configureConstraints()
     }
     
-    public required init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
-        configureSubviews()
-        configureConstraints()
+    @available(*, unavailable)
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
-    
+
     private func configureSubviews() {
         shape = .rounded(radius: 4)
         backgroundColor = .from(scheme: .placeholderBackground)

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationImageMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationImageMessageCell.swift
@@ -63,8 +63,8 @@ final class ConversationImageMessageCell: UIView,
         return containerView
     }
 
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    init(selfUser: UserType) {
+        super.init(frame: .zero)
         configureViews()
         createConstraints()
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationLocationMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationLocationMessageCell.swift
@@ -54,8 +54,8 @@ final class ConversationLocationMessageCell: UIView, ConversationMessageCell, Co
         return containerView
     }
 
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    init(selfUser: UserType) {
+        super.init(frame: .zero)
         configureViews()
         createConstraints()
 
@@ -65,6 +65,7 @@ final class ConversationLocationMessageCell: UIView, ConversationMessageCell, Co
         }
     }
 
+    @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationPingCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationPingCell.swift
@@ -19,7 +19,7 @@
 import Foundation
 import WireDataModel
 
-class ConversationPingCell: ConversationIconBasedCell, ConversationMessageCell {
+final class ConversationPingCell: ConversationIconBasedCell, ConversationMessageCell {
 
     typealias AnimationBlock = (_ animationBlock: Any, _ reps: Int) -> Void
     var animationBlock: AnimationBlock?
@@ -30,6 +30,15 @@ class ConversationPingCell: ConversationIconBasedCell, ConversationMessageCell {
         let pingColor: UIColor
         let pingText: NSAttributedString
         var message: ZMConversationMessage?
+    }
+    
+    init(selfUser: UserType) {
+        super.init(frame: .zero)
+    }
+    
+    @available(*, unavailable)
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 
     func configure(with object: Configuration, animated: Bool) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationPingCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationPingCell.swift
@@ -32,13 +32,8 @@ final class ConversationPingCell: ConversationIconBasedCell, ConversationMessage
         var message: ZMConversationMessage?
     }
     
-    init(selfUser: UserType) {
-        super.init(frame: .zero)
-    }
-    
-    @available(*, unavailable)
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+    override init(selfUser: UserType) {
+        super.init(selfUser: selfUser)
     }
 
     func configure(with object: Configuration, animated: Bool) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationVideoMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationVideoMessageCell.swift
@@ -37,18 +37,17 @@ final class ConversationVideoMessageCell: RoundedView, ConversationMessageCell {
     
     var isSelected: Bool = false
     
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    init(selfUser: UserType) {
+        super.init(frame: .zero)
         configureSubviews()
         configureConstraints()
     }
     
-    public required init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
-        configureSubviews()
-        configureConstraints()
+    @available(*, unavailable)
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
-    
+
     private func configureSubviews() {
         shape = .rounded(radius: 4)
         backgroundColor = .from(scheme: .placeholderBackground)

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationFileMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationFileMessageCell.swift
@@ -19,7 +19,7 @@
 import UIKit
 import WireDataModel
 
-class ConversationFileMessageCell: RoundedView, ConversationMessageCell {
+final class ConversationFileMessageCell: RoundedView, ConversationMessageCell {
 
     struct Configuration {
         let message: ZMConversationMessage
@@ -36,16 +36,15 @@ class ConversationFileMessageCell: RoundedView, ConversationMessageCell {
 
     var isSelected: Bool = false
 
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    init(selfUser: UserType) {
+        super.init(frame: .zero)
         configureSubviews()
         configureConstraints()
     }
 
-    public required init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
-        configureSubviews()
-        configureConstraints()
+    @available(*, unavailable)
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 
     private func configureSubviews() {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationLinkAttachmentCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationLinkAttachmentCell.swift
@@ -47,8 +47,8 @@ final class ConversationLinkAttachmentCell: UIView, ConversationMessageCell, Hig
 
     // MARK: - Initialization
 
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    init(selfUser: UserType) {
+        super.init(frame: .zero)
         configureSubviews()
         configureConstraints()
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationLinkPreviewArticleCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationLinkPreviewArticleCell.swift
@@ -43,16 +43,16 @@ final class ConversationLinkPreviewArticleCell: UIView, ConversationMessageCell,
 
     var configuration: Configuration?
 
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    init(selfUser: UserType) {
+        super.init(frame: .zero)
+        
         configureSubviews()
         configureConstraints()
     }
-
-    required init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
-        configureSubviews()
-        configureConstraints()
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 
     private func configureSubviews() {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationQuoteCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationQuoteCell.swift
@@ -144,7 +144,7 @@ final class ConversationReplyContentView: UIView {
 
 }
 
-class ConversationReplyCell: UIView, ConversationMessageCell {
+final class ConversationReplyCell: UIView, ConversationMessageCell {
     typealias Configuration = ConversationReplyContentView.Configuration
     var isSelected: Bool = false
 
@@ -154,14 +154,15 @@ class ConversationReplyCell: UIView, ConversationMessageCell {
     weak var delegate: ConversationMessageCellDelegate?
     weak var message: ZMConversationMessage?
 
-    override init(frame: CGRect) {
+    init(selfUser: UserType) {
         contentView = ConversationReplyContentView()
         container = ReplyRoundCornersView(containedView: contentView)
-        super.init(frame: frame)
+        super.init(frame: .zero)
         configureSubviews()
         configureConstraints()
     }
-
+    
+    @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationTextMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationTextMessageCell.swift
@@ -76,8 +76,8 @@ final class ConversationTextMessageCell: UIView,
         return messageTextView.layoutManager.usedRect(for: messageTextView.textContainer)
     }
 
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    init(selfUser: UserType) {
+        super.init(frame: .zero)
         setup()
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
@@ -172,7 +172,7 @@ extension ConversationMessageCellDescription {
     }
     
     func makeView() -> UIView {
-        let view = View()
+        let view = View(selfUser: ZMUser.selfUser()) ///TODO: inject
         let container = UIView()
         
         view.translatesAutoresizingMaskIntoConstraints = false

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
@@ -171,7 +171,7 @@ extension ConversationMessageCellDescription {
     }
     
     func makeView() -> UIView {
-        let view = View()
+        let view = View(selfUser: ZMUser.selfUser())
         let container = UIView()
         
         view.translatesAutoresizingMaskIntoConstraints = false

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
@@ -70,6 +70,11 @@ protocol ConversationMessageCell: class {
     
     /// Called after the cell as been moved off screen.
     func didEndDisplaying()
+
+    
+    /// allow injection self user when testing a ConversationMessageCell
+    /// - Parameter selfUser: self user for configuration
+    init(selfUser: UserType)
 }
 
 extension ConversationMessageCell {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
@@ -70,7 +70,6 @@ protocol ConversationMessageCell: class {
     
     /// Called after the cell as been moved off screen.
     func didEndDisplaying()
-
     
     /// allow injection self user when testing a ConversationMessageCell
     /// - Parameter selfUser: self user for configuration
@@ -172,7 +171,7 @@ extension ConversationMessageCellDescription {
     }
     
     func makeView() -> UIView {
-        let view = View(selfUser: ZMUser.selfUser()) ///TODO: inject
+        let view = View()
         let container = UIView()
         
         view.translatesAutoresizingMaskIntoConstraints = false

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCellTableViewAdapter.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCellTableViewAdapter.swift
@@ -94,7 +94,7 @@ class ConversationMessageCellTableViewAdapter<C: ConversationMessageCellDescript
     var showsMenu = false
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        self.cellView = C.View(selfUser: ZMUser.selfUser()) ///TODO: inject
+        self.cellView = C.View()
         self.cellView.translatesAutoresizingMaskIntoConstraints = false
         self.ephemeralCountdownView = EphemeralCountdownView()
         self.ephemeralCountdownView.translatesAutoresizingMaskIntoConstraints = false

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCellTableViewAdapter.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCellTableViewAdapter.swift
@@ -94,7 +94,7 @@ class ConversationMessageCellTableViewAdapter<C: ConversationMessageCellDescript
     var showsMenu = false
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        self.cellView = C.View(frame: .zero)
+        self.cellView = C.View(selfUser: ZMUser.selfUser()) ///TODO: inject
         self.cellView.translatesAutoresizingMaskIntoConstraints = false
         self.ephemeralCountdownView = EphemeralCountdownView()
         self.ephemeralCountdownView.translatesAutoresizingMaskIntoConstraints = false

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCellTableViewAdapter.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCellTableViewAdapter.swift
@@ -94,8 +94,8 @@ class ConversationMessageCellTableViewAdapter<C: ConversationMessageCellDescript
     var showsMenu = false
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        self.cellView = C.View()
-        self.cellView.translatesAutoresizingMaskIntoConstraints = false
+        cellView = C.View(selfUser: ZMUser.selfUser())
+        cellView.translatesAutoresizingMaskIntoConstraints = false
         self.ephemeralCountdownView = EphemeralCountdownView()
         self.ephemeralCountdownView.translatesAutoresizingMaskIntoConstraints = false
         

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/CustomMessageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/CustomMessageView.swift
@@ -20,7 +20,7 @@ import Foundation
 import UIKit
 import WireDataModel
 
-class CustomMessageView: UIView {
+final class CustomMessageView: UIView, ConversationMessageCell {
     public var isSelected: Bool = false
     
     weak var delegate: ConversationMessageCellDelegate? = nil
@@ -33,17 +33,18 @@ class CustomMessageView: UIView {
         }
     }
 
-    required public init?(coder aDecoder: NSCoder) {
+    @available(*, unavailable)
+    required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override init(frame: CGRect) {
+    init(selfUser: UserType) {
         messageLabel.isAccessibilityElement = true
         messageLabel.accessibilityLabel = "Text"
         messageLabel.linkTextAttributes = [NSAttributedString.Key.underlineStyle: NSUnderlineStyle().rawValue as NSNumber,
                                        NSAttributedString.Key.foregroundColor: ZMUser.selfUser().accentColor]
 
-        super.init(frame: frame)
+        super.init(frame: .zero)
         addSubview(messageLabel)
         messageLabel.translatesAutoresizingMaskIntoConstraints = false
 


### PR DESCRIPTION
## What's new in this PR?

Add `init(selfUser: UserType)` to `ConversationMessageCell` protocol to  allow injection self user when testing a ConversationMessageCell.