### PR TITLE
[Fix] Learn more link was broken on the empty search result screen

### DIFF
--- a/Wire-iOS/Sources/Helpers/URL+Wire.swift
+++ b/Wire-iOS/Sources/Helpers/URL+Wire.swift
@@ -169,7 +169,7 @@ extension URL {
     }
 
     static var wr_searchSupport: URL {
-        return BackendEnvironment.websiteLink(path: "support/search") // TODO jacob update URL when support page exists
+        return BackendEnvironment.websiteLink(path: "support/username") // TODO jacob update URL when new support page for search exists
     }
 
     static func wr_termsOfServicesURL(forTeamAccount isTeamAccount: Bool) -> URL {


### PR DESCRIPTION
## What's new in this PR?

### Issues

"Learn more" link on the empty search result screen leads to a 404 page.

### Causes

The link was linking to a not yet existing support page.

### Solutions

Link to https://support.wire.com/hc/en-us/articles/360001157305-What-are-usernames- for now and update it again later when the new support page is created.
