### PR TITLE
[Fix] App lock shown twice when encryption at rest is enabled

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockInteractor.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockInteractor.swift
@@ -54,6 +54,8 @@ final class AppLockInteractor {
     private var userSession: AppLockInteractorUserSession? {
         return _userSession ?? ZMUserSession.shared()
     }
+
+    private let isReadyForAuthentication = DispatchSemaphore(value: 1)
     
     var appState: AppState?
 
@@ -117,6 +119,7 @@ extension AppLockInteractor: AppLockInteractorInput {
     }
     
     func evaluateAuthentication(description: String) {
+        isReadyForAuthentication.wait()
         appLock?.evaluateAuthentication(scenario: authenticationScenario,
                                         description: description.localized) { [weak self] result, context in
             guard let `self` = self else { return }
@@ -127,6 +130,7 @@ extension AppLockInteractor: AppLockInteractorInput {
                 }
                 
                 self.output?.authenticationEvaluated(with: result)
+                self.isReadyForAuthentication.signal()
             }
         }
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

If encryption at rest is enabled, it is possible that the user is asked to use Touch ID or Face ID twice to unlock the app.

### Causes

Authenticating with device owner credentials (biometrics or device passcode) is handle via the LocalAuthentication framework. The authentication result is returned to us asynchronously, which we use to mutate local state. Because of this concurrent behavior, it's possible to ask the user to authenticate a second time before the results of the first time are fully finished being processed. Such a case can happen when encryption at rest is enabled and the user authentication happens very quickly.

### Solutions

Use a binary semaphore to prevent beginning a new authentication request before the last one has been fully completed.

