### PR TITLE
[Fix] Persist isAppLockActive value

### DIFF
--- a/Wire-iOS/Sources/Components/Settings/SettingsPropertyFactory.swift
+++ b/Wire-iOS/Sources/Components/Settings/SettingsPropertyFactory.swift
@@ -342,11 +342,9 @@ final class SettingsPropertyFactory {
                         self.delegate?.appLockOptionDidChange(self,
                                                               newValue: lockApp.boolValue,
                                                               callback: { result in
-                         if let userSession = self.userSession as? ZMUserSession {
-                             userSession.perform {
-                                 self.isAppLockActive = result
-                             }
-                         }
+                           self.userSession?.perform {
+                               self.isAppLockActive = result
+                           }
                         })
 
                     default:

--- a/Wire-iOS/Sources/Components/Settings/SettingsPropertyFactory.swift
+++ b/Wire-iOS/Sources/Components/Settings/SettingsPropertyFactory.swift
@@ -342,8 +342,12 @@ final class SettingsPropertyFactory {
                         self.delegate?.appLockOptionDidChange(self,
                                                               newValue: lockApp.boolValue,
                                                               callback: { result in
-                        self.isAppLockActive = result
-                        })                        
+                         if let userSession = self.userSession as? ZMUserSession {
+                             userSession.perform {
+                                 self.isAppLockActive = result
+                             }
+                         }
+                        })
 
                     default:
                         throw SettingsPropertyError.WrongValue("Incorrect type \(value) for key \(propertyName)")


### PR DESCRIPTION
## What's new in this PR?

### Issues

If change `isAppLockActive` state in the settings and terminate the app, the new value is not saved.

### Causes

`isAppLockActive` is a `managedObjectContext` property and we didn't persist the changes.

### Solutions

Save `managedObjectContext`.

