### PR TITLE
[Fix] Page indicator is hidden by notch

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallGridViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallGridViewController.swift
@@ -156,7 +156,7 @@ final class CallGridViewController: SpinnerCapableViewController {
             topStack.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor, constant: -20),
             pageIndicator.centerYAnchor.constraint(equalTo: view.centerYAnchor),
             pageIndicator.heightAnchor.constraint(equalToConstant: CGFloat.pageIndicatorHeight),
-            pageIndicator.centerXAnchor.constraint(equalTo: view.trailingAnchor, constant: -22) // (pageIndicatorHeight / 2 + 10)
+            pageIndicator.centerXAnchor.constraint(equalTo: view.safeTrailingAnchor, constant: -22) // (pageIndicatorHeight / 2 + 10)
         ])
 
         pageIndicator.transform = pageIndicator.transform.rotated(by: .pi/2)


### PR DESCRIPTION
## What's new in this PR?

### Issues

in the calling grid, the paging indicator is hidden by the notch on devices like iPhone X, 11, 12...

### Causes

constraints don't use safe area anchors

### Solutions

use safe trailing anchor for constraints