### PR TITLE
Revert "[Fix] App lock shown twice when encryption at rest is enabled…

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Overlay/AppLockInteractor.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/AppLockInteractor.swift
@@ -54,8 +54,6 @@ final class AppLockInteractor {
     private var userSession: AppLockInteractorUserSession? {
         return _userSession ?? ZMUserSession.shared()
     }
-
-    private let isReadyForAuthentication = DispatchSemaphore(value: 1)
     
     var appState: AppState?
 
@@ -119,7 +117,6 @@ extension AppLockInteractor: AppLockInteractorInput {
     }
     
     func evaluateAuthentication(description: String) {
-        isReadyForAuthentication.wait()
         appLock?.evaluateAuthentication(scenario: authenticationScenario,
                                         description: description.localized) { [weak self] result, context in
             guard let `self` = self else { return }
@@ -130,7 +127,6 @@ extension AppLockInteractor: AppLockInteractorInput {
                 }
                 
                 self.output?.authenticationEvaluated(with: result)
-                self.isReadyForAuthentication.signal()
             }
         }
     }


### PR DESCRIPTION
## What's new in this PR?

Some users have found that after authenticating the just see the blurred shield view. It appears to be related to the fix for duplicated app lock, so I'm reverting it now to unblock those users.

I'll resolve the issue about duplicated app lock in a separate PR.
