### PR TITLE
[Feature] Support enabling federation support from the command line

### DIFF
--- a/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
+++ b/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
@@ -210,6 +210,10 @@
             argument = "-ConsoleAnalytics"
             isEnabled = "NO">
          </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-FederationEnabled 1"
+            isEnabled = "NO">
+         </CommandLineArgument>
       </CommandLineArguments>
       <EnvironmentVariables>
          <EnvironmentVariable

--- a/Wire-iOS/Resources/Settings.bundle/Root.plist
+++ b/Wire-iOS/Resources/Settings.bundle/Root.plist
@@ -8,6 +8,16 @@
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 			<key>Title</key>
+			<string>Enable federation support</string>
+			<key>Key</key>
+			<string>FederationEnabled</string>
+			<key>DefaultValue</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSToggleSwitchSpecifier</string>
+			<key>Title</key>
 			<string>Only register for VoIP notifications</string>
 			<key>Key</key>
 			<string>VoIPNotificationsOnly</string>

--- a/Wire-iOS/Sources/AppDelegate.swift
+++ b/Wire-iOS/Sources/AppDelegate.swift
@@ -253,7 +253,7 @@ private extension AppDelegate {
         }
 
         configuration.blacklistDownloadInterval = Settings.shared.blacklistDownloadInterval
-        configuration.supportFederation = Settings.shared[.federationEnabled] ?? false
+        configuration.supportFederation = configuration.supportFederation || Settings.shared.federationEnabled
         let jailbreakDetector = JailbreakDetector()
 
         let sessionManager = SessionManager(appVersion: appVersion,

--- a/Wire-iOS/Sources/Components/Settings.swift
+++ b/Wire-iOS/Sources/Components/Settings.swift
@@ -123,6 +123,10 @@ class Settings {
         }
     }
 
+    var federationEnabled: Bool {
+        return defaults.bool(forKey: SettingKey.federationEnabled.rawValue)
+    }
+
     var blacklistDownloadInterval: TimeInterval {
         let HOURS_6 = 6 * 60 * 60
         let settingValue = defaults.integer(forKey: SettingKey.blackListDownloadInterval.rawValue)


### PR DESCRIPTION
## What's new in this PR?

Support enabling federation support from the command line and from the external settings app. This is useful when running automation tests or when debugging the app.