### PR TITLE
[Feature] Update hint notification behaviour for tiles without video

### DIFF
--- a/Wire-iOS Tests/Calling/CallGridViewControllerSnapshotTests.swift
+++ b/Wire-iOS Tests/Calling/CallGridViewControllerSnapshotTests.swift
@@ -251,6 +251,9 @@ final class CallGridViewControllerSnapshotTests: XCTestCase {
 extension CallGridViewControllerSnapshotTests {
 
     private func assertHint(input: HintTestCase.Input, output: HintTestCase.Output, file: StaticString = #file, line: UInt = #line) {
+        mockHintView.didCallHideAndStopTimer = false
+        mockHintView.hint = nil
+
         var maximizedView: BaseCallParticipantView?
         if case let .configurationChanged(participants) = input {
             configuration.callHasTwoParticipants = participants.isTwo
@@ -258,13 +261,15 @@ extension CallGridViewControllerSnapshotTests {
             if let stream = participants.stream {
                 configuration.streams = [stream]
 
-                maximizedView = BaseCallParticipantView(
-                    stream: stream,
-                    isCovered: false,
-                    shouldShowActiveSpeakerFrame: true,
-                    shouldShowBorderWhenVideoIsStopped: true,
-                    pinchToZoomRule: .enableWhenFitted
-                )
+                if case let .two(videoState) = participants, videoState.isMaximized {
+                    maximizedView = BaseCallParticipantView(
+                        stream: stream,
+                        isCovered: false,
+                        shouldShowActiveSpeakerFrame: true,
+                        shouldShowBorderWhenVideoIsStopped: true,
+                        pinchToZoomRule: .enableWhenFitted
+                    )
+                }
             }
         }
 
@@ -313,6 +318,15 @@ extension CallGridViewControllerSnapshotTests {
                     case screenSharing
                     case sharing(isMaximized: Bool)
                     case notSharing
+
+                    var isMaximized: Bool {
+                        switch self {
+                        case .sharing(isMaximized: let isMaximized):
+                            return isMaximized
+                        default:
+                            return false
+                        }
+                    }
 
                     var stream: Wire.Stream {
                         StreamStubProvider().stream(videoState: videoState)

--- a/Wire-iOS Tests/Calling/Mocks/MockCallGridHintNotificationLabel.swift
+++ b/Wire-iOS Tests/Calling/Mocks/MockCallGridHintNotificationLabel.swift
@@ -1,0 +1,32 @@
+//
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+@testable import Wire
+
+class MockCallGridHintNotificationLabel: CallGridHintNotificationLabel {
+
+    var hint: CallGridHintKind?
+    override func show(hint: CallGridHintKind) {
+        self.hint = hint
+    }
+
+    var didCallHideAndStopTimer: Bool = false
+    override func hideAndStopTimer() {
+        didCallHideAndStopTimer = true
+    }
+}

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -493,6 +493,7 @@
 		637387D52645B931004FEF79 /* AVSVideoViewProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637387D42645B931004FEF79 /* AVSVideoViewProtocol.swift */; };
 		637387E026492833004FEF79 /* ScalableViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637387DA2649277A004FEF79 /* ScalableViewTests.swift */; };
 		6375051B262477ED0083DC27 /* NotificationLabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6375051A262477ED0083DC27 /* NotificationLabelTests.swift */; };
+		637C825C267CED69009457CA /* Stream+Video.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637C825B267CED68009457CA /* Stream+Video.swift */; };
 		638332EA250282D200D18F42 /* OrientationDelta.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638332E9250282D200D18F42 /* OrientationDelta.swift */; };
 		639290A2252633E600046171 /* UIAlertController+DegradedCall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639290A1252633E600046171 /* UIAlertController+DegradedCall.swift */; };
 		63A5E6E424C1ACFC00F7D401 /* SettingsCellDescriptorFactory+Advanced.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63A5E6E324C1ACFC00F7D401 /* SettingsCellDescriptorFactory+Advanced.swift */; };
@@ -2153,6 +2154,7 @@
 		637387D42645B931004FEF79 /* AVSVideoViewProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVSVideoViewProtocol.swift; sourceTree = "<group>"; };
 		637387DA2649277A004FEF79 /* ScalableViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScalableViewTests.swift; sourceTree = "<group>"; };
 		6375051A262477ED0083DC27 /* NotificationLabelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationLabelTests.swift; sourceTree = "<group>"; };
+		637C825B267CED68009457CA /* Stream+Video.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stream+Video.swift"; sourceTree = "<group>"; };
 		638332E9250282D200D18F42 /* OrientationDelta.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrientationDelta.swift; sourceTree = "<group>"; };
 		6391628B24F6A39D0054962E /* CallParticipantViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallParticipantViewTests.swift; sourceTree = "<group>"; };
 		639290A1252633E600046171 /* UIAlertController+DegradedCall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertController+DegradedCall.swift"; sourceTree = "<group>"; };
@@ -4417,6 +4419,7 @@
 			children = (
 				EE378E2B24BDE5D50014118A /* Stream.swift */,
 				637387BC2644331F004FEF79 /* Stream+ActiveSpeaker.swift */,
+				637C825B267CED68009457CA /* Stream+Video.swift */,
 			);
 			path = Stream;
 			sourceTree = "<group>";
@@ -8623,6 +8626,7 @@
 				16D68E9B1CEF99C7003AB9E0 /* WaveformProgressView.swift in Sources */,
 				EF4C5D50233A17680092CA38 /* ConversationListContentController.swift in Sources */,
 				87BEB0441D3E478500DE9575 /* AssetLibrary.swift in Sources */,
+				637C825C267CED69009457CA /* Stream+Video.swift in Sources */,
 				EE43324B1F1A785800096D90 /* PopUpIconButtonView.swift in Sources */,
 				F17B0A9D219489DC005ECAD0 /* NetworkCondition+Helper.swift in Sources */,
 				879649002046EE5E00F46B4B /* BarController.swift in Sources */,

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -495,6 +495,7 @@
 		6375051B262477ED0083DC27 /* NotificationLabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6375051A262477ED0083DC27 /* NotificationLabelTests.swift */; };
 		637C825C267CED69009457CA /* Stream+Video.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637C825B267CED68009457CA /* Stream+Video.swift */; };
 		638332EA250282D200D18F42 /* OrientationDelta.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638332E9250282D200D18F42 /* OrientationDelta.swift */; };
+		638C88C62680F92D0074D512 /* MockCallGridHintNotificationLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638C88C52680F92D0074D512 /* MockCallGridHintNotificationLabel.swift */; };
 		639290A2252633E600046171 /* UIAlertController+DegradedCall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639290A1252633E600046171 /* UIAlertController+DegradedCall.swift */; };
 		63A5E6E424C1ACFC00F7D401 /* SettingsCellDescriptorFactory+Advanced.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63A5E6E324C1ACFC00F7D401 /* SettingsCellDescriptorFactory+Advanced.swift */; };
 		63A5E6F624C87E0000F7D401 /* SettingsCellDescriptorFactory+SoundAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63A5E6F524C87DFF00F7D401 /* SettingsCellDescriptorFactory+SoundAlert.swift */; };
@@ -2156,6 +2157,7 @@
 		6375051A262477ED0083DC27 /* NotificationLabelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationLabelTests.swift; sourceTree = "<group>"; };
 		637C825B267CED68009457CA /* Stream+Video.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stream+Video.swift"; sourceTree = "<group>"; };
 		638332E9250282D200D18F42 /* OrientationDelta.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrientationDelta.swift; sourceTree = "<group>"; };
+		638C88C52680F92D0074D512 /* MockCallGridHintNotificationLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCallGridHintNotificationLabel.swift; sourceTree = "<group>"; };
 		6391628B24F6A39D0054962E /* CallParticipantViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallParticipantViewTests.swift; sourceTree = "<group>"; };
 		639290A1252633E600046171 /* UIAlertController+DegradedCall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertController+DegradedCall.swift"; sourceTree = "<group>"; };
 		63A5E6E324C1ACFC00F7D401 /* SettingsCellDescriptorFactory+Advanced.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SettingsCellDescriptorFactory+Advanced.swift"; sourceTree = "<group>"; };
@@ -4367,6 +4369,7 @@
 		6340EF8E237AE90700EF8506 /* Calling */ = {
 			isa = PBXGroup;
 			children = (
+				638C88C42680F8DD0074D512 /* Mocks */,
 				87D7E1C420CACA820064C03D /* CallViewControllerTests.swift */,
 				EF6251D521395F7E00943708 /* CallGridViewControllerSnapshotTests.swift */,
 				6340EF95237AE93500EF8506 /* VoiceChannelStreamArrangmentTests.swift */,
@@ -4432,6 +4435,14 @@
 				6305E34A266530EC00A44933 /* RoundedBlurViewTests.swift */,
 			);
 			path = Components;
+			sourceTree = "<group>";
+		};
+		638C88C42680F8DD0074D512 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				638C88C52680F92D0074D512 /* MockCallGridHintNotificationLabel.swift */,
+			);
+			path = Mocks;
 			sourceTree = "<group>";
 		};
 		63B9F5B625E7D7040059020D /* Toast */ = {
@@ -8748,6 +8759,7 @@
 				BF5127161CC9119400F23DEA /* ZMSnapshotTestCase.swift in Sources */,
 				EF305247208742F300613C45 /* ConfirmPhoneViewControllerTests.swift in Sources */,
 				EF2E2F71223BC4A60038D7D9 /* VersionInfoViewControllerSnapshotTests.swift in Sources */,
+				638C88C62680F92D0074D512 /* MockCallGridHintNotificationLabel.swift in Sources */,
 				D525426820934629001C04C1 /* IconLabelButtonTests.swift in Sources */,
 				BFF655741E81235900D48337 /* ConversationAvatarViewTests.swift in Sources */,
 				EF1CB6F722B3C430004CB458 /* CallInfoRootViewControllerSnapshotTests.swift in Sources */,

--- a/Wire-iOS/Generated/Strings+Generated.swift
+++ b/Wire-iOS/Generated/Strings+Generated.swift
@@ -278,6 +278,8 @@ internal enum L10n {
         internal enum Hints {
           /// Double tap on a tile for fullscreen
           internal static let fullscreen = L10n.tr("Localizable", "call.grid.hints.fullscreen")
+          /// Double tap to go back
+          internal static let goBack = L10n.tr("Localizable", "call.grid.hints.go_back")
           /// Double tap to go back, pinch to zoom
           internal static let goBackOrZoom = L10n.tr("Localizable", "call.grid.hints.go_back_or_zoom")
           /// Pinch to zoom

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -691,6 +691,7 @@
 
 "call.grid.hints.fullscreen" = "Double tap on a tile for fullscreen";
 "call.grid.hints.go_back_or_zoom" = "Double tap to go back, pinch to zoom";
+"call.grid.hints.go_back" = "Double tap to go back";
 "call.grid.hints.zoom" = "Pinch to zoom";
 
 "call.video.paused" = "Video paused";

--- a/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallGridEvent.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallGridEvent.swift
@@ -20,6 +20,6 @@ import Foundation
 
 enum CallGridEvent {
     case configurationChanged
-    case maximizationChanged(maximized: Bool)
+    case maximizationChanged(stream: Stream, maximized: Bool)
     case viewDidLoad
 }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallGridHintNotificationLabel.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallGridHintNotificationLabel.swift
@@ -25,6 +25,7 @@ enum CallGridHintKind {
     case fullscreen
     case zoom
     case goBackOrZoom
+    case goBack
 
     var message: String {
         switch self {
@@ -34,6 +35,8 @@ enum CallGridHintKind {
             return HintString.zoom
         case .goBackOrZoom:
             return HintString.goBackOrZoom
+        case .goBack:
+            return HintString.goBack
         }
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallGridViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallGridViewController.swift
@@ -164,7 +164,7 @@ final class CallGridViewController: SpinnerCapableViewController {
         maximizedView = shouldMaximize ? view : nil
         view.isMaximized = shouldMaximize
         updateGrid(with: streams)
-        updateHint(for: .maximizationChanged(maximized: shouldMaximize))
+        updateHint(for: .maximizationChanged(stream: view.stream, maximized: view.isMaximized))
     }
 
     private func allowMaximizationToggling(for stream: Stream) -> Bool {
@@ -192,23 +192,24 @@ final class CallGridViewController: SpinnerCapableViewController {
         switch event {
         case .viewDidLoad:
             hintView.show(hint: .fullscreen)
-        case .configurationChanged:
+        case .configurationChanged where configuration.callHasTwoParticipants:
             guard
-                configuration.callHasTwoParticipants,
-                let stream = configuration.streams.first
+                let stream = configuration.streams.first,
+                stream.isSharingVideo
             else { return }
 
-            if stream.videoState == .some(.screenSharing) {
+            if stream.isScreenSharing {
                 hintView.show(hint: .zoom)
             } else if isMaximized(stream: stream) {
                 hintView.show(hint: .goBackOrZoom)
             }
-        case .maximizationChanged(maximized: let maximized):
+        case .maximizationChanged(stream: let stream, maximized: let maximized):
             if maximized {
-                hintView.show(hint: .goBackOrZoom)
+                hintView.show(hint: stream.isSharingVideo ? .goBackOrZoom : .goBack)
             } else {
                 hintView.hideAndStopTimer()
             }
+        default: break
         }
     }
 

--- a/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallGridViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallGridViewController.swift
@@ -168,7 +168,10 @@ final class CallGridViewController: SpinnerCapableViewController {
     }
 
     private func allowMaximizationToggling(for stream: Stream) -> Bool {
-        return !(configuration.callHasTwoParticipants && stream.videoState == .screenSharing)
+        let isStreamScreenSharingOneToOne = gridIsOneToOneWithFloatingTile && stream.isScreenSharing
+        let isStreamMinimizedAndNotSharingVideo = !isMaximized(stream: stream) && !stream.isSharingVideo
+
+        return !isStreamScreenSharingOneToOne && !(isStreamMinimizedAndNotSharingVideo && gridHasOnlyOneTile)
     }
 
     private func isMaximized(stream: Stream?) -> Bool {
@@ -381,10 +384,15 @@ final class CallGridViewController: SpinnerCapableViewController {
     // MARK: - Helpers
 
     private var shouldShowBorderWhenVideoIsStopped: Bool {
-        let gridHasOnlyOneTile = configuration.streams.count == 1
-        let gridIsOneToOneWithFloatingTile = gridHasOnlyOneTile && configuration.floatingStream != nil
+       !gridHasOnlyOneTile && !gridIsOneToOneWithFloatingTile
+    }
 
-        return !gridHasOnlyOneTile && !gridIsOneToOneWithFloatingTile
+    private var gridHasOnlyOneTile: Bool {
+        configuration.streams.count == 1
+    }
+
+    private var gridIsOneToOneWithFloatingTile: Bool {
+        gridHasOnlyOneTile && configuration.floatingStream != nil
     }
 
     private func cachedStreamView(for stream: Stream) -> OrientableView? {

--- a/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallGridViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallGridViewController.swift
@@ -43,17 +43,19 @@ final class CallGridViewController: SpinnerCapableViewController {
     }
 
     private var dataSource: [Stream] = []
-    private var maximizedView: BaseCallParticipantView?
     private let gridView = GridView(maxItemsPerPage: 8)
     private let thumbnailViewController = PinnableThumbnailViewController()
     private let networkConditionView = NetworkConditionIndicatorView()
-    private let hintView = CallGridHintNotificationLabel()
     private let pageIndicator = RoundedPageIndicator()
     private let topStack = UIStackView(axis: .vertical)
     private let mediaManager: AVSMediaManagerInterface
     private var viewCache = [AVSClient: OrientableView]()
 
     // MARK: - Public Properties
+
+    // These two views are public for testing purposes
+    var maximizedView: BaseCallParticipantView?
+    var hintView = CallGridHintNotificationLabel()
 
     var configuration: CallGridViewControllerInput {
         didSet {
@@ -191,7 +193,7 @@ final class CallGridViewController: SpinnerCapableViewController {
 
     // MARK: - Hint
 
-    private func updateHint(for event: CallGridEvent) {
+    func updateHint(for event: CallGridEvent) {
         switch event {
         case .viewDidLoad:
             hintView.show(hint: .fullscreen)

--- a/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallParticipantViews/BaseCallParticipantView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallParticipantViews/BaseCallParticipantView.swift
@@ -150,7 +150,7 @@ class BaseCallParticipantView: OrientableView, AVSIdentifierProvider {
     }
 
     private func hideVideoViewsIfNeeded() {
-        scalableView?.isHidden = !isSharingVideo
+        scalableView?.isHidden = !stream.isSharingVideo
     }
 
     // MARK: - Pinch To Zoom
@@ -197,16 +197,9 @@ class BaseCallParticipantView: OrientableView, AVSIdentifierProvider {
 
     // MARK: - Border Style
 
-    private var isSharingVideo: Bool {
-        guard let videoState = stream.videoState else {
-            return false
-        }
-        return videoState != .stopped
-    }
-
     private func updateBorderStyle() {
         let showBorderForActiveSpeaker = shouldShowActiveSpeakerFrame && stream.isParticipantUnmutedAndSpeakingNow
-        let showBorderForAudioParticipant = shouldShowBorderWhenVideoIsStopped && !isSharingVideo
+        let showBorderForAudioParticipant = shouldShowBorderWhenVideoIsStopped && !stream.isSharingVideo
 
         layer.borderWidth = (showBorderForActiveSpeaker || showBorderForAudioParticipant) && !isMaximized ? 1 : 0
         layer.borderColor = showBorderForActiveSpeaker ? UIColor.accent().cgColor : UIColor.black.cgColor

--- a/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallParticipantViews/BaseCallParticipantView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallParticipantViews/BaseCallParticipantView.swift
@@ -246,7 +246,7 @@ class BaseCallParticipantView: OrientableView, AVSIdentifierProvider {
             let name = stream.user?.name ?? ""
             let maximizationState = isMaximized ? "maximized" : "minimized"
             let activityState = stream.isParticipantUnmutedAndActive ? "active" : "inactive"
-            let viewKind = isSharingVideo ? "videoView" : "audioView"
+            let viewKind = stream.isSharingVideo ? "videoView" : "audioView"
             return "\(viewKind).\(name).\(maximizationState).\(activityState)"
         }
         set {}

--- a/Wire-iOS/Sources/UserInterface/Calling/CallGridView/Stream/Stream+Video.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallGridView/Stream/Stream+Video.swift
@@ -1,0 +1,32 @@
+//
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension Stream {
+    var isSharingVideo: Bool {
+        guard let videoState = videoState else {
+            return false
+        }
+        return videoState != .stopped
+    }
+
+    var isScreenSharing: Bool {
+        return videoState == .some(.screenSharing)
+    }
+}


### PR DESCRIPTION
## What's new in this PR?

In the calling grid, we use hint labels to notify the user about the actions available to them. The current hints are:
- `Double tap on a tile for fullscreen` - showed when the calling grid first appears
- `Double tap to go back, pinch to zoom` - showed when a user maximises a tile
- `Pinch to zoom` - showed when there's a screenshare in 1:1 calls

The calling grid now allows for non-video tiles, for which pinch-to-zoom is disabled. 
So, for non-video tiles, I changed the hint `Double tap to go back, pinch to zoom` into `Double tap to go back`

Maximising a non-video tile - when it's the only one in the grid - shows the `Double tap to go back` hint, but has no other effect since the tile already appears fullscreen. Thus I disabled maximisation in this case.

### Todo

- [ ] Update tests