### PR TITLE
[Fix] Rotation issues on iPhone

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Screen Curtain/ScreenCurtain.RootViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Screen Curtain/ScreenCurtain.RootViewController.swift
@@ -28,6 +28,25 @@ extension ScreenCurtain {
             return true
         }
 
+        override var shouldAutorotate: Bool {
+            return topmostViewController?.shouldAutorotate ?? true
+        }
+
+        override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+            return topmostViewController?.supportedInterfaceOrientations ?? wr_supportedInterfaceOrientations
+        }
+
+        private var topmostViewController: UIViewController? {
+            guard
+                let topmostViewController = UIApplication.shared.topmostViewController(),
+                !(topmostViewController is Self)
+            else {
+                return nil
+            }
+
+            return topmostViewController
+        }
+
         // MARK: - Life cycle
         
         override func viewDidLoad() {


### PR DESCRIPTION
## What's new in this PR?

### Issues

The native os ui components (status bar, keyboard, etc) are rotated when the phone is rotated.

### Causes

The `ScreenCurtain.RootViewController`, which sits in a secondary window, did not have any rotation behavior specified. This regression was caused because I forgot to copy over that logic when converting the `NotificationWindow` to the `ScreenCurtain`.

### Solutions

Specify the rotation behavior to match the top most view controller in the main window, as was defined in the `NotificationRootViewController`.

