### PR TITLE
fix: Markdown view's stackview has 0 height

### DIFF
--- a/Wire-iOS/Sources/UserInterface/MarkdownBarView.swift
+++ b/Wire-iOS/Sources/UserInterface/MarkdownBarView.swift
@@ -85,7 +85,7 @@ final class MarkdownBarView: UIView {
 
         addSubview(stackView)
 
-        stackView.translatesAutoresizingMaskIntoConstraints = true
+        stackView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
           stackView.topAnchor.constraint(equalTo: topAnchor),
           stackView.bottomAnchor.constraint(equalTo: bottomAnchor),


### PR DESCRIPTION
## What's new in this PR?

### Issues

After Cartography is removed, Markdown view's stackview disappeared

### Causes

it has 0 height.

### Solutions

set `translatesAutoresizingMaskIntoConstraints` to face to prevent generating autosizing constraints.