### PR TITLE
[Feature] Hide download, save and share buttons

### DIFF
--- a/Wire-iOS Tests/ConversationMessageActionControllerTests.swift
+++ b/Wire-iOS Tests/ConversationMessageActionControllerTests.swift
@@ -127,4 +127,54 @@ final class ConversationMessageActionControllerTests: XCTestCase, CoreDataFixtur
         XCTAssertTrue(supportsCopy)
     }
 
+    // MARK: - Save
+
+    func testThatItDoesNotShowSaveItemForAudioMessage_IfReceivingFilesIsRestricted() {
+        // GIVEN
+        let message = MockMessageFactory.audioMessage()
+        message!.senderUser = MockUserType.createUser(name: "Bob")
+        message!.conversation = otherUserConversation
+        message!.backingIsRestricted = true
+
+        // WHEN
+        let actionController = ConversationMessageActionController(responder: nil, message: message!, context: .content, view: UIView())
+        let supportsSave = actionController.canPerformAction(#selector(ConversationMessageActionController.saveMessage))
+
+        // THEN
+        XCTAssertFalse(supportsSave)
+    }
+
+    // MARK: - Download
+
+    func testThatItDoesNotShowDownloadItemForAudioMessage_IfReceivingFilesIsRestricted() {
+        // GIVEN
+        let message = MockMessageFactory.audioMessage()
+        message!.senderUser = MockUserType.createUser(name: "Bob")
+        message!.conversation = otherUserConversation
+        message!.backingIsRestricted = true
+
+        // WHEN
+        let actionController = ConversationMessageActionController(responder: nil, message: message!, context: .content, view: UIView())
+        let supportsDownload = actionController.canPerformAction(#selector(ConversationMessageActionController.downloadMessage))
+
+        // THEN
+        XCTAssertFalse(supportsDownload)
+    }
+
+    // MARK: - Forward
+
+    func testThatItDoesNotShowForwardItemForAudioMessage_IfReceivingFilesIsRestricted() {
+        // GIVEN
+        let message = MockMessageFactory.audioMessage()
+        message!.senderUser = MockUserType.createUser(name: "Bob")
+        message!.conversation = otherUserConversation
+        message!.backingIsRestricted = true
+
+        // WHEN
+        let actionController = ConversationMessageActionController(responder: nil, message: message!, context: .content, view: UIView())
+        let supportsForward = actionController.canPerformAction(#selector(ConversationMessageActionController.forwardMessage))
+
+        // THEN
+        XCTAssertFalse(supportsForward)
+    }
 }

--- a/Wire-iOS Tests/ConversationMessageCell/ConversationAudioMessageCellTests.swift
+++ b/Wire-iOS Tests/ConversationMessageCell/ConversationAudioMessageCellTests.swift
@@ -222,7 +222,7 @@ final class ConversationAudioMessageCellTests: XCTestCase {
     // MARK: - Receiving restrictions
 
     func testRestrictionMessageCell() {
-        message.backingIsRestritcted = true
+        message.backingIsRestricted = true
         message.backingFileMessageData.mimeType = "audio/x-m4a"
 
         verify(message: message)

--- a/Wire-iOS Tests/ConversationMessageCell/ConversationFileMessageCellTests.swift
+++ b/Wire-iOS Tests/ConversationMessageCell/ConversationFileMessageCellTests.swift
@@ -235,7 +235,7 @@ final class ConversationFileMessageTests: XCTestCase {
     // MARK: - Receiving restrictions
 
     func testRestrictionMessageCell() {
-        message.backingIsRestritcted = true
+        message.backingIsRestricted = true
         message.backingFileMessageData.mimeType = "application/pdf"
 
         verify(message: message)

--- a/Wire-iOS Tests/ConversationMessageCell/ConversationImageMessageTests.swift
+++ b/Wire-iOS Tests/ConversationMessageCell/ConversationImageMessageTests.swift
@@ -82,7 +82,7 @@ final class ConversationImageMessageTests: XCTestCase {
 
     func testRestrictionMessageCell() {
         createSut(imageName: "unsplash_matterhorn.jpg")
-        message.backingIsRestritcted = true
+        message.backingIsRestricted = true
 
         verify(message: message)
     }

--- a/Wire-iOS Tests/ConversationMessageCell/ConversationVideoMessageCellTests.swift
+++ b/Wire-iOS Tests/ConversationMessageCell/ConversationVideoMessageCellTests.swift
@@ -221,7 +221,7 @@ final class ConversationVideoMessageCellTests: XCTestCase {
     // MARK: - Receiving restrictions
 
     func testRestrictionMessageCell() {
-        message.backingIsRestritcted = true
+        message.backingIsRestricted = true
         message.backingFileMessageData.mimeType = "video/mp4"
 
         verify(message: message)

--- a/Wire-iOS Tests/Mocks/MockMessage.swift
+++ b/Wire-iOS Tests/Mocks/MockMessage.swift
@@ -348,9 +348,9 @@ class MockMessage: NSObject, ZMConversationMessage, ConversationCompositeMessage
     var linkAttachments: [LinkAttachment]?
     var needsLinkAttachmentsUpdate: Bool = false
     var isSilenced: Bool = false
-    var backingIsRestritcted: Bool = false
+    var backingIsRestricted: Bool = false
     var isRestricted: Bool {
-        return backingIsRestritcted
+        return backingIsRestricted
     }
 
     var isSent: Bool {

--- a/Wire-iOS/Sources/Helpers/Bundle+SecurityFlags.swift
+++ b/Wire-iOS/Sources/Helpers/Bundle+SecurityFlags.swift
@@ -20,7 +20,6 @@ import Foundation
 
 enum SecurityFlags {
     case clipboard
-    case saveMessage
     case generateLinkPreviews
     case forceConstantBitRateCalls
     case openFilePreview
@@ -36,8 +35,6 @@ enum SecurityFlags {
         switch self {
         case .clipboard:
             return "ClipboardEnabled"
-        case .saveMessage:
-            return "SaveMessageEnabled"
         case .generateLinkPreviews:
             return "GenerateLinkPreviewEnabled"
         case .forceConstantBitRateCalls:

--- a/Wire-iOS/Sources/Helpers/syncengine/ZMMessage+Actions.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMMessage+Actions.swift
@@ -109,7 +109,10 @@ extension ZMConversationMessage {
         guard let fileMessageData = self.fileMessageData else {
             return false
         }
-        return isFile && fileMessageData.transferState == .uploaded && fileMessageData.downloadState == .remote
+        return isFile
+            && fileMessageData.transferState == .uploaded
+            && fileMessageData.downloadState == .remote
+            && !isRestricted
     }
 
     var canCancelDownload: Bool {
@@ -121,7 +124,7 @@ extension ZMConversationMessage {
 
     /// Wether the content of the message can be saved to the disk.
     var canBeSaved: Bool {
-        if isEphemeral || !SecurityFlags.saveMessage.isEnabled {
+        if isEphemeral || isRestricted {
             return false
         }
 
@@ -144,7 +147,7 @@ extension ZMConversationMessage {
 
     /// Wether it should be possible to forward given message to another conversation.
     var canBeForwarded: Bool {
-        if isEphemeral {
+        if isEphemeral || isRestricted {
             return false
         }
 

--- a/Wire-iOS/Sources/Helpers/syncengine/ZMMessage+Actions.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMMessage+Actions.swift
@@ -106,13 +106,13 @@ extension ZMConversationMessage {
 
     /// Wether it is possible to download the message content.
     var canBeDownloaded: Bool {
-        guard let fileMessageData = self.fileMessageData else {
+        guard let fileMessageData = self.fileMessageData,
+              !isRestricted else {
             return false
         }
         return isFile
             && fileMessageData.transferState == .uploaded
             && fileMessageData.downloadState == .remote
-            && !isRestricted
     }
 
     var canCancelDownload: Bool {


### PR DESCRIPTION
## What's new in this PR?

If the file sharing feature is disabled, we should hide the `download`, `save` and `share` buttons on the message action toolbar.