### PR TITLE
Release/3.84

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -3,7 +3,7 @@ github "wireapp/Cartography" "4.0.0-xcode_12_4"
 github "wireapp/wire-ios-sync-engine" ~> 382.0.1
 github "wireapp/wire-ios-share-engine" ~> 219.0.2
 github "wireapp/FormatterKit" "1.8.1-swift3.0.2"
-github "wireapp/wire-ios-canvas" ~> 12.0.0
+github "wireapp/wire-ios-canvas" ~> 12.0
 github "wireapp/appcenter-sdk-apple" ~> 3.3.4
 github "wireapp/FLAnimatedImage" "1.0.12-wire"
 github "wireapp/Down" "v2.3.0_Xcode12.4"

--- a/Wire-iOS/Resources/Configuration/Version.xcconfig
+++ b/Wire-iOS/Resources/Configuration/Version.xcconfig
@@ -16,4 +16,4 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-WIRE_SHORT_VERSION = 3.83
+WIRE_SHORT_VERSION = 3.84

--- a/Wire-iOS/Settings+ColorScheme.swift
+++ b/Wire-iOS/Settings+ColorScheme.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2019 Wire Swiss GmbH
+// Copyright (C) 2021 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/Wire-iOS/UIControlState+ExpandState.swift
+++ b/Wire-iOS/UIControlState+ExpandState.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2020 Wire Swiss GmbH
+// Copyright (C) 2021 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -152,6 +152,32 @@ platform :ios do
         end
     end
 
+    desc "Build for release to AppStore without symbols"
+    lane :build_for_release_without_symbols do |options|
+        xcode_version = options[:xcode_version]
+
+        if !xcode_version.nil? 
+            xcversion(version: xcode_version)
+        end
+
+        build = Build.new(options: options)
+
+        build_app(
+            scheme: "Wire-iOS",
+            configuration: build.configuration,
+            export_method: build.export_method,
+            export_options: {"iCloudContainerEnvironment": "Production"},
+            derived_data_path: "DerivedData",
+            archive_path: build.archive_path(with_filename: true),
+            buildlog_path: build.build_path,
+            output_directory: build.artifact_path(with_filename: false),
+            output_name: build.filename,
+            include_bitcode: false,
+            include_symbols: false,
+            xcargs: "BUILD_NUMBER=#{build.build_number}"
+        )
+    end
+
     desc "Upload to AppStore"
     lane :upload_app_store do |options|
         build = Build.new(options: options)


### PR DESCRIPTION
## What's new in this PR?

Added `build_for_release_without_symbols` lane to build the app without symbols

related PR: https://github.com/wireapp/wire-ios-shared-resources/pull/51