### PR TITLE
[Fix] Grid layout for horizontal layout direction

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/CallGridView/Grid/GridView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallGridView/Grid/GridView.swift
@@ -152,7 +152,9 @@ private extension GridView {
         case (.moreThanTwo, .proportionalSplit):
             return numberOfItemsInPage.evenlyCeiled / 2
         case (.moreThanTwo, .middleSplit):
-            return isOddLastRow(indexPath) ? 1 : 2
+            let isOddLastRow = self.isOddLastRow(indexPath)
+            let isLayoutDirectionVertical = layoutDirection == .vertical
+            return isOddLastRow && isLayoutDirectionVertical ? 1 : 2
         case (.twoOrLess, .proportionalSplit):
             return numberOfItemsInPage
         case (.twoOrLess, .middleSplit):


### PR DESCRIPTION
## What's new in this PR?

### Issues

Given a call with an odd number of participants, in landscape orientation, the layout is broken.

<img src=https://user-images.githubusercontent.com/6436181/134218119-40b91a7c-6f05-4813-9a23-4c00eae229d0.png width=500 />

### Causes

In the implementation of `UICollectionViewDelegateFlowLayout`,  the logic for dynamic calculation of the item sizes is flawed. 
It **wrongly** assumes that the layout will be done this way:


<img src=https://user-images.githubusercontent.com/6436181/134220517-47521ccb-93d7-446d-9576-b4f2a5934217.png width=500 />

From here, the size of the last item is calculated to fit the assumed remaining space. 
**e.g:** for landscape, the 5th tile would be calculated to be twice the height of the other items

 **However**, since the actual layout in landscape looks like this:

<img src=https://user-images.githubusercontent.com/6436181/134218954-7a76063f-c829-421d-9bb9-2ea979e0edc2.png width=300 />

the size calculated for the last item is wrong, and as a result, it messes up the collection view's layout.
 
### Solutions

Update the size calculation logic so that the last tile remains the same size as the others in landscape


