### PR TITLE
Fix: remove cartography from incoming connection view

### DIFF
--- a/Wire-iOS Share Extension/UnlockViewController.swift
+++ b/Wire-iOS Share Extension/UnlockViewController.swift
@@ -148,7 +148,9 @@ extension UnlockViewController {
     
     private func createConstraints() {
         [contentView,
-         stackView].prepareForLayout()
+         stackView].forEach { (view) in
+            view.translatesAutoresizingMaskIntoConstraints = false
+        }
         
         let widthConstraint = contentView.createContentWidthConstraint()
         

--- a/Wire-iOS Share Extension/UnlockViewController.swift
+++ b/Wire-iOS Share Extension/UnlockViewController.swift
@@ -148,9 +148,7 @@ extension UnlockViewController {
     
     private func createConstraints() {
         [contentView,
-         stackView].forEach { (view) in
-            view.translatesAutoresizingMaskIntoConstraints = false
-        }
+         stackView].prepareForLayout()
         
         let widthConstraint = contentView.createContentWidthConstraint()
         

--- a/Wire-iOS/Sources/UserInterface/ConnectRequests/IncomingConnectionView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConnectRequests/IncomingConnectionView.swift
@@ -104,36 +104,36 @@ final class IncomingConnectionView: UIView {
          userImageView].prepareForLayout()
 
         NSLayoutConstraint.activate([
-          ignoreButton.leftAnchor.constraint(equalTo: incomingConnectionFooter.leftAnchor, constant: 16),
-          ignoreButton.topAnchor.constraint(equalTo: incomingConnectionFooter.topAnchor, constant: 12),
-          ignoreButton.bottomAnchor.constraint(equalTo: incomingConnectionFooter.bottomAnchor, constant: -16),
-          ignoreButton.heightAnchor.constraint(equalToConstant: 40),
-          ignoreButton.rightAnchor.constraint(equalTo: incomingConnectionFooter.centerXAnchor, constant: -8),
+            ignoreButton.leftAnchor.constraint(equalTo: incomingConnectionFooter.leftAnchor, constant: 16),
+            ignoreButton.topAnchor.constraint(equalTo: incomingConnectionFooter.topAnchor, constant: 12),
+            ignoreButton.bottomAnchor.constraint(equalTo: incomingConnectionFooter.bottomAnchor, constant: -16),
+            ignoreButton.heightAnchor.constraint(equalToConstant: 40),
+            ignoreButton.rightAnchor.constraint(equalTo: incomingConnectionFooter.centerXAnchor, constant: -8),
 
-          acceptButton.rightAnchor.constraint(equalTo: incomingConnectionFooter.rightAnchor, constant: -16),
-          acceptButton.leftAnchor.constraint(equalTo: incomingConnectionFooter.centerXAnchor, constant: 8),
-          acceptButton.centerYAnchor.constraint(equalTo: ignoreButton.centerYAnchor),
-          acceptButton.heightAnchor.constraint(equalTo: ignoreButton.heightAnchor),
+            acceptButton.rightAnchor.constraint(equalTo: incomingConnectionFooter.rightAnchor, constant: -16),
+            acceptButton.leftAnchor.constraint(equalTo: incomingConnectionFooter.centerXAnchor, constant: 8),
+            acceptButton.centerYAnchor.constraint(equalTo: ignoreButton.centerYAnchor),
+            acceptButton.heightAnchor.constraint(equalTo: ignoreButton.heightAnchor),
 
             usernameLabel.topAnchor.constraint(equalTo: topAnchor, constant: 18),
-          usernameLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
-          usernameLabel.leftAnchor.constraint(greaterThanOrEqualTo: leftAnchor),
+            usernameLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+            usernameLabel.leftAnchor.constraint(greaterThanOrEqualTo: leftAnchor),
 
-          userDetailView.centerXAnchor.constraint(equalTo: centerXAnchor),
-          userDetailView.topAnchor.constraint(equalTo: usernameLabel.bottomAnchor, constant: 4),
-          userDetailView.leftAnchor.constraint(greaterThanOrEqualTo: leftAnchor),
-          userDetailView.bottomAnchor.constraint(lessThanOrEqualTo: userImageView.topAnchor),
+            userDetailView.centerXAnchor.constraint(equalTo: centerXAnchor),
+            userDetailView.topAnchor.constraint(equalTo: usernameLabel.bottomAnchor, constant: 4),
+            userDetailView.leftAnchor.constraint(greaterThanOrEqualTo: leftAnchor),
+            userDetailView.bottomAnchor.constraint(lessThanOrEqualTo: userImageView.topAnchor),
 
-          userImageView.centerXAnchor.constraint(equalTo: centerXAnchor),
-          userImageView.centerYAnchor.constraint(equalTo: centerYAnchor),
-          userImageView.leftAnchor.constraint(greaterThanOrEqualTo: leftAnchor, constant: 54),
-          userImageView.widthAnchor.constraint(equalTo: userImageView.heightAnchor),
-          userImageView.heightAnchor.constraint(lessThanOrEqualToConstant: 264),
+            userImageView.centerXAnchor.constraint(equalTo: centerXAnchor),
+            userImageView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            userImageView.leftAnchor.constraint(greaterThanOrEqualTo: leftAnchor, constant: 54),
+            userImageView.widthAnchor.constraint(equalTo: userImageView.heightAnchor),
+            userImageView.heightAnchor.constraint(lessThanOrEqualToConstant: 264),
 
-          incomingConnectionFooter.topAnchor.constraint(greaterThanOrEqualTo: userImageView.bottomAnchor),
-          incomingConnectionFooter.leftAnchor.constraint(equalTo: leftAnchor),
-          incomingConnectionFooter.bottomAnchor.constraint(equalTo: bottomAnchor),
-          incomingConnectionFooter.rightAnchor.constraint(equalTo: rightAnchor)
+            incomingConnectionFooter.topAnchor.constraint(greaterThanOrEqualTo: userImageView.bottomAnchor),
+            incomingConnectionFooter.leftAnchor.constraint(equalTo: leftAnchor),
+            incomingConnectionFooter.bottomAnchor.constraint(equalTo: bottomAnchor),
+            incomingConnectionFooter.rightAnchor.constraint(equalTo: rightAnchor)
         ])
     }
 

--- a/Wire-iOS/Sources/UserInterface/ConnectRequests/IncomingConnectionView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConnectRequests/IncomingConnectionView.swift
@@ -17,7 +17,6 @@
 //
 
 import Foundation
-import Cartography
 import WireSyncEngine
 
 final class IncomingConnectionView: UIView {
@@ -97,39 +96,45 @@ final class IncomingConnectionView: UIView {
     }
 
     private func createConstraints() {
-        constrain(incomingConnectionFooter, acceptButton, ignoreButton) { incomingConnectionFooter, acceptButton, ignoreButton in
-            ignoreButton.left == incomingConnectionFooter.left + 16
-            ignoreButton.top == incomingConnectionFooter.top + 12
-            ignoreButton.bottom == incomingConnectionFooter.bottom - 16
-            ignoreButton.height == 40
-            ignoreButton.right == incomingConnectionFooter.centerX - 8
+        [incomingConnectionFooter,
+         acceptButton,
+         ignoreButton,
+         usernameLabel,
+         userDetailView,
+         userImageView].prepareForLayout()
 
-            acceptButton.right == incomingConnectionFooter.right - 16
-            acceptButton.left == incomingConnectionFooter.centerX + 8
-            acceptButton.centerY == ignoreButton.centerY
-            acceptButton.height == ignoreButton.height
-        }
+        NSLayoutConstraint.activate([
+          ignoreButton.leftAnchor.constraint(equalTo: incomingConnectionFooter.leftAnchor, constant: 16),
+          ignoreButton.topAnchor.constraint(equalTo: incomingConnectionFooter.topAnchor, constant: 12),
+          ignoreButton.bottomAnchor.constraint(equalTo: incomingConnectionFooter.bottomAnchor, constant: -16),
+          ignoreButton.heightAnchor.constraint(equalToConstant: 40),
+          ignoreButton.rightAnchor.constraint(equalTo: incomingConnectionFooter.centerXAnchor, constant: -8),
 
-        constrain(self, usernameLabel, userDetailView, incomingConnectionFooter, userImageView) { selfView, usernameLabel, userDetailView, incomingConnectionFooter, userImageView in
-            usernameLabel.top == selfView.top + 18
-            usernameLabel.centerX == selfView.centerX
-            usernameLabel.left >= selfView.left
+          acceptButton.rightAnchor.constraint(equalTo: incomingConnectionFooter.rightAnchor, constant: -16),
+          acceptButton.leftAnchor.constraint(equalTo: incomingConnectionFooter.centerXAnchor, constant: 8),
+          acceptButton.centerYAnchor.constraint(equalTo: ignoreButton.centerYAnchor),
+          acceptButton.heightAnchor.constraint(equalTo: ignoreButton.heightAnchor),
 
-            userDetailView.centerX == selfView.centerX
-            userDetailView.top == usernameLabel.bottom + 4
-            userDetailView.left >= selfView.left
-            userDetailView.bottom <= userImageView.top
+            usernameLabel.topAnchor.constraint(equalTo: topAnchor, constant: 18),
+          usernameLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+          usernameLabel.leftAnchor.constraint(greaterThanOrEqualTo: leftAnchor),
 
-            userImageView.center == selfView.center
-            userImageView.left >= selfView.left + 54
-            userImageView.width == userImageView.height
-            userImageView.height <= 264
+          userDetailView.centerXAnchor.constraint(equalTo: centerXAnchor),
+          userDetailView.topAnchor.constraint(equalTo: usernameLabel.bottomAnchor, constant: 4),
+          userDetailView.leftAnchor.constraint(greaterThanOrEqualTo: leftAnchor),
+          userDetailView.bottomAnchor.constraint(lessThanOrEqualTo: userImageView.topAnchor),
 
-            incomingConnectionFooter.top >= userImageView.bottom
-            incomingConnectionFooter.left == selfView.left
-            incomingConnectionFooter.bottom == selfView.bottom
-            incomingConnectionFooter.right == selfView.right
-        }
+          userImageView.centerXAnchor.constraint(equalTo: centerXAnchor),
+          userImageView.centerYAnchor.constraint(equalTo: centerYAnchor),
+          userImageView.leftAnchor.constraint(greaterThanOrEqualTo: leftAnchor, constant: 54),
+          userImageView.widthAnchor.constraint(equalTo: userImageView.heightAnchor),
+          userImageView.heightAnchor.constraint(lessThanOrEqualToConstant: 264),
+
+          incomingConnectionFooter.topAnchor.constraint(greaterThanOrEqualTo: userImageView.bottomAnchor),
+          incomingConnectionFooter.leftAnchor.constraint(equalTo: leftAnchor),
+          incomingConnectionFooter.bottomAnchor.constraint(equalTo: bottomAnchor),
+          incomingConnectionFooter.rightAnchor.constraint(equalTo: rightAnchor)
+        ])
     }
 
     // MARK: - Actions


### PR DESCRIPTION
## What's new in this PR?

 remove cartography from `IncomingConnectionView`