### PR TITLE
[Fix] hide active speaker frame when not in group call

### DIFF
--- a/Wire-iOS Tests/Calling/VideoGridViewControllerSnapshotTests.swift
+++ b/Wire-iOS Tests/Calling/VideoGridViewControllerSnapshotTests.swift
@@ -20,7 +20,7 @@ import XCTest
 @testable import Wire
 
 final class MockVideoGridConfiguration: VideoGridConfiguration {
-    var isCallOneToOne: Bool = false
+    var shouldShowActiveSpeakerFrame: Bool = true
     
     var floatingVideoStream: VideoStream?
 
@@ -67,7 +67,7 @@ final class VideoGridViewControllerSnapshotTests: ZMSnapshotTestCase {
     func testForActiveSpeakers_OneToOne() {
         configuration.videoStreams = [stubProvider.videoStream(participantName: "Bob", active: true)]
         configuration.floatingVideoStream = selfVideoStream
-        configuration.isCallOneToOne = true
+        configuration.shouldShowActiveSpeakerFrame = false
         createSut()
 
         verify(view: sut.view)

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/VideoConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/VideoConfiguration.swift
@@ -26,7 +26,7 @@ struct VideoConfiguration: VideoGridConfiguration {
     let floatingVideoStream: VideoStream?
     let videoStreams: [VideoStream]
     let networkQuality: NetworkQuality
-    let isCallOneToOne: Bool
+    let shouldShowActiveSpeakerFrame: Bool
 
     init(voiceChannel: VoiceChannel) {
         let videoStreamArrangment = voiceChannel.videoStreamArrangment
@@ -34,7 +34,7 @@ struct VideoConfiguration: VideoGridConfiguration {
         floatingVideoStream = videoStreamArrangment.preview
         videoStreams = videoStreamArrangment.grid
         networkQuality = voiceChannel.networkQuality
-        isCallOneToOne = voiceChannel.callHasTwoParticipants
+        shouldShowActiveSpeakerFrame = voiceChannel.shouldShowActiveSpeakerFrame
     }
 }
 
@@ -110,8 +110,12 @@ extension VoiceChannel {
         }
     }
     
-    fileprivate var callHasTwoParticipants: Bool {
+    private var callHasTwoParticipants: Bool {
         return connectedParticipants.count == 2
+    }
+    
+    fileprivate var shouldShowActiveSpeakerFrame: Bool {
+        return connectedParticipants.count > 2
     }
     
     var sortedActiveVideoStreams: [VideoStream] {

--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridConfiguration.swift
@@ -24,7 +24,7 @@ protocol VideoGridConfiguration {
     var floatingVideoStream: VideoStream? { get }
     var videoStreams: [VideoStream] { get }
     var networkQuality: NetworkQuality { get }
-    var isCallOneToOne: Bool { get }
+    var shouldShowActiveSpeakerFrame: Bool { get }
 
 }
 
@@ -44,7 +44,7 @@ extension VideoGridConfiguration {
         return floatingVideoStream == other.floatingVideoStream &&
             videoStreams == other.videoStreams &&
             networkQuality == other.networkQuality &&
-            isCallOneToOne == other.isCallOneToOne
+            shouldShowActiveSpeakerFrame == other.shouldShowActiveSpeakerFrame
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridViewController.swift
@@ -193,11 +193,12 @@ final class VideoGridViewController: UIViewController {
 
         if let view = viewCache[selfStreamId] as? SelfVideoPreviewView {
             view.stream = selfStream
+            view.shouldShowActiveSpeakerFrame = configuration.shouldShowActiveSpeakerFrame
         } else {
             viewCache[selfStreamId] = SelfVideoPreviewView(
                 stream: selfStream,
                 isCovered: isCovered,
-                shouldShowActiveSpeakerFrame: !configuration.isCallOneToOne
+                shouldShowActiveSpeakerFrame: configuration.shouldShowActiveSpeakerFrame
             )
         }
     }
@@ -236,7 +237,7 @@ final class VideoGridViewController: UIViewController {
         videoStreams.forEach {
             let view = (streamView(for: $0.stream) as? BaseVideoPreviewView)
             view?.stream = $0.stream
-            view?.shouldShowActiveSpeakerFrame = !configuration.isCallOneToOne
+            view?.shouldShowActiveSpeakerFrame = configuration.shouldShowActiveSpeakerFrame
             (view as? VideoPreviewView)?.isPaused = $0.isPaused
         }
     }
@@ -350,7 +351,7 @@ extension VideoGridViewController: UICollectionViewDataSource {
         if let streamView = viewCache[streamId] {
             return streamView
         } else {
-            let view = VideoPreviewView(stream: videoStream.stream, isCovered: isCovered, shouldShowActiveSpeakerFrame: !configuration.isCallOneToOne)
+            let view = VideoPreviewView(stream: videoStream.stream, isCovered: isCovered, shouldShowActiveSpeakerFrame: configuration.shouldShowActiveSpeakerFrame)
             viewCache[streamId] = view
             return view
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Active speaker frame is shown when it shouldn't be. It should only be shown in group calls.

### Causes

- Presently only hiding when there are strictly 2 participants, but still showing when only one participant is in the call.
- Missing update of the self preview's `shouldShowActiveSpeakerFrame` property

### Solutions

- Update condition for showing the frame
- Assign value to `shouldShowActiveSpeakerFrame` property of the self preview when configuration changes
