### PR TITLE
[Feature] disable join & leave haptics for group calls

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -470,6 +470,7 @@
 		6357B41626121D55008F1761 /* MockPanGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6357B41526121D55008F1761 /* MockPanGestureRecognizer.swift */; };
 		6357B41A261226C4008F1761 /* MockPinchGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6357B419261226C4008F1761 /* MockPinchGestureRecognizer.swift */; };
 		63589AA124DAA398008FEC8F /* UIAlertController+Permissions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63589AA024DAA398008FEC8F /* UIAlertController+Permissions.swift */; };
+		635BAFE6262DB34400B986A4 /* Array+CallParticipant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635BAFE5262DB34400B986A4 /* Array+CallParticipant.swift */; };
 		6363EC9B23D7622F00E74F67 /* NSMutableAttributedString+CompanyLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6363EC9A23D7622F00E74F67 /* NSMutableAttributedString+CompanyLogin.swift */; };
 		63654F8025B8CD260015344C /* RoundedSegmentedViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63654F7F25B8CD260015344C /* RoundedSegmentedViewTests.swift */; };
 		636E57BD2386BFD9005B4FD8 /* AvailabilityStringBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636E57BC2386BFD9005B4FD8 /* AvailabilityStringBuilderTests.swift */; };
@@ -2121,6 +2122,7 @@
 		6357B41526121D55008F1761 /* MockPanGestureRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPanGestureRecognizer.swift; sourceTree = "<group>"; };
 		6357B419261226C4008F1761 /* MockPinchGestureRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPinchGestureRecognizer.swift; sourceTree = "<group>"; };
 		63589AA024DAA398008FEC8F /* UIAlertController+Permissions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertController+Permissions.swift"; sourceTree = "<group>"; };
+		635BAFE5262DB34400B986A4 /* Array+CallParticipant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+CallParticipant.swift"; sourceTree = "<group>"; };
 		6363EC9A23D7622F00E74F67 /* NSMutableAttributedString+CompanyLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMutableAttributedString+CompanyLogin.swift"; sourceTree = "<group>"; };
 		63654F7F25B8CD260015344C /* RoundedSegmentedViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedSegmentedViewTests.swift; sourceTree = "<group>"; };
 		636E57BC2386BFD9005B4FD8 /* AvailabilityStringBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailabilityStringBuilderTests.swift; sourceTree = "<group>"; };
@@ -6293,6 +6295,7 @@
 				BF5FAC0020B6B738004CEB45 /* UIAlertController+OngoingCall.swift */,
 				BFE41862209B15F800503C7C /* Calling+Logs.swift */,
 				BFE41870209C8AFD00503C7C /* CallInfoConfiguration+Debug.swift */,
+				635BAFE5262DB34400B986A4 /* Array+CallParticipant.swift */,
 			);
 			path = Helper;
 			sourceTree = "<group>";
@@ -8383,6 +8386,7 @@
 				EFD1A61F224001AB00695792 /* ConversationInputBarViewController+CreateViews.swift in Sources */,
 				A96E803224CB2AB60010CD80 /* PasscodeSetupViewController.swift in Sources */,
 				5E3FB06C206BC7AC0075E910 /* TabBar.swift in Sources */,
+				635BAFE6262DB34400B986A4 /* Array+CallParticipant.swift in Sources */,
 				87B8C3411DF9788B0015EC89 /* MapOpening.swift in Sources */,
 				F112C58620497860007C1E8F /* Analytics+Guests.swift in Sources */,
 				875060731E5B3D9E005B21C7 /* FileBackupExcluder.swift in Sources */,

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -336,7 +336,7 @@ extension CallViewController: WireCallCenterCallParticipantObserver {
     }
 
     private func updateVideoGridPresentationModeIfNeeded(participants: [CallParticipant]) {
-        guard participants.filter(\.state.isConnected).count <= 2 else { return }
+        guard !participants.hasMoreThanTwoConnectedParticipants else { return }
 
         voiceChannel.videoGridPresentationMode = .allVideoStreams
     }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/VideoConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/VideoConfiguration.swift
@@ -197,12 +197,3 @@ private extension VideoGridPresentationMode {
         return self == .allVideoStreams
     }
 }
-
-private extension Array where Element == CallParticipant {
-    mutating func sortByName(selfStreamId: AVSClient?) {
-        self = self.sorted {
-            $0.streamId == selfStreamId ||
-            $0.user.name?.lowercased() < $1.user.name?.lowercased()
-        }
-    }
-}

--- a/Wire-iOS/Sources/UserInterface/Calling/Haptic Feedback/CallHapticsController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/Haptic Feedback/CallHapticsController.swift
@@ -50,7 +50,19 @@ final class CallHapticsController {
 
     // MARK: - Private
 
+    private func shouldUpdateParticipantsList(_ newParticipants: [CallParticipant]) -> Bool {
+        return !(Array(participants).hasMoreThanTwoConnectedParticipants || newParticipants.hasMoreThanTwoConnectedParticipants)
+    }
+
     private func updateParticipantsList(_ newParticipants: [CallParticipant]) {
+        defer {
+            participants = Set(newParticipants)
+        }
+
+        guard shouldUpdateParticipantsList(newParticipants) else {
+            return
+        }
+
         let updatedHashes = Set(newParticipants.map(\.hashValue))
         let participantsHashes = Set(participants.map(\.hashValue))
 
@@ -67,8 +79,6 @@ final class CallHapticsController {
             Log.haptics.debug("triggering join event")
             hapticGenerator.trigger(event: .join)
         }
-
-        participants = Set(newParticipants)
     }
 
     private func updateParticipantsVideoStateList(_ newParticipants: [CallParticipant]) {

--- a/Wire-iOS/Sources/UserInterface/Calling/Helper/Array+CallParticipant.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/Helper/Array+CallParticipant.swift
@@ -1,0 +1,34 @@
+//
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireSyncEngine
+
+extension Array where Element == CallParticipant {
+
+    var hasMoreThanTwoConnectedParticipants: Bool {
+        return filter(\.state.isConnected).count > 2
+    }
+
+    mutating func sortByName(selfStreamId: AVSClient?) {
+        self = self.sorted {
+            $0.streamId == selfStreamId ||
+                $0.user.name?.lowercased() < $1.user.name?.lowercased()
+        }
+    }
+}


### PR DESCRIPTION
## What's new in this PR?

This PR disables the join and leave haptics for group calls

### Changes
- Updated `CallHapticsController` logic
- Added an `Array+CallParticipant` helper
- Updated and renamed some tests for `CallHapticsControllerTests`

