### PR TITLE
[Fix] App stuck after creating custom passcode

### DIFF
--- a/Wire-iOS/Sources/UserInterface/CustomAppLock/Setup/PasscodeSetupViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/CustomAppLock/Setup/PasscodeSetupViewController.swift
@@ -240,6 +240,7 @@ final class PasscodeSetupViewController: UIViewController {
         presenter.storePasscode(passcode: passcode, callback: callback)
 
         authenticationCoordinator?.passcodeSetupControllerDidFinish()
+        passcodeSetupViewControllerDelegate?.passcodeSetupControllerDidFinish()
         dismiss(animated: true)
     }
 
@@ -262,7 +263,7 @@ final class PasscodeSetupViewController: UIViewController {
         let passcodeSetupViewController = PasscodeSetupViewController(variant: variant,
                                                                       context: context,
                                                                       callback: nil)
-        
+        passcodeSetupViewController.passcodeSetupViewControllerDelegate = delegate
         let keyboardAvoidingViewController = KeyboardAvoidingAuthenticationCoordinatedViewController(viewController: passcodeSetupViewController)
         
         keyboardAvoidingViewController.modalPresentationStyle = .fullScreen


### PR DESCRIPTION
## What's new in this PR?

**JIRA:** https://wearezeta.atlassian.net/browse/SQSERVICES-292

### Issues

After creating a custom passcode from the app lock screen, the user is presented with the blurred shield view and can not navigate anywhere else.

### Causes

The `AppLockModule` is the delegate of `PasscodeSetupViewController`, however I forgot to actually set the delegate value. I also noticed we don't invoke the delegate method after storing the passcode.

### Solutions

Set the delegate and call its method.

