### PR TITLE
Fix: xcode13 warning - Using 'class' keyword to define a class-constrained protocol is deprecated; use 'AnyObject' instead

### DIFF
--- a/Wire-iOS Share Extension/PasscodeTextField.swift
+++ b/Wire-iOS Share Extension/PasscodeTextField.swift
@@ -20,7 +20,7 @@ import Foundation
 import UIKit
 import WireCommonComponents
 
-protocol PasscodeTextFieldDelegate: class {
+protocol PasscodeTextFieldDelegate: AnyObject {
     func textFieldValueChanged(_ value: String?)
 }
 

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -7504,7 +7504,7 @@
 				DefaultBuildSystemTypeForWorkspace = Original;
 				LastSwiftMigration = 0710;
 				LastSwiftUpdateCheck = 0820;
-				LastUpgradeCheck = 1240;
+				LastUpgradeCheck = 1310;
 				ORGANIZATIONNAME = "Zeta Project Germany GmbH";
 				TargetAttributes = {
 					168A16A81D9597C2005CFA6C = {
@@ -9552,7 +9552,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = F156509721DCED3000210504 /* CommonComponents-Debug.xcconfig */;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
@@ -9566,7 +9566,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = F156509621DCED3000210504 /* CommonComponents-Release.xcconfig */;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";

--- a/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire Share Extension.xcscheme
+++ b/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire Share Extension.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1310"
    wasCreatedForAppExtension = "YES"
    version = "2.0">
    <BuildAction
@@ -94,6 +94,7 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES"
+      askForAppToLaunch = "Yes"
       launchAutomaticallySubstyle = "2">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
+++ b/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1310"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Wire-iOS.xcodeproj/xcshareddata/xcschemes/WireCommonComponents.xcscheme
+++ b/Wire-iOS.xcodeproj/xcshareddata/xcschemes/WireCommonComponents.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1310"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Wire-iOS/Sources/Analytics/AnalyticsProvider.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsProvider.swift
@@ -19,7 +19,7 @@
 import Foundation
 import WireDataModel
 
-protocol AnalyticsProvider: class {
+protocol AnalyticsProvider: AnyObject {
     var isOptedOut: Bool { get set }
     var selfUser: UserType? { get set }
 

--- a/Wire-iOS/Sources/AppStateCalculator.swift
+++ b/Wire-iOS/Sources/AppStateCalculator.swift
@@ -56,7 +56,7 @@ enum AppState: Equatable {
     }
 }
 
-protocol AppStateCalculatorDelegate: class {
+protocol AppStateCalculatorDelegate: AnyObject {
     func appStateCalculator(_: AppStateCalculator,
                             didCalculate appState: AppState,
                             completion: @escaping () -> Void)

--- a/Wire-iOS/Sources/AuthenticatedRouter.swift
+++ b/Wire-iOS/Sources/AuthenticatedRouter.swift
@@ -26,7 +26,7 @@ public enum NavigationDestination {
     case conversationList
 }
 
-protocol AuthenticatedRouterProtocol: class {
+protocol AuthenticatedRouterProtocol: AnyObject {
     func updateActiveCallPresentationState()
     func minimizeCallOverlay(animated: Bool, withCompletion completion: Completion?)
     func navigate(to destination: NavigationDestination)

--- a/Wire-iOS/Sources/Authentication/Backup/BackupRestoreController.swift
+++ b/Wire-iOS/Sources/Authentication/Backup/BackupRestoreController.swift
@@ -20,7 +20,7 @@ import Foundation
 import WireDataModel
 import WireSyncEngine
 
-protocol BackupRestoreControllerDelegate: class {
+protocol BackupRestoreControllerDelegate: AnyObject {
     func backupResoreControllerDidFinishRestoring(_ controller: BackupRestoreController)
 }
 

--- a/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
+++ b/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
@@ -24,7 +24,7 @@ import UIKit
  * Provides and asks for context when registering users.
  */
 
-protocol AuthenticationCoordinatorDelegate: class {
+protocol AuthenticationCoordinatorDelegate: AnyObject {
 
     /**
      * The coordinator finished authenticating the user.

--- a/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationStateController.swift
+++ b/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationStateController.swift
@@ -25,7 +25,7 @@ private let log = ZMSLog(tag: "Authentication")
  * A type of object that observes changes from an authentication state controller.
  */
 
-protocol AuthenticationStateControllerDelegate: class {
+protocol AuthenticationStateControllerDelegate: AnyObject {
 
     /**
      * Called when the current state changes in the state controller.

--- a/Wire-iOS/Sources/Authentication/Delegates/AuthenticationActioner.swift
+++ b/Wire-iOS/Sources/Authentication/Delegates/AuthenticationActioner.swift
@@ -22,7 +22,7 @@ import Foundation
  * An object that can execute authentication actions.
  */
 
-protocol AuthenticationActioner: class {
+protocol AuthenticationActioner: AnyObject {
 
     /**
      * Executes the list of actions, in the order they are stored.
@@ -56,7 +56,7 @@ extension AuthenticationActioner {
  * An object that can trigger authentication actions.
  */
 
-protocol AuthenticationActionable: class {
+protocol AuthenticationActionable: AnyObject {
 
     /**
      * The actioner to use to execute the actions. This variable will be set by another

--- a/Wire-iOS/Sources/Authentication/Delegates/AuthenticationCoordinatedViewController.swift
+++ b/Wire-iOS/Sources/Authentication/Delegates/AuthenticationCoordinatedViewController.swift
@@ -29,7 +29,7 @@ enum AuthenticationErrorFeedbackAction: Int {
 }
 
 /// A view controller that is managed by an authentication coordinator.
-protocol AuthenticationCoordinatedViewController: class {
+protocol AuthenticationCoordinatedViewController: AnyObject {
     /// The object that coordinates authentication.
     var authenticationCoordinator: AuthenticationCoordinator? { get set }
 

--- a/Wire-iOS/Sources/Authentication/Event Handlers/AuthenticationEventHandler.swift
+++ b/Wire-iOS/Sources/Authentication/Event Handlers/AuthenticationEventHandler.swift
@@ -28,7 +28,7 @@ import Foundation
  * next handler will be used. The first handler that returns a valid value will be used, and the call loop will be stopped.
  */
 
-protocol AuthenticationEventHandler: class {
+protocol AuthenticationEventHandler: AnyObject {
 
     /**
      * The type of context objects required to process the event.

--- a/Wire-iOS/Sources/Authentication/Event Handlers/AuthenticationEventResponderChain.swift
+++ b/Wire-iOS/Sources/Authentication/Event Handlers/AuthenticationEventResponderChain.swift
@@ -24,7 +24,7 @@ import WireDataModel
  * Provides information to the event responder chain and executes actions.
  */
 
-protocol AuthenticationEventResponderChainDelegate: class {
+protocol AuthenticationEventResponderChainDelegate: AnyObject {
 
     /// The object providing authentication status info.
     var statusProvider: AuthenticationStatusProvider { get }

--- a/Wire-iOS/Sources/Authentication/Helpers/CountryCode/CountryCodeTableViewController.swift
+++ b/Wire-iOS/Sources/Authentication/Helpers/CountryCode/CountryCodeTableViewController.swift
@@ -19,7 +19,7 @@
 import Foundation
 import UIKit
 
-protocol CountryCodeTableViewControllerDelegate: class {
+protocol CountryCodeTableViewControllerDelegate: AnyObject {
     func countryCodeTableViewController(_ viewController: UIViewController, didSelect country: Country)
 }
 

--- a/Wire-iOS/Sources/Authentication/Interface/Descriptions/ScreenDescriptions/AuthenticationStepDescription.swift
+++ b/Wire-iOS/Sources/Authentication/Interface/Descriptions/ScreenDescriptions/AuthenticationStepDescription.swift
@@ -29,18 +29,18 @@ enum ValueValidation {
     case error(TextFieldValidator.ValidationError, showVisualFeedback: Bool)
 }
 
-protocol ViewDescriptor: class {
+protocol ViewDescriptor: AnyObject {
     func create() -> UIView
 }
 
-protocol ValueSubmission: class {
+protocol ValueSubmission: AnyObject {
     var acceptsInput: Bool { get set }
     var valueSubmitted: ValueSubmitted? { get set }
     var valueValidated: ValueValidated? { get set }
 }
 
 /// A protocol for views that support performing the magic tap.
-protocol MagicTappable: class {
+protocol MagicTappable: AnyObject {
     func performMagicTap() -> Bool
 }
 

--- a/Wire-iOS/Sources/Authentication/Interface/Team Invites/TeamMemberInviteViewController.swift
+++ b/Wire-iOS/Sources/Authentication/Interface/Team Invites/TeamMemberInviteViewController.swift
@@ -20,7 +20,7 @@ import UIKit
 import WireCommonComponents
 import WireSyncEngine
 
-protocol TeamMemberInviteViewControllerDelegate: class {
+protocol TeamMemberInviteViewControllerDelegate: AnyObject {
     func teamInviteViewControllerDidFinish(_ controller: TeamMemberInviteViewController)
 }
 

--- a/Wire-iOS/Sources/Authentication/Interface/Views/PhoneNumberInputView.swift
+++ b/Wire-iOS/Sources/Authentication/Interface/Views/PhoneNumberInputView.swift
@@ -21,7 +21,7 @@ import UIKit
 import WireDataModel
 
 /// An object that receives notification about the phone number input view.
-protocol PhoneNumberInputViewDelegate: class {
+protocol PhoneNumberInputViewDelegate: AnyObject {
     func phoneNumberInputView(_ inputView: PhoneNumberInputView, didPickPhoneNumber phoneNumber: PhoneNumber)
     func phoneNumberInputView(_ inputView: PhoneNumberInputView, didValidatePhoneNumber phoneNumber: PhoneNumber, withResult validationError: TextFieldValidator.ValidationError?)
     func phoneNumberInputViewDidRequestCountryPicker(_ inputView: PhoneNumberInputView)

--- a/Wire-iOS/Sources/Authentication/Interface/Views/ValidatedTextField.swift
+++ b/Wire-iOS/Sources/Authentication/Interface/Views/ValidatedTextField.swift
@@ -20,7 +20,7 @@ import Foundation
 import UIKit
 import WireCommonComponents
 
-protocol TextFieldValidationDelegate: class {
+protocol TextFieldValidationDelegate: AnyObject {
 
     /// Delegate for validation. It is called when every time .editingChanged event fires
     ///

--- a/Wire-iOS/Sources/Authentication/Interface/Views/ValidatedTextField.swift
+++ b/Wire-iOS/Sources/Authentication/Interface/Views/ValidatedTextField.swift
@@ -30,7 +30,7 @@ protocol TextFieldValidationDelegate: AnyObject {
     func validationUpdated(sender: UITextField, error: TextFieldValidator.ValidationError?)
 }
 
-protocol ValidatedTextFieldDelegate: class {
+protocol ValidatedTextFieldDelegate: AnyObject {
     func buttonPressed(_ sender: UIButton)
 }
 

--- a/Wire-iOS/Sources/Components/AudioPlayer/AudioTrackPlayer.swift
+++ b/Wire-iOS/Sources/Components/AudioPlayer/AudioTrackPlayer.swift
@@ -30,7 +30,7 @@ enum MediaPlayerState: Int {
     case error
 }
 
-protocol MediaPlayer: class {
+protocol MediaPlayer: AnyObject {
     var title: String? { get }
     var sourceMessage: ZMConversationMessage? { get }
     var state: MediaPlayerState? { get }
@@ -41,7 +41,7 @@ protocol MediaPlayer: class {
 
 typealias AudioTrackCompletionHandler = (_ loaded: Bool, _ error: Error?) -> Void
 
-protocol AudioTrackPlayerDelegate: class {
+protocol AudioTrackPlayerDelegate: AnyObject {
     func stateDidChange(_ audioTrackPlayer: AudioTrackPlayer, state: MediaPlayerState?)
     func progressDidChange(_ audioTrackPlayer: AudioTrackPlayer, progress: Double)
 }

--- a/Wire-iOS/Sources/Components/CompanyLoginFlowOpener.swift
+++ b/Wire-iOS/Sources/Components/CompanyLoginFlowOpener.swift
@@ -22,7 +22,7 @@ import AuthenticationServices
 import UIKit
 import WireSyncEngine
 
-protocol CompanyLoginFlowHandlerDelegate: class {
+protocol CompanyLoginFlowHandlerDelegate: AnyObject {
     /// Called when the user cancels the company login flow.
     func userDidCancelCompanyLoginFlow()
 }

--- a/Wire-iOS/Sources/Components/ImageCache/DataTaskSession.swift
+++ b/Wire-iOS/Sources/Components/ImageCache/DataTaskSession.swift
@@ -24,7 +24,7 @@ import Foundation
  * A network session task that downloads data.
  */
 
-protocol DataTask: class {
+protocol DataTask: AnyObject {
 
     /// The unique identifier of the task within its session.
     var taskIdentifier: Int { get }
@@ -44,7 +44,7 @@ protocol DataTask: class {
  * An object that schedules and manages data tasks.
  */
 
-protocol DataTaskSession: class {
+protocol DataTaskSession: AnyObject {
 
     /// Creates a data request task for the given URL.
     func makeDataTask(with url: URL, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> DataTask

--- a/Wire-iOS/Sources/Components/Settings/SettingsPropertyFactory.swift
+++ b/Wire-iOS/Sources/Components/Settings/SettingsPropertyFactory.swift
@@ -50,7 +50,7 @@ enum SettingsPropertyError: Error {
     case WrongValue(String)
 }
 
-protocol SettingsPropertyFactoryDelegate: class {
+protocol SettingsPropertyFactoryDelegate: AnyObject {
     func asyncMethodDidStart(_ settingsPropertyFactory: SettingsPropertyFactory)
     func asyncMethodDidComplete(_ settingsPropertyFactory: SettingsPropertyFactory)
 

--- a/Wire-iOS/Sources/Components/Settings/ZMUserSessionInterface.swift
+++ b/Wire-iOS/Sources/Components/Settings/ZMUserSessionInterface.swift
@@ -20,7 +20,7 @@ import WireSyncEngine
 
 typealias UserSessionInterface = UserSessionSwiftInterface & UserSessionAppLockInterface
 
-protocol ZMUserSessionInterface: class {
+protocol ZMUserSessionInterface: AnyObject {
 
     func perform(_ changes: @escaping () -> Void)
 

--- a/Wire-iOS/Sources/Components/TokenField/TokenFieldDelegate.swift
+++ b/Wire-iOS/Sources/Components/TokenField/TokenFieldDelegate.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 
-protocol TokenFieldDelegate: class {
+protocol TokenFieldDelegate: AnyObject {
     func tokenField(_ tokenField: TokenField, changedTokensTo tokens: [Token<NSObjectProtocol>])
     func tokenField(_ tokenField: TokenField, changedFilterTextTo text: String)
     func tokenFieldDidConfirmSelection(_ controller: TokenField)

--- a/Wire-iOS/Sources/Components/TokenField/TokenizedTextView.swift
+++ b/Wire-iOS/Sources/Components/TokenField/TokenizedTextView.swift
@@ -18,7 +18,7 @@
 
 import UIKit
 
-protocol TokenizedTextViewDelegate: class {
+protocol TokenizedTextViewDelegate: AnyObject {
     func tokenizedTextView(_ textView: TokenizedTextView, didTapTextRange range: NSRange, fraction: CGFloat)
     func tokenizedTextView(_ textView: TokenizedTextView, textContainerInsetChanged textContainerInset: UIEdgeInsets)
 }

--- a/Wire-iOS/Sources/Helpers/syncengine/ClientRemovalObserver.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ClientRemovalObserver.swift
@@ -23,7 +23,7 @@ enum ClientRemovalUIError: Error {
     case noPasswordProvided
 }
 
-protocol ClientRemovalObserverDelegate: class {
+protocol ClientRemovalObserverDelegate: AnyObject {
     func present(_ clientRemovalObserver: ClientRemovalObserver,
                  viewControllerToPresent: UIViewController)
     func setIsLoadingViewVisible(_ clientRemovalObserver: ClientRemovalObserver, isVisible: Bool)

--- a/Wire-iOS/Sources/Managers/AddressBookHelper.swift
+++ b/Wire-iOS/Sources/Managers/AddressBookHelper.swift
@@ -21,7 +21,7 @@ import Contacts
 import WireSyncEngine
 import UIKit
 
-protocol AddressBookHelperProtocol: class {
+protocol AddressBookHelperProtocol: AnyObject {
     var isAddressBookAccessGranted: Bool { get }
     var isAddressBookAccessUnknown: Bool { get }
     var isAddressBookAccessDisabled: Bool { get }

--- a/Wire-iOS/Sources/Permissions/PermissionDeniedViewController.swift
+++ b/Wire-iOS/Sources/Permissions/PermissionDeniedViewController.swift
@@ -19,7 +19,7 @@
 import Foundation
 import UIKit
 
-protocol PermissionDeniedViewControllerDelegate: class {
+protocol PermissionDeniedViewControllerDelegate: AnyObject {
     func continueWithoutPermission(_ viewController: PermissionDeniedViewController)
 }
 

--- a/Wire-iOS/Sources/Permissions/ShareContactsViewController.swift
+++ b/Wire-iOS/Sources/Permissions/ShareContactsViewController.swift
@@ -19,7 +19,7 @@
 import Foundation
 import UIKit
 
-protocol ShareContactsViewControllerDelegate: class {
+protocol ShareContactsViewControllerDelegate: AnyObject {
     func shareDidSkip(_ viewController: UIViewController)
     func shareDidFinish(_ viewController: UIViewController)
 }

--- a/Wire-iOS/Sources/URLActionRouter.swift
+++ b/Wire-iOS/Sources/URLActionRouter.swift
@@ -23,7 +23,7 @@ extension Notification.Name {
 }
 
 // MARK: - URLActionRouterDelegete
-protocol URLActionRouterDelegate: class {
+protocol URLActionRouterDelegate: AnyObject {
 
     func urlActionRouterWillShowCompanyLoginError()
     func urlActionRouterCanDisplayAlerts() -> Bool

--- a/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
@@ -42,8 +42,7 @@ extension ConversationLike where Self: SwiftConversationLike {
     }
 }
 
-protocol AddParticipantsConversationCreationDelegate: class {
-
+protocol AddParticipantsConversationCreationDelegate: AnyObject {
     func addParticipantsViewController(_ addParticipantsViewController: AddParticipantsViewController, didPerform action: AddParticipantsViewController.CreateAction)
 }
 

--- a/Wire-iOS/Sources/UserInterface/Calling/CallActionsView/CallActionsView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallActionsView/CallActionsView.swift
@@ -19,7 +19,7 @@
 import UIKit
 import WireSyncEngine
 
-protocol CallActionsViewDelegate: class {
+protocol CallActionsViewDelegate: AnyObject {
     func callActionsView(_ callActionsView: CallActionsView, perform action: CallAction)
 }
 

--- a/Wire-iOS/Sources/UserInterface/Calling/CallController/ActiveCallRouter.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallController/ActiveCallRouter.swift
@@ -20,7 +20,7 @@ import UIKit
 import WireSyncEngine
 
 // MARK: - ActiveCallRouterProtocol
-protocol ActiveCallRouterProtocol: class {
+protocol ActiveCallRouterProtocol: AnyObject {
     func presentActiveCall(for voiceChannel: VoiceChannel, animated: Bool)
     func dismissActiveCall(animated: Bool, completion: Completion?)
     func minimizeCall(animated: Bool, completion: Completion?)

--- a/Wire-iOS/Sources/UserInterface/Calling/CallController/ActiveCallRouter.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallController/ActiveCallRouter.swift
@@ -31,7 +31,7 @@ protocol ActiveCallRouterProtocol: AnyObject {
 }
 
 // MARK: - CallQualityRouterProtocol
-protocol CallQualityRouterProtocol: class {
+protocol CallQualityRouterProtocol: AnyObject {
     func presentCallQualitySurvey(with callDuration: TimeInterval)
     func dismissCallQualitySurvey(completion: Completion?)
     func presentCallFailureDebugAlert()

--- a/Wire-iOS/Sources/UserInterface/Calling/CallDegradationViewController/CallDegradationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallDegradationViewController/CallDegradationController.swift
@@ -26,7 +26,7 @@ enum CallDegradationState: Equatable {
     case outgoing(degradedUser: HashBoxUser?)
 }
 
-protocol CallDegradationControllerDelegate: class {
+protocol CallDegradationControllerDelegate: AnyObject {
     func continueDegradedCall()
     func cancelDegradedCall()
 }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallGridViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallGridViewController.swift
@@ -23,7 +23,7 @@ import WireSyncEngine
 import avs
 import DifferenceKit
 
-protocol CallGridViewControllerDelegate: class {
+protocol CallGridViewControllerDelegate: AnyObject {
     func callGridViewController(_ viewController: CallGridViewController, perform action: CallGridAction)
 }
 

--- a/Wire-iOS/Sources/UserInterface/Calling/CallGridView/Grid/GridView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallGridView/Grid/GridView.swift
@@ -18,7 +18,7 @@
 
 import UIKit
 
-protocol GridViewDelegate: class {
+protocol GridViewDelegate: AnyObject {
     func gridView(_ gridView: GridView, didChangePageTo page: Int)
 }
 

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallAccessoryViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallAccessoryViewController.swift
@@ -20,7 +20,7 @@ import Foundation
 import UIKit
 import WireDataModel
 
-protocol CallAccessoryViewControllerDelegate: class {
+protocol CallAccessoryViewControllerDelegate: AnyObject {
     func callAccessoryViewControllerDidSelectShowMore(viewController: CallAccessoryViewController)
 }
 

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoRootViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoRootViewController.swift
@@ -21,7 +21,7 @@ import UIKit
 import SafariServices
 import WireDataModel
 
-protocol CallInfoRootViewControllerDelegate: class {
+protocol CallInfoRootViewControllerDelegate: AnyObject {
     func infoRootViewController(_ viewController: CallInfoRootViewController, perform action: CallAction)
     func infoRootViewController(_ viewController: CallInfoRootViewController, contextDidChange context: CallInfoRootViewController.Context)
 }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoViewController.swift
@@ -20,7 +20,7 @@ import Foundation
 import UIKit
 import WireSyncEngine
 
-protocol CallInfoViewControllerDelegate: class {
+protocol CallInfoViewControllerDelegate: AnyObject {
     func infoViewController(_ viewController: CallInfoViewController, perform action: CallAction)
 }
 

--- a/Wire-iOS/Sources/UserInterface/Calling/CallParticipantsListView/CallParticipantsListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallParticipantsListView/CallParticipantsListViewController.swift
@@ -20,7 +20,7 @@ import Foundation
 import UIKit
 import WireDataModel
 
-protocol CallParticipantsListViewControllerDelegate: class {
+protocol CallParticipantsListViewControllerDelegate: AnyObject {
     func callParticipantsListViewControllerDidSelectShowMore(viewController: CallParticipantsListViewController)
 }
 

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -20,7 +20,7 @@ import UIKit
 import WireSyncEngine
 import avs
 
-protocol CallViewControllerDelegate: class {
+protocol CallViewControllerDelegate: AnyObject {
     func callViewControllerDidDisappear(_ callController: CallViewController,
                                         for conversation: ZMConversation?)
 }

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionCell.swift
@@ -21,11 +21,11 @@ import UIKit
 import WireSyncEngine
 import WireCommonComponents
 
-protocol CollectionCellDelegate: class {
+protocol CollectionCellDelegate: AnyObject {
     func collectionCell(_ cell: CollectionCell, performAction: MessageAction)
 }
 
-protocol CollectionCellMessageChangeDelegate: class {
+protocol CollectionCellMessageChangeDelegate: AnyObject {
     func messageDidChange(_ cell: CollectionCell, changeInfo: MessageChangeInfo)
 }
 

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
@@ -19,7 +19,7 @@
 import UIKit
 import WireSyncEngine
 
-protocol CollectionsViewControllerDelegate: class {
+protocol CollectionsViewControllerDelegate: AnyObject {
     func collectionsViewController(_ viewController: CollectionsViewController, performAction: MessageAction, onMessage: ZMConversationMessage)
 }
 

--- a/Wire-iOS/Sources/UserInterface/Company Login/CompanyLoginController.swift
+++ b/Wire-iOS/Sources/UserInterface/Company Login/CompanyLoginController.swift
@@ -22,7 +22,7 @@ import UIKit
 import WireTransport
 import WireSyncEngine
 
-protocol CompanyLoginControllerDelegate: class {
+protocol CompanyLoginControllerDelegate: AnyObject {
 
     /// The `CompanyLoginController` will never present any alerts on its own and will
     /// always ask its delegate to handle the actual presentation of the alerts.

--- a/Wire-iOS/Sources/UserInterface/Components/CharacterInputField.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/CharacterInputField.swift
@@ -25,7 +25,7 @@ protocol CharacterInputFieldDelegate: AnyObject {
     func didFillInput(inputField: CharacterInputField, text: String)
 }
 
-protocol TextContainer: class {
+protocol TextContainer: AnyObject {
     var text: String? { get set }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Components/CharacterInputField.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/CharacterInputField.swift
@@ -19,7 +19,7 @@
 import Foundation
 import Cartography
 
-protocol CharacterInputFieldDelegate: class {
+protocol CharacterInputFieldDelegate: AnyObject {
     func shouldAcceptChanges(_ inputField: CharacterInputField) -> Bool
     func didChangeText(_ inputField: CharacterInputField, to: String)
     func didFillInput(inputField: CharacterInputField, text: String)

--- a/Wire-iOS/Sources/UserInterface/Components/CollectionLayouts/VerticalColumnCollectionViewLayout.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/CollectionLayouts/VerticalColumnCollectionViewLayout.swift
@@ -18,7 +18,7 @@
 
 import UIKit
 
-protocol VerticalColumnCollectionViewLayoutDelegate: class {
+protocol VerticalColumnCollectionViewLayoutDelegate: AnyObject {
     func collectionView(_ collectionView: UICollectionView, sizeOfItemAt indexPath: IndexPath) -> CGSize
 }
 

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/CallQualityController/CallQualityViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/CallQualityController/CallQualityViewController.swift
@@ -20,7 +20,7 @@ import Foundation
 import Cartography
 import UIKit
 
-protocol CallQualityViewControllerDelegate: class {
+protocol CallQualityViewControllerDelegate: AnyObject {
     func callQualityControllerDidFinishWithoutScore(_ controller: CallQualityViewController)
     func callQualityController(_ controller: CallQualityViewController, didSelect score: Int)
 }

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/SplitViewController.swift
@@ -34,12 +34,12 @@ enum SplitViewControllerLayoutSize {
     case regularLandscape
 }
 
-protocol SplitLayoutObservable: class {
+protocol SplitLayoutObservable: AnyObject {
     var layoutSize: SplitViewControllerLayoutSize { get }
     var leftViewControllerWidth: CGFloat { get }
 }
 
-protocol SplitViewControllerDelegate: class {
+protocol SplitViewControllerDelegate: AnyObject {
     func splitViewControllerShouldMoveLeftViewController(_ splitViewController: SplitViewController) -> Bool
 }
 

--- a/Wire-iOS/Sources/UserInterface/Components/Giphy/GiphySearchViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Giphy/GiphySearchViewController.swift
@@ -22,7 +22,7 @@ import FLAnimatedImage
 import WireCommonComponents
 import WireDataModel
 
-protocol GiphySearchViewControllerDelegate: class {
+protocol GiphySearchViewControllerDelegate: AnyObject {
     func giphySearchViewController(_ giphySearchViewController: GiphySearchViewController, didSelectImageData imageData: Data, searchTerm: String)
 }
 

--- a/Wire-iOS/Sources/UserInterface/Components/Loading/LoadingSpinner.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Loading/LoadingSpinner.swift
@@ -21,7 +21,7 @@ import UIKit
 typealias SpinnerCapableViewController = UIViewController & SpinnerCapable
 typealias SpinnerCompletion = Completion
 
-protocol SpinnerCapable: class {
+protocol SpinnerCapable: AnyObject {
     var dismissSpinner: SpinnerCompletion? { get set }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Components/MediaPlayerDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/MediaPlayerDelegate.swift
@@ -17,6 +17,6 @@
 
 import Foundation
 
-protocol MediaPlayerDelegate: class {
+protocol MediaPlayerDelegate: AnyObject {
     func mediaPlayer(_ mediaPlayer: MediaPlayer, didChangeTo state: MediaPlayerState)
 }

--- a/Wire-iOS/Sources/UserInterface/Components/NetworkStatus/NetworkStatusView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/NetworkStatus/NetworkStatusView.swift
@@ -25,7 +25,7 @@ enum NetworkStatusViewState {
     case offlineExpanded
 }
 
-protocol NetworkStatusViewDelegate: class {
+protocol NetworkStatusViewDelegate: AnyObject {
 
     /// Set this var to true after viewDidAppear. This flag prevents first layout animation when the UIViewController is created but not yet appear, if didChangeHeight called with animated = true.
     var shouldAnimateNetworkStatusView: Bool { get set }

--- a/Wire-iOS/Sources/UserInterface/Components/NetworkStatus/NetworkStatusViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/NetworkStatus/NetworkStatusViewController.swift
@@ -22,7 +22,7 @@ import WireSyncEngine
 
 typealias NetworkStatusBarDelegate = NetworkStatusViewControllerDelegate & NetworkStatusViewDelegate
 
-protocol NetworkStatusViewControllerDelegate: class {
+protocol NetworkStatusViewControllerDelegate: AnyObject {
 
     ///  return false if NetworkStatusViewController will not disapper in iPad regular mode with specific orientation.
     ///

--- a/Wire-iOS/Sources/UserInterface/Components/RoundedView/RoundedViewProtocol.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/RoundedView/RoundedViewProtocol.swift
@@ -25,7 +25,7 @@ import UIKit
  * You need to override `+ (Class *)layerClass` on `UIView` before conforming to this protocol.
  */
 
-protocol RoundedViewProtocol: class {
+protocol RoundedViewProtocol: AnyObject {
     var layer: CALayer { get }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Components/TabBar/TabBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/TabBar/TabBar.swift
@@ -18,7 +18,7 @@
 
 import UIKit
 
-protocol TabBarDelegate: class {
+protocol TabBarDelegate: AnyObject {
     func tabBar(_ tabBar: TabBar, didSelectItemAt index: Int)
 }
 

--- a/Wire-iOS/Sources/UserInterface/Components/TabBar/TabBarController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/TabBar/TabBarController.swift
@@ -18,7 +18,7 @@
 
 import UIKit
 
-protocol TabBarControllerDelegate: class {
+protocol TabBarControllerDelegate: AnyObject {
     func tabBarController(_ controller: TabBarController, tabBarDidSelectIndex: Int)
 }
 

--- a/Wire-iOS/Sources/UserInterface/Components/TextView/TextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/TextView/TextView.swift
@@ -23,7 +23,7 @@ import WireCommonComponents
 
 private let zmLog = ZMSLog(tag: "TextView")
 
-protocol InformalTextViewDelegate: class {
+protocol InformalTextViewDelegate: AnyObject {
     func textView(_ textView: UITextView, hasImageToPaste image: MediaAsset)
     func textView(_ textView: UITextView, firstResponderChanged resigned: Bool)
 }

--- a/Wire-iOS/Sources/UserInterface/Components/Views/BreathLoadingBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/BreathLoadingBar.swift
@@ -19,7 +19,7 @@
 import UIKit
 import QuartzCore
 
-protocol BreathLoadingBarDelegate: class {
+protocol BreathLoadingBarDelegate: AnyObject {
     func animationDidStarted()
     func animationDidStopped()
 }

--- a/Wire-iOS/Sources/UserInterface/Components/Views/EmailPasswordTextField.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/EmailPasswordTextField.swift
@@ -18,7 +18,7 @@
 
 import UIKit
 
-protocol EmailPasswordTextFieldDelegate: class {
+protocol EmailPasswordTextFieldDelegate: AnyObject {
     func textFieldDidUpdateText(_ textField: EmailPasswordTextField)
     func textFieldDidSubmitWithValidationError(_ textField: EmailPasswordTextField)
     func textField(_ textField: EmailPasswordTextField, didConfirmCredentials credentials: (String, String))

--- a/Wire-iOS/Sources/UserInterface/Components/Views/LinkInteractionTextView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/LinkInteractionTextView.swift
@@ -19,7 +19,7 @@
 import UIKit
 import WireDataModel
 
-protocol TextViewInteractionDelegate: class {
+protocol TextViewInteractionDelegate: AnyObject {
     func textView(_ textView: LinkInteractionTextView, open url: URL) -> Bool
     func textViewDidLongPress(_ textView: LinkInteractionTextView)
 }

--- a/Wire-iOS/Sources/UserInterface/Components/Views/PopUpIconButton.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/PopUpIconButton.swift
@@ -23,7 +23,7 @@ enum PopUpIconButtonExpandDirection {
     case left, right
 }
 
-protocol PopUpIconButtonDelegate: class {
+protocol PopUpIconButtonDelegate: AnyObject {
     func popUpIconButton(_ button: PopUpIconButton, didSelectIcon icon: StyleKitIcon)
 }
 

--- a/Wire-iOS/Sources/UserInterface/Components/Views/SeparatorViewProtocol.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/SeparatorViewProtocol.swift
@@ -25,7 +25,7 @@ protocol ViewWithContentView {
 extension UICollectionViewCell: ViewWithContentView {}
 extension UITableViewCell: ViewWithContentView {}
 
-protocol SeparatorViewProtocol: class {
+protocol SeparatorViewProtocol: AnyObject {
     var separator: UIView { get }
     var separatorLeadingAnchor: NSLayoutXAxisAnchor { get }
     var separatorInsetConstraint: NSLayoutConstraint! { get set }

--- a/Wire-iOS/Sources/UserInterface/Components/Views/TextSearchInputView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/TextSearchInputView.swift
@@ -22,7 +22,7 @@ import UIKit
 import WireCommonComponents
 import WireSystem
 
-protocol TextSearchInputViewDelegate: class {
+protocol TextSearchInputViewDelegate: AnyObject {
     func searchView(_ searchView: TextSearchInputView, didChangeQueryTo: String)
     func searchViewShouldReturn(_ searchView: TextSearchInputView) -> Bool
 }

--- a/Wire-iOS/Sources/UserInterface/Components/Views/UserCellSubtitleProtocol.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/UserCellSubtitleProtocol.swift
@@ -19,7 +19,7 @@
 import Foundation
 import WireDataModel
 
-protocol UserCellSubtitleProtocol: class {
+protocol UserCellSubtitleProtocol: AnyObject {
     func subtitle(forRegularUser user: UserType?) -> NSAttributedString?
 
     static var correlationFormatters: [ColorSchemeVariant: AddressBookCorrelationFormatter] { get set }

--- a/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsDataSource.swift
+++ b/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsDataSource.swift
@@ -20,7 +20,7 @@ import Foundation
 import WireDataModel
 import WireSyncEngine
 
-protocol ContactsDataSourceDelegate: class {
+protocol ContactsDataSourceDelegate: AnyObject {
 
     func dataSource(_ dataSource: ContactsDataSource, cellFor user: UserType, at indexPath: IndexPath) -> UITableViewCell
     func dataSource(_ dataSource: ContactsDataSource, didReceiveSearchResult newUser: [UserType])

--- a/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationOptionsViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationOptionsViewModel.swift
@@ -19,7 +19,7 @@
 import UIKit
 import WireUtilities
 
-protocol ConversationOptionsViewModelConfiguration: class {
+protocol ConversationOptionsViewModelConfiguration: AnyObject {
     var title: String { get }
     var allowGuests: Bool { get }
     var isCodeEnabled: Bool { get }
@@ -31,7 +31,7 @@ protocol ConversationOptionsViewModelConfiguration: class {
     func deleteLink(completion: @escaping (VoidResult) -> Void)
 }
 
-protocol ConversationOptionsViewModelDelegate: class {
+protocol ConversationOptionsViewModelDelegate: AnyObject {
     func viewModel(_ viewModel: ConversationOptionsViewModel, didUpdateState state: ConversationOptionsViewModel.State)
     func viewModel(_ viewModel: ConversationOptionsViewModel, didReceiveError error: Error)
     func viewModel(_ viewModel: ConversationOptionsViewModel, sourceView: UIView?, confirmRemovingGuests completion: @escaping (Bool) -> Void) -> UIAlertController?

--- a/Wire-iOS/Sources/UserInterface/Conversation/ArchivedListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ArchivedListViewController.swift
@@ -21,7 +21,7 @@ import WireDataModel
 
 // MARK: ArchivedListViewControllerDelegate
 
-protocol ArchivedListViewControllerDelegate: class {
+protocol ArchivedListViewControllerDelegate: AnyObject {
     func archivedListViewControllerWantsToDismiss(_ controller: ArchivedListViewController)
     func archivedListViewController(_ controller: ArchivedListViewController, didSelectConversation conversation: ZMConversation)
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
@@ -34,7 +34,7 @@ protocol ConversationMessageCellDelegate: MessageActionResponder {
  * A generic view that displays conversation contents.
  */
 
-protocol ConversationMessageCell: class {
+protocol ConversationMessageCell: AnyObject {
     /// The object that contains the configuration of the view.
     associatedtype Configuration
 
@@ -103,7 +103,7 @@ extension ConversationMessageCell {
  * the view type it declares as the contents of the cell.
  */
 
-protocol ConversationMessageCellDescription: class {
+protocol ConversationMessageCellDescription: AnyObject {
     /// The view that will be displayed for the cell.
     associatedtype View: ConversationMessageCell & UIView
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCellTableViewAdapter.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCellTableViewAdapter.swift
@@ -20,7 +20,7 @@ import Foundation
 import WireDataModel
 import UIKit
 
-protocol ConversationMessageCellMenuPresenter: class {
+protocol ConversationMessageCellMenuPresenter: AnyObject {
     func showMenu()
 }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
@@ -30,7 +30,7 @@ struct ConversationMessageContext: Equatable {
     let spacing: Float
 }
 
-protocol ConversationMessageSectionControllerDelegate: class {
+protocol ConversationMessageSectionControllerDelegate: AnyObject {
     func messageSectionController(_ controller: ConversationMessageSectionController, didRequestRefreshForMessage message: ZMConversationMessage)
 }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/TransferView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/TransferView.swift
@@ -19,7 +19,7 @@
 import Foundation
 import WireDataModel
 
-protocol TransferViewDelegate: class {
+protocol TransferViewDelegate: AnyObject {
     func transferView(_ view: TransferView, didSelect: MessageAction)
 }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/MessageActionResponder.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/MessageActionResponder.swift
@@ -19,7 +19,7 @@
 import Foundation
 import WireDataModel
 
-protocol MessageActionResponder: class {
+protocol MessageActionResponder: AnyObject {
     /// perform an action for the message
     ///
     /// - Parameters:

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/LinkViewDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/LinkViewDelegate.swift
@@ -20,7 +20,7 @@ import UIKit
 
 typealias ContextMenuLinkViewDelegate = ContextMenuDelegate & LinkViewDelegate
 
-protocol LinkViewDelegate: class {
+protocol LinkViewDelegate: AnyObject {
     var url: URL? { get }
     func linkViewWantsToOpenURL(_ view: UIView)
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
@@ -21,7 +21,7 @@ import WireSyncEngine
 import WireDataModel
 
 /// Observes events from the message toolbox.
-protocol MessageToolboxViewDelegate: class {
+protocol MessageToolboxViewDelegate: AnyObject {
     func messageToolboxDidRequestOpeningDetails(_ messageToolboxView: MessageToolboxView, preferredDisplayMode: MessageDetailsDisplayMode)
     func messageToolboxViewDidSelectResend(_ messageToolboxView: MessageToolboxView)
     func messageToolboxViewDidSelectDelete(_ sender: UIView?)

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/SavableImage.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/SavableImage.swift
@@ -30,12 +30,12 @@ protocol PhotoLibraryProtocol {
 
 extension PHPhotoLibrary: PhotoLibraryProtocol {}
 
-protocol AssetChangeRequestProtocol: class {
+protocol AssetChangeRequestProtocol: AnyObject {
     @discardableResult static func creationRequestForAsset(from image: UIImage) -> Self
     @discardableResult static func creationRequestForAssetFromImage(atFileURL fileURL: URL) -> Self?
 }
 
-protocol AssetCreationRequestProtocol: class {
+protocol AssetCreationRequestProtocol: AnyObject {
     static func forAsset() -> Self
     func addResource(with type: PHAssetResourceType,
                      data: Data,

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ContextMenuDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ContextMenuDelegate.swift
@@ -18,7 +18,7 @@
 import UIKit
 import WireDataModel
 
-protocol ContextMenuDelegate: class {
+protocol ContextMenuDelegate: AnyObject {
     var delegate: ConversationMessageCellDelegate? { get }
     var message: ZMConversationMessage? { get }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewControllerDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewControllerDelegate.swift
@@ -19,7 +19,7 @@ import Foundation
 import WireDataModel
 import UIKit
 
-protocol ConversationContentViewControllerDelegate: class {
+protocol ConversationContentViewControllerDelegate: AnyObject {
 
     func conversationContentViewController(_ contentViewController: ConversationContentViewController, willDisplayActiveMediaPlayerFor message: ZMConversationMessage?)
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationListBottomBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationListBottomBar.swift
@@ -23,7 +23,7 @@ enum ConversationListButtonType {
     case archive, startUI, list, folder
 }
 
-protocol ConversationListBottomBarControllerDelegate: class {
+protocol ConversationListBottomBarControllerDelegate: AnyObject {
     func conversationListBottomBar(_ bar: ConversationListBottomBarController, didTapButtonWithType buttonType: ConversationListButtonType)
 }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
@@ -62,7 +62,7 @@ final class ConversationCreationValues {
     }
 }
 
-protocol ConversationCreationControllerDelegate: class {
+protocol ConversationCreationControllerDelegate: AnyObject {
 
     func conversationCreationController(_ controller: ConversationCreationController,
                                         didSelectName name: String,

--- a/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
@@ -20,7 +20,7 @@ import Foundation
 import UIKit
 import WireDataModel
 
-protocol ConversationCreationValuesConfigurable: class {
+protocol ConversationCreationValuesConfigurable: AnyObject {
     func configure(with values: ConversationCreationValues)
 }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Create/SimpleTextField.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Create/SimpleTextField.swift
@@ -19,7 +19,7 @@
 import Foundation
 import UIKit
 
-protocol SimpleTextFieldDelegate: class {
+protocol SimpleTextFieldDelegate: AnyObject {
     func textField(_ textField: SimpleTextField, valueChanged value: SimpleTextField.Value)
     func textFieldReturnPressed(_ textField: SimpleTextField)
     func textFieldDidEndEditing(_ textField: SimpleTextField)

--- a/Wire-iOS/Sources/UserInterface/Conversation/Create/SimpleTextFieldValidator.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Create/SimpleTextFieldValidator.swift
@@ -20,7 +20,7 @@ import Foundation
 import WireUtilities
 import UIKit
 
-protocol SimpleTextFieldValidatorDelegate: class {
+protocol SimpleTextFieldValidatorDelegate: AnyObject {
     func textFieldValueChanged(_ value: String?)
     func textFieldValueSubmitted(_ value: String)
     func textFieldDidEndEditing()

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioEffectsPickerViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioEffectsPickerViewController.swift
@@ -21,7 +21,7 @@ import UIKit
 import avs
 import WireDataModel
 
-protocol AudioEffectsPickerDelegate: class {
+protocol AudioEffectsPickerDelegate: AnyObject {
     func audioEffectsPickerDidPickEffect(_ picker: AudioEffectsPickerViewController, effect: AVSAudioEffectType, resultFilePath: String)
 }
 
@@ -341,7 +341,7 @@ extension AudioEffectsPickerViewController: AudioPlayerControllerDelegate {
 
 }
 
-private protocol AudioPlayerControllerDelegate: class {
+private protocol AudioPlayerControllerDelegate: AnyObject {
 
     func audioPlayerControllerDidFinishPlaying()
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordViewController.swift
@@ -26,11 +26,11 @@ import WireCommonComponents
 
 private let zmLog = ZMSLog(tag: "UI")
 
-protocol AudioRecordBaseViewController: class {
+protocol AudioRecordBaseViewController: AnyObject {
     var delegate: AudioRecordViewControllerDelegate? { get set }
 }
 
-protocol AudioRecordViewControllerDelegate: class {
+protocol AudioRecordViewControllerDelegate: AnyObject {
     func audioRecordViewControllerDidCancel(_ audioRecordViewController: AudioRecordBaseViewController)
     func audioRecordViewControllerDidStartRecording(_ audioRecordViewController: AudioRecordBaseViewController)
     func audioRecordViewControllerWantsToSendAudio(_ audioRecordViewController: AudioRecordBaseViewController, recordingURL: URL, duration: TimeInterval, filter: AVSAudioEffectType)

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecorder.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecorder.swift
@@ -65,7 +65,7 @@ public enum RecordingError: Error {
     case toMaxDuration, toMaxSize
 }
 
-protocol AudioRecorderType: class {
+protocol AudioRecorderType: AnyObject {
     var format: AudioRecorderFormat { get }
     var state: AudioRecorderState { get set }
     var fileURL: URL? { get }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/AssetLibrary.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/AssetLibrary.swift
@@ -19,7 +19,7 @@
 import Foundation
 import Photos
 
-protocol AssetLibraryDelegate: class {
+protocol AssetLibraryDelegate: AnyObject {
     func assetLibraryDidChange(_ library: AssetLibrary)
 }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraCell.swift
@@ -19,7 +19,7 @@
 import Foundation
 import avs
 
-protocol CameraCellDelegate: class {
+protocol CameraCellDelegate: AnyObject {
     func cameraCellWantsToOpenFullCamera(_ cameraCell: CameraCell)
     func cameraCell(_ cameraCell: CameraCell, didPickImageData: Data)
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/CameraKeyboardViewController.swift
@@ -23,7 +23,7 @@ import WireSyncEngine
 
 private let zmLog = ZMSLog(tag: "UI")
 
-protocol CameraKeyboardViewControllerDelegate: class {
+protocol CameraKeyboardViewControllerDelegate: AnyObject {
     func cameraKeyboardViewController(_ controller: CameraKeyboardViewController, didSelectVideo: URL, duration: TimeInterval)
     func cameraKeyboardViewController(_ controller: CameraKeyboardViewController,
                                       didSelectImageData: Data,

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewControllerDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewControllerDelegate.swift
@@ -17,7 +17,7 @@
 
 import WireDataModel
 
-protocol ConversationInputBarViewControllerDelegate: class {
+protocol ConversationInputBarViewControllerDelegate: AnyObject {
     func conversationInputBarViewControllerDidComposeText(text: String, mentions: [Mention], replyingTo message: ZMConversationMessage?)
     func conversationInputBarViewControllerShouldBeginEditing(_ controller: ConversationInputBarViewController) -> Bool
     func conversationInputBarViewControllerShouldEndEditing(_ controller: ConversationInputBarViewController) -> Bool

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/Emoji/EmojiKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/Emoji/EmojiKeyboardViewController.swift
@@ -19,7 +19,7 @@
 import UIKit
 import Cartography
 
-protocol EmojiKeyboardViewControllerDelegate: class {
+protocol EmojiKeyboardViewControllerDelegate: AnyObject {
     func emojiKeyboardViewController(_ viewController: EmojiKeyboardViewController, didSelectEmoji emoji: String)
     func emojiKeyboardViewControllerDeleteTapped(_ viewController: EmojiKeyboardViewController)
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/Emoji/EmojiSectionViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/Emoji/EmojiSectionViewController.swift
@@ -20,7 +20,7 @@ import Foundation
 import UIKit
 import WireCommonComponents
 
-protocol EmojiSectionViewControllerDelegate: class {
+protocol EmojiSectionViewControllerDelegate: AnyObject {
     func sectionViewController(_ viewController: EmojiSectionViewController, didSelect: EmojiSectionType, scrolling: Bool)
 }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/EphemeralKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/EphemeralKeyboardViewController.swift
@@ -20,7 +20,7 @@ import UIKit
 import WireCommonComponents
 import WireDataModel
 
-protocol EphemeralKeyboardViewControllerDelegate: class {
+protocol EphemeralKeyboardViewControllerDelegate: AnyObject {
     func ephemeralKeyboardWantsToBeDismissed(_ keyboard: EphemeralKeyboardViewController)
 
     func ephemeralKeyboard(

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarEditView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarEditView.swift
@@ -23,7 +23,7 @@ enum EditButtonType {
     case undo, confirm, cancel
 }
 
-protocol InputBarEditViewDelegate: class {
+protocol InputBarEditViewDelegate: AnyObject {
     func inputBarEditView(_ editView: InputBarEditView, didTapButtonWithType buttonType: EditButtonType)
     func inputBarEditViewDidLongPressUndoButton(_ editView: InputBarEditView)
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InvisibleInputAccessoryView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InvisibleInputAccessoryView.swift
@@ -21,7 +21,7 @@ import UIKit
 // Because the system manages the input accessory view lifecycle and positioning, we have to monitor what
 // is being done to us and report back
 
-protocol InvisibleInputAccessoryViewDelegate: class {
+protocol InvisibleInputAccessoryViewDelegate: AnyObject {
     func invisibleInputAccessoryView(_ invisibleInputAccessoryView: InvisibleInputAccessoryView, superviewFrameChanged frame: CGRect?)
 }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ReplyComposingView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ReplyComposingView.swift
@@ -19,7 +19,7 @@
 import WireSyncEngine
 import UIKit
 
-protocol ReplyComposingViewDelegate: class {
+protocol ReplyComposingViewDelegate: AnyObject {
     func composingViewDidCancel(composingView: ReplyComposingView)
     func composingViewWantsToShowMessage(composingView: ReplyComposingView, message: ZMConversationMessage)
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/UIPopoverPresentationController+config.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/UIPopoverPresentationController+config.swift
@@ -19,7 +19,7 @@
 import Foundation
 import UIKit
 
-protocol PopoverPresenter: class {
+protocol PopoverPresenter: AnyObject {
 
     /// The presenting popover. Its frame should be updated when the orientation or screen size changes.
     var presentedPopover: UIPopoverPresentationController? {get set}

--- a/Wire-iOS/Sources/UserInterface/Conversation/Mentions/UserSearchResultsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Mentions/UserSearchResultsViewController.swift
@@ -27,11 +27,11 @@ protocol Dismissable: AnyObject {
     func dismiss()
 }
 
-protocol KeyboardCollapseObserver: class {
+protocol KeyboardCollapseObserver: AnyObject {
     var isKeyboardCollapsed: Bool { get }
 }
 
-protocol UserList: class {
+protocol UserList: AnyObject {
     var users: [UserType] { get set }
     var selectedUser: UserType? { get }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Mentions/UserSearchResultsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Mentions/UserSearchResultsViewController.swift
@@ -19,11 +19,11 @@
 import UIKit
 import WireDataModel
 
-protocol UserSearchResultsViewControllerDelegate: class {
+protocol UserSearchResultsViewControllerDelegate: AnyObject {
     func didSelect(user: UserType)
 }
 
-protocol Dismissable: class {
+protocol Dismissable: AnyObject {
     func dismiss()
 }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsDataSource.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsDataSource.swift
@@ -29,7 +29,7 @@ enum MessageDetailsDisplayMode: Int {
  * An object that observes changes in the message data source.
  */
 
-protocol MessageDetailsDataSourceObserver: class {
+protocol MessageDetailsDataSourceObserver: AnyObject {
     /// Called when the message details change.
     func dataSourceDidChange(_ dataSource: MessageDetailsDataSource)
 

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ArchivedListViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ArchivedListViewModel.swift
@@ -20,7 +20,7 @@ import Foundation
 import WireDataModel
 import WireSyncEngine
 
-protocol ArchivedListViewModelDelegate: class {
+protocol ArchivedListViewModelDelegate: AnyObject {
     func archivedListViewModel(_ model: ArchivedListViewModel, didUpdateArchivedConversationsWithChange change: ConversationListChangeInfo, applyChangesClosure: @escaping () -> Void)
     func archivedListViewModel(_ model: ArchivedListViewModel, didUpdateConversationWithChange change: ConversationChangeInfo)
 }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/Container/ViewModel/ConversationListViewControllerViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/Container/ViewModel/ConversationListViewControllerViewModel.swift
@@ -24,7 +24,7 @@ import WireCommonComponents
 typealias Completion = () -> Void
 typealias ResultHandler = (_ succeeded: Bool) -> Void
 
-protocol ConversationListContainerViewModelDelegate: class {
+protocol ConversationListContainerViewModelDelegate: AnyObject {
     init(viewModel: ConversationListViewController.ViewModel)
 
     func updateBottomBarSeparatorVisibility(with controller: ConversationListContentController)

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConnectRequestsCell.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConnectRequestsCell.swift
@@ -18,7 +18,7 @@
 
 import WireSyncEngine
 
-protocol SectionListCellType: class {
+protocol SectionListCellType: AnyObject {
     var sectionName: String? { get set }
     var cellIdentifier: String? { get set }
 }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListCellDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListCellDelegate.swift
@@ -17,7 +17,7 @@
 
 import Foundation
 
-protocol ConversationListCellDelegate: class {
+protocol ConversationListCellDelegate: AnyObject {
     func conversationListCellOverscrolled(_ cell: ConversationListCell)
     func conversationListCellJoinCallButtonTapped(_ cell: ConversationListCell)
 

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModelDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModelDelegate.swift
@@ -26,7 +26,7 @@ extension ZMConversation: ConversationListItem {}
 // Placeholder for conversation requests item
 final class ConversationListConnectRequestsItem: NSObject, ConversationListItem {}
 
-protocol ConversationListViewModelDelegate: class {
+protocol ConversationListViewModelDelegate: AnyObject {
     func listViewModel(_ model: ConversationListViewModel?, didSelectItem item: ConversationListItem?)
 
     func listViewModelShouldBeReloaded()
@@ -44,6 +44,6 @@ protocol ConversationListViewModelDelegate: class {
     )
 }
 
-protocol ConversationListViewModelRestorationDelegate: class {
+protocol ConversationListViewModelRestorationDelegate: AnyObject {
     func listViewModel(_ model: ConversationListViewModel?, didRestoreFolderEnabled enabled: Bool)
 }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentDelegate.swift
@@ -17,7 +17,7 @@
 
 import WireDataModel
 
-protocol ConversationListContentDelegate: class {
+protocol ConversationListContentDelegate: AnyObject {
     func conversationList(_ controller: ConversationListContentController?, didSelect conversation: ZMConversation?, focusOnView focus: Bool)
     /// This is called after a delete when there is an item to select
     func conversationList(_ controller: ConversationListContentController?, willSelectIndexPathAfterSelectionDeleted conv: IndexPath?)

--- a/Wire-iOS/Sources/UserInterface/ConversationList/UserNameTakeOverViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/UserNameTakeOverViewController.swift
@@ -18,7 +18,7 @@
 
 import UIKit
 
-protocol UserNameTakeOverViewControllerDelegate: class {
+protocol UserNameTakeOverViewControllerDelegate: AnyObject {
     func takeOverViewController(_ viewController: UserNameTakeOverViewController, didPerformAction action: UserNameTakeOverViewControllerAction)
 }
 

--- a/Wire-iOS/Sources/UserInterface/CustomAppLock/Setup/PasscodeSetupInteractor.swift
+++ b/Wire-iOS/Sources/UserInterface/CustomAppLock/Setup/PasscodeSetupInteractor.swift
@@ -21,12 +21,12 @@ import WireCommonComponents
 import WireTransport
 import WireSyncEngine
 
-protocol PasscodeSetupInteractorInput: class {
+protocol PasscodeSetupInteractorInput: AnyObject {
     func validate(error: TextFieldValidator.ValidationError?)
     func storePasscode(passcode: String) throws
 }
 
-protocol PasscodeSetupInteractorOutput: class {
+protocol PasscodeSetupInteractorOutput: AnyObject {
     func passcodeValidated(result: PasswordValidationResult)
 }
 

--- a/Wire-iOS/Sources/UserInterface/CustomAppLock/Setup/PasscodeSetupViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/CustomAppLock/Setup/PasscodeSetupViewController.swift
@@ -20,7 +20,7 @@ import UIKit
 import WireCommonComponents
 import Down
 
-protocol PasscodeSetupUserInterface: class {
+protocol PasscodeSetupUserInterface: AnyObject {
     var createButtonEnabled: Bool { get set }
     func setValidationLabelsState(errorReason: PasscodeError, passed: Bool)
 }

--- a/Wire-iOS/Sources/UserInterface/CustomAppLock/Setup/PasscodeSetupViewControllerDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/CustomAppLock/Setup/PasscodeSetupViewControllerDelegate.swift
@@ -17,7 +17,7 @@
 
 import Foundation
 
-protocol PasscodeSetupViewControllerDelegate: class {
+protocol PasscodeSetupViewControllerDelegate: AnyObject {
 
     func passcodeSetupControllerDidFinish()
     func passcodeSetupControllerWasDismissed()

--- a/Wire-iOS/Sources/UserInterface/CustomAppLock/Unlock/UnlockViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/CustomAppLock/Unlock/UnlockViewController.swift
@@ -21,7 +21,7 @@ import WireCommonComponents
 import WireDataModel
 import WireSyncEngine
 
-protocol UnlockViewControllerDelegate: class {
+protocol UnlockViewControllerDelegate: AnyObject {
 
     func unlockViewControllerDidUnlock()
 

--- a/Wire-iOS/Sources/UserInterface/CustomAppLock/Warning/AppLockChangeWarningViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/CustomAppLock/Warning/AppLockChangeWarningViewController.swift
@@ -21,7 +21,7 @@ import UIKit
 import WireSyncEngine
 import WireCommonComponents
 
-protocol AppLockChangeWarningViewControllerDelegate: class {
+protocol AppLockChangeWarningViewControllerDelegate: AnyObject {
 
     func appLockChangeWarningViewControllerDidDismiss()
 

--- a/Wire-iOS/Sources/UserInterface/CustomAppLock/WipeDatabase/WipeDatabaseInteractor.swift
+++ b/Wire-iOS/Sources/UserInterface/CustomAppLock/WipeDatabase/WipeDatabaseInteractor.swift
@@ -22,7 +22,7 @@ protocol WipeDatabaseInteractorInput: AnyObject {
     func deleteAccount()
 }
 
-protocol WipeDatabaseInteractorOutput: class {
+protocol WipeDatabaseInteractorOutput: AnyObject {
 }
 
 final class WipeDatabaseInteractor {

--- a/Wire-iOS/Sources/UserInterface/CustomAppLock/WipeDatabase/WipeDatabaseInteractor.swift
+++ b/Wire-iOS/Sources/UserInterface/CustomAppLock/WipeDatabase/WipeDatabaseInteractor.swift
@@ -18,7 +18,7 @@
 import Foundation
 import WireSyncEngine
 
-protocol WipeDatabaseInteractorInput: class {
+protocol WipeDatabaseInteractorInput: AnyObject {
     func deleteAccount()
 }
 

--- a/Wire-iOS/Sources/UserInterface/CustomAppLock/WipeDatabase/WipeDatabaseViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/CustomAppLock/WipeDatabase/WipeDatabaseViewController.swift
@@ -17,7 +17,7 @@
 
 import UIKit
 
-protocol WipeDatabaseUserInterface: class {
+protocol WipeDatabaseUserInterface: AnyObject {
     func presentConfirmAlert()
 }
 

--- a/Wire-iOS/Sources/UserInterface/Folders/FolderCreationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Folders/FolderCreationController.swift
@@ -20,11 +20,11 @@ import Foundation
 import UIKit
 import WireSyncEngine
 
-protocol FolderCreationValuesConfigurable: class {
+protocol FolderCreationValuesConfigurable: AnyObject {
     func configure(with name: String)
 }
 
-protocol FolderCreationControllerDelegate: class {
+protocol FolderCreationControllerDelegate: AnyObject {
 
     func folderController(
         _ controller: FolderCreationController,

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsFooterView.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsFooterView.swift
@@ -19,7 +19,7 @@
 import UIKit
 import WireDataModel
 
-protocol GroupDetailsFooterViewDelegate: class {
+protocol GroupDetailsFooterViewDelegate: AnyObject {
     func footerView(_ view: GroupDetailsFooterView, shouldPerformAction action: GroupDetailsFooterView.Action)
 }
 

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/GroupDetailsSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/GroupDetailsSectionController.swift
@@ -20,7 +20,7 @@ import Foundation
 import UIKit
 import WireDataModel
 
-protocol GroupDetailsUserDetailPresenter: class {
+protocol GroupDetailsUserDetailPresenter: AnyObject {
     func presentDetails(for user: UserType)
 }
 

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/GroupOptionsSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/GroupOptionsSectionController.swift
@@ -19,7 +19,7 @@
 import Foundation
 import WireDataModel
 
-protocol GroupOptionsSectionControllerDelegate: class {
+protocol GroupOptionsSectionControllerDelegate: AnyObject {
     func presentTimeoutOptions(animated: Bool)
     func presentGuestOptions(animated: Bool)
     func presentNotificationsOptions(animated: Bool)

--- a/Wire-iOS/Sources/UserInterface/Helpers/PerformClipboardAction.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/PerformClipboardAction.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 
-protocol PerformClipboardAction: class {
+protocol PerformClipboardAction: AnyObject {
     func shouldAllowPerformAction(isText: Bool, isClipboardEnabled: Bool, canFilesBeShared: Bool) -> Bool
 }
 

--- a/Wire-iOS/Sources/UserInterface/Helpers/ViewControllerDismisser.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/ViewControllerDismisser.swift
@@ -18,6 +18,6 @@
 
 import UIKit
 
-protocol ViewControllerDismisser: class {
+protocol ViewControllerDismisser: AnyObject {
     func dismiss(viewController: UIViewController, completion: Completion?)
 }

--- a/Wire-iOS/Sources/UserInterface/LegalHoldDetails/Sections/LegalHoldParticipantsSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/LegalHoldDetails/Sections/LegalHoldParticipantsSectionController.swift
@@ -35,7 +35,7 @@ private struct LegalHoldParticipantsSectionViewModel {
 
 }
 
-protocol LegalHoldParticipantsSectionControllerDelegate: class {
+protocol LegalHoldParticipantsSectionControllerDelegate: AnyObject {
 
     func legalHoldParticipantsSectionWantsToPresentUserProfile(for user: UserType)
 

--- a/Wire-iOS/Sources/UserInterface/Location/LocationSelectionViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Location/LocationSelectionViewController.swift
@@ -22,7 +22,7 @@ import MapKit
 import CoreLocation
 import UIKit
 
-protocol LocationSelectionViewControllerDelegate: class {
+protocol LocationSelectionViewControllerDelegate: AnyObject {
     func locationSelectionViewController(_ viewController: LocationSelectionViewController, didSelectLocationWithData locationData: LocationData)
     func locationSelectionViewControllerDidCancel(_ viewController: LocationSelectionViewController)
 }

--- a/Wire-iOS/Sources/UserInterface/Location/LocationSendViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Location/LocationSendViewController.swift
@@ -19,7 +19,7 @@
 import Cartography
 import UIKit
 
-protocol LocationSendViewControllerDelegate: class {
+protocol LocationSendViewControllerDelegate: AnyObject {
     func locationSendViewControllerSendButtonTapped(_ viewController: LocationSendViewController)
 }
 

--- a/Wire-iOS/Sources/UserInterface/Location/ModalTopBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Location/ModalTopBar.swift
@@ -18,7 +18,7 @@
 
 import UIKit
 
-protocol ModalTopBarDelegate: class {
+protocol ModalTopBarDelegate: AnyObject {
     func modelTopBarWantsToBeDismissed(_ topBar: ModalTopBar)
 }
 

--- a/Wire-iOS/Sources/UserInterface/MarkdownBarView.swift
+++ b/Wire-iOS/Sources/UserInterface/MarkdownBarView.swift
@@ -20,7 +20,7 @@ import UIKit
 import Down
 import WireCommonComponents
 
-protocol MarkdownBarViewDelegate: class {
+protocol MarkdownBarViewDelegate: AnyObject {
     func markdownBarView(_ view: MarkdownBarView, didSelectMarkdown markdown: Markdown, with sender: IconButton)
     func markdownBarView(_ view: MarkdownBarView, didDeselectMarkdown markdown: Markdown, with sender: IconButton)
 }

--- a/Wire-iOS/Sources/UserInterface/Overlay/ActiveCallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/ActiveCallViewController.swift
@@ -24,7 +24,7 @@ import WireSyncEngine
 
 private let zmLog = ZMSLog(tag: "calling")
 
-protocol ActiveCallViewControllerDelegate: class {
+protocol ActiveCallViewControllerDelegate: AnyObject {
     func activeCallViewControllerDidDisappear(_ activeCallViewController: ActiveCallViewController,
                                               for conversation: ZMConversation?)
 }

--- a/Wire-iOS/Sources/UserInterface/Overlay/CallTopOverlayController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/CallTopOverlayController.swift
@@ -22,7 +22,7 @@ import WireDataModel
 import WireSyncEngine
 import avs
 
-protocol CallTopOverlayControllerDelegate: class {
+protocol CallTopOverlayControllerDelegate: AnyObject {
     func voiceChannelTopOverlayWantsToRestoreCall(voiceChannel: VoiceChannel?)
 }
 

--- a/Wire-iOS/Sources/UserInterface/Screen Curtain/ScreenCurtainDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Screen Curtain/ScreenCurtainDelegate.swift
@@ -19,7 +19,7 @@
 import Foundation
 import WireSyncEngine
 
-protocol ScreenCurtainDelegate: class {
+protocol ScreenCurtainDelegate: AnyObject {
 
     /// Whether the screen curtain should be shown when the app
     /// resigns active.

--- a/Wire-iOS/Sources/UserInterface/SelfProfile/AccountSelectorView.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/AccountSelectorView.swift
@@ -19,7 +19,7 @@
 import UIKit
 import WireSyncEngine
 
-protocol AccountSelectorViewDelegate: class {
+protocol AccountSelectorViewDelegate: AnyObject {
     func accountSelectorDidSelect(account: Account)
 }
 

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptor.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptor.swift
@@ -37,7 +37,7 @@ import UIKit
  * @abstract Top-level protocol for model object of settings. Describes the way cell should be created or how the value
  * should be updated from the cell.
  */
-protocol SettingsCellDescriptorType: class {
+protocol SettingsCellDescriptorType: AnyObject {
     static var cellType: SettingsTableCell.Type {get}
     var visible: Bool {get}
     var title: String {get}
@@ -63,7 +63,7 @@ protocol SettingsGroupCellDescriptorType: SettingsCellDescriptorType {
     var viewController: UIViewController? {get set}
 }
 
-protocol SettingsSectionDescriptorType: class {
+protocol SettingsSectionDescriptorType: AnyObject {
     var cellDescriptors: [SettingsCellDescriptorType] {get}
     var visibleCellDescriptors: [SettingsCellDescriptorType] {get}
     var header: String? {get}

--- a/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ChangeHandleViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ChangeHandleViewController.swift
@@ -34,7 +34,7 @@ fileprivate extension UIView {
 
 }
 
-protocol ChangeHandleTableViewCellDelegate: class {
+protocol ChangeHandleTableViewCellDelegate: AnyObject {
     func tableViewCell(cell: ChangeHandleTableViewCell, shouldAllowEditingText text: String) -> Bool
     func tableViewCellDidChangeText(cell: ChangeHandleTableViewCell, text: String)
 }

--- a/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ConfirmEmailViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ConfirmEmailViewController.swift
@@ -20,7 +20,7 @@ import UIKit
 import WireDataModel
 import WireSyncEngine
 
-protocol ConfirmEmailDelegate: class {
+protocol ConfirmEmailDelegate: AnyObject {
     func resendVerification(inController controller: ConfirmEmailViewController)
     func didConfirmEmail(inController controller: ConfirmEmailViewController)
 }

--- a/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ConfirmPhoneViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ConfirmPhoneViewController.swift
@@ -29,7 +29,7 @@ private enum Section: Int {
     case buttons = 1
 }
 
-protocol ConfirmPhoneDelegate: class {
+protocol ConfirmPhoneDelegate: AnyObject {
     func resendVerificationCode(inController controller: ConfirmPhoneViewController)
     func didConfirmPhone(inController controller: ConfirmPhoneViewController)
 }

--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientColorVariantProtocol.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientColorVariantProtocol.swift
@@ -19,7 +19,7 @@
 import Foundation
 import UIKit
 
-protocol ClientListViewControllerDelegate: class {
+protocol ClientListViewControllerDelegate: AnyObject {
     func finishedDeleting(_ clientListViewController: ClientListViewController)
 }
 

--- a/Wire-iOS/Sources/UserInterface/Settings/SettingsCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/SettingsCell.swift
@@ -28,7 +28,7 @@ enum SettingsCellPreview {
     case color(UIColor)
 }
 
-protocol SettingsCellType: class {
+protocol SettingsCellType: AnyObject {
     var titleText: String {get set}
     var preview: SettingsCellPreview {get set}
     var titleColor: UIColor {get set}

--- a/Wire-iOS/Sources/UserInterface/SketchColorPickerController.swift
+++ b/Wire-iOS/Sources/UserInterface/SketchColorPickerController.swift
@@ -20,7 +20,7 @@ import Foundation
 import UIKit
 import WireSystem
 
-protocol SketchColorPickerControllerDelegate: class {
+protocol SketchColorPickerControllerDelegate: AnyObject {
     func sketchColorPickerController(_ controller: SketchColorPickerController, changedSelectedColor color: UIColor)
 }
 

--- a/Wire-iOS/Sources/UserInterface/Sketchpad/CanvasViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Sketchpad/CanvasViewController.swift
@@ -21,7 +21,7 @@ import WireCanvas
 import Cartography
 import WireCommonComponents
 
-protocol CanvasViewControllerDelegate: class {
+protocol CanvasViewControllerDelegate: AnyObject {
     func canvasViewController(_ canvasViewController: CanvasViewController, didExportImage image: UIImage)
 }
 

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/EmptySearchResultsView.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/EmptySearchResultsView.swift
@@ -43,7 +43,7 @@ extension EmptySearchResultsViewAction {
     }
 }
 
-protocol EmptySearchResultsViewDelegate: class {
+protocol EmptySearchResultsViewDelegate: AnyObject {
     func execute(action: EmptySearchResultsViewAction, from: EmptySearchResultsView)
 }
 

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/InviteTeamMember/InviteTeamMemberSection.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/InviteTeamMember/InviteTeamMemberSection.swift
@@ -20,7 +20,7 @@ import Foundation
 import UIKit
 import WireDataModel
 
-protocol InviteTeamMemberSectionDelegate: class {
+protocol InviteTeamMemberSectionDelegate: AnyObject {
     func inviteSectionDidRequestTeamManagement()
 }
 

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/SearchSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/SearchSectionController.swift
@@ -20,7 +20,7 @@ import Foundation
 import UIKit
 import WireDataModel
 
-protocol SearchSectionControllerDelegate: class {
+protocol SearchSectionControllerDelegate: AnyObject {
 
     func searchSectionController(_ searchSectionController: CollectionViewSectionController, didSelectUser user: UserType, at indexPath: IndexPath)
 

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/TopPeopleLine/TopPeopleLineCollectionViewControllerDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/TopPeopleLine/TopPeopleLineCollectionViewControllerDelegate.swift
@@ -19,7 +19,7 @@
 import Foundation
 import WireDataModel
 
-protocol TopPeopleLineCollectionViewControllerDelegate: class {
+protocol TopPeopleLineCollectionViewControllerDelegate: AnyObject {
 
     func topPeopleLineCollectionViewControllerDidSelect(_ conversation: ZMConversation)
 }

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/UserSelection.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/UserSelection.swift
@@ -21,7 +21,7 @@ import WireUtilities
 import WireDataModel
 
 @objc
-protocol UserSelectionObserver: class {
+protocol UserSelectionObserver: AnyObject {
 
     func userSelection(_ userSelection: UserSelection, didAddUser user: UserType)
     func userSelection(_ userSelection: UserSelection, didRemoveUser user: UserType)

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchHeaderViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchHeaderViewController.swift
@@ -21,7 +21,7 @@ import Cartography
 import UIKit
 import WireDataModel
 
-protocol SearchHeaderViewControllerDelegate: class {
+protocol SearchHeaderViewControllerDelegate: AnyObject {
     func searchHeaderViewController(_ searchHeaderViewController: SearchHeaderViewController, updatedSearchQuery query: String)
     func searchHeaderViewControllerDidConfirmAction(_ searchHeaderViewController: SearchHeaderViewController)
 }

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
@@ -55,7 +55,7 @@ extension SearchGroup {
     }
 }
 
-protocol SearchResultsViewControllerDelegate: class {
+protocol SearchResultsViewControllerDelegate: AnyObject {
 
     func searchResultsViewController(_ searchResultsViewController: SearchResultsViewController, didTapOnUser user: UserType, indexPath: IndexPath, section: SearchResultsViewControllerSection)
     func searchResultsViewController(_ searchResultsViewController: SearchResultsViewController, didDoubleTapOnUser user: UserType, indexPath: IndexPath)

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIDelegate.swift
@@ -19,7 +19,7 @@
 import Foundation
 import WireDataModel
 
-protocol StartUIDelegate: class {
+protocol StartUIDelegate: AnyObject {
     func startUI(_ startUI: StartUIViewController, didSelect user: UserType)
     func startUI(_ startUI: StartUIViewController, didSelect conversation: ZMConversation)
     func startUI(_ startUI: StartUIViewController,

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsContentController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsContentController.swift
@@ -24,7 +24,7 @@ import WireSyncEngine
  * An object that receives notifications from a profile details content controller.
  */
 
-protocol ProfileDetailsContentControllerDelegate: class {
+protocol ProfileDetailsContentControllerDelegate: AnyObject {
 
     /// Called when the profile details change.
     func profileDetailsContentDidChange()

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.swift
@@ -26,7 +26,7 @@ enum ProfileViewControllerTabBarIndex: Int {
     case devices
 }
 
-protocol ProfileViewControllerDelegate: class {
+protocol ProfileViewControllerDelegate: AnyObject {
     func profileViewController(_ controller: ProfileViewController?, wantsToNavigateTo conversation: ZMConversation)
     func profileViewController(_ controller: ProfileViewController?, wantsToCreateConversationWithName name: String?, users: UserSet)
 }

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.swift
@@ -31,7 +31,7 @@ protocol ProfileViewControllerDelegate: AnyObject {
     func profileViewController(_ controller: ProfileViewController?, wantsToCreateConversationWithName name: String?, users: UserSet)
 }
 
-protocol BackButtonTitleDelegate: class {
+protocol BackButtonTitleDelegate: AnyObject {
     func suggestedBackButtonTitle(for controller: ProfileViewController?) -> String?
 }
 

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewControllerViewModel.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewControllerViewModel.swift
@@ -265,7 +265,7 @@ extension ProfileViewControllerViewModel: BackButtonTitleDelegate {
     }
 }
 
-protocol ProfileViewControllerViewModelDelegate: class {
+protocol ProfileViewControllerViewModelDelegate: AnyObject {
     func updateShowVerifiedShield()
     func setupNavigationItems()
     func updateFooterViews()

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Views/IncomingRequestFooterView.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Views/IncomingRequestFooterView.swift
@@ -19,7 +19,7 @@
 import Foundation
 import UIKit
 
-protocol IncomingRequestFooterViewDelegate: class {
+protocol IncomingRequestFooterViewDelegate: AnyObject {
 
     /// Called when the user accepts or denies a connection request.
     func footerView(_ footerView: IncomingRequestFooterView, didRespondToRequestWithAction action: IncomingConnectionAction)

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Views/ParticipantDeviceHeaderView.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Views/ParticipantDeviceHeaderView.swift
@@ -18,7 +18,7 @@
 import Foundation
 import UIKit
 
-protocol ParticipantDeviceHeaderViewDelegate: class {
+protocol ParticipantDeviceHeaderViewDelegate: AnyObject {
     func participantsDeviceHeaderViewDidTapLearnMore(_ headerView: ParticipantDeviceHeaderView)
 }
 

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Views/ProfileFooterView.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Views/ProfileFooterView.swift
@@ -18,7 +18,7 @@
 
 import UIKit
 
-protocol ProfileFooterViewDelegate: class {
+protocol ProfileFooterViewDelegate: AnyObject {
 
     /// Called when the footer wants to perform a single action, from the left button.
     func footerView(_ footerView: ProfileFooterView, shouldPerformAction action: ProfileAction)

--- a/Wire-iOS/Sources/Viper/VIPER+Relationships.swift
+++ b/Wire-iOS/Sources/Viper/VIPER+Relationships.swift
@@ -36,30 +36,30 @@ import Foundation
 ///
 /// Typically contains methods fetch data and perform business logic.
 
-protocol InteractorPresenterInterface: class { }
+protocol InteractorPresenterInterface: AnyObject { }
 
 /// Interface of the presenter from the perspective of the interactor.
 ///
 /// Typically contains methods to report the results of data fetches
 /// and business logic.
 
-protocol PresenterInteractorInterface: class { }
+protocol PresenterInteractorInterface: AnyObject { }
 
 /// Interface of the presenter from the perspective of the view.
 ///
 /// Typically contains methods to react to view life cycle and
 /// use interaction events.
 
-protocol PresenterViewInterface: class { }
+protocol PresenterViewInterface: AnyObject { }
 
 /// Interface of the view from the perspective of the presenter.
 ///
 /// Typically contains methods to set and update view data.
 
-protocol ViewPresenterInterface: class { }
+protocol ViewPresenterInterface: AnyObject { }
 
 /// Interface of the router from the perspective of the presenter.
 ///
 /// Typically contains methods to react to navigation requests.
 
-protocol RouterPresenterInterface: class { }
+protocol RouterPresenterInterface: AnyObject { }

--- a/WireCommonComponents/URL+Backup.swift
+++ b/WireCommonComponents/URL+Backup.swift
@@ -22,7 +22,7 @@ import WireUtilities
 
 public typealias FileInDirectory = (FileManager.SearchPathDirectory, String)
 
-public protocol BackupExcluder: class {
+public protocol BackupExcluder: AnyObject {
     static func exclude(filesToExclude: [FileInDirectory]) throws
 }
 


### PR DESCRIPTION
## What's new in this PR?

Replace all protocol extends `class` with `AnyObject `