### PR TITLE
[Fix]: Hide Edit Button When One User Client In List

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
@@ -146,7 +146,7 @@ final class ClientListViewController: UIViewController,
     }
 
     fileprivate func initalizeProperties(_ clientsList: [UserClient]) {
-        self.clients = clientsList
+        self.clients = clientsList.filter { !$0.isSelfClient() }
         self.editingList = false
     }
 


### PR DESCRIPTION
## What's new in this PR?

this PR will solve the issue described in the comment of the following [ticket](https://wearezeta.atlassian.net/browse/SQCORE-432)

## Causes
The `clients` are not filtered from the `selfClient` at the beginning.

NOTA BENE: `clients` represent all the client registered not being selfClient

```swift
self.clients = userClients.filter { !$0.isSelfClient() }
```

## Solutions
The `clients` are now filtered from the `selfClient` at the beginning.
