### PR TITLE
[Fix] Crash when disabling Allow guests and Services

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation Options/CellConfiguration+ConversationOptions.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/CellConfiguration+ConversationOptions.swift
@@ -17,11 +17,12 @@
 //
 
 import Foundation
+import UIKit
 
 extension CellConfiguration {
 
     static func groupAdminToogle(get: @escaping () -> Bool,
-                                 set: @escaping (Bool) -> Void) -> CellConfiguration {
+                                 set: @escaping (Bool, UIView?) -> Void) -> CellConfiguration {
         return .iconToggle(
             title: "profile.profile.group_admin_options.title".localized,
             subtitle: "",
@@ -34,7 +35,7 @@ extension CellConfiguration {
         )
     }
 
-    static func allowGuestsToogle(get: @escaping () -> Bool, set: @escaping (Bool) -> Void) -> CellConfiguration {
+    static func allowGuestsToogle(get: @escaping () -> Bool, set: @escaping (Bool, UIView?) -> Void) -> CellConfiguration {
         return .iconToggle(
             title: "guest_room.allow_guests.title".localized,
             subtitle: "guest_room.allow_guests.subtitle".localized,

--- a/Wire-iOS/Sources/UserInterface/Conversation Options/CellConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/CellConfiguration.swift
@@ -43,7 +43,7 @@ enum CellConfiguration {
         icon: StyleKitIcon?,
         color: UIColor?,
         get: () -> Bool,
-        set: (Bool) -> Void)
+        set: (Bool, UIView?) -> Void)
 
     var cellType: CellConfigurationConfigurable.Type {
         switch self {

--- a/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationOptionsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationOptionsViewController.swift
@@ -100,15 +100,19 @@ final class ConversationOptionsViewController: UIViewController, UITableViewDele
         present(UIAlertController.checkYourConnection(), animated: false)
     }
 
-    func viewModel(_ viewModel: ConversationOptionsViewModel, confirmRemovingGuests completion: @escaping (Bool) -> Void) -> UIAlertController? {
+    func viewModel(_ viewModel: ConversationOptionsViewModel, sourceView: UIView? = nil, confirmRemovingGuests completion: @escaping (Bool) -> Void) -> UIAlertController? {
         let alertController = UIAlertController.confirmRemovingGuests(completion)
+        alertController.configPopover(pointToView: sourceView ?? view)
         present(alertController, animated: true)
 
         return alertController
     }
 
-    func viewModel(_ viewModel: ConversationOptionsViewModel, confirmRevokingLink completion: @escaping (Bool) -> Void) {
-        present(UIAlertController.confirmRevokingLink(completion), animated: true)
+    func viewModel(_ viewModel: ConversationOptionsViewModel, sourceView: UIView? = nil, confirmRevokingLink completion: @escaping (Bool) -> Void) {
+        let alertController = UIAlertController.confirmRevokingLink(completion)
+        present(alertController, animated: true)
+
+        alertController.configPopover(pointToView: sourceView ?? view)
     }
 
     func viewModel(_ viewModel: ConversationOptionsViewModel, wantsToShareMessage message: String, sourceView: UIView? = nil) {

--- a/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationOptionsViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationOptionsViewModel.swift
@@ -34,8 +34,8 @@ protocol ConversationOptionsViewModelConfiguration: class {
 protocol ConversationOptionsViewModelDelegate: class {
     func viewModel(_ viewModel: ConversationOptionsViewModel, didUpdateState state: ConversationOptionsViewModel.State)
     func viewModel(_ viewModel: ConversationOptionsViewModel, didReceiveError error: Error)
-    func viewModel(_ viewModel: ConversationOptionsViewModel, confirmRemovingGuests completion: @escaping (Bool) -> Void) -> UIAlertController?
-    func viewModel(_ viewModel: ConversationOptionsViewModel, confirmRevokingLink completion: @escaping (Bool) -> Void)
+    func viewModel(_ viewModel: ConversationOptionsViewModel, sourceView: UIView?, confirmRemovingGuests completion: @escaping (Bool) -> Void) -> UIAlertController?
+    func viewModel(_ viewModel: ConversationOptionsViewModel, sourceView: UIView?, confirmRevokingLink completion: @escaping (Bool) -> Void)
     func viewModel(_ viewModel: ConversationOptionsViewModel, wantsToShareMessage message: String, sourceView: UIView?)
 }
 
@@ -98,9 +98,9 @@ final class ConversationOptionsViewModel {
 
     private func computeVisibleRows() -> [CellConfiguration] {/// TODO: copy?
         var rows: [CellConfiguration] = [.allowGuestsToogle(
-                get: { [unowned self] in return self.configuration.allowGuests },
-                set: { [unowned self] in self.setAllowGuests($0) }
-            )]
+            get: { [unowned self] in return self.configuration.allowGuests },
+            set: { [unowned self] in self.setAllowGuests($0, view: $1) }
+        )]
 
         if configuration.allowGuests {
             rows.append(.linkHeader)
@@ -124,8 +124,11 @@ final class ConversationOptionsViewModel {
         return rows
     }
 
-    private func revokeLink() {
-        delegate?.viewModel(self, confirmRevokingLink: { [weak self] revoke in
+    /// revoke a conversation link
+    ///
+    /// - Parameter view: the source view which triggers revokeLink action
+    private func revokeLink(view: UIView? = nil) {
+        delegate?.viewModel(self, sourceView: view, confirmRevokingLink: { [weak self] revoke in
             guard let `self` = self else { return }
             guard revoke else { return self.updateRows() }
 
@@ -199,7 +202,13 @@ final class ConversationOptionsViewModel {
         }
     }
 
-    @discardableResult func setAllowGuests(_ allowGuests: Bool) -> UIAlertController? {
+
+    /// set conversation option AllowGuestsAndServices
+    /// - Parameters:
+    ///   - allowGuests: new state AllowGuestsAndServices
+    ///   - view: the source view which triggers setAllowGuests action
+    /// - Returns: alert controller
+    @discardableResult func setAllowGuests(_ allowGuests: Bool, view: UIView? = nil) -> UIAlertController? {
         func _setAllowGuests() {
             let item = CancelableItem(delay: 0.4) { [weak self] in
                 self?.state.isLoading = true
@@ -227,7 +236,7 @@ final class ConversationOptionsViewModel {
         // to confirm this action as all guests will be removed.
         if !allowGuests && configuration.areGuestOrServicePresent {
             // Make "remove guests and services" warning only appear if guests or services are present
-            return delegate?.viewModel(self, confirmRemovingGuests: { [weak self] remove in
+            return delegate?.viewModel(self, sourceView: view, confirmRemovingGuests: { [weak self] remove in
                 guard let `self` = self else { return }
                 guard remove else { return self.updateRows() }
                 self.link = nil

--- a/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationOptionsViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationOptionsViewModel.swift
@@ -202,7 +202,6 @@ final class ConversationOptionsViewModel {
         }
     }
 
-
     /// set conversation option AllowGuestsAndServices
     /// - Parameters:
     ///   - allowGuests: new state AllowGuestsAndServices

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Details/Cells/IconToggleSubtitleCell.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Details/Cells/IconToggleSubtitleCell.swift
@@ -27,7 +27,7 @@ final class IconToggleSubtitleCell: UITableViewCell, CellConfigurationConfigurab
     private let toggle = UISwitch()
     private let subtitleLabel = UILabel()
 
-    private var action: ((Bool) -> Void)?
+    private var action: ((Bool, UIView?) -> Void)?
     private var variant: ColorSchemeVariant = .light {
         didSet {
             styleViews()
@@ -96,7 +96,7 @@ final class IconToggleSubtitleCell: UITableViewCell, CellConfigurationConfigurab
     }
 
     @objc private func toggleChanged(_ sender: UISwitch) {
-        action?(sender.isOn)
+        action?(sender.isOn, self)
     }
 
     func configure(with configuration: CellConfiguration, variant: ColorSchemeVariant) {

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsContentController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsContentController.swift
@@ -238,7 +238,7 @@ final class ProfileDetailsContentController: NSObject,
 
             cell.configure(with: CellConfiguration.groupAdminToogle(get: {
                 return groupAdminEnabled
-            }, set: {_,_  in
+            }, set: {_,_ in
                 self.isAdminState.toggle()
                 self.delegate?.profileGroupRoleDidChange(isAdminRole: self.isAdminState)
                 self.updateConversationRole()

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsContentController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsContentController.swift
@@ -238,7 +238,7 @@ final class ProfileDetailsContentController: NSObject,
 
             cell.configure(with: CellConfiguration.groupAdminToogle(get: {
                 return groupAdminEnabled
-            }, set: {_ in
+            }, set: {_,_  in
                 self.isAdminState.toggle()
                 self.delegate?.profileGroupRoleDidChange(isAdminRole: self.isAdminState)
                 self.updateConversationRole()

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsContentController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsContentController.swift
@@ -238,7 +238,7 @@ final class ProfileDetailsContentController: NSObject,
 
             cell.configure(with: CellConfiguration.groupAdminToogle(get: {
                 return groupAdminEnabled
-            }, set: {_,_ in
+            }, set: {_, _ in
                 self.isAdminState.toggle()
                 self.delegate?.profileGroupRoleDidChange(isAdminRole: self.isAdminState)
                 self.updateConversationRole()


### PR DESCRIPTION
## What's new in this PR?

https://wearezeta.atlassian.net/browse/SQSERVICES-367

### Issues
There's a crash when user disables `Allow guests and Services` on **iPad**.

### Causes
On iPad, `UIAlertController` must be presented in a popover and the popover's source view (the view which the popover points to) must be set.

### Solutions
Set the source view for the `UIAlertController`. This fix required some additional changes that shouldn't affect the current behavior.
