### PR TITLE
[Fix] Crash when leaving large call

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallGridViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallGridViewController.swift
@@ -367,8 +367,7 @@ final class CallGridViewController: SpinnerCapableViewController {
         var endIndex = startIndex + gridView.maxItemsPerPage
         endIndex = min(endIndex, dataSource.count)
 
-        guard startIndex >= 0 &&
-              startIndex < dataSource.count &&
+        guard dataSource.indices.contains(startIndex),
               endIndex > startIndex
         else { return }
 

--- a/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallGridViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallGridViewController.swift
@@ -367,7 +367,10 @@ final class CallGridViewController: SpinnerCapableViewController {
         var endIndex = startIndex + gridView.maxItemsPerPage
         endIndex = min(endIndex, dataSource.count)
 
-        guard startIndex >= 0 else { return }
+        guard startIndex >= 0 &&
+              startIndex < dataSource.count &&
+              endIndex > startIndex
+        else { return }
 
         let clients = dataSource[startIndex..<endIndex]
             .filter(\.isSharingVideo)


### PR DESCRIPTION
## What's new in this PR?

### Issues

When hanging up a large conference call from the last page of the call grid, the app crashes

### Causes

Upon hanging up the call, the call configuration is updated and propagated to `CallGridViewController`.
Consequently, `requestVideoStreamsIfNeeded(forPage:Int)` is called. This method slices the `dataSource` array containing all streams by using the range of indexes of the elements presumed to be in the given page.


The range of indexes is calculated this way:
```
let startIndex = page * gridView.maxItemsPerPage
var endIndex = startIndex + gridView.maxItemsPerPage
endIndex = min(endIndex, dataSource.count)
```

Using `min(endIndex, dataSource.count)` ensures `endIndex` won't be out of `dataSource` bounds.
However, there is a risk for `startIndex` to be out of `dataSource`'s bounds and/or for `endIndex` to be lower than `startIndex`
 
### Solutions

`guard` against `startIndex` being out of bounds and against `endIndex` being lower than `startIndex`

