### PR TITLE
[Fix] video capture stops on presentation mode change

### DIFF
--- a/Wire-iOS Tests/Calling/SelfVideoPreviewViewTests.swift
+++ b/Wire-iOS Tests/Calling/SelfVideoPreviewViewTests.swift
@@ -57,7 +57,7 @@ class SelfVideoPreviewViewTests: XCTestCase {
         previewViewMock.isCapturing = false
 
         // When
-        sut.stream = stubProvider.videoStream(videoState: .started).stream
+        sut.updateCaptureState(with: .started)
 
         // Then
         XCTAssertTrue(previewViewMock.isCapturing)
@@ -68,7 +68,7 @@ class SelfVideoPreviewViewTests: XCTestCase {
         previewViewMock.isCapturing = false
         
         // When
-        sut.stream = stubProvider.videoStream(videoState: .stopped).stream
+        sut.updateCaptureState(with: .stopped)
         
         // Then
         XCTAssertFalse(previewViewMock.isCapturing)
@@ -79,7 +79,7 @@ class SelfVideoPreviewViewTests: XCTestCase {
         previewViewMock.isCapturing = false
         
         // When
-        sut.stream = stubProvider.videoStream(videoState: .paused).stream
+        sut.updateCaptureState(with: .paused)
         
         // Then
         XCTAssertFalse(previewViewMock.isCapturing)
@@ -90,7 +90,7 @@ class SelfVideoPreviewViewTests: XCTestCase {
         previewViewMock.isCapturing = false
         
         // When
-        sut.stream = stubProvider.videoStream(videoState: .badConnection).stream
+        sut.updateCaptureState(with: .badConnection)
         
         // Then
         XCTAssertFalse(previewViewMock.isCapturing)
@@ -101,9 +101,20 @@ class SelfVideoPreviewViewTests: XCTestCase {
         previewViewMock.isCapturing = false
         
         // When
-        sut.stream = stubProvider.videoStream(videoState: .screenSharing).stream
+        sut.updateCaptureState(with: .screenSharing)
         
         // Then
         XCTAssertFalse(previewViewMock.isCapturing)
+    }
+    
+    func testThatSettingStream_UpdatesCaptureState() {
+        // Given
+        previewViewMock.isCapturing = false
+        
+        // When
+        sut.stream = stubProvider.videoStream(videoState: .started).stream
+        
+        // Then
+        XCTAssertTrue(previewViewMock.isCapturing)
     }
 }

--- a/Wire-iOS Tests/Calling/VideoGridViewControllerSnapshotTests.swift
+++ b/Wire-iOS Tests/Calling/VideoGridViewControllerSnapshotTests.swift
@@ -27,6 +27,8 @@ final class MockVideoGridConfiguration: VideoGridConfiguration {
 
     var videoStreams: [VideoStream] = []
 
+    var videoState: VideoState = .stopped
+
     var networkQuality: NetworkQuality = .normal
     
     var presentationMode: VideoGridPresentationMode = .allVideoStreams

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/VideoConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/VideoConfiguration.swift
@@ -147,8 +147,8 @@ extension VoiceChannel {
         }
     }
     
-    private var selfStreamId: AVSClient? {
-        return ZMUser.selfUser()?.selfStreamId
+    private var selfStreamId: AVSClient {
+        return SelfUser.current.selfStreamId
     }
 
     private func selfStream(from videoStreams: [VideoStream], createIfNeeded: Bool) -> VideoStream? {
@@ -197,7 +197,7 @@ private extension VideoGridPresentationMode {
 }
 
 private extension Array where Element == CallParticipant {
-    mutating func sortByName(selfStreamId: AVSClient?) {
+    mutating func sortByName(selfStreamId: AVSClient) {
         self = self.sorted {
             $0.streamId == selfStreamId ||
             $0.user.name?.lowercased() < $1.user.name?.lowercased()

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/VideoConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/VideoConfiguration.swift
@@ -147,8 +147,8 @@ extension VoiceChannel {
         }
     }
     
-    private var selfStreamId: AVSClient {
-        return SelfUser.current.selfStreamId
+    private var selfStreamId: AVSClient? {
+        return ZMUser.selfUser()?.selfStreamId
     }
 
     private func selfStream(from videoStreams: [VideoStream], createIfNeeded: Bool) -> VideoStream? {
@@ -197,7 +197,7 @@ private extension VideoGridPresentationMode {
 }
 
 private extension Array where Element == CallParticipant {
-    mutating func sortByName(selfStreamId: AVSClient) {
+    mutating func sortByName(selfStreamId: AVSClient?) {
         self = self.sorted {
             $0.streamId == selfStreamId ||
             $0.user.name?.lowercased() < $1.user.name?.lowercased()

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/VideoConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/VideoConfiguration.swift
@@ -25,6 +25,7 @@ struct VideoConfiguration: VideoGridConfiguration {
 
     let floatingVideoStream: VideoStream?
     let videoStreams: [VideoStream]
+    let videoState: VideoState
     let networkQuality: NetworkQuality
     let shouldShowActiveSpeakerFrame: Bool
     let presentationMode: VideoGridPresentationMode
@@ -34,6 +35,7 @@ struct VideoConfiguration: VideoGridConfiguration {
        
         floatingVideoStream = videoStreamArrangment.preview
         videoStreams = videoStreamArrangment.grid
+        videoState = voiceChannel.videoState
         networkQuality = voiceChannel.networkQuality
         shouldShowActiveSpeakerFrame = voiceChannel.shouldShowActiveSpeakerFrame
         presentationMode = voiceChannel.videoGridPresentationMode
@@ -82,7 +84,7 @@ extension VoiceChannel {
     }
     
     private var videoStreamArrangementForNonEstablishedCall: VideoStreamArrangment {
-        guard videoGridPresentationMode.needsSelfStream, let stream = selfStream else {
+        guard videoGridPresentationMode.needsSelfStream, let stream = createSelfStream() else {
             return (nil, [])
         }
         return (nil, [stream])
@@ -119,7 +121,7 @@ extension VoiceChannel {
     
     // MARK: - Self Stream
     
-    private var selfStream: VideoStream? {
+    private func createSelfStream() -> VideoStream? {
         guard
             let selfUser = ZMUser.selfUser(),
             let userId = selfUser.remoteIdentifier,
@@ -151,7 +153,7 @@ extension VoiceChannel {
 
     private func selfStream(from videoStreams: [VideoStream], createIfNeeded: Bool) -> VideoStream? {
         guard let selfStream = videoStreams.first(where: { $0.stream.streamId == selfStreamId }) else {
-            return createIfNeeded ? self.selfStream : nil
+            return createIfNeeded ? createSelfStream() : nil
         }
         
         return selfStream

--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/SelfVideoPreviewView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/SelfVideoPreviewView.swift
@@ -38,11 +38,6 @@ final class SelfVideoPreviewView: BaseVideoPreviewView {
         stopCapture()
     }
     
-    override init(stream: Stream, isCovered: Bool, shouldShowActiveSpeakerFrame: Bool) {
-        super.init(stream: stream, isCovered: isCovered, shouldShowActiveSpeakerFrame: shouldShowActiveSpeakerFrame)
-        videoState = stream.videoState
-    }
-    
     override func setupViews() {
         super.setupViews()
         previewView.backgroundColor = .clear

--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/SelfVideoPreviewView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/SelfVideoPreviewView.swift
@@ -19,6 +19,7 @@
 import Foundation
 import UIKit
 import avs
+import WireSyncEngine
 
 final class SelfVideoPreviewView: BaseVideoPreviewView {
     
@@ -27,12 +28,19 @@ final class SelfVideoPreviewView: BaseVideoPreviewView {
     override var stream: Stream {
         didSet {
             guard stream != oldValue else { return }
-            updateCaptureState()
+            updateCaptureState(with: stream.videoState)
         }
     }
     
+    private var videoState: VideoState?
+
     deinit {
         stopCapture()
+    }
+    
+    override init(stream: Stream, isCovered: Bool, shouldShowActiveSpeakerFrame: Bool) {
+        super.init(stream: stream, isCovered: isCovered, shouldShowActiveSpeakerFrame: shouldShowActiveSpeakerFrame)
+        videoState = stream.videoState
     }
     
     override func setupViews() {
@@ -61,12 +69,15 @@ final class SelfVideoPreviewView: BaseVideoPreviewView {
         super.didMoveToWindow()
         
         if window != nil {
-            updateCaptureState()
+            updateCaptureState(with: stream.videoState)
         }
     }
     
-    private func updateCaptureState() {
-        stream.videoState == .some(.started) ? startCapture() : stopCapture()
+    func updateCaptureState(with newVideoState: VideoState?) {
+        guard newVideoState != self.videoState else { return }
+        
+        newVideoState == .some(.started) ? startCapture() : stopCapture()
+        self.videoState = newVideoState
     }
     
     func startCapture() {

--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridConfiguration.swift
@@ -23,6 +23,7 @@ protocol VideoGridConfiguration {
 
     var floatingVideoStream: VideoStream? { get }
     var videoStreams: [VideoStream] { get }
+    var videoState: VideoState { get }
     var networkQuality: NetworkQuality { get }
     var shouldShowActiveSpeakerFrame: Bool { get }
     var presentationMode: VideoGridPresentationMode { get }
@@ -46,7 +47,8 @@ extension VideoGridConfiguration {
             videoStreams == other.videoStreams &&
             networkQuality == other.networkQuality &&
             shouldShowActiveSpeakerFrame == other.shouldShowActiveSpeakerFrame &&
-            presentationMode == other.presentationMode
+            presentationMode == other.presentationMode &&
+            videoState == other.videoState
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridViewController.swift
@@ -207,7 +207,9 @@ final class VideoGridViewController: SpinnerCapableViewController {
     private func updateSelfPreview() {
         guard let selfStreamId = ZMUser.selfUser()?.selfStreamId else { return }
 
+        // No stream to show. Update the capture state.
         guard let selfStream = stream(with: selfStreamId) else {
+            Log.calling.debug("updating capture state to \(configuration.videoState)")
             selfPreviewView?.updateCaptureState(with: configuration.videoState)
             return
         }

--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridViewController.swift
@@ -205,7 +205,7 @@ final class VideoGridViewController: SpinnerCapableViewController {
     }
     
     private func updateSelfPreview() {
-        guard let selfStreamId = ZMUser.selfUser()?.selfStreamId else { return }
+        let selfStreamId = SelfUser.current.selfStreamId
 
         // No stream to show. Update the capture state.
         guard let selfStream = stream(with: selfStreamId) else {
@@ -270,7 +270,7 @@ final class VideoGridViewController: SpinnerCapableViewController {
         let currentStreamsIds = configuration.allStreamIds
 
         for deletedStreamId in existingStreamsIds.subtracting(currentStreamsIds) {
-            guard deletedStreamId != ZMUser.selfUser()?.selfStreamId else { return }
+            guard deletedStreamId != SelfUser.current.selfStreamId else { return }
             viewCache[deletedStreamId]?.removeFromSuperview()
             viewCache.removeValue(forKey: deletedStreamId)
         }

--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridViewController.swift
@@ -208,11 +208,11 @@ final class VideoGridViewController: SpinnerCapableViewController {
         guard let selfStreamId = ZMUser.selfUser()?.selfStreamId else { return }
 
         guard let selfStream = stream(with: selfStreamId) else {
-            (viewCache[selfStreamId] as? SelfVideoPreviewView)?.stopCapture()
+            selfPreviewView?.updateCaptureState(with: configuration.videoState)
             return
         }
 
-        if let view = viewCache[selfStreamId] as? SelfVideoPreviewView {
+        if let view = selfPreviewView {
             view.stream = selfStream
             view.shouldShowActiveSpeakerFrame = configuration.shouldShowActiveSpeakerFrame
         } else {
@@ -268,6 +268,7 @@ final class VideoGridViewController: SpinnerCapableViewController {
         let currentStreamsIds = configuration.allStreamIds
 
         for deletedStreamId in existingStreamsIds.subtracting(currentStreamsIds) {
+            guard deletedStreamId != ZMUser.selfUser()?.selfStreamId else { return }
             viewCache[deletedStreamId]?.removeFromSuperview()
             viewCache.removeValue(forKey: deletedStreamId)
         }

--- a/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/VideoGridView/VideoGridViewController.swift
@@ -205,7 +205,7 @@ final class VideoGridViewController: SpinnerCapableViewController {
     }
     
     private func updateSelfPreview() {
-        let selfStreamId = SelfUser.current.selfStreamId
+        guard let selfStreamId = ZMUser.selfUser()?.selfStreamId else { return }
 
         // No stream to show. Update the capture state.
         guard let selfStream = stream(with: selfStreamId) else {
@@ -270,7 +270,7 @@ final class VideoGridViewController: SpinnerCapableViewController {
         let currentStreamsIds = configuration.allStreamIds
 
         for deletedStreamId in existingStreamsIds.subtracting(currentStreamsIds) {
-            guard deletedStreamId != SelfUser.current.selfStreamId else { return }
+            guard deletedStreamId != ZMUser.selfUser()?.selfStreamId else { return }
             viewCache[deletedStreamId]?.removeFromSuperview()
             viewCache.removeValue(forKey: deletedStreamId)
         }

--- a/avs-versions
+++ b/avs-versions
@@ -17,4 +17,4 @@
 # along with this program. If not, see http://www.gnu.org/licenses/.
 #
 
-export APPSTORE_AVS_VERSION=6.7.7
+export APPSTORE_AVS_VERSION=6.7.10


### PR DESCRIPTION
## What's new in this PR?

### Issues

Video capture stop when the user changes the presentation mode from **all video streams** to **active speakers**.
note that this happens only if the user is not qualified for the active speakers mode.

### Causes

Since the user doesn't qualify for the active speakers mode, the `SelfVideoPreviewView` is removed from `VideoGridViewController`'s view cache, which causes the capturer to be stopped. 

### Solutions

#### 1. Prevent the `SelfVideoPreviewView` to be removed from the view cache. 
 
Pruning the view cache is good for the remote video views, but not critical for the self preview. 
Keeping the instance also improves user experience, because the view doesn't have to be recreated each time the user enables the video.

#### 2. Sync the self user's video state with the capturer state, instead of using the video state provided by `VideoStream`

The `VideoConfiguration` passed to `VideoGridViewController` contains a list of `VideoStream` to be displayed. In the use case where the self user's `VideoStream` is not in the list, we want the user's video state to be provided by the configuration in order to update the capturer state.