### PR TITLE
[Fix] Empty system message when removed from a conversation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ParticipantsStringFormatter.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ParticipantsStringFormatter.swift
@@ -28,7 +28,7 @@ private extension ConversationActionType {
         case .added(herself: true): return "content.system.conversation.guest.joined"
         case .added(herself: false): return localizationKey(with: "added", senderIsSelfUser: senderIsSelfUser)
         case .removed(reason: .legalHoldPolicyConflict): return (localizationKey(with: "removed", senderIsSelfUser: senderIsSelfUser) + ".legalhold")
-        case .removed(reason: .none): return localizationKey(with: "removed", senderIsSelfUser: senderIsSelfUser)
+        case .removed: return localizationKey(with: "removed", senderIsSelfUser: senderIsSelfUser)
         case .started(withName: .none), .none: return localizationKey(with: "started", senderIsSelfUser: senderIsSelfUser)
         case .started(withName: .some): return "content.system.conversation.with_name.participants"
         case .teamMemberLeave: return "content.system.conversation.team.member-leave"
@@ -173,7 +173,7 @@ final class ParticipantsStringFormatter {
                                                             .foregroundColor: UIColor.from(scheme: .textForeground)])
             return result += " " + learnMore
 
-        case .removed(reason: .none), .added(herself: false), .started(withName: .none):
+        case .removed, .added(herself: false), .started(withName: .none):
             result = formatKey(senderIsSelf).localized(args: senderName, nameSequence.string) && font && textColor
             if !senderIsSelf { result = result.adding(font: boldFont, to: senderName) }
 


### PR DESCRIPTION
## What's new in this PR?

**JIRA:** https://wearezeta.atlassian.net/browse/SQCORE-705

### Issues

When the self user is removed from a conversation, an empty system message appears, when it should say "You were removed".

### Causes

A switch over an enum was hitting the default branch which resulted in `nil` being returned instead of an attributed string. The `removed(ZMParticipantsRemovedReason)` has two seemingly possible values: `none` and `legalHoldPolicyConflict`. While the compiler doesn't complain with an error if only these two cases are handled, it does warn that not all cases might be handled (???). I think it might be have something to do with `ZMParticipantsRemovedReason` being an objective c enum... maybe the Swift compiler is getting confused.

### Solutions

Simply replace the pattern `.removed(reason: .none)` with `.removed` for now to unblock the RC, but I will create a ticket to address this properly.
