### PR TITLE
Fix: don't handle  error to align with other platforms

### DIFF
--- a/Wire-iOS/Generated/Strings+Generated.swift
+++ b/Wire-iOS/Generated/Strings+Generated.swift
@@ -1689,8 +1689,6 @@ internal enum L10n {
         }
       }
       internal enum Connection {
-        /// You cannot connect to because you reached the connection limit
-        internal static let connectionLimitReached = L10n.tr("Localizable", "error.connection.connection_limit_reached")
         /// Something went wrong, please try again
         internal static let genericError = L10n.tr("Localizable", "error.connection.generic_error")
         /// You cannot connect to this user due to legal hold.

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -625,7 +625,6 @@
 "inbox.connection_request.ignore_button_title" = "Ignore";
 "error.connection.title" = "Error";
 "error.connection.missing_legalhold_consent" = "You cannot connect to this user due to legal hold.";
-"error.connection.connection_limit_reached" = "You cannot connect to because you reached the connection limit";
 "error.connection.generic_error" = "Something went wrong, please try again";
 
 // Save image errors

--- a/Wire-iOS/Sources/Helpers/Error+Localization.swift
+++ b/Wire-iOS/Sources/Helpers/Error+Localization.swift
@@ -129,8 +129,6 @@ extension ConnectToUserError: LocalizedError {
         switch self {
         case .missingLegalholdConsent:
             return ConnectionError.missingLegalholdConsent
-        case .connectionLimitReached:
-            return ConnectionError.connectionLimitReached
         default:
             return ConnectionError.genericError
         }
@@ -150,8 +148,6 @@ extension UpdateConnectionError: LocalizedError {
         switch self {
         case .missingLegalholdConsent:
             return ConnectionError.missingLegalholdConsent
-        case .connectionLimitReached:
-            return ConnectionError.connectionLimitReached
         default:
             return ConnectionError.genericError
         }


### PR DESCRIPTION
## What's new in this PR?

Remove handling of the connection limit reached error case to align with the behaviour on other platforms. This error case was introduced in https://github.com/wireapp/wire-ios/pull/5298