### PR TITLE
[Fix] Wrong indicator icon for selfUser in conversation

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/CellComponents/SenderCellComponent.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/CellComponents/SenderCellComponent.swift
@@ -27,7 +27,7 @@ private struct SenderCellConfiguration {
     let textColor: UIColor
     let icon: StyleKitIcon?
 
-    init(user: UserType, in conversation: ConversationLike?) {
+    init(user: UserType) {
         fullName = user.name ?? ""
         if user.isServiceUser {
             textColor = .from(scheme: .textForeground)
@@ -38,8 +38,7 @@ private struct SenderCellConfiguration {
         } else if user.isFederated {
             textColor = user.nameAccentColor
             icon = .federated
-        } else if let conversation = conversation,
-                  user.isGuest(in: conversation) {
+        } else if !user.isTeamMember && !user.isSelfUser {
             textColor = user.nameAccentColor
             icon = .guest
         } else {
@@ -61,15 +60,12 @@ final class SenderCellComponent: UIView {
     var avatarSpacerWidthConstraint: NSLayoutConstraint?
     var observerToken: Any?
 
-    var conversation: ConversationLike?
-
     // MARK: - Configuration
 
-    func configure(with user: UserType, in conversation: ConversationLike?) {
+    func configure(with user: UserType) {
         avatar.user = user
-        self.conversation = conversation
 
-        let configuration = SenderCellConfiguration(user: user, in: conversation)
+        let configuration = SenderCellConfiguration(user: user)
         configureViews(for: configuration)
 
         if !ProcessInfo.processInfo.isRunningTests,
@@ -164,7 +160,7 @@ extension SenderCellComponent: ZMUserObserver {
             return
         }
 
-        let configuration = SenderCellConfiguration(user: changeInfo.user, in: conversation)
+        let configuration = SenderCellConfiguration(user: changeInfo.user)
         configureNameLabel(for: configuration)
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSenderMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSenderMessageCell.swift
@@ -51,7 +51,7 @@ class ConversationSenderMessageCell: UIView, ConversationMessageCell {
     }
 
     func configure(with object: Configuration, animated: Bool) {
-        senderView.configure(with: object.user, in: object.message.conversationLike)
+        senderView.configure(with: object.user)
         indicatorImageView.isHidden = object.indicatorIcon == nil
         indicatorImageView.image = object.indicatorIcon
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues
In the group conversation created by the member from another team, the `selfUser` has a guest icon in the conversation.

### Causes
We have displayed a guest icon based on the role in the current conversation. Since the conversation was created by a member of a different team, `selfUser` was considered a guest.

### Solutions
Display guest icon if `selfUser` is a team member.
