### PR TITLE
[Fix] Grid axis doesn't update when rotating to landscape for some devices

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallGridViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallGridViewController.swift
@@ -406,7 +406,7 @@ final class CallGridViewController: SpinnerCapableViewController {
     private func gridAxis(for traitCollection: UITraitCollection) -> UICollectionView.ScrollDirection {
         let isLandscape = UIApplication.shared.statusBarOrientation.isLandscape
         switch (traitCollection.userInterfaceIdiom, traitCollection.horizontalSizeClass, isLandscape) {
-        case (.pad, .regular, true), (.phone, .regular, true):
+        case (.pad, .regular, true), (.phone, _, true):
             return .horizontal
         default:
             return .vertical


### PR DESCRIPTION
## What's new in this PR?

### Issues

devices with `compact` horizontal size class (e.g: iPhone 7) have a wrong grid view layout when rotating to landscape

### Causes

when the device turns to landscape orientation, we should update the grid view axis to `.horizontal`
however, in the code, we only do so for phones with a `regular` horizontal size class

### Solutions

update grid view axis to `.horizontal` for both regular and compact horizontal size classes