### PR TITLE
[Chore] disable large conference call features

### DIFF
--- a/Wire-iOS Tests/Calling/CallInfoConfigurationTests.swift
+++ b/Wire-iOS Tests/Calling/CallInfoConfigurationTests.swift
@@ -36,12 +36,14 @@ final class CallInfoConfigurationTests: XCTestCase {
         mockSelfUser = MockUserType.createSelfUser(name: "Bob")
         mockUsers = SwiftMockLoader.mockUsers()
         mockOtherUser = mockUsers.first!
+        CallingConfiguration.config = .largeConferenceCalls
     }
 
     override func tearDown() {
         mockSelfUser = nil
         mockOtherUser = nil
         mockUsers = nil
+        CallingConfiguration.resetDefaultConfig()
 
         super.tearDown()
     }

--- a/Wire-iOS Tests/Calling/CallInfoRootViewControllerSnapshotTests.swift
+++ b/Wire-iOS Tests/Calling/CallInfoRootViewControllerSnapshotTests.swift
@@ -21,6 +21,16 @@ import XCTest
 
 final class CallInfoViewControllerSnapshotTests: XCTestCase {
 
+    override func setUp() {
+        super.setUp()
+        CallingConfiguration.config = .largeConferenceCalls
+    }
+
+    override func tearDown() {
+        CallingConfiguration.resetDefaultConfig()
+        super.tearDown()
+    }
+
     // MARK: - OneToOne Audio
 
     func testOneToOneIncomingAudioRinging() {

--- a/Wire-iOS Tests/Calling/CallInfoRootViewControllerTests.swift
+++ b/Wire-iOS Tests/Calling/CallInfoRootViewControllerTests.swift
@@ -33,6 +33,7 @@ final class CallInfoRootViewControllerTests: XCTestCase {
         mockOtherUser = MockUserType.createConnectedUser(name: "Bruno", inTeam: nil)
         mockSelfUser = MockUserType.createSelfUser(name: "Alice")
         mockUsers = SwiftMockLoader.mockUsers()
+        CallingConfiguration.config = .largeConferenceCalls
     }
 
     override func tearDown() {
@@ -40,6 +41,7 @@ final class CallInfoRootViewControllerTests: XCTestCase {
         mockSelfUser = nil
         mockOtherUser = nil
         mockUsers = nil
+        CallingConfiguration.resetDefaultConfig()
 
         super.tearDown()
     }

--- a/Wire-iOS Tests/Calling/CallInfoTestFixture.swift
+++ b/Wire-iOS Tests/Calling/CallInfoTestFixture.swift
@@ -65,7 +65,8 @@ struct CallInfoTestFixture {
             disableIdleTimer: false,
             cameraType: .front,
             networkQuality: .normal,
-            userEnabledCBR: false
+            userEnabledCBR: false,
+            variant: .dark
         )
     }
 
@@ -88,7 +89,8 @@ struct CallInfoTestFixture {
             disableIdleTimer: false,
             cameraType: .front,
             networkQuality: .normal,
-            userEnabledCBR: false
+            userEnabledCBR: false,
+            variant: .dark
         )
     }
 
@@ -111,7 +113,8 @@ struct CallInfoTestFixture {
             disableIdleTimer: false,
             cameraType: .front,
             networkQuality: .normal,
-            userEnabledCBR: false
+            userEnabledCBR: false,
+            variant: .dark
         )
     }
 
@@ -134,7 +137,8 @@ struct CallInfoTestFixture {
             disableIdleTimer: false,
             cameraType: .front,
             networkQuality: .normal,
-            userEnabledCBR: false
+            userEnabledCBR: false,
+            variant: .dark
         )
     }
 
@@ -157,7 +161,8 @@ struct CallInfoTestFixture {
             disableIdleTimer: false,
             cameraType: .front,
             networkQuality: .normal,
-            userEnabledCBR: false
+            userEnabledCBR: false,
+            variant: .dark
         )
     }
 
@@ -180,7 +185,8 @@ struct CallInfoTestFixture {
             disableIdleTimer: false,
             cameraType: .front,
             networkQuality: .normal,
-            userEnabledCBR: false
+            userEnabledCBR: false,
+            variant: .dark
         )
     }
 
@@ -203,7 +209,8 @@ struct CallInfoTestFixture {
             disableIdleTimer: false,
             cameraType: .front,
             networkQuality: .normal,
-            userEnabledCBR: true
+            userEnabledCBR: true,
+            variant: .dark
         )
     }
 
@@ -226,7 +233,8 @@ struct CallInfoTestFixture {
             disableIdleTimer: false,
             cameraType: .front,
             networkQuality: .normal,
-            userEnabledCBR: true
+            userEnabledCBR: true,
+            variant: .dark
         )
     }
 
@@ -249,7 +257,8 @@ struct CallInfoTestFixture {
             disableIdleTimer: false,
             cameraType: .front,
             networkQuality: .poor,
-            userEnabledCBR: false
+            userEnabledCBR: false,
+            variant: .dark
         )
     }
 
@@ -274,7 +283,8 @@ struct CallInfoTestFixture {
             disableIdleTimer: true,
             cameraType: .front,
             networkQuality: .normal,
-            userEnabledCBR: false
+            userEnabledCBR: false,
+            variant: .dark
         )
     }
 
@@ -297,7 +307,8 @@ struct CallInfoTestFixture {
             disableIdleTimer: true,
             cameraType: .front,
             networkQuality: .normal,
-            userEnabledCBR: false
+            userEnabledCBR: false,
+            variant: .dark
         )
     }
 
@@ -320,7 +331,8 @@ struct CallInfoTestFixture {
             disableIdleTimer: true,
             cameraType: .front,
             networkQuality: .normal,
-            userEnabledCBR: false
+            userEnabledCBR: false,
+            variant: .dark
         )
     }
 
@@ -343,7 +355,8 @@ struct CallInfoTestFixture {
             disableIdleTimer: true,
             cameraType: .front,
             networkQuality: .normal,
-            userEnabledCBR: false
+            userEnabledCBR: false,
+            variant: .dark
         )
     }
 
@@ -366,7 +379,8 @@ struct CallInfoTestFixture {
             disableIdleTimer: true,
             cameraType: .front,
             networkQuality: .normal,
-            userEnabledCBR: false
+            userEnabledCBR: false,
+            variant: .dark
         )
     }
 
@@ -389,7 +403,8 @@ struct CallInfoTestFixture {
             disableIdleTimer: true,
             cameraType: .front,
             networkQuality: .normal,
-            userEnabledCBR: false
+            userEnabledCBR: false,
+            variant: .dark
         )
     }
 
@@ -412,7 +427,8 @@ struct CallInfoTestFixture {
             disableIdleTimer: true,
             cameraType: .front,
             networkQuality: .normal,
-            userEnabledCBR: false
+            userEnabledCBR: false,
+            variant: .dark
         )
     }
 
@@ -437,7 +453,8 @@ struct CallInfoTestFixture {
             disableIdleTimer: false,
             cameraType: .front,
             networkQuality: .normal,
-            userEnabledCBR: false
+            userEnabledCBR: false,
+            variant: .dark
         )
     }
 
@@ -460,7 +477,8 @@ struct CallInfoTestFixture {
             disableIdleTimer: false,
             cameraType: .front,
             networkQuality: .normal,
-            userEnabledCBR: false
+            userEnabledCBR: false,
+            variant: .dark
         )
     }
 
@@ -483,7 +501,8 @@ struct CallInfoTestFixture {
             disableIdleTimer: false,
             cameraType: .front,
             networkQuality: .normal,
-            userEnabledCBR: false
+            userEnabledCBR: false,
+            variant: .dark
         )
     }
 
@@ -506,7 +525,8 @@ struct CallInfoTestFixture {
             disableIdleTimer: false,
             cameraType: .front,
             networkQuality: .normal,
-            userEnabledCBR: false
+            userEnabledCBR: false,
+            variant: .dark
         )
     }
 
@@ -529,7 +549,8 @@ struct CallInfoTestFixture {
             disableIdleTimer: true,
             cameraType: .front,
             networkQuality: .normal,
-            userEnabledCBR: false
+            userEnabledCBR: false,
+            variant: .dark
         )
     }
 
@@ -552,7 +573,8 @@ struct CallInfoTestFixture {
             disableIdleTimer: false,
             cameraType: .front,
             networkQuality: .normal,
-            userEnabledCBR: false
+            userEnabledCBR: false,
+            variant: .dark
         )
     }
 
@@ -575,7 +597,8 @@ struct CallInfoTestFixture {
             disableIdleTimer: false,
             cameraType: .front,
             networkQuality: .normal,
-            userEnabledCBR: true
+            userEnabledCBR: true,
+            variant: .dark
         )
     }
 
@@ -600,7 +623,8 @@ struct CallInfoTestFixture {
             disableIdleTimer: true,
             cameraType: .front,
             networkQuality: .normal,
-            userEnabledCBR: false
+            userEnabledCBR: false,
+            variant: .dark
         )
     }
 
@@ -623,7 +647,8 @@ struct CallInfoTestFixture {
             disableIdleTimer: true,
             cameraType: .front,
             networkQuality: .normal,
-            userEnabledCBR: false
+            userEnabledCBR: false,
+            variant: .dark
         )
     }
 
@@ -646,7 +671,8 @@ struct CallInfoTestFixture {
             disableIdleTimer: true,
             cameraType: .front,
             networkQuality: .normal,
-            userEnabledCBR: false
+            userEnabledCBR: false,
+            variant: .dark
         )
     }
 
@@ -669,7 +695,8 @@ struct CallInfoTestFixture {
             disableIdleTimer: true,
             cameraType: .front,
             networkQuality: .normal,
-            userEnabledCBR: false
+            userEnabledCBR: false,
+            variant: .dark
         )
     }
 
@@ -692,7 +719,8 @@ struct CallInfoTestFixture {
             disableIdleTimer: true,
             cameraType: .front,
             networkQuality: .poor,
-            userEnabledCBR: false
+            userEnabledCBR: false,
+            variant: .dark
         )
     }
 
@@ -715,7 +743,8 @@ struct CallInfoTestFixture {
             disableIdleTimer: true,
             cameraType: .front,
             networkQuality: .normal,
-            userEnabledCBR: false
+            userEnabledCBR: false,
+            variant: .dark
         )
     }
 
@@ -738,7 +767,8 @@ struct CallInfoTestFixture {
             disableIdleTimer: true,
             cameraType: .front,
             networkQuality: .normal,
-            userEnabledCBR: true
+            userEnabledCBR: true,
+            variant: .dark
         )
     }
 
@@ -761,7 +791,8 @@ struct CallInfoTestFixture {
             disableIdleTimer: true,
             cameraType: .front,
             networkQuality: .normal,
-            userEnabledCBR: true
+            userEnabledCBR: true,
+            variant: .dark
         )
     }
 
@@ -785,7 +816,8 @@ struct CallInfoTestFixture {
             disableIdleTimer: true,
             cameraType: .front,
             networkQuality: .normal,
-            userEnabledCBR: true
+            userEnabledCBR: true,
+            variant: .dark
         )
     }
 
@@ -809,7 +841,8 @@ struct CallInfoTestFixture {
             disableIdleTimer: true,
             cameraType: .front,
             networkQuality: .normal,
-            userEnabledCBR: true
+            userEnabledCBR: true,
+            variant: .dark
         )
     }
 

--- a/Wire-iOS Tests/Calling/VoiceChannelStreamArrangmentTests.swift
+++ b/Wire-iOS Tests/Calling/VoiceChannelStreamArrangmentTests.swift
@@ -58,6 +58,8 @@ class VoiceChannelStreamArrangementTests: XCTestCase {
         MockUser.mockSelf()?.remoteIdentifier = selfUserId
         MockUser.mockSelf()?.clients = [userClient]
         MockUser.mockSelf()?.isSelfUser = true
+
+        CallingConfiguration.config = .largeConferenceCalls
     }
 
     override func tearDown() {
@@ -65,6 +67,7 @@ class VoiceChannelStreamArrangementTests: XCTestCase {
         mockUser1 = nil
         mockUser2 = nil
         mockUser3 = nil
+        CallingConfiguration.resetDefaultConfig()
         super.tearDown()
     }
 

--- a/Wire-iOS Tests/Mocks/MockCallInfoViewControllerInput.swift
+++ b/Wire-iOS Tests/Mocks/MockCallInfoViewControllerInput.swift
@@ -38,6 +38,7 @@ struct MockCallInfoViewControllerInput: CallInfoViewControllerInput {
     var cameraType: CaptureDevice
     var networkQuality: NetworkQuality
     var userEnabledCBR: Bool
+    var variant: ColorSchemeVariant
 }
 
 extension MockCallInfoViewControllerInput: CustomDebugStringConvertible {}

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -496,6 +496,7 @@
 		639290A2252633E600046171 /* UIAlertController+DegradedCall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639290A1252633E600046171 /* UIAlertController+DegradedCall.swift */; };
 		63A5E6E424C1ACFC00F7D401 /* SettingsCellDescriptorFactory+Advanced.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63A5E6E324C1ACFC00F7D401 /* SettingsCellDescriptorFactory+Advanced.swift */; };
 		63A5E6F624C87E0000F7D401 /* SettingsCellDescriptorFactory+SoundAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63A5E6F524C87DFF00F7D401 /* SettingsCellDescriptorFactory+SoundAlert.swift */; };
+		63A874FC26CBAF2B000D3F27 /* CallingConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63A874FB26CBAF2A000D3F27 /* CallingConfiguration.swift */; };
 		63AFE23825B6E16B0054B067 /* RoundedSegmentedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AFE23725B6E16B0054B067 /* RoundedSegmentedView.swift */; };
 		63B2366F251B634C009EDB02 /* UIAlertController+OutdatedClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B2366E251B634C009EDB02 /* UIAlertController+OutdatedClient.swift */; };
 		63B9F5A525E528E70059020D /* ActiveSpeakerState+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B9F5A425E528E70059020D /* ActiveSpeakerState+Helper.swift */; };
@@ -2239,6 +2240,7 @@
 		639290A1252633E600046171 /* UIAlertController+DegradedCall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertController+DegradedCall.swift"; sourceTree = "<group>"; };
 		63A5E6E324C1ACFC00F7D401 /* SettingsCellDescriptorFactory+Advanced.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SettingsCellDescriptorFactory+Advanced.swift"; sourceTree = "<group>"; };
 		63A5E6F524C87DFF00F7D401 /* SettingsCellDescriptorFactory+SoundAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SettingsCellDescriptorFactory+SoundAlert.swift"; sourceTree = "<group>"; };
+		63A874FB26CBAF2A000D3F27 /* CallingConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallingConfiguration.swift; sourceTree = "<group>"; };
 		63AFE23725B6E16B0054B067 /* RoundedSegmentedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedSegmentedView.swift; sourceTree = "<group>"; };
 		63B2366E251B634C009EDB02 /* UIAlertController+OutdatedClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertController+OutdatedClient.swift"; sourceTree = "<group>"; };
 		63B9F5A425E528E70059020D /* ActiveSpeakerState+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ActiveSpeakerState+Helper.swift"; sourceTree = "<group>"; };
@@ -6524,6 +6526,7 @@
 				16A94AFA209C553A008A5718 /* CallViewController.swift */,
 				BFAC71F820A1CC5B002711C4 /* CallInfoConfiguration.swift */,
 				BFAC71FD20A1CE0D002711C4 /* CallGridConfiguration.swift */,
+				63A874FB26CBAF2A000D3F27 /* CallingConfiguration.swift */,
 			);
 			path = CallViewController;
 			sourceTree = "<group>";
@@ -8216,6 +8219,7 @@
 				F15650ED21DD1B4100210504 /* Reusable.swift in Sources */,
 				A9275F6324223FD3007CB2BC /* CGSize+Zoom.swift in Sources */,
 				A923F1C02428C12A003F361F /* URLs+zip.swift in Sources */,
+				63A874FC26CBAF2B000D3F27 /* CallingConfiguration.swift in Sources */,
 				876113EB1DD1FEC4007F5969 /* ConversationContentViewController+Forward.swift in Sources */,
 				16DD6E95228304B70090A74C /* LegalHoldDetailsViewController.swift in Sources */,
 				D550F56E204444EE009E09DD /* ConversationActionController+Leave.swift in Sources */,

--- a/Wire-iOS/Generated/Strings+Generated.swift
+++ b/Wire-iOS/Generated/Strings+Generated.swift
@@ -1079,7 +1079,7 @@ internal enum L10n {
         internal static let externalsGuestsServicesPresent = L10n.tr("Localizable", "conversation.banner.externals_guests_services_present")
         /// **Externals** are present
         internal static let externalsPresent = L10n.tr("Localizable", "conversation.banner.externals_present")
-        /// **External**s and **services** are present
+        /// **Externals** and **services** are present
         internal static let externalsServicesPresent = L10n.tr("Localizable", "conversation.banner.externals_services_present")
         /// **Guests** are present
         internal static let guestsPresent = L10n.tr("Localizable", "conversation.banner.guests_present")

--- a/Wire-iOS/Sources/UserInterface/Calling/CallActionsView/CallActionsView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallActionsView/CallActionsView.swift
@@ -52,7 +52,7 @@ enum MediaState: Equatable {
 }
 
 // This protocol describes the input for a `CallActionsView`.
-protocol CallActionsViewInputType: CallTypeProvider {
+protocol CallActionsViewInputType: CallTypeProvider, ColorVariantProvider {
     var canToggleMediaType: Bool { get }
     var isMuted: Bool { get }
     var mediaState: MediaState { get }
@@ -66,7 +66,15 @@ protocol CallActionsViewInputType: CallTypeProvider {
 
 extension CallActionsViewInputType {
     var appearance: CallActionAppearance {
-        .dark(blurred: true)
+        guard CallingConfiguration.config.isAudioCallColorSchemable else {
+            return .dark(blurred: true)
+        }
+
+        switch (isVideoCall, variant) {
+        case (true, _): return .dark(blurred: true)
+        case (false, .light): return .light
+        case (false, .dark): return .dark(blurred: false)
+        }
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Calling/CallController/ActiveCallRouter.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallController/ActiveCallRouter.swift
@@ -90,7 +90,7 @@ extension ActiveCallRouter: ActiveCallRouterProtocol {
         let activeCallViewController = ActiveCallViewController(voiceChannel: voiceChannel)
         activeCallViewController.delegate = callController
 
-        let modalVC = ModalPresentationViewController(viewController: activeCallViewController, enableDismissOnPan: false)
+        let modalVC = ModalPresentationViewController(viewController: activeCallViewController, enableDismissOnPan: !CallingConfiguration.config.paginationEnabled)
 
         rootViewController.isPresenting
             ? dismissPresentedAndPresentActiveCall(modalViewController: modalVC, animated: animated)

--- a/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallGridViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallGridViewController.swift
@@ -32,7 +32,13 @@ final class CallGridViewController: SpinnerCapableViewController {
     // MARK: - Statics
 
     static let isCoveredKey = "isCovered"
-    static let maxItemsPerPage = 8
+
+    static var maxItemsPerPage: Int {
+        switch CallingConfiguration.config.streamLimit {
+        case .limit(amount: let amount): return amount
+        case .noLimit: return 8
+        }
+    }
 
     // MARK: - Private Properties
 
@@ -49,7 +55,7 @@ final class CallGridViewController: SpinnerCapableViewController {
 
     private var visibleClientsSharingVideo: [AVSClient] = []
     private var dataSource: [Stream] = []
-    private let gridView = GridView(maxItemsPerPage: CallGridViewController.maxItemsPerPage)
+    private let gridView = GridView(maxItemsPerPage: maxItemsPerPage)
     private let thumbnailViewController = PinnableThumbnailViewController()
     private let networkConditionView = NetworkConditionIndicatorView()
     private let pageIndicator = RoundedPageIndicator()

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallStatusView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallStatusView.swift
@@ -163,11 +163,7 @@ extension CallStatusViewInputType {
     var effectiveColorVariant: ColorSchemeVariant {
         guard callingConfig.isAudioCallColorSchemable else { return .dark }
 
-        if isVideoCall {
-            return .dark
-        } else {
-            return variant
-        }
+        return isVideoCall ? .dark : variant
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallStatusView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallStatusView.swift
@@ -18,10 +18,14 @@
 
 import UIKit
 
-protocol CallStatusViewInputType: CallTypeProvider, CBRSettingProvider {
+protocol CallStatusViewInputType: CallTypeProvider, CBRSettingProvider, ColorVariantProvider {
     var state: CallStatusViewState { get }
     var isConstantBitRate: Bool { get }
     var title: String { get }
+}
+
+protocol ColorVariantProvider {
+    var variant: ColorSchemeVariant { get }
 }
 
 protocol CallTypeProvider {
@@ -33,10 +37,16 @@ protocol CBRSettingProvider {
 }
 
 extension CallStatusViewInputType {
+    var callingConfig: CallingConfiguration { .config }
+
     var overlayBackgroundColor: UIColor {
-        switch (isVideoCall, state) {
-        case (true, .ringingOutgoing), (true, .ringingIncoming): return UIColor.black.withAlphaComponent(0.4)
-        case (true, _), (false, _): return UIColor.black.withAlphaComponent(0.64)
+        switch (isVideoCall, state, callingConfig.isAudioCallColorSchemable) {
+        case (true, .ringingOutgoing, _), (true, .ringingIncoming, _):
+            return UIColor.black.withAlphaComponent(0.4)
+        case (true, _, _), (false, _, false):
+            return UIColor.black.withAlphaComponent(0.64)
+        case (false, _, true):
+            return variant == .light ? UIColor.from(scheme: .background, variant: .light) : .black
         }
     }
 }
@@ -151,7 +161,13 @@ extension CallStatusViewInputType {
     }
 
     var effectiveColorVariant: ColorSchemeVariant {
-        .dark
+        guard callingConfig.isAudioCallColorSchemable else { return .dark }
+
+        if isVideoCall {
+            return .dark
+        } else {
+            return variant
+        }
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallInfoConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallInfoConfiguration.swift
@@ -133,6 +133,7 @@ struct CallInfoConfiguration: CallInfoViewControllerInput {
     let callState: CallStateExtending
     let videoGridPresentationMode: VideoGridPresentationMode
     let allowPresentationModeUpdates: Bool
+    let variant: ColorSchemeVariant
 
     private let voiceChannelSnapshot: VoiceChannelSnapshot
 
@@ -163,6 +164,7 @@ struct CallInfoConfiguration: CallInfoViewControllerInput {
         callState = voiceChannel.state
         videoGridPresentationMode = voiceChannel.videoGridPresentationMode
         allowPresentationModeUpdates = voiceChannel.allowPresentationModeUpdates
+        variant = ColorScheme.default.variant
     }
 
     // This property has to be computed in order to return the correct call duration

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -248,7 +248,7 @@ final class CallViewController: UIViewController {
     }
 
     private func updateAppearance() {
-        view.backgroundColor = UIColor.from(scheme: .background, variant: .dark)
+        view.backgroundColor = UIColor.from(scheme: .background, variant: callInfoConfiguration.variant)
     }
 
     fileprivate func alertVideoUnavailable() {
@@ -471,12 +471,19 @@ extension CallViewController: CallGridViewControllerDelegate {
 
 extension CallViewController {
 
+    private var callingConfig: CallingConfiguration { .config }
+
     var isOverlayVisible: Bool {
         return callInfoRootViewController.view.alpha > 0
     }
 
     fileprivate var canHideOverlay: Bool {
         guard case .established = callInfoConfiguration.state else { return false }
+
+        guard callingConfig.canAudioCallHideOverlay else {
+            return callInfoConfiguration.isVideoCall
+        }
+
         return true
     }
 

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallingConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallingConfiguration.swift
@@ -1,0 +1,55 @@
+//
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+struct CallingConfiguration {
+    let canSwipeToDismissCall: Bool
+    let audioTilesEnabled: Bool
+    let paginationEnabled: Bool
+    let isAudioCallColorSchemable: Bool
+    let canAudioCallHideOverlay: Bool
+    let streamLimit: StreamLimit
+
+    static var config = Self.legacy
+
+    enum StreamLimit {
+        case noLimit
+        case limit(amount: Int)
+    }
+}
+
+extension CallingConfiguration {
+    private static var legacy = CallingConfiguration(
+        canSwipeToDismissCall: true,
+        audioTilesEnabled: false,
+        paginationEnabled: false,
+        isAudioCallColorSchemable: true,
+        canAudioCallHideOverlay: false,
+        streamLimit: .limit(amount: 12)
+    )
+
+    private static var largeConferenceCalls = CallingConfiguration(
+        canSwipeToDismissCall: false,
+        audioTilesEnabled: true,
+        paginationEnabled: true,
+        isAudioCallColorSchemable: false,
+        canAudioCallHideOverlay: true,
+        streamLimit: .noLimit
+    )
+}

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallingConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallingConfiguration.swift
@@ -26,7 +26,13 @@ struct CallingConfiguration {
     let canAudioCallHideOverlay: Bool
     let streamLimit: StreamLimit
 
-    static var config = Self.legacy
+    static var config = Self.default
+
+    private static let `default` = Self.legacy
+
+    static func resetDefaultConfig() {
+        config = Self.default
+    }
 
     enum StreamLimit {
         case noLimit
@@ -35,7 +41,7 @@ struct CallingConfiguration {
 }
 
 extension CallingConfiguration {
-    private static var legacy = CallingConfiguration(
+    static var legacy = CallingConfiguration(
         canSwipeToDismissCall: true,
         audioTilesEnabled: false,
         paginationEnabled: false,
@@ -44,7 +50,7 @@ extension CallingConfiguration {
         streamLimit: .limit(amount: 12)
     )
 
-    private static var largeConferenceCalls = CallingConfiguration(
+    static var largeConferenceCalls = CallingConfiguration(
         canSwipeToDismissCall: false,
         audioTilesEnabled: true,
         paginationEnabled: true,


### PR DESCRIPTION
## What's new in this PR?

This PR introduces a feature configuration mechanism in the calling code in order to disable key conferencing features that won't be included in the upcoming release.

Disabled / Enabled features:
- [Disabled] - audio tiles
- [Disabled] - pagination
- [Enabled] - swipe down to dismiss call
- [Enabled] - color schemed audio calls (light / dark)
- [Disabled] - toggling the overlay in an audio call
- [Updated] - stream limit in calling grid

### Changes
- Created a `CallingConfiguration` struct
- Enabled / disabled features according to the `CallingConfiguration`

### Notes
- The flags added in `CallingConfiguration` will likely be retired once the large conference calls features has been released
- Snapshot tests and unit tests were not updated to reflect the chosen configuration in order to avoid doing the work twice once the large conference calls feature is re-enabled.