### PR TITLE
[Fix] Crash when switching accounts

### DIFF
--- a/Wire-iOS/Sources/UserInterface/SelfProfile/AccountSelectorController.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/AccountSelectorController.swift
@@ -73,11 +73,10 @@ extension AccountSelectorController: AccountSelectorViewDelegate {
             return
         }
         
-        SessionManager.shared?.select(account, tearDownCompletion: {
-            ZClientViewController.shared?.conversationListViewController.dismiss(animated: true,
-                                                                                 completion: {
-                AppDelegate.shared.mediaPlaybackManager?.stop()
-            })
+        ZClientViewController.shared?.conversationListViewController.dismiss(animated: true,
+                                                                             completion: {
+            AppDelegate.shared.mediaPlaybackManager?.stop()
+            SessionManager.shared?.select(account)
         })
     }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Application would sometimes crash after switching accounts

### Causes

The `ConversationListViewController` had a retain cycle which would prevent it from getting released and therefore continue to observe the conversation list changes. When it attempted to apply a conversation list change it would crash because the `SelfUserProvider` would not be set during the account transition.

### Solutions

Fix the retain cycle by dismissing the `SelfProfileViewController` before the switching accounts. The `SelfProfileViewController` is presented by the `ConversationListViewController` and therefore holds a strong reference to it.