### PR TITLE
[Fix] Crashes with selfUser

### DIFF
--- a/Wire-iOS/Sources/Helpers/syncengine/ZMMessage+Actions.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMMessage+Actions.swift
@@ -24,7 +24,7 @@ extension ZMConversationMessage {
 
     /// Whether the message can be digitally signed in.
     var canBeDigitallySigned: Bool {
-        guard 
+        guard
             let selfUser = SelfUser.provider?.selfUser,
             selfUser.phoneNumber != nil,
             selfUser.isTeamMember,

--- a/Wire-iOS/Sources/Helpers/syncengine/ZMMessage+Actions.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMMessage+Actions.swift
@@ -24,10 +24,11 @@ extension ZMConversationMessage {
 
     /// Whether the message can be digitally signed in.
     var canBeDigitallySigned: Bool {
-        guard
-            SelfUser.current.phoneNumber != nil,
-            SelfUser.current.isTeamMember,
-            SelfUser.current.hasDigitalSignatureEnabled
+        guard let
+            selfUser = SelfUser.provider?.selfUser,
+            selfUser.phoneNumber != nil,
+            selfUser.isTeamMember,
+            selfUser.hasDigitalSignatureEnabled
         else {
             return false
         }

--- a/Wire-iOS/Sources/Helpers/syncengine/ZMMessage+Actions.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMMessage+Actions.swift
@@ -24,8 +24,8 @@ extension ZMConversationMessage {
 
     /// Whether the message can be digitally signed in.
     var canBeDigitallySigned: Bool {
-        guard let
-            selfUser = SelfUser.provider?.selfUser,
+        guard 
+            let selfUser = SelfUser.provider?.selfUser,
             selfUser.phoneNumber != nil,
             selfUser.isTeamMember,
             selfUser.hasDigitalSignatureEnabled

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationIconBasedCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationIconBasedCell.swift
@@ -90,7 +90,7 @@ class ConversationIconBasedCell: UIView {
 
         textLabel.linkTextAttributes = [
             NSAttributedString.Key.underlineStyle: NSUnderlineStyle().rawValue as NSNumber,
-            NSAttributedString.Key.foregroundColor: SelfUser.provider?.selfUser.accentColor ?? UIColor.white
+            NSAttributedString.Key.foregroundColor: SelfUser.provider?.selfUser.accentColor ?? UIColor.accent()
         ]
 
         lineView.backgroundColor = .from(scheme: .separator)

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationIconBasedCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationIconBasedCell.swift
@@ -90,7 +90,7 @@ class ConversationIconBasedCell: UIView {
 
         textLabel.linkTextAttributes = [
             NSAttributedString.Key.underlineStyle: NSUnderlineStyle().rawValue as NSNumber,
-            NSAttributedString.Key.foregroundColor: SelfUser.current.accentColor
+            NSAttributedString.Key.foregroundColor: SelfUser.provider?.selfUser.accentColor ?? UIColor.white
         ]
 
         lineView.backgroundColor = .from(scheme: .separator)

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListItemView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListItemView.swift
@@ -248,7 +248,7 @@ final class ConversationListItemView: UIView {
             selfUser.isTeamMember,
             let connectedUser = conversation.connectedUserType {
             title = AvailabilityStringBuilder.string(for: connectedUser, with: .list)
-            
+
             if connectedUser.availability != .none {
                 statusComponents.append(connectedUser.availability.localizedName)
             }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListItemView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListItemView.swift
@@ -244,10 +244,11 @@ final class ConversationListItemView: UIView {
         // Configure the title and status
         let title: NSAttributedString?
 
-        if SelfUser.current.isTeamMember,
-           let connectedUser = conversation.connectedUserType {
+        if let selfUser = SelfUser.provider?.selfUser,
+            selfUser.isTeamMember,
+            let connectedUser = conversation.connectedUserType {
             title = AvailabilityStringBuilder.string(for: connectedUser, with: .list)
-
+            
             if connectedUser.availability != .none {
                 statusComponents.append(connectedUser.availability.localizedName)
             }


### PR DESCRIPTION
## What's new in this PR?

### Issues
There are many crashes related to the `SelfUser` have been reported through `App Center`.

### Causes
There is currently no way to reproduce it. But according to the logs, the possible reason for these crashes is that 
`SelfUser. provider` is `nil`. 
```
class var current: UserType & ZMEditableUser {
        guard let provider = provider else { fatalError("Self user provider not set") }
        return provider.selfUser
}
```
However, we set the provider when the user transits to the `authenticated` state. 

### Solutions
Since this crash can't be reproduced at the moment, and there's no part of code that triggers this crash, the solution is to check if `selfUser` exists and provider is set.

### Notes

**Jira tickets with App Center links:**
https://wearezeta.atlassian.net/browse/SQSERVICES-296
https://wearezeta.atlassian.net/browse/SQSERVICES-297
https://wearezeta.atlassian.net/browse/SQSERVICES-303


