### PR TITLE
[Chore] Lint whitespace

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,5 +1,4 @@
 disabled_rules:
-    - return_arrow_whitespace
     - comment_spacing
     - vertical_parameter_alignment
     - closing_brace

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,5 +1,4 @@
 disabled_rules:
-    - no_space_in_method_call
     - return_arrow_whitespace
     - comment_spacing
     - vertical_parameter_alignment

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,5 +1,4 @@
 disabled_rules:
-    - comment_spacing
     - vertical_parameter_alignment
     - closing_brace
     - line_length

--- a/Wire-iOS Tests/AccountViewSnapshotTests.swift
+++ b/Wire-iOS Tests/AccountViewSnapshotTests.swift
@@ -109,7 +109,7 @@ final class AccountViewSnapshotTests: XCTestCase {
         verify(matching: sut)
     }
 
-    //MARK: - unread dot
+    // MARK: - unread dot
 
     func testThatItShowsBasicAccountWithPictureSelected_Team_withUnreadDot() {
         // GIVEN
@@ -165,7 +165,7 @@ final class AccountViewSnapshotTests: XCTestCase {
         verify(matching: sut)
     }
 
-    //MARK: - smaller icon for conversation list
+    // MARK: - smaller icon for conversation list
     func testThatItShowsBasicAccount_Team_conversationListContext() {
         // GIVEN
         let account = Account(userName: "Iggy Pop", userIdentifier: UUID(), teamName: "Wire", imageData: nil)

--- a/Wire-iOS Tests/Analytics/AnalyticsCallingTrackerTests.swift
+++ b/Wire-iOS Tests/Analytics/AnalyticsCallingTrackerTests.swift
@@ -54,94 +54,94 @@ final class AnalyticsCallingTrackerTests: XCTestCase, CoreDataFixtureTestHelper 
     }
 
     func testThatMultipleScreenSharingEventFromDifferentClientsCanBeTagged() {
-        //GIVEN
+        // GIVEN
         XCTAssert(sut.screenSharingStartTimes.isEmpty)
 
-        //WHEN
+        // WHEN
         sut.callParticipantsDidChange(conversation: mockConversation, participants: [callParticipant(clientId: clientId1, videoState: .screenSharing)])
 
-        //THEN
+        // THEN
         XCTAssertEqual(sut.screenSharingStartTimes.count, 1)
 
-        //WHEN
+        // WHEN
         sut.callParticipantsDidChange(conversation: mockConversation, participants: [callParticipant(clientId: clientId2, videoState: .screenSharing)])
 
-        //THEN
+        // THEN
         XCTAssertEqual(sut.screenSharingStartTimes.count, 2)
     }
 
     func testThatStopStateRemovesAnItemFromScreenSharingInfos() {
-        //GIVEN
+        // GIVEN
         XCTAssert(sut.screenSharingStartTimes.isEmpty)
 
-        //WHEN
+        // WHEN
         participantStartScreenSharing(callParticipant: callParticipant(clientId: clientId1, videoState: .screenSharing))
         participantStoppedVideo(callParticipant: callParticipant(clientId: clientId1, videoState: .stopped))
 
-        //THEN
+        // THEN
         XCTAssertEqual(sut.screenSharingStartTimes.count, 0)
     }
 
     func testThatMultipleScreenShareEventsCanBeTagged() {
-        //GIVEN
+        // GIVEN
         XCTAssert(sut.screenSharingStartTimes.isEmpty)
 
-        //WHEN
+        // WHEN
         participantStartScreenSharing(callParticipant: callParticipant(clientId: clientId1, videoState: .screenSharing))
         participantStoppedVideo(callParticipant: callParticipant(clientId: clientId1, videoState: .stopped))
 
-        //start screen sharing again
+        // start screen sharing again
         participantStartScreenSharing(callParticipant: callParticipant(clientId: clientId1, videoState: .screenSharing))
 
-        //THEN
+        // THEN
         XCTAssertEqual(sut.screenSharingStartTimes.count, 1)
 
-        //WHEN
+        // WHEN
         participantStoppedVideo(callParticipant: callParticipant(clientId: clientId1, videoState: .stopped))
 
-        //THEN
+        // THEN
         XCTAssertEqual(sut.screenSharingStartTimes.count, 0)
     }
 
     func testThatMultipleParticipantsScreenShareEventsCanBeTagged() {
-        //GIVEN
+        // GIVEN
         XCTAssert(sut.screenSharingStartTimes.isEmpty)
 
-        //WHEN
+        // WHEN
         participantStartScreenSharing(callParticipant: callParticipant(clientId: clientId1, videoState: .screenSharing))
         participantStartScreenSharing(callParticipant: callParticipant(clientId: clientId2, videoState: .screenSharing))
 
-        //THEN
+        // THEN
         XCTAssertEqual(sut.screenSharingStartTimes.count, 2)
 
-        //WHEN
+        // WHEN
         participantStoppedVideo(callParticipant: callParticipant(clientId: clientId1, videoState: .stopped))
 
-        //THEN
+        // THEN
         XCTAssertEqual(sut.screenSharingStartTimes.count, 1)
 
-        //WHEN
+        // WHEN
         participantStoppedVideo(callParticipant: callParticipant(clientId: clientId2, videoState: .stopped))
 
-        //THEN
+        // THEN
         XCTAssertEqual(sut.screenSharingStartTimes.count, 0)
     }
 
     func testThatMultipleScreenShareEventsWouldNotBeTagged() {
-        //GIVEN
+        // GIVEN
         XCTAssert(sut.screenSharingStartTimes.isEmpty)
 
-        //WHEN
+        // WHEN
         participantStartScreenSharing(callParticipant: callParticipant(clientId: clientId1, videoState: .screenSharing))
         participantStartScreenSharing(callParticipant: callParticipant(clientId: clientId1, videoState: .screenSharing))
 
-        //THEN
+        // THEN
         XCTAssertEqual(sut.screenSharingStartTimes.count, 1)
 
-        //WHEN
+        // WHEN
         participantStoppedVideo(callParticipant: callParticipant(clientId: clientId1, videoState: .stopped))
 
-        //THEN
+        // THEN
         XCTAssertEqual(sut.screenSharingStartTimes.count, 0)
     }
 
@@ -150,7 +150,7 @@ final class AnalyticsCallingTrackerTests: XCTestCase, CoreDataFixtureTestHelper 
     }
 
     private func participantStoppedVideo(callParticipant: CallParticipant) {
-        //insert an mock callInfo
+        // insert an mock callInfo
         let callInfo = CallInfo(connectingDate: Date(), establishedDate: nil, maximumCallParticipants: 1, toggledVideo: false, outgoing: true, video: true)
         sut.callInfos[mockConversation.remoteIdentifier!] = callInfo
 

--- a/Wire-iOS Tests/Analytics/AnalyticsCountlyProviderTests.swift
+++ b/Wire-iOS Tests/Analytics/AnalyticsCountlyProviderTests.swift
@@ -65,7 +65,7 @@ final class AnalyticsCountlyProviderTests: XCTestCase, CoreDataFixtureTestHelper
     func testThatAppOpenIsStoredAndTaggedAfterSelfUserIsSet() {
         coreDataFixture.teamTest {
 
-            //GIVEN
+            // GIVEN
             sut = Analytics(optedOut: false)
             let analyticsCountlyProvider = AnalyticsCountlyProvider(
                 countlyInstanceType: MockCountly.self,
@@ -75,18 +75,18 @@ final class AnalyticsCountlyProviderTests: XCTestCase, CoreDataFixtureTestHelper
 
             sut.provider = analyticsCountlyProvider
 
-            //WHEN
+            // WHEN
             XCTAssertEqual(analyticsCountlyProvider.pendingEvents.count, 0)
             sut.tagEvent("app.open")
 
-            //THEN
+            // THEN
             XCTAssertEqual(analyticsCountlyProvider.pendingEvents.count, 1)
             XCTAssertEqual(MockCountly.recordEventCount, 0)
 
-            //WHEN
+            // WHEN
             sut.selfUser = coreDataFixture.selfUser
 
-            //THEN
+            // THEN
             XCTAssertEqual(MockCountly.startCount, 1)
 
             XCTAssertEqual(analyticsCountlyProvider.pendingEvents.count, 0)
@@ -96,7 +96,7 @@ final class AnalyticsCountlyProviderTests: XCTestCase, CoreDataFixtureTestHelper
 
     func testThatCountlyIsNotStartedForNonTeamMember() {
         coreDataFixture.nonTeamTest {
-            //GIVEN
+            // GIVEN
             sut = Analytics(optedOut: false)
 
             let analyticsCountlyProvider = AnalyticsCountlyProvider(
@@ -107,10 +107,10 @@ final class AnalyticsCountlyProviderTests: XCTestCase, CoreDataFixtureTestHelper
 
             sut.provider = analyticsCountlyProvider
 
-            //WHEN
+            // WHEN
             sut.selfUser = coreDataFixture.selfUser
 
-            //THEN
+            // THEN
             XCTAssertEqual(MockCountly.startCount, 0)
         }
     }

--- a/Wire-iOS Tests/AnimatedListMenuViewTests.swift
+++ b/Wire-iOS Tests/AnimatedListMenuViewTests.swift
@@ -21,25 +21,25 @@ import XCTest
 final class AnimatedListMenuViewTests: XCTestCase {
 
     func testThatProgressIsClamped() {
-        //GIVEN
+        // GIVEN
         let sut = AnimatedListMenuView()
 
-        //WHEN
+        // WHEN
         sut.progress = 1.3
 
-        //THEN
+        // THEN
         XCTAssertEqual(sut.progress, 1)
 
-        //WHEN
+        // WHEN
         sut.progress = -1
 
-        //THEN
+        // THEN
         XCTAssertEqual(sut.progress, 0)
 
-        //WHEN
+        // WHEN
         sut.progress = 0.5
 
-        //THEN
+        // THEN
         XCTAssertEqual(sut.progress, 0.5)
     }
 }

--- a/Wire-iOS Tests/App Lock/Tests/AppLockModuleInteractorTests.swift
+++ b/Wire-iOS Tests/App Lock/Tests/AppLockModuleInteractorTests.swift
@@ -28,7 +28,7 @@ final class AppLockModuleInteractorTests: XCTestCase {
     private var appLock: AppLockModule.MockAppLockController!
     private var authenticationType: AppLockModule.MockAuthenticationTypeDetector!
     private var applicationStateProvider: AppLockModule.MockApplicationStateProvider!
-    
+
     override func setUp() {
         super.setUp()
         presenter = .init()

--- a/Wire-iOS Tests/ArticleViewTests.swift
+++ b/Wire-iOS Tests/ArticleViewTests.swift
@@ -185,7 +185,7 @@ final class ArticleViewTests: XCTestCase {
             self.sut.translatesAutoresizingMaskIntoConstraints = false
             self.sut.configure(withTextMessageData: self.articleWithPicture(), obfuscated: false)
             XCTAssert(self.waitForGroupsToBeEmpty([MediaAssetCache.defaultImageCache.dispatchGroup]))
-            
+
             return self.sut
         } as () -> UIView)
     }

--- a/Wire-iOS Tests/BackgroundViewControllerTests.swift
+++ b/Wire-iOS Tests/BackgroundViewControllerTests.swift
@@ -52,7 +52,7 @@ final class BackgroundViewControllerTests: XCTestCase {
         // make sure view is loaded
         _ = sut.view
         // WHEN
-        ///TODO: hacks to make below line passes
+        /// TODO: hacks to make below line passes
         selfUser.accentColorValue = selfUser.accentColorValue
 
         XCTAssertTrue(waitForGroupsToBeEmpty([sut.dispatchGroup], timeout: 10))

--- a/Wire-iOS Tests/Backup/BackupExcluderTests.swift
+++ b/Wire-iOS Tests/Backup/BackupExcluderTests.swift
@@ -22,7 +22,7 @@ import WireCommonComponents
 
 private final class MockBackupExcluder: BackupExcluder {}
 
-final class BackupExcluderTests: XCTestCase { ///TODO: test protocol instead
+final class BackupExcluderTests: XCTestCase { /// TODO: test protocol instead
     private var sut: MockBackupExcluder!
     let filename = "test.txt"
 

--- a/Wire-iOS Tests/Button/ButtonTests.swift
+++ b/Wire-iOS Tests/Button/ButtonTests.swift
@@ -31,36 +31,36 @@ final class ButtonTests: XCTestCase {
     }
 
     func testForLongTitleCanBeWrapped() {
-        //GIVEN
+        // GIVEN
         sut.titleLabel?.lineBreakMode = .byWordWrapping
         sut.titleLabel?.numberOfLines = 0
         sut.titleEdgeInsets = UIEdgeInsets(top: 10, left: 10, bottom: 20, right: 20)
         sut.setTitle("Dummy button with long long long long long long long long title", for: .normal)
 
-        //WHEN & THEN
+        // WHEN & THEN
         verifyInAllPhoneWidths(matching: sut)
     }
 
     func testForStyleChangedToFull() {
-        //GIVEN
+        // GIVEN
         sut.setTitle("Dummy button", for: .normal)
 
-        //WHEN
+        // WHEN
         sut.style = .full
 
-        //THEN
+        // THEN
         verify(matching: sut)
     }
 
     func testForStyleChangedToEmpty() {
-        //GIVEN
+        // GIVEN
         sut.setTitle("Dummy button", for: .normal)
 
-        //WHEN
+        // WHEN
         sut.style = .full
         sut.style = .empty
 
-        //THEN
+        // THEN
         verify(matching: sut)
     }
 }

--- a/Wire-iOS Tests/Button/SpinnerButtonTests.swift
+++ b/Wire-iOS Tests/Button/SpinnerButtonTests.swift
@@ -32,46 +32,46 @@ final class SpinnerButtonTests: XCTestCase {
     }
 
     func testForShortTitle() {
-        //GIVEN
+        // GIVEN
         createSut(title: "Yes, I am safe.")
 
-        //WHEN
+        // WHEN
 
-        //THEN
+        // THEN
         XCTAssert(sut.isEnabled)
         verifyInAllPhoneWidths(matching: sut)
     }
 
     func testForSpinnerOverlapsTitle() {
-        //GIVEN
+        // GIVEN
         createSut(title: "No, I need rescue. I am on the west side.")
 
-        //WHEN
+        // WHEN
         sut.isLoading = true
 
-        //THEN
+        // THEN
         verifyInWidths(matching: sut,
                        widths: Set([300]),
                        snapshotBackgroundColor: UIColor.from(scheme: .contentBackground).withAlphaComponent(CGFloat.SpinnerButton.spinnerBackgroundAlpha))
     }
 
     func testForSpinnerIsHidden() {
-        //GIVEN
+        // GIVEN
         createSut()
 
-        //WHEN
+        // WHEN
 
-        //THEN
+        // THEN
         XCTAssert(sut.isEnabled)
         verifyInAllPhoneWidths(matching: sut)
     }
 
     func testForSpinnerIsShown() {
-        //GIVEN
+        // GIVEN
 
-        //WHEN
+        // WHEN
 
-        //THEN
+        // THEN
         ColorScheme.default.variant = .dark
         createSut()
         sut.isLoading = true

--- a/Wire-iOS Tests/Calling/CallHapticsControllerTests.swift
+++ b/Wire-iOS Tests/Calling/CallHapticsControllerTests.swift
@@ -99,14 +99,14 @@ final class CallHapticsControllerTests: ZMSnapshotTestCase {
 
         sut.updateParticipants([first])
 
-        //when
+        // when
         generator.reset()
         sut.updateParticipants([
             first,
             second
         ])
 
-        //then
+        // then
         XCTAssertEqual(generator.triggeredEvents, [.join])
     }
 

--- a/Wire-iOS Tests/Calling/CallInfoConfigurationTests.swift
+++ b/Wire-iOS Tests/Calling/CallInfoConfigurationTests.swift
@@ -454,7 +454,7 @@ final class CallInfoConfigurationTests: XCTestCase {
         let configuration = CallInfoConfiguration(voiceChannel: mockVoiceChannel, preferedVideoPlaceholderState: .hidden, permissions: CallPermissions(), cameraType: .front, userEnabledCBR: false, selfUser: mockSelfUser)
 
         // then
-        assertEquals(fixture.groupAudioEstablishedVideoUnavailable(mockUsers: mockUsers), configuration)//canToggleMediaType
+        assertEquals(fixture.groupAudioEstablishedVideoUnavailable(mockUsers: mockUsers), configuration)// canToggleMediaType
     }
 
     func testGroupAudioEstablishedNonTeamUserRemoteTurnedVideoOn() {

--- a/Wire-iOS Tests/Calling/CallInfoRootViewControllerTests.swift
+++ b/Wire-iOS Tests/Calling/CallInfoRootViewControllerTests.swift
@@ -294,7 +294,7 @@ final class CallInfoRootViewControllerTests: XCTestCase {
         // when
         sut = CallInfoRootViewController(configuration: fixture.groupVideoIncomingUndeterminedPermissions, selfUser: mockSelfUser)
 
-        //then
+        // then
         verify(matching: sut)
     }
 
@@ -305,7 +305,7 @@ final class CallInfoRootViewControllerTests: XCTestCase {
         // when
         sut = CallInfoRootViewController(configuration: fixture.groupVideoIncomingDeniedPermissions, selfUser: mockSelfUser)
 
-        //then
+        // then
         verify(matching: sut)
     }
 

--- a/Wire-iOS Tests/Calling/CallInfoTestFixture.swift
+++ b/Wire-iOS Tests/Calling/CallInfoTestFixture.swift
@@ -554,7 +554,7 @@ struct CallInfoTestFixture {
         )
     }
 
-    func groupAudioEstablishedVideoUnavailable(mockUsers: [MockUserType]) ->  CallInfoViewControllerInput {
+    func groupAudioEstablishedVideoUnavailable(mockUsers: [MockUserType]) -> CallInfoViewControllerInput {
         return MockCallInfoViewControllerInput(
             allowPresentationModeUpdates: false,
             videoGridPresentationMode: .allVideoStreams,

--- a/Wire-iOS Tests/Color/ColorSchemeTests.swift
+++ b/Wire-iOS Tests/Color/ColorSchemeTests.swift
@@ -34,11 +34,11 @@ final class ColorSchemeTests: XCTestCase {
     }
 
     func testForIsCurrentAccentColor() {
-        ///GIVEN
+        /// GIVEN
         sut.accentColor = .black
         let alphaBlack = UIColor(displayP3Red: 0, green: 0, blue: 0, alpha: 0)
 
-        ///THEN
+        /// THEN
         XCTAssertEqual(sut.accentColor, .black)
         XCTAssert(sut.isCurrentAccentColor(.black))
 

--- a/Wire-iOS Tests/CombinationTest.swift
+++ b/Wire-iOS Tests/CombinationTest.swift
@@ -20,7 +20,7 @@ import XCTest
 @testable import Wire
 
 struct Mutator<SUT: Copyable, Variant: Hashable> {
-    typealias Applicator = (SUT, Variant)->(SUT)
+    typealias Applicator = (SUT, Variant) -> (SUT)
     typealias CombinationPair = (combination: Variant, result: SUT)
     let applicator: Applicator
     let combinations: Set<Variant>
@@ -64,7 +64,7 @@ class CombinationTest<SUT: Copyable, Variant: Hashable> {
         return current
     }
 
-    @discardableResult func testAll(_ test: (CombinationChainPair)->(Bool?)) -> [CombinationChainPair] {
+    @discardableResult func testAll(_ test: (CombinationChainPair) -> (Bool?)) -> [CombinationChainPair] {
         return self.allCombinations().compactMap {
             !(test($0) ?? true) ? $0 : .none
         }

--- a/Wire-iOS Tests/ConversationContentViewControllerTests.swift
+++ b/Wire-iOS Tests/ConversationContentViewControllerTests.swift
@@ -44,7 +44,7 @@ final class ConversationContentViewControllerTests: XCTestCase, CoreDataFixtureT
 
         sut = ConversationContentViewController(conversation: mockConversation, mediaPlaybackManager: nil, session: mockZMUserSession)
 
-        ///Call the setup codes in viewDidLoad
+        /// Call the setup codes in viewDidLoad
         sut.loadViewIfNeeded()
     }
 

--- a/Wire-iOS Tests/ConversationDetail/GroupDetailsViewControllerSnapshotTests.swift
+++ b/Wire-iOS Tests/ConversationDetail/GroupDetailsViewControllerSnapshotTests.swift
@@ -96,7 +96,7 @@ final class GroupDetailsViewControllerSnapshotTests: XCTestCase {
 
         sut = GroupDetailsViewController(conversation: mockConversation)
 
-        //THEN
+        // THEN
         verify(matching: sut)
     }
 

--- a/Wire-iOS Tests/ConversationImagesViewControllerTests.swift
+++ b/Wire-iOS Tests/ConversationImagesViewControllerTests.swift
@@ -78,7 +78,7 @@ final class ConversationImagesViewControllerTests: CoreDataSnapshotTestCase {
 
         sut.setBoundsSizeAsIPhone4_7Inch()
 
-        ///calls viewWillAppear
+        /// calls viewWillAppear
         sut.beginAppearanceTransition(true, animated: false)
 
         verify(view: navigatorController.view)

--- a/Wire-iOS Tests/ConversationList/Container/ConversationListViewControllerTests.swift
+++ b/Wire-iOS Tests/ConversationList/Container/ConversationListViewControllerTests.swift
@@ -47,7 +47,7 @@ final class ConversationListViewControllerTests: XCTestCase {
 
     }
 
-    //MARK: - View controller
+    // MARK: - View controller
 
     func testForNoConversations() {
         verify(matching: sut)
@@ -60,7 +60,7 @@ final class ConversationListViewControllerTests: XCTestCase {
         verify(matching: sut)
     }
 
-    //MARK: - PermissionDeniedViewController
+    // MARK: - PermissionDeniedViewController
     func testForPremissionDeniedViewController() {
         sut.showPermissionDeniedViewController()
 

--- a/Wire-iOS Tests/ConversationList/Container/ConversationListViewControllerViewModelSnapshotTests.swift
+++ b/Wire-iOS Tests/ConversationList/Container/ConversationListViewControllerViewModelSnapshotTests.swift
@@ -49,7 +49,7 @@ final class ConversationListViewControllerViewModelSnapshotTests: XCTestCase {
         super.tearDown()
     }
 
-    //MARK: - Action menu
+    // MARK: - Action menu
     func testForActionMenu() {
         coreDataFixture.teamTest {
             sut.showActionMenu(for: coreDataFixture.otherUserConversation, from: mockViewController.view)

--- a/Wire-iOS Tests/ConversationList/Container/MockConversationListContainer.swift
+++ b/Wire-iOS Tests/ConversationList/Container/MockConversationListContainer.swift
@@ -32,7 +32,7 @@ final class MockConversationListContainer: UIViewController, ConversationListCon
     }
 
     var hasUsernameTakeoverViewController: Bool {
-        //no-op
+        // no-op
         return false
     }
 
@@ -46,7 +46,7 @@ final class MockConversationListContainer: UIViewController, ConversationListCon
     }
 
     func scrollViewDidScroll(scrollView: UIScrollView!) {
-        //no-op
+        // no-op
     }
 
     func setState(_ state: ConversationListState, animated: Bool, completion: Completion?) {
@@ -54,34 +54,34 @@ final class MockConversationListContainer: UIViewController, ConversationListCon
     }
 
     func showNoContactLabel(animated: Bool) {
-        //no-op
+        // no-op
     }
 
     func hideNoContactLabel(animated: Bool) {
-        //no-op
+        // no-op
     }
 
     func openChangeHandleViewController(with handle: String) {
-        //no-op
+        // no-op
     }
 
     func showNewsletterSubscriptionDialogIfNeeded(completionHandler: @escaping ResultHandler) {
-        //no-op
+        // no-op
     }
 
     func updateArchiveButtonVisibilityIfNeeded(showArchived: Bool) {
-        //no-op
+        // no-op
     }
 
     func removeUsernameTakeover() {
-        //no-op
+        // no-op
     }
 
     func showUsernameTakeover(suggestedHandle: String, name: String) {
-        //no-op
+        // no-op
     }
 
     func showPermissionDeniedViewController() {
-        //no-op
+        // no-op
     }
 }

--- a/Wire-iOS Tests/ConversationList/ConversationListCell/ConversationStatusLineTests+Muting.swift
+++ b/Wire-iOS Tests/ConversationList/ConversationListCell/ConversationStatusLineTests+Muting.swift
@@ -52,7 +52,7 @@ extension ConversationStatusLineTests_Muting {
         XCTAssertEqual(status.string, "Replied to your message")
     }
 
-    ///TODO: move this test to SE
+    /// TODO: move this test to SE
     func testStatusShowSpecialSummaryForSingleEphemeralReplyWhenOnlyReplies_group() {
         // GIVEN
         let sut = self.createGroupConversation()

--- a/Wire-iOS Tests/ConversationList/ConversationListViewModel/ConversationListViewModelTests.swift
+++ b/Wire-iOS Tests/ConversationList/ConversationListViewModel/ConversationListViewModelTests.swift
@@ -21,15 +21,15 @@ import DifferenceKit
 
 final class MockConversationListViewModelDelegate: NSObject, ConversationListViewModelDelegate {
     func listViewModel(_ model: ConversationListViewModel?, didUpdateSection section: Int) {
-        //no-op
+        // no-op
     }
 
     func listViewModel(_ model: ConversationListViewModel?, didUpdateSectionForReload section: Int, animated: Bool) {
-        //no-op
+        // no-op
     }
 
     func listViewModel(_ model: ConversationListViewModel?, didChangeFolderEnabled folderEnabled: Bool) {
-        //no-op
+        // no-op
     }
 
     func reload<C>(
@@ -41,15 +41,15 @@ final class MockConversationListViewModelDelegate: NSObject, ConversationListVie
     }
 
     func listViewModelShouldBeReloaded() {
-        //no-op
+        // no-op
     }
 
     func listViewModel(_ model: ConversationListViewModel?, didSelectItem item: ConversationListItem?) {
-        //no-op
+        // no-op
     }
 
     func listViewModel(_ model: ConversationListViewModel?, didUpdateConversationWithChange change: ConversationChangeInfo?) {
-        //no-op
+        // no-op
     }
 }
 
@@ -101,16 +101,16 @@ final class ConversationListViewModelTests: XCTestCase {
     }
 
     func testForNumberOfItems() {
-        ///GIVEN
+        /// GIVEN
         sut.folderEnabled = true
 
         let mockConversation = ZMConversation()
 
         fillDummyConversations(mockConversation: mockConversation)
 
-        ///WHEN
+        /// WHEN
 
-        ///THEN
+        /// THEN
         XCTAssertEqual(sut.numberOfItems(inSection: 0), 0)
         XCTAssertEqual(sut.numberOfItems(inSection: Int(sectionGroups)), 2)
         XCTAssertEqual(sut.numberOfItems(inSection: Int(sectionContacts)), 1)
@@ -118,97 +118,97 @@ final class ConversationListViewModelTests: XCTestCase {
     }
 
     func testForIndexPathOfItemAndItemForIndexPath() {
-        ///GIVEN
+        /// GIVEN
         sut.folderEnabled = true
 
         let mockConversation = ZMConversation()
 
         fillDummyConversations(mockConversation: mockConversation)
 
-        ///WHEN
+        /// WHEN
         guard let indexPath = sut.indexPath(for: mockConversation) else { XCTFail("indexPath is nil ")
             return
         }
 
         let item = sut.item(for: indexPath)
 
-        ///THEN
+        /// THEN
         XCTAssertEqual(item as? AnyHashable, mockConversation)
     }
 
     func testThatOutOfBoundIndexPathReturnsNilItem() {
-        ///GIVEN & WHEN
+        /// GIVEN & WHEN
         let mockConversation = ZMConversation()
         fillDummyConversations(mockConversation: mockConversation)
 
-        ///THEN
+        /// THEN
         XCTAssertNil(sut.item(for: IndexPath(item: 1000, section: 1000)))
     }
 
     func testThatNonExistConversationHasNilIndexPath() {
-        ///GIVEN & WHEN
+        /// GIVEN & WHEN
 
-        ///THEN
+        /// THEN
         XCTAssertNil(sut.indexPath(for: ZMConversation()))
     }
 
     func testForSectionCount() {
-        ///GIVEN
+        /// GIVEN
 
-        ///WHEN
+        /// WHEN
         sut.folderEnabled = true
 
-        ///THEN
+        /// THEN
         XCTAssertEqual(sut.sectionCount, 4)
 
-        ///WHEN
+        /// WHEN
         sut.folderEnabled = false
         XCTAssertEqual(sut.sectionCount, 2)
     }
 
     func testForSectionAtIndex() {
-        ///GIVEN
+        /// GIVEN
         sut.folderEnabled = true
 
         let mockConversation = ZMConversation()
 
         fillDummyConversations(mockConversation: mockConversation)
 
-        ///WHEN
+        /// WHEN
 
-        ///THEN
+        /// THEN
         XCTAssertEqual(sut.section(at: Int(sectionGroups))?.first as? AnyHashable, mockConversation)
 
         XCTAssertNil(sut.section(at: 100))
     }
 
     func testForItemAfter() {
-        ///GIVEN
+        /// GIVEN
         sut.folderEnabled = true
 
         let mockConversation = ZMConversation()
 
         fillDummyConversations(mockConversation: mockConversation)
 
-        ///WHEN
+        /// WHEN
 
-        ///THEN
+        /// THEN
         XCTAssertEqual(sut.item(after: 0, section: sectionGroups), IndexPath(item: 1, section: Int(sectionGroups)))
         XCTAssertEqual(sut.item(after: 1, section: 1), IndexPath(item: 0, section: 2))
         XCTAssertEqual(sut.item(after: 0, section: sectionContacts), nil)
     }
 
     func testForItemPervious() {
-        ///GIVEN
+        /// GIVEN
         sut.folderEnabled = true
 
         let mockConversation = ZMConversation()
 
         fillDummyConversations(mockConversation: mockConversation)
 
-        ///WHEN
+        /// WHEN
 
-        ///THEN
+        /// THEN
         XCTAssertEqual(sut.itemPrevious(to: 0, section: sectionGroups), nil)
 
         XCTAssertEqual(sut.itemPrevious(to: 1, section: sectionGroups), IndexPath(item: 0, section: Int(sectionGroups)))
@@ -223,10 +223,10 @@ final class ConversationListViewModelTests: XCTestCase {
 
         fillDummyConversations(mockConversation: mockConversation)
 
-        ///WHEN & THEN
+        /// WHEN & THEN
         XCTAssert(sut.select(itemToSelect: mockConversation))
 
-        ///THEN
+        /// THEN
         XCTAssertEqual(sut.selectedItem as? AnyHashable, mockConversation)
     }
 
@@ -238,31 +238,31 @@ final class ConversationListViewModelTests: XCTestCase {
 
         fillDummyConversations(mockConversation: mockConversation)
 
-        ///WHEN
+        /// WHEN
         let indexPath = sut.indexPath(for: mockConversation)!
 
-        ///THEN
+        /// THEN
         XCTAssertEqual(sut.selectItem(at: indexPath) as? AnyHashable, mockConversation)
     }
 
     // MARK: - state
     func testThatSectionIsExpandedAfterSelected() {
-        ///GIVEN
+        /// GIVEN
         sut.folderEnabled = true
         let mockConversation = ZMConversation()
         fillDummyConversations(mockConversation: mockConversation)
-        sut.setCollapsed(sectionIndex: Int(sectionGroups), collapsed: true)///todo
+        sut.setCollapsed(sectionIndex: Int(sectionGroups), collapsed: true)/// todo
 
-        ///WHEN
+        /// WHEN
         XCTAssert(sut.collapsed(at: Int(sectionGroups)))
         XCTAssert(sut.select(itemToSelect: mockConversation))
 
-        ///THEN
+        /// THEN
         XCTAssertFalse(sut.collapsed(at: Int(sectionGroups)))
     }
 
     func testThatCollapseStateCanBeRestoredAfterFolderDisabled() {
-        ///GIVEN
+        /// GIVEN
         sut.folderEnabled = true
 
         let mockConversation = ZMConversation()
@@ -271,7 +271,7 @@ final class ConversationListViewModelTests: XCTestCase {
 
         XCTAssertFalse(sut.collapsed(at: 1))
 
-        ///WHEN
+        /// WHEN
         sut.setCollapsed(sectionIndex: 1, collapsed: true)
 
         XCTAssert(sut.collapsed(at: 1))
@@ -282,9 +282,9 @@ final class ConversationListViewModelTests: XCTestCase {
         XCTAssertFalse(sut.collapsed(at: 1))
         sut.folderEnabled = true
 
-        ///THEN
+        /// THEN
 
-        ///collapsed state is restored
+        /// collapsed state is restored
         XCTAssert(sut.collapsed(at: 1))
     }
 

--- a/Wire-iOS Tests/ConversationListBottomBarControllerTests.swift
+++ b/Wire-iOS Tests/ConversationListBottomBarControllerTests.swift
@@ -54,7 +54,7 @@ final class ConversationListBottomBarControllerTests: ZMSnapshotTestCase {
             self.sut = ConversationListBottomBarController()
             self.sut.delegate = self.mockDelegate
 
-            ///SUT has a priority 750 height constraint. fix its height first
+            /// SUT has a priority 750 height constraint. fix its height first
             NSLayoutConstraint.activate([
                 sut.view.heightAnchor.constraint(equalToConstant: 56)
                 ])

--- a/Wire-iOS Tests/ConversationOptionsViewControllerTests.swift
+++ b/Wire-iOS Tests/ConversationOptionsViewControllerTests.swift
@@ -65,7 +65,7 @@ final class ConversationOptionsViewControllerTests: XCTestCase {
 
         let viewModel = ConversationOptionsViewModel(configuration: config)
 
-        ///Show the alert
+        /// Show the alert
         let sut = viewModel.setAllowGuests(false)
 
         // Then
@@ -80,7 +80,7 @@ final class ConversationOptionsViewControllerTests: XCTestCase {
         /// for ConversationOptionsViewModel's delegate
         _ = ConversationOptionsViewController(viewModel: viewModel, variant: .light)
 
-        ///Show the alert
+        /// Show the alert
         let sut = viewModel.setAllowGuests(false)!
 
         // Then

--- a/Wire-iOS Tests/CountryCodeTableViewControllerTests.swift
+++ b/Wire-iOS Tests/CountryCodeTableViewControllerTests.swift
@@ -39,7 +39,7 @@ final class CountryCodeTableViewControllerTests: XCTestCase {
         // GIVEN & WHEN
         let filteredResult = sut.filter(searchText: "49") as? [Country]
 
-        //THEN
+        // THEN
         XCTAssertEqual(filteredResult?.first?.displayName, "Germany")
     }
 

--- a/Wire-iOS Tests/CustomAppLock/WipeDatabaseViewControllerTests.swift
+++ b/Wire-iOS Tests/CustomAppLock/WipeDatabaseViewControllerTests.swift
@@ -43,13 +43,13 @@ final class WipeDatabaseViewControllerTests: XCTestCase {
     }
 
     func testForConfirmAlert() {
-        //GIVEN
+        // GIVEN
         sut = WipeDatabaseViewController()
 
-        //WHEN
+        // WHEN
         sut.presentConfirmAlert()
 
-        //THEN
+        // THEN
         verify(matching: sut.confirmController!.alertController)
     }
 }

--- a/Wire-iOS Tests/DateFormatterTests.swift
+++ b/Wire-iOS Tests/DateFormatterTests.swift
@@ -106,7 +106,7 @@ final class DateFormatterTests: XCTestCase {
 
         XCTAssert(dateString.hasPrefix(String(month)), "dateString is \(dateString)")
 
-        ///Confirm "day" & "Month" exists in dateString
+        /// Confirm "day" & "Month" exists in dateString
         XCTAssert(dateString.contains("日"))
         XCTAssert(dateString.contains("月"))
     }
@@ -123,7 +123,7 @@ final class DateFormatterTests: XCTestCase {
         return dateString
     }
 
-    //MARK:- wr_formattedDate tests
+    // MARK:- wr_formattedDate tests
 
     func testWr_formattedDateForTwoHourBefore() {
         // GIVEN
@@ -144,7 +144,7 @@ final class DateFormatterTests: XCTestCase {
 
         // THEN
         XCTAssertFalse(dateString.contains("just now"), "dateString is \(dateString)")
-        ///If two hours before is yesterday, dateString looks like "Yesterday at 11:17 PM"
+        /// If two hours before is yesterday, dateString looks like "Yesterday at 11:17 PM"
         XCTAssert(dateString.hasPrefix(String(hour)) ||
             (dateString.replacingOccurrences(of: "Yesterday at ", with: "").hasPrefix(String(hour))
             ), "hour is \(hour), dateString is \(dateString)")

--- a/Wire-iOS Tests/GroupConversationCellTests.swift
+++ b/Wire-iOS Tests/GroupConversationCellTests.swift
@@ -70,32 +70,32 @@ final class GroupConversationCellTests: XCTestCase {
     }
 
     func testOneToOneConversation() {
-        //GIVEN & WHEN
+        // GIVEN & WHEN
         let otherUserConversation = createOneOnOneConversation()
 
-        //THEN
+        // THEN
         verify(conversation: otherUserConversation)
     }
 
     func testGroupConversation() {
-        //GIVEN
+        // GIVEN
         let groupConversation = createGroupConversation()
 
-        //WHEN
+        // WHEN
         groupConversation.displayName = "Anna, Bruno, Claire, Dean"
 
-        //THEN
+        // THEN
         verify(conversation: groupConversation)
     }
 
     func testGroupConversationWithVeryLongName() {
-        //GIVEN
+        // GIVEN
         let groupConversation = createGroupConversation()
 
-        //WHEN
+        // WHEN
         groupConversation.displayName  = "Loooooooooooooooooooooooooong name"
 
-        //THEN
+        // THEN
         verify(conversation: groupConversation)
     }
 

--- a/Wire-iOS Tests/InputBar/InputBarTests.swift
+++ b/Wire-iOS Tests/InputBar/InputBarTests.swift
@@ -59,7 +59,7 @@ final class InputBarTests: ZMSnapshotTestCase {
         super.tearDown()
     }
 
-    //MARK: - placeholder
+    // MARK: - placeholder
 
     func testNoText() {
         verifyInAllPhoneWidths(view: sut)
@@ -74,7 +74,7 @@ final class InputBarTests: ZMSnapshotTestCase {
         verifyInAllPhoneWidths(view: sut)
     }
 
-    //MARK: - Text inputted
+    // MARK: - Text inputted
 
     func testShortText() {
         sut.textView.text = shortText

--- a/Wire-iOS Tests/LinkOpeningOption/BrowserOpeningOptionTests.swift
+++ b/Wire-iOS Tests/LinkOpeningOption/BrowserOpeningOptionTests.swift
@@ -26,20 +26,20 @@ final class BrowserOpeningOptionTests: XCTestCase {
     }
 
     func testThatDefaultBrowserIsSafari() {
-        //GIVEN & WHEN
+        // GIVEN & WHEN
         Settings.shared.reset()
         let preference: BrowserOpeningOption = BrowserOpeningOption.storedPreference
 
-        //THEN
+        // THEN
         XCTAssertEqual(preference, BrowserOpeningOption.safari)
     }
 
     func testThatBrowserCanBeChangedToSnowhaze() {
-        //GIVEN & WHEN
+        // GIVEN & WHEN
         let browserOpeningOption: BrowserOpeningOption = .snowhaze
         Settings.shared[.browserOpeningRawValue] = browserOpeningOption
 
-        //THEN
+        // THEN
         XCTAssertEqual(BrowserOpeningOption.storedPreference, BrowserOpeningOption.snowhaze)
     }
 }

--- a/Wire-iOS Tests/Mocks/MockConversation.swift
+++ b/Wire-iOS Tests/Mocks/MockConversation.swift
@@ -18,13 +18,13 @@
 import Foundation
 @testable import Wire
 
-///TODO: rename to MockConversation after objc MockConversation is retired
+/// TODO: rename to MockConversation after objc MockConversation is retired
 class SwiftMockConversation: NSObject, Conversation  {
 	var sortedOtherParticipants: [UserType] = []
 	var sortedServiceUsers: [UserType] = []
 
 	func verifyLegalHoldSubjects() {
-		//no-op
+		// no-op
 	}
 
 	var sortedActiveParticipantsUserTypes: [UserType] = []
@@ -79,7 +79,7 @@ final class MockInputBarConversationType: SwiftMockConversation, InputBarConvers
     var messageDestructionTimeoutValue: TimeInterval = 0
 
     func setIsTyping(_ isTyping: Bool) {
-        //no-op
+        // no-op
     }
 
     var isReadOnly: Bool = false

--- a/Wire-iOS Tests/Mocks/MockUser+Service.swift
+++ b/Wire-iOS Tests/Mocks/MockUser+Service.swift
@@ -23,7 +23,7 @@ extension MockUser {
         return self.hasTeam
     }
 
-    //MARK: - clients
+    // MARK: - clients
     @discardableResult
     func feature(withUserClients numClients: Int) -> [MockUserClient]? {
         var newClients: [AnyHashable] = []

--- a/Wire-iOS Tests/Mocks/MockUser+filename.swift
+++ b/Wire-iOS Tests/Mocks/MockUser+filename.swift
@@ -24,7 +24,7 @@ extension MockUser {
     ///
     /// - Parameter suffix: a mocking input
     /// - Returns: a mocking output
-    func filename(suffix: String? = nil)-> String {
+    func filename(suffix: String? = nil) -> String {
         return "dummy.txt"
     }
 

--- a/Wire-iOS Tests/PhoneNumberTests.swift
+++ b/Wire-iOS Tests/PhoneNumberTests.swift
@@ -21,30 +21,30 @@ import XCTest
 final class PhoneNumberTests: XCTestCase {
 
     func testThatPhoneNumberStructWithLeadingZeroCanBeCompared() {
-        //GIVEN
+        // GIVEN
         let phoneNumber1 = PhoneNumber(fullNumber: "+49017612345678")
         let phoneNumber2 = PhoneNumber(fullNumber: "+4917612345678")
 
-        //WHEN & THEN
+        // WHEN & THEN
         XCTAssertEqual(phoneNumber1, phoneNumber2)
 
     }
 
     func testThatDifferentNumbersAreNotEqual() {
-        //GIVEN
+        // GIVEN
         let phoneNumber1 = PhoneNumber(fullNumber: "+4917212345678")
         let phoneNumber2 = PhoneNumber(fullNumber: "+4917612345678")
 
-        //WHEN & THEN
+        // WHEN & THEN
         XCTAssertNotEqual(phoneNumber1, phoneNumber2)
     }
 
     func testThatUSnumberAreCamparable() {
-        //GIVEN
+        // GIVEN
         let phoneNumber1 = PhoneNumber(countryCode: 1, numberWithoutCode: "5417543010")
         let phoneNumber2 = PhoneNumber(fullNumber: "+1-541-754-3010")
 
-        //WHEN & THEN
+        // WHEN & THEN
         XCTAssertEqual(phoneNumber1, phoneNumber2)
     }
 }

--- a/Wire-iOS Tests/ProfileDetailsViewControllerTests.swift
+++ b/Wire-iOS Tests/ProfileDetailsViewControllerTests.swift
@@ -575,7 +575,7 @@ final class ProfileDetailsViewControllerTests: XCTestCase {
         verifyContents(user: otherUser, viewer: selfUser, conversation: group, expectedContents: [])
     }
 
-    func test_Group_SelfUser_SCIM() {///FIXME: can self user disable myself as admin? In this test since self user.isConnected == false we do not show it.
+    func test_Group_SelfUser_SCIM() {/// FIXME: can self user disable myself as admin? In this test since self user.isConnected == false we do not show it.
         // GIVEN
         selfUser.availability = .busy
         selfUser.readReceiptsEnabled = true
@@ -591,7 +591,7 @@ final class ProfileDetailsViewControllerTests: XCTestCase {
         ])
     }
 
-    ///FIXME: can self user disable myself as admin? In this test since self user.isConnected == false we do not show it.
+    /// FIXME: can self user disable myself as admin? In this test since self user.isConnected == false we do not show it.
     func test_Group_SelfUser_NoSCIM() {
         // GIVEN
         selfUser.availability = .busy

--- a/Wire-iOS Tests/SettingsTextCellSnapshotTests.swift
+++ b/Wire-iOS Tests/SettingsTextCellSnapshotTests.swift
@@ -61,7 +61,7 @@ final class SettingsTextCellSnapshotTests: CoreDataSnapshotTestCase {
         // WHEN
         cellDescriptor.featureCell(sut)
 
-        //THEN
+        // THEN
         XCTAssertFalse(sut.textInput.isUserInteractionEnabled)
     }
 }

--- a/Wire-iOS Tests/SketchColorPickerControllerSnapshotTests.swift
+++ b/Wire-iOS Tests/SketchColorPickerControllerSnapshotTests.swift
@@ -64,12 +64,12 @@ final class SketchColorPickerControllerSnapshotTests: XCTestCase {
     }
 
     func testForColorButtonBumpedThreeTimes() {
-        //GIVEN & WHEN
+        // GIVEN & WHEN
         for _ in 1...3 {
             sut.collectionView(sut.colorsCollectionView, didSelectItemAt: IndexPath(item: 1, section: 0))
         }
 
-        //THEN
+        // THEN
         verify(matching: sut)
     }
 }

--- a/Wire-iOS Tests/SplitViewControllerTests.swift
+++ b/Wire-iOS Tests/SplitViewControllerTests.swift
@@ -184,7 +184,7 @@ final class SplitViewControllerTests: XCTestCase {
         XCTAssertEqual(sut.rightView.frame.origin.x, sut.view.frame.size.width, "rightView should stop at the right edge of the sut.view!")
     }
 
-    ///TODO
+    /// TODO
     func testThatSetLeftViewControllerUnrevealedWithoutAnimationHidesLeftView() {
         // GIVEN
         setupLeftView(isLeftViewControllerRevealed: true, animated: false)

--- a/Wire-iOS Tests/StartUIViewControllerSnapshotTests.swift
+++ b/Wire-iOS Tests/StartUIViewControllerSnapshotTests.swift
@@ -40,7 +40,7 @@ final class MockAddressBookHelper: NSObject, AddressBookHelperProtocol {
     }
 
     func requestPermissions(_ callback: ((Bool) -> ())?) {
-        //no-op
+        // no-op
         callback?(false)
     }
 }

--- a/Wire-iOS Tests/Status/StatusMessageTypeTests.swift
+++ b/Wire-iOS Tests/Status/StatusMessageTypeTests.swift
@@ -19,10 +19,10 @@ import XCTest
 @testable import Wire
 
 func localizeString (stringToLocalize: String, language: String) -> String? {
-    guard let path = Bundle.main.path (forResource: language, ofType: "lproj") else { return nil }
+    guard let path = Bundle.main.path(forResource: language, ofType: "lproj") else { return nil }
 
-    let languageBundle = Bundle (path: path)
-    return languageBundle! .localizedString (forKey: stringToLocalize, value: "", table: nil)
+    let languageBundle = Bundle(path: path)
+    return languageBundle! .localizedString(forKey: stringToLocalize, value: "", table: nil)
 }
 
 final class StatusMessageTypeTests: XCTestCase {

--- a/Wire-iOS Tests/SwiftSnapshotTesting/CoreDataFixture.swift
+++ b/Wire-iOS Tests/SwiftSnapshotTesting/CoreDataFixture.swift
@@ -89,7 +89,7 @@ final class CoreDataFixture {
     //
     var selfUserProvider: SelfUserProvider!
 
-    ///From ZMSnapshot
+    /// From ZMSnapshot
 
     typealias ConfigurationWithDeviceType = (_ view: UIView, _ isPad: Bool) -> Void
     typealias Configuration = (_ view: UIView) -> Void
@@ -120,7 +120,7 @@ final class CoreDataFixture {
     var documentsDirectory: URL?
 
     init() {
-        ///From ZMSnapshotTestCase
+        /// From ZMSnapshotTestCase
 
         XCTAssertEqual(UIScreen.main.scale, 2, "Snapshot tests need to be run on a device with a 2x scale")
         if UIDevice.current.systemVersion.compare("10", options: .numeric, range: nil, locale: .current) == .orderedAscending {

--- a/Wire-iOS Tests/SwiftSnapshotTesting/XCTestCase+SnapshotTesting.swift
+++ b/Wire-iOS Tests/SwiftSnapshotTesting/XCTestCase+SnapshotTesting.swift
@@ -440,7 +440,7 @@ extension XCTestCase {
         controller.dismiss(animated: false, completion: completion)
     }
 
-    //MARK: - verify a UIViewController with a set of widths. The SUT is created in the closure instead of reusing
+    // MARK: - verify a UIViewController with a set of widths. The SUT is created in the closure instead of reusing
 
     func verifyInAllPhoneWidths(createSut: () -> UIView,
                                 snapshotBackgroundColor: UIColor? = nil,

--- a/Wire-iOS Tests/UITraitEnvironmentTests.swift
+++ b/Wire-iOS Tests/UITraitEnvironmentTests.swift
@@ -73,7 +73,7 @@ final class MockRegularView: NSObject, UITraitEnvironment {
     var traitCollection: UITraitCollection = UITraitCollection(horizontalSizeClass: .regular)
 
     func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        ///no-op
+        /// no-op
     }
 
 }

--- a/Wire-iOS Tests/URL/URL+StringTests.swift
+++ b/Wire-iOS Tests/URL/URL+StringTests.swift
@@ -20,34 +20,34 @@ import XCTest
 
 final class URL_StringTests: XCTestCase {
     func testThatURLSchemeIsRemoved() {
-        //GIVEN
+        // GIVEN
         let sut = URL(string: "https://www.example.org/abc?1234/")
 
-        //WHEN & THEN
+        // WHEN & THEN
         XCTAssertEqual(sut?.urlWithoutScheme, "www.example.org/abc?1234/")
     }
 
     func testThatURLSchemeAndHostIsRemoved() {
-        //GIVEN
+        // GIVEN
         let sut = URL(string: "https://www.example.org/abc?1234/")
 
-        //WHEN & THEN
+        // WHEN & THEN
         XCTAssertEqual(sut?.urlWithoutSchemeAndHost, "/abc?1234/")
     }
 
     func testThatWWWIsRemoved() {
-        //GIVEN
+        // GIVEN
         let sut = URL(string: "https://www.example.org/abc?1234/")
 
-        //WHEN & THEN
+        // WHEN & THEN
         XCTAssertEqual(sut?.host?.removingPrefixWWW, "example.org")
     }
 
     func testThatTrailingSlashIsRemoved() {
-        //GIVEN
+        // GIVEN
         let sut = URL(string: "https://www.example.org/abc?1234/")
 
-        //WHEN & THEN
+        // WHEN & THEN
         XCTAssertEqual(sut?.absoluteString.removingTrailingForwardSlash, "https://www.example.org/abc?1234")
     }
 }

--- a/Wire-iOS Tests/Utils/CoreDataSnapshotTestCase.swift
+++ b/Wire-iOS Tests/Utils/CoreDataSnapshotTestCase.swift
@@ -148,7 +148,7 @@ class CoreDataSnapshotTestCase: ZMSnapshotTestCase {
         conversation.setPrimitiveValue(1, forKey: ZMConversationInternalEstimatedUnreadCountKey)
     }
 
-//MARK: - mock conversation
+// MARK: - mock conversation
 
     func createGroupConversation() -> ZMConversation {
         return ZMConversation.createGroupConversation(moc: uiMOC, otherUser: otherUser, selfUser: selfUser)
@@ -162,7 +162,7 @@ class CoreDataSnapshotTestCase: ZMSnapshotTestCase {
         return ZMConversation.createGroupConversationOnlyAdmin(moc: uiMOC, selfUser: selfUser)
     }
 
-//MARK: - mock service user
+// MARK: - mock service user
 
     func createServiceUser() -> ZMUser {
         let serviceUser = ZMUser.insertNewObject(in: uiMOC)

--- a/Wire-iOS Tests/Utils/XCTestCase+DeviceSize.swift
+++ b/Wire-iOS Tests/Utils/XCTestCase+DeviceSize.swift
@@ -23,7 +23,7 @@ extension XCTestCase {
     static let DeviceSizeIPhone6          = CGSize(width: 375, height: 667)
     static let DeviceSizeIPhone6Plus      = CGSize(width: 414, height: 736)
     static let DeviceSizeIPhoneX          = CGSize(width: 375, height: 812)
-    static let DeviceSizeIPhoneXR         = CGSize(width: 414, height: 896) ///same size as iPhone Xs Max
+    static let DeviceSizeIPhoneXR         = CGSize(width: 414, height: 896) /// same size as iPhone Xs Max
     static let DeviceSizeIPadPortrait     = CGSize(width: 768, height: 1024)
     static let DeviceSizeIPadLandscape    = CGSize(width: 1024, height: 768)
 

--- a/Wire-iOS/Sources/Analytics/Analytics.swift
+++ b/Wire-iOS/Sources/Analytics/Analytics.swift
@@ -88,11 +88,11 @@ final class Analytics: NSObject {
 
 extension Analytics: AnalyticsType {
     func setPersistedAttributes(_ attributes: [String: NSObject]?, for event: String) {
-        //no-op
+        // no-op
     }
 
     func persistedAttributes(for event: String) -> [String: NSObject]? {
-        //no-op
+        // no-op
         return nil
     }
 

--- a/Wire-iOS/Sources/Analytics/AnalyticsConsoleProvider.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsConsoleProvider.swift
@@ -48,12 +48,12 @@ extension AnalyticsConsoleProvider: AnalyticsProvider {
     /// no-op
     var selfUser: UserType? {
         get {
-            //no-op
+            // no-op
             return nil
         }
 
         set {
-            //no-op
+            // no-op
         }
     }
 

--- a/Wire-iOS/Sources/Analytics/AnalyticsCountlyProvider.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsCountlyProvider.swift
@@ -213,7 +213,7 @@ final class AnalyticsCountlyProvider: AnalyticsProvider {
 
     func tagEvent(_ event: String,
                   attributes: [String: Any]) {
-        //store the event before self user is assigned, send it later when self user is ready.
+        // store the event before self user is assigned, send it later when self user is ready.
         guard selfUser != nil else {
             pendingEvents.append(PendingEvent(event, attributes))
             return
@@ -240,7 +240,7 @@ final class AnalyticsCountlyProvider: AnalyticsProvider {
     }
 
     func setSuperProperty(_ name: String, value: Any?) {
-        //TODO
+        // TODO
     }
 
     func flush(completion: Completion?) {

--- a/Wire-iOS/Sources/Analytics/Events/Analytics+Services.swift
+++ b/Wire-iOS/Sources/Analytics/Events/Analytics+Services.swift
@@ -19,7 +19,7 @@
 import Foundation
 import WireDataModel
 
-///TODO: move to DM
+/// TODO: move to DM
 fileprivate extension ZMConversation {
     var otherNonServiceParticipants: [UserType] {
         let users = Array(localParticipants)

--- a/Wire-iOS/Sources/Analytics/Events/ZMConversation+Analytics.swift
+++ b/Wire-iOS/Sources/Analytics/Events/ZMConversation+Analytics.swift
@@ -50,7 +50,7 @@ extension ZMConversation {
         return ConversationType.type(self)?.analyticsTypeString
     }
 
-    ///TODO: move to DM
+    /// TODO: move to DM
     /// Whether the conversation is a 1-on-1 conversation with a service user
     var isOneOnOneServiceUserConversation: Bool {
         guard self.localParticipants.count == 2,
@@ -62,7 +62,7 @@ extension ZMConversation {
                 otherUser.providerIdentifier != nil
     }
 
-    ///TODO: move to DM
+    /// TODO: move to DM
     /// Whether the conversation includes at least 1 service user.
     var includesServiceUser: Bool {
         let participants = Array(localParticipants)

--- a/Wire-iOS/Sources/AppRootRouter.swift
+++ b/Wire-iOS/Sources/AppRootRouter.swift
@@ -55,7 +55,7 @@ public class AppRootRouter: NSObject {
     // MARK: - Private Set Property
     private(set) var sessionManager: SessionManager
 
-    //TO DO: This should be private
+    // TO DO: This should be private
     private(set) var rootViewController: RootViewController
 
     // MARK: - Initialization

--- a/Wire-iOS/Sources/Authentication/Coordinator/Coordinator+Delegates/AuthenticationCoordinator+PasscodeSetup.swift
+++ b/Wire-iOS/Sources/Authentication/Coordinator/Coordinator+Delegates/AuthenticationCoordinator+PasscodeSetup.swift
@@ -19,7 +19,7 @@ import Foundation
 
 extension AuthenticationCoordinator: PasscodeSetupViewControllerDelegate {
     func passcodeSetupControllerWasDismissed() {
-        //no-op
+        // no-op
     }
 
     func passcodeSetupControllerDidFinish() {

--- a/Wire-iOS/Sources/Authentication/Helpers/CountryCode/CountryCodeTableViewController.swift
+++ b/Wire-iOS/Sources/Authentication/Helpers/CountryCode/CountryCodeTableViewController.swift
@@ -140,7 +140,7 @@ extension CountryCodeTableViewController: UISearchBarDelegate {
 
 // MARK: - UISearchResultsUpdating
 
-///TODO: test
+/// TODO: test
 extension CountryCodeTableViewController: UISearchResultsUpdating {
 
     func filter(searchText: String?) -> [Any]? {

--- a/Wire-iOS/Sources/Authentication/Interface/Team Invites/TeamMemberInviteViewController.swift
+++ b/Wire-iOS/Sources/Authentication/Interface/Team Invites/TeamMemberInviteViewController.swift
@@ -198,10 +198,10 @@ final class TeamMemberInviteViewController: AuthenticationStepViewController {
     // MARK: - AuthenticationCoordinatedViewController
 
     func executeErrorFeedbackAction(_ feedbackAction: AuthenticationErrorFeedbackAction) {
-        //no-op
+        // no-op
     }
 
     func displayError(_ error: Error) {
-        //no-op
+        // no-op
     }
 }

--- a/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationStepController.swift
+++ b/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationStepController.swift
@@ -362,7 +362,7 @@ extension AuthenticationStepController {
     // MARK: - AuthenticationCoordinatedViewController
 
     func displayError(_ error: Error) {
-        //no-op
+        // no-op
     }
 
     func executeErrorFeedbackAction(_ feedbackAction: AuthenticationErrorFeedbackAction) {

--- a/Wire-iOS/Sources/Authentication/Interface/ViewControllers/RemoveClientStepViewController.swift
+++ b/Wire-iOS/Sources/Authentication/Interface/ViewControllers/RemoveClientStepViewController.swift
@@ -123,11 +123,11 @@ final class RemoveClientStepViewController: UIViewController, AuthenticationCoor
     // MARK: - AuthenticationCoordinatedViewController
 
     func executeErrorFeedbackAction(_ feedbackAction: AuthenticationErrorFeedbackAction) {
-        //no-op
+        // no-op
     }
 
     func displayError(_ error: Error) {
-        //no-op
+        // no-op
     }
 }
 

--- a/Wire-iOS/Sources/Authentication/Interface/Views/ValidatedTextField.swift
+++ b/Wire-iOS/Sources/Authentication/Interface/Views/ValidatedTextField.swift
@@ -195,7 +195,7 @@ final class ValidatedTextField: AccessoryTextField, TextContainer, Themeable {
             autocapitalizationType = .none
             returnKeyType = isNew ? .default : .continue
             if #available(iOS 12, *) {
-                //Hack: disable auto fill passcode
+                // Hack: disable auto fill passcode
                 textContentType = .oneTimeCode
                 passwordRules = textFieldValidator.passwordRules
             } else {

--- a/Wire-iOS/Sources/Authentication/Landing/LandingViewController.swift
+++ b/Wire-iOS/Sources/Authentication/Landing/LandingViewController.swift
@@ -562,10 +562,10 @@ final class LandingViewController: AuthenticationStepViewController {
     // MARK: - AuthenticationCoordinatedViewController
 
     func executeErrorFeedbackAction(_ feedbackAction: AuthenticationErrorFeedbackAction) {
-        //no-op
+        // no-op
     }
 
     func displayError(_ error: Error) {
-        //no-op
+        // no-op
     }
 }

--- a/Wire-iOS/Sources/Components/Buttons/SpinnerButton.swift
+++ b/Wire-iOS/Sources/Components/Buttons/SpinnerButton.swift
@@ -80,7 +80,7 @@ final class SpinnerButton: Button {
             titleLabel.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor, constant: CGFloat.SpinnerButton.contentInset)])
     }
 
-    ///custom full style with accent color for disabled state.
+    /// custom full style with accent color for disabled state.
     override func updateFullStyle() {
         setBackgroundImageColor(UIColor.AlarmButton.alarmRed, for: .disabled)
         setBackgroundImageColor(UIColor.AlarmButton.alarmRed, for: .normal)
@@ -92,7 +92,7 @@ final class SpinnerButton: Button {
         setTitleColor(UIColor.from(scheme: .textDimmed, variant: variant), for: .highlighted)
     }
 
-    ///custom empty style with accent color for disabled state.
+    /// custom empty style with accent color for disabled state.
     override func updateEmptyStyle() {
         // remember reset background image colors when style is switch
         setBackgroundImageColor(.clear, for: .disabled)

--- a/Wire-iOS/Sources/Components/ShareViewController/ShareViewController.swift
+++ b/Wire-iOS/Sources/Components/ShareViewController/ShareViewController.swift
@@ -251,7 +251,7 @@ extension ShareViewController: TokenFieldDelegate {
     }
 
     func tokenFieldDidConfirmSelection(_ controller: TokenField) {
-        //no-op
+        // no-op
     }
 
 }

--- a/Wire-iOS/Sources/Components/TokenField/TokenField.swift
+++ b/Wire-iOS/Sources/Components/TokenField/TokenField.swift
@@ -427,7 +427,7 @@ final class TokenField: UIView {
         return NSAttributedString(string: collapsedText, attributes: textAttributes)
     }
 
-    ///clean filter text other then NSTextAttachment
+    /// clean filter text other then NSTextAttachment
     func clearFilterText() {
         guard let text = textView.text else { return }
 

--- a/Wire-iOS/Sources/Components/TokenField/TokenizedTextView.swift
+++ b/Wire-iOS/Sources/Components/TokenField/TokenizedTextView.swift
@@ -23,8 +23,8 @@ protocol TokenizedTextViewDelegate: class {
     func tokenizedTextView(_ textView: TokenizedTextView, textContainerInsetChanged textContainerInset: UIEdgeInsets)
 }
 
-//! Custom UITextView subclass to be used in TokenField.
-//! Shouldn't be used anywhere else.
+// ! Custom UITextView subclass to be used in TokenField.
+// ! Shouldn't be used anywhere else.
 // TODO: as a inner class of TokenField
 
 final class TokenizedTextView: TextView {

--- a/Wire-iOS/Sources/ForegroundNotificationFilter.swift
+++ b/Wire-iOS/Sources/ForegroundNotificationFilter.swift
@@ -29,7 +29,7 @@ final class ForegroundNotificationFilter {
     }
 }
 
-//TO DO: Ask for the logic, not clear when a notification shuld be presented
+// TO DO: Ask for the logic, not clear when a notification shuld be presented
 extension ForegroundNotificationFilter: ForegroundNotificationResponder {
 
     func shouldPresentNotification(with userInfo: NotificationUserInfo) -> Bool {

--- a/Wire-iOS/Sources/Helpers/ImageCache.swift
+++ b/Wire-iOS/Sources/Helpers/ImageCache.swift
@@ -19,7 +19,7 @@
 import Foundation
 import UIKit
 
-///TODO: remove public after MockUser is convert to Swift
+/// TODO: remove public after MockUser is convert to Swift
 public final class ImageCache<T: AnyObject> {
     var cache: NSCache<NSString, T> = NSCache()
     var processingQueue = DispatchQueue(label: "ImageCacheQueue", qos: .background, attributes: [.concurrent])

--- a/Wire-iOS/Sources/Helpers/UIImage+ImageUtilities.swift
+++ b/Wire-iOS/Sources/Helpers/UIImage+ImageUtilities.swift
@@ -133,7 +133,7 @@ extension UIImage {
 
         guard let scaledImage = CGImageSourceCreateThumbnailAtIndex(source, 0, UIImage.thumbnailOptions(withMaxSize: longSideLength)) else { return nil }
 
-        ///TODO: read screen scale
+        /// TODO: read screen scale
         self.init(cgImage: scaledImage, scale: 2.0, orientation: .up)
     }
 

--- a/Wire-iOS/Sources/Helpers/UIScreen+SafeArea.swift
+++ b/Wire-iOS/Sources/Helpers/UIScreen+SafeArea.swift
@@ -40,8 +40,8 @@ extension UIScreen {
 
     static var hasNotch: Bool {
         if #available(iOS 12, *) {
-            ///on iOS12 insets.top == 20 on device without notch.
-            ///insets.top == 44 on device with notch.
+            /// on iOS12 insets.top == 20 on device without notch.
+            /// insets.top == 44 on device with notch.
             guard let window = UIApplication.shared.keyWindow else { return false }
             let insets = window.safeAreaInsets
 

--- a/Wire-iOS/Sources/Helpers/UserClient+Fingerprint.swift
+++ b/Wire-iOS/Sources/Helpers/UserClient+Fingerprint.swift
@@ -20,7 +20,7 @@ import Foundation
 import UIKit
 import WireDataModel
 
-//TODO: merge to UserClientType or stay in UI project? It is depends on localized string resource
+// TODO: merge to UserClientType or stay in UI project? It is depends on localized string resource
 protocol UserClientTypeAttributedString {
     func attributedRemoteIdentifier(_ attributes: [NSAttributedString.Key: AnyObject], boldAttributes: [NSAttributedString.Key: AnyObject], uppercase: Bool) -> NSAttributedString
 }

--- a/Wire-iOS/Sources/Helpers/syncengine/ZMConversation+Additions.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMConversation+Additions.swift
@@ -20,7 +20,7 @@ import WireSyncEngine
 
 extension ZMConversation {
 
-    ///TODO: move to DM
+    /// TODO: move to DM
     var firstActiveParticipantOtherThanSelf: ZMUser? {
         guard let selfUser = ZMUser.selfUser() else { return localParticipants.first }
 

--- a/Wire-iOS/Sources/LaunchSequenceOperation.swift
+++ b/Wire-iOS/Sources/LaunchSequenceOperation.swift
@@ -112,7 +112,7 @@ final class AppCenterOperation: NSObject, LaunchSequenceOperation {
             MSAppCenter.setTrackingEnabled(false)
             return
         }
-        UserDefaults.standard.set(true, forKey: "kBITExcludeApplicationSupportFromBackup") //check
+        UserDefaults.standard.set(true, forKey: "kBITExcludeApplicationSupportFromBackup") // check
 
         guard !TrackingManager.shared.disableCrashSharing else {
             MSAppCenter.setTrackingEnabled(false)

--- a/Wire-iOS/Sources/UserInterface/Availability/AvailabilityStringBuilder.swift
+++ b/Wire-iOS/Sources/UserInterface/Availability/AvailabilityStringBuilder.swift
@@ -43,7 +43,7 @@ final class AvailabilityStringBuilder: NSObject {
                 color = UIColor.from(scheme: .textForeground)
             }
             case .placeholder: do {
-                guard availability != .none else { //Should use the default placeholder string
+                guard availability != .none else { // Should use the default placeholder string
                     return nil
                 }
                 title = "availability.\(availability.canonicalName)".localized.localizedUppercase

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -310,7 +310,7 @@ extension CallViewController: ActiveSpeakersObserver {
     }
 }
 
-//MARK: - WireCallCenterCallParticipantObserver
+// MARK: - WireCallCenterCallParticipantObserver
 
 extension CallViewController: WireCallCenterCallParticipantObserver {
 

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
@@ -25,7 +25,7 @@ protocol CollectionsViewControllerDelegate: class {
 }
 
 final class CollectionsViewController: UIViewController {
-    var onDismiss: ((CollectionsViewController)->Void)?
+    var onDismiss: ((CollectionsViewController) -> Void)?
     let sections: CollectionsSectionSet
     weak var delegate: CollectionsViewControllerDelegate?
     var isShowingSearchResults: Bool {

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
@@ -161,7 +161,7 @@ final class CollectionsViewController: UIViewController {
         navigationController?.interactivePopGestureRecognizer?.isEnabled = true
         navigationController?.interactivePopGestureRecognizer?.delegate = self
 
-        ///Prevent content overlaps navi bar
+        /// Prevent content overlaps navi bar
         navigationController?.navigationBar.isTranslucent = false
     }
 

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/RotationAwareNavigationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/RotationAwareNavigationController.swift
@@ -21,7 +21,7 @@ import UIKit
 
 final class RotationAwareNavigationController: UINavigationController, PopoverPresenter, SpinnerCapable {
 
-    //MARK: SpinnerCapable
+    // MARK: SpinnerCapable
     var dismissSpinner: SpinnerCompletion?
 
     // PopoverPresenter

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewControllerTransitionContext.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewControllerTransitionContext.swift
@@ -86,19 +86,19 @@ final class SplitViewControllerTransitionContext: NSObject, UIViewControllerCont
     }
 
     func updateInteractiveTransition(_ percentComplete: CGFloat) {
-        //no-op
+        // no-op
     }
 
     func finishInteractiveTransition() {
-        //no-op
+        // no-op
     }
 
     func cancelInteractiveTransition() {
-        //no-op
+        // no-op
     }
 
     func pauseInteractiveTransition() {
-        //no-op
+        // no-op
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/Components/KeyboardAvoidingViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/KeyboardAvoidingViewController.swift
@@ -21,7 +21,7 @@ import UIKit
 
 class KeyboardAvoidingViewController: UIViewController, SpinnerCapable {
 
-    //MARK: SpinnerCapable
+    // MARK: SpinnerCapable
     var dismissSpinner: SpinnerCompletion?
 
     let viewController: UIViewController
@@ -133,7 +133,7 @@ class KeyboardAvoidingViewController: UIViewController, SpinnerCapable {
         if !keyboardFrameInView.origin.y.isInfinite,
             modalPresentationStyle == .formSheet,
             let frame = presentationController?.frameOfPresentedViewInContainerView {
-            bottomOffset += frame.minY ///TODO: no need to add when no keyboard
+            bottomOffset += frame.minY /// TODO: no need to add when no keyboard
         }
 
         guard bottomEdgeConstraint.constant != bottomOffset else { return }

--- a/Wire-iOS/Sources/UserInterface/Components/NetworkStatus/NetworkStatusViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/NetworkStatus/NetworkStatusViewController.swift
@@ -129,7 +129,7 @@ final class NetworkStatusViewController: UIViewController {
         case .onlineSynchronizing:
             return .onlineSynchronizing
         @unknown default:
-            ///TODO: ZMNetworkState change to NS_CLOSED_ENUM 
+            /// TODO: ZMNetworkState change to NS_CLOSED_ENUM 
             fatalError()
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Components/UIPasteboard+MediaAsset.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/UIPasteboard+MediaAsset.swift
@@ -32,7 +32,7 @@ extension UIPasteboard {
         }
     }
 
-    ///TODO: get/set
+    /// TODO: get/set
     func mediaAsset() -> MediaAsset? {
         if contains(pasteboardTypes: [kUTTypeGIF as String]) {
             let data: Data? = self.data(forPasteboardType: kUTTypeGIF as String)

--- a/Wire-iOS/Sources/UserInterface/Components/Views/CheckmarkCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/CheckmarkCell.swift
@@ -79,7 +79,7 @@ final class CheckmarkCell: RightIconDetailsCell {
         }
 
         set {
-            //no op
+            // no op
         }
     }
 
@@ -89,7 +89,7 @@ final class CheckmarkCell: RightIconDetailsCell {
         }
 
         set {
-            //no op
+            // no op
         }
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Components/Views/PassthroughTouchesView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/PassthroughTouchesView.swift
@@ -26,7 +26,7 @@ final class PassthroughTouchesView: UIView {
         }
 
         set {
-            //no-op
+            // no-op
         }
     }
 

--- a/Wire-iOS/Sources/UserInterface/ConnectRequests/ConnectRequestsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConnectRequests/ConnectRequestsViewController.swift
@@ -164,6 +164,6 @@ extension ConnectRequestsViewController: ZMConversationListObserver {
 
 extension ConnectRequestsViewController: ZMUserObserver {
     func userDidChange(_ change: UserChangeInfo) {
-        tableView.reloadData() //may need a slightly different approach, like enumerating through table cells of type FirstTimeTableViewCell and setting their bgColor property
+        tableView.reloadData() // may need a slightly different approach, like enumerating through table cells of type FirstTimeTableViewCell and setting their bgColor property
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation Options/CellConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/CellConfiguration.swift
@@ -35,7 +35,7 @@ enum CellConfiguration {
                     color: UIColor?,
                     action: Action)
 
-    ///For toggle without icon, leave icon and color nil
+    /// For toggle without icon, leave icon and color nil
     case iconToggle(title: String,
         subtitle: String,
         identifier: String,

--- a/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationOptionsViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationOptionsViewModel.swift
@@ -96,7 +96,7 @@ final class ConversationOptionsViewModel {
         state.rows = computeVisibleRows()
     }
 
-    private func computeVisibleRows() -> [CellConfiguration] {///TODO: copy?
+    private func computeVisibleRows() -> [CellConfiguration] {/// TODO: copy?
         var rows: [CellConfiguration] = [.allowGuestsToogle(
                 get: { [unowned self] in return self.configuration.allowGuests },
                 set: { [unowned self] in self.setAllowGuests($0) }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/CellComponents/SenderCellComponent.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/CellComponents/SenderCellComponent.swift
@@ -146,7 +146,7 @@ final class SenderCellComponent: UIView {
         return NSAttributedString(string: string, attributes: [.foregroundColor: kind.color, .font: kind.font])
     }
 
-    //MARK: - tap gesture of avatar
+    // MARK: - tap gesture of avatar
 
     @objc func tappedOnAvatar() {
         guard let user = avatar.user else { return }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCell.swift
@@ -906,7 +906,7 @@ final class ConversationNewDeviceSystemMessageCellDescription: ConversationMessa
     private static func configuration(for systemMessage: ZMSystemMessageData, in conversation: ZMConversation) -> View.Configuration {
 
         let textAttributes = TextAttributes(boldFont: .mediumSemiboldFont, normalFont: .mediumFont, textColor: UIColor.from(scheme: .textForeground), link: View.userClientURL)
-        let clients = systemMessage.clients.compactMap ({ $0 as? UserClientType })
+        let clients = systemMessage.clients.compactMap({ $0 as? UserClientType })
         let users = systemMessage.userTypes.lazy
             .compactMap { $0 as? UserType }
             .sorted { $0.name < $1.name }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/MessageAction.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/MessageAction.swift
@@ -38,7 +38,7 @@ enum MessageAction: CaseIterable {
     showInConversation,
     sketchDraw,
     sketchEmoji,
-    ///Not included in ConversationMessageActionController.allMessageActions, for image viewer/open quote
+    /// Not included in ConversationMessageActionController.allMessageActions, for image viewer/open quote
     present,
     openQuote,
     resetSession

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
@@ -310,7 +310,7 @@ final class MessageToolboxView: UIView {
                 self.detailsLabel.isHidden = timestamp == nil
                 self.detailsLabel.numberOfLines = 1
                 self.statusLabel.attributedText = status
-                //override accessibilityLabel if the attributed string has customized accessibilityLabel
+                // override accessibilityLabel if the attributed string has customized accessibilityLabel
                 if let accessibilityLabel = status?.accessibilityLabel {
                     self.statusLabel.accessibilityLabel = accessibilityLabel
                 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/NSAttributedString+MessageFormatting.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/NSAttributedString+MessageFormatting.swift
@@ -184,7 +184,7 @@ extension NSMutableAttributedString {
 
         let allowedIndexSet = IndexSet(integersIn: Range<Int>(wholeRange)!, excluding: excludedRanges)
 
-        ///reverse the order of replacing, if we start replace from the beginning, the string may be shorten and other ranges may be invalid.
+        /// reverse the order of replacing, if we start replace from the beginning, the string may be shorten and other ranges may be invalid.
         for range in allowedIndexSet.rangeView.sorted(by: {$0.lowerBound > $1.lowerBound}) {
             let convertedRange = NSRange(location: range.lowerBound, length: range.upperBound - range.lowerBound)
             mutableString.resolveEmoticonShortcuts(in: convertedRange)

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+ConversationMessageCellDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+ConversationMessageCellDelegate.swift
@@ -23,7 +23,7 @@ import WireDataModel
 extension UIView {
     func targetView(for message: ZMConversationMessage!, dataSource: ConversationTableViewDataSource) -> UIView {
 
-        ///if the view is a tableView, search for a visible cell that contains the message and the cell is a SelectableView
+        /// if the view is a tableView, search for a visible cell that contains the message and the cell is a SelectableView
         guard let tableView: UITableView = self as? UITableView else {
             return self
         }
@@ -53,7 +53,7 @@ extension ConversationContentViewController: ConversationMessageCellDelegate {
                         view: UIView) {
         let actionView = view.targetView(for: message, dataSource: dataSource)
 
-        ///Do not dismiss Modal for forward since share VC is present in a popover
+        /// Do not dismiss Modal for forward since share VC is present in a popover
         let shouldDismissModal = action != .delete && action != .copy &&
             !(action == .forward && isIPadRegular())
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
@@ -127,7 +127,7 @@ extension ZMConversationMessage {
     }
 }
 
-extension ZMConversationList {///TODO mv to DM
+extension ZMConversationList {/// TODO mv to DM
     func shareableConversations(excluding: ZMConversation? = nil) -> [ZMConversation] {
         return self.map { $0 as! ZMConversation }.filter { (conversation: ZMConversation) -> (Bool) in
             return (conversation.conversationType == .oneOnOne || conversation.conversationType == .group) &&

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
@@ -24,7 +24,7 @@ private let zmLog = ZMSLog(tag: "ConversationContentViewController")
 
 /// The main conversation view controller
 final class ConversationContentViewController: UIViewController, PopoverPresenter, SpinnerCapable {
-    //MARK: PopoverPresenter
+    // MARK: PopoverPresenter
     var presentedPopover: UIPopoverPresentationController?
     var popoverPointToView: UIView?
     var dismissSpinner: SpinnerCompletion?
@@ -396,6 +396,6 @@ extension ConversationContentViewController: UITableViewDelegate {
 
 extension ConversationContentViewController: UITableViewDataSourcePrefetching {
     func tableView(_ tableView: UITableView, prefetchRowsAt indexPaths: [IndexPath]) {
-        //no-op
+        // no-op
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+ConversationContentViewControllerDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+ConversationContentViewControllerDelegate.swift
@@ -130,7 +130,7 @@ extension ConversationViewController {
         createAndPresentParticipantsPopoverController(with: sourceView.bounds, from: sourceView, contentViewController: viewController)
     }
 
-    //MARK: - Application Events & Notifications
+    // MARK: - Application Events & Notifications
 
     @objc
     func menuDidHide(_ notification: Notification?) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
@@ -325,7 +325,7 @@ final class ConversationViewController: UIViewController {
         updateRightNavigationItemsButtons()
     }
 
-    //MARK: - ParticipantsPopover
+    // MARK: - ParticipantsPopover
 
     private func hideAndDestroyParticipantsPopover() {
         if (presentedViewController is GroupDetailsViewController) || (presentedViewController is ProfileViewController) {
@@ -334,7 +334,7 @@ final class ConversationViewController: UIViewController {
     }
 }
 
-//MARK: - InvisibleInputAccessoryViewDelegate
+// MARK: - InvisibleInputAccessoryViewDelegate
 
 extension ConversationViewController: InvisibleInputAccessoryViewDelegate {
 
@@ -369,7 +369,7 @@ extension ConversationViewController: InvisibleInputAccessoryViewDelegate {
     }
 }
 
-//MARK: - ZMConversationObserver
+// MARK: - ZMConversationObserver
 
 extension ConversationViewController: ZMConversationObserver {
     public func conversationDidChange(_ note: ConversationChangeInfo) {
@@ -404,7 +404,7 @@ extension ConversationViewController: ZMConversationObserver {
     }
 }
 
-//MARK: - ZMConversationListObserver
+// MARK: - ZMConversationListObserver
 
 extension ConversationViewController: ZMConversationListObserver {
     public func conversationListDidChange(_ changeInfo: ConversationListChangeInfo) {
@@ -419,7 +419,7 @@ extension ConversationViewController: ZMConversationListObserver {
     }
 }
 
-//MARK: - InputBar
+// MARK: - InputBar
 
 extension ConversationViewController: ConversationInputBarViewControllerDelegate {
     func conversationInputBarViewControllerDidComposeText(text: String,

--- a/Wire-iOS/Sources/UserInterface/Conversation/Create/Sections/ConversationCreateNameSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Create/Sections/ConversationCreateNameSectionController.swift
@@ -59,7 +59,7 @@ final class ConversationCreateNameSectionController: NSObject, CollectionViewSec
         nameCell?.textField.resignFirstResponder()
     }
 
-    //MARK: - collectionView
+    // MARK: - collectionView
 
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return 1

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
@@ -420,7 +420,7 @@ extension CameraKeyboardViewController: UICollectionViewDelegateFlowLayout, UICo
         }
     }
 
-    ///TODO: a protocol for this for testing
+    /// TODO: a protocol for this for testing
     @objc
     var shouldBlockCallingRelatedActions: Bool {
         return ZMUserSession.shared()?.isCallOngoing ?? false

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Audio.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Audio.swift
@@ -186,7 +186,7 @@ extension ConversationInputBarViewController {
             }, completion: nil)
     }
 
-    func hideCameraKeyboardViewController(_ completion: @escaping ()->Void) {
+    func hideCameraKeyboardViewController(_ completion: @escaping () -> Void) {
         self.inputBar.textView.resignFirstResponder()
         delay(0.3) {
             self.mode = .textInput

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
@@ -62,7 +62,7 @@ extension ConversationInputBarViewController: CameraKeyboardViewControllerDelega
                     let popover = videoEditor.popoverPresentationController
                     popover?.sourceView = self.parent?.view
 
-                    ///arrow point to camera button.
+                    /// arrow point to camera button.
                     popover?.permittedArrowDirections = .down
 
                     popover?.sourceRect = self.photoButton.popoverSourceRect(from: self)

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+DragAndDrop.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+DragAndDrop.swift
@@ -53,7 +53,7 @@ extension ConversationInputBarViewController: UIDropInteractionDelegate {
                             }
                 }
             })
-            ///TODO: it's a temporary solution to drag only one image, while we have no design for multiple images
+            /// TODO: it's a temporary solution to drag only one image, while we have no design for multiple images
             break
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+KeyCommand.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+KeyCommand.swift
@@ -35,8 +35,8 @@ extension ConversationInputBarViewController {
         } else if inputBar.textView.text.count == 0 {
             commands.append(UIKeyCommand(input: UIKeyCommand.inputUpArrow, modifierFlags: [], action: #selector(upArrowPressed), discoverabilityTitle: "conversation.input_bar.shortcut.edit_last_message".localized))
         } else if let mentionsView = mentionsView as? UIViewController, !mentionsView.view.isHidden {
-            commands.append(UIKeyCommand(input: UIKeyCommand.inputUpArrow, modifierFlags: [], action: #selector(upArrowPressedForMention), discoverabilityTitle: "conversation.input_bar.shortcut.choosePreviousMention".localized)) ///TODO: string rsc
-            commands.append(UIKeyCommand(input: UIKeyCommand.inputDownArrow, modifierFlags: [], action: #selector(downArrowPressedForMention), discoverabilityTitle: "conversation.input_bar.shortcut.chooseNextMention".localized)) ///TODO: string rsc
+            commands.append(UIKeyCommand(input: UIKeyCommand.inputUpArrow, modifierFlags: [], action: #selector(upArrowPressedForMention), discoverabilityTitle: "conversation.input_bar.shortcut.choosePreviousMention".localized)) /// TODO: string rsc
+            commands.append(UIKeyCommand(input: UIKeyCommand.inputDownArrow, modifierFlags: [], action: #selector(downArrowPressedForMention), discoverabilityTitle: "conversation.input_bar.shortcut.chooseNextMention".localized)) /// TODO: string rsc
 
         }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
@@ -160,7 +160,7 @@ final class ConversationInputBarViewController: UIViewController,
         return view
     }()
 
-    //MARK: custom keyboards
+    // MARK: custom keyboards
     var audioRecordViewController: AudioRecordViewController?
     var audioRecordViewContainer: UIView?
     var audioRecordKeyboardViewController: AudioRecordKeyboardViewController?
@@ -168,7 +168,7 @@ final class ConversationInputBarViewController: UIViewController,
     var cameraKeyboardViewController: CameraKeyboardViewController?
     var ephemeralKeyboardViewController: EphemeralKeyboardViewController?
 
-    //MARK: text input
+    // MARK: text input
     lazy var sendController: ConversationInputBarSendController = {
         return ConversationInputBarSendController(conversation: conversation)
     }()
@@ -177,7 +177,7 @@ final class ConversationInputBarViewController: UIViewController,
     var quotedMessage: ZMConversationMessage?
     var replyComposingView: ReplyComposingView?
 
-    //MARK: feedback
+    // MARK: feedback
     lazy var impactFeedbackGenerator: UIImpactFeedbackGenerator = UIImpactFeedbackGenerator(style: .light)
     private lazy var notificationFeedbackGenerator: UINotificationFeedbackGenerator = UINotificationFeedbackGenerator()
 
@@ -653,7 +653,7 @@ extension ConversationInputBarViewController: GiphySearchViewControllerDelegate 
 
 extension ConversationInputBarViewController: UIImagePickerControllerDelegate {
 
-    ///TODO: check this is still necessary on iOS 13?
+    /// TODO: check this is still necessary on iOS 13?
     private func statusBarBlinksRedFix() {
         // Workaround http://stackoverflow.com/questions/26651355/
         do {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/Emoji/EmojiSectionViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/Emoji/EmojiSectionViewController.swift
@@ -106,7 +106,7 @@ final class EmojiSectionViewController: UIViewController {
             fallthrough
         case .changed:
             let location = recognizer.location(in: view)
-            guard let button = sectionButtons.filter ({ $0.frame.contains(location) }).first else { return }
+            guard let button = sectionButtons.filter({ $0.frame.contains(location) }).first else { return }
             guard let type = typesByButton[button] else { return }
             sectionDelegate?.sectionViewController(self, didSelect: type, scrolling: true)
             selectedType = type

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/TypingIndicatorView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/TypingIndicatorView.swift
@@ -68,7 +68,7 @@ final class AnimatedPenView: UIView {
 
     func setupConstraints() {
         constrain(self, dots, pen) { container, dots, pen in
-            ///lower the priority to prevent this breaks when TypingIndicatorView's width = 0
+            /// lower the priority to prevent this breaks when TypingIndicatorView's width = 0
             distribute(by: 2, horizontally: dots, pen) ~ .defaultHigh
 
             dots.left == container.left
@@ -162,14 +162,14 @@ final class TypingIndicatorView: UIView {
         constrain(self, container, nameLabel, animatedPen, expandingLine) { view, container, nameLabel, animatedPen, expandingLine in
             container.edges == view.edges
 
-            ///lower the priority to prevent this breaks when TypingIndicatorView's width = 0
+            /// lower the priority to prevent this breaks when TypingIndicatorView's width = 0
             distribute(by: 4, horizontally: animatedPen, nameLabel) ~ .defaultHigh
 
             animatedPen.left == container.left + 8
             animatedPen.centerY == container.centerY
 
             nameLabel.top == container.top + 4
-            ///lower the priority to prevent this breaks when container's height = 0
+            /// lower the priority to prevent this breaks when container's height = 0
             nameLabel.bottom == container.bottom - 4 ~ .defaultHigh
             nameLabel.right == container.right - 8
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsContentViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsContentViewController.swift
@@ -303,7 +303,7 @@ extension MessageDetailsContentViewController: ProfileViewControllerDelegate {
     }
 
     func profileViewController(_ controller: ProfileViewController?, wantsToCreateConversationWithName name: String?, users: UserSet) {
-        //no-op
+        // no-op
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/ConversationList/Container/ViewModel/ZMConversationList+HasConversation.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/Container/ViewModel/ZMConversationList+HasConversation.swift
@@ -27,7 +27,7 @@ extension ZMConversationList {
     }
 }
 
-///TODO: move to DM
+/// TODO: move to DM
 extension ZMConversationList: ConversationListHelperType {
     static var hasArchivedConversations: Bool {
         guard let session = ZMUserSession.shared() else { return false }
@@ -36,7 +36,7 @@ extension ZMConversationList: ConversationListHelperType {
     }
 }
 
-///TODO: retire this static helper, refactor as  ZMUserSession's property
+/// TODO: retire this static helper, refactor as  ZMUserSession's property
 protocol ConversationListHelperType {
     static var hasArchivedConversations: Bool { get }
 }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListCell.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListCell.swift
@@ -52,7 +52,7 @@ final class ConversationListCell: SwipeMenuCollectionCell,
     private var titleBottomMarginConstraint: NSLayoutConstraint?
     private var typingObserverToken: Any?
 
-    //MARK: - SectionListCellType
+    // MARK: - SectionListCellType
     var sectionName: String?
     var cellIdentifier: String?
 

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListHeaderView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListHeaderView.swift
@@ -107,7 +107,7 @@ final class ConversationListHeaderView: UICollectionReusableView {
         }
 
         set {
-            //no op
+            // no op
         }
     }
 
@@ -117,7 +117,7 @@ final class ConversationListHeaderView: UICollectionReusableView {
         }
 
         set {
-            //no op
+            // no op
         }
     }
 

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
@@ -337,7 +337,7 @@ final class ConversationListViewModel: NSObject {
         return items[indexPath.item]
     }
 
-    ///TODO: Question: we may have multiple items in folders now. return array of IndexPaths?
+    /// TODO: Question: we may have multiple items in folders now. return array of IndexPaths?
     func indexPath(for item: ConversationListItem?) -> IndexPath? {
         guard let item = item else { return nil }
 
@@ -511,7 +511,7 @@ final class ConversationListViewModel: NSObject {
 
             newValue[sectionNumber].items = newList
 
-            ///Refresh the section header(since it may be hidden if the sectio is empty) when a section becomes empty/from empty to non-empty
+            /// Refresh the section header(since it may be hidden if the sectio is empty) when a section becomes empty/from empty to non-empty
             if sections[sectionNumber].items.isEmpty || newList.isEmpty {
                 sections = newValue
                 delegate?.listViewModel(self, didUpdateSectionForReload: sectionNumber, animated: true)
@@ -533,7 +533,7 @@ final class ConversationListViewModel: NSObject {
 
         if let sectionNumber = sectionNumber(for: kind) {
 
-            ///When the section is collaped, the setData closure of the reload() above is not called and we need to set here to make sure the folder badge calculation is correct
+            /// When the section is collaped, the setData closure of the reload() above is not called and we need to set here to make sure the folder badge calculation is correct
             if collapsed(at: sectionNumber) {
                 sections = newValue
             }
@@ -703,7 +703,7 @@ extension ConversationListViewModel: ConversationDirectoryObserver {
             // so we prefer to do the simple reload instead.
             reload()
         } else {
-            ///TODO: When 2 sections are visible and a conversation belongs to both, the lower section's update animation is missing since it started after the top section update animation started. To fix this we should calculate the change set in one batch.
+            /// TODO: When 2 sections are visible and a conversation belongs to both, the lower section's update animation is missing since it started after the top section update animation started. To fix this we should calculate the change set in one batch.
             /// TODO: wait for SE update for returning multiple items in changeInfo.updatedLists
             for updatedList in changeInfo.updatedLists {
                 if let kind = self.kind(of: updatedList) {

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ZMConversation+Status.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ZMConversation+Status.swift
@@ -374,7 +374,7 @@ final class SecurityAlertMatcher: ConversationStatusMatcher {
     }
 
     func icon(with status: ConversationStatus, conversation: MatcherConversation) -> ConversationStatusIcon? {
-        return nil ///TODO: icon for poll message
+        return nil /// TODO: icon for poll message
     }
 
     var combinesWith: [ConversationStatusMatcher] = []

--- a/Wire-iOS/Sources/UserInterface/CustomAppLock/Setup/PasscodeSetupViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/CustomAppLock/Setup/PasscodeSetupViewController.swift
@@ -27,11 +27,11 @@ protocol PasscodeSetupUserInterface: class {
 
 extension PasscodeSetupViewController: AuthenticationCoordinatedViewController {
     func executeErrorFeedbackAction(_ feedbackAction: AuthenticationErrorFeedbackAction) {
-        //no-op
+        // no-op
     }
 
     func displayError(_ error: Error) {
-        //no-op
+        // no-op
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Folders/FolderCreationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Folders/FolderCreationController.swift
@@ -100,7 +100,7 @@ final class FolderCreationController: UIViewController {
         collectionView.fitInSuperview(safely: true)
 
         collectionViewController.collectionView = collectionView
-        collectionViewController.sections = [nameSection]//, errorSection]
+        collectionViewController.sections = [nameSection]// , errorSection]
 
         navBarBackgroundView.backgroundColor = UIColor.from(scheme: .barBackground, variant: colorSchemeVariant)
         view.addSubview(navBarBackgroundView)

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
@@ -273,7 +273,7 @@ extension GroupDetailsViewController: ProfileViewControllerDelegate {
     }
 
     func profileViewController(_ controller: ProfileViewController?, wantsToCreateConversationWithName name: String?, users: UserSet) {
-        //no-op
+        // no-op
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupParticipantsDetail/GroupParticipantsDetailViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupParticipantsDetail/GroupParticipantsDetailViewController.swift
@@ -205,6 +205,6 @@ extension GroupParticipantsDetailViewController: ProfileViewControllerDelegate {
     }
 
     func profileViewController(_ controller: ProfileViewController?, wantsToCreateConversationWithName name: String?, users: UserSet) {
-            //no-op
+            // no-op
     }
 }

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/ParticipantsSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/ParticipantsSectionController.swift
@@ -199,7 +199,7 @@ final class ParticipantsSectionController: GroupDetailsSectionController {
         return cell
     }
 
-    ///MARK: - footer
+    /// MARK: - footer
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForFooterInSection section: Int) -> CGSize {
 

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/ReceiptOptionsSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/ReceiptOptionsSectionController.swift
@@ -106,13 +106,13 @@ final class ReceiptOptionsSectionController: GroupDetailsSectionController {
         return false
     }
 
-    ///MARK: - header
+    /// MARK: - header
 
     override func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
         return CGSize(width: collectionView.bounds.size.width, height: emptySectionHeaderHeight)
     }
 
-    ///MARK: - footer
+    /// MARK: - footer
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForFooterInSection section: Int) -> CGSize {
 

--- a/Wire-iOS/Sources/UserInterface/Helpers/UINavigationController+Additions.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UINavigationController+Additions.swift
@@ -60,7 +60,7 @@ extension UINavigationController {
     }
 
     @discardableResult open func popToRootViewController(animated: Bool,
-                                                         completion: (()-> Void)?) -> [UIViewController]? {
+                                                         completion: (() -> Void)?) -> [UIViewController]? {
         let controllers = popToRootViewController(animated: true)
         if animated, let coordinator = transitionCoordinator {
             coordinator.animate(alongsideTransition: nil) { _ in

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController+ProfileViewControllerDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController+ProfileViewControllerDelegate.swift
@@ -26,7 +26,7 @@ extension ZClientViewController: ProfileViewControllerDelegate {
     }
 
     func profileViewController(_ controller: ProfileViewController?, wantsToCreateConversationWithName name: String?, users: UserSet) {
-        //no-op. Profile viewer does not have function to create a group conversation.
+        // no-op. Profile viewer does not have function to create a group conversation.
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -157,7 +157,7 @@ final class ZClientViewController: UIViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(colorSchemeControllerDidApplyChanges(_:)), name: NSNotification.colorSchemeControllerDidApplyColorSchemeChange, object: nil)
 
         if Bundle.developerModeEnabled {
-            //better way of dealing with this?
+            // better way of dealing with this?
             NotificationCenter.default.addObserver(self, selector: #selector(requestLoopNotification(_:)), name: NSNotification.Name(rawValue: ZMLoggingRequestLoopNotificationName), object: nil)
             NotificationCenter.default.addObserver(self, selector: #selector(inconsistentStateNotification(_:)), name: NSNotification.Name(rawValue: ZMLoggingInconsistentStateNotificationName), object: nil)
         }
@@ -659,7 +659,7 @@ final class ZClientViewController: UIViewController {
         }
     }
 
-    ///MARK: - select conversation
+    /// MARK: - select conversation
 
     /// Select a conversation and move the focus to the conversation view.
     ///

--- a/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
@@ -213,7 +213,7 @@ extension SelfProfileViewController: SettingsPropertyFactoryDelegate {
     func appLockOptionDidChange(_ settingsPropertyFactory: SettingsPropertyFactory,
                                 newValue: Bool,
                                 callback: @escaping ResultHandler) {
-        //There is an additional check for the simulator because there's no way to disable the device passcode on the simulator. We need it for testing.
+        // There is an additional check for the simulator because there's no way to disable the device passcode on the simulator. We need it for testing.
         guard AuthenticationType.current == .unavailable || (UIDevice.isSimulator && AuthenticationType.current == .passcode) else {
             callback(newValue)
             return
@@ -252,7 +252,7 @@ extension SelfProfileViewController: SettingsPropertyFactoryDelegate {
 
 extension SelfProfileViewController: PasscodeSetupViewControllerDelegate {
     func passcodeSetupControllerDidFinish() {
-        //no-op
+        // no-op
     }
 
     func passcodeSetupControllerWasDismissed() {

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+DataUsagePermissions.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+DataUsagePermissions.swift
@@ -26,7 +26,7 @@ extension SettingsCellDescriptorFactory {
 
         var items: [SettingsSectionDescriptor] = [sendCrashDataSection]
 
-        //show analytics toggle for team members only
+        // show analytics toggle for team members only
         if isTeamMember {
             let sendAnalyticsData = SettingsPropertyToggleCellDescriptor(settingsProperty: settingsPropertyFactory.property(.disableAnalyticsSharing), inverse: true)
             let sendAnalyticsDataSection = SettingsSectionDescriptor(cellDescriptors: [sendAnalyticsData], footer: "self.settings.privacy_analytics_menu.description.title".localized)

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Options.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Options.swift
@@ -261,7 +261,7 @@ extension SettingsCellDescriptorFactory {
         let section = SettingsSectionDescriptor(cellDescriptors: cells.map { $0 as SettingsCellDescriptorType })
         let preview: PreviewGeneratorType = { descriptor in
             let value = property.value().value() as? Int
-            guard let option = value.flatMap ({ SettingsColorScheme(rawValue: $0) }) else { return .text(SettingsColorScheme.defaultPreference.displayString) }
+            guard let option = value.flatMap({ SettingsColorScheme(rawValue: $0) }) else { return .text(SettingsColorScheme.defaultPreference.displayString) }
             return .text(option.displayString)
         }
         return SettingsGroupCellDescriptor(items: [section], title: property.propertyName.settingsPropertyLabelText, identifier: nil, previewGenerator: preview)
@@ -280,7 +280,7 @@ extension SettingsCellDescriptorFactory {
         let section = SettingsSectionDescriptor(cellDescriptors: cells.map { $0 as SettingsCellDescriptorType })
         let preview: PreviewGeneratorType = { descriptor in
             let value = property.value().value() as? Int
-            guard let option = value.flatMap ({ TweetOpeningOption(rawValue: $0) }) else { return .text(TweetOpeningOption.none.displayString) }
+            guard let option = value.flatMap({ TweetOpeningOption(rawValue: $0) }) else { return .text(TweetOpeningOption.none.displayString) }
             return .text(option.displayString)
         }
         return SettingsGroupCellDescriptor(items: [section], title: property.propertyName.settingsPropertyLabelText, identifier: nil, previewGenerator: preview)
@@ -299,7 +299,7 @@ extension SettingsCellDescriptorFactory {
         let section = SettingsSectionDescriptor(cellDescriptors: cells.map { $0 as SettingsCellDescriptorType }, header: nil, footer: "open_link.maps.footer".localized, visibilityAction: nil)
         let preview: PreviewGeneratorType = { descriptor in
             let value = property.value().value() as? Int
-            guard let option = value.flatMap ({ MapsOpeningOption(rawValue: $0) }) else { return .text(MapsOpeningOption.apple.displayString) }
+            guard let option = value.flatMap({ MapsOpeningOption(rawValue: $0) }) else { return .text(MapsOpeningOption.apple.displayString) }
             return .text(option.displayString)
         }
         return SettingsGroupCellDescriptor(items: [section], title: property.propertyName.settingsPropertyLabelText, identifier: nil, previewGenerator: preview)
@@ -318,7 +318,7 @@ extension SettingsCellDescriptorFactory {
         let section = SettingsSectionDescriptor(cellDescriptors: cells.map { $0 as SettingsCellDescriptorType })
         let preview: PreviewGeneratorType = { descriptor in
             let value = property.value().value() as? Int
-            guard let option = value.flatMap ({ BrowserOpeningOption(rawValue: $0) }) else { return .text(BrowserOpeningOption.safari.displayString) }
+            guard let option = value.flatMap({ BrowserOpeningOption(rawValue: $0) }) else { return .text(BrowserOpeningOption.safari.displayString) }
             return .text(option.displayString)
         }
         return SettingsGroupCellDescriptor(items: [section], title: property.propertyName.settingsPropertyLabelText, identifier: nil, previewGenerator: preview)

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+SoundAlert.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+SoundAlert.swift
@@ -83,7 +83,7 @@ extension SettingsCellDescriptorFactory {
             case .none:
                 return .text("self.settings.sound_menu.no_sounds.title".localized)
             @unknown default:
-                ///TODO: change AVSIntensityLevel to NS_CLOSED_ENUM
+                /// TODO: change AVSIntensityLevel to NS_CLOSED_ENUM
                 return .text("")
             }
         } as PreviewGeneratorType

--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/SettingsClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/SettingsClientViewController.swift
@@ -38,7 +38,7 @@ final class SettingsClientViewController: UIViewController,
                                           ClientColorVariantProtocol,
                                           SpinnerCapable {
 
-    //MARK: SpinnerCapable
+    // MARK: SpinnerCapable
     var dismissSpinner: SpinnerCompletion?
 
     fileprivate static let deleteCellReuseIdentifier: String = "DeleteCellReuseIdentifier"
@@ -391,7 +391,7 @@ final class SettingsClientViewController: UIViewController,
     }
 }
 
-//MARK: - ClientRemovalObserverDelegate
+// MARK: - ClientRemovalObserverDelegate
 
 extension SettingsClientViewController: ClientRemovalObserverDelegate {
     func setIsLoadingViewVisible(_ clientRemovalObserver: ClientRemovalObserver, isVisible: Bool) {

--- a/Wire-iOS/Sources/UserInterface/Settings/VersionInfoViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/VersionInfoViewController.swift
@@ -47,17 +47,17 @@ final class VersionInfoViewController: UIViewController {
         closeButton = IconButton()
         view.addSubview(closeButton)
 
-        //Cosmetics
+        // Cosmetics
         closeButton.setIcon(.cross, size: .small, for: UIControl.State.normal)
         closeButton.setIconColor(UIColor.black, for: UIControl.State.normal)
 
-        //Layout
+        // Layout
         closeButton.translatesAutoresizingMaskIntoConstraints = false
 
         closeButton.pinToSuperview(safely: true, anchor: .top, inset: 24)
         closeButton.pinToSuperview(safely: true, anchor: .trailing, inset: 18)
 
-        //Target
+        // Target
         closeButton.addTarget(self, action: #selector(self.closeButtonTapped(_:)), for: .touchUpInside)
     }
 

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/ProfilePresenter+ProfileViewControllerDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/ProfilePresenter+ProfileViewControllerDelegate.swift
@@ -30,6 +30,6 @@ extension ProfilePresenter: ProfileViewControllerDelegate {
     }
 
     func profileViewController(_ controller: ProfileViewController?, wantsToCreateConversationWithName name: String?, users: UserSet) {
-        //no-op.
+        // no-op.
     }
 }

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.swift
@@ -165,7 +165,7 @@ final class StartUIViewController: UIViewController, SpinnerCapable {
     }
 
     func showKeyboardIfNeeded() {
-        let conversationCount = ZMConversationList.conversations(inUserSession: ZMUserSession.shared()!).count ///TODO: unwrap
+        let conversationCount = ZMConversationList.conversations(inUserSession: ZMUserSession.shared()!).count /// TODO: unwrap
         if conversationCount > StartUIViewController.InitiallyShowsKeyboardConversationThreshold {
             _ = searchHeader.tokenField.becomeFirstResponder()
         }

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Devices/UserClientListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Devices/UserClientListViewController.swift
@@ -148,7 +148,7 @@ extension UserClientListViewController: ZMUserObserver {
     func userDidChange(_ changeInfo: UserChangeInfo) {
         guard changeInfo.clientsChanged || changeInfo.trustLevelChanged else { return }
 
-        ///TODO: add clients to userType
+        /// TODO: add clients to userType
         headerView.showUnencryptedLabel = (user as? ZMUser)?.clients.isEmpty == true
         clients = UserClientListViewController.clientsSortedByRelevance(for: user)
         collectionView.reloadData()

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.swift
@@ -208,7 +208,7 @@ final class ProfileViewController: UIViewController {
     }
 
     private func setupProfileDetailsViewController() -> ProfileDetailsViewController {
-        ///TODO: pass the whole view Model/stuct/context
+        /// TODO: pass the whole view Model/stuct/context
         let profileDetailsViewController = ProfileDetailsViewController(user: viewModel.user,
                                                                         viewer: viewModel.viewer,
                                                                         conversation: viewModel.conversation,
@@ -345,7 +345,7 @@ extension ProfileViewController: ProfileFooterViewDelegate, IncomingRequestFoote
     }
 
     private func openSelfProfile() {
-        ///do not reveal list view for iPad regular mode
+        /// do not reveal list view for iPad regular mode
         let leftViewControllerRevealed: Bool
         if let presentingViewController = presentingViewController {
             leftViewControllerRevealed = !presentingViewController.isIPadRegular(device: UIDevice.current)

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewControllerViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewControllerViewModel.swift
@@ -183,7 +183,7 @@ final class ProfileViewControllerViewModel: NSObject {
     // MARK: - Factories
 
     func makeUserNameDetailViewModel() -> UserNameDetailViewModel {
-        //TODO: add addressBookEntry to ZMUser
+        // TODO: add addressBookEntry to ZMUser
         return UserNameDetailViewModel(user: user, fallbackName: user.name ?? "", addressBookName: (user as? ZMUser)?.addressBookEntry?.cachedName)
     }
 


### PR DESCRIPTION
## What's new in this PR?

This PR fixes violations for the following lint rules:

- [No space in method call](https://realm.github.io/SwiftLint/no_space_in_method_call.html)
- [Returning whitespace](https://realm.github.io/SwiftLint/return_arrow_whitespace.html)
- [Comment spacing](https://realm.github.io/SwiftLint/comment_spacing.html)

All changes have been made with `SwiftLint autocorrect`.