### PR TITLE
[Fix] Navigation from push notification when switching accounts

### DIFF
--- a/Wire-iOS Tests/Routers/URLActionRouterTests.swift
+++ b/Wire-iOS Tests/Routers/URLActionRouterTests.swift
@@ -59,6 +59,51 @@ final class URLActionRouterTests: XCTestCase {
         // THEN
         XCTAssertFalse(router.wasDeepLinkOpened)
     }
+
+    // MARK: Navigation
+
+    func testThatNavigationPerformed_WhenAuthenticatedRouterIsAvailable() {
+        // GIVEN
+        let authenticatedRouter = MockAuthenticatedRouter()
+        let router = TestableURLActionRouter(viewController: RootViewController())
+        router.authenticatedRouter = authenticatedRouter
+
+        // WHEN
+        router.navigate(to: .converationList)
+
+        // THEN
+        if case .converationList = authenticatedRouter.didNavigateToDestination { } else {
+            XCTFail()
+        }
+    }
+
+    func testThatNavigationPerformed_WhenAuthenticatedRouterBecomesAvailable() {
+        // GIVEN
+        let authenticatedRouter = MockAuthenticatedRouter()
+        let router = TestableURLActionRouter(viewController: RootViewController())
+        router.navigate(to: .converationList)
+
+        // WHEN
+        router.authenticatedRouter = authenticatedRouter
+
+        // THEN
+        if case .converationList = authenticatedRouter.didNavigateToDestination { } else {
+            XCTFail()
+        }
+    }
+}
+
+class MockAuthenticatedRouter: AuthenticatedRouterProtocol {
+
+    func updateActiveCallPresentationState() { }
+
+    func minimizeCallOverlay(animated: Bool, withCompletion completion: Completion?) { }
+
+    var didNavigateToDestination: NavigationDestination?
+    func navigate(to destination: NavigationDestination) {
+        didNavigateToDestination = destination
+    }
+
 }
 
 class TestableURLActionRouter: URLActionRouter {

--- a/Wire-iOS/Sources/AppRootRouter.swift
+++ b/Wire-iOS/Sources/AppRootRouter.swift
@@ -402,7 +402,7 @@ extension AppRootRouter {
 
         if case .authenticated = appState {
             authenticatedRouter?.updateActiveCallPresentationState()
-
+            urlActionRouter.authenticatedRouter = authenticatedRouter
             ZClientViewController.shared?.legalHoldDisclosureController?.discloseCurrentState(cause: .appOpen)
         }
 

--- a/Wire-iOS/Sources/AuthenticatedRouter.swift
+++ b/Wire-iOS/Sources/AuthenticatedRouter.swift
@@ -19,9 +19,17 @@
 import UIKit
 import WireSyncEngine
 
+public enum NavigationDestination {
+    case conversation(ZMConversation, ZMConversationMessage?)
+    case userProfile(UserType)
+    case connectionRequest(UUID)
+    case converationList
+}
+
 protocol AuthenticatedRouterProtocol: class {
     func updateActiveCallPresentationState()
     func minimizeCallOverlay(animated: Bool, withCompletion completion: Completion?)
+    func navigate(to destination: NavigationDestination)
 }
 
 class AuthenticatedRouter: NSObject {
@@ -68,6 +76,19 @@ extension AuthenticatedRouter: AuthenticatedRouterProtocol {
     func minimizeCallOverlay(animated: Bool,
                              withCompletion completion: Completion?) {
         activeCallRouter.minimizeCall(animated: animated, completion: completion)
+    }
+
+    func navigate(to destination: NavigationDestination) {
+        switch destination {
+        case .conversation(let converation, let message):
+            _viewController?.showConversation(converation, at: message)
+        case .connectionRequest(let userId):
+            _viewController?.showConnectionRequest(userId: userId)
+        case .converationList:
+            _viewController?.showConversationList()
+        case .userProfile(let user):
+            _viewController?.showUserProfile(user: user)
+        }
     }
 }
 

--- a/Wire-iOS/Sources/URLActionRouter.swift
+++ b/Wire-iOS/Sources/URLActionRouter.swift
@@ -42,10 +42,16 @@ class URLActionRouter: URLActionRouterProtocol {
     // MARK: - Public Property
     var sessionManager: SessionManager?
     weak var delegate: URLActionRouterDelegete?
+    weak var authenticatedRouter: AuthenticatedRouterProtocol? {
+        didSet {
+            performPendingNavigation()
+        }
+    }
 
     // MARK: - Private Property
     private let rootViewController: RootViewController
     private var url: URL?
+    private var pendingDestination: NavigationDestination?
 
     // MARK: - Initialization
     public init(viewController: RootViewController,
@@ -92,6 +98,24 @@ class URLActionRouter: URLActionRouterProtocol {
     private func resetDeepLinkURL() {
         url = nil
     }
+
+    func performPendingNavigation() {
+        guard let destination = pendingDestination else {
+            return
+        }
+
+        pendingDestination = nil
+        navigate(to: destination)
+    }
+
+    func navigate(to destination: NavigationDestination) {
+        guard authenticatedRouter != nil else {
+            pendingDestination = destination
+            return
+        }
+
+        authenticatedRouter?.navigate(to: destination)
+    }
 }
 
 // MARK: - PresentationDelegate
@@ -120,31 +144,19 @@ extension URLActionRouter: PresentationDelegate {
     }
 
     func showConnectionRequest(userId: UUID) {
-        guard let zClientViewController = rootViewController.firstChild(ofType: ZClientViewController.self) else {
-            return
-        }
-        zClientViewController.showConnectionRequest(userId: userId)
+        navigate(to: .connectionRequest(userId))
     }
 
     func showUserProfile(user: UserType) {
-        guard let zClientViewController = rootViewController.firstChild(ofType: ZClientViewController.self) else {
-            return
-        }
-        zClientViewController.showUserProfile(user: user)
+        navigate(to: .userProfile(user))
     }
 
     func showConversation(_ conversation: ZMConversation, at message: ZMConversationMessage?) {
-        guard let zClientViewController = rootViewController.firstChild(ofType: ZClientViewController.self) else {
-            return
-        }
-        zClientViewController.showConversation(conversation, at: message)
+        navigate(to: .conversation(conversation, message))
     }
 
     func showConversationList() {
-        guard let zClientViewController = rootViewController.firstChild(ofType: ZClientViewController.self) else {
-            return
-        }
-        zClientViewController.showConversationList()
+        navigate(to: .converationList)
     }
 
     // MARK: - Private Implementation


### PR DESCRIPTION
## What's new in this PR?

### Issues

App doesn't navigate to the conversation when opening the application via a push notification in all cases.

### Causes

The method call for navigating to a specific conversation sometimes happen before the app finished transitioning to the `.authenticated` state which causes the action not be performed at all. One case when this happens is when the account needs to change on multi account setup.

### Solutions

Delay the method call for navigating until the `.authenticated` state has been reached.