### PR TITLE
[Fix] Grid view offset on rotation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallGridViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallGridViewController.swift
@@ -397,6 +397,11 @@ final class CallGridViewController: SpinnerCapableViewController {
         coordinator.animate(alongsideTransition: { [updateGridViewAxis] _ in updateGridViewAxis() })
     }
 
+    override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.willTransition(to: newCollection, with: coordinator)
+        gridView.saveFirstVisibleIndexPath()
+    }
+
     private func updateGridViewAxis() {
         let newAxis = gridAxis(for: traitCollection)
         guard newAxis != gridView.layoutDirection else { return }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallGridView/Grid/GridView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallGridView/Grid/GridView.swift
@@ -36,7 +36,7 @@ final class GridView: UICollectionView {
 
     var layoutDirection: UICollectionView.ScrollDirection = .vertical {
         didSet {
-            reloadData()
+            layout.invalidateLayout()
         }
     }
 

--- a/Wire-iOS/Sources/UserInterface/Calling/CallGridView/Grid/GridView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallGridView/Grid/GridView.swift
@@ -44,6 +44,7 @@ final class GridView: UICollectionView {
 
     let maxItemsPerPage: Int
     private(set) var currentPage: Int = 0
+    private var firstVisibleIndexPath: IndexPath?
 
     // MARK: - Private Properties
 
@@ -87,6 +88,9 @@ final class GridView: UICollectionView {
         return numberOfItems / maxItemsPerPage + (numberOfItems % maxItemsPerPage == 0 ? 0 : 1)
     }
 
+    func saveFirstVisibleIndexPath() {
+        firstVisibleIndexPath = indexPathForItem(at: contentOffset)
+    }
 }
 
 // MARK: - Segment calculation
@@ -189,6 +193,15 @@ extension GridView: UICollectionViewDelegateFlowLayout {
         let height = maxHeight / CGFloat(itemsInColumn)
 
         return CGSize(width: width, height: height)
+    }
+
+    func collectionView(_ collectionView: UICollectionView, targetContentOffsetForProposedContentOffset proposedContentOffset: CGPoint) -> CGPoint {
+        guard
+            let indexPath = firstVisibleIndexPath,
+            let attributes = layoutAttributesForItem(at: indexPath)
+        else { return proposedContentOffset }
+
+        return attributes.frame.origin
     }
 
     func collectionView(


### PR DESCRIPTION
## What's new in this PR?

### Issues

After rotating the device, the position in the scrollview of the calling grid changes. It should stay on the same page instead.

### Causes

When the device orientation changes, the layout is updated.
Consequently, the content offset isn't pointing to the same cell as before the rotation.

### Solutions

Before the rotation, save the index path of the item at the content offset position.
Then, in `collectionView(_ collectionView: UICollectionView, targetContentOffsetForProposedContentOffset proposedContentOffset: CGPoint)` use the saved index path to calculate and return the correct content offset