### PR TITLE
[Fix] Switch backend alert shown twice when switching accounts

### DIFF
--- a/Wire-iOS/Sources/AppRootRouter.swift
+++ b/Wire-iOS/Sources/AppRootRouter.swift
@@ -406,9 +406,9 @@ extension AppRootRouter {
             ZClientViewController.shared?.legalHoldDisclosureController?.discloseCurrentState(cause: .appOpen)
         }
 
+        urlActionRouter.performPendingActions()
         resetSelfUserProviderIfNeeded(for: appState)
         resetAuthenticatedRouterIfNeeded(for: appState)
-        urlActionRouter.openDeepLink(for: appState)
         appStateTransitionGroup.leave()
     }
 
@@ -474,14 +474,27 @@ extension AppRootRouter {
     }
 }
 
-// MARK: - URLActionRouterDelegete
-extension AppRootRouter: URLActionRouterDelegete {
+// MARK: - URLActionRouterDelegate
+
+extension AppRootRouter: URLActionRouterDelegate {
+
     func urlActionRouterWillShowCompanyLoginError() {
         authenticationCoordinator?.cancelCompanyLogin()
     }
+
+    func urlActionRouterCanDisplayAlerts() -> Bool {
+        switch appStateCalculator.appState {
+        case .authenticated, .unauthenticated:
+            return true
+        default:
+            return false
+        }
+    }
+
 }
 
 // MARK: - ApplicationStateObserving
+
 extension AppRootRouter: ApplicationStateObserving {
     func addObserverToken(_ token: NSObjectProtocol) {
         observerTokens.append(token)
@@ -511,6 +524,7 @@ extension AppRootRouter: ApplicationStateObserving {
 }
 
 // MARK: - ContentSizeCategoryObserving
+
 extension AppRootRouter: ContentSizeCategoryObserving {
     func contentSizeCategoryDidChange() {
         NSAttributedString.invalidateParagraphStyle()
@@ -532,6 +546,7 @@ extension AppRootRouter: ContentSizeCategoryObserving {
 }
 
 // MARK: - AudioPermissionsObserving
+
 extension AppRootRouter: AudioPermissionsObserving {
     func userDidGrantAudioPermissions() {
         sessionManager.updateCallNotificationStyleFromSettings()

--- a/Wire-iOS/Sources/AppStateCalculator.swift
+++ b/Wire-iOS/Sources/AppStateCalculator.swift
@@ -56,17 +56,6 @@ enum AppState: Equatable {
     }
 }
 
-extension AppState {
-    var canProcessDeepLinks: Bool {
-      switch self {
-      case .unauthenticated, .authenticated:
-        return true
-      default:
-        return false
-      }
-    }
-}
-
 protocol AppStateCalculatorDelegate: class {
     func appStateCalculator(_: AppStateCalculator,
                             didCalculate appState: AppState,
@@ -90,10 +79,6 @@ class AppStateCalculator {
             return false
         }
         return true
-    }
-
-    var canProcessDeepLinks: Bool {
-        return appState.canProcessDeepLinks
     }
 
     // MARK: - Private Set Property


### PR DESCRIPTION
## What's new in this PR?

### Issues

When opening a deep link to switch backend the alert would be shown again after switching to your second account.

### Causes

The `URLActionRouter` stores the link in a `url` property for later processing when the application has reached a valid app state. For the backend switch case though it was processing the deep link immediately and storing it in the `url` property for later processing which gets triggered when the app enters  the `.authenticated` state after switching accounts.

### Solutions

Remove the `url` property and show or delay showing alerts in a similar way as we do for app navigation.