### PR TITLE
[Fix] Grid resets to different page during UI updates

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallGridViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallGridViewController.swift
@@ -397,11 +397,6 @@ final class CallGridViewController: SpinnerCapableViewController {
         coordinator.animate(alongsideTransition: { [updateGridViewAxis] _ in updateGridViewAxis() })
     }
 
-    override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {
-        super.willTransition(to: newCollection, with: coordinator)
-        gridView.saveFirstVisibleIndexPath()
-    }
-
     private func updateGridViewAxis() {
         let newAxis = gridAxis(for: traitCollection)
         guard newAxis != gridView.layoutDirection else { return }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallGridView/Grid/GridView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallGridView/Grid/GridView.swift
@@ -88,8 +88,14 @@ final class GridView: UICollectionView {
         return numberOfItems / maxItemsPerPage + (numberOfItems % maxItemsPerPage == 0 ? 0 : 1)
     }
 
-    func saveFirstVisibleIndexPath() {
-        firstVisibleIndexPath = indexPathForItem(at: contentOffset)
+}
+
+// MARK: - Helpers
+
+private extension GridView {
+    func firstIndexPath(forPage page: Int) -> IndexPath? {
+        let yPosition = CGFloat(page) * bounds.height + 1
+        return indexPathForItem(at: CGPoint(x: 0, y: yPosition))
     }
 }
 
@@ -197,7 +203,7 @@ extension GridView: UICollectionViewDelegateFlowLayout {
 
     func collectionView(_ collectionView: UICollectionView, targetContentOffsetForProposedContentOffset proposedContentOffset: CGPoint) -> CGPoint {
         guard
-            let indexPath = firstVisibleIndexPath,
+            let indexPath = firstIndexPath(forPage: currentPage),
             let attributes = layoutAttributesForItem(at: indexPath)
         else { return proposedContentOffset }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

1. Join a call with multiple pages
2. Go to landscape
3. Go back to portrait
4. Scroll to different page

#### actual result

after some time, the page resets to the page that the grid was on after changing orientation

#### expected result

the page doesn't reset

### Causes

`collectionView(_ collectionView: UICollectionView, targetContentOffsetForProposedContentOffset proposedContentOffset: CGPoint)`  is called when the grid is updated, thus setting the grid's offset to the offset of `firstVisibleIndexPath` which was saved upon rotating the device

### Solutions

Instead of using the first visible indexPath, rely on the current page 

