### PR TITLE
[Fix] Conversation search in share extension

### DIFF
--- a/Wire-iOS Share Extension/ConversationSelectionViewController.swift
+++ b/Wire-iOS Share Extension/ConversationSelectionViewController.swift
@@ -89,7 +89,7 @@ extension ConversationSelectionViewController : UISearchResultsUpdating {
     func updateSearchResults(for searchController: UISearchController) {
         if let searchText = searchController.searchBar.text, !searchText.isEmpty {
             visibleConversations = allConversations.filter { conversation in
-                if let _ = conversation.name.range(of: searchText, options: .diacriticInsensitive) {
+                if let _ = conversation.name.range(of: searchText, options: [.diacriticInsensitive, .caseInsensitive]) {
                     return true
                 } else {
                     return false


### PR DESCRIPTION
## What's new in this PR?

https://wearezeta.atlassian.net/browse/SQSERVICES-62

### Issues

Conversation search in share extension is case sensitive

### Solutions

Add `.caseInsensitive` option to the search.
