### PR TITLE
[Chore] Lint line length above 250 characters

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,5 +1,4 @@
 disabled_rules:
-    - line_length
     - function_body_length
     - type_body_length
     - file_length
@@ -32,3 +31,12 @@ disabled_rules:
 included:
     - Wire-iOS/Sources
     - Wire-iOS Tests/
+
+
+# In order to deal with the huge number of violations, first set
+# very high limits then iteratively reduce the limits and resolve
+# the few violations. Repeat this until we find suitable limits.
+
+line_length:
+    warning: 250
+    error: 250

--- a/Wire-iOS Tests/ConversationCell/MarkDownSnapshotTests.swift
+++ b/Wire-iOS Tests/ConversationCell/MarkDownSnapshotTests.swift
@@ -40,12 +40,15 @@ final class MarkDownSnapshotTests: XCTestCase {
     }
 
     func testMentionInFirstParagraph() {
+        // swiftlint:disable line_length
         let messageText =
         """
-@Bruno @Wire There was an old goat who had seven little kids, and loved them with all the love of a mother for her children. One day she wanted to go into the forest and fetch some food.
+        @Bruno @Wire There was an old goat who had seven little kids, and loved them with all the love of a mother for her children. One day she wanted to go into the forest and fetch some food.
         So she called all seven to her and said: 'Dear children, I have to go into the forest, be on your guard against the wolf; if he comes in, he will devour you all, skin, hair, and everything.
-The wretch often disguises himself, but you will know him at once by his rough voice and his black feet.' The kids said: 'Dear mother, we will take good care of ourselves; you may go away without any anxiety.' Then the old one bleated, and went on her way with an easy mind.
-"""
+        The wretch often disguises himself, but you will know him at once by his rough voice and his black feet.' The kids said: 'Dear mother, we will take good care of ourselves; you may go away without any anxiety.' Then the old one bleated, and went on her way with an easy mind.
+        """
+        // swiftlint:enable line_length
+
         let mention = Mention(range: NSRange(location: 0, length: 12), user: mockOtherUser)
         let message = MockMessageFactory.messageTemplate(sender: mockSelfUser)
         let textMessageData = MockTextMessageData()
@@ -59,12 +62,14 @@ The wretch often disguises himself, but you will know him at once by his rough v
 
     /// compare with above tests, the line spacing should be the same for both case.
     func testNoMentrionParagraph() {
+        // swiftlint:disable line_length
         let messageText =
         """
-@Bruno @Wire There was an old goat who had seven little kids, and loved them with all the love of a mother for her children. One day she wanted to go into the forest and fetch some food.
+        @Bruno @Wire There was an old goat who had seven little kids, and loved them with all the love of a mother for her children. One day she wanted to go into the forest and fetch some food.
         So she called all seven to her and said: 'Dear children, I have to go into the forest, be on your guard against the wolf; if he comes in, he will devour you all, skin, hair, and everything.
-The wretch often disguises himself, but you will know him at once by his rough voice and his black feet.' The kids said: 'Dear mother, we will take good care of ourselves; you may go away without any anxiety.' Then the old one bleated, and went on her way with an easy mind.
-"""
+        The wretch often disguises himself, but you will know him at once by his rough voice and his black feet.' The kids said: 'Dear mother, we will take good care of ourselves; you may go away without any anxiety.' Then the old one bleated, and went on her way with an easy mind.
+        """
+        // swiftlint:enable line_length
 
         let message = MockMessageFactory.textMessage(withText: messageText, sender: mockSelfUser, includingRichMedia: false)
 

--- a/Wire-iOS Tests/ConversationCell/MultiParagraphSnapshotTests.swift
+++ b/Wire-iOS Tests/ConversationCell/MultiParagraphSnapshotTests.swift
@@ -21,6 +21,7 @@ import XCTest
 
 final class MultiParagraphSnapshotTests: XCTestCase {
     func testThatLineHeightOfListIsConsistent_Chinese() {
+        // swiftlint:disable:next line_length
         let messageText = "1. 子曰：「雍也，可使南面。」仲弓問子桑伯子。子曰：「可也，簡。」仲弓曰：「居敬而行簡，以臨其民，不亦可乎？居簡而行簡，無乃大簡乎？」子曰：「雍之言然。」\n2. 哀公問：「弟子孰爲好學？」孔子對曰：「有顏回者，好學；不遷怒，不貳過，不幸短命死矣！今也則亡，未聞好學者也。」\n3. 子華使於齊，冉子爲其母請粟。子曰：「與之釜。」請益，曰：「與之庾。」冉子與之粟五秉。子曰：「赤之適齊也，乘肥馬，衣輕裘；吾聞之也：君子周急不繼富。」原思爲之宰，與之粟九百，辭。子曰：「毋！以與爾鄰里鄉黨乎！」"
 
         let mockSelfUser = MockUserType.createDefaultSelfUser()

--- a/Wire-iOS Tests/ConversationCell/TextMessageMentionsTests.swift
+++ b/Wire-iOS Tests/ConversationCell/TextMessageMentionsTests.swift
@@ -97,10 +97,13 @@ final class TextMessageMentionsTests: XCTestCase {
     }
 
     func testThatItRendersMentions_SelfMention_LongText() {
+        // swiftlint:disable line_length
         let messageText =
-"""
-She was a liar. She had no diseases at all. I had seen her at Free and Clear, my blood parasites group Thursdays. Then at Hope, my bimonthly sickle cell circle. And again at Seize the Day, my tuberculosis Friday night. @Marla, the big tourist. Her lie reflected my lie, and suddenly, I felt nothing.
-"""
+        """
+        She was a liar. She had no diseases at all. I had seen her at Free and Clear, my blood parasites group Thursdays. Then at Hope, my bimonthly sickle cell circle. And again at Seize the Day, my tuberculosis Friday night. @Marla, the big tourist. Her lie reflected my lie, and suddenly, I felt nothing.
+        """
+        // swiftlint:enable line_length
+
         selfUser.name = "Tyler Durden"
         selfUser.initials = "TD"
         let mention = Mention(range: NSRange(location: 219, length: 6), user: selfUser)
@@ -109,10 +112,14 @@ She was a liar. She had no diseases at all. I had seen her at Free and Clear, my
 
     func testThatItRendersMentions_SelfMention_LongText_Dark() {
         setColorScheme(.dark)
+
+        // swiftlint:disable line_length
         let messageText =
         """
-She was a liar. She had no diseases at all. I had seen her at Free and Clear, my blood parasites group Thursdays. Then at Hope, my bimonthly sickle cell circle. And again at Seize the Day, my tuberculosis Friday night. @Marla, the big tourist. Her lie reflected my lie, and suddenly, I felt nothing.
-"""
+        She was a liar. She had no diseases at all. I had seen her at Free and Clear, my blood parasites group Thursdays. Then at Hope, my bimonthly sickle cell circle. And again at Seize the Day, my tuberculosis Friday night. @Marla, the big tourist. Her lie reflected my lie, and suddenly, I felt nothing.
+        """
+        // swiftlint:enable line_length
+
         selfUser.name = "Tyler Durden"
         selfUser.initials = "TD"
         let mention = Mention(range: NSRange(location: 219, length: 6), user: selfUser)

--- a/Wire-iOS Tests/ConversationList/ConversationListCell/ConversationListCellTests.swift
+++ b/Wire-iOS Tests/ConversationList/ConversationListCell/ConversationListCellTests.swift
@@ -32,7 +32,18 @@ private final class MockConversation: MockStableRandomParticipantsConversation, 
     var status: ConversationStatus
 
     required init() {
-        status = ConversationStatus(isGroup: false, hasMessages: false, hasUnsentMessages: false, messagesRequiringAttention: [], messagesRequiringAttentionByType: [:], isTyping: false, mutedMessageTypes: .none, isOngoingCall: false, isBlocked: false, isSelfAnActiveMember: true, hasSelfMention: false, hasSelfReply: false)
+        status = ConversationStatus(isGroup: false,
+                                    hasMessages: false,
+                                    hasUnsentMessages: false,
+                                    messagesRequiringAttention: [],
+                                    messagesRequiringAttentionByType: [:],
+                                    isTyping: false,
+                                    mutedMessageTypes: .none,
+                                    isOngoingCall: false,
+                                    isBlocked: false,
+                                    isSelfAnActiveMember: true,
+                                    hasSelfMention: false,
+                                    hasSelfReply: false)
     }
 
     static func createOneOnOneConversation(otherUser: MockUserType) -> MockConversation {

--- a/Wire-iOS Tests/ConversationMessageCell/ConversationMessageSectionControllerTests.swift
+++ b/Wire-iOS Tests/ConversationMessageCell/ConversationMessageSectionControllerTests.swift
@@ -28,7 +28,14 @@ final class ConversationMessageSectionControllerTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        context = ConversationMessageContext(isSameSenderAsPrevious: false, isTimeIntervalSinceLastMessageSignificant: false, isFirstMessageOfTheDay: false, isFirstUnreadMessage: false, isLastMessage: false, searchQueries: [], previousMessageIsKnock: false, spacing: 0)
+        context = ConversationMessageContext(isSameSenderAsPrevious: false,
+                                             isTimeIntervalSinceLastMessageSignificant: false,
+                                             isFirstMessageOfTheDay: false,
+                                             isFirstUnreadMessage: false,
+                                             isLastMessage: false,
+                                             searchQueries: [],
+                                             previousMessageIsKnock: false,
+                                             spacing: 0)
     }
 
     override func tearDown() {

--- a/Wire-iOS Tests/ConversationMessageCell/ConversationTextMessageTests.swift
+++ b/Wire-iOS Tests/ConversationMessageCell/ConversationTextMessageTests.swift
@@ -39,6 +39,7 @@ final class ConversationTextMessageTests: XCTestCase {
 
     func testPlainText() {
         // GIVEN
+        // swiftlint:disable:next line_length
         let message = MockMessageFactory.textMessage(withText: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. ")
         message.senderUser = mockOtherUser
 

--- a/Wire-iOS Tests/ConversationReplyCellTests.swift
+++ b/Wire-iOS Tests/ConversationReplyCellTests.swift
@@ -75,6 +75,7 @@ final class ConversationReplyCellTests: CoreDataSnapshotTestCase {
 
     func testThatItTruncatesTextAfterFourLines_31() {
         // GIVEN
+        // swiftlint:disable:next line_length
         let message = MockMessageFactory.textMessage(withText: "@Bruno do we have the latest mockup files ready to go for the annual report? Once we have the copy finalized I would like to drop it in and get this out as quickly as possible. We can also add more lines to the test message if we need.")
         message.backingTextMessageData?.mentions = [Mention(range: NSRange(location: 0, length: 6), user: otherUser)]
         message.senderUser = MockUserType.createSelfUser(name: "Alice")
@@ -218,12 +219,14 @@ final class ConversationReplyCellTests: CoreDataSnapshotTestCase {
 
     func testThatItRendersMarkdownListMoreThan4Line() {
         // GIVEN
+        // swiftlint:disable line_length
         let markdownNoHeaders = """
         1. In den alten Zeiten, wo das Wünschen noch geholfen hat, lebte ein König, dessen Töchter waren alle schön;
         2. aber die jüngste war so schön, daß die Sonne selber, die doch so vieles gesehen hat, sich verwunderte, sooft sie ihr ins Gesicht schien.
         3. Nahe bei dem Schlosse des Königs lag ein großer dunkler Wald, und in dem Walde unter einer alten Linde war ein Brunnen;
         4. wenn nun der Tag recht heiß war, so ging das Königskind hinaus in den Wald und setzte sich an den Rand des kühlen Brunnens - und wenn sie Langeweile hatte, so nahm sie eine goldene Kugel, warf sie in die Höhe und fing sie wieder; und das war ihr liebstes Spielwerk.
         """
+        // swiftlint:enable line_length
 
         let message = MockMessageFactory.textMessage(withText: markdownNoHeaders)
         message.senderUser = MockUserType.createSelfUser(name: "Alice")

--- a/Wire-iOS Tests/HandleChangeStateTests.swift
+++ b/Wire-iOS Tests/HandleChangeStateTests.swift
@@ -43,7 +43,11 @@ class HandleChangeStateTests: XCTestCase {
                                                   availability: .unknown)
 
         // THEN
-        XCTAssertThrowsError(try handleChangeState.validate("testusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestuser1")) { error in
+        // swiftlint:disable line_length
+        let longHandle = "testusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestusertestuser1"
+        // swiftlint:enable line_length
+
+        XCTAssertThrowsError(try handleChangeState.validate(longHandle)) { error in
             XCTAssertEqual(error as! HandleChangeState.ValidationError,
                            HandleChangeState.ValidationError.tooLong)
         }

--- a/Wire-iOS Tests/InputBar/InputBarTests.swift
+++ b/Wire-iOS Tests/InputBar/InputBarTests.swift
@@ -22,7 +22,10 @@ import XCTest
 final class InputBarTests: ZMSnapshotTestCase {
 
     let shortText = "Lorem ipsum dolor"
+
+    // swiftlint:disable:next line_length
     let longText = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est"
+
     let LTRText = "ناك حقيقة مثبتة منذ"
 
     let buttons = { () -> [UIButton] in

--- a/Wire-iOS Tests/ShareViewControllerTests.swift
+++ b/Wire-iOS Tests/ShareViewControllerTests.swift
@@ -91,6 +91,7 @@ final class ShareViewControllerTests: XCTestCase {
     }
 
     func testThatItRendersCorrectlyShareViewController_MultiLineTextMessage() {
+        // swiftlint:disable:next line_length
         let message: MockShareableMessage = MockMessageFactory.textMessage(withText: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce tempor nulla nec justo tincidunt iaculis. Suspendisse et viverra lacus. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Aliquam pretium suscipit purus, sed eleifend erat ullamcorper non. Sed non enim diam. Fusce pulvinar turpis sit amet pretium finibus. Donec ipsum massa, aliquam eget sollicitudin vel, fringilla eget arcu. Donec faucibus porttitor nisi ut fermentum. Donec sit amet massa sodales, facilisis neque et, condimentum leo. Maecenas quis vulputate libero, id suscipit magna.")
         makeTestForShareViewController(message: message)
     }

--- a/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationCredentialsViewController.swift
+++ b/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationCredentialsViewController.swift
@@ -25,7 +25,13 @@ import WireTransport
  * The view controller to use to ask the user to enter their credentials.
  */
 
-final class AuthenticationCredentialsViewController: AuthenticationStepController, CountryCodeTableViewControllerDelegate, EmailPasswordTextFieldDelegate, PhoneNumberInputViewDelegate, TabBarDelegate, TextFieldValidationDelegate, UITextFieldDelegate {
+final class AuthenticationCredentialsViewController: AuthenticationStepController,
+                                                     CountryCodeTableViewControllerDelegate,
+                                                     EmailPasswordTextFieldDelegate,
+                                                     PhoneNumberInputViewDelegate,
+                                                     TabBarDelegate,
+                                                     TextFieldValidationDelegate,
+                                                     UITextFieldDelegate {
 
     /// Types of flow provided by the view controller.
     enum FlowType {

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -70,7 +70,14 @@ final class CallViewController: UIViewController {
         self.mediaManager = mediaManager
         self.proximityMonitorManager = proximityMonitorManager
         videoConfiguration = VideoConfiguration(voiceChannel: voiceChannel)
-        callInfoConfiguration = CallInfoConfiguration(voiceChannel: voiceChannel, preferedVideoPlaceholderState: preferedVideoPlaceholderState, permissions: permissionsConfiguration, cameraType: cameraType, mediaManager: mediaManager, userEnabledCBR: CallViewController.userEnabledCBR, selfUser: selfUser)
+
+        callInfoConfiguration = CallInfoConfiguration(voiceChannel: voiceChannel,
+                                                      preferedVideoPlaceholderState: preferedVideoPlaceholderState,
+                                                      permissions: permissionsConfiguration,
+                                                      cameraType: cameraType,
+                                                      mediaManager: mediaManager,
+                                                      userEnabledCBR: CallViewController.userEnabledCBR,
+                                                      selfUser: selfUser)
 
         callInfoRootViewController = CallInfoRootViewController(configuration: callInfoConfiguration, selfUser: ZMUser.selfUser())
         videoGridViewController = VideoGridViewController(configuration: videoConfiguration)
@@ -217,7 +224,14 @@ final class CallViewController: UIViewController {
     }
 
     fileprivate func updateConfiguration() {
-        callInfoConfiguration = CallInfoConfiguration(voiceChannel: voiceChannel, preferedVideoPlaceholderState: preferedVideoPlaceholderState, permissions: permissions, cameraType: cameraType, mediaManager: mediaManager, userEnabledCBR: CallViewController.userEnabledCBR, selfUser: ZMUser.selfUser())
+        callInfoConfiguration = CallInfoConfiguration(voiceChannel: voiceChannel,
+                                                      preferedVideoPlaceholderState: preferedVideoPlaceholderState,
+                                                      permissions: permissions,
+                                                      cameraType: cameraType,
+                                                      mediaManager: mediaManager,
+                                                      userEnabledCBR: CallViewController.userEnabledCBR,
+                                                      selfUser: ZMUser.selfUser())
+
         callInfoRootViewController.configuration = callInfoConfiguration
         videoConfiguration = VideoConfiguration(voiceChannel: voiceChannel)
         videoGridViewController.configuration = videoConfiguration

--- a/Wire-iOS/Sources/UserInterface/Components/Views/WebLinkTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/WebLinkTextView.swift
@@ -19,7 +19,11 @@
 import UIKit
 
 // This subclass is used for the legal text in the Welcome screen and the reset password text in the login screen
-// Purpose of this class is to reduce the amount of duplicate code to set the default properties of this NSTextView. On the Mac client we are using something similar to also stop the user from being able to select the text (selection property needs to be enabled to make the NSLinkAttribute work on the string). We may want to add this in the future here as well
+// Purpose of this class is to reduce the amount of duplicate code to set the default properties of this NSTextView.
+// On the Mac client we are using something similar to also stop the user from being able to select the text
+// (selection property needs to be enabled to make the NSLinkAttribute work on the string). We may want to add this
+// in the future here as well
+
 final class WebLinkTextView: UITextView {
 
     init() {

--- a/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationNotificationOptionsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationNotificationOptionsViewController.swift
@@ -118,7 +118,11 @@ extension ConversationNotificationOptionsViewController: UICollectionViewDelegat
             let view = collectionView.dequeueReusableSupplementaryView(ofKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: "SectionHeader", for: indexPath)
             return view
         } else {
-            guard let view = collectionView.dequeueReusableSupplementaryView(ofKind: UICollectionView.elementKindSectionFooter, withReuseIdentifier: "SectionFooter", for: indexPath) as? SectionFooter else { return UICollectionReusableView(frame: .zero) }
+            let dequeuedView = collectionView.dequeueReusableSupplementaryView(ofKind: UICollectionView.elementKindSectionFooter,
+                                                                               withReuseIdentifier: "SectionFooter",
+                                                                               for: indexPath)
+
+            guard let view = dequeuedView as? SectionFooter else { return UICollectionReusableView(frame: .zero) }
             view.titleLabel.text = "group_details.notification_options_cell.description".localized
             return view
         }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
@@ -701,7 +701,9 @@ extension ConversationListViewModel: ConversationDirectoryObserver {
             // so we prefer to do the simple reload instead.
             reload()
         } else {
-            /// TODO: When 2 sections are visible and a conversation belongs to both, the lower section's update animation is missing since it started after the top section update animation started. To fix this we should calculate the change set in one batch.
+            /// TODO: When 2 sections are visible and a conversation belongs to both, the lower section's update
+            /// animation is missing since it started after the top section update animation started. To fix this
+            /// we should calculate the change set in one batch.
             /// TODO: wait for SE update for returning multiple items in changeInfo.updatedLists
             for updatedList in changeInfo.updatedLists {
                 if let kind = self.kind(of: updatedList) {

--- a/Wire-iOS/Sources/UserInterface/CustomAppLock/Unlock/UnlockViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/CustomAppLock/Unlock/UnlockViewController.swift
@@ -259,7 +259,11 @@ final class UnlockViewController: UIViewController {
     }
 
     func showWrongPasscodeMessage() {
-        let textAttachment = NSTextAttachment.textAttachment(for: .exclamationMarkCircle, with: UIColor.PasscodeUnlock.error, iconSize: StyleKitIcon.Size.CreatePasscode.errorIconSize, verticalCorrection: -1, insets: UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 4))
+        let textAttachment = NSTextAttachment.textAttachment(for: .exclamationMarkCircle,
+                                                             with: UIColor.PasscodeUnlock.error,
+                                                             iconSize: StyleKitIcon.Size.CreatePasscode.errorIconSize,
+                                                             verticalCorrection: -1,
+                                                             insets: UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 4))
 
         let attributedString = NSAttributedString(string: "unlock.error_label".localized) && UnlockViewController.errorFont
 

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
@@ -137,8 +137,13 @@ final class GroupDetailsViewController: UIViewController, ZMConversationObserver
             if admins.count <= Int.ConversationParticipants.maxNumberWithoutTruncation || admins.isEmpty {
                 if admins.count >= Int.ConversationParticipants.maxNumberOfDisplayed && (participants.count > Int.ConversationParticipants.maxNumberWithoutTruncation) { // Dispay the ShowAll button after the first section
                     let adminSection = ParticipantsSectionController(participants: admins,
-                                                                     conversationRole: .admin, conversation: conversation,
-                                                                     delegate: self, totalParticipantsCount: participants.count, clipSection: true, maxParticipants: admins.count - 1, maxDisplayedParticipants: Int.ConversationParticipants.maxNumberOfDisplayed)
+                                                                     conversationRole: .admin,
+                                                                     conversation: conversation,
+                                                                     delegate: self,
+                                                                     totalParticipantsCount: participants.count,
+                                                                     clipSection: true,
+                                                                     maxParticipants: admins.count - 1,
+                                                                     maxDisplayedParticipants: Int.ConversationParticipants.maxNumberOfDisplayed)
                     sections.append(adminSection)
                 } else {
                     let adminSection = ParticipantsSectionController(participants: admins,
@@ -153,9 +158,15 @@ final class GroupDetailsViewController: UIViewController, ZMConversationObserver
                             sections.append(memberSection)
                         }
                     } else { // Display the ShowAll button after the second section
+                        let maxParticipants = Int.ConversationParticipants.maxNumberWithoutTruncation - admins.count
                         let memberSection = ParticipantsSectionController(participants: members,
-                                                                          conversationRole: .member, conversation: conversation,
-                                                                          delegate: self, totalParticipantsCount: participants.count, clipSection: true, maxParticipants: (Int.ConversationParticipants.maxNumberWithoutTruncation - admins.count), maxDisplayedParticipants: (Int.ConversationParticipants.maxNumberWithoutTruncation - admins.count) - 2)
+                                                                          conversationRole: .member,
+                                                                          conversation: conversation,
+                                                                          delegate: self,
+                                                                          totalParticipantsCount: participants.count,
+                                                                          clipSection: true,
+                                                                          maxParticipants: maxParticipants,
+                                                                          maxDisplayedParticipants: maxParticipants - 2)
                         sections.append(memberSection)
                     }
                 }

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupParticipantsDetail/GroupParticipantsDetailViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupParticipantsDetail/GroupParticipantsDetailViewController.swift
@@ -141,11 +141,23 @@ final class GroupParticipantsDetailViewController: UIViewController {
     private func computeSections() -> [CollectionViewSectionController] {
         sections = []
         if !viewModel.admins.isEmpty {
-            sections.append(ParticipantsSectionController(participants: viewModel.admins, conversationRole: .admin, conversation: viewModel.conversation, delegate: self, totalParticipantsCount: viewModel.admins.count, clipSection: false, showSectionCount: false))
+            sections.append(ParticipantsSectionController(participants: viewModel.admins,
+                                                          conversationRole: .admin,
+                                                          conversation: viewModel.conversation,
+                                                          delegate: self,
+                                                          totalParticipantsCount: viewModel.admins.count,
+                                                          clipSection: false,
+                                                          showSectionCount: false))
         }
 
         if !viewModel.members.isEmpty {
-            sections.append(ParticipantsSectionController(participants: viewModel.members, conversationRole: .member, conversation: viewModel.conversation, delegate: self, totalParticipantsCount: viewModel.members.count, clipSection: false, showSectionCount: false))
+            sections.append(ParticipantsSectionController(participants: viewModel.members,
+                                                          conversationRole: .member,
+                                                          conversation: viewModel.conversation,
+                                                          delegate: self,
+                                                          totalParticipantsCount: viewModel.members.count,
+                                                          clipSection: false,
+                                                          showSectionCount: false))
         }
 
         return sections

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController+SplitViewControllerDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController+SplitViewControllerDelegate.swift
@@ -19,7 +19,9 @@ import Foundation
 
 extension ZClientViewController: SplitViewControllerDelegate {
     public func splitViewControllerShouldMoveLeftViewController(_ splitViewController: SplitViewController) -> Bool {
-        return splitViewController.rightViewController != nil && splitViewController.leftViewController == backgroundViewController && conversationListViewController.state == .conversationList && (conversationListViewController.presentedViewController == nil || splitViewController.isLeftViewControllerRevealed == false)
-
+        return splitViewController.rightViewController != nil &&
+            splitViewController.leftViewController == backgroundViewController &&
+            conversationListViewController.state == .conversationList &&
+            (conversationListViewController.presentedViewController == nil || splitViewController.isLeftViewControllerRevealed == false)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsExternalScreenCellDescriptor.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsExternalScreenCellDescriptor.swift
@@ -61,7 +61,13 @@ class SettingsExternalScreenCellDescriptor: SettingsExternalScreenCellDescriptor
         )
     }
 
-    convenience init(title: String, isDestructive: Bool, presentationStyle: PresentationStyle, presentationAction: @escaping () -> (UIViewController?), previewGenerator: PreviewGeneratorType? = .none, icon: StyleKitIcon? = nil, accessoryViewMode: AccessoryViewMode = .default) {
+    convenience init(title: String,
+                     isDestructive: Bool,
+                     presentationStyle: PresentationStyle,
+                     presentationAction: @escaping () -> (UIViewController?),
+                     previewGenerator: PreviewGeneratorType? = .none,
+                     icon: StyleKitIcon? = nil,
+                     accessoryViewMode: AccessoryViewMode = .default) {
         self.init(
             title: title,
             isDestructive: isDestructive,
@@ -74,7 +80,15 @@ class SettingsExternalScreenCellDescriptor: SettingsExternalScreenCellDescriptor
         )
     }
 
-    init(title: String, isDestructive: Bool, presentationStyle: PresentationStyle, identifier: String?, presentationAction: @escaping () -> (UIViewController?), previewGenerator: PreviewGeneratorType? = .none, icon: StyleKitIcon? = nil, accessoryViewMode: AccessoryViewMode = .default) {
+    init(title: String,
+         isDestructive: Bool,
+         presentationStyle: PresentationStyle,
+         identifier: String?,
+         presentationAction: @escaping () -> (UIViewController?),
+         previewGenerator: PreviewGeneratorType? = .none,
+         icon: StyleKitIcon? = nil,
+         accessoryViewMode: AccessoryViewMode = .default) {
+
         self.title = title
         self.destructive = isDestructive
         self.presentationStyle = presentationStyle

--- a/Wire-iOS/Sources/UserInterface/Settings/ProfileSelfPictureViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/ProfileSelfPictureViewController.swift
@@ -152,9 +152,16 @@ final class ProfileSelfPictureViewController: UIViewController {
             options.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
             options.fetchLimit = 1
 
+            // If asset is found, grab its thumbnail and create a CALayer with its contents.
             if let asset = PHAsset.fetchAssets(with: options).firstObject {
-                // If asset is found, grab its thumbnail, create a CALayer with its contents,
-                PHImageManager.default().requestImage(for: asset, targetSize: libraryButtonSize.applying(CGAffineTransform(scaleX: view.contentScaleFactor, y: view.contentScaleFactor)), contentMode: .aspectFill, options: nil, resultHandler: { result, _ in
+                let scaleFactor = view.contentScaleFactor
+                let targetSize = libraryButtonSize.applying(CGAffineTransform(scaleX: scaleFactor, y: scaleFactor))
+
+                PHImageManager.default().requestImage(for: asset,
+                                                      targetSize: targetSize,
+                                                      contentMode: .aspectFill,
+                                                      options: nil) { result, _ in
+
                     DispatchQueue.main.async(execute: {
                         self.libraryButton.imageView?.contentMode = .scaleAspectFill
                         self.libraryButton.contentVerticalAlignment = .center
@@ -166,8 +173,7 @@ final class ProfileSelfPictureViewController: UIViewController {
                         self.libraryButton.layer.cornerRadius = 5
                         self.libraryButton.clipsToBounds = true
                     })
-
-                })
+                }
             }
         }
 


### PR DESCRIPTION
## What's new in this PR?

This PR introduces the [line length](https://realm.github.io/SwiftLint/line_length.html) lint rule. This is a configurable rule and by default reports lines with length between 120 and 200 characters as warnings, and lines longer than 200 characters as errors.

If we use this default configuration, then more than 2000 violations are reported. In order to deal with this in manageable chucks, I propose we set very high limits to reduce the number of violations to a reasonable size, fix those, then repeat the process repeatedly, each time lowering the limits just a little. We can continue this until we find the appropriate limits.

### Note

In some cases we don't want to split a long line into separate lines, such as we need a very long string for testing. I've dealt with these by using disable comments when needed, but I guess another way is to move test data into a separate file that is excluded from linting.