### PR TITLE
SwiftLint: Fix warnings regarding redundant_nil_coalescing rule

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Collections/NoResultsView.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/NoResultsView.swift
@@ -35,7 +35,7 @@ final class NoResultsView: UIView {
         }
     }
 
-    var icon: StyleKitIcon? = nil {
+    var icon: StyleKitIcon? {
         didSet {
             iconView.image = icon?.makeImage(size: 160, color: placeholderColor)
         }

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/SectionCollectionViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/SectionCollectionViewController.swift
@@ -30,7 +30,7 @@ protocol CollectionViewSectionController: UICollectionViewDataSource, UICollecti
 
 final class SectionCollectionViewController: NSObject {
 
-    var collectionView: UICollectionView? = nil {
+    var collectionView: UICollectionView? {
         didSet {
             collectionView?.dataSource = self
             collectionView?.delegate = self

--- a/Wire-iOS/Sources/UserInterface/Components/Views/SeparatorCollectionViewCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/SeparatorCollectionViewCell.swift
@@ -81,7 +81,7 @@ class SeparatorCollectionViewCell: UICollectionViewCell, SeparatorViewProtocol, 
     }
 
     // if nil the background color is the default content background color for the theme
-    @objc dynamic var contentBackgroundColor: UIColor? = nil {
+    @objc dynamic var contentBackgroundColor: UIColor? {
         didSet {
             guard oldValue != contentBackgroundColor else { return }
             applyColorScheme(colorSchemeVariant)

--- a/Wire-iOS/Sources/UserInterface/Components/Views/SeparatorTableViewCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/SeparatorTableViewCell.swift
@@ -83,7 +83,7 @@ class SeparatorTableViewCell: UITableViewCell, SeparatorViewProtocol, Themeable 
     }
 
     // if nil the background color is the default content background color for the theme
-    @objc dynamic var contentBackgroundColor: UIColor? = nil {
+    @objc dynamic var contentBackgroundColor: UIColor? {
         didSet {
             guard oldValue != contentBackgroundColor else { return }
             applyColorScheme(colorSchemeVariant)

--- a/Wire-iOS/Sources/UserInterface/Components/Views/UserImageView/BadgeUserImageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/UserImageView/BadgeUserImageView.swift
@@ -40,7 +40,7 @@ final class BadgeUserImageView: UserImageView {
     }
 
     /// The badge icon.
-    var badgeIcon: StyleKitIcon? = nil {
+    var badgeIcon: StyleKitIcon? {
         didSet {
             updateIconView(with: badgeIcon, animated: false)
         }

--- a/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsCell.swift
+++ b/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsCell.swift
@@ -23,7 +23,7 @@ typealias ContactsCellActionButtonHandler = (UserType, ContactsCell.Action) -> V
 
 /// A UITableViewCell version of UserCell, with simpler functionality for contact Screen with table view index bar
 final class ContactsCell: UITableViewCell, SeparatorViewProtocol {
-    var user: UserType? = nil {
+    var user: UserType? {
         didSet {
             avatar.user = user
             updateTitleLabel()
@@ -45,7 +45,7 @@ final class ContactsCell: UITableViewCell, SeparatorViewProtocol {
     }
 
     // if nil the background color is the default content background color for the theme
-    var contentBackgroundColor: UIColor? = nil {
+    var contentBackgroundColor: UIColor? {
         didSet {
             guard oldValue != contentBackgroundColor else { return }
             applyColorScheme(colorSchemeVariant)

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
@@ -173,7 +173,7 @@ final class InputBar: UIView {
         inputBarState.changeEphemeralState(to: newState)
     }
 
-    var invisibleInputAccessoryView: InvisibleInputAccessoryView? = nil {
+    var invisibleInputAccessoryView: InvisibleInputAccessoryView? {
         didSet {
             textView.inputAccessoryView = invisibleInputAccessoryView
         }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListAccessoryView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListAccessoryView.swift
@@ -20,7 +20,7 @@ import UIKit
 import WireCommonComponents
 
 final class ConversationListAccessoryView: UIView {
-    var icon: ConversationStatusIcon? = nil {
+    var icon: ConversationStatusIcon? {
         didSet {
             if icon != oldValue {
                 updateForIcon()

--- a/Wire-iOS/Sources/UserInterface/SelfProfile/AccountSelectorView.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/AccountSelectorView.swift
@@ -29,7 +29,7 @@ final class AccountSelectorView: UIView {
     private var selfUserObserverToken: NSObjectProtocol!
     private var applicationDidBecomeActiveToken: NSObjectProtocol!
 
-    fileprivate var accounts: [Account]? = nil {
+    fileprivate var accounts: [Account]? {
         didSet {
             guard ZMUserSession.shared() != nil else {
                 return

--- a/Wire-iOS/Sources/UserInterface/Settings/SettingsCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/SettingsCell.swift
@@ -122,7 +122,7 @@ class SettingsTableCell: UITableViewCell, SettingsCellType {
         }
     }
 
-    var icon: StyleKitIcon? = nil {
+    var icon: StyleKitIcon? {
         didSet {
             if let icon = icon {
                 iconImageView.setIcon(icon, size: .tiny, color: UIColor.white)

--- a/Wire-iOS/Sources/UserInterface/Sketchpad/CanvasViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Sketchpad/CanvasViewController.swift
@@ -43,7 +43,7 @@ final class CanvasViewController: UIViewController, UINavigationControllerDelega
     let hintLabel = UILabel()
     let hintImageView = UIImageView()
     var isEmojiKeyboardInTransition = false
-    var sketchImage: UIImage? = nil {
+    var sketchImage: UIImage? {
         didSet {
             if let image = sketchImage {
                 canvas.referenceImage = image

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/Cells/GroupConversationCell.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/Cells/GroupConversationCell.swift
@@ -40,7 +40,7 @@ final class GroupConversationCell: UICollectionViewCell, Themeable {
     }
 
     // if nil the background color is the default content background color for the theme
-    @objc dynamic var contentBackgroundColor: UIColor? = nil {
+    @objc dynamic var contentBackgroundColor: UIColor? {
         didSet {
             guard oldValue != contentBackgroundColor else { return }
             applyColorScheme(colorSchemeVariant)

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/Cells/InviteTeamMemberCell.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/Cells/InviteTeamMemberCell.swift
@@ -137,7 +137,7 @@ final class OpenServicesAdminCell: StartUIIconCell, Themeable {
         }
     }
 
-    @objc dynamic var contentBackgroundColor: UIColor? = nil {
+    @objc dynamic var contentBackgroundColor: UIColor? {
         didSet {
             guard oldValue != contentBackgroundColor else { return }
             applyColorScheme(colorSchemeVariant)

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/Contacts/ContactsSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/Contacts/ContactsSectionController.swift
@@ -22,7 +22,7 @@ import WireDataModel
 class ContactsSectionController: SearchSectionController {
 
     var contacts: [UserType] = []
-    var selection: UserSelection? = nil {
+    var selection: UserSelection? {
         didSet {
             selection?.add(observer: self)
         }


### PR DESCRIPTION
## What's new in this PR?

Removing  `= nil` from many cases around the project because it is redundant.