### PR TITLE
[Fix] Overlapping app state transitions

### DIFF
--- a/Wire-iOS/Sources/AppRootRouter.swift
+++ b/Wire-iOS/Sources/AppRootRouter.swift
@@ -172,6 +172,8 @@ public class AppRootRouter: NSObject {
     ///     - completion: A block executed after the transition has completed.
 
     private func enqueueTransition(to appState: AppState, completion: @escaping () -> Void = {}) {
+        // Perform the wait on a background queue to we don't cause
+        // a deadlock on the main queue.
         appStateTransitionQueue.async { [weak self] in
             guard let `self` = self else { return }
 

--- a/Wire-iOS/Sources/AppRootRouter.swift
+++ b/Wire-iOS/Sources/AppRootRouter.swift
@@ -172,8 +172,8 @@ public class AppRootRouter: NSObject {
     ///     - completion: A block executed after the transition has completed.
 
     private func enqueueTransition(to appState: AppState, completion: @escaping () -> Void = {}) {
-        // Perform the wait on a background queue to we don't cause
-        // a deadlock on the main queue.
+        // Perform the wait on a background queue so we don't cause a
+        // deadlock on the main queue.
         appStateTransitionQueue.async { [weak self] in
             guard let `self` = self else { return }
 

--- a/Wire-iOS/Sources/AppRootRouter.swift
+++ b/Wire-iOS/Sources/AppRootRouter.swift
@@ -312,6 +312,7 @@ extension AppRootRouter {
                 error?.userSessionErrorCode == .accountDeleted,
             let sessionManager = SessionManager.shared
         else {
+            completion()
             return
         }
 
@@ -324,6 +325,7 @@ extension AppRootRouter {
                                                               statusProvider: AuthenticationStatusProvider())
 
         guard let authenticationCoordinator = authenticationCoordinator else {
+            completion()
             return
         }
 
@@ -333,8 +335,6 @@ extension AppRootRouter {
 
         rootViewController.set(childViewController: navigationController,
                                completion: completion)
-
-        presentAlertForDeletedAccountIfNeeded(error)
     }
 
     private func showAuthenticated(isComingFromRegistration: Bool, completion: @escaping () -> Void) {
@@ -343,6 +343,7 @@ extension AppRootRouter {
             let authenticatedRouter = buildAuthenticatedRouter(account: selectedAccount,
                                                                isComingFromRegistration: isComingFromRegistration)
         else {
+            completion()
             return
         }
 
@@ -418,7 +419,9 @@ extension AppRootRouter {
     }
 
     private func applicationDidTransition(to appState: AppState) {
-        if case .authenticated = appState {
+        if case .unauthenticated(let error) = appState {
+           presentAlertForDeletedAccountIfNeeded(error)
+        } else if case .authenticated = appState {
             authenticatedRouter?.updateActiveCallPresentationState()
             urlActionRouter.openDeepLink(needsAuthentication: true)
 

--- a/Wire-iOS/Sources/AppRootRouter.swift
+++ b/Wire-iOS/Sources/AppRootRouter.swift
@@ -234,7 +234,7 @@ extension AppRootRouter: AppStateCalculatorDelegate {
         case .locked:
             // TODO: [John] Avoid singleton.
             screenCurtain.delegate = ZMUserSession.shared()
-            showAppLock()
+            showAppLock(completion: completionBlock)
         }
     }
 
@@ -358,9 +358,10 @@ extension AppRootRouter {
                                completion: completion)
     }
 
-    private func showAppLock() {
+    private func showAppLock(completion: @escaping () -> Void) {
         guard let session = ZMUserSession.shared() else { fatalError() }
-        rootViewController.set(childViewController: AppLockModule.build(session: session))
+        rootViewController.set(childViewController: AppLockModule.build(session: session),
+                               completion: completion)
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## What's new in this PR?

### Issues

We have been experiencing several crashes lately when the trying to access the `SelfUser.current`, typically from the conversation list or in the conversation content.

### Causes

`SelfUser.current` intentionally crashes when `SelfUser.provider == nil`. The self user provider is configured during the app state transition:

- The provider is set when `applicationWillTransition(to: .authenticated)` is called, and
- The provider is reset when `applicationDidTransition(to: appState)`, where `appState != .authenticated`.

The problem however is that we can repeatedly call these methods in any order, for example:

```swift
// The self user isn't set yet, so SelfUser.current will crash.
applicationWillTransition(to: .migrating)

// This will set the provider, SelfUser.current won't crash.
applicationWillTransition(to: .authenticated)

// This will reset the provider, SelfUser.current will crash
applicationDidTransition(to: .migrating)

// Here we typically cause a load of the conversation list, which will
// result in an eventual call to SelfUser.current. But it's not set,
// so it will crash.
applicationDidTransition(to: .authenticated)
```

This exact scenario is currently happening due to recent changes that put the app through the migrating state each time the app launches.

### Solutions

Consider transitions (delimited by `applicationWillTransition` and `applicationDidTransition`) as atomic, meaning that we only begin a transition once the previous one (if any) has completed.

### Note

This is just a draft implementation, I'm looking for feedback whether there is a cleaner/simpler way to achieve this.