### PR TITLE
Fix: MarkDownSnapshotTests without subclassing ConversationCellSnapshotTestCase

### DIFF
--- a/Wire-iOS Tests/ConversationCell/MarkDownSnapshotTests.swift
+++ b/Wire-iOS Tests/ConversationCell/MarkDownSnapshotTests.swift
@@ -16,20 +16,27 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
+import XCTest
+@testable import Wire
+//import SnapshotTesting
 
-final class MarkDownSnapshotTests: ConversationCellSnapshotTestCase {
+final class MarkDownSnapshotTests: XCTestCase {
     var mockOtherUser: MockUserType!
-    
+    var mockSelfUser: MockUserType!
+
     override func setUp() {
         super.setUp()
 
         mockOtherUser = MockUserType.createUser(name: "Bruno")
-        
+        UIColor.setAccentOverride(.vividRed)
+
+        mockSelfUser = MockUserType.createSelfUser(name: "selfUser")
+        mockSelfUser.accentColorValue = .vividRed
     }
     
     override func tearDown() {
         mockOtherUser = nil
+        mockSelfUser = nil
         
         super.tearDown()
     }

--- a/Wire-iOS Tests/ConversationCell/MarkDownSnapshotTests.swift
+++ b/Wire-iOS Tests/ConversationCell/MarkDownSnapshotTests.swift
@@ -19,6 +19,21 @@
 import Foundation
 
 final class MarkDownSnapshotTests: ConversationCellSnapshotTestCase {
+    var mockOtherUser: MockUserType!
+    
+    override func setUp() {
+        super.setUp()
+
+        mockOtherUser = MockUserType.createUser(name: "Bruno")
+        
+    }
+    
+    override func tearDown() {
+        mockOtherUser = nil
+        
+        super.tearDown()
+    }
+
 
     func testMentionInFirstParagraph() {
         let messageText =
@@ -27,9 +42,13 @@ final class MarkDownSnapshotTests: ConversationCellSnapshotTestCase {
         So she called all seven to her and said: 'Dear children, I have to go into the forest, be on your guard against the wolf; if he comes in, he will devour you all, skin, hair, and everything.
 The wretch often disguises himself, but you will know him at once by his rough voice and his black feet.' The kids said: 'Dear mother, we will take good care of ourselves; you may go away without any anxiety.' Then the old one bleated, and went on her way with an easy mind.
 """
-        let mention = Mention(range: NSRange(location: 0, length: 12), user: otherUser)
-        let message = try! otherUserConversation.appendText(content: messageText, mentions: [mention], fetchLinkPreview: false)
-
+        let mention = Mention(range: NSRange(location: 0, length: 12), user: mockOtherUser)
+        let message = MockMessageFactory.messageTemplate(sender: mockSelfUser)
+        let textMessageData = MockTextMessageData()
+        textMessageData.messageText = messageText
+        message.backingTextMessageData = textMessageData
+        
+        textMessageData.mentions = [mention]
 
         verify(message: message)
     }
@@ -42,7 +61,9 @@ The wretch often disguises himself, but you will know him at once by his rough v
         So she called all seven to her and said: 'Dear children, I have to go into the forest, be on your guard against the wolf; if he comes in, he will devour you all, skin, hair, and everything.
 The wretch often disguises himself, but you will know him at once by his rough voice and his black feet.' The kids said: 'Dear mother, we will take good care of ourselves; you may go away without any anxiety.' Then the old one bleated, and went on her way with an easy mind.
 """
-        let message = try! otherUserConversation.appendText(content: messageText, mentions: [], fetchLinkPreview: false)
+//        let message = try! otherUserConversation.appendText(content: messageText, mentions: [], fetchLinkPreview: false)
+
+        let message = MockMessageFactory.textMessage(withText: messageText, sender: mockSelfUser, includingRichMedia: false)!
 
 
         verify(message: message)

--- a/Wire-iOS Tests/ConversationCell/MarkDownSnapshotTests.swift
+++ b/Wire-iOS Tests/ConversationCell/MarkDownSnapshotTests.swift
@@ -18,7 +18,6 @@
 
 import XCTest
 @testable import Wire
-//import SnapshotTesting
 
 final class MarkDownSnapshotTests: XCTestCase {
     var mockOtherUser: MockUserType!
@@ -33,14 +32,13 @@ final class MarkDownSnapshotTests: XCTestCase {
         mockSelfUser = MockUserType.createSelfUser(name: "selfUser")
         mockSelfUser.accentColorValue = .vividRed
     }
-    
+
     override func tearDown() {
         mockOtherUser = nil
         mockSelfUser = nil
-        
+
         super.tearDown()
     }
-
 
     func testMentionInFirstParagraph() {
         let messageText =
@@ -54,13 +52,13 @@ The wretch often disguises himself, but you will know him at once by his rough v
         let textMessageData = MockTextMessageData()
         textMessageData.messageText = messageText
         message.backingTextMessageData = textMessageData
-        
+
         textMessageData.mentions = [mention]
 
         verify(message: message)
     }
 
-    ///compare with above tests, the line spacing should be the same for both case.
+    /// compare with above tests, the line spacing should be the same for both case.
     func testNoMentrionParagraph() {
         let messageText =
         """
@@ -71,7 +69,6 @@ The wretch often disguises himself, but you will know him at once by his rough v
 //        let message = try! otherUserConversation.appendText(content: messageText, mentions: [], fetchLinkPreview: false)
 
         let message = MockMessageFactory.textMessage(withText: messageText, sender: mockSelfUser, includingRichMedia: false)!
-
 
         verify(message: message)
     }

--- a/Wire-iOS Tests/ConversationCell/MarkDownSnapshotTests.swift
+++ b/Wire-iOS Tests/ConversationCell/MarkDownSnapshotTests.swift
@@ -66,7 +66,6 @@ The wretch often disguises himself, but you will know him at once by his rough v
         So she called all seven to her and said: 'Dear children, I have to go into the forest, be on your guard against the wolf; if he comes in, he will devour you all, skin, hair, and everything.
 The wretch often disguises himself, but you will know him at once by his rough voice and his black feet.' The kids said: 'Dear mother, we will take good care of ourselves; you may go away without any anxiety.' Then the old one bleated, and went on her way with an easy mind.
 """
-//        let message = try! otherUserConversation.appendText(content: messageText, mentions: [], fetchLinkPreview: false)
 
         let message = MockMessageFactory.textMessage(withText: messageText, sender: mockSelfUser, includingRichMedia: false)!
 

--- a/Wire-iOS Tests/ConversationMessageCell/ConversationCellSnapshotTestCase.swift
+++ b/Wire-iOS Tests/ConversationMessageCell/ConversationCellSnapshotTestCase.swift
@@ -34,8 +34,7 @@ extension XCTestCase {
                 file: StaticString = #file,
                 testName: String = #function,
                 line: UInt = #line) {
-        
-        
+
         if allColorSchemes {
             ColorScheme.default.variant = .dark
             verify(matching: createUIStackView(message: message, context: context, waitForImagesToLoad: waitForImagesToLoad, waitForTextViewToLoad: waitForTextViewToLoad, snapshotBackgroundColor: snapshotBackgroundColor),
@@ -45,7 +44,7 @@ extension XCTestCase {
                    file: file,
                    testName: testName,
                    line: line)
-            
+
             ColorScheme.default.variant = .light
             verify(matching: createUIStackView(message: message, context: context, waitForImagesToLoad: waitForImagesToLoad, waitForTextViewToLoad: waitForTextViewToLoad, snapshotBackgroundColor: snapshotBackgroundColor),
                    snapshotBackgroundColor: snapshotBackgroundColor,
@@ -73,16 +72,16 @@ extension XCTestCase {
                         testName: String = #function,
                         line: UInt = #line) {
         let backgroundColor = snapshotBackgroundColor ?? (ColorScheme.default.variant == .light ? .white : .black)
-        
+
         if allWidths {
-            verifyInAllPhoneWidths(matching:value,
+            verifyInAllPhoneWidths(matching: value,
                                    snapshotBackgroundColor: backgroundColor,
                                    named: name,
                                    file: file,
                                    testName: testName,
                                    line: line)
         } else {
-            verifyInWidths(matching:value,
+            verifyInWidths(matching: value,
                            widths: [smallestWidth],
                            snapshotBackgroundColor: backgroundColor,
                            named: name,
@@ -91,7 +90,7 @@ extension XCTestCase {
                            line: line)
         }
     }
-    
+
     private func createUIStackView(
         message: ZMConversationMessage,
         context: ConversationMessageContext?,
@@ -100,26 +99,26 @@ extension XCTestCase {
         snapshotBackgroundColor: UIColor?
     ) -> UIStackView {
         let context = (context ?? ConversationCellSnapshotTestCase.defaultContext)!
-        
+
         let section = ConversationMessageSectionController(message: message, context: context)
         let views = section.cellDescriptions.map({ $0.makeView() })
         let stackView = UIStackView(arrangedSubviews: views)
         stackView.axis = .vertical
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.backgroundColor = snapshotBackgroundColor ?? (ColorScheme.default.variant == .light ? .white : .black)
-        
+
         if waitForImagesToLoad {
             XCTAssert(waitForGroupsToBeEmpty([MediaAssetCache.defaultImageCache.dispatchGroup]))
         }
-        
+
         if waitForTextViewToLoad {
             // We need to run the run loop for UITextView to highlight detected links
             let delay = Date().addingTimeInterval(1)
             RunLoop.main.run(until: delay)
         }
-        
+
         return stackView
-        
+
     }
 
 }
@@ -130,7 +129,7 @@ extension XCTestCase {
  */
 class ConversationCellSnapshotTestCase: XCTestCase, CoreDataFixtureTestHelper {
     var coreDataFixture: CoreDataFixture!
-    
+
     var mockSelfUser: MockUserType!
 
     fileprivate static let defaultContext = ConversationMessageContext(isSameSenderAsPrevious: false,
@@ -141,27 +140,26 @@ class ConversationCellSnapshotTestCase: XCTestCase, CoreDataFixtureTestHelper {
                                                                        searchQueries: [],
                                                                        previousMessageIsKnock: false,
                                                                        spacing: 0)
-    
+
     override class func setUp() {
         resetDayFormatter()
-        
+
         [Message.shortDateFormatter, Message.shortTimeFormatter].forEach {
             $0.locale = Locale(identifier: "en_US")
             $0.timeZone = TimeZone(abbreviation: "CET")
         }
     }
-    
-    
+
     override class func tearDown() {
         ColorScheme.default.variant = .light
     }
-    
+
     override func setUp() {
         super.setUp()
         coreDataFixture = CoreDataFixture()
-        
+
         ColorScheme.default.variant = .light
-        
+
         mockSelfUser = MockUserType.createSelfUser(name: "selfUser")
         mockSelfUser.accentColorValue = .vividRed
     }
@@ -172,7 +170,7 @@ class ConversationCellSnapshotTestCase: XCTestCase, CoreDataFixtureTestHelper {
 
         super.tearDown()
     }
-        
+
 }
 
 func XCTAssertArrayEqual(_ descriptions: [Any], _ expectedDescriptions: [Any], file: StaticString = #file, line: UInt = #line) {

--- a/Wire-iOS Tests/Mocks/MockMessage+Creation.swift
+++ b/Wire-iOS Tests/Mocks/MockMessage+Creation.swift
@@ -169,8 +169,10 @@ final class MockMessageFactory {
         return MockMessageFactory.textMessage(withText: text, includingRichMedia: false)
     }
 
-    class func textMessage(withText text: String?, includingRichMedia shouldIncludeRichMedia: Bool) -> MockMessage? {
-        let message = MockMessageFactory.messageTemplate()
+    class func textMessage(withText text: String?,
+                           sender: UserType? = nil,
+                           includingRichMedia shouldIncludeRichMedia: Bool) -> MockMessage? {
+        let message = MockMessageFactory.messageTemplate(sender: sender)
 
         let textMessageData = MockTextMessageData()
         textMessageData.messageText = shouldIncludeRichMedia ? "Check this 500lb squirrel! -> https://www.youtube.com/watch?v=0so5er4X3dc" : text!

--- a/Wire-iOS/Sources/UserInterface/Components/Views/MarkdownTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/MarkdownTextView.swift
@@ -20,7 +20,6 @@ import Foundation
 import MobileCoreServices
 import Down
 import UIKit
-import WireDataModel
 import WireSyncEngine
 
 extension Notification.Name {


### PR DESCRIPTION
## What's new in this PR?

Rewrite `MarkDownSnapshotTests` to prevent subclassing  `ConversationCellSnapshotTestCase` which creates `ZMUser` objects can not be released.