### PR TITLE
[Fix] Ambiguous translation for string

### DIFF
--- a/Wire-iOS/Generated/Strings+Generated.swift
+++ b/Wire-iOS/Generated/Strings+Generated.swift
@@ -903,6 +903,8 @@ internal enum L10n {
             internal static func joined(_ p1: Any) -> String {
               return L10n.tr("Localizable", "content.system.conversation.guest.joined", String(describing: p1))
             }
+            /// You joined
+            internal static let youJoined = L10n.tr("Localizable", "content.system.conversation.guest.you_joined")
           }
           internal enum Invite {
             /// Invite people

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -455,6 +455,7 @@
 "content.system.conversation.you.left" = "%@ left";
 "content.system.conversation.team.member-leave" = "%@ was removed from the team.";
 "content.system.conversation.guest.joined" = "%@ joined";
+"content.system.conversation.guest.you_joined" = "You joined";
 
 "content.system.conversation.invite.title" = "Services and people outside your team can join this conversation.";
 "content.system.conversation.invite.button" = "Invite people";

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ParticipantsStringFormatter.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ParticipantsStringFormatter.swift
@@ -140,11 +140,16 @@ final class ParticipantsStringFormatter {
     /// Title when the subject (sender) is performing the action alone.
     func title(senderName: String, senderIsSelf: Bool) -> NSAttributedString? {
         switch message.actionType {
+        case .added(herself: true) where senderIsSelf:
+            return L10n.Localizable.Content.System.Conversation.Guest.youJoined && font && textColor
+
         case .left, .teamMemberLeave, .added(herself: true):
             let formatKey = message.actionType.formatKey
             let title = formatKey(senderIsSelf).localized(args: senderName) && font && textColor
             return senderIsSelf ? title : title.adding(font: boldFont, to: senderName)
-        default: return nil
+
+        default:
+            return nil
         }
     }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

When the self user joins a conversation as a guest, a system message is shown stating "You joined". The "you" part is inserted into the localized string and may another user's name, e.g. "John joined". 

One localized string is used for both the first and third persons, but languages that have conjugation require separate translations for these cases, e.g in German "Sie sind beigetreten" and "John ist beigetreten".

### Solutions

Add a second  localizable string to allow translators to disambiguate these different scenarios. 
