### PR TITLE
[Fix] Stuck on migration screen after restoring backup

### DIFF
--- a/Wire-iOS/Sources/AppRootRouter.swift
+++ b/Wire-iOS/Sources/AppRootRouter.swift
@@ -240,7 +240,7 @@ extension AppRootRouter: AppStateCalculatorDelegate {
 
     private func resetAuthenticationCoordinatorIfNeeded(for state: AppState) {
         switch state {
-        case .unauthenticated:
+        case .unauthenticated, .migrating:
             break // do not reset the authentication coordinator for unauthenticated state
         default:
             authenticationCoordinator = nil // reset the authentication coordinator when we no longer need it

--- a/Wire-iOS/Sources/AppRootRouter.swift
+++ b/Wire-iOS/Sources/AppRootRouter.swift
@@ -241,7 +241,6 @@ extension AppRootRouter: AppStateCalculatorDelegate {
     private func resetAuthenticationCoordinatorIfNeeded(for state: AppState) {
         switch state {
         case .authenticated:
-            // reset the authentication coordinator when we no longer need it
             authenticationCoordinator = nil
             break
         default:

--- a/Wire-iOS/Sources/AppRootRouter.swift
+++ b/Wire-iOS/Sources/AppRootRouter.swift
@@ -240,10 +240,12 @@ extension AppRootRouter: AppStateCalculatorDelegate {
 
     private func resetAuthenticationCoordinatorIfNeeded(for state: AppState) {
         switch state {
-        case .unauthenticated, .migrating:
-            break // do not reset the authentication coordinator for unauthenticated state
+        case .authenticated:
+            // reset the authentication coordinator when we no longer need it
+            authenticationCoordinator = nil
+            break
         default:
-            authenticationCoordinator = nil // reset the authentication coordinator when we no longer need it
+            break
         }
     }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

Application gets stuck on the migration screen after restoring a backup.

### Causes

When the application transitions away from the `.unauthenticated` state we release the `AuthenticationCoordinator`, which is responsible for signalling when the login flow is completed. After https://github.com/wireapp/wire-ios-data-model/pull/1144 we started to attempt a migration every time we load the database. We still need to register a new client after restoring a backup so we don't immediately  transition to the `.authenticated` state and later when the client is registered we don't the state changed because `AuthenticationCoordinator` is gone.

The flow now looks like this:
- Restoring backup
- Migrating
- Registering client & perform slow sync
- Authenticated

### Solutions

Don't release the `AuthenticationCoordinator` when transitioning to the `.migrating` state.