### PR TITLE
[Fix] Delete passcode if app lock is disabled in team settings

### DIFF
--- a/Wire-iOS Tests/AppLock/AppLockInteractorTests.swift
+++ b/Wire-iOS Tests/AppLock/AppLockInteractorTests.swift
@@ -93,7 +93,7 @@ final class AppLockMock: AppLockType {
     }
 
     func storePasscode(_ passcode: String) throws {
-
+        isCustomPasscodeNotSet = false
     }
 
     func fetchPasscode() -> Data? {
@@ -101,7 +101,7 @@ final class AppLockMock: AppLockType {
     }
 
     func deletePasscode() throws {
-
+        isCustomPasscodeNotSet = true
     }
 }
 

--- a/Wire-iOS Tests/ZClientViewControllerTests.swift
+++ b/Wire-iOS Tests/ZClientViewControllerTests.swift
@@ -21,16 +21,19 @@ import XCTest
 
 final class ZClientViewControllerTests: XCTestCase {
     var sut: ZClientViewController!
+    var userSessionMock: MockZMUserSession!
 
     override func setUp() {
         super.setUp()
 
         let mockSelfUser = MockUserType.createSelfUser(name: "Bob")
-        sut = ZClientViewController(account: Account.mockAccount(imageData: mockImageData), selfUser: mockSelfUser)
+        userSessionMock = MockZMUserSession()
+        sut = ZClientViewController(account: Account.mockAccount(imageData: mockImageData), selfUser: mockSelfUser, userSession: userSessionMock)
     }
 
     override func tearDown() {
         sut = nil
+        userSessionMock = nil
 
         super.tearDown()
     }
@@ -55,4 +58,18 @@ final class ZClientViewControllerTests: XCTestCase {
         XCTAssertNil(alert)
     }
 
+    func testThatCustomPasscodeWillBeDeleted_AfterDisablingApplock() {
+        /// GIVEN
+        try! sut._userSession!.appLockController.storePasscode("test")
+        sut._userSession!.appLockController.needsToNotifyUser = true
+        sut._userSession!.appLockController.isActive = false
+        XCTAssertFalse(sut._userSession!.appLockController.isCustomPasscodeNotSet)
+        
+        /// WHEN
+        sut.notifyUserOfDisabledAppLockIfNeeded()
+        sut.changeWarningViewController?.confirmButtonTapped(sender: nil)
+        
+        /// THEN
+        XCTAssertTrue(sut._userSession!.appLockController.isCustomPasscodeNotSet)
+    }
 }

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController+FeatureChange.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController+FeatureChange.swift
@@ -36,10 +36,11 @@ extension ZClientViewController {
     }
     
     func notifyUserOfDisabledAppLockIfNeeded() {
-        guard let appLock = appLock,
-            let warningVC = changeWarningViewController,
+        guard 
+            let appLock = appLock,
             appLock.needsToNotifyUser,
-            !appLock.isActive else {
+            !appLock.isActive
+            let warningVC = changeWarningViewController, else {
                 return
         }
         

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController+FeatureChange.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController+FeatureChange.swift
@@ -39,8 +39,8 @@ extension ZClientViewController {
         guard 
             let appLock = appLock,
             appLock.needsToNotifyUser,
-            !appLock.isActive
-            let warningVC = changeWarningViewController, else {
+            !appLock.isActive,
+            let warningVC = changeWarningViewController else {
                 return
         }
         

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController+FeatureChange.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController+FeatureChange.swift
@@ -26,7 +26,11 @@ extension ZClientViewController {
             return
         }
         if appLock.needsToNotifyUser && !appLock.isActive {
-            let warningVC = AppLockChangeWarningViewController(isAppLockActive: appLock.isActive)
+            let warningVC = AppLockChangeWarningViewController(isAppLockActive: appLock.isActive) {
+                if !appLock.isCustomPasscodeNotSet {
+                    try? appLock.deletePasscode()
+                }
+            }
             warningVC.modalPresentationStyle = .fullScreen
             present(warningVC, animated: false)
         }

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController+FeatureChange.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController+FeatureChange.swift
@@ -27,9 +27,7 @@ extension ZClientViewController {
         }
         if appLock.needsToNotifyUser && !appLock.isActive {
             let warningVC = AppLockChangeWarningViewController(isAppLockActive: appLock.isActive) {
-                if !appLock.isCustomPasscodeNotSet {
-                    try? appLock.deletePasscode()
-                }
+                try? appLock.deletePasscode()
             }
             warningVC.modalPresentationStyle = .fullScreen
             present(warningVC, animated: false)

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController+FeatureChange.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController+FeatureChange.swift
@@ -21,17 +21,30 @@ import WireSyncEngine
 
 extension ZClientViewController {
     
+    var appLock: AppLockType? {
+        return _userSession?.appLockController
+    }
+    
+    var changeWarningViewController: AppLockChangeWarningViewController? {
+        guard let appLock = appLock else {
+            return nil
+        }
+        
+        return AppLockChangeWarningViewController(isAppLockActive: appLock.isActive) {
+            try? appLock.deletePasscode()
+        }
+    }
+    
     func notifyUserOfDisabledAppLockIfNeeded() {
-        guard let appLock = ZMUserSession.shared()?.appLockController else {
-            return
+        guard let appLock = appLock,
+            let warningVC = changeWarningViewController,
+            appLock.needsToNotifyUser,
+            !appLock.isActive else {
+                return
         }
-        if appLock.needsToNotifyUser && !appLock.isActive {
-            let warningVC = AppLockChangeWarningViewController(isAppLockActive: appLock.isActive) {
-                try? appLock.deletePasscode()
-            }
-            warningVC.modalPresentationStyle = .fullScreen
-            present(warningVC, animated: false)
-        }
+        
+        warningVC.modalPresentationStyle = .fullScreen
+        present(warningVC, animated: false)
     }
     
 }

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -53,6 +53,9 @@ final class ZClientViewController: UIViewController {
     private var networkAvailabilityObserverToken: Any?
     private var pendingInitialStateRestore = false
     
+    // For tests
+    var _userSession: UserSessionInterface?
+    
     /// init method for testing allows injecting an Account object and self user
     ///
     /// - Parameters:
@@ -60,8 +63,9 @@ final class ZClientViewController: UIViewController {
     ///   - selfUser: a SelfUserType object
     required init(account: Account,
                   selfUser: SelfUserType,
-                  userSession: ZMUserSession? = ZMUserSession.shared()) {
-        backgroundViewController = BackgroundViewController(user: selfUser, userSession: userSession)
+                  userSession: UserSessionInterface? = ZMUserSession.shared()) {
+        _userSession = userSession
+        backgroundViewController = BackgroundViewController(user: selfUser, userSession: userSession as? ZMUserSession)
         conversationListViewController = ConversationListViewController(account: account, selfUser: selfUser)
         
         super.init(nibName:nil, bundle:nil)

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -53,7 +53,6 @@ final class ZClientViewController: UIViewController {
     private var networkAvailabilityObserverToken: Any?
     private var pendingInitialStateRestore = false
     
-    // For tests
     var _userSession: UserSessionInterface?
     
     /// init method for testing allows injecting an Account object and self user

--- a/Wire-iOS/Sources/UserInterface/Overlay/CustomAppLock/Warning/AppLockChangeWarningViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/CustomAppLock/Warning/AppLockChangeWarningViewController.swift
@@ -131,7 +131,7 @@ final class AppLockChangeWarningViewController: UIViewController {
     // MARK: - Actions
 
     @objc
-    private func confirmButtonTapped(sender: AnyObject?) {
+    func confirmButtonTapped(sender: AnyObject?) {
         if let session = ZMUserSession.shared() {
             session.perform {
                 session.appLockController.needsToNotifyUser = false


### PR DESCRIPTION
## What's new in this PR?

https://wearezeta.atlassian.net/browse/SQSERVICES-203

### Issues
Disabling app lock in team settings doesn't delete the custom passcode in keychain. 

### Solutions

Delete the passcode when the client receives a notification that the team admin has disabled mandatory app lock.