### PR TITLE
[Fix] call UI not dismissing after call ends

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/CallController/ActiveCallRouter.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallController/ActiveCallRouter.swift
@@ -96,7 +96,10 @@ extension ActiveCallRouter: ActiveCallRouterProtocol {
     }
 
     func dismissActiveCall(animated: Bool = true, completion: Completion? = nil) {
-        guard isActiveCallShown else { return }
+        guard isActiveCallShown else {
+            completion?()
+            return
+        }
         rootViewController.dismiss(animated: animated, completion: { [weak self] in
             self?.isActiveCallShown = false
             self?.scheduledPostCallAction?()


### PR DESCRIPTION
## What's new in this PR?

### Issues

**given** an ongoing 1:1 call and the call UI is minimised 
**when** the call is ended from the remote side
**then** the call UI is not dismissed and is irresponsive

### Causes

The `ActiveCallRouter` has a method `dismissActiveCall(animated:completion:)`
The `completion` block is called after dismissing the active call.
However, if the active call is minimised, there is nothing to dismiss and the completion block won't be executed.

### Solutions

Call the completion block even if the active call is minimised.

