### PR TITLE
[Fix]: Hide Edit Button When One User Client In List

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
@@ -66,7 +66,7 @@ final class ClientListViewController: UIViewController,
             if clients.count > 0 {
                 createRightBarButtonItem()
             } else {
-                self.navigationItem.rightBarButtonItem = nil
+                self.editingList = false
             }
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
@@ -44,7 +44,7 @@ final class ClientListViewController: UIViewController,
 
     var editingList: Bool = false {
         didSet {
-            guard clients.count > 0 else {
+            guard !clients.isEmpty else {
                 self.navigationItem.rightBarButtonItem = nil
                 self.navigationItem.setHidesBackButton(false, animated: true)
                 return
@@ -63,7 +63,7 @@ final class ClientListViewController: UIViewController,
             self.sortedClients = self.clients.filter(clientFilter).sorted(by: clientSorter)
             self.clientsTableView?.reloadData()
 
-            if clients.count > 0 {
+            if !clients.isEmpty {
                 createRightBarButtonItem()
             } else {
                 self.editingList = false


### PR DESCRIPTION
## What's new in this PR?

### Issues

When we have just one client in the client list the edit button is shown

### Causes

not set correctly to false `editList` when in the client list is empty 

NOTA BENE: `clients` represent all the client registered not being selfClient

```swift
self.clients = userClients.filter { !$0.isSelfClient() }
```

I'm highlighting this to you cause it confuse me a lot but then i discovered it :-) 

### Solutions

Set  `editList` to `false` when `clients.count == 0` (See NOTA BENE)

