### PR TITLE
add unavailable to unused init coder

### DIFF
--- a/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.View.LockView.swift
+++ b/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.View.LockView.swift
@@ -96,6 +96,7 @@ extension AppLockModule.View {
             toggleConstraints()
         }
 
+        @available(*, unavailable)
         required init?(coder aDecoder: NSCoder) {
             fatal("init(coder) is not implemented")
         }

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionCellHeader.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionCellHeader.swift
@@ -36,6 +36,7 @@ final class CollectionCellHeader: UIView {
         }
     }
 
+    @available(*, unavailable)
     required init(coder: NSCoder) {
         fatal("init(coder: NSCoder) is not implemented")
     }

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionHeaderView.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionHeaderView.swift
@@ -76,6 +76,7 @@ final class CollectionHeaderView: UICollectionReusableView {
 
     var selectionAction: ((CollectionsSectionSet) -> Void)? = .none
 
+    @available(*, unavailable)
     required init(coder: NSCoder) {
         fatal("init(coder: NSCoder) is not implemented")
     }

--- a/Wire-iOS/Sources/UserInterface/Collections/TextSearch/TextSearchResultFooter.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/TextSearch/TextSearchResultFooter.swift
@@ -36,6 +36,7 @@ final class TextSearchResultFooter: UIView {
         }
     }
 
+    @available(*, unavailable)
     required init(coder: NSCoder) {
         fatal("init(coder: NSCoder) is not implemented")
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ObfuscationView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ObfuscationView.swift
@@ -47,6 +47,7 @@ final class ObfuscationView: UIImageView {
         }
     }
 
+    @available(*, unavailable)
     required init(coder: NSCoder) {
         fatal("initWithCoder: not implemented")
     }

--- a/Wire-iOS/Sources/UserInterface/Overlay/CallTopOverlayController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/CallTopOverlayController.swift
@@ -55,6 +55,7 @@ final class CallTopOverlayController: UIViewController {
             super.init(frame: .zero)
         }
 
+        @available(*, unavailable)
         required init?(coder aDecoder: NSCoder) {
             fatalError("init(coder:) has not been implemented")
         }

--- a/Wire-iOS/Sources/UserInterface/Settings/AccentColorPickerController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/AccentColorPickerController.swift
@@ -143,6 +143,7 @@ class ColorPickerController: UIViewController {
             checkmarkView.isHidden = true
         }
 
+        @available(*, unavailable)
         required init?(coder aDecoder: NSCoder) {
             fatalError("init(coder:) has not been implemented")
         }

--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/SettingsClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/SettingsClientViewController.swift
@@ -168,6 +168,7 @@ final class SettingsClientViewController: UIViewController,
         fatalError("init(nibNameOrNil:nibBundleOrNil:) has not been implemented")
     }
 
+    @available(*, unavailable)
     required init(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }


### PR DESCRIPTION
## What's new in this PR?

Mark unused `init?(coder aDecoder: NSCoder)` as unavailable