### PR TITLE
[Fix] Share/forward the message

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
@@ -47,8 +47,9 @@ extension Array where Element == ZMConversation {
         forEach {
             guard let timeout = $0.activeMessageDestructionTimeoutValue,
                   let type = $0.activeMessageDestructionTimeoutType else {
-                return
-            }
+                      block($0)
+                      return
+                  }
             $0.setMessageDestructionTimeoutValue(.init(rawValue: 0), for: type)
             block($0)
             $0.setMessageDestructionTimeoutValue(timeout, for: type)


### PR DESCRIPTION
## What's new in this PR?

### Issues
User is not able to share/forward the message from one conversation to another one.

### Causes
There was a check if `activeMessageDestructionTimeoutValue == nil` we do not forward the message. It happened by accident during refactoring.

### Solutions
We should be able to forward NonEphemeral messages, and the message's `activeMessageDestructionTimeoutValue` should depend on the sender's settings, not the recipient's.
