### PR TITLE
[Chore] Rename localization keys for app lock module

### DIFF
--- a/Wire-iOS/Generated/Strings+Generated.swift
+++ b/Wire-iOS/Generated/Strings+Generated.swift
@@ -81,6 +81,22 @@ internal enum L10n {
         }
       }
     }
+    internal enum AppLockModule {
+      internal enum Button {
+        /// Unlock
+        internal static let title = L10n.tr("Localizable", "appLockModule.button.title")
+      }
+      internal enum Message {
+        /// Unlock Wire with Face ID or Passcode
+        internal static let faceID = L10n.tr("Localizable", "appLockModule.message.faceID")
+        /// Unlock Wire with Passcode
+        internal static let passcode = L10n.tr("Localizable", "appLockModule.message.passcode")
+        /// To unlock Wire, turn on Passcode in your device settings
+        internal static let passcodeUnavailable = L10n.tr("Localizable", "appLockModule.message.passcodeUnavailable")
+        /// Unlock Wire with Touch ID or Passcode
+        internal static let touchID = L10n.tr("Localizable", "appLockModule.message.touchID")
+      }
+    }
     internal enum ArchivedList {
       /// archive
       internal static let title = L10n.tr("Localizable", "archived_list.title")
@@ -3783,18 +3799,6 @@ internal enum L10n {
               /// Unlock with Touch ID or enter your passcode.
               internal static let touchId = L10n.tr("Localizable", "self.settings.privacy_security.lock_app.subtitle.touch_id")
             }
-          }
-          internal enum LockCancelled {
-            /// Unlock
-            internal static let action = L10n.tr("Localizable", "self.settings.privacy_security.lock_cancelled.action")
-            /// Unlock Wire with Face ID or Passcode
-            internal static let descriptionFaceId = L10n.tr("Localizable", "self.settings.privacy_security.lock_cancelled.description_face_id")
-            /// Unlock Wire with Passcode
-            internal static let descriptionPasscode = L10n.tr("Localizable", "self.settings.privacy_security.lock_cancelled.description_passcode")
-            /// To unlock Wire, turn on Passcode in your device settings
-            internal static let descriptionPasscodeUnavailable = L10n.tr("Localizable", "self.settings.privacy_security.lock_cancelled.description_passcode_unavailable")
-            /// Unlock Wire with Touch ID or Passcode
-            internal static let descriptionTouchId = L10n.tr("Localizable", "self.settings.privacy_security.lock_cancelled.description_touch_id")
           }
           internal enum LockPassword {
             internal enum Description {

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -1176,12 +1176,6 @@
 "self.settings.privacy_security.lock_password.description.wrong_password" = "Wrong password. Please try again.";
 "self.settings.privacy_security.lock_password.description.wrong_offline_password" = "Wrong password. If you recently changed your password, connect to the internet and try again.";
 
-"self.settings.privacy_security.lock_cancelled.description_face_id" = "Unlock Wire with Face ID or Passcode";
-"self.settings.privacy_security.lock_cancelled.description_touch_id" = "Unlock Wire with Touch ID or Passcode";
-"self.settings.privacy_security.lock_cancelled.description_passcode" = "Unlock Wire with Passcode";
-"self.settings.privacy_security.lock_cancelled.description_passcode_unavailable" = "To unlock Wire, turn on Passcode in your device settings";
-"self.settings.privacy_security.lock_cancelled.action" = "Unlock";
-
 "self.settings.privacy_security.disable_link_previews.title" = "Create Link Previews";
 "self.settings.privacy_security.disable_link_previews.footer" = "Previews may still be shown for links from other people.";
 
@@ -1848,3 +1842,12 @@
 
 "wipe_database_completion.title" = "Database deleted";
 "wipe_database_completion.subtitle" = "Your data and messages have been deleted. You can now log in again as a new device.";
+
+// MARK: - App lock module
+
+"appLockModule.message.faceID" = "Unlock Wire with Face ID or Passcode";
+"appLockModule.message.touchID" = "Unlock Wire with Touch ID or Passcode";
+"appLockModule.message.passcode" = "Unlock Wire with Passcode";
+"appLockModule.message.passcodeUnavailable" = "To unlock Wire, turn on Passcode in your device settings";
+"appLockModule.button.title" = "Unlock";
+

--- a/Wire-iOS/Resources/ar.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/ar.lproj/Localizable.strings
@@ -1176,12 +1176,6 @@
 "self.settings.privacy_security.lock_password.description.wrong_password" = "كلمة مرور خاطئة. الرجاء حاول مرة أخرى.";
 "self.settings.privacy_security.lock_password.description.wrong_offline_password" = "Wrong password. If you recently changed your password, connect to the internet and try again.";
 
-"self.settings.privacy_security.lock_cancelled.description_face_id" = "Unlock Wire with Face ID or Passcode";
-"self.settings.privacy_security.lock_cancelled.description_touch_id" = "فتح قفل Wire بإستخدام Touch ID أو رمز الدخول";
-"self.settings.privacy_security.lock_cancelled.description_passcode" = "Unlock Wire with Passcode";
-"self.settings.privacy_security.lock_cancelled.description_passcode_unavailable" = "To unlock Wire, turn on Passcode in your device settings";
-"self.settings.privacy_security.lock_cancelled.action" = "فتح القفل";
-
 "self.settings.privacy_security.disable_link_previews.title" = "إنشاء معاينات للروابط";
 "self.settings.privacy_security.disable_link_previews.footer" = "قد تظهر المعاينات للروابط من الأشخاص الآخرين.";
 
@@ -1848,3 +1842,11 @@
 
 "wipe_database_completion.title" = "Database deleted";
 "wipe_database_completion.subtitle" = "Your data and messages have been deleted. You can now log in again as a new device.";
+
+// Mark: - App lock module
+
+"appLockModule.message.faceID" = "Unlock Wire with Face ID or Passcode";
+"appLockModule.message.touchID" = "فتح قفل Wire بإستخدام Touch ID أو رمز الدخول";
+"appLockModule.message.passcode" = "Unlock Wire with Passcode";
+"appLockModule.message.passcodeUnavailable" = "To unlock Wire, turn on Passcode in your device settings";
+"appLockModule.button.title" = "فتح القفل";

--- a/Wire-iOS/Resources/da.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/da.lproj/Localizable.strings
@@ -1176,12 +1176,6 @@
 "self.settings.privacy_security.lock_password.description.wrong_password" = "Forkert adgangskode. Prøv igen.";
 "self.settings.privacy_security.lock_password.description.wrong_offline_password" = "Wrong password. If you recently changed your password, connect to the internet and try again.";
 
-"self.settings.privacy_security.lock_cancelled.description_face_id" = "Unlock Wire with Face ID or Passcode";
-"self.settings.privacy_security.lock_cancelled.description_touch_id" = "Åben Wire med Touch ID eller adgangskode";
-"self.settings.privacy_security.lock_cancelled.description_passcode" = "Unlock Wire with Passcode";
-"self.settings.privacy_security.lock_cancelled.description_passcode_unavailable" = "To unlock Wire, turn on Passcode in your device settings";
-"self.settings.privacy_security.lock_cancelled.action" = "Åben";
-
 "self.settings.privacy_security.disable_link_previews.title" = "Create Link Previews";
 "self.settings.privacy_security.disable_link_previews.footer" = "Previews kan stadig blive vist for link fra andre.";
 
@@ -1848,3 +1842,11 @@
 
 "wipe_database_completion.title" = "Database deleted";
 "wipe_database_completion.subtitle" = "Your data and messages have been deleted. You can now log in again as a new device.";
+
+// Mark: - App lock module
+
+"appLockModule.message.faceID" = "Unlock Wire with Face ID or Passcode";
+"appLockModule.message.touchID" = "Åben Wire med Touch ID eller adgangskode";
+"appLockModule.message.passcode" = "Unlock Wire with Passcode";
+"appLockModule.message.passcodeUnavailable" = "To unlock Wire, turn on Passcode in your device settings";
+"appLockModule.button.title" = "Åben";

--- a/Wire-iOS/Resources/de.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/de.lproj/Localizable.strings
@@ -1176,12 +1176,6 @@
 "self.settings.privacy_security.lock_password.description.wrong_password" = "Falsches Passwort. Bitte erneut versuchen.";
 "self.settings.privacy_security.lock_password.description.wrong_offline_password" = "Falsches Passwort. Falls das Passwort kürzlich geändert wurde, bitte eine Verbindung zum Internet herstellen und erneut versuchen.";
 
-"self.settings.privacy_security.lock_cancelled.description_face_id" = "Wire mit Face ID oder Kennwort entsperren";
-"self.settings.privacy_security.lock_cancelled.description_touch_id" = "Wire mit Touch ID oder Kennwort entsperren";
-"self.settings.privacy_security.lock_cancelled.description_passcode" = "Wire mit Passwort entsperren";
-"self.settings.privacy_security.lock_cancelled.description_passcode_unavailable" = "Um Wire zu entsperren, bitte den Code in den Geräteeinstellungen aktivieren";
-"self.settings.privacy_security.lock_cancelled.action" = "Entsperren";
-
 "self.settings.privacy_security.disable_link_previews.title" = "Link-Vorschau erstellen";
 "self.settings.privacy_security.disable_link_previews.footer" = "Vorschauen für Links von anderen Personen können weiterhin angezeigt werden.";
 
@@ -1848,3 +1842,11 @@
 
 "wipe_database_completion.title" = "Daten gelöscht";
 "wipe_database_completion.subtitle" = "Ihre Daten und Nachrichten wurden gelöscht. Sie können sich nun wieder anmelden.";
+
+// Mark: - App lock module
+
+"appLockModule.message.faceID" = "Wire mit Face ID oder Kennwort entsperren";
+"appLockModule.message.touchID" = "Wire mit Touch ID oder Kennwort entsperren";
+"appLockModule.message.passcode" = "Wire mit Passwort entsperren";
+"appLockModule.message.passcodeUnavailable" = "Um Wire zu entsperren, bitte den Code in den Geräteeinstellungen aktivieren";
+"appLockModule.button.title" = "Entsperren";

--- a/Wire-iOS/Resources/es.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/es.lproj/Localizable.strings
@@ -1176,12 +1176,6 @@
 "self.settings.privacy_security.lock_password.description.wrong_password" = "Contraseña incorrecta. Por favor, inténtelo de nuevo.";
 "self.settings.privacy_security.lock_password.description.wrong_offline_password" = "Wrong password. If you recently changed your password, connect to the internet and try again.";
 
-"self.settings.privacy_security.lock_cancelled.description_face_id" = "Unlock Wire with Face ID or Passcode";
-"self.settings.privacy_security.lock_cancelled.description_touch_id" = "Desbloquea Wire con Touch ID o el código";
-"self.settings.privacy_security.lock_cancelled.description_passcode" = "Desbloquear Wire con Passcode";
-"self.settings.privacy_security.lock_cancelled.description_passcode_unavailable" = "Para desbloquear Wire, habilite el uso de Passcode en la configuracion del dispositivo";
-"self.settings.privacy_security.lock_cancelled.action" = "Desbloquear";
-
 "self.settings.privacy_security.disable_link_previews.title" = "Crear vista previa de los enlaces";
 "self.settings.privacy_security.disable_link_previews.footer" = "Las vistas previas todavía pueden mostrarse para enlaces de otras personas.";
 
@@ -1848,3 +1842,11 @@
 
 "wipe_database_completion.title" = "Database deleted";
 "wipe_database_completion.subtitle" = "Your data and messages have been deleted. You can now log in again as a new device.";
+
+// Mark: - App lock module
+
+"appLockModule.message.faceID" = "Unlock Wire with Face ID or Passcode";
+"appLockModule.message.touchID" = "Desbloquea Wire con Touch ID o el código";
+"appLockModule.message.passcode" = "Desbloquear Wire con Passcode";
+"appLockModule.message.passcodeUnavailable" = "Para desbloquear Wire, habilite el uso de Passcode en la configuracion del dispositivo";
+"appLockModule.button.title" = "Desbloquear";

--- a/Wire-iOS/Resources/et.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/et.lproj/Localizable.strings
@@ -1176,12 +1176,6 @@
 "self.settings.privacy_security.lock_password.description.wrong_password" = "Vale parool. Palun proovi uuesti.";
 "self.settings.privacy_security.lock_password.description.wrong_offline_password" = "Wrong password. If you recently changed your password, connect to the internet and try again.";
 
-"self.settings.privacy_security.lock_cancelled.description_face_id" = "Unlock Wire with Face ID or Passcode";
-"self.settings.privacy_security.lock_cancelled.description_touch_id" = "Ava Wire Touch ID või parooliga";
-"self.settings.privacy_security.lock_cancelled.description_passcode" = "Unlock Wire with Passcode";
-"self.settings.privacy_security.lock_cancelled.description_passcode_unavailable" = "To unlock Wire, turn on Passcode in your device settings";
-"self.settings.privacy_security.lock_cancelled.action" = "Vabasta lukust";
-
 "self.settings.privacy_security.disable_link_previews.title" = "Näita veebilinkide eelvaadet";
 "self.settings.privacy_security.disable_link_previews.footer" = "Eelvaateid võidakse siiski näidata teiste saadetud linkide puhul.";
 
@@ -1848,3 +1842,11 @@
 
 "wipe_database_completion.title" = "Database deleted";
 "wipe_database_completion.subtitle" = "Your data and messages have been deleted. You can now log in again as a new device.";
+
+// Mark: - App lock module
+
+"appLockModule.message.faceID" = "Unlock Wire with Face ID or Passcode";
+"appLockModule.message.touchID" = "Ava Wire Touch ID või parooliga";
+"appLockModule.message.passcode" = "Unlock Wire with Passcode";
+"appLockModule.message.passcodeUnavailable" = "To unlock Wire, turn on Passcode in your device settings";
+"appLockModule.button.title" = "Vabasta lukust";

--- a/Wire-iOS/Resources/fi.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/fi.lproj/Localizable.strings
@@ -1176,12 +1176,6 @@
 "self.settings.privacy_security.lock_password.description.wrong_password" = "Väärä salasana. Yritä uudelleen.";
 "self.settings.privacy_security.lock_password.description.wrong_offline_password" = "Wrong password. If you recently changed your password, connect to the internet and try again.";
 
-"self.settings.privacy_security.lock_cancelled.description_face_id" = "Unlock Wire with Face ID or Passcode";
-"self.settings.privacy_security.lock_cancelled.description_touch_id" = "Avaa Wire Touch tunnuksella tai Salasanalla";
-"self.settings.privacy_security.lock_cancelled.description_passcode" = "Unlock Wire with Passcode";
-"self.settings.privacy_security.lock_cancelled.description_passcode_unavailable" = "To unlock Wire, turn on Passcode in your device settings";
-"self.settings.privacy_security.lock_cancelled.action" = "Avaa lukitus";
-
 "self.settings.privacy_security.disable_link_previews.title" = "Luo linkin esikatselukuvat";
 "self.settings.privacy_security.disable_link_previews.footer" = "Esikatselut saattavat silti näkyä muiden lähettämissä linkeissä.";
 
@@ -1848,3 +1842,11 @@
 
 "wipe_database_completion.title" = "Database deleted";
 "wipe_database_completion.subtitle" = "Your data and messages have been deleted. You can now log in again as a new device.";
+
+// Mark: - App lock module
+
+"appLockModule.message.faceID" = "Unlock Wire with Face ID or Passcode";
+"appLockModule.message.touchID" = "Avaa Wire Touch tunnuksella tai Salasanalla";
+"appLockModule.message.passcode" = "Unlock Wire with Passcode";
+"appLockModule.message.passcodeUnavailable" = "To unlock Wire, turn on Passcode in your device settings";
+"appLockModule.button.title" = "Avaa lukitus";

--- a/Wire-iOS/Resources/fr.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/fr.lproj/Localizable.strings
@@ -1176,12 +1176,6 @@
 "self.settings.privacy_security.lock_password.description.wrong_password" = "Mot de passe incorrect. Veuillez réessayer.";
 "self.settings.privacy_security.lock_password.description.wrong_offline_password" = "Mot de passe incorrect. Si vous avez récemment changé votre mot de passe, connectez-vous à internet et réessayez.";
 
-"self.settings.privacy_security.lock_cancelled.description_face_id" = "Déverrouillez Wire avec Face ID ou votre Code";
-"self.settings.privacy_security.lock_cancelled.description_touch_id" = "Déverrouillez Wire avec Touch ID ou votre Code";
-"self.settings.privacy_security.lock_cancelled.description_passcode" = "Déverrouillez Wire avec votre Code";
-"self.settings.privacy_security.lock_cancelled.description_passcode_unavailable" = "Pour déverrouiller Wire, veuillez configurer votre code d'authentification dans les paramètres de votre appareil";
-"self.settings.privacy_security.lock_cancelled.action" = "Déverrouiller";
-
 "self.settings.privacy_security.disable_link_previews.title" = "Créer un aperçu des liens";
 "self.settings.privacy_security.disable_link_previews.footer" = "Les aperçus peuvent toujours s'afficher pour les liens venant d'autres contacts.";
 
@@ -1848,3 +1842,11 @@
 
 "wipe_database_completion.title" = "Base de données supprimée";
 "wipe_database_completion.subtitle" = "Vos données et messages ont été supprimés. Vous pouvez maintenant vous reconnecter en tant que nouvel appareil.";
+
+// Mark: - App lock module
+
+"appLockModule.message.faceID" = "Déverrouillez Wire avec Face ID ou votre Code";
+"appLockModule.message.touchID" = "Déverrouillez Wire avec Touch ID ou votre Code";
+"appLockModule.message.passcode" = "Déverrouillez Wire avec votre Code";
+"appLockModule.message.passcodeUnavailable" = "Pour déverrouiller Wire, veuillez configurer votre code d'authentification dans les paramètres de votre appareil";
+"appLockModule.button.title" = "Déverrouiller";

--- a/Wire-iOS/Resources/it.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/it.lproj/Localizable.strings
@@ -1176,12 +1176,6 @@
 "self.settings.privacy_security.lock_password.description.wrong_password" = "Password errata. Riprova.";
 "self.settings.privacy_security.lock_password.description.wrong_offline_password" = "Password errata. Se hai cambiato di recente la password, connettiti ad internet e riprova.";
 
-"self.settings.privacy_security.lock_cancelled.description_face_id" = "Sblocca Wire con Face ID o codice d'accesso";
-"self.settings.privacy_security.lock_cancelled.description_touch_id" = "Sblocca Wire con Touch ID o Passcode";
-"self.settings.privacy_security.lock_cancelled.description_passcode" = "Sblocca Wire con codice d'accesso";
-"self.settings.privacy_security.lock_cancelled.description_passcode_unavailable" = "Per sbloccare Wire, attiva il codice d'accesso nelle impostazioni del dispositivo";
-"self.settings.privacy_security.lock_cancelled.action" = "Sblocca";
-
 "self.settings.privacy_security.disable_link_previews.title" = "Crea anteprime dei link";
 "self.settings.privacy_security.disable_link_previews.footer" = "È possibile che vengano comunque mostrate delle anteprime per i link inviati dagli altri utenti.";
 
@@ -1848,3 +1842,11 @@
 
 "wipe_database_completion.title" = "Database deleted";
 "wipe_database_completion.subtitle" = "Your data and messages have been deleted. You can now log in again as a new device.";
+
+// Mark: - App lock module
+
+"appLockModule.message.faceID" = "Sblocca Wire con Face ID o codice d'accesso";
+"appLockModule.message.touchID" = "Sblocca Wire con Touch ID o Passcode";
+"appLockModule.message.passcode" = "Sblocca Wire con codice d'accesso";
+"appLockModule.message.passcodeUnavailable" = "Per sbloccare Wire, attiva il codice d'accesso nelle impostazioni del dispositivo";
+"appLockModule.button.title" = "Sblocca";

--- a/Wire-iOS/Resources/ja.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/ja.lproj/Localizable.strings
@@ -1176,12 +1176,6 @@
 "self.settings.privacy_security.lock_password.description.wrong_password" = "パスワードが違います、もう一度入力してください。";
 "self.settings.privacy_security.lock_password.description.wrong_offline_password" = "Wrong password. If you recently changed your password, connect to the internet and try again.";
 
-"self.settings.privacy_security.lock_cancelled.description_face_id" = "Face ID またはパスコードでWireのロックを解除する";
-"self.settings.privacy_security.lock_cancelled.description_touch_id" = "Touch ID またはパスコードでWireのロックを解除する";
-"self.settings.privacy_security.lock_cancelled.description_passcode" = "パスコードでWireのロックを解除する";
-"self.settings.privacy_security.lock_cancelled.description_passcode_unavailable" = "Wireのロック解除には、デバイス設定からパスコードを設定します。";
-"self.settings.privacy_security.lock_cancelled.action" = "ロックを解除";
-
 "self.settings.privacy_security.disable_link_previews.title" = "リンク プレビューを作成します。";
 "self.settings.privacy_security.disable_link_previews.footer" = "他ユーザーからのリンクがプレビュー表示されれます";
 
@@ -1848,3 +1842,11 @@
 
 "wipe_database_completion.title" = "Database deleted";
 "wipe_database_completion.subtitle" = "Your data and messages have been deleted. You can now log in again as a new device.";
+
+// Mark: - App lock module
+
+"appLockModule.message.faceID" = "Face ID またはパスコードでWireのロックを解除する";
+"appLockModule.message.touchID" = "Touch ID またはパスコードでWireのロックを解除する";
+"appLockModule.message.passcode" = "パスコードでWireのロックを解除する";
+"appLockModule.message.passcodeUnavailable" = "Wireのロック解除には、デバイス設定からパスコードを設定します。";
+"appLockModule.button.title" = "ロックを解除";

--- a/Wire-iOS/Resources/lt.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/lt.lproj/Localizable.strings
@@ -1176,12 +1176,6 @@
 "self.settings.privacy_security.lock_password.description.wrong_password" = "Neteisingas slaptažodis. Bandykite dar kartą.";
 "self.settings.privacy_security.lock_password.description.wrong_offline_password" = "Neteisingas slaptažodis. Jei slaptažodį neseniai pasikeitėte, prisijunkite prie interneto ir bandykite dar kartą.";
 
-"self.settings.privacy_security.lock_cancelled.description_face_id" = "Atrakinti „Wire“ naudojant „Face ID“ arba slaptąjį kodą";
-"self.settings.privacy_security.lock_cancelled.description_touch_id" = "Atrakinti „Wire“ naudojant „Touch ID“ arba slaptąjį kodą";
-"self.settings.privacy_security.lock_cancelled.description_passcode" = "Atrakinti „Wire“ naudojant slaptąjį kodą";
-"self.settings.privacy_security.lock_cancelled.description_passcode_unavailable" = "Norėdami atrakinti „Wire“ savo įrenginio nustatymuose įjunkite „Passcode“";
-"self.settings.privacy_security.lock_cancelled.action" = "Atrakinti";
-
 "self.settings.privacy_security.disable_link_previews.title" = "Rodyti svetainių vaizdą";
 "self.settings.privacy_security.disable_link_previews.footer" = "Kitų žmonių siunčiamų nuorodų peržiūros vis dar gali būti rodomos.";
 
@@ -1848,3 +1842,11 @@
 
 "wipe_database_completion.title" = "Database deleted";
 "wipe_database_completion.subtitle" = "Your data and messages have been deleted. You can now log in again as a new device.";
+
+// Mark: - App lock module
+
+"appLockModule.message.faceID" = "Atrakinti „Wire“ naudojant „Face ID“ arba slaptąjį kodą";
+"appLockModule.message.touchID" = "Atrakinti „Wire“ naudojant „Touch ID“ arba slaptąjį kodą";
+"appLockModule.message.passcode" = "Atrakinti „Wire“ naudojant slaptąjį kodą";
+"appLockModule.message.passcodeUnavailable" = "Norėdami atrakinti „Wire“ savo įrenginio nustatymuose įjunkite „Passcode“";
+"appLockModule.button.title" = "Atrakinti";

--- a/Wire-iOS/Resources/nl.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/nl.lproj/Localizable.strings
@@ -1176,12 +1176,6 @@
 "self.settings.privacy_security.lock_password.description.wrong_password" = "Fout wachtwoord. Probeer opnieuw.";
 "self.settings.privacy_security.lock_password.description.wrong_offline_password" = "Wrong password. If you recently changed your password, connect to the internet and try again.";
 
-"self.settings.privacy_security.lock_cancelled.description_face_id" = "Ontgrendel Wire met Face ID of Wachtwoord";
-"self.settings.privacy_security.lock_cancelled.description_touch_id" = "Ontgrendel Wire met Touch ID of Wachtwoord";
-"self.settings.privacy_security.lock_cancelled.description_passcode" = "Ontgrendel Wire met wachtwoord";
-"self.settings.privacy_security.lock_cancelled.description_passcode_unavailable" = "To unlock Wire, turn on Passcode in your device settings";
-"self.settings.privacy_security.lock_cancelled.action" = "Ontgrendel";
-
 "self.settings.privacy_security.disable_link_previews.title" = "Maak link voorvertoningen aan";
 "self.settings.privacy_security.disable_link_previews.footer" = "Linkvoorbeelden kunnen nog steeds getoond worden voor links van andere mensen.";
 
@@ -1848,3 +1842,11 @@
 
 "wipe_database_completion.title" = "Database deleted";
 "wipe_database_completion.subtitle" = "Your data and messages have been deleted. You can now log in again as a new device.";
+
+// Mark: - App lock module
+
+"appLockModule.message.faceID" = "Ontgrendel Wire met Face ID of Wachtwoord";
+"appLockModule.message.touchID" = "Ontgrendel Wire met Touch ID of Wachtwoord";
+"appLockModule.message.passcode" = "Ontgrendel Wire met wachtwoord";
+"appLockModule.message.passcodeUnavailable" = "To unlock Wire, turn on Passcode in your device settings";
+"appLockModule.button.title" = "Ontgrendel";

--- a/Wire-iOS/Resources/pl.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/pl.lproj/Localizable.strings
@@ -1176,12 +1176,6 @@
 "self.settings.privacy_security.lock_password.description.wrong_password" = "Niewłaściwe hasło, proszę spróbować ponownie.";
 "self.settings.privacy_security.lock_password.description.wrong_offline_password" = "Wrong password. If you recently changed your password, connect to the internet and try again.";
 
-"self.settings.privacy_security.lock_cancelled.description_face_id" = "Unlock Wire with Face ID or Passcode";
-"self.settings.privacy_security.lock_cancelled.description_touch_id" = "Odblokuj Wire za pomocą Touch ID lub kodem";
-"self.settings.privacy_security.lock_cancelled.description_passcode" = "Unlock Wire with Passcode";
-"self.settings.privacy_security.lock_cancelled.description_passcode_unavailable" = "To unlock Wire, turn on Passcode in your device settings";
-"self.settings.privacy_security.lock_cancelled.action" = "Odblokuj";
-
 "self.settings.privacy_security.disable_link_previews.title" = "Create Link Previews";
 "self.settings.privacy_security.disable_link_previews.footer" = "Podglądy linków otrzymanych od innych osób mogą być nadal wyświetlane.";
 
@@ -1848,3 +1842,11 @@
 
 "wipe_database_completion.title" = "Database deleted";
 "wipe_database_completion.subtitle" = "Your data and messages have been deleted. You can now log in again as a new device.";
+
+// Mark: - App lock module
+
+"appLockModule.message.faceID" = "Unlock Wire with Face ID or Passcode";
+"appLockModule.message.touchID" = "Odblokuj Wire za pomocą Touch ID lub kodem";
+"appLockModule.message.passcode" = "Unlock Wire with Passcode";
+"appLockModule.message.passcodeUnavailable" = "To unlock Wire, turn on Passcode in your device settings";
+"appLockModule.button.title" = "Odblokuj";

--- a/Wire-iOS/Resources/pt-BR.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/pt-BR.lproj/Localizable.strings
@@ -1176,12 +1176,6 @@
 "self.settings.privacy_security.lock_password.description.wrong_password" = "Senha incorreta. Por favor, tente novamente.";
 "self.settings.privacy_security.lock_password.description.wrong_offline_password" = "Senha incorreta. Se você alterou sua senha recentemente, conecte-se à internet e tente novamente.";
 
-"self.settings.privacy_security.lock_cancelled.description_face_id" = "Desbloqueie o Wire com o Face ID ou Código";
-"self.settings.privacy_security.lock_cancelled.description_touch_id" = "Desbloqueie o Wire com o Touch ID ou Código";
-"self.settings.privacy_security.lock_cancelled.description_passcode" = "Desbloquear Wire com senha";
-"self.settings.privacy_security.lock_cancelled.description_passcode_unavailable" = "Para desbloquear o Wire, ative o código de acesso nas configurações do dispositivo";
-"self.settings.privacy_security.lock_cancelled.action" = "Desbloquear";
-
 "self.settings.privacy_security.disable_link_previews.title" = "Criar pré-visualizações de links";
 "self.settings.privacy_security.disable_link_previews.footer" = "Pré-Visualizações ainda serão mostradas para links de outras pessoas.";
 
@@ -1848,3 +1842,11 @@
 
 "wipe_database_completion.title" = "Banco de dados excluído";
 "wipe_database_completion.subtitle" = "Seus dados e mensagens foram excluídos. Agora você pode fazer login novamente como um novo dispositivo.";
+
+// Mark: - App lock module
+
+"appLockModule.message.faceID" = "Desbloqueie o Wire com o Face ID ou Código";
+"appLockModule.message.touchID" = "Desbloqueie o Wire com o Touch ID ou Código";
+"appLockModule.message.passcode" = "Desbloquear Wire com senha";
+"appLockModule.message.passcodeUnavailable" = "Para desbloquear o Wire, ative o código de acesso nas configurações do dispositivo";
+"appLockModule.button.title" = "Desbloquear";

--- a/Wire-iOS/Resources/ru.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/ru.lproj/Localizable.strings
@@ -1176,12 +1176,6 @@
 "self.settings.privacy_security.lock_password.description.wrong_password" = "Неверный пароль. Пожалуйста, попробуйте еще раз.";
 "self.settings.privacy_security.lock_password.description.wrong_offline_password" = "Неверный пароль. Если вы недавно сменили пароль, подключитесь к интернету и попробуйте еще раз.";
 
-"self.settings.privacy_security.lock_cancelled.description_face_id" = "Разблокировать Wire с помощью Face ID или кода доступа";
-"self.settings.privacy_security.lock_cancelled.description_touch_id" = "Разблокируйте Wire с помощью Touch ID или кода доступа";
-"self.settings.privacy_security.lock_cancelled.description_passcode" = "Разблокировать Wire с помощью кода доступа";
-"self.settings.privacy_security.lock_cancelled.description_passcode_unavailable" = "Для разблокировки Wire включите код доступа в настройках вашего устройства";
-"self.settings.privacy_security.lock_cancelled.action" = "Разблокировать";
-
 "self.settings.privacy_security.disable_link_previews.title" = "Показывать предпросмотр отправляемых вами ссылок";
 "self.settings.privacy_security.disable_link_previews.footer" = "Эта опция не влияет на предварительный просмотр ссылок от других пользователей.";
 
@@ -1848,3 +1842,11 @@
 
 "wipe_database_completion.title" = "База данных удалена";
 "wipe_database_completion.subtitle" = "Ваши данные и сообщения были удалены. Теперь вы можете повторно авторизоваться как новое устройство.";
+
+// Mark: - App lock module
+
+"appLockModule.message.faceID" = "Разблокировать Wire с помощью Face ID или кода доступа";
+"appLockModule.message.touchID" = "Разблокируйте Wire с помощью Touch ID или кода доступа";
+"appLockModule.message.passcode" = "Разблокировать Wire с помощью кода доступа";
+"appLockModule.message.passcodeUnavailable" = "Для разблокировки Wire включите код доступа в настройках вашего устройства";
+"appLockModule.button.title" = "Разблокировать";

--- a/Wire-iOS/Resources/sl.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/sl.lproj/Localizable.strings
@@ -1176,12 +1176,6 @@
 "self.settings.privacy_security.lock_password.description.wrong_password" = "Napačno geslo. Poizkusite znova.";
 "self.settings.privacy_security.lock_password.description.wrong_offline_password" = "Wrong password. If you recently changed your password, connect to the internet and try again.";
 
-"self.settings.privacy_security.lock_cancelled.description_face_id" = "Unlock Wire with Face ID or Passcode";
-"self.settings.privacy_security.lock_cancelled.description_touch_id" = "Odkleni Wire s Touch ID ali geslom";
-"self.settings.privacy_security.lock_cancelled.description_passcode" = "Unlock Wire with Passcode";
-"self.settings.privacy_security.lock_cancelled.description_passcode_unavailable" = "To unlock Wire, turn on Passcode in your device settings";
-"self.settings.privacy_security.lock_cancelled.action" = "Odkleni";
-
 "self.settings.privacy_security.disable_link_previews.title" = "Create Link Previews";
 "self.settings.privacy_security.disable_link_previews.footer" = "Predogledi se še vedno lahko prikazujejo za povezave drugih ljudi.";
 
@@ -1848,3 +1842,11 @@
 
 "wipe_database_completion.title" = "Database deleted";
 "wipe_database_completion.subtitle" = "Your data and messages have been deleted. You can now log in again as a new device.";
+
+// Mark: - App lock module
+
+"appLockModule.message.faceID" = "Unlock Wire with Face ID or Passcode";
+"appLockModule.message.touchID" = "Odkleni Wire s Touch ID ali geslom";
+"appLockModule.message.passcode" = "Unlock Wire with Passcode";
+"appLockModule.message.passcodeUnavailable" = "To unlock Wire, turn on Passcode in your device settings";
+"appLockModule.button.title" = "Odkleni";

--- a/Wire-iOS/Resources/tr.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/tr.lproj/Localizable.strings
@@ -1176,12 +1176,6 @@
 "self.settings.privacy_security.lock_password.description.wrong_password" = "Yanlış şifre. Lütfen tekrar deneyin.";
 "self.settings.privacy_security.lock_password.description.wrong_offline_password" = "Wrong password. If you recently changed your password, connect to the internet and try again.";
 
-"self.settings.privacy_security.lock_cancelled.description_face_id" = "Yüz Tanıma veya Şifre ile Wire'ın Kilidini Açın";
-"self.settings.privacy_security.lock_cancelled.description_touch_id" = "Lütfen Wire'ın Touch ID veya şifre ile kilidini açın";
-"self.settings.privacy_security.lock_cancelled.description_passcode" = "Şifre ile Wire'ın Kilidini Açın";
-"self.settings.privacy_security.lock_cancelled.description_passcode_unavailable" = "To unlock Wire, turn on Passcode in your device settings";
-"self.settings.privacy_security.lock_cancelled.action" = "Kilidi aç";
-
 "self.settings.privacy_security.disable_link_previews.title" = "Bağlantı Önizlemeleri Oluştur";
 "self.settings.privacy_security.disable_link_previews.footer" = "Ön izlemeler hala başkalarından gelen bağlantılar için görüntülenebilir olabilir.";
 
@@ -1848,3 +1842,11 @@
 
 "wipe_database_completion.title" = "Database deleted";
 "wipe_database_completion.subtitle" = "Your data and messages have been deleted. You can now log in again as a new device.";
+
+// Mark: - App lock module
+
+"appLockModule.message.faceID" = "Yüz Tanıma veya Şifre ile Wire'ın Kilidini Açın";
+"appLockModule.message.touchID" = "Lütfen Wire'ın Touch ID veya şifre ile kilidini açın";
+"appLockModule.message.passcode" = "Şifre ile Wire'ın Kilidini Açın";
+"appLockModule.message.passcodeUnavailable" = "To unlock Wire, turn on Passcode in your device settings";
+"appLockModule.button.title" = "Kilidi aç";

--- a/Wire-iOS/Resources/uk.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/uk.lproj/Localizable.strings
@@ -1176,12 +1176,6 @@
 "self.settings.privacy_security.lock_password.description.wrong_password" = "Невірний пароль. Будь ласка, спробуйте ще раз.";
 "self.settings.privacy_security.lock_password.description.wrong_offline_password" = "Невірний пароль. Якщо ви нещодавно змінили ваш пароль, підключіться до Інтернету та спробуйте ще раз.";
 
-"self.settings.privacy_security.lock_cancelled.description_face_id" = "Розблокувати Wire за допомогою Face ID або коду допуску";
-"self.settings.privacy_security.lock_cancelled.description_touch_id" = "Розблокувати Wire за допомогою Touch ID або коду допуску";
-"self.settings.privacy_security.lock_cancelled.description_passcode" = "Розблокувати Wire за допомогою коду допуску";
-"self.settings.privacy_security.lock_cancelled.description_passcode_unavailable" = "Увімкніть Код допуску в налаштуваннях пристрою, щоб роблокувати Wire";
-"self.settings.privacy_security.lock_cancelled.action" = "Розблокувати";
-
 "self.settings.privacy_security.disable_link_previews.title" = "Генерувати попередній перегляд для посилань";
 "self.settings.privacy_security.disable_link_previews.footer" = "Дана опція не впливає на попередній перегляд лінків від інших людей.";
 
@@ -1848,3 +1842,11 @@
 
 "wipe_database_completion.title" = "База даних видалена";
 "wipe_database_completion.subtitle" = "Ваші дані та повідомлення було видалено. Тепер ви можете увійти ще раз з новим пристроєм.";
+
+// Mark: - App lock module
+
+"appLockModule.message.faceID" = "Розблокувати Wire за допомогою Face ID або коду допуску";
+"appLockModule.message.touchID" = "Розблокувати Wire за допомогою Touch ID або коду допуску";
+"appLockModule.message.passcode" = "Розблокувати Wire за допомогою коду допуску";
+"appLockModule.message.passcodeUnavailable" = "Увімкніть Код допуску в налаштуваннях пристрою, щоб роблокувати Wire";
+"appLockModule.button.title" = "Розблокувати";

--- a/Wire-iOS/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/zh-Hans.lproj/Localizable.strings
@@ -1176,12 +1176,6 @@
 "self.settings.privacy_security.lock_password.description.wrong_password" = "密码错误，请重试。";
 "self.settings.privacy_security.lock_password.description.wrong_offline_password" = "密码错误，如果您最近更改过密码，连接到网路并重试。";
 
-"self.settings.privacy_security.lock_cancelled.description_face_id" = "使用Face ID或密码解锁Wire";
-"self.settings.privacy_security.lock_cancelled.description_touch_id" = "通过Touch ID或Passcode解锁";
-"self.settings.privacy_security.lock_cancelled.description_passcode" = "使用密码解锁Wire";
-"self.settings.privacy_security.lock_cancelled.description_passcode_unavailable" = "要解锁Wire，请在设置中选择打开密码";
-"self.settings.privacy_security.lock_cancelled.action" = "解锁";
-
 "self.settings.privacy_security.disable_link_previews.title" = "创建链接预览";
 "self.settings.privacy_security.disable_link_previews.footer" = "仍会为其他人的链接显示预览";
 
@@ -1848,3 +1842,11 @@
 
 "wipe_database_completion.title" = "Database deleted";
 "wipe_database_completion.subtitle" = "Your data and messages have been deleted. You can now log in again as a new device.";
+
+// Mark: - App lock module
+
+"appLockModule.message.faceID" = "使用Face ID或密码解锁Wire";
+"appLockModule.message.touchID" = "通过Touch ID或Passcode解锁";
+"appLockModule.message.passcode" = "使用密码解锁Wire";
+"appLockModule.message.passcodeUnavailable" = "要解锁Wire，请在设置中选择打开密码";
+"appLockModule.button.title" = "解锁";

--- a/Wire-iOS/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/zh-Hant.lproj/Localizable.strings
@@ -1176,12 +1176,6 @@
 "self.settings.privacy_security.lock_password.description.wrong_password" = "密碼錯誤，請再試一次。";
 "self.settings.privacy_security.lock_password.description.wrong_offline_password" = "密碼錯誤，如果您最近更改過密碼，連接到網路並重試。";
 
-"self.settings.privacy_security.lock_cancelled.description_face_id" = "請使用Face ID或密碼解鎖Wire";
-"self.settings.privacy_security.lock_cancelled.description_touch_id" = "請使用Touch ID或密碼解鎖Wire";
-"self.settings.privacy_security.lock_cancelled.description_passcode" = "用密碼解鎖Wire";
-"self.settings.privacy_security.lock_cancelled.description_passcode_unavailable" = "要解鎖Wire，請在設置中選擇打開密碼";
-"self.settings.privacy_security.lock_cancelled.action" = "解鎖";
-
 "self.settings.privacy_security.disable_link_previews.title" = "製作連結預覽";
 "self.settings.privacy_security.disable_link_previews.footer" = "其他人的連結預覽可能會顯示出來";
 
@@ -1848,3 +1842,11 @@
 
 "wipe_database_completion.title" = "數據庫已刪除";
 "wipe_database_completion.subtitle" = "Your data and messages have been deleted. You can now log in again as a new device.";
+
+// Mark: - App lock module
+
+"appLockModule.message.faceID" = "請使用Face ID或密碼解鎖Wire";
+"appLockModule.message.touchID" = "請使用Touch ID或密碼解鎖Wire";
+"appLockModule.message.passcode" = "用密碼解鎖Wire";
+"appLockModule.message.passcodeUnavailable" = "要解鎖Wire，請在設置中選擇打開密碼";
+"appLockModule.button.title" = "解鎖";

--- a/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.View.LockView.swift
+++ b/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.View.LockView.swift
@@ -33,6 +33,12 @@ extension AppLockModule.View {
                 authenticateLabel.text = message
             }
         }
+
+        var buttonTitle: String = "" {
+            didSet {
+                authenticateButton.setTitle(buttonTitle, for: .normal)
+            }
+        }
         
         var showReauth: Bool = false {
             didSet {
@@ -83,7 +89,6 @@ extension AppLockModule.View {
             contentContainerView.addSubview(authenticateLabel)
             contentContainerView.addSubview(authenticateButton)
             
-            authenticateButton.setTitle("self.settings.privacy_security.lock_cancelled.action".localized, for: .normal)
             authenticateButton.addTarget(self, action: #selector(LockView.onReauthenticatePressed(_:)), for: .touchUpInside)
 
             createConstraints(nibView: shieldView)

--- a/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.View.swift
+++ b/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.View.swift
@@ -81,17 +81,21 @@ extension AppLockModule {
 
             switch authenticationType {
             case .faceID:
-                return "self.settings.privacy_security.lock_cancelled.description_face_id".localized
+                return Strings.Message.faceID
 
             case .touchID:
-                return "self.settings.privacy_security.lock_cancelled.description_touch_id".localized
+                return Strings.Message.touchID
 
             case .passcode:
-                return "self.settings.privacy_security.lock_cancelled.description_passcode".localized
+                return Strings.Message.passcode
 
             case .unavailable:
-                return "self.settings.privacy_security.lock_cancelled.description_passcode_unavailable".localized
+                return Strings.Message.passcodeUnavailable
             }
+        }
+
+        var buttonTitle: String {
+            return Strings.Button.title
         }
 
     }
@@ -105,6 +109,7 @@ extension AppLockModule.View: AppLockViewPresenterInterface {
     func refresh(withModel model: AppLockModule.ViewModel) {
         lockView.showReauth = model.showReauth
         lockView.message = model.message
+        lockView.buttonTitle = model.buttonTitle
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.swift
+++ b/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.swift
@@ -28,6 +28,7 @@ enum AppLockModule: ModuleInterface {
     typealias Session = UserSessionAppLockInterface & UserSessionEncryptionAtRestInterface
     typealias PasscodePreference = AppLockPasscodePreference
     typealias AuthenticationResult = AppLockAuthenticationResult
+    typealias Strings = L10n.Localizable.AppLockModule
 
     static func build(session: Session) -> View {
         let router = Router()


### PR DESCRIPTION
## What's new in this PR?

In an attempt to clean up the localized string a bit, I have renamed some strings used only in the app lock module. These strings were previously named to be part of the settings screen, even though they have nothing to do with the settings screen.

I also propose changing the way we write localized string keys to use camel case. I feel that they're easier to read and easier to type, but of course it's just as suggestion.

This PR also makes use of the new type safe localized string keys.

## TODO

In order to preserve the existing translations, I've renamed the keys in all the localized files. These steps should be completed when the PR has been approved.

- [x] Pull translations
- [x] Push sources
- [x] Push translations