### PR TITLE
[Fix] App lock not shown share extension

### DIFF
--- a/Wire-iOS Share Extension/ShareExtensionViewController.swift
+++ b/Wire-iOS Share Extension/ShareExtensionViewController.swift
@@ -77,8 +77,13 @@ final class ShareExtensionViewController: SLComposeServiceViewController {
     /// stores extensionContext?.attachments
     fileprivate var attachments: [AttachmentType: [NSItemProvider]] = [:]
     
-    fileprivate var currentAccount: Account? = nil
-    fileprivate var localAuthenticationStatus: LocalAuthenticationStatus = .disabled
+    fileprivate var currentAccount: Account? = nil {
+        didSet {
+            localAuthenticationStatus = .denied
+        }
+    }
+
+    fileprivate var localAuthenticationStatus: LocalAuthenticationStatus = .denied
     private var observer: SendableBatchObserver? = nil
     private weak var progressViewController: SendingProgressViewController? = nil
 

--- a/Wire-iOS Share Extension/ShareExtensionViewController.swift
+++ b/Wire-iOS Share Extension/ShareExtensionViewController.swift
@@ -424,11 +424,7 @@ final class ShareExtensionViewController: SLComposeServiceViewController {
     }
     
     private func presentChooseAccount() {
-        requireLocalAuthenticationIfNeeded(with: { [weak self] (status) in
-            if let status = status, status != .denied {
-                self?.showChooseAccount()
-            }
-        })
+        showChooseAccount()
     }
     
     private func presentChooseConversation() {

--- a/Wire-iOS Share Extension/ShareExtensionViewController.swift
+++ b/Wire-iOS Share Extension/ShareExtensionViewController.swift
@@ -484,12 +484,12 @@ final class ShareExtensionViewController: SLComposeServiceViewController {
             callback(localAuthenticationStatus)
             return
         }
-        
-        guard localAuthenticationStatus != .granted, sharingSession.isDatabaseLocked else {
+
+        guard localAuthenticationStatus == .denied || sharingSession.isDatabaseLocked else {
             callback(localAuthenticationStatus)
             return
         }
-        
+
         let scenario: AppLockController.AuthenticationScenario
         
         if sharingSession.encryptMessagesAtRest {


### PR DESCRIPTION
## What's new in this PR?

**JIRA:** https://wearezeta.atlassian.net/browse/SQSERVICES-221

### Issues

The app lock is not shown in the share extension.

### Causes

Authentication is only required if the current status is not `granted` **AND** the database is locked.

### Solutions

1. Always start in a `denied` state.
2. Require authentication if in a `denied` state **OR** the database is locked

Additionally, since app lock is per account now, we only require authentication when selecting the conversation (and not also when selecting the account). When the account changes, we reset the authentication state back to `denied`.
