### PR TITLE
[Fix] SCIM users can email field

### DIFF
--- a/Wire-iOS Tests/UserRightTests.swift
+++ b/Wire-iOS Tests/UserRightTests.swift
@@ -1,0 +1,118 @@
+//
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+@testable import Wire
+
+class UserRightTests: XCTestCase {
+
+    // MARK: - Properties
+
+    var selfUser: MockUserType!
+
+    // MARK: - Set up
+
+    override func setUp() {
+        super.setUp()
+        selfUser = MockUserType()
+        SelfUser.provider = SelfProvider(selfUser: selfUser)
+    }
+
+    override func tearDown() {
+        selfUser = nil
+        SelfUser.provider = nil
+        super.tearDown()
+    }
+
+    // MARK: - Tests
+
+    func test_SelfUserRights_NoSelfUser() {
+        // Given
+        SelfUser.provider = nil
+
+        // Then
+        XCTAssertFalse(UserRight.selfUserIsPermitted(to: .resetPassword))
+        XCTAssertFalse(UserRight.selfUserIsPermitted(to: .editName))
+        XCTAssertFalse(UserRight.selfUserIsPermitted(to: .editHandle))
+        XCTAssertFalse(UserRight.selfUserIsPermitted(to: .editEmail))
+        XCTAssertFalse(UserRight.selfUserIsPermitted(to: .editPhone))
+        XCTAssertFalse(UserRight.selfUserIsPermitted(to: .editProfilePicture))
+        XCTAssertFalse(UserRight.selfUserIsPermitted(to: .editAccentColor))
+    }
+
+    func test_SelfUserRights_ManagedByWire_NormalLogin() {
+        // Given
+        selfUser.managedByWire = true
+        selfUser.usesCompanyLogin = false
+
+        // Then
+        XCTAssertTrue(UserRight.selfUserIsPermitted(to: .resetPassword))
+        XCTAssertTrue(UserRight.selfUserIsPermitted(to: .editName))
+        XCTAssertTrue(UserRight.selfUserIsPermitted(to: .editHandle))
+        XCTAssertTrue(UserRight.selfUserIsPermitted(to: .editEmail))
+        XCTAssertTrue(UserRight.selfUserIsPermitted(to: .editPhone))
+        XCTAssertTrue(UserRight.selfUserIsPermitted(to: .editProfilePicture))
+        XCTAssertTrue(UserRight.selfUserIsPermitted(to: .editAccentColor))
+    }
+
+    func test_SelfUserRights_ManagedByWire_SSOLogin() {
+        // Given
+        selfUser.managedByWire = true
+        selfUser.usesCompanyLogin = true
+
+        // Then
+        XCTAssertTrue(UserRight.selfUserIsPermitted(to: .resetPassword))
+        XCTAssertTrue(UserRight.selfUserIsPermitted(to: .editName))
+        XCTAssertTrue(UserRight.selfUserIsPermitted(to: .editHandle))
+        XCTAssertTrue(UserRight.selfUserIsPermitted(to: .editEmail))
+        XCTAssertTrue(UserRight.selfUserIsPermitted(to: .editPhone))
+        XCTAssertTrue(UserRight.selfUserIsPermitted(to: .editProfilePicture))
+        XCTAssertTrue(UserRight.selfUserIsPermitted(to: .editAccentColor))
+    }
+
+    func test_SelfUserRights_NotManagedByWire_NormalLogin() {
+        // Given
+        selfUser.managedByWire = false
+        selfUser.usesCompanyLogin = false
+
+        // Then
+        XCTAssertTrue(UserRight.selfUserIsPermitted(to: .resetPassword))
+        XCTAssertFalse(UserRight.selfUserIsPermitted(to: .editName))
+        XCTAssertFalse(UserRight.selfUserIsPermitted(to: .editHandle))
+        XCTAssertFalse(UserRight.selfUserIsPermitted(to: .editEmail))
+        XCTAssertFalse(UserRight.selfUserIsPermitted(to: .editPhone))
+        XCTAssertTrue(UserRight.selfUserIsPermitted(to: .editProfilePicture))
+        XCTAssertFalse(UserRight.selfUserIsPermitted(to: .editAccentColor))
+    }
+
+    func test_SelfUserRights_NotManagedByWire_SSOLogin() {
+        // Given
+        selfUser.managedByWire = false
+        selfUser.usesCompanyLogin = true
+
+        // Then
+        XCTAssertFalse(UserRight.selfUserIsPermitted(to: .resetPassword))
+        XCTAssertFalse(UserRight.selfUserIsPermitted(to: .editName))
+        XCTAssertFalse(UserRight.selfUserIsPermitted(to: .editHandle))
+        XCTAssertFalse(UserRight.selfUserIsPermitted(to: .editEmail))
+        XCTAssertFalse(UserRight.selfUserIsPermitted(to: .editPhone))
+        XCTAssertTrue(UserRight.selfUserIsPermitted(to: .editProfilePicture))
+        XCTAssertFalse(UserRight.selfUserIsPermitted(to: .editAccentColor))
+    }
+
+}

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1171,6 +1171,7 @@
 		EEE81E9623E0521300A1D035 /* TopPeopleLineCollectionViewControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE81E9523E0521300A1D035 /* TopPeopleLineCollectionViewControllerDelegate.swift */; };
 		EEE81E9823E0815600A1D035 /* ProfilePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE81E9723E0815600A1D035 /* ProfilePresenter.swift */; };
 		EEE81E9A23E091DF00A1D035 /* ProfilePresenter+ProfileViewControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE81E9923E091DF00A1D035 /* ProfilePresenter+ProfileViewControllerDelegate.swift */; };
+		EEEB8B57260B685300554C39 /* UserRightTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEEB8B56260B685300554C39 /* UserRightTests.swift */; };
 		EEEED9A623F6AF80008C94CA /* TestingAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEEED9A423F6AF7A008C94CA /* TestingAppDelegate.swift */; };
 		EEEED9B223F6EA53008C94CA /* MockUserType+ZMEditableUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEEED9B023F6EA4F008C94CA /* MockUserType+ZMEditableUser.swift */; };
 		EEF28EEA1F1613DA007642E2 /* MarkdownBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF28EE91F1613DA007642E2 /* MarkdownBarView.swift */; };
@@ -2935,6 +2936,7 @@
 		EEE81E9523E0521300A1D035 /* TopPeopleLineCollectionViewControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopPeopleLineCollectionViewControllerDelegate.swift; sourceTree = "<group>"; };
 		EEE81E9723E0815600A1D035 /* ProfilePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilePresenter.swift; sourceTree = "<group>"; };
 		EEE81E9923E091DF00A1D035 /* ProfilePresenter+ProfileViewControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProfilePresenter+ProfileViewControllerDelegate.swift"; sourceTree = "<group>"; };
+		EEEB8B56260B685300554C39 /* UserRightTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRightTests.swift; sourceTree = "<group>"; };
 		EEEED9A423F6AF7A008C94CA /* TestingAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestingAppDelegate.swift; sourceTree = "<group>"; };
 		EEEED9B023F6EA4F008C94CA /* MockUserType+ZMEditableUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MockUserType+ZMEditableUser.swift"; sourceTree = "<group>"; };
 		EEF28EE91F1613DA007642E2 /* MarkdownBarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MarkdownBarView.swift; path = ../../MarkdownBarView.swift; sourceTree = "<group>"; };
@@ -6158,6 +6160,7 @@
 				542CDF3F24B32E2100DF0B39 /* HandleChangeStateTests.swift */,
 				63CE88A32506A83300E457C7 /* OrientationDeltaTests.swift */,
 				6338610125ED3DEC0077BC05 /* ToastViewTests.swift */,
+				EEEB8B56260B685300554C39 /* UserRightTests.swift */,
 			);
 			path = "Wire-iOS Tests";
 			sourceTree = "<group>";
@@ -8736,6 +8739,7 @@
 				162AE74D219DB1BD00581D98 /* ConversationImageMessageTests.swift in Sources */,
 				A91833112419275E00CBD0B7 /* TokenSeparatorAttachmentTests.swift in Sources */,
 				EF15A7B420BC304A00A045C7 /* SavableImageTests.swift in Sources */,
+				EEEB8B57260B685300554C39 /* UserRightTests.swift in Sources */,
 				5E294597219087CA0045ACFA /* ConversationReplyCellTests.swift in Sources */,
 				EF3371C52216F067005ED048 /* MockUser+SelfUserFromSession.swift in Sources */,
 				BFE2542720BE9EA200F62041 /* CallHapticsControllerTests.swift in Sources */,

--- a/Wire-iOS/Sources/UserInterface/Settings/UserRight.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/UserRight.swift
@@ -24,31 +24,40 @@ protocol UserRightInterface {
 }
 
 final class UserRight: UserRightInterface {
+
     enum Permission {
-        case resetPassword,
-             editName,
-             editHandle,
-             editEmail,
-             editPhone,
-             editProfilePicture,
-             editAccentColor
+
+        case resetPassword
+        case editName
+        case editHandle
+        case editEmail
+        case editPhone
+        case editProfilePicture
+        case editAccentColor
+
     }
 
     static func selfUserIsPermitted(to permission: UserRight.Permission) -> Bool {
-        let selfUser = ZMUser.selfUser()
-        let usesCompanyLogin = selfUser?.usesCompanyLogin == true
+        guard let selfUser = SelfUser.provider?.selfUser else { return false }
+
+        let isProfileEditable = selfUser.managedByWire
+        let usesCompanyLogin = selfUser.usesCompanyLogin
 
         switch permission {
         case .editEmail:
         #if EMAIL_EDITING_DISABLED
             return false
         #else
-            return isProfileEditable || !usesCompanyLogin
+            return isProfileEditable
         #endif
+
         case .resetPassword:
             return isProfileEditable || !usesCompanyLogin
+
         case .editProfilePicture:
-            return true // NOTE we always allow editing for now since settting profile picture is not yet supported by SCIM
+            // NOTE we always allow editing for now since settting profile picture is not yet supported by SCIM.
+            return true
+
         case .editName,
              .editHandle,
              .editPhone,
@@ -57,7 +66,4 @@ final class UserRight: UserRightInterface {
         }
     }
 
-    private static var isProfileEditable: Bool {
-        return ZMUser.selfUser()?.managedByWire ?? true
-    }
 }


### PR DESCRIPTION
## What's new in this PR?

**JIRA:** https://wearezeta.atlassian.net/browse/SQSERVICES-177

### Issues

SCIM users can edit the email field in the settings, but this is not allowed and the backend will reject the request.

### Causes

Incorrect condition in `UserRights`, namely we were allowing SCIM users to edit the email field if they were not using SSO to login. But SCIM users should never be able to change their email from within Wire.

### Solutions

Change the condition to be dependent only on whether the self user is a SCIM user or not.
