### PR TITLE
[Chore] Bump Down

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -6,6 +6,6 @@ github "wireapp/FormatterKit" "1.8.1-swift3.0.2"
 github "wireapp/wire-ios-canvas" ~> 11.0.1
 github "wireapp/appcenter-sdk-apple" ~> 3.3.4
 github "wireapp/FLAnimatedImage" "1.0.12-wire"
-github "wireapp/Down" "v2.2.3_Xcode11.4.1"
+github "wireapp/Down" "v2.3.0_Xcode11.4.1"
 github "wireapp/DifferenceKit" "1.1.5_XCode11.4.1"
 github "wireapp/countly-sdk-ios" ~> 20.04.3

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,6 +1,6 @@
 github "wireapp/Cartography" "4.0.0-xcode_11_4_1"
 github "wireapp/DifferenceKit" "1.1.5_XCode11.4.1"
-github "wireapp/Down" "v2.2.3_Xcode11.4.1"
+github "wireapp/Down" "v2.3.0_Xcode11.4.1"
 github "wireapp/FLAnimatedImage" "1.0.12-wire"
 github "wireapp/FormatterKit" "1.8.1-swift3.0.2"
 github "wireapp/HTMLString" "6.0.1"


### PR DESCRIPTION
## What's new in this PR?

Minor bump for Down to include:

[[Feature] Add option to render only valid links](https://github.com/wireapp/Down/pull/20)
[[Fix] Crash when parsing empty block quote](https://github.com/wireapp/Down/pull/19)
