### PR TITLE
[Feature] Unlock app after creating passcode

### DIFF
--- a/Wire-iOS Tests/AppLock/AppLockPresenterTests.swift
+++ b/Wire-iOS Tests/AppLock/AppLockPresenterTests.swift
@@ -531,6 +531,22 @@ final class AppLockPresenterTests: XCTestCase {
         // Then
         XCTAssertTrue(appLockInteractor.didCallEvaluateAuthentication)
     }
+    
+    // Mark: - Creating passcode
+    
+    func testThatItUnlocksAppAfterCreatingAPasscode() {
+        // Given
+        set(authNeeded: true, authenticationState: .needed)
+        appLockInteractor.needsToCreateCustomPasscode = true
+        
+        // When
+        sut.requireAuthenticationIfNeeded()
+        
+        // Then
+        XCTAssertTrue(userInterface.presentCreatePasscodeScreenCalled)
+        XCTAssertEqual(userInterface.contentsDimmed, false)
+    }
+
 }
 
 extension AppLockPresenterTests {

--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockPresenter.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockPresenter.swift
@@ -113,9 +113,9 @@ final class AppLockPresenter {
 
             if appLockInteractorInput.needsToCreateCustomPasscode {
                 userInterface?.presentCreatePasscodeScreen(callback: { _ in
-                    // User needs to enter the newly created passcode after creation.
-                    self.setContents(dimmed: true, withReauth: true)
                     self.appLockInteractorInput.needsToNotifyUser = false
+                    self.setContents(dimmed: false)
+                    self.appUnlocked()
                 })
             } else {
                 presentWarningIfNeeded {


### PR DESCRIPTION
## What's new in this PR?

**JIRA:** https://wearezeta.atlassian.net/browse/SQSERVICES-195

### Changes

If the app Lock Screen is shown and we need to create a custom passcode, then after creating the passcode the user is required to enter that passcode again to unlock the app. Product has decided that this is an unnecessary step so we should no longer require the user to enter the passcode a second time.

