### PR TITLE
fix: title cases in shortcut hints

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -1924,6 +1924,6 @@
 
 //MARK: - Keyboard shortcut
 "keyboardshortcut.scrollToBottom" = "Scroll to bottom";
-"keyboardshortcut.conversationDetail" = "Conversation detail...";
-"keyboardshortcut.searchInConversation" = "Search in conversation...";
+"keyboardshortcut.conversationDetail" = "Conversation Detail...";
+"keyboardshortcut.searchInConversation" = "Search in Conversation...";
 "keyboardshortcut.openPeople" = "People";

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -307,7 +307,7 @@
 "conversation.connection_view.in_address_book" = "in Contacts";
 
 "conversation.input_bar.shortcut.send" = "Send Message";
-"conversation.input_bar.shortcut.newline" = "Insert line break";
+"conversation.input_bar.shortcut.newline" = "Insert Line Break";
 "conversation.input_bar.shortcut.edit_last_message" = "Edit Last Message";
 "conversation.input_bar.shortcut.cancel_editing_message" = "Cancel";
 "conversation.input_bar.shortcut.choose_previous_mention" = "Choose previous mention";
@@ -1923,7 +1923,7 @@
 "appLockModule.goToSettingsButton.title" = "Go to settings";
 
 //MARK: - Keyboard shortcut
-"keyboardshortcut.scrollToBottom" = "Scroll to bottom";
+"keyboardshortcut.scrollToBottom" = "Scroll to Bottom";
 "keyboardshortcut.conversationDetail" = "Conversation Detail...";
 "keyboardshortcut.searchInConversation" = "Search in Conversation...";
 "keyboardshortcut.openPeople" = "People";


### PR DESCRIPTION
## What's new in this PR?

Unity shortcut hints cases in Title cases.