### PR TITLE
[Fix] Avoid crash when app lock is enabled

### DIFF
--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -89,13 +89,13 @@ final class ZClientViewController: UIViewController {
 
         NotificationCenter.default.addObserver(self, selector: #selector(contentSizeCategoryDidChange(_:)), name: UIContentSizeCategory.didChangeNotification, object: nil)
 
-        NotificationCenter.default.addObserver(forName: .featureDidChangeNotification, object: nil, queue: .main) { (note) in
+        NotificationCenter.default.addObserver(forName: .featureDidChangeNotification, object: nil, queue: .main) { [weak self] (note) in
             guard let change = note.object as? Feature.FeatureChange,
                   let session = SessionManager.shared,
                   session.usePackagingFeatureConfig else { return }
             switch change {
             case .conferenceCallingIsAvailable:
-                self.presentConferenceCallingAvailableAlert()
+                self?.presentConferenceCallingAvailableAlert()
             }
         }
 


### PR DESCRIPTION
## What's new in this PR?

### Issues

Application was sometimes crashing when opening a push notification with app lock enabled.

### Causes

`ZClientViewController` was captured by retain cycle so state transitions were being forwarded to UI components which had been torn down and specifically the SelfUser was no longer available, which caused a `precondition()` to be triggered.

### Solutions

Remove the retain cycle by making `self` weak in a newly introduced observer.

### Notes

Introduced by https://github.com/wireapp/wire-ios/pull/5254


