### PR TITLE
Fix: always use landscape mode UI layout on macOS

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.swift
@@ -322,22 +322,19 @@ final class SplitViewController: UIViewController, SplitLayoutObservable {
     }
 
     private var isiOSAppOnMac: Bool {
-        let isiOSAppOnMac: Bool
         if #available(iOS 14.0, *) {
-            isiOSAppOnMac = ProcessInfo.processInfo.isiOSAppOnMac
-        } else {
-            isiOSAppOnMac = false
+            return ProcessInfo.processInfo.isiOSAppOnMac
         }
-        
-        return isiOSAppOnMac
+
+        return false
     }
-    
+
     /// Update layoutSize for the change of traitCollection and the current orientation
     ///
     /// - Parameters:
     ///   - traitCollection: the new traitCollection
     private func updateLayoutSize(for traitCollection: UITraitCollection) {
-        
+
         switch (isiOSAppOnMac, traitCollection.horizontalSizeClass, UIApplication.shared.statusBarOrientation.isPortrait) {
         case (true, _, true):
             layoutSize = .regularLandscape

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.swift
@@ -336,12 +336,10 @@ final class SplitViewController: UIViewController, SplitLayoutObservable {
     private func updateLayoutSize(for traitCollection: UITraitCollection) {
 
         switch (isiOSAppOnMac, traitCollection.horizontalSizeClass, UIApplication.shared.statusBarOrientation.isPortrait) {
-        case (true, _, true):
+        case (true, _, true), (false, .regular, false):
             layoutSize = .regularLandscape
         case (false, .regular, true):
             layoutSize = .regularPortrait
-        case (false, .regular, false):
-            layoutSize = .regularLandscape
         default:
             layoutSize = .compact
         }

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.swift
@@ -309,7 +309,7 @@ final class SplitViewController: UIViewController, SplitLayoutObservable {
         }
     }
 
-    // MARK: - updte size
+    // MARK: - update size
 
     /// return true if right view (mostly conversation screen) is fully visible
     var isRightViewControllerRevealed: Bool {
@@ -321,18 +321,36 @@ final class SplitViewController: UIViewController, SplitLayoutObservable {
         }
     }
 
+    private var isiOSAppOnMac: Bool {
+        let isiOSAppOnMac: Bool
+        if #available(iOS 14.0, *) {
+            if ProcessInfo.processInfo.isiOSAppOnMac {
+                isiOSAppOnMac = true
+            } else {
+                isiOSAppOnMac = false
+            }
+        } else {
+            isiOSAppOnMac = false
+        }
+        
+        return isiOSAppOnMac
+    }
+    
     /// Update layoutSize for the change of traitCollection and the current orientation
     ///
     /// - Parameters:
     ///   - traitCollection: the new traitCollection
     private func updateLayoutSize(for traitCollection: UITraitCollection) {
-        switch (traitCollection.horizontalSizeClass, UIApplication.shared.statusBarOrientation.isPortrait) {
-        case (.regular, true):
-            self.layoutSize = .regularPortrait
-        case (.regular, false):
-            self.layoutSize = .regularLandscape
+        
+        switch (isiOSAppOnMac, traitCollection.horizontalSizeClass, UIApplication.shared.statusBarOrientation.isPortrait) {
+        case (true, _, true):
+            layoutSize = .regularLandscape
+        case (false, .regular, true):
+            layoutSize = .regularPortrait
+        case (false, .regular, false):
+            layoutSize = .regularLandscape
         default:
-            self.layoutSize = .compact
+            layoutSize = .compact
         }
     }
 

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.swift
@@ -324,11 +324,7 @@ final class SplitViewController: UIViewController, SplitLayoutObservable {
     private var isiOSAppOnMac: Bool {
         let isiOSAppOnMac: Bool
         if #available(iOS 14.0, *) {
-            if ProcessInfo.processInfo.isiOSAppOnMac {
-                isiOSAppOnMac = true
-            } else {
-                isiOSAppOnMac = false
-            }
+            isiOSAppOnMac = ProcessInfo.processInfo.isiOSAppOnMac
         } else {
             isiOSAppOnMac = false
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

When the iOS app runs Mac OS, conversation list view is not show 

### Causes

The app runs on portrait mode

### Solutions

When the app is running on macOS, always use landscape mode