### PR TITLE
Fix: clean up warning related to conversatonLike part 3

### DIFF
--- a/Wire-iOS/Sources/Helpers/syncengine/Conversation+Participants.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/Conversation+Participants.swift
@@ -53,6 +53,7 @@ extension ZMConversation {
         }
     }
 
+    ///TODO: mv this to protocol extension
     func removeOrShowError(participant user: UserType, completion: ((VoidResult) -> Void)? = nil) {
         guard let session = ZMUserSession.shared(),
             session.networkState != .offline else {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsContentViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsContentViewController.swift
@@ -33,7 +33,7 @@ final class MessageDetailsContentViewController: UIViewController {
     // MARK: - Configuration
 
     /// The conversation that is being accessed.
-    let conversation: ZMConversation
+    let conversation: GroupDetailsConversationType
 
     /// The type of the displayed content.
     let contentType: ContentType
@@ -75,14 +75,15 @@ final class MessageDetailsContentViewController: UIViewController {
      * Creates a view controller to display message details of a certain type.
      */
 
-    init(contentType: ContentType, conversation: ZMConversation) {
+    init(contentType: ContentType, conversation: GroupDetailsConversationType) {
         self.contentType = contentType
         self.conversation = conversation
         super.init(nibName: nil, bundle: nil)
         updateTitle()
     }
 
-    public required init?(coder aDecoder: NSCoder) {
+    @available(*, unavailable)
+    required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsDataSource.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsDataSource.swift
@@ -47,7 +47,7 @@ final class MessageDetailsDataSource: NSObject, ZMMessageObserver, ZMUserObserve
     let message: ZMConversationMessage
 
     /// The conversation where the message is
-    let conversation: ZMConversation
+    let conversation: GroupDetailsConversationType
 
     /// How to display the message details.
     let displayMode: MessageDetailsDisplayMode
@@ -79,7 +79,7 @@ final class MessageDetailsDataSource: NSObject, ZMMessageObserver, ZMUserObserve
 
     init(message: ZMConversationMessage) {
         self.message = message
-        self.conversation = message.conversation!
+        self.conversation = message.conversationLike as! GroupDetailsConversationType
 
         // Assign the initial data
         self.reactions = MessageDetailsCellDescription.makeReactionCells(message.sortedLikers)

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+ClearContent.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+ClearContent.swift
@@ -47,6 +47,7 @@ enum ClearContentResult {
         return "meta.menu.delete_content.dialog_message".localized
     }
 
+    ///TODO: change to  ConversationLike
     static func options(for conversation: ZMConversation) -> [ClearContentResult] {
         if conversation.conversationType == .oneOnOne || !conversation.isSelfAnActiveMember {
             return [.delete(leave: false), .cancel]

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+Notifications.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+Notifications.swift
@@ -61,7 +61,9 @@ enum NotificationResult: CaseIterable {
         }
     }
 
-    func action(for conversation: ZMConversation, handler: @escaping (NotificationResult) -> Void) -> UIAlertAction {
+    //TODO: change to ConversationLike
+    func action(for conversation: ZMConversation,
+                handler: @escaping (NotificationResult) -> Void) -> UIAlertAction {
         let checkmarkText: String
 
         if let mutedMessageTypes = self.mutedMessageTypes, conversation.mutedMessageTypes == mutedMessageTypes {

--- a/Wire-iOS/Sources/UserInterface/SelfProfile/ProfileHeaderViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/ProfileHeaderViewController.swift
@@ -57,7 +57,7 @@ final class ProfileHeaderViewController: UIViewController, Themeable {
     }
 
     /// Associated conversation, if displayed in the context of a conversation
-    let conversation: ZMConversation?
+    let conversation: ConversationLike?
 
     /// The user that is displayed.
     let user: UserType
@@ -122,7 +122,10 @@ final class ProfileHeaderViewController: UIViewController, Themeable {
      * - note: You can change the options later through the `options` property.
      */
 
-    init(user: UserType, viewer: UserType = SelfUser.current, conversation: ZMConversation? = nil, options: Options) {
+    init(user: UserType,
+         viewer: UserType = SelfUser.current,
+         conversation: ConversationLike? = nil,
+         options: Options) {
         self.user = user
         isAdminRole = conversation.map(self.user.isGroupAdmin) ?? false
         self.viewer = viewer

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsContentController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsContentController.swift
@@ -64,7 +64,7 @@ final class ProfileDetailsContentController: NSObject,
     let viewer: UserType
 
     /// The conversation where the profile details will be displayed.
-    let conversation: ZMConversation?
+    let conversation: ConversationLike?
 
     /// The current group admin status for UI.
     private var isAdminState: Bool
@@ -94,7 +94,7 @@ final class ProfileDetailsContentController: NSObject,
 
     init(user: UserType,
          viewer: UserType,
-         conversation: ZMConversation?) {
+         conversation: ConversationLike?) {
         self.user = user
         self.viewer = viewer
         self.conversation = conversation
@@ -154,7 +154,8 @@ final class ProfileDetailsContentController: NSObject,
             // Do not show group admin toggle for self user or requesting connection user
             var items: [ProfileDetailsContentController.Content] = []
 
-            if let conversation = conversation {
+            if let conversation = conversation as? ZMConversation {
+                ///TODO: add canModifyOtherMember to protocol
                 let viewerCanChangeOtherRoles = viewer.canModifyOtherMember(in: conversation)
                 let userCanHaveRoleChanged = !user.isWirelessUser
 
@@ -284,7 +285,8 @@ final class ProfileDetailsContentController: NSObject,
     }
 
     private func updateConversationRole() {
-        let groupRoles = self.conversation?.getRoles()
+        ///TODO: getRoles in protocol
+        let groupRoles = (conversation as? ZMConversation)?.getRoles()
         let newParticipantRole = groupRoles?.first {
             $0.name == (self.isAdminState ? ZMConversation.defaultAdminRoleName : ZMConversation.defaultMemberRoleName)
         }
@@ -295,7 +297,8 @@ final class ProfileDetailsContentController: NSObject,
             let user = (user as? ZMUser) ?? (user as? ZMSearchUser)?.user
             else { return }
 
-        conversation?.updateRole(of: user, to: role, session: session) { (result) in
+        ///TODO: mv updateRole to protocol
+        (conversation as? ZMConversation)?.updateRole(of: user, to: role, session: session) { (result) in
             if case .failure = result {
                 self.isAdminState.toggle()
                 self.updateUI()

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsViewController.swift
@@ -32,7 +32,7 @@ final class ProfileDetailsViewController: UIViewController, Themeable {
     let viewer: UserType
 
     /// The conversation where the profile is displayed.
-    let conversation: ZMConversation?
+    let conversation: ConversationLike?
 
     let context: ProfileViewControllerContext
 
@@ -76,7 +76,7 @@ final class ProfileDetailsViewController: UIViewController, Themeable {
 
     init(user: UserType,
          viewer: UserType,
-         conversation: ZMConversation?,
+         conversation: ConversationLike?,
          context: ProfileViewControllerContext) {
 
         var profileHeaderOptions: ProfileHeaderViewController.Options = [.hideUsername, .hideHandle, .hideTeamName]

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileActionsFactory.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileActionsFactory.swift
@@ -97,7 +97,7 @@ final class ProfileActionsFactory {
     let viewer: UserType
 
     /// The conversation that the user wants to perform the actions in.
-    let conversation: ZMConversation?
+    let conversation: ConversationLike?
 
     /// The context of the Profile VC
     let context: ProfileViewControllerContext
@@ -112,7 +112,10 @@ final class ProfileActionsFactory {
      * perform the actions in.
      */
 
-    init(user: UserType, viewer: UserType, conversation: ZMConversation?, context: ProfileViewControllerContext) {
+    init(user: UserType,
+         viewer: UserType,
+         conversation: ConversationLike?,
+         context: ProfileViewControllerContext) {
         self.user = user
         self.viewer = viewer
         self.conversation = conversation
@@ -140,7 +143,7 @@ final class ProfileActionsFactory {
             return [.block(isBlocked: true)]
         }
 
-        var conversation: ZMConversation?
+        var conversation: ConversationLike?
 
         // If there is no conversation and open profile from a conversation, offer to connect to the user if possible
         if let selfConversation = self.conversation {
@@ -166,7 +169,7 @@ final class ProfileActionsFactory {
 
             // Notifications, Archive, Delete Contents if available for every 1:1
             if let conversation = conversation {
-                let notificationAction: ProfileAction = viewer.isTeamMember ? .manageNotifications : .mute(isMuted: conversation.mutedMessageTypes != .none)
+                let notificationAction: ProfileAction = viewer.isTeamMember ? .manageNotifications : .mute(isMuted: (conversation as? ZMConversation)?.mutedMessageTypes != .none)
                 actions.append(contentsOf: [notificationAction, .archive, .deleteContents])
             }
 
@@ -195,7 +198,8 @@ final class ProfileActionsFactory {
             }
 
             // Only non-guests and non-partners are allowed to remove
-            if let conversation = conversation, viewer.canRemoveUser(from: conversation) {
+            if let conversation = conversation as? ZMConversation,
+               viewer.canRemoveUser(from: conversation) {
                 actions.append(.removeFromGroup)
             }
 

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.swift
@@ -71,7 +71,7 @@ final class ProfileViewController: UIViewController {
 
     convenience init(user: UserType,
                      viewer: UserType,
-                     conversation: ZMConversation? = nil,
+                     conversation: ConversationLike? = nil,
                      context: ProfileViewControllerContext? = nil,
                      viewControllerDismisser: ViewControllerDismisser? = nil) {
         let profileViewControllerContext: ProfileViewControllerContext
@@ -403,7 +403,7 @@ extension ProfileViewController: ProfileFooterViewDelegate, IncomingRequestFoote
     // MARK: Notifications
 
     private func presentNotificationsOptions(from targetView: UIView) {
-        guard let conversation = viewModel.conversation else { return }
+        guard let conversation = viewModel.conversation as? ZMConversation else { return }
 
         let title = "\(conversation.displayName) • \(NotificationResult.title)"
         let controller = UIAlertController(title: title, message: nil, preferredStyle: .actionSheet)
@@ -414,7 +414,7 @@ extension ProfileViewController: ProfileFooterViewDelegate, IncomingRequestFoote
     // MARK: Delete Contents
 
     private func presentDeleteConfirmationPrompt(from targetView: UIView) {
-        guard let conversation = viewModel.conversation else { return }
+        guard let conversation = viewModel.conversation as? ZMConversation else { return }
 
         let controller = UIAlertController(title: ClearContentResult.title, message: nil, preferredStyle: .actionSheet)
         ClearContentResult.options(for: conversation).map { $0.action(viewModel.handleDeleteResult) }.forEach(controller.addAction)
@@ -433,7 +433,7 @@ extension ProfileViewController: ProfileFooterViewDelegate, IncomingRequestFoote
         )
 
         let removeAction = UIAlertAction(title: "profile.remove_dialog_button_remove_confirm".localized, style: .destructive) { _ in
-            self.viewModel.conversation?.removeOrShowError(participant: otherUser) { result in
+            (self.viewModel.conversation as? ZMConversation)?.removeOrShowError(participant: otherUser) { result in
                 switch result {
                 case .success:
                     self.returnToPreviousScreen()

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewControllerViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewControllerViewModel.swift
@@ -34,7 +34,7 @@ enum ProfileViewControllerContext {
 
 final class ProfileViewControllerViewModel: NSObject {
     let user: UserType
-    let conversation: ZMConversation?
+    let conversation: ConversationLike?
     let viewer: UserType
     let context: ProfileViewControllerContext
 
@@ -50,7 +50,7 @@ final class ProfileViewControllerViewModel: NSObject {
     weak var viewModelDelegate: ProfileViewControllerViewModelDelegate?
 
     init(user: UserType,
-         conversation: ZMConversation?,
+         conversation: ConversationLike?,
          viewer: UserType,
          context: ProfileViewControllerContext) {
         self.user = user
@@ -123,7 +123,8 @@ final class ProfileViewControllerViewModel: NSObject {
 
     func archiveConversation() {
         transitionToListAndEnqueue {
-            self.conversation?.isArchived.toggle()
+            ///TODO: add isArchived to protocol
+            (self.conversation as? ZMConversation)?.isArchived.toggle()
         }
     }
 
@@ -141,7 +142,8 @@ final class ProfileViewControllerViewModel: NSObject {
 
     func updateMute(enableNotifications: Bool) {
         ZMUserSession.shared()?.enqueue {
-            self.conversation?.mutedMessageTypes = enableNotifications ? .none : .all
+            //TODO: mv mutedMessageTypes to protocol
+            (self.conversation as? ZMConversation)?.mutedMessageTypes = enableNotifications ? .none : .all
             // update the footer view to display the correct mute/unmute button
             self.viewModelDelegate?.updateFooterViews()
         }
@@ -150,7 +152,7 @@ final class ProfileViewControllerViewModel: NSObject {
     func handleNotificationResult(_ result: NotificationResult) {
         if let mutedMessageTypes = result.mutedMessageTypes {
             ZMUserSession.shared()?.perform {
-                self.conversation?.mutedMessageTypes = mutedMessageTypes
+                (self.conversation as? ZMConversation)?.mutedMessageTypes = mutedMessageTypes
             }
         }
     }
@@ -160,9 +162,10 @@ final class ProfileViewControllerViewModel: NSObject {
     func handleDeleteResult(_ result: ClearContentResult) {
         guard case .delete(leave: let leave) = result else { return }
         transitionToListAndEnqueue {
-            self.conversation?.clearMessageHistory()
+            ///TODO: mv clearMessageHistory to protocol
+            (self.conversation as? ZMConversation)?.clearMessageHistory()
             if leave {
-                self.conversation?.removeOrShowError(participant: SelfUser.current)
+                (self.conversation as? ZMConversation)?.removeOrShowError(participant: SelfUser.current)
             }
         }
     }
@@ -188,7 +191,10 @@ final class ProfileViewControllerViewModel: NSObject {
     }
 
     var profileActionsFactory: ProfileActionsFactory {
-        return ProfileActionsFactory(user: user, viewer: viewer, conversation: conversation, context: context)
+        return ProfileActionsFactory(user: user,
+                                     viewer: viewer,
+                                     conversation: conversation,
+                                     context: context)
     }
 
     // MARK: Connect


### PR DESCRIPTION
## What's new in this PR?

Fix the warnings of using deprecated `conversation`