### PR TITLE
[Fix] Add restrictions to drag & drop files depends on SecurityFlags

### DIFF
--- a/Wire-iOS Tests/ConversationInputBarViewController/ConversationInputBarViewController+DropInteractionTests.swift
+++ b/Wire-iOS Tests/ConversationInputBarViewController/ConversationInputBarViewController+DropInteractionTests.swift
@@ -36,15 +36,27 @@ final class ConversationInputBarViewControllerDropInteractionTests: XCTestCase {
             output: .forbidden
         )
 
-        // Drop file and the file sharing feature is disabled.
+        // Drop file, the clipboard is disabled and the file sharing feature is disabled.
         assert(
             input: (isText: false, isClipboardEnabled: false, canFilesBeShared: false),
             output: .forbidden
         )
 
-        // Drop file and the file sharing feature is enabled.
+        // Drop file, the clipboard is disabled and the file sharing feature is enabled.
         assert(
             input: (isText: false, isClipboardEnabled: false, canFilesBeShared: true),
+            output: .forbidden
+        )
+
+        // Drop file, the clipboard is enabled and the file sharing feature is disabled.
+        assert(
+            input: (isText: false, isClipboardEnabled: true, canFilesBeShared: false),
+            output: .forbidden
+        )
+
+        // Drop file when the clipboard is enabled and the file sharing feature is enabled.
+        assert(
+            input: (isText: false, isClipboardEnabled: true, canFilesBeShared: true),
             output: .copy
         )
 

--- a/Wire-iOS Tests/ConversationInputBarViewController/ConversationInputBarViewController+DropInteractionTests.swift
+++ b/Wire-iOS Tests/ConversationInputBarViewController/ConversationInputBarViewController+DropInteractionTests.swift
@@ -79,5 +79,5 @@ extension ConversationInputBarViewControllerDropInteractionTests {
 
         XCTAssertEqual(dropProposal.operation, output, file: file, line: line)
     }
-    
+
 }

--- a/Wire-iOS Tests/ConversationInputBarViewController/ConversationInputBarViewController+DropInteractionTests.swift
+++ b/Wire-iOS Tests/ConversationInputBarViewController/ConversationInputBarViewController+DropInteractionTests.swift
@@ -22,7 +22,7 @@ import WireCommonComponents
 
 final class ConversationInputBarViewControllerDropInteractionTests: XCTestCase {
 
-    func test_ItEvaluatesAuthentication() {
+    func testThatItHandlesDroppingFiles() {
 
         // Drop text and the clipboard is enabled.
         assert(

--- a/Wire-iOS Tests/ConversationInputBarViewController/ConversationInputBarViewController+DropInteractionTests.swift
+++ b/Wire-iOS Tests/ConversationInputBarViewController/ConversationInputBarViewController+DropInteractionTests.swift
@@ -1,0 +1,71 @@
+//
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+@testable import Wire
+import WireCommonComponents
+
+final class ConversationInputBarViewControllerDropInteractionTests: XCTestCase {
+
+    func test_ItEvaluatesAuthentication() {
+
+        // Drop text and the clipboard is enabled.
+        assert(
+            input: (isText: true, isClipboardEnabled: true, canFilesBeShared: false),
+            output: .copy
+        )
+
+        // Drop text and the clipboard is disabled.
+        assert(
+            input: (isText: true, isClipboardEnabled: false, canFilesBeShared: false),
+            output: .forbidden
+        )
+
+        // Drop file and the file sharing feature is disabled.
+        assert(
+            input: (isText: false, isClipboardEnabled: false, canFilesBeShared: false),
+            output: .forbidden
+        )
+
+        // Drop file and the file sharing feature is enabled.
+        assert(
+            input: (isText: false, isClipboardEnabled: false, canFilesBeShared: true),
+            output: .copy
+        )
+
+    }
+}
+
+// MARK: - Helpers
+
+extension ConversationInputBarViewControllerDropInteractionTests {
+
+    typealias Input = (isText: Bool, isClipboardEnabled: Bool, canFilesBeShared: Bool)
+    typealias Output = UIDropOperation
+
+    private func assert(input: Input, output: Output, file: StaticString = #file, line: UInt = #line) {
+        let mockConversation = MockInputBarConversationType()
+        let sut = ConversationInputBarViewController(conversation: mockConversation)
+        let dropProposal = sut.dropProposal(isText: input.isText,
+                                            isClipboardEnabled: input.isClipboardEnabled,
+                                            canFilesBeShared: input.canFilesBeShared)
+
+        XCTAssertEqual(dropProposal.operation, output, file: file, line: line)
+    }
+    
+}

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		060E5336257668EE00BDDEBB /* SettingsPropertyFactory+AppLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 060E5335257668EE00BDDEBB /* SettingsPropertyFactory+AppLock.swift */; };
 		061275D726F23535006E8D4C /* ConversationInputBarViewController+DropInteractionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 061275D626F23535006E8D4C /* ConversationInputBarViewController+DropInteractionTests.swift */; };
+		061275DE26F304CB006E8D4C /* DragInteractionRestrictionTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 061275DD26F304CB006E8D4C /* DragInteractionRestrictionTextView.swift */; };
 		061282632379C25500C1A53C /* UITextView+ReplaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 061282622379C25500C1A53C /* UITextView+ReplaceTests.swift */; };
 		0617001523E48B66005C262D /* VerticalTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0617001423E48B66005C262D /* VerticalTransition.swift */; };
 		0619FBBB258A1DF700A0F3E2 /* ZClientViewController+FeatureChange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0619FBBA258A1DF700A0F3E2 /* ZClientViewController+FeatureChange.swift */; };
@@ -1757,6 +1758,7 @@
 /* Begin PBXFileReference section */
 		060E5335257668EE00BDDEBB /* SettingsPropertyFactory+AppLock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SettingsPropertyFactory+AppLock.swift"; sourceTree = "<group>"; };
 		061275D626F23535006E8D4C /* ConversationInputBarViewController+DropInteractionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationInputBarViewController+DropInteractionTests.swift"; sourceTree = "<group>"; };
+		061275DD26F304CB006E8D4C /* DragInteractionRestrictionTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragInteractionRestrictionTextView.swift; sourceTree = "<group>"; };
 		061282622379C25500C1A53C /* UITextView+ReplaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextView+ReplaceTests.swift"; sourceTree = "<group>"; };
 		0617001423E48B66005C262D /* VerticalTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalTransition.swift; sourceTree = "<group>"; };
 		0619FBBA258A1DF700A0F3E2 /* ZClientViewController+FeatureChange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZClientViewController+FeatureChange.swift"; sourceTree = "<group>"; };
@@ -4882,6 +4884,7 @@
 				EF266C602003B75C00A8C136 /* BreathLoadingBar.swift */,
 				871BC1CE1D34F8F800DF0793 /* PassthroughTouchesView.swift */,
 				871BC1D31D34F8F800DF0793 /* ResizingTextView.swift */,
+				061275DD26F304CB006E8D4C /* DragInteractionRestrictionTextView.swift */,
 				870C97C21D670C9A00F6FD7D /* NextResponderTextView.swift */,
 				F14FB862214941050012A131 /* Mentions */,
 				EE8E926D2024F085000F4752 /* MarkdownTextView.swift */,
@@ -8716,6 +8719,7 @@
 				5E8FFC1621EF46600052DF03 /* AuthenticationCoordinator+Backup.swift in Sources */,
 				F14FB864214941160012A131 /* MentionsTextAttachment.swift in Sources */,
 				EF2F6DA320ED11D2007B6D70 /* UIColor+Accent.swift in Sources */,
+				061275DE26F304CB006E8D4C /* DragInteractionRestrictionTextView.swift in Sources */,
 				5EBBE97121878D09008BC1B7 /* ConversationMessageToolboxCell.swift in Sources */,
 				8775BF1E2007CFB200A8AD93 /* UIControlBlockAPI.swift in Sources */,
 				EF1A461E21ADACF50009B6B9 /* RightIconDetailsCell.swift in Sources */,

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		060E5336257668EE00BDDEBB /* SettingsPropertyFactory+AppLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 060E5335257668EE00BDDEBB /* SettingsPropertyFactory+AppLock.swift */; };
+		061275D726F23535006E8D4C /* ConversationInputBarViewController+DropInteractionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 061275D626F23535006E8D4C /* ConversationInputBarViewController+DropInteractionTests.swift */; };
 		061282632379C25500C1A53C /* UITextView+ReplaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 061282622379C25500C1A53C /* UITextView+ReplaceTests.swift */; };
 		0617001523E48B66005C262D /* VerticalTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0617001423E48B66005C262D /* VerticalTransition.swift */; };
 		0619FBBB258A1DF700A0F3E2 /* ZClientViewController+FeatureChange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0619FBBA258A1DF700A0F3E2 /* ZClientViewController+FeatureChange.swift */; };
@@ -1755,6 +1756,7 @@
 
 /* Begin PBXFileReference section */
 		060E5335257668EE00BDDEBB /* SettingsPropertyFactory+AppLock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SettingsPropertyFactory+AppLock.swift"; sourceTree = "<group>"; };
+		061275D626F23535006E8D4C /* ConversationInputBarViewController+DropInteractionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationInputBarViewController+DropInteractionTests.swift"; sourceTree = "<group>"; };
 		061282622379C25500C1A53C /* UITextView+ReplaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextView+ReplaceTests.swift"; sourceTree = "<group>"; };
 		0617001423E48B66005C262D /* VerticalTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalTransition.swift; sourceTree = "<group>"; };
 		0619FBBA258A1DF700A0F3E2 /* ZClientViewController+FeatureChange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZClientViewController+FeatureChange.swift"; sourceTree = "<group>"; };
@@ -7105,6 +7107,7 @@
 				EF63528C209C4A9300F5E950 /* ConversationInputBarViewControllerTests.swift */,
 				EE373FA923FBF438008C1E52 /* ConversationInputBarViewControllerDelegateTests.swift */,
 				EFC57A0F21BABCC90008DBE6 /* ConversationInputBarViewControllerAudioRecorderSnapshotTests.swift */,
+				061275D626F23535006E8D4C /* ConversationInputBarViewController+DropInteractionTests.swift */,
 			);
 			path = ConversationInputBarViewController;
 			sourceTree = "<group>";
@@ -9124,6 +9127,7 @@
 				EF6A33D32192F5BD00970698 /* CoreDataSnapshotTestCase+appendMessage.swift in Sources */,
 				EF2A8DE9214A8B38002C9058 /* MockUser+Service.swift in Sources */,
 				8787BDD91BF374420096B1B5 /* SettingsPropertyTests.swift in Sources */,
+				061275D726F23535006E8D4C /* ConversationInputBarViewController+DropInteractionTests.swift in Sources */,
 				EF1D80DD22275F8F00BCA8D3 /* MockUser+MockUserArray.swift in Sources */,
 				A92C443224EE9805006A4AB3 /* SearchResultsViewControllerTests.swift in Sources */,
 				D5943440203DCECA006AA0C0 /* ConversationOptionsViewControllerTests.swift in Sources */,

--- a/Wire-iOS/Sources/UserInterface/Components/Views/DragInteractionRestrictionTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/DragInteractionRestrictionTextView.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2020 Wire Swiss GmbH
+// Copyright (C) 2021 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -18,22 +18,12 @@
 
 import UIKit
 
-class ResizingTextView: DragInteractionRestrictionTextView {
-    override var contentSize: CGSize {
-        didSet {
-            invalidateIntrinsicContentSize()
-        }
+class DragInteractionRestrictionTextView: TextView {
+
+    convenience init() {
+        self.init(frame: .zero)
+
+        textDragInteraction?.isEnabled = SecurityFlags.clipboard.isEnabled
     }
 
-    override var intrinsicContentSize: CGSize {
-        return sizeThatFits(CGSize(width: bounds.size.width, height: UIView.noIntrinsicMetric))
-    }
-
-    override func paste(_ sender: Any?) {
-        super.paste(sender)
-
-        // Work-around for text view scrolling too far when pasting text smaller
-        // than the maximum height of the text view.
-        setContentOffset(CGPoint(x: 0, y: 0), animated: false)
-    }
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+DragAndDrop.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+DragAndDrop.swift
@@ -59,11 +59,11 @@ extension ConversationInputBarViewController: UIDropInteractionDelegate {
     }
 
     func dropInteraction(_ interaction: UIDropInteraction, sessionDidUpdate session: UIDropSession) -> UIDropProposal {
-        return UIDropProposal(operation: .copy)
+        return SecurityFlags.clipboard.isEnabled ? UIDropProposal(operation: .copy) : UIDropProposal(operation: .forbidden)
     }
 
     func dropInteraction(_ interaction: UIDropInteraction, canHandle session: UIDropSession) -> Bool {
-        return session.canLoadObjects(ofClass: UIImage.self)
+        return true
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+DragAndDrop.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+DragAndDrop.swift
@@ -69,14 +69,17 @@ extension ConversationInputBarViewController: UIDropInteractionDelegate {
     }
 
     func dropProposal(isText: Bool, isClipboardEnabled: Bool, canFilesBeShared: Bool) -> UIDropProposal {
-        switch (isText, isClipboardEnabled, canFilesBeShared) {
-        case (true, true, _),
-             (false, _, true):
-            return UIDropProposal(operation: .copy)
-        default:
-            return UIDropProposal(operation: .forbidden)
-        }
+      return shouldAllowDropInteraction(isText: isText, isClipboardEnabled: isClipboardEnabled, canFilesBeShared: canFilesBeShared)
+        ? UIDropProposal(operation: .copy)
+        : UIDropProposal(operation: .forbidden)
+    }
 
+    private func shouldAllowDropInteraction(isText: Bool, isClipboardEnabled: Bool, canFilesBeShared: Bool) -> Bool {
+      if isText {
+        return isClipboardEnabled
+      } else {
+        return isClipboardEnabled && canFilesBeShared
+      }
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+DragAndDrop.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+DragAndDrop.swift
@@ -59,11 +59,24 @@ extension ConversationInputBarViewController: UIDropInteractionDelegate {
     }
 
     func dropInteraction(_ interaction: UIDropInteraction, sessionDidUpdate session: UIDropSession) -> UIDropProposal {
-        return SecurityFlags.clipboard.isEnabled ? UIDropProposal(operation: .copy) : UIDropProposal(operation: .forbidden)
+        return dropProposal(isText: session.canLoadObjects(ofClass: NSString.self),
+                            isClipboardEnabled: SecurityFlags.clipboard.isEnabled,
+                            canFilesBeShared: canFilesBeShared)
     }
 
     func dropInteraction(_ interaction: UIDropInteraction, canHandle session: UIDropSession) -> Bool {
         return true
+    }
+
+    func dropProposal(isText: Bool, isClipboardEnabled: Bool, canFilesBeShared: Bool) -> UIDropProposal {
+        switch (isText, isClipboardEnabled, canFilesBeShared) {
+        case (true, true, _),
+             (false, _, true):
+            return UIDropProposal(operation: .copy)
+        default:
+            return UIDropProposal(operation: .forbidden)
+        }
+
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
@@ -322,7 +322,6 @@ final class ConversationInputBarViewController: UIViewController,
 
         let interaction = UIDropInteraction(delegate: self)
         inputBar.textView.addInteraction(interaction)
-        inputBar.textView.textDragInteraction?.isEnabled = SecurityFlags.clipboard.isEnabled
 
         setupObservers()
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
@@ -322,6 +322,7 @@ final class ConversationInputBarViewController: UIViewController,
 
         let interaction = UIDropInteraction(delegate: self)
         inputBar.textView.addInteraction(interaction)
+        inputBar.textView.textDragInteraction?.isEnabled = SecurityFlags.clipboard.isEnabled
 
         setupObservers()
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues
There is **drag & drop** feature for iPhones in iOS 15 and this is an issue for **file sharing and copy / paste** restrictions for BK build.

### Solutions
1. Prevent file dropping if SecurityFlags.clipboard.isEnabled is false.
2. Disable the drag interaction if SecurityFlags.clipboard.isEnabled is false.


### Notes

https://wearezeta.atlassian.net/browse/SQSERVICES-755
The playground build for **iOS 15** that has a restriction for drag&drop feature: **3.87 (992928)**

### Attachments


