### PR TITLE
Xcode 12: test with iPhone device

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -9128,7 +9128,7 @@
 			baseConfigurationReference = F1B24234219B2C9B00F7035C /* Wire-iOS-Release.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD)";
-				ONLY_ACTIVE_ARCH = YES;
+				ONLY_ACTIVE_ARCH = NO;
 			};
 			name = Release;
 		};

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -9086,7 +9086,6 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				APPLICATION_EXTENSION_API_ONLY = NO;
-				EXCLUDED_ARCHS = i386;
 			};
 			name = Debug;
 		};
@@ -9120,8 +9119,6 @@
 			baseConfigurationReference = F1B24232219B2C9B00F7035C /* Wire-iOS-Debug.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD)";
-				EXCLUDED_ARCHS = "";
-				"EXCLUDED_ARCHS[sdk=*]" = "";
 				ONLY_ACTIVE_ARCH = YES;
 			};
 			name = Debug;
@@ -9131,7 +9128,6 @@
 			baseConfigurationReference = F1B24234219B2C9B00F7035C /* Wire-iOS-Release.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD)";
-				EXCLUDED_ARCHS = "";
 				ONLY_ACTIVE_ARCH = YES;
 			};
 			name = Release;
@@ -9140,7 +9136,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = F114466821A2F8BC00B5FEBA /* Tests-Debug.xcconfig */;
 			buildSettings = {
-				EXCLUDED_ARCHS = "i386 arm64";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				VALIDATE_WORKSPACE = YES;
 			};
@@ -9161,7 +9156,6 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				APPLICATION_EXTENSION_API_ONLY = NO;
-				EXCLUDED_ARCHS = i386;
 				VALIDATE_WORKSPACE = YES;
 			};
 			name = Debug;

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -9102,7 +9102,7 @@
 		8F42C556199244A700288E4D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"EXCLUDED_ARCHS[sdk=*]" = "i386 arm64";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator14.4]" = "i386 arm64";
 				HEADER_SEARCH_PATHS = "$(SDKROOT)/usr/include/libxml2";
 				VALIDATE_WORKSPACE = YES;
 			};

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -9086,7 +9086,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				APPLICATION_EXTENSION_API_ONLY = NO;
-				EXCLUDED_ARCHS = "i386 arm64";
+				EXCLUDED_ARCHS = i386;
 			};
 			name = Debug;
 		};
@@ -9120,7 +9120,10 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = F1B24232219B2C9B00F7035C /* Wire-iOS-Debug.xcconfig */;
 			buildSettings = {
-				EXCLUDED_ARCHS = "i386 arm64";
+				ARCHS = "$(ARCHS_STANDARD)";
+				EXCLUDED_ARCHS = "";
+				"EXCLUDED_ARCHS[sdk=*]" = "";
+				ONLY_ACTIVE_ARCH = YES;
 			};
 			name = Debug;
 		};
@@ -9128,6 +9131,9 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = F1B24234219B2C9B00F7035C /* Wire-iOS-Release.xcconfig */;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
+				EXCLUDED_ARCHS = "";
+				ONLY_ACTIVE_ARCH = YES;
 			};
 			name = Release;
 		};
@@ -9156,7 +9162,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				APPLICATION_EXTENSION_API_ONLY = NO;
-				EXCLUDED_ARCHS = "i386 arm64";
+				EXCLUDED_ARCHS = i386;
 				VALIDATE_WORKSPACE = YES;
 			};
 			name = Debug;

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -9102,7 +9102,6 @@
 		8F42C556199244A700288E4D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"EXCLUDED_ARCHS[sdk=iphonesimulator14.4]" = "i386 arm64";
 				HEADER_SEARCH_PATHS = "$(SDKROOT)/usr/include/libxml2";
 				VALIDATE_WORKSPACE = YES;
 			};

--- a/setup.sh
+++ b/setup.sh
@@ -54,7 +54,7 @@ echo "ℹ️  Downloading AVS library..."
 echo ""
 
 echo "ℹ️  Downloading additional assets..."
-./Scripts/download-assets.sh "$@"
+./Scripts/download-assets.sh -b "chore/xcode12_simulator"
 echo ""
 
 echo "ℹ️  Doing additional postprocessing..."


### PR DESCRIPTION
## What's new in this PR?

fix the issue that can not install debug build on iPhone 12.

### dependency
- [ ] https://github.com/wireapp/wire-ios-build-configuration/pull/51