### PR TITLE
[Fix] video capture state

### DIFF
--- a/Wire-iOS Tests/Calling/SelfVideoPreviewViewTests.swift
+++ b/Wire-iOS Tests/Calling/SelfVideoPreviewViewTests.swift
@@ -1,0 +1,109 @@
+//
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import XCTest
+import avs
+
+@testable import Wire
+
+class MockAVSVideoPreview: AVSVideoPreview {
+    var isCapturing: Bool = false
+    
+    override func startVideoCapture() {
+        isCapturing = true
+    }
+    
+    override func stopVideoCapture() {
+        isCapturing = false
+    }
+}
+
+class SelfVideoPreviewViewTests: XCTestCase {
+    var sut: SelfVideoPreviewView!
+    var stubProvider = VideoStreamStubProvider()
+    var previewViewMock = MockAVSVideoPreview()
+    
+    override func setUp() {
+        super.setUp()
+        
+        let stream = stubProvider.videoStream().stream
+        sut = SelfVideoPreviewView(stream: stream, isCovered: false, shouldShowActiveSpeakerFrame: false)
+        sut.previewView = previewViewMock
+    }
+    
+    override func tearDown() {
+        sut = nil
+        super.tearDown()
+    }
+    
+    func testCapturerState_ForVideoState_Started() {
+        // Given
+        previewViewMock.isCapturing = false
+
+        // When
+        sut.stream = stubProvider.videoStream(videoState: .started).stream
+
+        // Then
+        XCTAssertTrue(previewViewMock.isCapturing)
+    }
+    
+    func testCapturerState_ForVideoState_Stopped() {
+        // Given
+        previewViewMock.isCapturing = false
+        
+        // When
+        sut.stream = stubProvider.videoStream(videoState: .stopped).stream
+        
+        // Then
+        XCTAssertFalse(previewViewMock.isCapturing)
+    }
+    
+    func testCapturerState_ForVideoState_Paused() {
+        // Given
+        previewViewMock.isCapturing = false
+        
+        // When
+        sut.stream = stubProvider.videoStream(videoState: .paused).stream
+        
+        // Then
+        XCTAssertFalse(previewViewMock.isCapturing)
+    }
+    
+    func testCapturerState_ForVideoState_BadConnection() {
+        // Given
+        previewViewMock.isCapturing = false
+        
+        // When
+        sut.stream = stubProvider.videoStream(videoState: .badConnection).stream
+        
+        // Then
+        XCTAssertFalse(previewViewMock.isCapturing)
+    }
+    
+    func testCapturerState_ForVideoState_ScreenSharing() {
+        // Given
+        previewViewMock.isCapturing = false
+        
+        // When
+        sut.stream = stubProvider.videoStream(videoState: .screenSharing).stream
+        
+        // Then
+        XCTAssertFalse(previewViewMock.isCapturing)
+    }
+}

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -453,6 +453,7 @@
 		636B716C23C39D6700B624D6 /* AppLockViewControllerSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636B716923C39D0600B624D6 /* AppLockViewControllerSnapshotTests.swift */; };
 		636E57BD2386BFD9005B4FD8 /* AvailabilityStringBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636E57BC2386BFD9005B4FD8 /* AvailabilityStringBuilderTests.swift */; };
 		6370DA212577934C00B5C8F1 /* PulsingIconImageViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6370DA202577934C00B5C8F1 /* PulsingIconImageViewTests.swift */; };
+		6372A0F225C8438B000CCB2D /* SelfVideoPreviewViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6372A0F125C8438A000CCB2D /* SelfVideoPreviewViewTests.swift */; };
 		6372AAA72492719100C5F307 /* GridCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6372AAA62492719100C5F307 /* GridCell.swift */; };
 		6372AAAA249A4F2600C5F307 /* Int+Even.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6372AAA9249A4F2600C5F307 /* Int+Even.swift */; };
 		638332EA250282D200D18F42 /* OrientationDelta.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638332E9250282D200D18F42 /* OrientationDelta.swift */; };
@@ -2072,6 +2073,7 @@
 		636B716923C39D0600B624D6 /* AppLockViewControllerSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockViewControllerSnapshotTests.swift; sourceTree = "<group>"; };
 		636E57BC2386BFD9005B4FD8 /* AvailabilityStringBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailabilityStringBuilderTests.swift; sourceTree = "<group>"; };
 		6370DA202577934C00B5C8F1 /* PulsingIconImageViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PulsingIconImageViewTests.swift; sourceTree = "<group>"; };
+		6372A0F125C8438A000CCB2D /* SelfVideoPreviewViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelfVideoPreviewViewTests.swift; sourceTree = "<group>"; };
 		6372AAA62492719100C5F307 /* GridCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GridCell.swift; sourceTree = "<group>"; };
 		6372AAA9249A4F2600C5F307 /* Int+Even.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+Even.swift"; sourceTree = "<group>"; };
 		638332E9250282D200D18F42 /* OrientationDelta.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrientationDelta.swift; sourceTree = "<group>"; };
@@ -4243,6 +4245,7 @@
 				6340EF95237AE93500EF8506 /* VoiceChannelVideoStreamArrangmentTests.swift */,
 				6340660825B204B100C0B4BA /* VideoStreamStubProvider.swift */,
 				6391628B24F6A39D0054962E /* VideoPreviewViewTests.swift */,
+				6372A0F125C8438A000CCB2D /* SelfVideoPreviewViewTests.swift */,
 				16A94AF5209B04A5008A5718 /* GridViewTests.swift */,
 				164B533B20A0A5E800EC8265 /* CallInfoConfigurationTests.swift */,
 				D58192042091F34E003BA7EC /* CallActionsViewTests.swift */,
@@ -8524,6 +8527,7 @@
 				EFB23D0B1FC853CF0055B866 /* AccessoryTextFieldValidationTests.swift in Sources */,
 				EEAC654C206BD64700365C0C /* LinkInteractionTextViewTests.swift in Sources */,
 				5501FFAB22B28F330050D8FC /* MockSelfLegalHoldSubject.swift in Sources */,
+				6372A0F225C8438B000CCB2D /* SelfVideoPreviewViewTests.swift in Sources */,
 				5E8FFC0621ECCC7C0052DF03 /* AuthenticationInterfaceBuilderTests.swift in Sources */,
 				5EE115E1204EEC7D002AD6C2 /* CallQualityControllerTests.swift in Sources */,
 				EFE043992149CE8D00BC3079 /* ContactsViewControllerSnapshotTests.swift in Sources */,

--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/SelfVideoPreviewView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/SelfVideoPreviewView.swift
@@ -24,6 +24,13 @@ final class SelfVideoPreviewView: BaseVideoPreviewView {
     
     private let previewView = AVSVideoPreview()
         
+    override var stream: Stream {
+        didSet {
+            guard stream != oldValue else { return }
+            updateCaptureState()
+        }
+    }
+    
     deinit {
         stopCapture()
     }
@@ -56,6 +63,10 @@ final class SelfVideoPreviewView: BaseVideoPreviewView {
         if window != nil {
             startCapture()
         }
+    }
+    
+    private func updateCaptureState() {
+        stream.videoState == .some(.started) ? startCapture() : stopCapture()
     }
     
     func startCapture() {

--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/SelfVideoPreviewView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/SelfVideoPreviewView.swift
@@ -61,7 +61,7 @@ final class SelfVideoPreviewView: BaseVideoPreviewView {
         super.didMoveToWindow()
         
         if window != nil {
-            startCapture()
+            updateCaptureState()
         }
     }
     

--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/SelfVideoPreviewView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/SelfVideoPreviewView.swift
@@ -22,7 +22,7 @@ import avs
 
 final class SelfVideoPreviewView: BaseVideoPreviewView {
     
-    private let previewView = AVSVideoPreview()
+    var previewView = AVSVideoPreview()
         
     override var stream: Stream {
         didSet {

--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridViewController.swift
@@ -184,10 +184,10 @@ final class VideoGridViewController: UIViewController {
     }
 
     private func updateSelfPreview() {
-        guard
-            let selfStreamId = ZMUser.selfUser()?.selfStreamId,
-            let selfStream = stream(with: selfStreamId)
-        else {
+        guard let selfStreamId = ZMUser.selfUser()?.selfStreamId else { return }
+
+        guard let selfStream = stream(with: selfStreamId) else {
+            (viewCache[selfStreamId] as? SelfVideoPreviewView)?.stopCapture()
             return
         }
 


### PR DESCRIPTION
## What's new in this PR?

start self preview capture only when video state is `.started`