### PR TITLE
[Fix] Conversation list can not be opened from the Share extension

### DIFF
--- a/Wire-iOS Share Extension/ShareExtensionViewController.swift
+++ b/Wire-iOS Share Extension/ShareExtensionViewController.swift
@@ -517,7 +517,7 @@ extension ShareExtensionViewController {
             let sharingSession = sharingSession,
             sharingSession.appLockController.isActive || sharingSession.encryptMessagesAtRest
             else {
-                localAuthenticationStatus = .disabled
+                localAuthenticationStatus = .granted
                 completion()
                 return
         }


### PR DESCRIPTION
## What's new in this PR?

https://wearezeta.atlassian.net/browse/SQSERVICES-263

### Issues

Conversation list can't be opened on tapping while using a Share extension.


### Causes

When app lock and EAR feature are not active we send the wrong authentication status.

### Solutions

Don't ask for authentication if app lock and EAR feature are not active.

