### PR TITLE
[Fix] Device authentication requested when app is minimized

### DIFF
--- a/Wire-iOS Tests/App Lock/Mocks/AppLockModule.MockApplicationStateProvider.swift
+++ b/Wire-iOS Tests/App Lock/Mocks/AppLockModule.MockApplicationStateProvider.swift
@@ -1,0 +1,30 @@
+//
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+@testable import Wire
+
+extension AppLockModule {
+
+    class MockApplicationStateProvider: ApplicationStateProvider {
+
+        var applicationState = UIApplication.State.active
+
+    }
+
+}

--- a/Wire-iOS Tests/App Lock/Tests/AppLockModuleInteractorTests.swift
+++ b/Wire-iOS Tests/App Lock/Tests/AppLockModuleInteractorTests.swift
@@ -42,7 +42,7 @@ final class AppLockModuleInteractorTests: XCTestCase {
         sut = .init(session: session,
                     authenticationType: authenticationType,
                     applicationStateProvider: applicationStateProvider)
-        
+
         sut.presenter = presenter
     }
     
@@ -147,9 +147,23 @@ final class AppLockModuleInteractorTests: XCTestCase {
 
     // MARK: - Evaluate authentication
 
-    func test_EvaluateAuthentication_OnlyIfApplicationIsActive() {
+    func test_EvaluateAuthentication_ReturnsDeniedIfAppIsInactive() {
         // Given
         applicationStateProvider.applicationState = .inactive
+        authenticationType.current = .faceID
+
+        // When
+        sut.executeRequest(.evaluateAuthentication)
+        XCTAssertTrue(waitForGroupsToBeEmpty([sut.dispatchGroup]))
+
+        // Then
+        XCTAssertEqual(appLock.methodCalls.evaluateAuthentication.count, 0)
+        XCTAssertEqual(presenter.results, [.authenticationDenied(.faceID)])
+    }
+
+    func test_EvaluateAuthentication_ReturnsDeniedIfAppIsInBackground() {
+        // Given
+        applicationStateProvider.applicationState = .background
         authenticationType.current = .faceID
 
         // When

--- a/Wire-iOS Tests/App Lock/Tests/AppLockModuleInteractorTests.swift
+++ b/Wire-iOS Tests/App Lock/Tests/AppLockModuleInteractorTests.swift
@@ -27,6 +27,7 @@ final class AppLockModuleInteractorTests: XCTestCase {
     private var session: AppLockModule.MockSession!
     private var appLock: AppLockModule.MockAppLockController!
     private var authenticationType: AppLockModule.MockAuthenticationTypeDetector!
+    private var applicationStateProvider: AppLockModule.MockApplicationStateProvider!
     
     override func setUp() {
         super.setUp()
@@ -34,10 +35,14 @@ final class AppLockModuleInteractorTests: XCTestCase {
         session = .init()
         appLock = .init()
         authenticationType = .init()
+        applicationStateProvider = .init()
 
         session.appLockController = appLock
 
-        sut = .init(session: session, authenticationType: authenticationType)
+        sut = .init(session: session,
+                    authenticationType: authenticationType,
+                    applicationStateProvider: applicationStateProvider)
+        
         sut.presenter = presenter
     }
     
@@ -47,6 +52,7 @@ final class AppLockModuleInteractorTests: XCTestCase {
         session = nil
         appLock = nil
         authenticationType = nil
+        applicationStateProvider = nil
         super.tearDown()
     }
 
@@ -140,6 +146,20 @@ final class AppLockModuleInteractorTests: XCTestCase {
 
 
     // MARK: - Evaluate authentication
+
+    func test_EvaluateAuthentication_OnlyIfApplicationIsActive() {
+        // Given
+        applicationStateProvider.applicationState = .inactive
+        authenticationType.current = .faceID
+
+        // When
+        sut.executeRequest(.evaluateAuthentication)
+        XCTAssertTrue(waitForGroupsToBeEmpty([sut.dispatchGroup]))
+
+        // Then
+        XCTAssertEqual(appLock.methodCalls.evaluateAuthentication.count, 0)
+        XCTAssertEqual(presenter.results, [.authenticationDenied(.faceID)])
+    }
 
     func test_EvaluateAuthentication_SessionIsAlreadyUnlocked() {
         // Given

--- a/Wire-iOS Tests/App Lock/Tests/AppLockModulePresenterTests.swift
+++ b/Wire-iOS Tests/App Lock/Tests/AppLockModulePresenterTests.swift
@@ -109,9 +109,9 @@ final class AppLockModulePresenterTests: XCTestCase {
 
     // MARK: - Process Event
 
-    func test_ViewDidLoad() {
+    func test_ViewDidAppear() {
         // When
-        sut.processEvent(.viewDidLoad)
+        sut.processEvent(.viewDidAppear)
 
         // Then
         XCTAssertEqual(interactor.requests, [.initiateAuthentication])

--- a/Wire-iOS Tests/App Lock/Tests/AppLockModuleViewTests.swift
+++ b/Wire-iOS Tests/App Lock/Tests/AppLockModuleViewTests.swift
@@ -42,12 +42,12 @@ final class AppLockModuleViewTests: XCTestCase {
 
     // MARK: - Event sending
 
-    func test_ItSendsEvent_WhenViewLoads() {
+    func test_ItSendsEvent_WhenViewAppears() {
         // When
-        sut.loadViewIfNeeded()
+        sut.viewDidAppear(false)
 
         // Then
-        XCTAssertEqual(presenter.events, [.viewDidLoad])
+        XCTAssertEqual(presenter.events, [.viewDidAppear])
     }
 
     func test_ItSendsEvent_WhenLockViewRequestReauthentication() {
@@ -59,7 +59,7 @@ final class AppLockModuleViewTests: XCTestCase {
         sut.lockView.actionRequested?()
 
         // Then
-        XCTAssertEqual(presenter.events, [.viewDidLoad, .unlockButtonTapped])
+        XCTAssertEqual(presenter.events, [.unlockButtonTapped])
     }
 
     func test_ItSendsEvent_WhenLockViewRequestOpenDeviceSettings() {
@@ -71,7 +71,7 @@ final class AppLockModuleViewTests: XCTestCase {
         sut.lockView.actionRequested?()
 
         // Then
-        XCTAssertEqual(presenter.events, [.viewDidLoad, .openDeviceSettingsButtonTapped])
+        XCTAssertEqual(presenter.events, [.openDeviceSettingsButtonTapped])
     }
 
     func test_ItSendsEvent_WhenPasscodeSetupFinishes() {

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1104,6 +1104,8 @@
 		EE2538852166151C00932606 /* ConversationActionController+Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2538842166151C00932606 /* ConversationActionController+Notifications.swift */; };
 		EE2C42EC25B70F2200B07EFF /* AppLockModule.MockAuthenticationTypeDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2C42EB25B70F2200B07EFF /* AppLockModule.MockAuthenticationTypeDetector.swift */; };
 		EE2FC1D81F56F89800A9A418 /* ConversationImagesViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2FC1D71F56F89800A9A418 /* ConversationImagesViewControllerTests.swift */; };
+		EE329F9525E65AC100861EC6 /* AppLockModule.MockApplicationStateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE329F9325E65ABE00861EC6 /* AppLockModule.MockApplicationStateProvider.swift */; };
+		EE329F9725E65D4700861EC6 /* ApplicationStateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE329F9625E65D4700861EC6 /* ApplicationStateProvider.swift */; };
 		EE34D6D924336A6600F5BD1C /* TeamMetadataRefresher.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE34D6D824336A6600F5BD1C /* TeamMetadataRefresher.swift */; };
 		EE34D6E1243373B100F5BD1C /* TimeInterval+Units.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE34D6E0243373B100F5BD1C /* TimeInterval+Units.swift */; };
 		EE34D6E32433767500F5BD1C /* TeamMetadataRefresherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE34D6E22433767500F5BD1C /* TeamMetadataRefresherTests.swift */; };
@@ -2866,6 +2868,8 @@
 		EE2538842166151C00932606 /* ConversationActionController+Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationActionController+Notifications.swift"; sourceTree = "<group>"; };
 		EE2C42EB25B70F2200B07EFF /* AppLockModule.MockAuthenticationTypeDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockModule.MockAuthenticationTypeDetector.swift; sourceTree = "<group>"; };
 		EE2FC1D71F56F89800A9A418 /* ConversationImagesViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConversationImagesViewControllerTests.swift; sourceTree = "<group>"; };
+		EE329F9325E65ABE00861EC6 /* AppLockModule.MockApplicationStateProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockModule.MockApplicationStateProvider.swift; sourceTree = "<group>"; };
+		EE329F9625E65D4700861EC6 /* ApplicationStateProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationStateProvider.swift; sourceTree = "<group>"; };
 		EE34D6D824336A6600F5BD1C /* TeamMetadataRefresher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamMetadataRefresher.swift; sourceTree = "<group>"; };
 		EE34D6E0243373B100F5BD1C /* TimeInterval+Units.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TimeInterval+Units.swift"; sourceTree = "<group>"; };
 		EE34D6E22433767500F5BD1C /* TeamMetadataRefresherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TeamMetadataRefresherTests.swift; path = "Wire-iOS Tests/TeamMetadataRefresherTests.swift"; sourceTree = SOURCE_ROOT; };
@@ -3394,6 +3398,7 @@
 			children = (
 				1693D9661CEDB26200D1F13C /* UIApplication+Permissions.swift */,
 				064AD4C325DD31A600143D74 /* UIApplication+OpenURL.swift */,
+				EE329F9625E65D4700861EC6 /* ApplicationStateProvider.swift */,
 			);
 			path = UIApplication;
 			sourceTree = "<group>";
@@ -6489,6 +6494,7 @@
 				EE7F466125B1CD5B001B3EE4 /* AppLockModule.MockSession.swift */,
 				EE7F466A25B1CE2B001B3EE4 /* AppLockModule.MockAppLockController.swift */,
 				EE2C42EB25B70F2200B07EFF /* AppLockModule.MockAuthenticationTypeDetector.swift */,
+				EE329F9325E65ABE00861EC6 /* AppLockModule.MockApplicationStateProvider.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -7576,6 +7582,7 @@
 				5EFE9BFF21246483007932A6 /* RegistrationFinalErrorHandler.swift in Sources */,
 				EF46ECCD231D5B4B00D425DA /* ConversationListViewControllerViewModel+StartUIDelegate.swift in Sources */,
 				5EA73D8C20D901E80001D106 /* ConversationTimeoutOptionsViewController.swift in Sources */,
+				EE329F9725E65D4700861EC6 /* ApplicationStateProvider.swift in Sources */,
 				8750A00F21934F1A00DC8DB6 /* AnimatedListMenuView.swift in Sources */,
 				A92E731C2407F54A007C1FFE /* AttributedStringOperators.swift in Sources */,
 				8708C6831F50860100845C7D /* AccountView.swift in Sources */,
@@ -8700,6 +8707,7 @@
 				540C8AA9255ABD7600AA6992 /* URLActionRouterTests.swift in Sources */,
 				EF7F74041FCC033D0059C13F /* EmailAdresssValidatorTests.swift in Sources */,
 				A96316A523F2B10500AFDB71 /* ProfileTitleViewSnapshotTests.swift in Sources */,
+				EE329F9525E65AC100861EC6 /* AppLockModule.MockApplicationStateProvider.swift in Sources */,
 				EF6251D421392FFE00943708 /* MockTapGestureRecognizer.swift in Sources */,
 				5E628028222021970039A8AB /* ProfileFooterViewTests.swift in Sources */,
 				A984AAE924099A9B002CFF2E /* SettingsTests.swift in Sources */,

--- a/Wire-iOS/Sources/Helpers/UIApplication/ApplicationStateProvider.swift
+++ b/Wire-iOS/Sources/Helpers/UIApplication/ApplicationStateProvider.swift
@@ -1,0 +1,28 @@
+//
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import UIKit
+
+protocol ApplicationStateProvider {
+
+    var applicationState: UIApplication.State { get }
+
+}
+
+extension UIApplication: ApplicationStateProvider {}

--- a/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.Presenter.swift
+++ b/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.Presenter.swift
@@ -69,7 +69,7 @@ extension AppLockModule.Presenter: AppLockPresenterViewInterface {
 
     func processEvent(_ event: AppLockModule.Event) {
         switch event {
-        case .viewDidLoad, .unlockButtonTapped, .applicationWillEnterForeground:
+        case .viewDidAppear, .unlockButtonTapped, .applicationWillEnterForeground:
             interactor.executeRequest(.initiateAuthentication)
 
         case .passcodeSetupCompleted, .customPasscodeVerified:

--- a/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.View.swift
+++ b/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.View.swift
@@ -39,7 +39,11 @@ extension AppLockModule {
             super.viewDidLoad()
             setUpViews()
             setUpObserver()
-            presenter.processEvent(.viewDidLoad)
+        }
+
+        override func viewDidAppear(_ animated: Bool) {
+            super.viewDidAppear(animated)
+            presenter.processEvent(.viewDidAppear)
         }
 
         // MARK: - Methods

--- a/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.swift
+++ b/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.swift
@@ -47,7 +47,7 @@ extension AppLockModule {
 
     enum Event: Equatable {
 
-        case viewDidLoad
+        case viewDidAppear
         case applicationWillEnterForeground
         case unlockButtonTapped
         case openDeviceSettingsButtonTapped


### PR DESCRIPTION
## What's new in this PR?

**JIRA:** https://wearezeta.atlassian.net/browse/SQSERVICES-294

### Issues

On iOS 14, if the encryption at rest is enabled, when the app is minimized, then the native device authentication (faceID, touchID or passcode) UI is presented, even though Wire is not visible.

### Causes

When EAR is enabled, when the app becomes inactive (moves to the background) the user session is locked. This triggers a change to the Wire app state, and we transitioned to the `locked` state and load the `AppLockModule`. When the view is loaded, we initiate the authentication flow, which results in asking for user authentication.

This only appears on iOS 14, and is probably due to a change that `viewDidLoad` and other lifecycle methods may be invoked even when the app is in the background.

### Solutions

While it makes sense to inform the presenter to initiate authentication when the `viewDidAppear` (and not when `viewDidLoad`), and I have made this change, it is not enough to solve the problem because also the `viewDidAppear` method is invoked when the app is in the background.

Instead we place a guard statement in the interactor before it asks the app lock controller to evaluate authentication. We only want to evaluate authenticate if the app is in an `active` state.

There's one caveat with this however, and that is when the app is brought to the foreground, we re-trigger the authentication flow as convenience to the user so they do not have to explicitly tap a button to authenticate. This is triggered by a `applicationWillEnterForeground` notification, but unfortunately this usually happens before the application transitions to the `active` state. So in this situation, the user must tap the unlock button explicitly. But this only affects EAR users and not normal app lock users.
