### PR TITLE
refactor: `CallEnded` event to work with the new analytics event

### DIFF
--- a/Wire-iOS/Sources/Analytics/AnalyticsCallingTracker.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsCallingTracker.swift
@@ -130,7 +130,13 @@ extension AnalyticsCallingTracker: WireCallCenterCallStateObserver {
                 guard let establishedDate = callInfo.establishedDate else { return }
                 let duration = Double(-establishedDate.timeIntervalSinceNow)
 
-                Analytics.shared.tagEvent(.endedCall(asVideoCall: video, callDirection: .outgoing, callDuration: duration, callParticipants: participants, videoEnabled: toggleVideo, screenShareEnabled: screenShare, callEndedReason: .normal, conversation: conversation))
+                Analytics.shared.tagEvent(.endedCall(asVideoCall: video,
+                                                     callDirection: .outgoing,
+                                                     callDuration: duration,
+                                                     callParticipants: participants,
+                                                     videoEnabled: toggleVideo,
+                                                     screenShareEnabled: screenShare,
+                                                     callEndedReason: .normal, conversation: conversation))
 
             }
             callInfos[conversationId] = nil

--- a/Wire-iOS/Sources/Analytics/AnalyticsCallingTracker.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsCallingTracker.swift
@@ -122,7 +122,8 @@ extension AnalyticsCallingTracker: WireCallCenterCallStateObserver {
             callParticipantObserverToken = WireCallCenterV3.addCallParticipantObserver(observer: self, for: conversation, userSession: userSession)
         case .terminating(let reason):
             if let callInfo = callInfos[conversationId],
-            guard let establishedDate = callInfo.establishedDate else { return } {
+               let establishedDate = callInfo.establishedDate {
+                
                 let isVideoCall = conversation.voiceChannel?.isVideoCall ?? false
                 let toggleVideo = callInfo.toggledVideo
                 let maximumCallParticipants = callInfo.maximumCallParticipants

--- a/Wire-iOS/Sources/Analytics/AnalyticsCallingTracker.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsCallingTracker.swift
@@ -122,10 +122,10 @@ extension AnalyticsCallingTracker: WireCallCenterCallStateObserver {
             callParticipantObserverToken = WireCallCenterV3.addCallParticipantObserver(observer: self, for: conversation, userSession: userSession)
         case .terminating(let reason):
             if let callInfo = callInfos[conversationId] {
-                let video = conversation.voiceChannel?.isVideoCall ?? false
+                let isVideoCall = conversation.voiceChannel?.isVideoCall ?? false
                 let toggleVideo = callInfo.toggledVideo
-                let participants = Double(callInfo.maximumCallParticipants)
-                let screenShare = conversation.voiceChannel?.videoState ==  .screenSharing
+                let maximumCallParticipants = Double(callInfo.maximumCallParticipants)
+                let isSharingScreen = conversation.voiceChannel?.videoState ==  .screenSharing
                 guard let establishedDate = callInfo.establishedDate else { return }
                 let duration = -establishedDate.timeIntervalSinceNow
 

--- a/Wire-iOS/Sources/Analytics/AnalyticsCallingTracker.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsCallingTracker.swift
@@ -121,8 +121,8 @@ extension AnalyticsCallingTracker: WireCallCenterCallStateObserver {
 
             callParticipantObserverToken = WireCallCenterV3.addCallParticipantObserver(observer: self, for: conversation, userSession: userSession)
         case .terminating(let reason):
-            if let callInfo = callInfos[conversationId] {
-                guard let establishedDate = callInfo.establishedDate else { return }
+            if let callInfo = callInfos[conversationId],
+            guard let establishedDate = callInfo.establishedDate else { return } {
                 let isVideoCall = conversation.voiceChannel?.isVideoCall ?? false
                 let toggleVideo = callInfo.toggledVideo
                 let maximumCallParticipants = callInfo.maximumCallParticipants

--- a/Wire-iOS/Sources/Analytics/AnalyticsCallingTracker.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsCallingTracker.swift
@@ -123,7 +123,7 @@ extension AnalyticsCallingTracker: WireCallCenterCallStateObserver {
         case .terminating(let reason):
             if let callInfo = callInfos[conversationId],
                let establishedDate = callInfo.establishedDate {
-                
+
                 let isVideoCall = conversation.voiceChannel?.isVideoCall ?? false
                 let toggleVideo = callInfo.toggledVideo
                 let maximumCallParticipants = callInfo.maximumCallParticipants

--- a/Wire-iOS/Sources/Analytics/AnalyticsCallingTracker.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsCallingTracker.swift
@@ -120,7 +120,6 @@ extension AnalyticsCallingTracker: WireCallCenterCallStateObserver {
             }
 
             callParticipantObserverToken = WireCallCenterV3.addCallParticipantObserver(observer: self, for: conversation, userSession: userSession)
-            // swiftlint:disable line_length
         case .terminating(reason: let reason):
             if let callInfo = callInfos[conversationId] {
                 let video = conversation.voiceChannel?.isVideoCall ?? false

--- a/Wire-iOS/Sources/Analytics/AnalyticsCallingTracker.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsCallingTracker.swift
@@ -135,7 +135,8 @@ extension AnalyticsCallingTracker: WireCallCenterCallStateObserver {
                                                      callParticipants: participants,
                                                      videoEnabled: toggleVideo,
                                                      screenShareEnabled: screenShare,
-                                                     callClosedReason: reason, conversation: conversation))
+                                                     callClosedReason: reason,
+                                                     conversation: conversation))
 
             }
             callInfos[conversationId] = nil

--- a/Wire-iOS/Sources/Analytics/AnalyticsCallingTracker.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsCallingTracker.swift
@@ -122,19 +122,19 @@ extension AnalyticsCallingTracker: WireCallCenterCallStateObserver {
             callParticipantObserverToken = WireCallCenterV3.addCallParticipantObserver(observer: self, for: conversation, userSession: userSession)
         case .terminating(let reason):
             if let callInfo = callInfos[conversationId] {
+                guard let establishedDate = callInfo.establishedDate else { return }
                 let isVideoCall = conversation.voiceChannel?.isVideoCall ?? false
                 let toggleVideo = callInfo.toggledVideo
-                let maximumCallParticipants = Double(callInfo.maximumCallParticipants)
+                let maximumCallParticipants = callInfo.maximumCallParticipants
                 let isSharingScreen = conversation.voiceChannel?.videoState ==  .screenSharing
-                guard let establishedDate = callInfo.establishedDate else { return }
                 let duration = -establishedDate.timeIntervalSinceNow
 
-                Analytics.shared.tagEvent(.endedCall(asVideoCall: video,
+                Analytics.shared.tagEvent(.endedCall(asVideoCall: isVideoCall,
                                                      callDirection: .outgoing,
                                                      callDuration: duration,
-                                                     callParticipants: participants,
+                                                     callParticipants: maximumCallParticipants,
                                                      videoEnabled: toggleVideo,
-                                                     screenShareEnabled: screenShare,
+                                                     screenShareEnabled: isSharingScreen,
                                                      callClosedReason: reason,
                                                      conversation: conversation))
 

--- a/Wire-iOS/Sources/Analytics/AnalyticsCallingTracker.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsCallingTracker.swift
@@ -123,9 +123,9 @@ extension AnalyticsCallingTracker: WireCallCenterCallStateObserver {
         case .terminating(let reason):
             if let callInfo = callInfos[conversationId] {
                 let video = conversation.voiceChannel?.isVideoCall ?? false
-                let toggleVideo = callInfo.toggledVideo ? true : false
+                let toggleVideo = callInfo.toggledVideo
                 let participants = Double(callInfo.maximumCallParticipants)
-                let screenShare = conversation.voiceChannel?.videoState ==  .screenSharing ? true : false
+                let screenShare = conversation.voiceChannel?.videoState ==  .screenSharing
                 guard let establishedDate = callInfo.establishedDate else { return }
                 let duration = -establishedDate.timeIntervalSinceNow
 

--- a/Wire-iOS/Sources/Analytics/AnalyticsCallingTracker.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsCallingTracker.swift
@@ -120,7 +120,7 @@ extension AnalyticsCallingTracker: WireCallCenterCallStateObserver {
             }
 
             callParticipantObserverToken = WireCallCenterV3.addCallParticipantObserver(observer: self, for: conversation, userSession: userSession)
-        case .terminating(reason: let reason):
+        case .terminating(let reason):
             if let callInfo = callInfos[conversationId] {
                 let video = conversation.voiceChannel?.isVideoCall ?? false
                 let toggleVideo = callInfo.toggledVideo ? true : false
@@ -135,7 +135,7 @@ extension AnalyticsCallingTracker: WireCallCenterCallStateObserver {
                                                      callParticipants: participants,
                                                      videoEnabled: toggleVideo,
                                                      screenShareEnabled: screenShare,
-                                                     callEndedReason: .normal, conversation: conversation))
+                                                     callClosedReason: reason, conversation: conversation))
 
             }
             callInfos[conversationId] = nil
@@ -182,37 +182,6 @@ extension AnalyticsCallingTracker: WireCallCenterCallParticipantObserver {
             Analytics.shared.tagEvent(.screenShare(callDirection: .incoming, duration: -screenSharingDate.timeIntervalSinceNow, in: conversation))
 
             screenSharingStartTimes[screenSharedParticipant.clientId] = nil
-        }
-    }
-}
-
-private extension CallClosedReason {
-
-    var analyticsValue: String {
-        switch self {
-        case .canceled:
-            return "canceled"
-        case .normal, .stillOngoing:
-            return "normal"
-        case .inputOutputError:
-            return "io_error"
-        case .internalError:
-            return "internal_error"
-        case .securityDegraded:
-            return "security_degraded"
-        case .anweredElsewhere:
-            return "answered_elsewhere"
-        case .timeout:
-            return "timeout"
-        case .unknown:
-            return "unknown"
-        case .lostMedia:
-            return "drop"
-        case .rejectedElsewhere:
-            return "rejected_elsewhere"
-        case .outdatedClient:
-            return "outdated_client"
-
         }
     }
 }

--- a/Wire-iOS/Sources/Analytics/AnalyticsCallingTracker.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsCallingTracker.swift
@@ -120,10 +120,18 @@ extension AnalyticsCallingTracker: WireCallCenterCallStateObserver {
             }
 
             callParticipantObserverToken = WireCallCenterV3.addCallParticipantObserver(observer: self, for: conversation, userSession: userSession)
-
+            // swiftlint:disable line_length
         case .terminating(reason: let reason):
             if let callInfo = callInfos[conversationId] {
-                analytics.tag(callEvent: .ended(reason: reason.analyticsValue), in: conversation, callInfo: callInfo)
+                let video = conversation.voiceChannel?.isVideoCall ?? false
+                let toggleVideo = callInfo.toggledVideo ? true : false
+                let participants = Double(callInfo.maximumCallParticipants)
+                let screenShare = conversation.voiceChannel?.videoState ==  .screenSharing ? true : false
+                guard let establishedDate = callInfo.establishedDate else { return }
+                let duration = Double(-establishedDate.timeIntervalSinceNow)
+
+                Analytics.shared.tagEvent(.endedCall(asVideoCall: video, callDirection: .outgoing, callDuration: duration, callParticipants: participants, videoEnabled: toggleVideo, screenShareEnabled: screenShare, callEndedReason: .normal, conversation: conversation))
+
             }
             callInfos[conversationId] = nil
 

--- a/Wire-iOS/Sources/Analytics/AnalyticsCallingTracker.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsCallingTracker.swift
@@ -127,7 +127,7 @@ extension AnalyticsCallingTracker: WireCallCenterCallStateObserver {
                 let participants = Double(callInfo.maximumCallParticipants)
                 let screenShare = conversation.voiceChannel?.videoState ==  .screenSharing ? true : false
                 guard let establishedDate = callInfo.establishedDate else { return }
-                let duration = Double(-establishedDate.timeIntervalSinceNow)
+                let duration = -establishedDate.timeIntervalSinceNow
 
                 Analytics.shared.tagEvent(.endedCall(asVideoCall: video,
                                                      callDirection: .outgoing,

--- a/Wire-iOS/Sources/Analytics/AnalyticsConsoleProvider.swift
+++ b/Wire-iOS/Sources/Analytics/AnalyticsConsoleProvider.swift
@@ -67,9 +67,9 @@ extension AnalyticsConsoleProvider: AnalyticsProvider {
     func tagEvent(_ event: AnalyticsEvent) {
         tagEvent(event.name, attributes: event.attributes.rawValue)
     }
-    
-    func tagEvent(_ event: String, attributes: [String : Any] = [:]) {
-        
+
+    func tagEvent(_ event: String, attributes: [String: Any] = [:]) {
+
         let printableAttributes = attributes
 
         var loggingDict = [String: Any]()

--- a/Wire-iOS/Sources/Analytics/Countly/CountlyUserInterface.swift
+++ b/Wire-iOS/Sources/Analytics/Countly/CountlyUserInterface.swift
@@ -24,7 +24,7 @@ protocol CountlyUserInterface {
     func set(_ key: String, value: String)
 
     func unSet(_ key: String)
-    
+
     func save()
 
 }

--- a/Wire-iOS/Sources/Analytics/Events/Analytics+CallEvents.swift
+++ b/Wire-iOS/Sources/Analytics/Events/Analytics+CallEvents.swift
@@ -20,6 +20,7 @@ import Foundation
 import UIKit
 import WireDataModel
 
+// swiftlint:disable line_length
 enum CallEvent {
     case initiated,
          received,
@@ -74,11 +75,16 @@ extension Analytics {
         attributes.merge(attributesForDirection(with: callInfo), strategy: .preferNew)
 
         switch event {
-        case .ended(reason: let reason):
-            attributes.merge(attributesForSetupTime(with: callInfo), strategy: .preferNew)
-            attributes.merge(attributesForCallDuration(with: callInfo), strategy: .preferNew)
-            attributes.merge(attributesForVideoToogle(with: callInfo), strategy: .preferNew)
-            attributes.merge(["reason": reason], strategy: .preferNew)
+        case .ended(reason: _):
+            let video = conversation.voiceChannel?.isVideoCall ?? false
+            let toggleVideo = callInfo.toggledVideo ? true : false
+            let participants = Double(callInfo.maximumCallParticipants)
+            let screenShare = conversation.voiceChannel?.videoState ==  .screenSharing ? true : false
+            guard let establishedDate = callInfo.establishedDate else { return [:] }
+            let duration = Double(-establishedDate.timeIntervalSinceNow)
+
+            Analytics.shared.tagEvent(.endedCall(asVideoCall: video, callDirection: .outgoing, callDuration: duration, callParticipants: participants, videoEnabled: toggleVideo, screenShareEnabled: screenShare, callEndedReason: .normal, conversation: conversation))
+
         case .screenSharing(let duration):
             Analytics.shared.tagEvent(.screenShare(callDirection: .incoming, duration: duration, in: conversation))
         default:

--- a/Wire-iOS/Sources/Analytics/Events/Analytics+CallEvents.swift
+++ b/Wire-iOS/Sources/Analytics/Events/Analytics+CallEvents.swift
@@ -19,13 +19,14 @@
 import Foundation
 import UIKit
 import WireDataModel
+import WireSyncEngine
 
 enum CallEvent {
     case initiated,
          received,
          answered,
          established,
-         ended(reason: String),
+         ended(reason: CallClosedReason),
          screenSharing(duration: TimeInterval)
 }
 
@@ -74,7 +75,7 @@ extension Analytics {
         attributes.merge(attributesForDirection(with: callInfo), strategy: .preferNew)
 
         switch event {
-        case .ended(reason: _):
+        case .ended(let reason):
             let video = conversation.voiceChannel?.isVideoCall ?? false
             let toggleVideo = callInfo.toggledVideo ? true : false
             let participants = Double(callInfo.maximumCallParticipants)
@@ -88,7 +89,7 @@ extension Analytics {
                                                  callParticipants: participants,
                                                  videoEnabled: toggleVideo,
                                                  screenShareEnabled: screenShare,
-                                                 callEndedReason: .normal,
+                                                 callClosedReason: reason,
                                                  conversation: conversation))
 
         case .screenSharing(let duration):

--- a/Wire-iOS/Sources/Analytics/Events/Analytics+CallEvents.swift
+++ b/Wire-iOS/Sources/Analytics/Events/Analytics+CallEvents.swift
@@ -76,19 +76,19 @@ extension Analytics {
 
         switch event {
         case .ended(let reason):
+            guard let establishedDate = callInfo.establishedDate else { return [:] }
             let isVideoCall = conversation.voiceChannel?.isVideoCall ?? false
             let toggleVideo = callInfo.toggledVideo
-            let participants = Double(callInfo.maximumCallParticipants)
-            let screenShare = conversation.voiceChannel?.videoState ==  .screenSharing
-            guard let establishedDate = callInfo.establishedDate else { return [:] }
+            let maximumCallParticipants = callInfo.maximumCallParticipants
+            let isScreenSharing = conversation.voiceChannel?.videoState ==  .screenSharing
             let duration = -establishedDate.timeIntervalSinceNow
 
-            Analytics.shared.tagEvent(.endedCall(asVideoCall: video,
+            Analytics.shared.tagEvent(.endedCall(asVideoCall: isVideoCall,
                                                  callDirection: .outgoing,
                                                  callDuration: duration,
-                                                 callParticipants: participants,
+                                                 callParticipants: maximumCallParticipants,
                                                  videoEnabled: toggleVideo,
-                                                 screenShareEnabled: screenShare,
+                                                 screenShareEnabled: isScreenSharing,
                                                  callClosedReason: reason,
                                                  conversation: conversation))
 

--- a/Wire-iOS/Sources/Analytics/Events/Analytics+CallEvents.swift
+++ b/Wire-iOS/Sources/Analytics/Events/Analytics+CallEvents.swift
@@ -76,7 +76,7 @@ extension Analytics {
 
         switch event {
         case .ended(let reason):
-            let video = conversation.voiceChannel?.isVideoCall ?? false
+            let isVideoCall = conversation.voiceChannel?.isVideoCall ?? false
             let toggleVideo = callInfo.toggledVideo
             let participants = Double(callInfo.maximumCallParticipants)
             let screenShare = conversation.voiceChannel?.videoState ==  .screenSharing

--- a/Wire-iOS/Sources/Analytics/Events/Analytics+CallEvents.swift
+++ b/Wire-iOS/Sources/Analytics/Events/Analytics+CallEvents.swift
@@ -20,7 +20,6 @@ import Foundation
 import UIKit
 import WireDataModel
 
-// swiftlint:disable line_length
 enum CallEvent {
     case initiated,
          received,
@@ -83,7 +82,14 @@ extension Analytics {
             guard let establishedDate = callInfo.establishedDate else { return [:] }
             let duration = Double(-establishedDate.timeIntervalSinceNow)
 
-            Analytics.shared.tagEvent(.endedCall(asVideoCall: video, callDirection: .outgoing, callDuration: duration, callParticipants: participants, videoEnabled: toggleVideo, screenShareEnabled: screenShare, callEndedReason: .normal, conversation: conversation))
+            Analytics.shared.tagEvent(.endedCall(asVideoCall: video,
+                                                 callDirection: .outgoing,
+                                                 callDuration: duration,
+                                                 callParticipants: participants,
+                                                 videoEnabled: toggleVideo,
+                                                 screenShareEnabled: screenShare,
+                                                 callEndedReason: .normal,
+                                                 conversation: conversation))
 
         case .screenSharing(let duration):
             Analytics.shared.tagEvent(.screenShare(callDirection: .incoming, duration: duration, in: conversation))

--- a/Wire-iOS/Sources/Analytics/Events/Analytics+CallEvents.swift
+++ b/Wire-iOS/Sources/Analytics/Events/Analytics+CallEvents.swift
@@ -77,11 +77,11 @@ extension Analytics {
         switch event {
         case .ended(let reason):
             let video = conversation.voiceChannel?.isVideoCall ?? false
-            let toggleVideo = callInfo.toggledVideo ? true : false
+            let toggleVideo = callInfo.toggledVideo
             let participants = Double(callInfo.maximumCallParticipants)
-            let screenShare = conversation.voiceChannel?.videoState ==  .screenSharing ? true : false
+            let screenShare = conversation.voiceChannel?.videoState ==  .screenSharing
             guard let establishedDate = callInfo.establishedDate else { return [:] }
-            let duration = Double(-establishedDate.timeIntervalSinceNow)
+            let duration = -establishedDate.timeIntervalSinceNow
 
             Analytics.shared.tagEvent(.endedCall(asVideoCall: video,
                                                  callDirection: .outgoing,

--- a/Wire-iOS/Sources/Analytics/Events/Analytics+CallStateEvents.swift
+++ b/Wire-iOS/Sources/Analytics/Events/Analytics+CallStateEvents.swift
@@ -51,8 +51,15 @@ extension AnalyticsEvent {
         return event
     }
 
-    // swiftlint:disable line_length
-    static func endedCall(asVideoCall: Bool, callDirection: CallDirection, callDuration: Double, callParticipants: Double, videoEnabled: Bool, screenShareEnabled: Bool, callEndedReason: ReasonCallEnded, conversation: ZMConversation) -> AnalyticsEvent {
+    static func endedCall(asVideoCall: Bool,
+                          callDirection: CallDirection,
+                          callDuration: Double,
+                          callParticipants: Double,
+                          videoEnabled: Bool,
+                          screenShareEnabled: Bool,
+                          callEndedReason: ReasonCallEnded,
+                          conversation: ZMConversation) -> AnalyticsEvent {
+        
         var event = AnalyticsEvent(name: "calling.ended_call")
         event.attributes = conversation.analyticsAttributes
         event.attributes[.startedAsVideoCall] = asVideoCall

--- a/Wire-iOS/Sources/Analytics/Events/Analytics+CallStateEvents.swift
+++ b/Wire-iOS/Sources/Analytics/Events/Analytics+CallStateEvents.swift
@@ -57,9 +57,8 @@ extension AnalyticsEvent {
                           callParticipants: Double,
                           videoEnabled: Bool,
                           screenShareEnabled: Bool,
-                          callEndedReason: ReasonCallEnded,
+                          callEndedReason: CallEndReason,
                           conversation: ZMConversation) -> AnalyticsEvent {
-        
         var event = AnalyticsEvent(name: "calling.ended_call")
         event.attributes = conversation.analyticsAttributes
         event.attributes[.startedAsVideoCall] = asVideoCall
@@ -72,7 +71,7 @@ extension AnalyticsEvent {
         return event
     }
 
-    enum ReasonCallEnded: String, AnalyticsAttributeValue {
+    enum CallEndReason: String, AnalyticsAttributeValue {
         case normal = "normal"
         case selfReason = "self"
         case other = "other"
@@ -124,7 +123,7 @@ private extension AnalyticsAttributeKey {
 
     /// The peak number of participants in the call.
     ///
-    /// Expected to refer to a value of type `AnalyticsCallParticipantsType`.
+    /// Expected to refer to a value of type `RoundedInt`.
     static let callParticipants  = AnalyticsAttributeKey(rawValue: "call_participants")
 
     /// Whether the video was enabled at least once by any user.

--- a/Wire-iOS/Sources/Analytics/Events/Analytics+CallStateEvents.swift
+++ b/Wire-iOS/Sources/Analytics/Events/Analytics+CallStateEvents.swift
@@ -51,6 +51,41 @@ extension AnalyticsEvent {
         return event
     }
 
+    // swiftlint:disable line_length
+    static func endedCall(asVideoCall: Bool, callDirection: CallDirection, callDuration: Double, callParticipants: Double, videoEnabled: Bool, screenShareEnabled: Bool, callEndedReason: ReasonCallEnded, conversation: ZMConversation) -> AnalyticsEvent {
+        var event = AnalyticsEvent(name: "calling.ended_call")
+        event.attributes = conversation.analyticsAttributes
+        event.attributes[.startedAsVideoCall] = asVideoCall
+        event.attributes[.callDirection] = callDirection
+        event.attributes[.callDuration] = RoundedInt(Int(callDuration), factor: 6)
+        event.attributes[.callParticipants] = RoundedInt(Int(callParticipants), factor: 6)
+        event.attributes[.videoEnabled] = videoEnabled
+        event.attributes[.screenShareEnabled] = screenShareEnabled
+        event.attributes[.callEndedReason] = callEndedReason
+        return event
+    }
+
+    enum ReasonCallEnded: String, AnalyticsAttributeValue {
+        case normal = "normal"
+        case selfReason = "self"
+        case other = "other"
+        case gsmCall = "gsm_call"
+        case internalError = "internal_error"
+        case timeout = "timeout"
+        case lostMedia = "lost_media"
+        case cancelled = "cancelled"
+        case answeredElsewhere = "answered_elsewhere"
+        case ioError = "io_error"
+        case stillOngoing = "still_ongoing"
+        case timeoutEccon = "timeout_econn"
+        case dataChannel = "data_channel"
+        case rejected = "rejected"
+
+        var analyticsValue: String {
+            return rawValue
+        }
+    }
+
     enum CallDirection: String, AnalyticsAttributeValue {
 
         case incoming
@@ -75,9 +110,33 @@ private extension AnalyticsAttributeKey {
     /// Expected to refer to a value of type `AnalyticsCallDirectionType`.
     static let callDirection  = AnalyticsAttributeKey(rawValue: "call_direction")
 
-    /// The duration of the screen-sharing.
+    /// The duration of the call in seconds.
+    ///
+    /// Expected to refer to a value of type `RoundedInt`.
+    static let callDuration  = AnalyticsAttributeKey(rawValue: "call_duration")
+
+    /// The peak number of participants in the call.
+    ///
+    /// Expected to refer to a value of type `AnalyticsCallParticipantsType`.
+    static let callParticipants  = AnalyticsAttributeKey(rawValue: "call_participants")
+
+    /// Whether the video was enabled at least once by any user.
+    ///
+    /// Expected to refer to a value of type `Boolean`.
+    static let videoEnabled  = AnalyticsAttributeKey(rawValue: "call_AV_switch_toggle")
+
+    /// Whether screen sharing was enabled at least once by any user.
+    ///
+    /// Expected to refer to a value of type `Boolean`.
+    static let screenShareEnabled  = AnalyticsAttributeKey(rawValue: "call_screen_share")
+
+    /// The duration of the screen share in seconds.
     ///
     /// Expected to refer to a value of type `RoundedInt`.
     static let screenShareDuration = AnalyticsAttributeKey(rawValue: "screen_share_duration")
 
+    /// The reason the call ended, according to AVS.
+    ///
+    /// Expected to refer to a value of type `AnalyticsCallEndedReasonType`.
+    static let callEndedReason  = AnalyticsAttributeKey(rawValue: "call_end_reason")
 }

--- a/Wire-iOS/Sources/Analytics/Events/Analytics+CallStateEvents.swift
+++ b/Wire-iOS/Sources/Analytics/Events/Analytics+CallStateEvents.swift
@@ -104,7 +104,6 @@ extension AnalyticsEvent {
         return event
     }
 
-
     enum CallDirection: String, AnalyticsAttributeValue {
 
         case incoming

--- a/Wire-iOS/Sources/Analytics/Events/Analytics+CallStateEvents.swift
+++ b/Wire-iOS/Sources/Analytics/Events/Analytics+CallStateEvents.swift
@@ -18,6 +18,39 @@
 
 import Foundation
 import WireDataModel
+import WireSyncEngine
+
+extension CallClosedReason: AnalyticsAttributeValue {
+    public var analyticsValue: String {
+        switch self {
+        case .normal:
+            return "normal"
+        case .canceled:
+            return "cancelled"
+        case .anweredElsewhere:
+            return "answered_elsewhere"
+        case .rejectedElsewhere:
+            return "rejected"
+        case .timeout:
+            return "timeout"
+        case .lostMedia:
+            return "lost_media"
+        case .internalError:
+            return "internal_error"
+        case .inputOutputError:
+            return "io_error"
+        case .stillOngoing:
+            return "still_ongoing"
+        case .securityDegraded:
+            return "security_degraded"
+        case .outdatedClient:
+            return "outdated_client"
+        case .unknown:
+            return "unknown"
+        }
+    }
+
+}
 
 extension AnalyticsEvent {
 
@@ -57,7 +90,7 @@ extension AnalyticsEvent {
                           callParticipants: Double,
                           videoEnabled: Bool,
                           screenShareEnabled: Bool,
-                          callEndedReason: CallEndReason,
+                          callClosedReason: CallClosedReason,
                           conversation: ZMConversation) -> AnalyticsEvent {
         var event = AnalyticsEvent(name: "calling.ended_call")
         event.attributes = conversation.analyticsAttributes
@@ -67,30 +100,10 @@ extension AnalyticsEvent {
         event.attributes[.callParticipants] = RoundedInt(Int(callParticipants), factor: 6)
         event.attributes[.videoEnabled] = videoEnabled
         event.attributes[.screenShareEnabled] = screenShareEnabled
-        event.attributes[.callEndedReason] = callEndedReason
+        event.attributes[.callEndedReason] = callClosedReason
         return event
     }
 
-    enum CallEndReason: String, AnalyticsAttributeValue {
-        case normal = "normal"
-        case selfReason = "self"
-        case other = "other"
-        case gsmCall = "gsm_call"
-        case internalError = "internal_error"
-        case timeout = "timeout"
-        case lostMedia = "lost_media"
-        case cancelled = "cancelled"
-        case answeredElsewhere = "answered_elsewhere"
-        case ioError = "io_error"
-        case stillOngoing = "still_ongoing"
-        case timeoutEccon = "timeout_econn"
-        case dataChannel = "data_channel"
-        case rejected = "rejected"
-
-        var analyticsValue: String {
-            return rawValue
-        }
-    }
 
     enum CallDirection: String, AnalyticsAttributeValue {
 

--- a/Wire-iOS/Sources/Analytics/Events/Analytics+CallStateEvents.swift
+++ b/Wire-iOS/Sources/Analytics/Events/Analytics+CallStateEvents.swift
@@ -87,7 +87,7 @@ extension AnalyticsEvent {
     static func endedCall(asVideoCall: Bool,
                           callDirection: CallDirection,
                           callDuration: Double,
-                          callParticipants: Double,
+                          callParticipants: Int,
                           videoEnabled: Bool,
                           screenShareEnabled: Bool,
                           callClosedReason: CallClosedReason,
@@ -156,6 +156,6 @@ private extension AnalyticsAttributeKey {
 
     /// The reason the call ended, according to AVS.
     ///
-    /// Expected to refer to a value of type `AnalyticsCallEndedReasonType`.
+    /// Expected to refer to a value of type `CallClosedReason`.
     static let callEndedReason  = AnalyticsAttributeKey(rawValue: "call_end_reason")
 }

--- a/Wire-iOS/Sources/UserInterface/Collections/ConversationImagesViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/ConversationImagesViewController.swift
@@ -346,7 +346,7 @@ final class ConversationImagesViewController: TintColorCorrectedViewController {
                                        view: sender as? UIView ?? view)
     }
 
-    //MARK: icon button actions
+    // MARK: icon button actions
 
     @objc
     private func copyCurrent(_ sender: AnyObject!) {

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/NSAttributedString+Down.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/NSAttributedString+Down.swift
@@ -35,7 +35,7 @@ extension NSAttributedString {
         if result.string.last == "\n" {
             result.deleteCharacters(in: NSMakeRange(result.length - 1, 1))
         }
-        
+
         guard !result.string.isEmpty else {
             return .init(string: text)
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarSendController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarSendController.swift
@@ -64,7 +64,7 @@ final class ConversationInputBarSendController: NSObject {
             }
         }, completionHandler: {
             Analytics.shared.tagEvent(.contributed(.textMessage, in: conversation))
-            
+
         })
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This is the last big refactor for a major analytics event to make it work with the new analytics mechanism. @johnxnguyen I will leave some comments for you.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
