### PR TITLE
[Chore] Update Viper templates

### DIFF
--- a/Templates/Viper/Module.xctemplate/___FILEBASENAME___Module.Interactor.swift
+++ b/Templates/Viper/Module.xctemplate/___FILEBASENAME___Module.Interactor.swift
@@ -22,6 +22,8 @@ extension ___VARIABLE_productName:identifier___Module {
 
     final class Interactor: InteractorInterface {
 
+        // MARK: - Properties
+
         weak var presenter: ___VARIABLE_productName:identifier___PresenterInteractorInterface!
 
     }
@@ -29,6 +31,14 @@ extension ___VARIABLE_productName:identifier___Module {
 }
 
 
-// MARK: - API for presenter
+// MARK: - Execute request
 
-extension ___VARIABLE_productName:identifier___Module.Interactor: ___VARIABLE_productName:identifier___InteractorPresenterInterface { }
+extension ___VARIABLE_productName:identifier___Module.Interactor: ___VARIABLE_productName:identifier___InteractorPresenterInterface {
+
+    func execute(request: ___VARIABLE_productName:identifier___Module.Request) {
+        switch request {
+
+        }
+    }
+
+}

--- a/Templates/Viper/Module.xctemplate/___FILEBASENAME___Module.Interactor.swift
+++ b/Templates/Viper/Module.xctemplate/___FILEBASENAME___Module.Interactor.swift
@@ -35,7 +35,7 @@ extension ___VARIABLE_productName:identifier___Module {
 
 extension ___VARIABLE_productName:identifier___Module.Interactor: ___VARIABLE_productName:identifier___InteractorPresenterInterface {
 
-    func execute(request: ___VARIABLE_productName:identifier___Module.Request) {
+    func executeRequest(_ request: ___VARIABLE_productName:identifier___Module.Request) {
         switch request {
 
         }

--- a/Templates/Viper/Module.xctemplate/___FILEBASENAME___Module.Presenter.swift
+++ b/Templates/Viper/Module.xctemplate/___FILEBASENAME___Module.Presenter.swift
@@ -36,7 +36,7 @@ extension ___VARIABLE_productName:identifier___Module {
 
 extension ___VARIABLE_productName:identifier___Module.Presenter: ___VARIABLE_productName:identifier___PresenterInteractorInterface {
 
-    func handle(result: ___VARIABLE_productName:identifier___Module.Result) {
+    func handleResult(_ result: ___VARIABLE_productName:identifier___Module.Result) {
         switch result {
 
         }
@@ -48,7 +48,7 @@ extension ___VARIABLE_productName:identifier___Module.Presenter: ___VARIABLE_pro
 
 extension ___VARIABLE_productName:identifier___Module.Presenter: ___VARIABLE_productName:identifier___PresenterViewInterface {
 
-    func process(event: ___VARIABLE_productName:identifier___Module.Event) {
+    func processEvent(_ event: ___VARIABLE_productName:identifier___Module.Event) {
         switch event {
         case .viewDidLoad:
           break

--- a/Templates/Viper/Module.xctemplate/___FILEBASENAME___Module.Presenter.swift
+++ b/Templates/Viper/Module.xctemplate/___FILEBASENAME___Module.Presenter.swift
@@ -22,18 +22,37 @@ extension ___VARIABLE_productName:identifier___Module {
 
     final class Presenter: PresenterInterface {
 
-        var router: ___VARIABLE_productName:identifier___RouterPresenterInterface!
+        // MARK: - Properties
+
         var interactor: ___VARIABLE_productName:identifier___InteractorPresenterInterface!
         weak var view: ___VARIABLE_productName:identifier___ViewPresenterInterface!
+        var router: ___VARIABLE_productName:identifier___RouterPresenterInterface!
 
     }
 
 }
 
-// MARK: - API for interactor
+// MARK: - Handle result
 
-extension ___VARIABLE_productName:identifier___Module.Presenter: ___VARIABLE_productName:identifier___PresenterInteractorInterface { }
+extension ___VARIABLE_productName:identifier___Module.Presenter: ___VARIABLE_productName:identifier___PresenterInteractorInterface {
 
-// MARK: - API for view
+    func handle(result: ___VARIABLE_productName:identifier___Module.Result) {
+        switch result {
 
-extension ___VARIABLE_productName:identifier___Module.Presenter: ___VARIABLE_productName:identifier___PresenterViewInterface { }
+        }
+    }
+
+}
+
+// MARK: - Process event
+
+extension ___VARIABLE_productName:identifier___Module.Presenter: ___VARIABLE_productName:identifier___PresenterViewInterface {
+
+    func process(event: ___VARIABLE_productName:identifier___Module.Event) {
+        switch event {
+        case .viewDidLoad:
+          break
+        }
+    }
+
+}

--- a/Templates/Viper/Module.xctemplate/___FILEBASENAME___Module.Router.swift
+++ b/Templates/Viper/Module.xctemplate/___FILEBASENAME___Module.Router.swift
@@ -35,7 +35,7 @@ extension ___VARIABLE_productName:identifier___Module {
 
 extension ___VARIABLE_productName:identifier___Module.Router: ___VARIABLE_productName:identifier___RouterPresenterInterface {
 
-    func perform(action: ___VARIABLE_productName:identifier___Module.Action) {
+    func performAction(_ action: ___VARIABLE_productName:identifier___Module.Action) {
         switch action {
 
         }

--- a/Templates/Viper/Module.xctemplate/___FILEBASENAME___Module.Router.swift
+++ b/Templates/Viper/Module.xctemplate/___FILEBASENAME___Module.Router.swift
@@ -23,12 +23,22 @@ extension ___VARIABLE_productName:identifier___Module {
 
     final class Router: RouterInterface {
 
-        weak var viewController: UIViewController?
+        // MARK: - Properties
+
+        weak var view: View!
 
     }
 
 }
 
-// MARK: - API for presenter
+// MARK: - Perform action
 
-extension ___VARIABLE_productName:identifier___Module.Router: ___VARIABLE_productName:identifier___RouterPresenterInterface { }
+extension ___VARIABLE_productName:identifier___Module.Router: ___VARIABLE_productName:identifier___RouterPresenterInterface {
+
+    func perform(action: ___VARIABLE_productName:identifier___Module.Action) {
+        switch action {
+
+        }
+    }
+
+}

--- a/Templates/Viper/Module.xctemplate/___FILEBASENAME___Module.View.swift
+++ b/Templates/Viper/Module.xctemplate/___FILEBASENAME___Module.View.swift
@@ -31,7 +31,7 @@ extension ___VARIABLE_productName:identifier___Module {
 
         override func viewDidLoad() {
             super.viewDidLoad()
-            presenter.process(event: .viewDidLoad)
+            presenter.processEvent(.viewDidLoad)
         }
 
     }
@@ -50,7 +50,7 @@ extension ___VARIABLE_productName:identifier___Module {
 
 extension ___VARIABLE_productName:identifier___Module.View: ___VARIABLE_productName:identifier___ViewPresenterInterface {
 
-    func refresh(with model: ___VARIABLE_productName:identifier___Module.ViewModel) {
+    func refresh(withModel model: ___VARIABLE_productName:identifier___Module.ViewModel) {
 
     }
 

--- a/Templates/Viper/Module.xctemplate/___FILEBASENAME___Module.View.swift
+++ b/Templates/Viper/Module.xctemplate/___FILEBASENAME___Module.View.swift
@@ -23,12 +23,35 @@ extension ___VARIABLE_productName:identifier___Module {
 
     final class View: UIViewController, ViewInterface {
 
+        // MARK: - Properties
+
         var presenter: ___VARIABLE_productName:identifier___PresenterViewInterface!
+
+        // MARK: - Life cycle
+
+        override func viewDidLoad() {
+            super.viewDidLoad()
+            presenter.process(event: .viewDidLoad)
+        }
 
     }
 
 }
 
-// MARK: - API for presenter
+// MARK: - View model
 
-extension ___VARIABLE_productName:identifier___Module.View: ___VARIABLE_productName:identifier___ViewPresenterInterface { }
+extension ___VARIABLE_productName:identifier___Module {
+
+    enum ViewModel: Equatable {}
+
+}
+
+// MARK: - Refresh
+
+extension ___VARIABLE_productName:identifier___Module.View: ___VARIABLE_productName:identifier___ViewPresenterInterface {
+
+    func refresh(with model: ___VARIABLE_productName:identifier___Module.ViewModel) {
+
+    }
+
+}

--- a/Templates/Viper/Module.xctemplate/___FILEBASENAME___Module.swift
+++ b/Templates/Viper/Module.xctemplate/___FILEBASENAME___Module.swift
@@ -21,52 +21,68 @@ import Foundation
 enum ___FILEBASENAMEASIDENTIFIER___: ModuleInterface {
 
     static func build() -> View {
-        let router = Router()
         let interactor = Interactor()
         let presenter = Presenter()
         let view = View()
+        let router = Router()
 
-        assemble(router: router, interactor: interactor, presenter: presenter, view: view)
-
-        router.viewController = view
+        assemble(interactor: interactor, presenter: presenter, view: view, router: router)
 
         return view
     }
 
 }
 
-// MARK: - Router / Presenter
+extension ___FILEBASENAMEASIDENTIFIER___ {
 
-protocol ___VARIABLE_productName:identifier___RouterPresenterInterface: RouterPresenterInterface {
+  enum Event: Equatable {
 
-    /// Router API exposed to the presenter.
+      case viewDidLoad
+
+  }
+
+  enum Request: Equatable {}
+
+  enum Result: Equatable {}
+
+  enum Action: Equatable {}
 
 }
 
-// MARK: - Interactor / Presenter
-
-protocol ___VARIABLE_productName:identifier___PresenterInteractorInterface: PresenterInteractorInterface {
-
-    /// Presenter API exposed to the interactor.
-
-}
+// MARK: - Interactor
 
 protocol ___VARIABLE_productName:identifier___InteractorPresenterInterface: InteractorPresenterInterface {
 
-    /// Interactor API exposed to the presenter.
+    func execute(request: ___FILEBASENAMEASIDENTIFIER___.Request)
 
 }
 
-// MARK: - View / Presenter
+// MARK: - Presenter
 
-protocol ___VARIABLE_productName:identifier___ViewPresenterInterface: ViewPresenterInterface {
+protocol ___VARIABLE_productName:identifier___PresenterInteractorInterface: PresenterInteractorInterface {
 
-    /// View API exposed to the presenter.
+    func handle(result: ___FILEBASENAMEASIDENTIFIER___.Result)
 
 }
 
 protocol ___VARIABLE_productName:identifier___PresenterViewInterface: PresenterViewInterface {
 
-    /// Presenter API exposed to the view.
+    func process(event: ___FILEBASENAMEASIDENTIFIER___.Event)
+
+}
+
+// MARK: - View
+
+protocol ___VARIABLE_productName:identifier___ViewPresenterInterface: ViewPresenterInterface {
+
+    func refresh(with model: ___FILEBASENAMEASIDENTIFIER___.ViewModel)
+
+}
+
+// MARK: - Router
+
+protocol ___VARIABLE_productName:identifier___RouterPresenterInterface: RouterPresenterInterface {
+
+    func perform(action: ___FILEBASENAMEASIDENTIFIER___.Action)
 
 }

--- a/Templates/Viper/Module.xctemplate/___FILEBASENAME___Module.swift
+++ b/Templates/Viper/Module.xctemplate/___FILEBASENAME___Module.swift
@@ -53,7 +53,7 @@ extension ___FILEBASENAMEASIDENTIFIER___ {
 
 protocol ___VARIABLE_productName:identifier___InteractorPresenterInterface: InteractorPresenterInterface {
 
-    func execute(request: ___FILEBASENAMEASIDENTIFIER___.Request)
+    func executeRequest(_ request: ___FILEBASENAMEASIDENTIFIER___.Request)
 
 }
 
@@ -61,13 +61,13 @@ protocol ___VARIABLE_productName:identifier___InteractorPresenterInterface: Inte
 
 protocol ___VARIABLE_productName:identifier___PresenterInteractorInterface: PresenterInteractorInterface {
 
-    func handle(result: ___FILEBASENAMEASIDENTIFIER___.Result)
+    func handleResult(_ result: ___FILEBASENAMEASIDENTIFIER___.Result)
 
 }
 
 protocol ___VARIABLE_productName:identifier___PresenterViewInterface: PresenterViewInterface {
 
-    func process(event: ___FILEBASENAMEASIDENTIFIER___.Event)
+    func processEvent(_ event: ___FILEBASENAMEASIDENTIFIER___.Event)
 
 }
 
@@ -75,7 +75,7 @@ protocol ___VARIABLE_productName:identifier___PresenterViewInterface: PresenterV
 
 protocol ___VARIABLE_productName:identifier___ViewPresenterInterface: ViewPresenterInterface {
 
-    func refresh(with model: ___FILEBASENAMEASIDENTIFIER___.ViewModel)
+    func refresh(withModel model: ___FILEBASENAMEASIDENTIFIER___.ViewModel)
 
 }
 
@@ -83,6 +83,6 @@ protocol ___VARIABLE_productName:identifier___ViewPresenterInterface: ViewPresen
 
 protocol ___VARIABLE_productName:identifier___RouterPresenterInterface: RouterPresenterInterface {
 
-    func perform(action: ___FILEBASENAMEASIDENTIFIER___.Action)
+    func performAction(_ action: ___FILEBASENAMEASIDENTIFIER___.Action)
 
 }

--- a/Templates/Viper/Tests.xctemplate/___FILEBASENAME___Module.MockInteractor.swift
+++ b/Templates/Viper/Tests.xctemplate/___FILEBASENAME___Module.MockInteractor.swift
@@ -25,16 +25,14 @@ extension ___VARIABLE_productName:identifier___Module {
 
         // MARK: - Metrics
 
-        var methodCalls = MethodCalls()
+        var requests = [Request]()
 
         // MARK: - Methods
 
+        func execute(request: ___VARIABLE_productName:identifier___Module.Request) {
+            requests.append(request)
+        }
+
     }
-
-}
-
-extension ___VARIABLE_productName:identifier___Module.MockInteractor {
-
-    struct MethodCalls { }
 
 }

--- a/Templates/Viper/Tests.xctemplate/___FILEBASENAME___Module.MockInteractor.swift
+++ b/Templates/Viper/Tests.xctemplate/___FILEBASENAME___Module.MockInteractor.swift
@@ -29,7 +29,7 @@ extension ___VARIABLE_productName:identifier___Module {
 
         // MARK: - Methods
 
-        func execute(request: ___VARIABLE_productName:identifier___Module.Request) {
+        func executeRequest(_ request: ___VARIABLE_productName:identifier___Module.Request) {
             requests.append(request)
         }
 

--- a/Templates/Viper/Tests.xctemplate/___FILEBASENAME___Module.MockPresenter.swift
+++ b/Templates/Viper/Tests.xctemplate/___FILEBASENAME___Module.MockPresenter.swift
@@ -30,11 +30,11 @@ extension ___VARIABLE_productName:identifier___Module {
 
         // MARK: - Methods
 
-        func handle(result: ___VARIABLE_productName:identifier___Module.Result) {
+        func handleResult(_ result: ___VARIABLE_productName:identifier___Module.Result) {
             results.append(result)
         }
 
-        func process(event: ___VARIABLE_productName:identifier___Module.Event) {
+        func processEvent(_ event: ___VARIABLE_productName:identifier___Module.Event) {
             events.append(event)
         }
 

--- a/Templates/Viper/Tests.xctemplate/___FILEBASENAME___Module.MockPresenter.swift
+++ b/Templates/Viper/Tests.xctemplate/___FILEBASENAME___Module.MockPresenter.swift
@@ -25,16 +25,19 @@ extension ___VARIABLE_productName:identifier___Module {
 
         // MARK: - Metrics
 
-        var methodCalls = MethodCalls()
+        var results = [Result]()
+        var events = [Event]()
 
         // MARK: - Methods
 
+        func handle(result: ___VARIABLE_productName:identifier___Module.Result) {
+            results.append(result)
+        }
+
+        func process(event: ___VARIABLE_productName:identifier___Module.Event) {
+            events.append(event)
+        }
+
     }
-
-}
-
-extension ___VARIABLE_productName:identifier___Module.MockPresenter {
-
-    struct MethodCalls { }
 
 }

--- a/Templates/Viper/Tests.xctemplate/___FILEBASENAME___Module.MockRouter.swift
+++ b/Templates/Viper/Tests.xctemplate/___FILEBASENAME___Module.MockRouter.swift
@@ -29,7 +29,7 @@ extension ___VARIABLE_productName:identifier___Module {
 
         // MARK: - Methods
 
-        func perform(action: ___VARIABLE_productName:identifier___Module.Action) {
+        func performAction(_ action: ___VARIABLE_productName:identifier___Module.Action) {
             actions.append(action)
         }
 

--- a/Templates/Viper/Tests.xctemplate/___FILEBASENAME___Module.MockRouter.swift
+++ b/Templates/Viper/Tests.xctemplate/___FILEBASENAME___Module.MockRouter.swift
@@ -25,16 +25,14 @@ extension ___VARIABLE_productName:identifier___Module {
 
         // MARK: - Metrics
 
-        var methodCalls = MethodCalls()
+        var actions = [Action]()
 
         // MARK: - Methods
 
+        func perform(action: ___VARIABLE_productName:identifier___Module.Action) {
+            actions.append(action)
+        }
+
     }
-
-}
-
-extension ___VARIABLE_productName:identifier___Module.MockRouter {
-
-    struct MethodCalls { }
 
 }

--- a/Templates/Viper/Tests.xctemplate/___FILEBASENAME___Module.MockView.swift
+++ b/Templates/Viper/Tests.xctemplate/___FILEBASENAME___Module.MockView.swift
@@ -25,16 +25,14 @@ extension ___VARIABLE_productName:identifier___Module {
 
         // MARK: - Metrics
 
-        var methodCalls = MethodCalls()
+        var models = [ViewModel]()
 
         // MARK: - Methods
 
+        func refresh(with model: ___VARIABLE_productName:identifier___Module.ViewModel) {
+            models.append(model)
+        }
+
     }
-
-}
-
-extension ___VARIABLE_productName:identifier___Module.MockView {
-
-    struct MethodCalls { }
 
 }

--- a/Templates/Viper/Tests.xctemplate/___FILEBASENAME___Module.MockView.swift
+++ b/Templates/Viper/Tests.xctemplate/___FILEBASENAME___Module.MockView.swift
@@ -29,7 +29,7 @@ extension ___VARIABLE_productName:identifier___Module {
 
         // MARK: - Methods
 
-        func refresh(with model: ___VARIABLE_productName:identifier___Module.ViewModel) {
+        func refresh(withModel model: ___VARIABLE_productName:identifier___Module.ViewModel) {
             models.append(model)
         }
 

--- a/Wire-iOS/Sources/Viper/Viper+Interfaces.swift
+++ b/Wire-iOS/Sources/Viper/Viper+Interfaces.swift
@@ -26,40 +26,27 @@ import UIKit
 
 protocol ModuleInterface {
 
-    associatedtype Router where Router: RouterInterface
     associatedtype Interactor where Interactor: InteractorInterface
     associatedtype Presenter where Presenter: PresenterInterface
     associatedtype View where View: UIViewController & ViewInterface
+    associatedtype Router where Router: RouterInterface
 
     /// Assembles the module by connecting each component together.
 
-    static func assemble(router: Router, interactor: Interactor, presenter: Presenter, view: View)
+    static func assemble(interactor: Interactor, presenter: Presenter, view: View, router: Router)
 
 }
 
 extension ModuleInterface {
 
-    static func assemble(router: Router, interactor: Interactor, presenter: Presenter, view: View) {
-        router.viewController = view
+    static func assemble(interactor: Interactor, presenter: Presenter, view: View, router: Router) {
         interactor.presenter = (presenter as! Self.Interactor.PresenterInteractor)
         presenter.interactor = (interactor as! Self.Presenter.InteractorPresenter)
         presenter.router = (router as! Self.Presenter.RouterPresenter)
         presenter.view = (view as! Self.Presenter.ViewPresenter)
         view.presenter = (presenter as! Self.View.PresenterView)
+        router.view = (view as! Self.Router.View)
     }
-
-}
-
-
-// MARK: - Router
-
-/// The module component responsible for view navigation.
-
-protocol RouterInterface: RouterPresenterInterface {
-
-    /// A weak reference to the view controller
-
-    var viewController: UIViewController? { get set }
 
 }
 
@@ -86,13 +73,9 @@ protocol InteractorInterface: InteractorPresenterInterface {
 
 protocol PresenterInterface: PresenterInteractorInterface & PresenterViewInterface {
 
-    associatedtype RouterPresenter
     associatedtype InteractorPresenter
     associatedtype ViewPresenter
-
-    /// A strong reference to the router.
-
-    var router: RouterPresenter! { get set }
+    associatedtype RouterPresenter
 
     /// A strong reference to the interactor.
 
@@ -101,6 +84,10 @@ protocol PresenterInterface: PresenterInteractorInterface & PresenterViewInterfa
     /// A weak reference to the view.
 
     var view: ViewPresenter! { get set }
+
+    /// A strong reference to the router.
+
+    var router: RouterPresenter! { get set }
 
 }
 
@@ -116,5 +103,19 @@ protocol ViewInterface: ViewPresenterInterface {
     /// A strong reference to the presenter.
 
     var presenter: PresenterView! { get set }
+
+}
+
+// MARK: - Router
+
+/// The module component responsible for navigation to other modules.
+
+protocol RouterInterface: RouterPresenterInterface {
+
+    associatedtype View: UIViewController
+
+    /// A weak reference to the view controller
+
+    var view: View! { get set }
 
 }


### PR DESCRIPTION
## What's new in this PR?

Update the both the Viper templates to align with the implementation outlined [here](https://wearezeta.atlassian.net/wiki/spaces/IOS/pages/245105434/Viper+architecture+Draft). With these changes, the only thing that you need to do after generating a module is to define the `Event`, `Request`, `Result`, `ViewModel` and `Action` enum cases (and how to handle them of course!).

In summary:

- Provide empty enums for each message type.
- Provide protocol requirements for each relationship.
- Provide implementations of those requirements which empty switches.
- Provide a default `viewDidLoad` event.
- Simplify the mock components to record only the message types.
- Moved the position of "Router" from first to last in the `build` method and other places.
- Added missing mark labels
