### PR TITLE
[Fix] Drag and drop image from browser

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Views/MarkdownTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/MarkdownTextView.swift
@@ -721,7 +721,6 @@ private extension NSRange {
     }
 }
 
-
 private extension UIPasteboard {
 
     var hasText: Bool {

--- a/Wire-iOS/Sources/UserInterface/Components/Views/MarkdownTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/MarkdownTextView.swift
@@ -724,7 +724,7 @@ private extension NSRange {
 
 private extension UIPasteboard {
 
-    func hasText() -> Bool {
+    var hasText: Bool {
         /// Image copied from browser can be both NSString and UIImage
         return hasStrings && !hasImages
     }

--- a/Wire-iOS/Sources/UserInterface/Components/Views/MarkdownTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/MarkdownTextView.swift
@@ -67,7 +67,7 @@ final class MarkdownTextView: NextResponderTextView, PerformClipboardAction {
              #selector(UIResponderStandardEditActions.copy(_:)):
 
             let pasteboard = UIPasteboard.general
-            guard shouldAllowPerformAction(isText: pasteboard.hasText(),
+            guard shouldAllowPerformAction(isText: pasteboard.hasText,
                                          isClipboardEnabled: SecurityFlags.clipboard.isEnabled,
                                          canFilesBeShared: canFilesBeShared) else { return false }
             fallthrough

--- a/Wire-iOS/Sources/UserInterface/Components/Views/MarkdownTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/MarkdownTextView.swift
@@ -67,7 +67,7 @@ final class MarkdownTextView: NextResponderTextView, PerformClipboardAction {
              #selector(UIResponderStandardEditActions.copy(_:)):
 
             let pasteboard = UIPasteboard.general
-            guard shouldAllowPerformAction(isText: pasteboard.hasStrings,
+            guard shouldAllowPerformAction(isText: pasteboard.hasText(),
                                          isClipboardEnabled: SecurityFlags.clipboard.isEnabled,
                                          canFilesBeShared: canFilesBeShared) else { return false }
             fallthrough
@@ -719,4 +719,14 @@ private extension NSRange {
 
         return range
     }
+}
+
+
+private extension UIPasteboard {
+
+    func hasText() -> Bool {
+        /// Image copied from browser can be both NSString and UIImage
+        return hasStrings && !hasImages
+    }
+
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+DragAndDrop.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+DragAndDrop.swift
@@ -27,39 +27,49 @@ extension ConversationInputBarViewController: UIDropInteractionDelegate, Perform
     func dropInteraction(_ interaction: UIDropInteraction, performDrop session: UIDropSession) {
 
         for dragItem in session.items {
-            dragItem.itemProvider.loadObject(ofClass: UIImage.self, completionHandler: { object, error in
-
-                guard error == nil else { return zmLog.error("Failed to load dragged item: \(error!.localizedDescription)") }
-                guard let draggedImage = object as? UIImage else { return }
-
-                DispatchQueue.main.async {
-                    let context = ConfirmAssetViewController.Context(asset: .image(mediaAsset: draggedImage),
-                                                                     onConfirm: { [unowned self] _ in
-                                                                                    self.dismiss(animated: true) {
-                                                                                        if let draggedImageData = draggedImage.pngData() {
-                                                                                            self.sendController.sendMessage(withImageData: draggedImageData)
-                                                                                        }
-                                                                                    }
-                                                                                },
-                                                                     onCancel: { [unowned self] in
-                                                                                    self.dismiss(animated: true)
-                                                                                }
-                    )
-
-                    let confirmImageViewController = ConfirmAssetViewController(context: context)
-                    confirmImageViewController.previewTitle = self.conversation.displayName.localizedUppercase
-                    self.present(confirmImageViewController, animated: true) {
-                            }
+            let itemProvider = dragItem.itemProvider
+            if itemProvider.hasText() {
+                itemProvider.loadObject(ofClass: NSString.self) { [self] object, error in
+                    guard let draggedText = object as? String else { return }
+                    DispatchQueue.main.async {
+                        self.inputBar.textView.text = draggedText
+                    }
                 }
-            })
+            } else if itemProvider.canLoadObject(ofClass: UIImage.self) {
+                itemProvider.loadObject(ofClass: UIImage.self, completionHandler: { object, error in
 
-            // TODO: it's a temporary solution to drag only one image, while we have no design for multiple images
-            break
+                    guard error == nil else { return zmLog.error("Failed to load dragged item: \(error!.localizedDescription)") }
+                    guard let draggedImage = object as? UIImage else { return }
+
+                    DispatchQueue.main.async {
+                        let context = ConfirmAssetViewController.Context(asset: .image(mediaAsset: draggedImage),
+                                                                         onConfirm: { [unowned self] _ in
+                                                                            self.dismiss(animated: true) {
+                                                                                if let draggedImageData = draggedImage.pngData() {
+                                                                                    self.sendController.sendMessage(withImageData: draggedImageData)
+                                                                                }
+                                                                            }
+                                                                         },
+                                                                         onCancel: { [unowned self] in
+                                                                            self.dismiss(animated: true)
+                                                                         }
+                        )
+
+                        let confirmImageViewController = ConfirmAssetViewController(context: context)
+                        confirmImageViewController.previewTitle = self.conversation.displayName.localizedUppercase
+                        self.present(confirmImageViewController, animated: true) {
+                        }
+                    }
+                })
+
+                // TODO: it's a temporary solution to drag only one image, while we have no design for multiple images
+                break
+            }
         }
     }
 
     func dropInteraction(_ interaction: UIDropInteraction, sessionDidUpdate session: UIDropSession) -> UIDropProposal {
-        return dropProposal(isText: session.canLoadObjects(ofClass: NSString.self),
+        return dropProposal(isText: session.hasText(),
                             isClipboardEnabled: SecurityFlags.clipboard.isEnabled,
                             canFilesBeShared: canFilesBeShared)
     }
@@ -72,6 +82,24 @@ extension ConversationInputBarViewController: UIDropInteractionDelegate, Perform
       return shouldAllowPerformAction(isText: isText, isClipboardEnabled: isClipboardEnabled, canFilesBeShared: canFilesBeShared)
         ? UIDropProposal(operation: .copy)
         : UIDropProposal(operation: .forbidden)
+    }
+
+}
+
+private extension UIDropSession {
+
+    func hasText() -> Bool {
+        /// Image dragged from browser can be both NSString and UIImage
+        return canLoadObjects(ofClass: NSString.self) && !canLoadObjects(ofClass: UIImage.self)
+    }
+
+}
+
+private extension NSItemProvider {
+
+    func hasText() -> Bool {
+        /// Image dragged from browser can be both NSString and UIImage
+        return canLoadObject(ofClass: NSString.self) && !canLoadObject(ofClass: UIImage.self)
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+DragAndDrop.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+DragAndDrop.swift
@@ -29,7 +29,7 @@ extension ConversationInputBarViewController: UIDropInteractionDelegate, Perform
         for dragItem in session.items {
             let itemProvider = dragItem.itemProvider
             if itemProvider.hasText() {
-                itemProvider.loadObject(ofClass: NSString.self) { [self] object, error in
+                itemProvider.loadObject(ofClass: NSString.self) { [self] object, _ in
                     guard let draggedText = object as? String else { return }
                     DispatchQueue.main.async {
                         self.inputBar.textView.text = draggedText
@@ -89,7 +89,7 @@ extension ConversationInputBarViewController: UIDropInteractionDelegate, Perform
 private extension UIDropSession {
 
     func hasText() -> Bool {
-        /// Image dragged from browser can be both NSString and UIImage
+        // Image dragged from browser can be both NSString and UIImage
         return canLoadObjects(ofClass: NSString.self) && !canLoadObjects(ofClass: UIImage.self)
     }
 
@@ -98,7 +98,7 @@ private extension UIDropSession {
 private extension NSItemProvider {
 
     func hasText() -> Bool {
-        /// Image dragged from browser can be both NSString and UIImage
+        // Image dragged from browser can be both NSString and UIImage
         return canLoadObject(ofClass: NSString.self) && !canLoadObject(ofClass: UIImage.self)
     }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues
We can drag and drop an image from the browser if the file sharing feature is disabled.

### Causes
Image copied from browser can be both `NSString` and `UIImage` at the same time and the file sharing feature allows user to copy text.

### Solutions
And a helper method and check if the copied object is a string and not an image.

