### PR TITLE
[Fix] The close button is not visible on the connection request view

### DIFF
--- a/Wire-iOS Tests/DeviceManagement/ProfileViewControllerTests.swift
+++ b/Wire-iOS Tests/DeviceManagement/ProfileViewControllerTests.swift
@@ -48,53 +48,181 @@ final class ProfileViewControllerTests: XCTestCase {
         super.tearDown()
     }
 
+    // MARK: - .profileViewer  Context
+
     func testForContextProfileViewer() {
+        // GIVEN
         selfUser.teamRole = .member
         mockUser.emailAddress = nil
+
+        // WHEN
         sut = ProfileViewController(user: mockUser,
                                     viewer: selfUser,
                                     context: .profileViewer)
 
+        // THEN
         verify(matching: sut)
     }
 
     func testForContextProfileViewerForSelfUser() {
+        // GIVEN
         selfUser.teamRole = .member
         selfUser.emailAddress = nil
+
+        // WHEN
         sut = ProfileViewController(user: selfUser,
                                     viewer: selfUser,
                                     context: .profileViewer)
 
+        // THEN
         verify(matching: sut)
     }
 
     func testForUserName() {
+        // GIVEN
         selfUser.teamRole = .member
         selfUser.emailAddress = nil
         selfUser.availability = .busy
         selfUser.isTrusted = true
+
+        // WHEN
         sut = ProfileViewController(user: selfUser,
                                     viewer: selfUser,
                                     context: .profileViewer)
         sut.updateShowVerifiedShield()
         let navWrapperController = sut.wrapInNavigationController()
+        sut.viewDidAppear(false)
+
+        // THEN
         verify(matching: navWrapperController)
     }
 
+    func testForContextProfileViewerUnderLegalHold() {
+        // GIVEN
+        selfUser.teamRole = .member
+        mockUser.emailAddress = nil
+        mockUser.isUnderLegalHold = true
+
+        // WHEN
+        sut = ProfileViewController(user: mockUser,
+                                    viewer: selfUser,
+                                    context: .profileViewer)
+        let navWrapperController = sut.wrapInNavigationController()
+        sut.viewDidAppear(false)
+
+        // THEN
+        verify(matching: navWrapperController)
+    }
+
+    func testForContextProfileViewerUnderLegalHold_WithSelfUserOutsideTeam() {
+        // GIVEN
+        let selfUserOutsideTeam = MockUser.createSelfUser(name: "John Johnson", inTeam: nil)
+        selfUserOutsideTeam.handle = "johnjohnson"
+        selfUserOutsideTeam.feature(withUserClients: 6)
+
+        mockUser.emailAddress = nil
+        mockUser.isUnderLegalHold = true
+
+        // WHEN
+        sut = ProfileViewController(user: mockUser,
+                                    viewer: selfUserOutsideTeam,
+                                    context: .profileViewer)
+        let navWrapperController = sut.wrapInNavigationController()
+        sut.viewDidAppear(false)
+
+        // THEN
+        verify(matching: navWrapperController)
+    }
+
+    func testForContextProfileViewerForSelfUserUnderLegalHold() {
+        // GIVEN
+        selfUser.teamRole = .member
+        selfUser.emailAddress = nil
+        selfUser.isUnderLegalHold = true
+
+        // WHEN
+        sut = ProfileViewController(user: selfUser,
+                                    viewer: selfUser,
+                                    context: .profileViewer)
+        let navWrapperController = sut.wrapInNavigationController()
+        sut.viewDidAppear(false)
+
+        // THEN
+        verify(matching: navWrapperController)
+    }
+
+    func testItRequestsDataRefeshForTeamMembers() {
+        // GIVEN
+        mockUser.isTeamMember = true
+
+        // WHEN
+        sut = ProfileViewController(user: mockUser,
+                                    viewer: selfUser,
+                                    context: .profileViewer)
+
+        // THEN
+        XCTAssertEqual(mockUser.refreshDataCount, 1)
+        XCTAssertEqual(mockUser.refreshMembershipCount, 1)
+    }
+
+    func testItDoesNotRequestsDataRefeshForNonTeamMembers() {
+        // GIVEN
+        mockUser.isTeamMember = false
+
+        // WHEN
+        sut = ProfileViewController(user: mockUser,
+                                    viewer: selfUser,
+                                    context: .profileViewer)
+
+        // THEN
+        XCTAssertEqual(mockUser.refreshDataCount, 0)
+        XCTAssertEqual(mockUser.refreshMembershipCount, 0)
+    }
+
+    // MARK: - .deviceList  Context
+
+    func testForDeviceListContext() {
+        // WHEN
+        sut = ProfileViewController(user: mockUser, viewer: selfUser, context: .deviceList)
+
+        // THEN
+        verify(matching: sut)
+    }
+
+    func testForWrapInNavigationController() {
+        // GIVEN
+        sut = ProfileViewController(user: mockUser, viewer: selfUser, context: .deviceList)
+
+        // WHEN
+        let navWrapperController = sut.wrapInNavigationController()
+        sut.viewDidAppear(false)
+
+        // THEN
+        verify(matching: navWrapperController)
+    }
+
+    // MARK: - .oneToOneConversation  Context
+
     func testForContextOneToOneConversation() {
+        // GIVEN
         let selfUser = MockUserType.createSelfUser(name: "Bob", inTeam: UUID())
         mockUser.emailAddress = nil
 
         let conversation = MockConversation.oneOnOneConversation()
         conversation.activeParticipants = [selfUser, mockUser]
 
-        sut = ProfileViewController(user: mockUser, viewer: selfUser,
-                                    conversation: conversation.convertToRegularConversation(), context: .oneToOneConversation)
+        // WHEN
+        sut = ProfileViewController(user: mockUser,
+                                    viewer: selfUser,
+                                    conversation: conversation.convertToRegularConversation(),
+                                    context: .oneToOneConversation)
 
+        // THEN
         verify(matching: sut)
     }
 
     func testForContextOneToOneConversationForPartnerRole() {
+        // GIVEN
         selfUser.teamRole = .partner
         selfUser.canCreateConversation = false
         mockUser.emailAddress = nil
@@ -102,16 +230,17 @@ final class ProfileViewControllerTests: XCTestCase {
         let conversation = MockConversation.oneOnOneConversation()
         conversation.activeParticipants = [selfUser, mockUser]
 
-        sut = ProfileViewController(user: mockUser, viewer: selfUser,
-                                    conversation: conversation.convertToRegularConversation(), context: .oneToOneConversation)
+        // WHEN
+        sut = ProfileViewController(user: mockUser,
+                                    viewer: selfUser,
+                                    conversation: conversation.convertToRegularConversation(),
+                                    context: .oneToOneConversation)
 
+        // THEN
         verify(matching: sut)
     }
 
-    func testForDeviceListContext() {
-        sut = ProfileViewController(user: mockUser, viewer: selfUser, context: .deviceList)
-        verify(matching: sut)
-    }
+    // MARK: - .groupConversation  Context
 
     func testForIncomingRequest() {
         // GIVEN
@@ -125,82 +254,13 @@ final class ProfileViewControllerTests: XCTestCase {
         conversation.activeParticipants = [selfUser, mockUser]
 
         // WHEN
-        sut = ProfileViewController(user: mockUser, viewer: selfUser,
-                                    conversation: conversation.convertToRegularConversation(), context: .groupConversation)
+        sut = ProfileViewController(user: mockUser,
+                                    viewer: selfUser,
+                                    conversation: conversation.convertToRegularConversation(),
+                                    context: .groupConversation)
 
         // THEN
         verify(matching: sut)
     }
 
-    func testForWrapInNavigationController() {
-        sut = ProfileViewController(user: mockUser, viewer: selfUser, context: .deviceList)
-        let navWrapperController = sut.wrapInNavigationController()
-
-        verify(matching: navWrapperController)
-    }
-
-    func testForContextProfileViewerUnderLegalHold() {
-        selfUser.teamRole = .member
-        mockUser.emailAddress = nil
-        mockUser.isUnderLegalHold = true
-        sut = ProfileViewController(user: mockUser,
-                                    viewer: selfUser,
-                                    context: .profileViewer)
-        let navWrapperController = sut.wrapInNavigationController()
-
-        verify(matching: navWrapperController)
-    }
-
-    func testForContextProfileViewerUnderLegalHold_WithSelfUserOutsideTeam() {
-        let selfUserOutsideTeam = MockUser.createSelfUser(name: "John Johnson", inTeam: nil)
-        selfUserOutsideTeam.handle = "johnjohnson"
-        selfUserOutsideTeam.feature(withUserClients: 6)
-
-        mockUser.emailAddress = nil
-        mockUser.isUnderLegalHold = true
-        sut = ProfileViewController(user: mockUser,
-                                    viewer: selfUserOutsideTeam,
-                                    context: .profileViewer)
-        let navWrapperController = sut.wrapInNavigationController()
-
-        verify(matching: navWrapperController)
-    }
-
-    func testForContextProfileViewerForSelfUserUnderLegalHold() {
-        selfUser.teamRole = .member
-        selfUser.emailAddress = nil
-        selfUser.isUnderLegalHold = true
-        sut = ProfileViewController(user: selfUser,
-                                    viewer: selfUser,
-                                    context: .profileViewer)
-        let navWrapperController = sut.wrapInNavigationController()
-
-        verify(matching: navWrapperController)
-    }
-
-    func testItRequestsDataRefeshForTeamMembers() {
-        // Given
-        mockUser.isTeamMember = true
-
-        sut = ProfileViewController(user: mockUser,
-                                    viewer: selfUser,
-                                    context: .profileViewer)
-
-        // Then
-        XCTAssertEqual(mockUser.refreshDataCount, 1)
-        XCTAssertEqual(mockUser.refreshMembershipCount, 1)
-    }
-
-    func testItDoesNotRequestsDataRefeshForNonTeamMembers() {
-        // Given
-        mockUser.isTeamMember = false
-
-        sut = ProfileViewController(user: mockUser,
-                                    viewer: selfUser,
-                                    context: .profileViewer)
-
-        // Then
-        XCTAssertEqual(mockUser.refreshDataCount, 0)
-        XCTAssertEqual(mockUser.refreshMembershipCount, 0)
-    }
 }

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.swift
@@ -175,7 +175,6 @@ final class ProfileViewController: UIViewController {
 
         view.backgroundColor = UIColor.from(scheme: .barBackground)
 
-        setupNavigationItems()
         setupHeader()
         setupTabsController()
         setupConstraints()
@@ -185,6 +184,7 @@ final class ProfileViewController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        setupNavigationItems()
         UIAccessibility.post(notification: UIAccessibility.Notification.screenChanged, argument: navigationItem.titleView)
     }
 


### PR DESCRIPTION
## What's new in this PR?

https://wearezeta.atlassian.net/browse/SQSERVICES-385

### Issues
A connection request view that was opened via a deep link doesn't have a close button.

### Causes
Before showing the `close button`, we check how many controllers in the navigation controller. If there's more than one view controller, it means there's a `back button` and a `close button` is not needed. 

In our case we have 2 view controllers:
- search user VC (contains a spinner)
- profile VC (contains a connection request UI)

But the `search user VC` should be replaced with the `profile VC` when it is loaded.
For some unknown reason, when `viewDidLoad` method is called, the `search user VC` still exists and it means the there're two view controllers in the stack. And the navigation items are configured in the `viewDidLoad` method.

### Solutions
Move the navigation items  setup to the `viewDidAppear` method.
