### PR TITLE
[Fix] Do not request to create a custom passcode if EAR is enabled

### DIFF
--- a/Wire-iOS Tests/App Lock/Tests/AppLockModuleInteractorTests.swift
+++ b/Wire-iOS Tests/App Lock/Tests/AppLockModuleInteractorTests.swift
@@ -113,6 +113,19 @@ final class AppLockModuleInteractorTests: XCTestCase {
         XCTAssertEqual(presenter.results, [.readyForAuthentication(shouldInform: true)])
     }
     
+    func test_InitiateAuthentication_DoesNotNeedToCreateCustomPasscode_WhenDatabaseIsLocked() {
+        // Given
+        session.lock = .database
+        appLock.isCustomPasscodeSet = false
+        appLock.requireCustomPasscode = true
+
+        // When
+        sut.executeRequest(.initiateAuthentication)
+
+        // Then
+        XCTAssertEqual(presenter.results, [.readyForAuthentication(shouldInform: false)])
+    }
+    
     func test_InitiateAuthentication_SessionIsAlreadyUnlocked() {
         // Given
         session.lock = .none
@@ -124,7 +137,6 @@ final class AppLockModuleInteractorTests: XCTestCase {
         XCTAssertEqual(appLock.methodCalls.evaluateAuthentication.count, 0)
         XCTAssertEqual(appLock.methodCalls.open.count, 1)
     }
-
 
     // MARK: - Evaluate authentication
 

--- a/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.Interactor.swift
+++ b/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.Interactor.swift
@@ -70,6 +70,7 @@ extension AppLockModule {
         }
 
         private var needsToCreateCustomPasscode: Bool {
+            guard passcodePreference != .deviceOnly else { return false }
             guard !appLock.isCustomPasscodeSet else { return false }
             return appLock.requireCustomPasscode || authenticationType.current == .unavailable
         }


### PR DESCRIPTION
## What's new in this PR?

https://wearezeta.atlassian.net/browse/SQSERVICES-300

### Issues
The App asks to create a custom passcode when it's not needed (**EAR** and Applock are enabled).


### Causes
We didn't check if EAR is enabled when a custom passcode is required.

### Solutions
Ask to create a custom passcode when it's needed and EAR isn't enabled.
