### PR TITLE
[Fix] Team user should have analytics enabled by default

### DIFF
--- a/Wire-iOS/Sources/AppRootRouter.swift
+++ b/Wire-iOS/Sources/AppRootRouter.swift
@@ -361,17 +361,17 @@ extension AppRootRouter {
     }
 
     private func setupAnalyticsSharing() {
-        Analytics.shared.selfUser = SelfUser.current
-
         guard
             appStateCalculator.wasUnauthenticated,
-            Analytics.shared.selfUser?.isTeamMember ?? false
+            let selfUser = SelfUser.provider?.selfUser,
+            selfUser.isTeamMember
         else {
             return
         }
 
         TrackingManager.shared.disableCrashSharing = true
         TrackingManager.shared.disableAnalyticsSharing = false
+        Analytics.shared.provider?.selfUser = selfUser
     }
 
     private func buildAuthenticatedRouter(account: Account, isComingFromRegistration: Bool) -> AuthenticatedRouter? {


### PR DESCRIPTION
## What's new in this PR?

### Context

Analytics usage is opt-in for non team members, and opt-out for team members.

### Issues

When a team member logs into a device for the first time, the analytics usage opted out.

### Causes

The code that enables the default opt in for team members was returning early because there didn't yet exist an instance of the analytics provider, which would only be created once the user was opted in.

### Solutions

Don't rely on the (not yet existing) analytics provider to get the self user, but rather `SelfUser.provider`.

### Notes

There are no tests for setting up analytics yet, but it is something I am addressing in a separate refactoring branch.
