### PR TITLE
fix: Image viewer has a double height toolbar

### DIFF
--- a/Wire-iOS/Sources/Components/Buttons/IconButton.swift
+++ b/Wire-iOS/Sources/Components/Buttons/IconButton.swift
@@ -96,32 +96,32 @@ class IconButton: ButtonWithLargerHitArea {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override public func layoutSubviews() {
+    override func layoutSubviews() {
         super.layoutSubviews()
 
         updateCircularCornerRadius()
     }
 
     // MARK: - Observing state
-    override public var isHighlighted: Bool {
+    override var isHighlighted: Bool {
         didSet {
             updateForNewStateIfNeeded()
         }
     }
 
-    override public var isSelected: Bool {
+    override var isSelected: Bool {
         didSet {
             updateForNewStateIfNeeded()
         }
     }
 
-    override public var isEnabled: Bool {
+    override var isEnabled: Bool {
         didSet {
             updateForNewStateIfNeeded()
         }
     }
 
-    override public func setTitleColor(_ color: UIColor?, for state: UIControl.State) {
+    override func setTitleColor(_ color: UIColor?, for state: UIControl.State) {
         super.setTitleColor(color, for: state)
 
         if adjustsTitleWhenHighlighted && state.contains(.normal) {

--- a/Wire-iOS/Sources/UserInterface/Collections/ConversationImagesViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/ConversationImagesViewController.swift
@@ -242,7 +242,6 @@ final class ConversationImagesViewController: TintColorCorrectedViewController {
         // if the current message is ephemeral, then it will be the only
         // message b/c ephemeral messages are excluded in the collection.
         if !currentMessage.isEphemeral {
-
             let copyButton = iconButton(messageAction:
                 .copy)
 
@@ -278,7 +277,7 @@ final class ConversationImagesViewController: TintColorCorrectedViewController {
     private func createControlsBar() {
         let buttons = createControlsBarButtons()
 
-        self.buttonsBar = InputBarButtonsView(buttons: buttons)
+        buttonsBar = InputBarButtonsView(buttons: buttons)
         self.buttonsBar.clipsToBounds = true
         self.buttonsBar.expandRowButton.setIconColor(UIColor.from(scheme: .textForeground), for: .normal)
         self.buttonsBar.backgroundColor = UIColor.from(scheme: .barBackground)
@@ -346,6 +345,8 @@ final class ConversationImagesViewController: TintColorCorrectedViewController {
                                        for: message ?? currentMessage,
                                        view: sender as? UIView ?? view)
     }
+
+    //MARK: icon button actions
 
     @objc
     private func copyCurrent(_ sender: AnyObject!) {

--- a/Wire-iOS/Sources/UserInterface/Components/Views/ImageToolbarView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/ImageToolbarView.swift
@@ -49,7 +49,7 @@ final class ImageToolbarView: UIView {
         }
     }
 
-    public var imageIsEphemeral = false {
+    var imageIsEphemeral = false {
         didSet {
             guard oldValue != imageIsEphemeral else { return }
             updateButtonConfiguration()

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
@@ -332,7 +332,8 @@ final class InputBar: UIView {
         rightAccessoryStackView.layoutMargins = UIEdgeInsets(top: 0, left: rightInset, bottom: 0, right: rightInset)
     }
 
-    @objc fileprivate func didTapBackground(_ gestureRecognizer: UITapGestureRecognizer!) {
+    @objc
+    private func didTapBackground(_ gestureRecognizer: UITapGestureRecognizer!) {
         guard gestureRecognizer.state == .recognized else { return }
         buttonsView.showRow(0, animated: true)
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarButtonsView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarButtonsView.swift
@@ -40,7 +40,7 @@ final class InputBarButtonsView: UIView {
     fileprivate(set) var currentRow: RowIndex = 0
 
     fileprivate lazy var buttonRowTopInset: NSLayoutConstraint = buttonOuterContainer.topAnchor.constraint(equalTo: buttonInnerContainer.topAnchor)
-    fileprivate lazy var buttonRowHeight: NSLayoutConstraint = buttonInnerContainer.heightAnchor.constraint(equalToConstant: 0)
+    private lazy var buttonRowHeight: NSLayoutConstraint = buttonInnerContainer.heightAnchor.constraint(equalToConstant: 0)
     fileprivate var lastLayoutWidth: CGFloat = 0
 
     let expandRowButton = IconButton()
@@ -98,7 +98,7 @@ final class InputBarButtonsView: UIView {
             buttonInnerContainer.bottomAnchor.constraint(equalTo: buttonOuterContainer.bottomAnchor),
             buttonRowHeight,
 
-            buttonOuterContainer.heightAnchor.constraint(equalTo: buttonInnerContainer.heightAnchor),
+            buttonOuterContainer.heightAnchor.constraint(equalToConstant: constants.buttonsBarHeight),
             buttonOuterContainer.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -UIScreen.safeArea.bottom),
             buttonOuterContainer.leadingAnchor.constraint(equalTo: leadingAnchor),
             buttonOuterContainer.trailingAnchor.constraint(equalTo: trailingAnchor),
@@ -202,7 +202,6 @@ final class InputBarButtonsView: UIView {
             button.translatesAutoresizingMaskIntoConstraints = false
 
             if button == expandRowButton {
-
                 constraints.append(contentsOf: [
                     button.topAnchor.constraint(equalTo: topAnchor),
                     button.heightAnchor.constraint(equalToConstant: constants.buttonsBarHeight)
@@ -291,7 +290,8 @@ extension InputBarButtonsView {
         showRow(0, animated: true)
     }
 
-    @objc fileprivate func ellipsisButtonPressed(_ button: UIButton!) {
+    @objc
+    private func ellipsisButtonPressed(_ button: UIButton!) {
         showRow(currentRow == 0 ? 1 : 0, animated: true)
     }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Image viewer has a double height toolbar

### Causes

`buttonOuterContainer` height constraint is link to inner container

### Solutions

`buttonOuterContainer` should always has a constant height

