### PR TITLE
chore: enable "Patches" log tag in settings SQSERVICES-1031

### DIFF
--- a/Wire-iOS/Sources/Components/Settings+Logging.swift
+++ b/Wire-iOS/Sources/Components/Settings+Logging.swift
@@ -56,7 +56,8 @@ extension Settings {
             "Crypto",
             "cryptobox",
             "backend-environment",
-            "Backup"
+            "Backup",
+            "Patches"
         ]
 
         if let savedTags = UserDefaults.shared().object(forKey: enabledLogsKey) as? [String] {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The "Patches" log tag wasn't enabled in the testflight build.

### Causes 

It was enabled in the wrong place (environment var)

### Solutions

Enable it in the right place.

### Testing

Nothing to test

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
