### PR TITLE
[Chore] Add crowdin config

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,36 @@
+# Credentials.
+
+"project_id_env": "CROWDIN_PROJECT_ID"
+"api_token_env" : "CROWDIN_API_TOKEN"
+"base_path" : "."
+"base_url" : "https://api.crowdin.com"
+
+# Preserve file structure on Crowdin.
+
+"preserve_hierarchy": true
+
+# Specify which source files to upload and where to store their
+# downloaded translation.
+
+files: [
+ {
+  "source" : "/Wire-iOS/Resources/Base.lproj/Localizable.strings",
+  "dest" : "/App/Wire-iOS/Resources/Localizable.strings",
+  "translation" : "/Wire-iOS/Resources/%osx_code%/%original_file_name%",
+ },
+ {
+  "source" : "/Wire-iOS/Resources/Base.lproj/Localizable.stringsdict",
+  "dest" : "/App/Wire-iOS/Resources/Localizable.stringsdict",
+  "translation" : "/Wire-iOS/Resources/%osx_code%/%original_file_name%",
+ },
+ {
+  "source" : "/Wire-iOS/Resources/Base.lproj/InfoPlist.strings",
+  "dest" : "/App/Wire-iOS/Resources/InfoPlist.strings",
+  "translation" : "/Wire-iOS/Resources/%osx_code%/%original_file_name%",
+ },
+ {
+  "source" : "/Wire-iOS Share Extension/Base.lproj/Localizable.strings",
+  "dest" : "/App/Wire-iOS Share Extension/Localizable.strings",
+  "translation" : "/Wire-iOS Share Extension/%osx_code%/%original_file_name%",
+ },
+]


### PR DESCRIPTION
## What's new in this PR?

Add a [Crowdin CLI config file](https://support.crowdin.com/configuration-file/) to allow use of the [Crowdin CLI](https://support.crowdin.com/cli-tool/). We currently upload source strings and download translations through a jenkins pipeline, which is good at what it does, but it only does those two things. 

The `crowdin` cli offers more ways to interact with crowdin and can help solve issues like renaming localization keys without losing existing translations. Or, instead of logging on to Bob, you could pull in all translations with `crowdin pull` and make a pr yourself. 

To be able to use `crowdin`, you need to set two environment variables:

- `CROWDIN_PROJECT_ID` should contain the id of the Wire crowdin project. This can be found by logging in to crowdin, going to Settings > API & Webhooks > Project id.
- `CROWDIN_API_TOKEN` should contain your **personal** crowdin access token, which can be generated by logging in to crowdin, going to Account settings > API > New token

### Notes

I've made sure that the source files and downloaded files match the existing structure found on crowdin. I've confirmed this by creating my own crowdin project and the source strings to that project.
