### PR TITLE
[Fix] Stuck on login if same logout error happens twice

### DIFF
--- a/Wire-iOS/Generated/Strings+Generated.swift
+++ b/Wire-iOS/Generated/Strings+Generated.swift
@@ -60,7 +60,7 @@ internal enum L10n {
     internal enum AccountDeletedMissingPasscodeAlert {
       /// In order to use Wire, please set a passcode in your device settings.
       internal static let message = L10n.tr("Localizable", "account_deleted_missing_passcode_alert.message")
-      /// No Device Passcode
+      /// No device passcode
       internal static let title = L10n.tr("Localizable", "account_deleted_missing_passcode_alert.title")
     }
     internal enum AccountDeletedSessionExpiredAlert {

--- a/Wire-iOS/Sources/AppStateCalculator.swift
+++ b/Wire-iOS/Sources/AppStateCalculator.swift
@@ -39,7 +39,7 @@ enum AppState: Equatable {
         case (.authenticated, .authenticated):
             return true
         case let (.unauthenticated(error1), .unauthenticated(error2)):
-            return error1 == error2
+            return error1 === error2
         case (blacklisted, blacklisted):
             return true
         case (jailbroken, jailbroken):


### PR DESCRIPTION
## What's new in this PR?

### Issues

If the user is logged out while in `.unauthenticated` state, the app can get stuck if this happens twice with the same error.

### Causes

We only transition between app states if the new state is different from the previous state. The error associated with the `.unauthenticated` state is part of the equality check and we expect to reload unauthenticated view controller if we move to the `.unauthenticated` state associated with an error.  This only works for the first error but if the same error happens a second time we could potentially get stuck since the app state will determined to not have changed.

### Solutions

Change to error comparison from an object to a reference equality check . We could also check that if error is not `nil` and in that case always consider the app state to have changed.