### PR TITLE
refactor: ScreenShare event to work with the new analytics mechanism

### DIFF
--- a/Wire-iOS/Sources/Analytics/Analytics.swift
+++ b/Wire-iOS/Sources/Analytics/Analytics.swift
@@ -105,7 +105,7 @@ extension Analytics: AnalyticsType {
 extension Analytics: AnalyticsLike {
 
     func tagEvent(_ event: AnalyticsEvent) {
-        tagEvent(event.name, attributes: event.attributes.rawValue)
+        provider?.tagEvent(event)
     }
 
 }

--- a/Wire-iOS/Sources/Analytics/AnalyticsCallingTracker.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsCallingTracker.swift
@@ -165,12 +165,10 @@ extension AnalyticsCallingTracker: WireCallCenterCallParticipantObserver {
         } else if let screenSharedParticipant = participants.first(where: { $0.state.videoState == .stopped && ($0.user as? ZMUser != selfUser) }),
                   let screenSharingDate = screenSharingStartTimes[screenSharedParticipant.clientId],
                   let conversationId = conversation.remoteIdentifier,
-                  let callInfo = callInfos[conversationId] {
+                  let _ = callInfos[conversationId] {
 
             // When videoState == .stopped from a remote participant, tag the event if we found a record in screenSharingInfos set with matching clientId
-            analytics.tag(callEvent: .screenSharing(duration: -screenSharingDate.timeIntervalSinceNow),
-                          in: conversation,
-                          callInfo: callInfo)
+            Analytics.shared.tagEvent(.screenShare(callDirection: .outgoing, duration:  -screenSharingDate.timeIntervalSinceNow, in: conversation))
 
             screenSharingStartTimes[screenSharedParticipant.clientId] = nil
         }

--- a/Wire-iOS/Sources/Analytics/AnalyticsCallingTracker.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsCallingTracker.swift
@@ -163,9 +163,7 @@ extension AnalyticsCallingTracker: WireCallCenterCallParticipantObserver {
            screenSharingStartTimes[participant.clientId] == nil {
             screenSharingStartTimes[participant.clientId] = Date()
         } else if let screenSharedParticipant = participants.first(where: { $0.state.videoState == .stopped && ($0.user as? ZMUser != selfUser) }),
-                  let screenSharingDate = screenSharingStartTimes[screenSharedParticipant.clientId],
-                  let conversationId = conversation.remoteIdentifier,
-                  let _ = callInfos[conversationId] {
+                  let screenSharingDate = screenSharingStartTimes[screenSharedParticipant.clientId] {
 
             // When videoState == .stopped from a remote participant, tag the event if we found a record in screenSharingInfos set with matching clientId
             Analytics.shared.tagEvent(.screenShare(callDirection: .incoming, duration: -screenSharingDate.timeIntervalSinceNow, in: conversation))

--- a/Wire-iOS/Sources/Analytics/AnalyticsCallingTracker.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsCallingTracker.swift
@@ -168,7 +168,7 @@ extension AnalyticsCallingTracker: WireCallCenterCallParticipantObserver {
                   let _ = callInfos[conversationId] {
 
             // When videoState == .stopped from a remote participant, tag the event if we found a record in screenSharingInfos set with matching clientId
-            Analytics.shared.tagEvent(.screenShare(callDirection: .outgoing, duration:  -screenSharingDate.timeIntervalSinceNow, in: conversation))
+            Analytics.shared.tagEvent(.screenShare(callDirection: .incoming, duration: -screenSharingDate.timeIntervalSinceNow, in: conversation))
 
             screenSharingStartTimes[screenSharedParticipant.clientId] = nil
         }

--- a/Wire-iOS/Sources/Analytics/Events/Analytics+CallEvents.swift
+++ b/Wire-iOS/Sources/Analytics/Events/Analytics+CallEvents.swift
@@ -80,8 +80,7 @@ extension Analytics {
             attributes.merge(attributesForVideoToogle(with: callInfo), strategy: .preferNew)
             attributes.merge(["reason": reason], strategy: .preferNew)
         case .screenSharing(let duration):
-            attributes["screen_share_direction"] = "incoming"
-            attributes["screen_share_duration"] = Int(round(duration / 5)) * 5
+            Analytics.shared.tagEvent(.screenShare(callDirection: .incoming, duration: duration, in: conversation))
         default:
             break
         }

--- a/Wire-iOS/Sources/Analytics/Events/Analytics+CallStateEvents.swift
+++ b/Wire-iOS/Sources/Analytics/Events/Analytics+CallStateEvents.swift
@@ -77,7 +77,7 @@ private extension AnalyticsAttributeKey {
 
     /// The duration of the screen-sharing.
     ///
-    /// Expected to refer to a value of type `AnalyticsScreenShareDurationType`.
+    /// Expected to refer to a value of type `RoundedInt`.
     static let screenShareDuration = AnalyticsAttributeKey(rawValue: "screen_share_duration")
 
 }

--- a/Wire-iOS/Sources/Analytics/Events/Analytics+CallStateEvents.swift
+++ b/Wire-iOS/Sources/Analytics/Events/Analytics+CallStateEvents.swift
@@ -42,7 +42,12 @@ extension AnalyticsEvent {
         event.attributes[.startedAsVideoCall] = asVideoCall
         return event
     }
+
+    static func screenShare(callDirection: CallDirection, duration: Double, in conversation: ZMConversation) -> AnalyticsEvent {
+        var event = AnalyticsEvent(name: "calling.screen_share")
+        event.attributes = conversation.analyticsAttributes
         event.attributes[.callDirection] = callDirection
+        event.attributes[.screenShareDuration] =  RoundedInt(Int(duration), factor: 6)
         return event
     }
 
@@ -69,5 +74,10 @@ private extension AnalyticsAttributeKey {
     ///
     /// Expected to refer to a value of type `AnalyticsCallDirectionType`.
     static let callDirection  = AnalyticsAttributeKey(rawValue: "call_direction")
+
+    /// The duration of the screen-sharing.
+    ///
+    /// Expected to refer to a value of type `AnalyticsScreenShareDurationType`.
+    static let screenShareDuration = AnalyticsAttributeKey(rawValue: "screen_share_duration")
 
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

In this PR I transition the screenShare event to work with the new mechanism. In addition to that I fixed an issue regarding a failing test from the previous PR's regarding refactoring analytics. We were calling the `tagEvent` method from the previous implementation before the refactoring. Now we're calling the correct (updated) `tagEvent` method and the failing test has been fixed.

### Notes
Remaining stuff to be done is to transition the `EndCall` event to work with the new mechanism and then clean things up by removing old code etc.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
