### PR TITLE
[Fix] Remove excessive logging

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallGridViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallGridViewController.swift
@@ -263,8 +263,6 @@ final class CallGridViewController: SpinnerCapableViewController {
     // MARK: - Grid Update
 
     private func updateState() {
-        Log.calling.debug("\nUpdating video configuration from:\n\(videoConfigurationDescription())")
-
         displaySpinnerIfNeeded()
         updateSelfCallParticipantView()
         updateFloatingView(with: configuration.floatingStream)
@@ -273,8 +271,6 @@ final class CallGridViewController: SpinnerCapableViewController {
         updateGridViewAxis()
         updateHint(for: .configurationChanged)
         requestVideoStreamsIfNeeded(forPage: gridView.currentPage)
-
-        Log.calling.debug("\nUpdated video configuration to:\n\(videoConfigurationDescription())")
     }
 
     private func displaySpinnerIfNeeded() {
@@ -457,13 +453,6 @@ final class CallGridViewController: SpinnerCapableViewController {
             return nil
         }
         return viewCache[selfStreamId] as? SelfCallParticipantView
-    }
-
-    private func videoConfigurationDescription() -> String {
-        return """
-        showing self preview: \(selfCallParticipantView != nil)
-        videos in grid: [\(dataSource)]\n
-        """
     }
 
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

(in **internal** builds)
When in a conference call with a large number of participants (50+), the iOS app is very slow:
- Pagination is slow
- Audio only comes after a few minutes
- The call drops

### Causes

In the logs, we can find a lot of unnecessary information being dropped each time the call configuration changes. It's suspected to be the cause of the issues listed above

### Solutions

Remove the unnecessary logs