### PR TITLE
[Fix] call router not restoring call from top overlay

### DIFF
--- a/Wire-iOS Tests/Calling/ActiveCallRouterTests.swift
+++ b/Wire-iOS Tests/Calling/ActiveCallRouterTests.swift
@@ -66,4 +66,21 @@ class ActiveCallRouterTests: XCTestCase {
         XCTAssertTrue(executed)
     }
 
+    func testThat_ItSetIsActiveCallShown_ToFalse_When_RestoringCallFromTopOverlay() {
+        // given
+        let conversation = ((MockConversation.oneOnOneConversation() as Any) as! ZMConversation)
+        let voiceChannel = MockVoiceChannel(conversation: conversation)
+        let mockSelfClient = MockUserClient()
+        mockSelfClient.remoteIdentifier = "selfClient123"
+        MockUser.mockSelf().clients = Set([mockSelfClient])
+
+        sut.isActiveCallShown = true
+
+        // when
+        sut.voiceChannelTopOverlayWantsToRestoreCall(voiceChannel: voiceChannel)
+
+        // then
+        XCTAssertFalse(sut.isActiveCallShown)
+    }
+
 }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallController/ActiveCallRouter.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallController/ActiveCallRouter.swift
@@ -221,6 +221,7 @@ extension ActiveCallRouter: CallQualityRouterProtocol {
 extension ActiveCallRouter: CallTopOverlayControllerDelegate {
     func voiceChannelTopOverlayWantsToRestoreCall(voiceChannel: VoiceChannel?) {
         guard let voiceChannel = voiceChannel else { return }
+        isActiveCallShown = false
         presentActiveCall(for: voiceChannel, animated: true)
     }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

After switching accounts to answer a call, tapping on the minimised call in the top overlay doesn't show the call screen.

### Causes

`isActiveCallShown` evaluates to `true` even though the call screen is dismissed. 
This is because two things happen:
- First, the call screen is presented
- Second, the conversation is presented
Thus, the call screen is dismissed without going through `ActiveCallRouter`, which is responsible for setting `isActiveCallShown` appropriately.

### Solutions

set `isActiveCallShown` to `false` when the event is coming from the top overlay

