### PR TITLE
[Fix] Double warning notification

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController.swift
@@ -18,6 +18,7 @@
 import Foundation
 import UIKit
 import WireDataModel
+import WireSyncEngine
 
 enum ConversationListState {
     case conversationList
@@ -83,6 +84,10 @@ final class ConversationListViewController: UIViewController {
         return conversationListOnboardingHint
     }()
 
+    deinit {
+        NotificationCenter.default.removeObserver(self, name: ZMConnectionNotification.missingLegalHoldConsent, object: nil)
+    }
+
     convenience init(account: Account, selfUser: SelfUserType) {
         let viewModel = ConversationListViewController.ViewModel(account: account, selfUser: selfUser)
 
@@ -133,7 +138,7 @@ final class ConversationListViewController: UIViewController {
         /// update
         hideNoContactLabel(animated: false)
 
-        viewModel.setupObservers()
+        setupObservers()
 
         listContentController.collectionView.scrollRectToVisible(CGRect(x: 0, y: 0, width: view.bounds.size.width, height: 1), animated: false)
     }
@@ -193,6 +198,16 @@ final class ConversationListViewController: UIViewController {
     }
 
     // MARK: - setup UI
+
+    private func setupObservers() {
+        viewModel.setupObservers()
+        NotificationCenter.default.addObserver(self, selector: #selector(showErrorAlertForConnectionRequest), name: ZMConnectionNotification.missingLegalHoldConsent, object: nil)
+    }
+
+    @objc
+    func showErrorAlertForConnectionRequest() {
+        UIAlertController.showErrorAlert(message: L10n.Localizable.Error.Connection.missingLegalholdConsent)
+    }
 
     private func setupTopBar() {
         add(topBarViewController, to: contentContainer)

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
@@ -44,10 +44,6 @@ final class GroupDetailsViewController: UIViewController, ZMConversationObserver
         return ColorScheme.default.statusBarStyle
     }
 
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
     init(conversation: GroupDetailsConversationType) {
         self.conversation = conversation
         collectionViewController = SectionCollectionViewController()
@@ -64,17 +60,11 @@ final class GroupDetailsViewController: UIViewController, ZMConversationObserver
                 }
             }
         }
-        NotificationCenter.default.addObserver(self, selector: #selector(showErrorAlertForConnectionRequest), name: ZMConnectionNotification.missingLegalHoldConsent, object: nil)
     }
 
     @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    @objc
-    func showErrorAlertForConnectionRequest() {
-        UIAlertController.showErrorAlert(message: L10n.Localizable.Error.Connection.missingLegalholdConsent)
     }
 
     func createSubviews() {

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
@@ -180,7 +180,7 @@ final class SearchResultsViewController: UIViewController {
 
     deinit {
         searchDirectory?.tearDown()
-        NotificationCenter.default.removeObserver(self)
+//        NotificationCenter.default.removeObserver(self)
     }
 
     init(userSelection: UserSelection,
@@ -217,7 +217,7 @@ final class SearchResultsViewController: UIViewController {
         createGroupSection.delegate = self
         inviteTeamMemberSection.delegate = self
 
-        NotificationCenter.default.addObserver(self, selector: #selector(showErrorAlertForConnectionRequest), name: ZMConnectionNotification.missingLegalHoldConsent, object: nil)
+//        NotificationCenter.default.addObserver(self, selector: #selector(showErrorAlertForConnectionRequest), name: ZMConnectionNotification.missingLegalHoldConsent, object: nil)
     }
 
     @available(*, unavailable)
@@ -233,6 +233,13 @@ final class SearchResultsViewController: UIViewController {
         super.viewWillAppear(animated)
         sectionController.collectionView?.reloadData()
         sectionController.collectionView?.collectionViewLayout.invalidateLayout()
+
+        NotificationCenter.default.addObserver(self, selector: #selector(showErrorAlertForConnectionRequest), name: ZMConnectionNotification.missingLegalHoldConsent, object: nil)
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        NotificationCenter.default.removeObserver(self)
     }
 
     override func viewDidLoad() {

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
@@ -239,7 +239,7 @@ final class SearchResultsViewController: UIViewController {
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        NotificationCenter.default.removeObserver(self)
+        NotificationCenter.default.removeObserver(self, name: ZMConnectionNotification.missingLegalHoldConsent, object: nil)
     }
 
     override func viewDidLoad() {

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
@@ -230,13 +230,10 @@ final class SearchResultsViewController: UIViewController {
         super.viewWillAppear(animated)
         sectionController.collectionView?.reloadData()
         sectionController.collectionView?.collectionViewLayout.invalidateLayout()
-
-        NotificationCenter.default.addObserver(self, selector: #selector(showErrorAlertForConnectionRequest), name: ZMConnectionNotification.missingLegalHoldConsent, object: nil)
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        NotificationCenter.default.removeObserver(self, name: ZMConnectionNotification.missingLegalHoldConsent, object: nil)
     }
 
     override func viewDidLoad() {
@@ -247,11 +244,6 @@ final class SearchResultsViewController: UIViewController {
         updateVisibleSections()
 
         searchResultsView.emptyResultContainer.isHidden = !isResultEmpty
-    }
-
-    @objc
-    func showErrorAlertForConnectionRequest() {
-        UIAlertController.showErrorAlert(message: L10n.Localizable.Error.Connection.missingLegalholdConsent)
     }
 
     @objc

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
@@ -180,7 +180,6 @@ final class SearchResultsViewController: UIViewController {
 
     deinit {
         searchDirectory?.tearDown()
-//        NotificationCenter.default.removeObserver(self)
     }
 
     init(userSelection: UserSelection,
@@ -216,8 +215,6 @@ final class SearchResultsViewController: UIViewController {
         servicesSection.delegate = self
         createGroupSection.delegate = self
         inviteTeamMemberSection.delegate = self
-
-//        NotificationCenter.default.addObserver(self, selector: #selector(showErrorAlertForConnectionRequest), name: ZMConnectionNotification.missingLegalHoldConsent, object: nil)
     }
 
     @available(*, unavailable)

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
@@ -232,10 +232,6 @@ final class SearchResultsViewController: UIViewController {
         sectionController.collectionView?.collectionViewLayout.invalidateLayout()
     }
 
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-    }
-
     override func viewDidLoad() {
         super.viewDidLoad()
 


### PR DESCRIPTION
## What's new in this PR?

### Issues
There is a double warning notification when connecting to new user while being under LH. The issue is not reproducible every time.

### Causes
The issue is not reproducible every time. The BE error response observer has been placed in the init () method of `SearchResultsViewController`. For some unknown reason, sometimes there are 2 instances of `SearchResultsViewController` and, as a result, there are 2 observers that display an alert message.

### Solutions
Move the observer to the viewWillAppear() method.


### Notes
https://wearezeta.atlassian.net/browse/SQSERVICES-485

