### PR TITLE
Revert "[Chore] bump avs (#5122)"

### DIFF
--- a/avs-versions
+++ b/avs-versions
@@ -17,4 +17,4 @@
 # along with this program. If not, see http://www.gnu.org/licenses/.
 #
 
-export APPSTORE_AVS_VERSION=7.2.3
+export APPSTORE_AVS_VERSION=7.1.6


### PR DESCRIPTION
This reverts commit f41fb5ccb8ca2f04ec16a5a35c2f12f1c58b748a.

We need to stay on 6.1.x until the selective video endpoint is integrated