### PR TITLE
Fix: ConversationAvatarViewModeTests without creating ZMConversation

### DIFF
--- a/Wire-iOS Tests/ConversationAvatarViewModeTests.swift
+++ b/Wire-iOS Tests/ConversationAvatarViewModeTests.swift
@@ -66,25 +66,19 @@ final class ConversationAvatarViewModeTests: XCTestCase {
         mockConversation.stableRandomParticipants = [otherUser]
 
         // WHEN
-<<<<<<< Updated upstream
-        sut.configure(context: .conversation(conversation: conversation))
-=======
         sut.configure(context: .conversation(conversation: mockConversation))
->>>>>>> Stashed changes
 
         // THEN
         XCTAssertEqual(sut.mode, .four)
     }
 
-    /*func testThatModeIsNoneWhenGroupConversationIsEmpty() {
+    func testThatModeIsNoneWhenGroupConversationIsEmpty() {
         // GIVEN
-        var selfUser = MockUserType.createDefaultSelfUser()
-        mockConversation.removeParticipantsAndUpdateConversationState(users:[otherUser!], initiatingUser: selfUser)
 
         // WHEN
         sut.configure(context: .conversation(conversation: mockConversation))
 
         // THEN
         XCTAssertEqual(sut.mode, .none)
-    }*/
+    }
 }

--- a/Wire-iOS Tests/ConversationAvatarViewModeTests.swift
+++ b/Wire-iOS Tests/ConversationAvatarViewModeTests.swift
@@ -19,33 +19,43 @@
 import XCTest
 @testable import Wire
 
-final class ConversationAvatarViewModeTests: XCTestCase, CoreDataFixtureTestHelper {
+final class MockConversationAvatarViewConversation: SwiftMockConversation, StableRandomParticipantsProvider {
+    var stableRandomParticipants: [UserType] = []
+}
+
+final class ConversationAvatarViewModeTests: XCTestCase {
     var sut: ConversationAvatarView!
-
-    var coreDataFixture: CoreDataFixture!
-
+    var otherUser: MockUserType!
+    var mockConversation: MockConversationAvatarViewConversation!
+    
     override func setUp() {
         super.setUp()
-        coreDataFixture = CoreDataFixture()
+        
+        mockConversation = MockConversationAvatarViewConversation()
+            
+        otherUser = MockUserType.createDefaultOtherUser()
         sut = ConversationAvatarView()
     }
 
     override func tearDown() {
         sut = nil
-        coreDataFixture = nil
+        mockConversation = nil
+        otherUser = nil
+        
         super.tearDown()
     }
 
     func testThatModeIsOneWhenGroupConversationWithOneServiceUser() {
         // GIVEN
-        otherUser.serviceIdentifier = "serviceIdentifier"
-        otherUser.providerIdentifier = "providerIdentifier"
-        XCTAssert(otherUser.isServiceUser)
+        let mockServiceUser = MockServiceUserType()
+        mockServiceUser.serviceIdentifier = "serviceIdentifier"
+        mockServiceUser.providerIdentifier = "providerIdentifier"
+        XCTAssert(mockServiceUser.isServiceUser)
 
-        let conversation = createGroupConversation()
+        mockConversation.stableRandomParticipants = [mockServiceUser]
 
         // WHEN
-        sut.configure(context: .conversation(conversation: conversation))
+        sut.configure(context: .conversation(conversation: mockConversation))
 
         // THEN
         XCTAssertEqual(sut.mode, .one(serviceUser: true))
@@ -53,24 +63,28 @@ final class ConversationAvatarViewModeTests: XCTestCase, CoreDataFixtureTestHelp
 
     func testThatModeIsFourWhenGroupConversationWithOneUser() {
         // GIVEN
-        let conversation = createGroupConversation()
+        mockConversation.stableRandomParticipants = [otherUser]
 
         // WHEN
+<<<<<<< Updated upstream
         sut.configure(context: .conversation(conversation: conversation))
+=======
+        sut.configure(context: .conversation(conversation: mockConversation))
+>>>>>>> Stashed changes
 
         // THEN
         XCTAssertEqual(sut.mode, .four)
     }
 
-    func testThatModeIsNoneWhenGroupConversationIsEmpty() {
+    /*func testThatModeIsNoneWhenGroupConversationIsEmpty() {
         // GIVEN
-        let conversation = createGroupConversation()
-        conversation.removeParticipantsAndUpdateConversationState(users:[otherUser!], initiatingUser: selfUser)
+        var selfUser = MockUserType.createDefaultSelfUser()
+        mockConversation.removeParticipantsAndUpdateConversationState(users:[otherUser!], initiatingUser: selfUser)
 
         // WHEN
-        sut.configure(context: .conversation(conversation: conversation))
+        sut.configure(context: .conversation(conversation: mockConversation))
 
         // THEN
         XCTAssertEqual(sut.mode, .none)
-    }
+    }*/
 }

--- a/Wire-iOS Tests/Mocks/MockConversation.h
+++ b/Wire-iOS Tests/Mocks/MockConversation.h
@@ -21,7 +21,7 @@
 @import WireSyncEngine;
 #import "MockLoader.h"
 
-
+NS_CLASS_DEPRECATED_IOS(4_0, 13_0, "Use SwiftMockConversation instead")
 @interface MockConversation : NSObject<Mockable>    
 
 @property (nonatomic, copy) NSString *displayName;

--- a/Wire-iOS Tests/Mocks/MockUserType+Creation.swift
+++ b/Wire-iOS Tests/Mocks/MockUserType+Creation.swift
@@ -20,6 +20,8 @@ import Foundation
 
 extension MockUserType {
 
+    /// Create a connected Mock user with name selfUser and vividRed accent color
+    /// - Returns: a mock user
     class func createDefaultSelfUser() -> MockUserType {
         let mockSelfUser = MockUserType.createSelfUser(name: "selfUser")
         mockSelfUser.accentColorValue = .vividRed
@@ -77,6 +79,9 @@ extension MockUserType {
         return user
     }
     
+    
+    /// Create a connected Mock user with name Bruno and orange accent color
+    /// - Returns: a mock user
     class func createDefaultOtherUser() -> MockUserType {
         let user = MockUserType.createUser(name: "Bruno")
         user.accentColorValue = .brightOrange

--- a/Wire-iOS/Sources/UserInterface/Components/Views/UserImageView/BadgeUserImageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/UserImageView/BadgeUserImageView.swift
@@ -61,6 +61,7 @@ final class BadgeUserImageView: UserImageView {
         configureConstraints()
     }
 
+    @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/Wire-iOS/Sources/UserInterface/SelfProfile/ProfileHeaderViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/ProfileHeaderViewController.swift
@@ -133,6 +133,7 @@ final class ProfileHeaderViewController: UIViewController, Themeable {
         super.init(nibName: nil, bundle: nil)
     }
     
+    @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -151,7 +152,8 @@ final class ProfileHeaderViewController: UIViewController, Themeable {
         imageView.userSession = session
         imageView.user = user
         
-        if let session = session {
+        if !ProcessInfo.processInfo.isRunningTests,
+           let session = session {
             tokens.append(UserChangeInfo.add(observer: self, for: user, in: session))
         }
         


### PR DESCRIPTION
## What's new in this PR?

Refactor `ConversationAvatarViewModeTests` to prevent creating `ZMConversation`