### PR TITLE
[Fix] Push navigation in a multi account configuration

### DIFF
--- a/Wire-iOS/Sources/AppRootRouter.swift
+++ b/Wire-iOS/Sources/AppRootRouter.swift
@@ -407,8 +407,17 @@ extension AppRootRouter {
         }
 
         resetSelfUserProviderIfNeeded(for: appState)
+        resetAuthenticatedRouterIfNeeded(for: appState)
         urlActionRouter.openDeepLink(for: appState)
         appStateTransitionGroup.leave()
+    }
+
+    private func resetAuthenticatedRouterIfNeeded(for appState: AppState) {
+        switch appState {
+        case .authenticated: break
+        default:
+            authenticatedRouter = nil
+        }
     }
 
     private func resetSelfUserProviderIfNeeded(for appState: AppState) {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Opening Wire from a push navigation doesn't navigate to the correct conversation when you are signed in to multiple accounts.

### Causes

The navigation is attempted to early because `authenticatedRouter` property is still set during the account loading phase.

### Solutions

Reset the `authenticatedRouter` when the app transitions out of the authenticated state.