### PR TITLE
remove Backup hack for simulator build

### DIFF
--- a/Wire-iOS/Sources/Authentication/Backup/BackupRestoreController.swift
+++ b/Wire-iOS/Sources/Authentication/Backup/BackupRestoreController.swift
@@ -54,13 +54,6 @@ final class BackupRestoreController: NSObject {
 
     fileprivate func showFilePicker() {
         // Test code to verify restore
-        #if arch(i386) || arch(x86_64)
-        let testFilePath = "/var/tmp/backup.ios_wbu"
-        if FileManager.default.fileExists(atPath: testFilePath) {
-            self.restore(with: URL(fileURLWithPath: testFilePath))
-            return
-        }
-        #endif
 
         let picker = UIDocumentPickerViewController(
             documentTypes: BackupRestoreController.WireBackupUTIs,

--- a/Wire-iOS/Sources/UserInterface/Settings/BackupViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/BackupViewController.swift
@@ -212,19 +212,14 @@ fileprivate extension BackupViewController {
     }
     
     private func presentShareSheet(with url: URL, from indexPath: IndexPath) {
-        #if arch(i386) || arch(x86_64)
-            let tmpURL = URL(fileURLWithPath: "/var/tmp/").appendingPathComponent(url.lastPathComponent)
-            try! FileManager.default.moveItem(at: url, to: tmpURL)
-        #else
-            let activityController = UIActivityViewController(activityItems: [url], applicationActivities: nil)
-            activityController.completionWithItemsHandler = { _, _, _, _ in
-                SessionManager.clearPreviousBackups()
-            }
-            activityController.popoverPresentationController.apply {
-                $0.sourceView = tableView
-                $0.sourceRect = tableView.rectForRow(at: indexPath)
-            }
-            self.present(activityController, animated: true)
-        #endif
+        let activityController = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+        activityController.completionWithItemsHandler = { _, _, _, _ in
+            SessionManager.clearPreviousBackups()
+        }
+        activityController.popoverPresentationController.apply {
+            $0.sourceView = tableView
+            $0.sourceRect = tableView.rectForRow(at: indexPath)
+        }
+        self.present(activityController, animated: true)
     }
 }


### PR DESCRIPTION
## What's new in this PR?

From the request of QA, remove the hack for the simulator for loading and saving a backup file.