### PR TITLE
[Fix] The app crashes on Login screen

### DIFF
--- a/Wire-iOS/Sources/AppRootRouter.swift
+++ b/Wire-iOS/Sources/AppRootRouter.swift
@@ -191,6 +191,7 @@ extension AppRootRouter: AppStateCalculatorDelegate {
         case .migrating:
             showLaunchScreen(isLoading: true, completion: completionBlock)
         case .unauthenticated(error: let error):
+            screenCurtain.delegate = nil
             configureUnauthenticatedAppearance()
             showUnauthenticatedFlow(error: error, completion: completionBlock)
         case .authenticated(completedRegistration: let completedRegistration):


### PR DESCRIPTION
## What's new in this PR?
https://wearezeta.atlassian.net/browse/SQCORE-510

### Issues
The app crashes on showing the control centre while user is on Login screen.

### Causes
The app loses focus when the control centre shows. This event triggered `applicationWillResignActive()` of `ScreenCurtain`. We are trying to access the user session at a time when it does not exist yet. This is because` screenCurtain.delegate `points to a different user session that exists on Wire.

### Solutions
In the `unauthenticated` state, set `screenCurtain.delegate = nil` and prevent using the wrong user session.


