### PR TITLE
[Fix]: SQCORE-490 Preserve Last AppState

### DIFF
--- a/Wire-iOS/Sources/AppStateCalculator.swift
+++ b/Wire-iOS/Sources/AppStateCalculator.swift
@@ -28,6 +28,29 @@ enum AppState: Equatable {
     case jailbroken
     case migrating
     case loading(account: Account, from: Account?)
+    
+    static func ==(lhs: AppState, rhs: AppState) -> Bool {
+        switch (lhs, rhs) {
+        case (.headless, .headless):
+            return true
+        case (.locked, .locked):
+            return true
+        case (.authenticated, .authenticated):
+            return true
+        case let (.unauthenticated(error1), .unauthenticated(error2)):
+            return error1 == error2
+        case (blacklisted, blacklisted):
+            return true
+        case (jailbroken, jailbroken):
+            return true
+        case (migrating, migrating):
+            return true
+        case let (loading(accountTo1, accountFrom1), loading(accountTo2, accountFrom2)):
+            return accountTo1 == accountTo2 && accountFrom1 == accountFrom2
+        default:
+            return false
+        }
+    }
 }
 
 protocol AppStateCalculatorDelegate: class {


### PR DESCRIPTION
## What's new in this PR?

### Issues

for more info about the issue see the [bug](https://wearezeta.atlassian.net/browse/SQCORE-490). 

### Causes

in this particular case the transition were made cause the cause the current app state was `.authenticated(completedRegistration: true)` and the new state was `.authenticated(completedRegistration: false)`

### Solutions

as you can understand the value of `completedRegistration` is not important to the UI transition state, so for avoid this kind of issue I have defined the `equality operators` on the `AppState enum`.