### PR TITLE
[Fix] Call router post call action

### DIFF
--- a/Wire-iOS Tests/Calling/ActiveCallRouterTests.swift
+++ b/Wire-iOS Tests/Calling/ActiveCallRouterTests.swift
@@ -1,0 +1,69 @@
+//
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import XCTest
+@testable import Wire
+
+class ActiveCallRouterTests: XCTestCase {
+
+    var sut: ActiveCallRouter!
+
+    override func setUp() {
+        super.setUp()
+        sut = ActiveCallRouter(rootviewController: RootViewController())
+    }
+
+    override func tearDown() {
+        sut = nil
+        super.tearDown()
+    }
+
+    func testThat_ItExecutesPostCallAction_IfActiveCall_IsNotShown() {
+        // given
+        sut.isActiveCallShown = false
+        var executed = false
+
+        // when
+        sut.executeOrSchedulePostCallAction {
+            executed = true
+        }
+
+        // then
+        XCTAssertTrue(executed)
+        XCTAssertNil(sut.scheduledPostCallAction)
+    }
+
+    func testThat_ItSavesPostCallAction_IfActiveCall_IsShown() {
+        // given
+        sut.isActiveCallShown = true
+        var executed = false
+
+        // when
+        sut.executeOrSchedulePostCallAction {
+            executed = true
+        }
+
+        // then
+        XCTAssertNotNil(sut.scheduledPostCallAction)
+        XCTAssertFalse(executed)
+        sut.scheduledPostCallAction?()
+        XCTAssertTrue(executed)
+    }
+
+}

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -467,6 +467,7 @@
 		634497D924A492140000131D /* VideoParticipantDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634497D824A492140000131D /* VideoParticipantDetailView.swift */; };
 		634497DB24A49BF80000131D /* BaseVideoPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634497DA24A49BF70000131D /* BaseVideoPreviewView.swift */; };
 		63495DB423EB2D7B002A7C59 /* AutomationHelper+BackendEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63495DB323EB2D7B002A7C59 /* AutomationHelper+BackendEnvironment.swift */; };
+		634FDB87263AF418002D6B94 /* ActiveCallRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634FDB86263AF418002D6B94 /* ActiveCallRouterTests.swift */; };
 		6357B41626121D55008F1761 /* MockPanGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6357B41526121D55008F1761 /* MockPanGestureRecognizer.swift */; };
 		6357B41A261226C4008F1761 /* MockPinchGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6357B419261226C4008F1761 /* MockPinchGestureRecognizer.swift */; };
 		63589AA124DAA398008FEC8F /* UIAlertController+Permissions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63589AA024DAA398008FEC8F /* UIAlertController+Permissions.swift */; };
@@ -2118,6 +2119,7 @@
 		634497D824A492140000131D /* VideoParticipantDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoParticipantDetailView.swift; sourceTree = "<group>"; };
 		634497DA24A49BF70000131D /* BaseVideoPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseVideoPreviewView.swift; sourceTree = "<group>"; };
 		63495DB323EB2D7B002A7C59 /* AutomationHelper+BackendEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AutomationHelper+BackendEnvironment.swift"; sourceTree = "<group>"; };
+		634FDB86263AF418002D6B94 /* ActiveCallRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveCallRouterTests.swift; sourceTree = "<group>"; };
 		6357B41526121D55008F1761 /* MockPanGestureRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPanGestureRecognizer.swift; sourceTree = "<group>"; };
 		6357B419261226C4008F1761 /* MockPinchGestureRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPinchGestureRecognizer.swift; sourceTree = "<group>"; };
 		63589AA024DAA398008FEC8F /* UIAlertController+Permissions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertController+Permissions.swift"; sourceTree = "<group>"; };
@@ -4339,6 +4341,7 @@
 				16A94AEC20934AA8008A5718 /* CallParticipantsViewTests.swift */,
 				634273EA24B60D4B00EC2976 /* VideoParticipantDetailsViewTests.swift */,
 				BFE2542620BE9EA200F62041 /* CallHapticsControllerTests.swift */,
+				634FDB86263AF418002D6B94 /* ActiveCallRouterTests.swift */,
 			);
 			path = Calling;
 			sourceTree = "<group>";
@@ -8780,6 +8783,7 @@
 				1658C19820A1E55200148F6D /* CallInfoRootViewControllerTests.swift in Sources */,
 				EF68856820F611D50074CA0F /* CanvasViewControllerTests.swift in Sources */,
 				EF31DC7C2092020300A4F09F /* UIViewController+iPhoneSize.swift in Sources */,
+				634FDB87263AF418002D6B94 /* ActiveCallRouterTests.swift in Sources */,
 				EEE60E2C2179D99100D03346 /* GroupDetailsNotificationOptionsCellTests.swift in Sources */,
 				87DE06B41D2663960009411F /* AudioEffectsPickerViewControllerTests.swift in Sources */,
 				BFF9446C20F6480C00531BC3 /* ThumbnailCreationTests.swift in Sources */,

--- a/Wire-iOS/Sources/UserInterface/Calling/CallController/ActiveCallRouter.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallController/ActiveCallRouter.swift
@@ -157,7 +157,7 @@ extension ActiveCallRouter: ActiveCallRouterProtocol {
     // MARK: - Helpers
 
     private func executeOrSchedulePostCallAction(_ action: @escaping () -> Void) {
-        if isActiveCallShown {
+        if !isActiveCallShown {
             action()
         } else {
             scheduledPostCallAction = action

--- a/Wire-iOS/Sources/UserInterface/Calling/CallController/ActiveCallRouter.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallController/ActiveCallRouter.swift
@@ -41,16 +41,18 @@ protocol CallQualityRouterProtocol: class {
 // MARK: - ActiveCallRouter
 class ActiveCallRouter: NSObject {
 
+    // MARK: - Public Property
+    var isActiveCallShown = false
+
     // MARK: - Private Property
     private let rootViewController: RootViewController
     private let callController: CallController
     private let callQualityController: CallQualityController
     private var transitioningDelegate: CallQualityAnimator
 
-    private var isActiveCallShown = false
     private var isCallQualityShown = false
     private var isCallTopOverlayShown = false
-    private var scheduledPostCallAction: (() -> Void)?
+    private(set) var scheduledPostCallAction: (() -> Void)?
 
     private var zClientViewController: ZClientViewController? {
         return rootViewController.firstChild(ofType: ZClientViewController.self)
@@ -156,7 +158,7 @@ extension ActiveCallRouter: ActiveCallRouterProtocol {
 
     // MARK: - Helpers
 
-    private func executeOrSchedulePostCallAction(_ action: @escaping () -> Void) {
+    func executeOrSchedulePostCallAction(_ action: @escaping () -> Void) {
         if !isActiveCallShown {
             action()
         } else {


### PR DESCRIPTION
## What's new in this PR?

### Issues

The degradation alert is not showing up after the call 

### Causes

In `ActiveCallRouter`, the post call action is executed directly if the active call is shown. It should be the opposite.

### Solutions

Execute post call action directly only when the active call is not shown, otherwise, save the action for after the call.

