### PR TITLE
fix: replace deprecated methods

### DIFF
--- a/Wire-iOS Share Extension/ConversationSelectionViewController.swift
+++ b/Wire-iOS Share Extension/ConversationSelectionViewController.swift
@@ -43,7 +43,7 @@ final class ConversationSelectionViewController : UITableViewController {
         tableView.estimatedRowHeight = 56
         tableView.register(TargetConversationCell.self, forCellReuseIdentifier: cellReuseIdentifier)
         
-        searchController.dimsBackgroundDuringPresentation = false
+        searchController.obscuresBackgroundDuringPresentation = false
         searchController.hidesNavigationBarDuringPresentation = false
         searchController.searchBar.isTranslucent = false
 

--- a/Wire-iOS/Sources/Authentication/Helpers/CountryCode/CountryCodeTableViewController.swift
+++ b/Wire-iOS/Sources/Authentication/Helpers/CountryCode/CountryCodeTableViewController.swift
@@ -79,7 +79,7 @@ final class CountryCodeTableViewController: UITableViewController, UISearchContr
 
         resultsTableViewController.tableView.delegate = self
         searchController.delegate = self
-        searchController.dimsBackgroundDuringPresentation = false
+        searchController.obscuresBackgroundDuringPresentation = false
         searchController.searchBar.delegate = self
         searchController.searchBar.backgroundColor = UIColor.white
 


### PR DESCRIPTION
## What's new in this PR?

replace `dimsBackgroundDuringPresentation` which is dropped in iOS 12 with `obscuresBackgroundDuringPresentation` 