### PR TITLE
Fix: remove cartography from Tabbar and activate constraints in one batch

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/TabBar/TabBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/TabBar/TabBar.swift
@@ -16,7 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-import Cartography
+import UIKit
 
 protocol TabBarDelegate: class {
     func tabBar(_ tabBar: TabBar, didSelectItemAt index: Int)
@@ -34,7 +34,7 @@ final class TabBar: UIView {
 
     private let selectionLineView = UIView()
     private(set) var tabs: [Tab] = []
-    private var lineLeadingConstraint: NSLayoutConstraint?
+    private lazy var lineLeadingConstraint: NSLayoutConstraint = selectionLineView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: tabInset)
     private var didUpdateInitialBarPosition = false
 
     var style: ColorSchemeVariant {
@@ -93,14 +93,6 @@ final class TabBar: UIView {
 
         addSubview(selectionLineView)
         selectionLineView.backgroundColor = style == .dark ? .white : .black
-
-        constrain(self, selectionLineView) { selfView, selectionLineView in
-            lineLeadingConstraint = selectionLineView.leading == selfView.leading + tabInset
-            selectionLineView.height == 1
-            selectionLineView.bottom == selfView.bottom
-            let widthInset = tabInset * 2 / CGFloat(items.count)
-            selectionLineView.width == selfView.width / CGFloat(items.count) - widthInset
-        }
     }
 
     override func layoutSubviews() {
@@ -113,12 +105,12 @@ final class TabBar: UIView {
 
     private func updateLinePosition(animated: Bool) {
         let offset = CGFloat(selectedIndex) * selectionLineView.bounds.width
-        guard offset != lineLeadingConstraint?.constant else { return }
+        guard offset != lineLeadingConstraint.constant else { return }
         updateLinePosition(offset: offset, animated: animated)
     }
 
     private func updateLinePosition(offset: CGFloat, animated: Bool) {
-        lineLeadingConstraint?.constant = offset + tabInset
+        lineLeadingConstraint.constant = offset + tabInset
 
         if animated {
             UIView.animate(
@@ -138,14 +130,22 @@ final class TabBar: UIView {
     }
 
     fileprivate func createConstraints() {
-        constrain(self, stackView) { selfView, stackView in
-            stackView.left == selfView.left + tabInset
-            stackView.right == selfView.right - tabInset
-            stackView.top == selfView.top
-            stackView.height == 48
+        let widthInset: CGFloat = tabInset * 2 / CGFloat(items.count)
 
-            selfView.bottom == stackView.bottom
-        }
+        [selectionLineView, stackView].prepareForLayout()
+        NSLayoutConstraint.activate([
+            lineLeadingConstraint,
+            selectionLineView.heightAnchor.constraint(equalToConstant: 1),
+            selectionLineView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            selectionLineView.widthAnchor.constraint(equalTo: widthAnchor, multiplier: 1.0 / CGFloat(items.count), constant: -widthInset),
+
+            stackView.leftAnchor.constraint(equalTo: leftAnchor, constant: tabInset),
+            stackView.rightAnchor.constraint(equalTo: rightAnchor, constant: -tabInset),
+            stackView.topAnchor.constraint(equalTo: topAnchor),
+            stackView.heightAnchor.constraint(equalToConstant: 48),
+
+            bottomAnchor.constraint(equalTo: stackView.bottomAnchor)
+        ])
     }
 
     fileprivate func makeButtonForItem(_ index: Int, _ item: UITabBarItem) -> Tab {


### PR DESCRIPTION
## What's new in this PR?

Remove Cartography from `Tabbar`