### PR TITLE
[Fix] App lock warning is displayed twice

### DIFF
--- a/Wire-iOS Tests/AppLock/AppLockPresenterTests.swift
+++ b/Wire-iOS Tests/AppLock/AppLockPresenterTests.swift
@@ -66,7 +66,6 @@ private final class AppLockUserInterfaceMock: AppLockUserInterface {
 
 private final class AppLockInteractorMock: AppLockInteractorInput {
     var needsToCreateCustomPasscode: Bool = false
-    var shouldUseCustomPasscode: Bool = false
     var isCustomPasscodeNotSet: Bool = false
     var _isAuthenticationNeeded: Bool = false
     var didCallIsAuthenticationNeeded: Bool = false
@@ -521,23 +520,10 @@ final class AppLockPresenterTests: XCTestCase {
         XCTAssertFalse(appLockInteractor.needsToNotifyUser)
     }
 
-    func testThatIt_PresentsUnlockScreen() {
-        // Given
-        appLockInteractor._isAuthenticationNeeded = true
-        appLockInteractor.shouldUseCustomPasscode = true
-
-        // When
-        sut.requireAuthentication()
-
-        // Then
-        XCTAssertTrue(userInterface.presentUnlockScreenCalled)
-    }
-
     func testThatIt_AsksToEvaluateAuthentication() {
         // Given
         appLockInteractor._isAuthenticationNeeded = true
         appLockInteractor.needsToCreateCustomPasscode = false
-        appLockInteractor.shouldUseCustomPasscode = false
 
         // When
         sut.requireAuthentication()

--- a/Wire-iOS Tests/AppLock/AppLockPresenterTests.swift
+++ b/Wire-iOS Tests/AppLock/AppLockPresenterTests.swift
@@ -30,15 +30,18 @@ private final class AppLockUserInterfaceMock: AppLockUserInterface {
     var requestPasswordMessage: String?
     var presentCreatePasscodeScreenCalled: Bool = false
     var presentWarningScreenCalled: Bool = false
-    
+
+    var presentUnlockScreenCalled: Bool = false
     func presentUnlockScreen(with message: String,
                              callback: @escaping RequestPasswordController.Callback) {
         requestPasswordMessage = message
         callback(passwordInput)
+        presentUnlockScreenCalled = true
     }
     
     func presentCreatePasscodeScreen(callback: ResultHandler?) {
         presentCreatePasscodeScreenCalled = true
+        callback?(true)
     }
     
     func presentWarningScreen(callback: ResultHandler?) {
@@ -62,6 +65,8 @@ private final class AppLockUserInterfaceMock: AppLockUserInterface {
 }
 
 private final class AppLockInteractorMock: AppLockInteractorInput {
+    var needsToCreateCustomPasscode: Bool = false
+    var shouldUseCustomPasscode: Bool = false
     var isCustomPasscodeNotSet: Bool = false
     var _isAuthenticationNeeded: Bool = false
     var didCallIsAuthenticationNeeded: Bool = false
@@ -486,6 +491,59 @@ final class AppLockPresenterTests: XCTestCase {
         
         //then
         XCTAssertFalse(userInterface.presentWarningScreenCalled)
+    }
+
+    // MARK: - Require authentication
+
+    func testThatIt_AsksToCreateCustomPasscode() {
+        // Given
+        appLockInteractor._isAuthenticationNeeded = true
+        appLockInteractor.needsToCreateCustomPasscode = true
+
+        // When
+        sut.requireAuthentication()
+
+        // Then
+        XCTAssertTrue(userInterface.presentCreatePasscodeScreenCalled)
+    }
+
+    func testThatIt_ResetsNeedsToNotifyUserFlag_AfterDisplayingCreatePasscodeScreen() {
+        // Given
+        appLockInteractor._isAuthenticationNeeded = true
+        appLockInteractor.needsToNotifyUser = true
+        appLockInteractor.needsToCreateCustomPasscode = true
+
+        // When
+        sut.requireAuthentication()
+
+        // Then
+        XCTAssertTrue(userInterface.presentCreatePasscodeScreenCalled)
+        XCTAssertFalse(appLockInteractor.needsToNotifyUser)
+    }
+
+    func testThatIt_PresentsUnlockScreen() {
+        // Given
+        appLockInteractor._isAuthenticationNeeded = true
+        appLockInteractor.shouldUseCustomPasscode = true
+
+        // When
+        sut.requireAuthentication()
+
+        // Then
+        XCTAssertTrue(userInterface.presentUnlockScreenCalled)
+    }
+
+    func testThatIt_AsksToEvaluateAuthentication() {
+        // Given
+        appLockInteractor._isAuthenticationNeeded = true
+        appLockInteractor.needsToCreateCustomPasscode = false
+        appLockInteractor.shouldUseCustomPasscode = false
+
+        // When
+        sut.requireAuthentication()
+
+        // Then
+        XCTAssertTrue(appLockInteractor.didCallEvaluateAuthentication)
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockInteractor.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockInteractor.swift
@@ -26,7 +26,6 @@ typealias AppLockInteractorUserSession = UserSessionVerifyPasswordInterface & Us
 
 protocol AppLockInteractorInput: class {
     var needsToCreateCustomPasscode: Bool { get }
-    var shouldUseCustomPasscode: Bool { get }
     var isCustomPasscodeNotSet: Bool { get }
     var isAuthenticationNeeded: Bool { get }
     var isDimmingScreenWhenInactive: Bool { get }
@@ -100,11 +99,7 @@ final class AppLockInteractor {
 extension AppLockInteractor: AppLockInteractorInput {
 
     var needsToCreateCustomPasscode: Bool {
-        return (shouldUseCustomPasscode || shouldUseBiometricsOrCustomPasscode) && isCustomPasscodeNotSet
-    }
-
-    var shouldUseCustomPasscode: Bool {
-        return AuthenticationType.current == .unavailable
+        return (AuthenticationType.current == .unavailable || shouldUseBiometricsOrCustomPasscode) && isCustomPasscodeNotSet
     }
 
     var isCustomPasscodeNotSet: Bool {

--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockInteractor.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockInteractor.swift
@@ -25,6 +25,8 @@ import LocalAuthentication
 typealias AppLockInteractorUserSession = UserSessionVerifyPasswordInterface & UserSessionEncryptionAtRestInterface & UserSessionAppLockInterface
 
 protocol AppLockInteractorInput: class {
+    var needsToCreateCustomPasscode: Bool { get }
+    var shouldUseCustomPasscode: Bool { get }
     var isCustomPasscodeNotSet: Bool { get }
     var isAuthenticationNeeded: Bool { get }
     var isDimmingScreenWhenInactive: Bool { get }
@@ -76,7 +78,7 @@ final class AppLockInteractor {
     var shouldUseBiometricsOrCustomPasscode: Bool {
         return appLock?.config.useBiometricsOrCustomPasscode ?? false
     }
-    
+
     var needsToNotifyUser: Bool {
         get {
             return appLock?.needsToNotifyUser ?? false
@@ -96,6 +98,15 @@ final class AppLockInteractor {
 
 // MARK: - Interface
 extension AppLockInteractor: AppLockInteractorInput {
+
+    var needsToCreateCustomPasscode: Bool {
+        return (shouldUseCustomPasscode || shouldUseBiometricsOrCustomPasscode) && isCustomPasscodeNotSet
+    }
+
+    var shouldUseCustomPasscode: Bool {
+        return AuthenticationType.current == .unavailable
+    }
+
     var isCustomPasscodeNotSet: Bool {
         return appLock?.isCustomPasscodeNotSet ?? false
     }

--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockPresenter.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockPresenter.swift
@@ -110,9 +110,23 @@ final class AppLockPresenter {
         case .needed, .authenticated:
             authenticationState = .needed
             setContents(dimmed: true)
-            presentWarningIfNeeded {
-                self.appLockInteractorInput.evaluateAuthentication(description: AuthenticationMessageKey.deviceAuthentication)
+
+            if appLockInteractorInput.needsToCreateCustomPasscode {
+                userInterface?.presentCreatePasscodeScreen(callback: { _ in
+                    // User needs to enter the newly created passcode after creation.
+                    self.setContents(dimmed: true, withReauth: true)
+                    self.appLockInteractorInput.needsToNotifyUser = false
+                })
+            } else if appLockInteractorInput.shouldUseCustomPasscode {
+                presentWarningIfNeeded {
+                    self.requestAccountPassword(with: AuthenticationMessageKey.accountPassword)
+                }
+            } else {
+                presentWarningIfNeeded {
+                    self.appLockInteractorInput.evaluateAuthentication(description: AuthenticationMessageKey.deviceAuthentication)
+                }
             }
+
         case .cancelled:
             setContents(dimmed: true, withReauth: true)
         case .pendingPassword:

--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockPresenter.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockPresenter.swift
@@ -117,10 +117,6 @@ final class AppLockPresenter {
                     self.setContents(dimmed: true, withReauth: true)
                     self.appLockInteractorInput.needsToNotifyUser = false
                 })
-            } else if appLockInteractorInput.shouldUseCustomPasscode {
-                presentWarningIfNeeded {
-                    self.requestAccountPassword(with: AuthenticationMessageKey.accountPassword)
-                }
             } else {
                 presentWarningIfNeeded {
                     self.appLockInteractorInput.evaluateAuthentication(description: AuthenticationMessageKey.deviceAuthentication)


### PR DESCRIPTION
## What's new in this PR?

**JIRA:** https://wearezeta.atlassian.net/browse/SQSERVICES-201

### Issues

If a user who has no device passcode set, when when app lock becomes mandatory, then when they open the app they are warned twice about the configuration change. First they see the warning screen, then they see the same warning but on the create passcode screen.

### Causes

There are two screens that contain the warning. One should be shown when the user has at least a device passcode set, and the other is for the case when they need to create a custom passcode. The current code path first displays the first warning, then proceeds to attempt to authenticate. The result from this attempt indicates that the custom passcode is needed, then we see that the custom passcode needs to be set, in which case we display the warning again.

### Solutions

Before we attempt to show any warning, split the control path into three cases:

1. We need to set a custom passcode. Then show the create passcode screen with the warning.
2. There is already a custom passcode, then present the warning, then the custom passcode unlock screen.
3. There is at least the device passcode, then present the warning, then present the native OS authentication UI.

