### PR TITLE
[Fix] show bitrate label when CBR is enforced

### DIFF
--- a/Wire-iOS Tests/CallStatusViewTests.swift
+++ b/Wire-iOS Tests/CallStatusViewTests.swift
@@ -26,6 +26,7 @@ struct MockStatusViewConfiguration: CallStatusViewInputType {
     var isConstantBitRate: Bool
     let title: String
     let userEnabledCBR: Bool
+    let isForcedCBR: Bool
 }
 
 final class CallStatusViewTests: ZMSnapshotTestCase {
@@ -35,7 +36,7 @@ final class CallStatusViewTests: ZMSnapshotTestCase {
     override func setUp() {
         super.setUp()
         snapshotBackgroundColor = .white
-        sut = CallStatusView(configuration: MockStatusViewConfiguration(state: .connecting, isVideoCall: false, variant: .dark, isConstantBitRate: false, title: "Italy Trip", userEnabledCBR: false))
+        sut = CallStatusView(configuration: MockStatusViewConfiguration(state: .connecting, isVideoCall: false, variant: .dark, isConstantBitRate: false, title: "Italy Trip", userEnabledCBR: false, isForcedCBR: false))
         sut.translatesAutoresizingMaskIntoConstraints = false
         sut.widthAnchor.constraint(equalToConstant: 320).isActive = true
         sut.setNeedsLayout()
@@ -55,7 +56,8 @@ final class CallStatusViewTests: ZMSnapshotTestCase {
             variant: .light,
             isConstantBitRate: false,
             title: "Amazing Way Too Long Group Conversation Name",
-            userEnabledCBR: false
+            userEnabledCBR: false,
+            isForcedCBR: false
         )
 
         // Then
@@ -64,7 +66,7 @@ final class CallStatusViewTests: ZMSnapshotTestCase {
 
     func testConnectingAudioCallLight() {
         // When
-        sut.configuration = MockStatusViewConfiguration(state: .connecting, isVideoCall: false, variant: .light, isConstantBitRate: false, title: "Italy Trip", userEnabledCBR: false)
+        sut.configuration = MockStatusViewConfiguration(state: .connecting, isVideoCall: false, variant: .light, isConstantBitRate: false, title: "Italy Trip", userEnabledCBR: false, isForcedCBR: false)
 
         // Then
         verify(view: sut)
@@ -73,7 +75,7 @@ final class CallStatusViewTests: ZMSnapshotTestCase {
     func testConnectingAudioCallDark() {
         // When
         snapshotBackgroundColor = .black
-        sut.configuration = MockStatusViewConfiguration(state: .connecting, isVideoCall: false, variant: .dark, isConstantBitRate: false, title: "Italy Trip", userEnabledCBR: false)
+        sut.configuration = MockStatusViewConfiguration(state: .connecting, isVideoCall: false, variant: .dark, isConstantBitRate: false, title: "Italy Trip", userEnabledCBR: false, isForcedCBR: false)
 
         // Then
         verify(view: sut)
@@ -81,7 +83,7 @@ final class CallStatusViewTests: ZMSnapshotTestCase {
 
     func testIncomingAudioLight() {
         // When
-        sut.configuration = MockStatusViewConfiguration(state: .ringingIncoming(name: "Ulrike"), isVideoCall: false, variant: .light, isConstantBitRate: false, title: "Italy Trip", userEnabledCBR: false)
+        sut.configuration = MockStatusViewConfiguration(state: .ringingIncoming(name: "Ulrike"), isVideoCall: false, variant: .light, isConstantBitRate: false, title: "Italy Trip", userEnabledCBR: false, isForcedCBR: false)
 
         // Then
         verify(view: sut)
@@ -89,7 +91,7 @@ final class CallStatusViewTests: ZMSnapshotTestCase {
 
     func testIncomingAudioLightOneOnOne() {
         // When
-        sut.configuration = MockStatusViewConfiguration(state: .ringingIncoming(name: nil), isVideoCall: false, variant: .light, isConstantBitRate: false, title: "Miguel", userEnabledCBR: false)
+        sut.configuration = MockStatusViewConfiguration(state: .ringingIncoming(name: nil), isVideoCall: false, variant: .light, isConstantBitRate: false, title: "Miguel", userEnabledCBR: false, isForcedCBR: false)
 
         // Then
         verify(view: sut)
@@ -98,7 +100,7 @@ final class CallStatusViewTests: ZMSnapshotTestCase {
     func testIncomingAudioDark() {
         // When
         snapshotBackgroundColor = .black
-        sut.configuration = MockStatusViewConfiguration(state: .ringingIncoming(name: "Ulrike"), isVideoCall: false, variant: .dark, isConstantBitRate: false, title: "Italy Trip", userEnabledCBR: false)
+        sut.configuration = MockStatusViewConfiguration(state: .ringingIncoming(name: "Ulrike"), isVideoCall: false, variant: .dark, isConstantBitRate: false, title: "Italy Trip", userEnabledCBR: false, isForcedCBR: false)
 
         // Then
         verify(view: sut)
@@ -107,7 +109,7 @@ final class CallStatusViewTests: ZMSnapshotTestCase {
     func testIncomingVideoLight() {
         // When
         snapshotBackgroundColor = .black
-        sut.configuration = MockStatusViewConfiguration(state: .ringingIncoming(name: "Ulrike"), isVideoCall: true, variant: .light, isConstantBitRate: false, title: "Italy Trip", userEnabledCBR: false)
+        sut.configuration = MockStatusViewConfiguration(state: .ringingIncoming(name: "Ulrike"), isVideoCall: true, variant: .light, isConstantBitRate: false, title: "Italy Trip", userEnabledCBR: false, isForcedCBR: false)
 
         // Then
         verify(view: sut)
@@ -116,7 +118,7 @@ final class CallStatusViewTests: ZMSnapshotTestCase {
     func testIncomingVideoDark() {
         // When
         snapshotBackgroundColor = .black
-        sut.configuration = MockStatusViewConfiguration(state: .ringingIncoming(name: "Ulrike"), isVideoCall: true, variant: .dark, isConstantBitRate: false, title: "Italy Trip", userEnabledCBR: false)
+        sut.configuration = MockStatusViewConfiguration(state: .ringingIncoming(name: "Ulrike"), isVideoCall: true, variant: .dark, isConstantBitRate: false, title: "Italy Trip", userEnabledCBR: false, isForcedCBR: false)
 
         // Then
         verify(view: sut)
@@ -124,7 +126,7 @@ final class CallStatusViewTests: ZMSnapshotTestCase {
 
     func testOutgoingLight() {
         // When
-        sut.configuration = MockStatusViewConfiguration(state: .ringingOutgoing, isVideoCall: false, variant: .light, isConstantBitRate: false, title: "Italy Trip", userEnabledCBR: false)
+        sut.configuration = MockStatusViewConfiguration(state: .ringingOutgoing, isVideoCall: false, variant: .light, isConstantBitRate: false, title: "Italy Trip", userEnabledCBR: false, isForcedCBR: false)
 
         // Then
         verify(view: sut)
@@ -133,7 +135,7 @@ final class CallStatusViewTests: ZMSnapshotTestCase {
     func testOutgoingDark() {
         // When
         snapshotBackgroundColor = .black
-        sut.configuration = MockStatusViewConfiguration(state: .ringingOutgoing, isVideoCall: true, variant: .dark, isConstantBitRate: false, title: "Italy Trip", userEnabledCBR: false)
+        sut.configuration = MockStatusViewConfiguration(state: .ringingOutgoing, isVideoCall: true, variant: .dark, isConstantBitRate: false, title: "Italy Trip", userEnabledCBR: false, isForcedCBR: false)
 
         // Then
         verify(view: sut)
@@ -141,7 +143,7 @@ final class CallStatusViewTests: ZMSnapshotTestCase {
 
     func testEstablishedBriefLight() {
         // When
-        sut.configuration = MockStatusViewConfiguration(state: .established(duration: 42), isVideoCall: false, variant: .light, isConstantBitRate: false, title: "Italy Trip", userEnabledCBR: false)
+        sut.configuration = MockStatusViewConfiguration(state: .established(duration: 42), isVideoCall: false, variant: .light, isConstantBitRate: false, title: "Italy Trip", userEnabledCBR: false, isForcedCBR: false)
 
         // Then
         verify(view: sut)
@@ -150,7 +152,7 @@ final class CallStatusViewTests: ZMSnapshotTestCase {
     func testEstablishedBriefDark() {
         // When
         snapshotBackgroundColor = .black
-        sut.configuration = MockStatusViewConfiguration(state: .established(duration: 42), isVideoCall: true, variant: .dark, isConstantBitRate: false, title: "Italy Trip", userEnabledCBR: false)
+        sut.configuration = MockStatusViewConfiguration(state: .established(duration: 42), isVideoCall: true, variant: .dark, isConstantBitRate: false, title: "Italy Trip", userEnabledCBR: false, isForcedCBR: false)
 
         // Then
         verify(view: sut)
@@ -158,7 +160,7 @@ final class CallStatusViewTests: ZMSnapshotTestCase {
 
     func testEstablishedLongLight() {
         // When
-        sut.configuration = MockStatusViewConfiguration(state: .established(duration: 321), isVideoCall: false, variant: .light, isConstantBitRate: false, title: "Italy Trip", userEnabledCBR: false)
+        sut.configuration = MockStatusViewConfiguration(state: .established(duration: 321), isVideoCall: false, variant: .light, isConstantBitRate: false, title: "Italy Trip", userEnabledCBR: false, isForcedCBR: false)
 
         // Then
         verify(view: sut)
@@ -167,7 +169,7 @@ final class CallStatusViewTests: ZMSnapshotTestCase {
     func testEstablishedLongDark() {
         // When
         snapshotBackgroundColor = .black
-        sut.configuration = MockStatusViewConfiguration(state: .established(duration: 321), isVideoCall: true, variant: .dark, isConstantBitRate: false, title: "Italy Trip", userEnabledCBR: false)
+        sut.configuration = MockStatusViewConfiguration(state: .established(duration: 321), isVideoCall: true, variant: .dark, isConstantBitRate: false, title: "Italy Trip", userEnabledCBR: false, isForcedCBR: false)
 
         // Then
         verify(view: sut)
@@ -175,7 +177,7 @@ final class CallStatusViewTests: ZMSnapshotTestCase {
 
     func testConstantBitRateLight() {
         // When
-        sut.configuration = MockStatusViewConfiguration(state: .established(duration: 321), isVideoCall: false, variant: .light, isConstantBitRate: true, title: "Italy Trip", userEnabledCBR: true)
+        sut.configuration = MockStatusViewConfiguration(state: .established(duration: 321), isVideoCall: false, variant: .light, isConstantBitRate: true, title: "Italy Trip", userEnabledCBR: true, isForcedCBR: false)
 
         // Then
         verify(view: sut)
@@ -184,7 +186,7 @@ final class CallStatusViewTests: ZMSnapshotTestCase {
     func testConstantBitRateDark() {
         // When
         snapshotBackgroundColor = .black
-        sut.configuration = MockStatusViewConfiguration(state: .established(duration: 321), isVideoCall: true, variant: .dark, isConstantBitRate: true, title: "Italy Trip", userEnabledCBR: true)
+        sut.configuration = MockStatusViewConfiguration(state: .established(duration: 321), isVideoCall: true, variant: .dark, isConstantBitRate: true, title: "Italy Trip", userEnabledCBR: true, isForcedCBR: false)
 
         // Then
         verify(view: sut)
@@ -192,7 +194,7 @@ final class CallStatusViewTests: ZMSnapshotTestCase {
 
     func testVariableBitRateLight() {
         // When
-        sut.configuration = MockStatusViewConfiguration(state: .established(duration: 321), isVideoCall: false, variant: .light, isConstantBitRate: false, title: "Italy Trip", userEnabledCBR: true)
+        sut.configuration = MockStatusViewConfiguration(state: .established(duration: 321), isVideoCall: false, variant: .light, isConstantBitRate: false, title: "Italy Trip", userEnabledCBR: true, isForcedCBR: false)
 
         // Then
         verify(view: sut)
@@ -201,7 +203,7 @@ final class CallStatusViewTests: ZMSnapshotTestCase {
     func testVariableBitRateDark() {
         // When
         snapshotBackgroundColor = .black
-        sut.configuration = MockStatusViewConfiguration(state: .established(duration: 321), isVideoCall: true, variant: .dark, isConstantBitRate: false, title: "Italy Trip", userEnabledCBR: true)
+        sut.configuration = MockStatusViewConfiguration(state: .established(duration: 321), isVideoCall: true, variant: .dark, isConstantBitRate: false, title: "Italy Trip", userEnabledCBR: true, isForcedCBR: false)
 
         // Then
         verify(view: sut)
@@ -209,7 +211,7 @@ final class CallStatusViewTests: ZMSnapshotTestCase {
 
     func testReconnectingLight() {
         // When
-        sut.configuration = MockStatusViewConfiguration(state: .reconnecting, isVideoCall: false, variant: .light, isConstantBitRate: false, title: "Italy Trip", userEnabledCBR: false)
+        sut.configuration = MockStatusViewConfiguration(state: .reconnecting, isVideoCall: false, variant: .light, isConstantBitRate: false, title: "Italy Trip", userEnabledCBR: false, isForcedCBR: false)
 
         // Then
         verify(view: sut)
@@ -218,7 +220,7 @@ final class CallStatusViewTests: ZMSnapshotTestCase {
     func testReconnectingDark() {
         // When
         snapshotBackgroundColor = .black
-        sut.configuration = MockStatusViewConfiguration(state: .reconnecting, isVideoCall: true, variant: .dark, isConstantBitRate: false, title: "Italy Trip", userEnabledCBR: false)
+        sut.configuration = MockStatusViewConfiguration(state: .reconnecting, isVideoCall: true, variant: .dark, isConstantBitRate: false, title: "Italy Trip", userEnabledCBR: false, isForcedCBR: false)
 
         // Then
         verify(view: sut)
@@ -226,7 +228,7 @@ final class CallStatusViewTests: ZMSnapshotTestCase {
 
     func testEndingLight() {
         // When
-        sut.configuration = MockStatusViewConfiguration(state: .terminating, isVideoCall: false, variant: .light, isConstantBitRate: false, title: "Italy Trip", userEnabledCBR: false)
+        sut.configuration = MockStatusViewConfiguration(state: .terminating, isVideoCall: false, variant: .light, isConstantBitRate: false, title: "Italy Trip", userEnabledCBR: false, isForcedCBR: false)
 
         // Then
         verify(view: sut)
@@ -235,7 +237,7 @@ final class CallStatusViewTests: ZMSnapshotTestCase {
     func testEndingDark() {
         // When
         snapshotBackgroundColor = .black
-        sut.configuration = MockStatusViewConfiguration(state: .terminating, isVideoCall: true, variant: .dark, isConstantBitRate: false, title: "Italy Trip", userEnabledCBR: false)
+        sut.configuration = MockStatusViewConfiguration(state: .terminating, isVideoCall: true, variant: .dark, isConstantBitRate: false, title: "Italy Trip", userEnabledCBR: false, isForcedCBR: false)
 
         // Then
         verify(view: sut)

--- a/Wire-iOS Tests/Calling/CallInfoTestFixture.swift
+++ b/Wire-iOS Tests/Calling/CallInfoTestFixture.swift
@@ -66,7 +66,8 @@ struct CallInfoTestFixture {
             cameraType: .front,
             networkQuality: .normal,
             userEnabledCBR: false,
-            variant: .dark
+            variant: .dark,
+            isForcedCBR: false
         )
     }
 
@@ -90,7 +91,8 @@ struct CallInfoTestFixture {
             cameraType: .front,
             networkQuality: .normal,
             userEnabledCBR: false,
-            variant: .dark
+            variant: .dark,
+            isForcedCBR: false
         )
     }
 
@@ -114,7 +116,8 @@ struct CallInfoTestFixture {
             cameraType: .front,
             networkQuality: .normal,
             userEnabledCBR: false,
-            variant: .dark
+            variant: .dark,
+            isForcedCBR: false
         )
     }
 
@@ -138,7 +141,8 @@ struct CallInfoTestFixture {
             cameraType: .front,
             networkQuality: .normal,
             userEnabledCBR: false,
-            variant: .dark
+            variant: .dark,
+            isForcedCBR: false
         )
     }
 
@@ -162,7 +166,8 @@ struct CallInfoTestFixture {
             cameraType: .front,
             networkQuality: .normal,
             userEnabledCBR: false,
-            variant: .dark
+            variant: .dark,
+            isForcedCBR: false
         )
     }
 
@@ -186,7 +191,8 @@ struct CallInfoTestFixture {
             cameraType: .front,
             networkQuality: .normal,
             userEnabledCBR: false,
-            variant: .dark
+            variant: .dark,
+            isForcedCBR: false
         )
     }
 
@@ -210,7 +216,8 @@ struct CallInfoTestFixture {
             cameraType: .front,
             networkQuality: .normal,
             userEnabledCBR: true,
-            variant: .dark
+            variant: .dark,
+            isForcedCBR: false
         )
     }
 
@@ -234,7 +241,8 @@ struct CallInfoTestFixture {
             cameraType: .front,
             networkQuality: .normal,
             userEnabledCBR: true,
-            variant: .dark
+            variant: .dark,
+            isForcedCBR: false
         )
     }
 
@@ -258,7 +266,8 @@ struct CallInfoTestFixture {
             cameraType: .front,
             networkQuality: .poor,
             userEnabledCBR: false,
-            variant: .dark
+            variant: .dark,
+            isForcedCBR: false
         )
     }
 
@@ -284,7 +293,8 @@ struct CallInfoTestFixture {
             cameraType: .front,
             networkQuality: .normal,
             userEnabledCBR: false,
-            variant: .dark
+            variant: .dark,
+            isForcedCBR: false
         )
     }
 
@@ -308,7 +318,8 @@ struct CallInfoTestFixture {
             cameraType: .front,
             networkQuality: .normal,
             userEnabledCBR: false,
-            variant: .dark
+            variant: .dark,
+            isForcedCBR: false
         )
     }
 
@@ -332,7 +343,8 @@ struct CallInfoTestFixture {
             cameraType: .front,
             networkQuality: .normal,
             userEnabledCBR: false,
-            variant: .dark
+            variant: .dark,
+            isForcedCBR: false
         )
     }
 
@@ -356,7 +368,8 @@ struct CallInfoTestFixture {
             cameraType: .front,
             networkQuality: .normal,
             userEnabledCBR: false,
-            variant: .dark
+            variant: .dark,
+            isForcedCBR: false
         )
     }
 
@@ -380,7 +393,8 @@ struct CallInfoTestFixture {
             cameraType: .front,
             networkQuality: .normal,
             userEnabledCBR: false,
-            variant: .dark
+            variant: .dark,
+            isForcedCBR: false
         )
     }
 
@@ -404,7 +418,8 @@ struct CallInfoTestFixture {
             cameraType: .front,
             networkQuality: .normal,
             userEnabledCBR: false,
-            variant: .dark
+            variant: .dark,
+            isForcedCBR: false
         )
     }
 
@@ -428,7 +443,8 @@ struct CallInfoTestFixture {
             cameraType: .front,
             networkQuality: .normal,
             userEnabledCBR: false,
-            variant: .dark
+            variant: .dark,
+            isForcedCBR: false
         )
     }
 
@@ -454,7 +470,8 @@ struct CallInfoTestFixture {
             cameraType: .front,
             networkQuality: .normal,
             userEnabledCBR: false,
-            variant: .dark
+            variant: .dark,
+            isForcedCBR: false
         )
     }
 
@@ -478,7 +495,8 @@ struct CallInfoTestFixture {
             cameraType: .front,
             networkQuality: .normal,
             userEnabledCBR: false,
-            variant: .dark
+            variant: .dark,
+            isForcedCBR: false
         )
     }
 
@@ -502,7 +520,8 @@ struct CallInfoTestFixture {
             cameraType: .front,
             networkQuality: .normal,
             userEnabledCBR: false,
-            variant: .dark
+            variant: .dark,
+            isForcedCBR: false
         )
     }
 
@@ -526,7 +545,8 @@ struct CallInfoTestFixture {
             cameraType: .front,
             networkQuality: .normal,
             userEnabledCBR: false,
-            variant: .dark
+            variant: .dark,
+            isForcedCBR: false
         )
     }
 
@@ -550,7 +570,8 @@ struct CallInfoTestFixture {
             cameraType: .front,
             networkQuality: .normal,
             userEnabledCBR: false,
-            variant: .dark
+            variant: .dark,
+            isForcedCBR: false
         )
     }
 
@@ -574,7 +595,8 @@ struct CallInfoTestFixture {
             cameraType: .front,
             networkQuality: .normal,
             userEnabledCBR: false,
-            variant: .dark
+            variant: .dark,
+            isForcedCBR: false
         )
     }
 
@@ -598,7 +620,8 @@ struct CallInfoTestFixture {
             cameraType: .front,
             networkQuality: .normal,
             userEnabledCBR: true,
-            variant: .dark
+            variant: .dark,
+            isForcedCBR: false
         )
     }
 
@@ -624,7 +647,8 @@ struct CallInfoTestFixture {
             cameraType: .front,
             networkQuality: .normal,
             userEnabledCBR: false,
-            variant: .dark
+            variant: .dark,
+            isForcedCBR: false
         )
     }
 
@@ -648,7 +672,8 @@ struct CallInfoTestFixture {
             cameraType: .front,
             networkQuality: .normal,
             userEnabledCBR: false,
-            variant: .dark
+            variant: .dark,
+            isForcedCBR: false
         )
     }
 
@@ -672,7 +697,8 @@ struct CallInfoTestFixture {
             cameraType: .front,
             networkQuality: .normal,
             userEnabledCBR: false,
-            variant: .dark
+            variant: .dark,
+            isForcedCBR: false
         )
     }
 
@@ -696,7 +722,8 @@ struct CallInfoTestFixture {
             cameraType: .front,
             networkQuality: .normal,
             userEnabledCBR: false,
-            variant: .dark
+            variant: .dark,
+            isForcedCBR: false
         )
     }
 
@@ -720,7 +747,8 @@ struct CallInfoTestFixture {
             cameraType: .front,
             networkQuality: .poor,
             userEnabledCBR: false,
-            variant: .dark
+            variant: .dark,
+            isForcedCBR: false
         )
     }
 
@@ -744,7 +772,8 @@ struct CallInfoTestFixture {
             cameraType: .front,
             networkQuality: .normal,
             userEnabledCBR: false,
-            variant: .dark
+            variant: .dark,
+            isForcedCBR: false
         )
     }
 
@@ -768,7 +797,8 @@ struct CallInfoTestFixture {
             cameraType: .front,
             networkQuality: .normal,
             userEnabledCBR: true,
-            variant: .dark
+            variant: .dark,
+            isForcedCBR: false
         )
     }
 
@@ -792,7 +822,8 @@ struct CallInfoTestFixture {
             cameraType: .front,
             networkQuality: .normal,
             userEnabledCBR: true,
-            variant: .dark
+            variant: .dark,
+            isForcedCBR: false
         )
     }
 
@@ -817,7 +848,8 @@ struct CallInfoTestFixture {
             cameraType: .front,
             networkQuality: .normal,
             userEnabledCBR: true,
-            variant: .dark
+            variant: .dark,
+            isForcedCBR: false
         )
     }
 
@@ -842,7 +874,8 @@ struct CallInfoTestFixture {
             cameraType: .front,
             networkQuality: .normal,
             userEnabledCBR: true,
-            variant: .dark
+            variant: .dark,
+            isForcedCBR: false
         )
     }
 

--- a/Wire-iOS Tests/Calling/CallStatusViewInputTypeTests.swift
+++ b/Wire-iOS Tests/Calling/CallStatusViewInputTypeTests.swift
@@ -1,0 +1,53 @@
+//
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import XCTest
+@testable import Wire
+
+struct MockCallStatusViewInputType: CallStatusViewInputType {
+    var state: CallStatusViewState
+    var isConstantBitRate: Bool
+    var title: String
+    var isVideoCall: Bool
+    var userEnabledCBR: Bool
+    var isForcedCBR: Bool
+    var variant: ColorSchemeVariant
+}
+
+extension MockCallStatusViewInputType {
+    static func fixture(isForcedCBR: Bool, userEnabledCBR: Bool) -> CallStatusViewInputType {
+        return MockCallStatusViewInputType(state: .established(duration: 200), isConstantBitRate: true, title: "title", isVideoCall: false, userEnabledCBR: userEnabledCBR, isForcedCBR: isForcedCBR, variant: .dark)
+    }
+}
+
+class CallStatusViewInputTypeTests: XCTestCase {
+
+    func testShouldShowBitRateLabel() {
+        var sut: CallStatusViewInputType
+
+        sut = MockCallStatusViewInputType.fixture(isForcedCBR: true, userEnabledCBR: false)
+        XCTAssertTrue(sut.shouldShowBitrateLabel)
+
+        sut = MockCallStatusViewInputType.fixture(isForcedCBR: false, userEnabledCBR: true)
+        XCTAssertTrue(sut.shouldShowBitrateLabel)
+
+        sut = MockCallStatusViewInputType.fixture(isForcedCBR: false, userEnabledCBR: false)
+        XCTAssertFalse(sut.shouldShowBitrateLabel)
+    }
+}

--- a/Wire-iOS Tests/Mocks/MockCallInfoViewControllerInput.swift
+++ b/Wire-iOS Tests/Mocks/MockCallInfoViewControllerInput.swift
@@ -39,6 +39,7 @@ struct MockCallInfoViewControllerInput: CallInfoViewControllerInput {
     var networkQuality: NetworkQuality
     var userEnabledCBR: Bool
     var variant: ColorSchemeVariant
+    var isForcedCBR: Bool
 }
 
 extension MockCallInfoViewControllerInput: CustomDebugStringConvertible {}

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -503,6 +503,8 @@
 		638332EA250282D200D18F42 /* OrientationDelta.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638332E9250282D200D18F42 /* OrientationDelta.swift */; };
 		638C88C62680F92D0074D512 /* MockCallGridHintNotificationLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638C88C52680F92D0074D512 /* MockCallGridHintNotificationLabel.swift */; };
 		639290A2252633E600046171 /* UIAlertController+DegradedCall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639290A1252633E600046171 /* UIAlertController+DegradedCall.swift */; };
+		639A8F2D26DE41ED0080B8FE /* CallStatusViewInputType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639A8F2C26DE41EC0080B8FE /* CallStatusViewInputType.swift */; };
+		639A8F3A26DE42AF0080B8FE /* CallStatusViewInputTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639A8F3626DE429F0080B8FE /* CallStatusViewInputTypeTests.swift */; };
 		63A5E6E424C1ACFC00F7D401 /* SettingsCellDescriptorFactory+Advanced.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63A5E6E324C1ACFC00F7D401 /* SettingsCellDescriptorFactory+Advanced.swift */; };
 		63A5E6F624C87E0000F7D401 /* SettingsCellDescriptorFactory+SoundAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63A5E6F524C87DFF00F7D401 /* SettingsCellDescriptorFactory+SoundAlert.swift */; };
 		63A874FC26CBAF2B000D3F27 /* CallingConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63A874FB26CBAF2A000D3F27 /* CallingConfiguration.swift */; };
@@ -2256,6 +2258,8 @@
 		638C88C52680F92D0074D512 /* MockCallGridHintNotificationLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCallGridHintNotificationLabel.swift; sourceTree = "<group>"; };
 		6391628B24F6A39D0054962E /* CallParticipantViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallParticipantViewTests.swift; sourceTree = "<group>"; };
 		639290A1252633E600046171 /* UIAlertController+DegradedCall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertController+DegradedCall.swift"; sourceTree = "<group>"; };
+		639A8F2C26DE41EC0080B8FE /* CallStatusViewInputType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallStatusViewInputType.swift; sourceTree = "<group>"; };
+		639A8F3626DE429F0080B8FE /* CallStatusViewInputTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallStatusViewInputTypeTests.swift; sourceTree = "<group>"; };
 		63A5E6E324C1ACFC00F7D401 /* SettingsCellDescriptorFactory+Advanced.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SettingsCellDescriptorFactory+Advanced.swift"; sourceTree = "<group>"; };
 		63A5E6F524C87DFF00F7D401 /* SettingsCellDescriptorFactory+SoundAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SettingsCellDescriptorFactory+SoundAlert.swift"; sourceTree = "<group>"; };
 		63A874FB26CBAF2A000D3F27 /* CallingConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallingConfiguration.swift; sourceTree = "<group>"; };
@@ -4556,6 +4560,7 @@
 				634FDB86263AF418002D6B94 /* ActiveCallRouterTests.swift */,
 				637387DA2649277A004FEF79 /* ScalableViewTests.swift */,
 				6314DC5B266F68D8005E3139 /* RoundedPageIndicatorTests.swift */,
+				639A8F3626DE429F0080B8FE /* CallStatusViewInputTypeTests.swift */,
 			);
 			path = Calling;
 			sourceTree = "<group>";
@@ -6617,6 +6622,7 @@
 				BFC0673C2099DD7D00204179 /* CallInfoViewController.swift */,
 				BFCCA4FD20A0A03D000A4F33 /* CallInfoRootViewController.swift */,
 				BFE3FEE9209747D6003D9AB5 /* CallStatusView.swift */,
+				639A8F2C26DE41EC0080B8FE /* CallStatusViewInputType.swift */,
 				BFE65AB220A047EB00689063 /* CallAccessoryViewController.swift */,
 				BFE41869209B6E3700503C7C /* UserImageViewContainer.swift */,
 				BFE4186E209B706600503C7C /* CallInfoViewControllerAccessoryType.swift */,
@@ -7804,6 +7810,7 @@
 				1639A80F225F863000868AB9 /* ProfileHeaderViewController.swift in Sources */,
 				6305206024FFD68100ED295A /* UIEdgeInsets+DeviceOrientation.swift in Sources */,
 				5EE73BE62122C6DC0032986D /* AuthenticationStartAddAccountEventHandler.swift in Sources */,
+				639A8F2D26DE41ED0080B8FE /* CallStatusViewInputType.swift in Sources */,
 				EEF28EED1F16692A007642E2 /* InputBarSecondaryButtonsView.swift in Sources */,
 				EF58B557218B463F00750A2B /* ConversationInputBarViewController+KeyCommand.swift in Sources */,
 				5E8DA76A211B2E8700360979 /* AuthenticationCoordinator+InitialSync.swift in Sources */,
@@ -8948,6 +8955,7 @@
 				06A5CFB62632A4D4006D2891 /* ConversationMessageSenderSnapshotTests.swift in Sources */,
 				5E52376220E7E50F00649241 /* ColorTilesViewController.swift in Sources */,
 				6340EF96237AE93500EF8506 /* VoiceChannelStreamArrangmentTests.swift in Sources */,
+				639A8F3A26DE42AF0080B8FE /* CallStatusViewInputTypeTests.swift in Sources */,
 				EF1FCE5021B69381003E0BE2 /* ReadReceiptViewModelTests.swift in Sources */,
 				EF4478522090BF8700BD9827 /* FullscreenImageViewControllerTests.swift in Sources */,
 				F127BD571E262E9F0093B2F1 /* CollectionsViewControllerTests.swift in Sources */,

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoViewController.swift
@@ -55,7 +55,8 @@ extension CallInfoViewControllerInput {
             userEnabledCBR == other.userEnabledCBR &&
             callState.isEqual(toCallState: other.callState) &&
             videoGridPresentationMode == other.videoGridPresentationMode &&
-            allowPresentationModeUpdates == other.allowPresentationModeUpdates
+            allowPresentationModeUpdates == other.allowPresentationModeUpdates &&
+            isForcedCBR == other.isForcedCBR
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallStatusView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallStatusView.swift
@@ -18,39 +18,6 @@
 
 import UIKit
 
-protocol CallStatusViewInputType: CallTypeProvider, CBRSettingProvider, ColorVariantProvider {
-    var state: CallStatusViewState { get }
-    var isConstantBitRate: Bool { get }
-    var title: String { get }
-}
-
-protocol ColorVariantProvider {
-    var variant: ColorSchemeVariant { get }
-}
-
-protocol CallTypeProvider {
-    var isVideoCall: Bool { get }
-}
-
-protocol CBRSettingProvider {
-    var userEnabledCBR: Bool { get }
-}
-
-extension CallStatusViewInputType {
-    var callingConfig: CallingConfiguration { .config }
-
-    var overlayBackgroundColor: UIColor {
-        switch (isVideoCall, state, callingConfig.isAudioCallColorSchemable) {
-        case (true, .ringingOutgoing, _), (true, .ringingIncoming, _):
-            return UIColor.black.withAlphaComponent(0.4)
-        case (true, _, _), (false, _, false):
-            return UIColor.black.withAlphaComponent(0.64)
-        case (false, _, true):
-            return variant == .light ? UIColor.from(scheme: .background, variant: .light) : .black
-        }
-    }
-}
-
 enum CallStatusViewState: Equatable {
     case none
     case connecting
@@ -126,7 +93,7 @@ final class CallStatusView: UIView {
     private func updateConfiguration() {
         titleLabel.text = configuration.title
         subtitleLabel.text = configuration.displayString
-        bitrateLabel.isHidden = !configuration.isConstantBitRate
+        bitrateLabel.isHidden = !configuration.shouldShowBitrateLabel
         bitrateLabel.bitRateStatus = BitRateStatus(configuration.isConstantBitRate)
 
         [titleLabel, subtitleLabel, bitrateLabel].forEach {
@@ -145,8 +112,7 @@ private let callDurationFormatter: DateComponentsFormatter = {
     return formatter
 }()
 
-extension CallStatusViewInputType {
-
+private extension CallStatusViewInputType {
     var displayString: String {
         switch state {
         case .none: return ""
@@ -159,11 +125,4 @@ extension CallStatusViewInputType {
         case .terminating: return "call.status.terminating".localized
         }
     }
-
-    var effectiveColorVariant: ColorSchemeVariant {
-        guard callingConfig.isAudioCallColorSchemable else { return .dark }
-
-        return isVideoCall ? .dark : variant
-    }
-
 }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallStatusView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallStatusView.swift
@@ -126,7 +126,7 @@ final class CallStatusView: UIView {
     private func updateConfiguration() {
         titleLabel.text = configuration.title
         subtitleLabel.text = configuration.displayString
-        bitrateLabel.isHidden = !configuration.userEnabledCBR
+        bitrateLabel.isHidden = !configuration.isConstantBitRate
         bitrateLabel.bitRateStatus = BitRateStatus(configuration.isConstantBitRate)
 
         [titleLabel, subtitleLabel, bitrateLabel].forEach {

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallStatusViewInputType.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallStatusViewInputType.swift
@@ -1,0 +1,64 @@
+//
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import UIKit
+
+protocol CallStatusViewInputType: CallTypeProvider, CBRSettingProvider, ColorVariantProvider {
+    var state: CallStatusViewState { get }
+    var isConstantBitRate: Bool { get }
+    var title: String { get }
+}
+
+protocol ColorVariantProvider {
+    var variant: ColorSchemeVariant { get }
+}
+
+protocol CallTypeProvider {
+    var isVideoCall: Bool { get }
+}
+
+protocol CBRSettingProvider {
+    var userEnabledCBR: Bool { get }
+    var isForcedCBR: Bool { get }
+}
+
+extension CallStatusViewInputType {
+    var callingConfig: CallingConfiguration { .config }
+
+    var overlayBackgroundColor: UIColor {
+        switch (isVideoCall, state, callingConfig.isAudioCallColorSchemable) {
+        case (true, .ringingOutgoing, _), (true, .ringingIncoming, _):
+            return UIColor.black.withAlphaComponent(0.4)
+        case (true, _, _), (false, _, false):
+            return UIColor.black.withAlphaComponent(0.64)
+        case (false, _, true):
+            return variant == .light ? UIColor.from(scheme: .background, variant: .light) : .black
+        }
+    }
+
+    var effectiveColorVariant: ColorSchemeVariant {
+        guard callingConfig.isAudioCallColorSchemable else { return .dark }
+
+        return isVideoCall ? .dark : variant
+    }
+
+    var shouldShowBitrateLabel: Bool {
+        isForcedCBR ? isConstantBitRate : userEnabledCBR
+    }
+}

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallInfoConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallInfoConfiguration.swift
@@ -130,6 +130,7 @@ struct CallInfoConfiguration: CallInfoViewControllerInput {
     let mediaManager: AVSMediaManagerInterface
     let networkQuality: NetworkQuality
     let userEnabledCBR: Bool
+    let isForcedCBR: Bool
     let callState: CallStateExtending
     let videoGridPresentationMode: VideoGridPresentationMode
     let allowPresentationModeUpdates: Bool
@@ -156,6 +157,7 @@ struct CallInfoConfiguration: CallInfoViewControllerInput {
         canToggleMediaType = voiceChannel.canToggleMediaType(with: permissions, selfUser: selfUser)
         isVideoCall = voiceChannel.internalIsVideoCall
         isConstantBitRate = voiceChannel.isConstantBitRateAudioActive
+        isForcedCBR = SecurityFlags.forceConstantBitRateCalls.isEnabled
         title = voiceChannel.conversation?.displayName ?? ""
         mediaState = voiceChannel.mediaState(with: permissions)
         videoPlaceholderState = voiceChannel.videoPlaceholderState ?? preferedVideoPlaceholderState


### PR DESCRIPTION
## What's new in this PR?

### Issues

The CBR label is not shown when CBR is enforced (in build configuration)

### Causes

The visibility of the CBR label depends on wether or not CBR was enabled by the user in the settings. 
When CBR is enforced, the CBR settings are not available.

### Solutions

Showing the CBR label should take into account wether or not CBR is enforced in the build configuration

