### PR TITLE
fix: Navbar is transparent in user profile screen IC-19

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+ConversationContentViewControllerDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+ConversationContentViewControllerDelegate.swift
@@ -35,7 +35,7 @@ extension ConversationViewController: ConversationContentViewControllerDelegate 
 
         endEditing()
 
-        createAndPresentParticipantsPopoverController(with: frame, from: view, contentViewController: profileViewController.wrapInNavigationController())
+        createAndPresentParticipantsPopoverController(with: frame, from: view, contentViewController: profileViewController.wrapInNavigationController(setBackgroundColor: true))
     }
 
     func conversationContentViewController(_ contentViewController: ConversationContentViewController, willDisplayActiveMediaPlayerFor message: ZMConversationMessage?) {

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController+ShowContentDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController+ShowContentDelegate.swift
@@ -23,7 +23,7 @@ import WireSyncEngine
 
 extension ZClientViewController {
     private func wrapInNavigationControllerAndPresent(viewController: UIViewController) {
-        let navWrapperController: UINavigationController = viewController.wrapInNavigationController()
+        let navWrapperController: UINavigationController = viewController.wrapInNavigationController(setBackgroundColor: true)
         navWrapperController.modalPresentationStyle = .formSheet
 
         dismissAllModalControllers(callback: { [weak self] in

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/ProfilePresenter.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/ProfilePresenter.swift
@@ -74,7 +74,7 @@ final class ProfilePresenter: NSObject, ViewControllerDismisser {
         profileViewController.delegate = self
         profileViewController.viewControllerDismisser = self
 
-        let navigationController = profileViewController.wrapInNavigationController()
+        let navigationController = profileViewController.wrapInNavigationController(setBackgroundColor: true)
         navigationController.transitioningDelegate = transitionDelegate
         navigationController.modalPresentationStyle = .formSheet
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/IC-19" title="IC-19" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/secure/viewavatar?size=medium&avatarId=10818&avatarType=issuetype" />IC-19</a>  Fix transparent navbar
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Navbar is transparent on the user profile screen in some cases.

### Solutions

Set background color.

### Notes (Optional)

This approach is very brittle. We should find a way to solve this without editing every single place where we present a screen.

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
