### PR TITLE
[Fix] Tapping cell show wrong conversation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
@@ -705,11 +705,13 @@ extension ConversationListViewModel: ConversationDirectoryObserver {
             /// animation is missing since it started after the top section update animation started. To fix this
             /// we should calculate the change set in one batch.
             /// TODO: wait for SE update for returning multiple items in changeInfo.updatedLists
-            for updatedList in changeInfo.updatedLists {
-                if let kind = self.kind(of: updatedList) {
-                    update(for: kind)
+            DispatchQueue.main.async(execute: {
+                for updatedList in changeInfo.updatedLists {
+                    if let kind = self.kind(of: updatedList) {
+                        self.update(for: kind)
+                    }
                 }
-            }
+            })
         }
     }
 

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
@@ -371,12 +371,6 @@ final class ConversationListViewModel: NSObject {
         return conversationDirectory.conversations(by: conversationListType).map({ SectionItem(item: $0, kind: kind) })
     }
 
-    private func reload() {
-        updateAllSections()
-        log.debug("RELOAD conversation list")
-        delegate?.listViewModelShouldBeReloaded()
-    }
-
     /// Select the item at an index path
     ///
     /// - Parameter indexPath: indexPath of the item to select

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
@@ -710,7 +710,7 @@ extension ConversationListViewModel: ConversationDirectoryObserver {
             /// TODO: wait for SE update for returning multiple items in changeInfo.updatedLists
             for updatedList in changeInfo.updatedLists {
                 if let kind = self.kind(of: updatedList) {
-                    self.update(for: kind)
+                    update(for: kind)
                 }
             }
         }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
@@ -499,7 +499,7 @@ final class ConversationListViewModel: NSObject {
         return nil
     }
 
-    private func update(for kind: Section.Kind?) {
+    private func update(for kind: Section.Kind? = nil) {
         guard let conversationDirectory = userSession?.conversationDirectory else { return }
 
         var newValue: [Section]
@@ -702,7 +702,7 @@ extension ConversationListViewModel: ConversationDirectoryObserver {
         if changeInfo.reloaded {
             // If the section was empty in certain cases collection view breaks down on the big amount of conversations,
             // so we prefer to do the simple reload instead.
-            update(for: nil)
+            update()
         } else {
             /// TODO: When 2 sections are visible and a conversation belongs to both, the lower section's update
             /// animation is missing since it started after the top section update animation started. To fix this


### PR DESCRIPTION
## What's new in this PR?

### Issues
When a user taps on a conversation, the wrong conversation opens.

### Causes
Seems like the the "standard" reloadData() for the collectionView (conversation list) conflicts with incremental reloading of the conversation list.

### Solutions
Always use an incremental reload of the collectionView when we need to update the list of conversations.

### Notes
https://wearezeta.atlassian.net/browse/SQSERVICES-308
