### PR TITLE
[Fix] Crash after picking credentials from keychain when adding second account

### DIFF
--- a/Wire-iOS/Sources/AppRootRouter.swift
+++ b/Wire-iOS/Sources/AppRootRouter.swift
@@ -391,7 +391,7 @@ extension AppRootRouter {
 extension AppRootRouter {
     private func applicationWillTransition(to appState: AppState) {
         appStateTransitionGroup.enter()
-        configureSelfUserProvider(for: appState)
+        configureSelfUserProviderIfNeeded(for: appState)
         configureColorScheme()
     }
 
@@ -406,12 +406,12 @@ extension AppRootRouter {
             ZClientViewController.shared?.legalHoldDisclosureController?.discloseCurrentState(cause: .appOpen)
         }
 
-        resetSelfUserProvider(for: appState)
+        resetSelfUserProviderIfNeeded(for: appState)
         urlActionRouter.openDeepLink(for: appState)
         appStateTransitionGroup.leave()
     }
 
-    private func resetSelfUserProvider(for appState: AppState) {
+    private func resetSelfUserProviderIfNeeded(for appState: AppState) {
         guard AppDelegate.shared.shouldConfigureSelfUserProvider else { return }
 
         switch appState {
@@ -421,7 +421,7 @@ extension AppRootRouter {
         }
     }
 
-    private func configureSelfUserProvider(for appState: AppState) {
+    private func configureSelfUserProviderIfNeeded(for appState: AppState) {
         guard AppDelegate.shared.shouldConfigureSelfUserProvider else { return }
 
         if case .authenticated = appState {

--- a/Wire-iOS/Sources/AppRootRouter.swift
+++ b/Wire-iOS/Sources/AppRootRouter.swift
@@ -391,15 +391,8 @@ extension AppRootRouter {
 extension AppRootRouter {
     private func applicationWillTransition(to appState: AppState) {
         appStateTransitionGroup.enter()
-        if case .authenticated = appState {
-            if AppDelegate.shared.shouldConfigureSelfUserProvider {
-                SelfUser.provider = ZMUserSession.shared()
-            }
-        }
-
-        let colorScheme = ColorScheme.default
-        colorScheme.accentColor = .accent()
-        colorScheme.variant = Settings.shared.colorSchemeVariant
+        configureSelfUserProvider(for: appState)
+        configureColorScheme()
     }
 
     private func applicationDidTransition(to appState: AppState) {
@@ -411,12 +404,35 @@ extension AppRootRouter {
             authenticatedRouter?.updateActiveCallPresentationState()
 
             ZClientViewController.shared?.legalHoldDisclosureController?.discloseCurrentState(cause: .appOpen)
-        } else if AppDelegate.shared.shouldConfigureSelfUserProvider {
-            SelfUser.provider = nil
         }
 
+        resetSelfUserProvider(for: appState)
         urlActionRouter.openDeepLink(for: appState)
         appStateTransitionGroup.leave()
+    }
+
+    private func resetSelfUserProvider(for appState: AppState) {
+        guard AppDelegate.shared.shouldConfigureSelfUserProvider else { return }
+
+        switch appState {
+        case .authenticated: break
+        default:
+            SelfUser.provider = nil
+        }
+    }
+
+    private func configureSelfUserProvider(for appState: AppState) {
+        guard AppDelegate.shared.shouldConfigureSelfUserProvider else { return }
+
+        if case .authenticated = appState {
+            SelfUser.provider = ZMUserSession.shared()
+        }
+    }
+
+    private func configureColorScheme() {
+        let colorScheme = ColorScheme.default
+        colorScheme.accentColor = .accent()
+        colorScheme.variant = Settings.shared.colorSchemeVariant
     }
 
     private func presentAlertForDeletedAccountIfNeeded(_ error: NSError?) {

--- a/Wire-iOS/Sources/AppRootRouter.swift
+++ b/Wire-iOS/Sources/AppRootRouter.swift
@@ -405,7 +405,9 @@ extension AppRootRouter {
     private func applicationDidTransition(to appState: AppState) {
         if case .unauthenticated(let error) = appState {
             presentAlertForDeletedAccountIfNeeded(error)
-        } else if case .authenticated = appState {
+        }
+
+        if case .authenticated = appState {
             authenticatedRouter?.updateActiveCallPresentationState()
 
             ZClientViewController.shared?.legalHoldDisclosureController?.discloseCurrentState(cause: .appOpen)


### PR DESCRIPTION
## What's new in this PR?

### Issues

1. User A logs in to Wire App User A taps on self profile 
2. User A taps on Add Account 
3. User A sees suggested accounts on top of keyboard
4.  User A taps on suggested account 
5. User A enters passcode/biometrics

App crashes

### Causes

When the app returns the password picker it triggers `AppRootRouter.applicationDidBecomeActive()` and calls `teamMetadataRefresher.triggerRefreshIfNeeded()`, which end up accessing the `SelfUser.provider` which is not `nil` as expected in this scenario. This causes the app to crash when force unwrapping the `managedObjectContext` when it tries to retrieve the self user.

The `SelfUser.provider` is not nil because when the user taps "Add account" we log the user out with an error, which causes the app to take the first if branch:

https://github.com/wireapp/wire-ios/blob/cce055353f63a5d50834e11df3b7cb2cbd4ef38e/Wire-iOS/Sources/AppRootRouter.swift#L406

And the SelfUser.provider from the previous session therefore remains.

### Solutions

Break out the the first if branch into a separate if statement since we always want to un-set the `SelfUser.provider`