### PR TITLE
[Fix] SearchBar background in share extension

### DIFF
--- a/Wire-iOS Share Extension/ConversationSelectionViewController.swift
+++ b/Wire-iOS Share Extension/ConversationSelectionViewController.swift
@@ -45,8 +45,7 @@ final class ConversationSelectionViewController : UITableViewController {
         
         searchController.dimsBackgroundDuringPresentation = false
         searchController.hidesNavigationBarDuringPresentation = false
-        searchController.searchBar.searchBarStyle = .minimal
-        searchController.searchBar.backgroundColor = UIColor.white
+        searchController.searchBar.isTranslucent = false
 
         preferredContentSize = UIScreen.main.bounds.size
         definesPresentationContext = true

--- a/Wire-iOS Share Extension/ConversationSelectionViewController.swift
+++ b/Wire-iOS Share Extension/ConversationSelectionViewController.swift
@@ -46,6 +46,7 @@ final class ConversationSelectionViewController : UITableViewController {
         searchController.dimsBackgroundDuringPresentation = false
         searchController.hidesNavigationBarDuringPresentation = false
         searchController.searchBar.searchBarStyle = .minimal
+        searchController.searchBar.backgroundColor = UIColor.white
 
         preferredContentSize = UIScreen.main.bounds.size
         definesPresentationContext = true


### PR DESCRIPTION
## What's new in this PR?
https://wearezeta.atlassian.net/browse/SQSERVICES-63

### Issues
Conversation search field is transparent and conversation list is visible through the field in share extension.

### Solutions
Set the background color for the searchBar.

