### PR TITLE
remove ConversationCellSnapshotTestCase

### DIFF
--- a/Wire-iOS Tests/ConversationMessageCell/XCTestCase+VerifyMessage.swift
+++ b/Wire-iOS Tests/ConversationMessageCell/XCTestCase+VerifyMessage.swift
@@ -20,6 +20,17 @@ import XCTest
 @testable import Wire
 import SnapshotTesting
 
+extension ConversationMessageContext {
+    fileprivate static let defaultContext = ConversationMessageContext(isSameSenderAsPrevious: false,
+                                                                       isTimeIntervalSinceLastMessageSignificant: false,
+                                                                       isFirstMessageOfTheDay: false,
+                                                                       isFirstUnreadMessage: false,
+                                                                       isLastMessage: false,
+                                                                       searchQueries: [],
+                                                                       previousMessageIsKnock: false,
+                                                                       spacing: 0)
+}
+
 extension XCTestCase {
     /**
      * Performs a snapshot test for a message
@@ -98,7 +109,7 @@ extension XCTestCase {
         waitForTextViewToLoad: Bool,
         snapshotBackgroundColor: UIColor?
     ) -> UIStackView {
-        let context = (context ?? ConversationCellSnapshotTestCase.defaultContext)!
+        let context = (context ?? ConversationMessageContext.defaultContext)!
 
         let section = ConversationMessageSectionController(message: message, context: context)
         let views = section.cellDescriptions.map({ $0.makeView() })
@@ -123,55 +134,6 @@ extension XCTestCase {
 
 }
 
-/**
- * A base test class for section-based messages. Use the section property to build
- * your layout and call `verifySectionSnapshots` to record and verify the snapshot.
- */
-class ConversationCellSnapshotTestCase: XCTestCase, CoreDataFixtureTestHelper {
-    var coreDataFixture: CoreDataFixture!
-
-    var mockSelfUser: MockUserType!
-
-    fileprivate static let defaultContext = ConversationMessageContext(isSameSenderAsPrevious: false,
-                                                                       isTimeIntervalSinceLastMessageSignificant: false,
-                                                                       isFirstMessageOfTheDay: false,
-                                                                       isFirstUnreadMessage: false,
-                                                                       isLastMessage: false,
-                                                                       searchQueries: [],
-                                                                       previousMessageIsKnock: false,
-                                                                       spacing: 0)
-
-    override class func setUp() {
-        resetDayFormatter()
-
-        [Message.shortDateFormatter, Message.shortTimeFormatter].forEach {
-            $0.locale = Locale(identifier: "en_US")
-            $0.timeZone = TimeZone(abbreviation: "CET")
-        }
-    }
-
-    override class func tearDown() {
-        ColorScheme.default.variant = .light
-    }
-
-    override func setUp() {
-        super.setUp()
-        coreDataFixture = CoreDataFixture()
-
-        ColorScheme.default.variant = .light
-
-        mockSelfUser = MockUserType.createSelfUser(name: "selfUser")
-        mockSelfUser.accentColorValue = .vividRed
-    }
-
-    override func tearDown() {
-        coreDataFixture = nil
-        mockSelfUser = nil
-
-        super.tearDown()
-    }
-
-}
 
 func XCTAssertArrayEqual(_ descriptions: [Any], _ expectedDescriptions: [Any], file: StaticString = #file, line: UInt = #line) {
     let classes = descriptions.map { String(describing: $0) }

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -268,7 +268,7 @@
 		5E35F7802183131400D3F4FE /* ConversationLinkAttachmentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E35F77F2183131300D3F4FE /* ConversationLinkAttachmentCell.swift */; };
 		5E35F78421833AF000D3F4FE /* ZMConversationMessage+Sender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E35F78321833AF000D3F4FE /* ZMConversationMessage+Sender.swift */; };
 		5E35F786218340EB00D3F4FE /* ConversationLocationMessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E35F785218340EB00D3F4FE /* ConversationLocationMessageCell.swift */; };
-		5E35F78B2187069400D3F4FE /* ConversationCellSnapshotTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E35F7892187068500D3F4FE /* ConversationCellSnapshotTestCase.swift */; };
+		5E35F78B2187069400D3F4FE /* XCTestCase+VerifyMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E35F7892187068500D3F4FE /* XCTestCase+VerifyMessage.swift */; };
 		5E35F78D21870EDB00D3F4FE /* ConversationPingMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E35F78C21870EDB00D3F4FE /* ConversationPingMessageTests.swift */; };
 		5E39FC5F225CBBD400C682B8 /* password_rules.json in Resources */ = {isa = PBXBuildFile; fileRef = 5E39FC5E225CBBD300C682B8 /* password_rules.json */; };
 		5E39FC61225CBBEF00C682B8 /* PasscodeRules+Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E39FC60225CBBEF00C682B8 /* PasscodeRules+Shared.swift */; };
@@ -1883,7 +1883,7 @@
 		5E35F77F2183131300D3F4FE /* ConversationLinkAttachmentCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationLinkAttachmentCell.swift; sourceTree = "<group>"; };
 		5E35F78321833AF000D3F4FE /* ZMConversationMessage+Sender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversationMessage+Sender.swift"; sourceTree = "<group>"; };
 		5E35F785218340EB00D3F4FE /* ConversationLocationMessageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationLocationMessageCell.swift; sourceTree = "<group>"; };
-		5E35F7892187068500D3F4FE /* ConversationCellSnapshotTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationCellSnapshotTestCase.swift; sourceTree = "<group>"; };
+		5E35F7892187068500D3F4FE /* XCTestCase+VerifyMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+VerifyMessage.swift"; sourceTree = "<group>"; };
 		5E35F78C21870EDB00D3F4FE /* ConversationPingMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationPingMessageTests.swift; sourceTree = "<group>"; };
 		5E39FC5E225CBBD300C682B8 /* password_rules.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = password_rules.json; sourceTree = "<group>"; };
 		5E39FC60225CBBEF00C682B8 /* PasscodeRules+Shared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PasscodeRules+Shared.swift"; sourceTree = "<group>"; };
@@ -3813,7 +3813,7 @@
 				5EBBE96721871F70008BC1B7 /* MockCell.swift */,
 				5EBBE9722187A844008BC1B7 /* MessageToolboxViewTests.swift */,
 				5E35F7702180B8C600D3F4FE /* ConversationMessageSectionControllerTests.swift */,
-				5E35F7892187068500D3F4FE /* ConversationCellSnapshotTestCase.swift */,
+				5E35F7892187068500D3F4FE /* XCTestCase+VerifyMessage.swift */,
 				5E35F78C21870EDB00D3F4FE /* ConversationPingMessageTests.swift */,
 				162AE739219AC4C100581D98 /* ConversationTextMessageTests.swift */,
 				162AE747219B26AF00581D98 /* ConversationSystemMessageTests.swift */,
@@ -8610,7 +8610,7 @@
 				A918330D241922EB00CBD0B7 /* TokenTextAttachmentTests.swift in Sources */,
 				8790907A2121A120006219B4 /* VariantsBuilder.swift in Sources */,
 				5EBF47C421B2F8710021CFFC /* MessageDetailsActionTests.swift in Sources */,
-				5E35F78B2187069400D3F4FE /* ConversationCellSnapshotTestCase.swift in Sources */,
+				5E35F78B2187069400D3F4FE /* XCTestCase+VerifyMessage.swift in Sources */,
 				EF4018C02059761D00CFBCB0 /* MockApplication.swift in Sources */,
 				5E35F7722180B8CD00D3F4FE /* ConversationMessageSectionControllerTests.swift in Sources */,
 				EF1D8BA821EE49550001A4CC /* TeamMemberInviteViewControllerSnapshotTests.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

remove no longer use `ConversationCellSnapshotTestCase`.