### PR TITLE
[Chore] Add Crowdin GitHub action

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -31,3 +31,5 @@ jobs:
           
           config: crowdin.yml
           dryrun_action: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,0 +1,33 @@
+name: Crowdin Action
+
+on:
+  push:
+    branches: [ develop ]
+    
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  synchronize-with-crowdin:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Crowdin action
+        uses: crowdin/github-action@1.0.4
+        with:
+          # For more info: https://github.com/crowdin/github-action/blob/master/action.yml
+          upload_sources: true
+          download_translations: true
+          upload_translations: false
+          
+          create_pull_request: true
+          localization_branch_name: chore/update-localization
+          commit_message: "[Chore] Update localization"
+          pull_request_title: "[Chore] Update localization"
+          pull_request_body: "This PR pulls in the latest localization translations from Crowdin."
+          
+          config: crowdin.yml
+          dryrun_action: true

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -3,7 +3,7 @@ name: Crowdin Action
 on:
   push:
     branches: [ develop ]
-    
+
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -16,20 +16,21 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Crowdin action
-        uses: crowdin/github-action@1.0.4
+        uses: wireapp/github-action@1.1.0
         with:
           # For more info: https://github.com/crowdin/github-action/blob/master/action.yml
+          project_id: ${{ secrets.CROWDIN_PROJECT_ID }}          
+          token: ${{ secrets.CROWDIN_API_TOKEN }}
+          config: crowdin.yml
+          
           upload_sources: true
           download_translations: true
           upload_translations: false
-          
+
           create_pull_request: true
           localization_branch_name: chore/update-localization
           commit_message: "[Chore] Update localization"
           pull_request_title: "[Chore] Update localization"
           pull_request_body: "This PR pulls in the latest localization translations from Crowdin."
-          
-          config: crowdin.yml
-          dryrun_action: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What's new in this PR?

### Issues

Synchronizing localized strings to and from Crowdin is a bit of a hassle.

### Causes

Pushing localization sources and pulling new translations is currently a manual process. It is achieved using the Crowdin CLI tool, but this needs to be installed locally and the user needs to have a crowdin account to set up a personal access token. 

### Solutions

The Crowdin Github action can do all of this for us automatically. It is set up to run when a new commit is made to `develop`, which will upload and source strings to Crowdin. It will also automatically download new translations to the specified branch and open a pull request.

### To do

- [x] Set up crowdin account for the action and set the personal access token.

### Notes

See for more info: https://support.crowdin.com/github-crowdin-action/