### PR TITLE
remove CODECOV_TOKEN from fastlane

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,7 +60,6 @@ steps:
 - script: |
     fastlane post_test
   env:  
-    CODECOV_TOKEN: $(CODECOV_TOKEN)
     DEPENDENCIES_BASE_URL: "https://raw.githubusercontent.com/wireapp/wire-ios-shared-resources/master"
     GITHUB_ACCESS_TOKEN: $(GITHUB_ACCESS_TOKEN)   
   displayName: "Post Test"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -298,7 +298,6 @@ platform :ios do
         end
 
         sh codecov
-
     end
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -287,9 +287,6 @@ platform :ios do
         codecov = "./codecov -J '^Wire$' -D ../DerivedData"
 
         if ENV["BUILD_REASON"] == "PullRequest"
-            if ENV["CODECOV_TOKEN"].nil?
-                UI.user_error! "codecov.io token missing for current repository. Set it in CODECOV_TOKEN environment variable"
-            end
 
             if ENV["BUILD_SOURCEBRANCH"].nil?
                 UI.user_error! "Source branch env variable missing. Set BUILD_SOURCEBRANCH to fix it"
@@ -297,7 +294,7 @@ platform :ios do
 
             pull_request_number = ENV["BUILD_SOURCEBRANCH"].split("/")[2] # For PRs the branch is in format "refs/pull/1/merge"
 
-            codecov << " -t #{ENV["CODECOV_TOKEN"]} -P #{pull_request_number}"
+            codecov << " -P #{pull_request_number}"
         end
 
         sh codecov


### PR DESCRIPTION
## What's new in this PR?

Since this repo is public, CODECOV_TOKEN should be unnecessary when running codecov and it can be removed

###TODO
- [ ] (optional) remove the similar code in other public repos