### PR TITLE
chore: fix self_in_property_initialization SwiftLint Warning

### DIFF
--- a/Wire-iOS/Sources/Authentication/Landing/LandingViewController.swift
+++ b/Wire-iOS/Sources/Authentication/Landing/LandingViewController.swift
@@ -112,7 +112,7 @@ final class LandingViewController: AuthenticationStepViewController {
         return label
     }()
 
-    private let buttonStackView: UIStackView = {
+    private lazy var buttonStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.distribution = .fillEqually
         stackView.axis = .vertical
@@ -124,7 +124,7 @@ final class LandingViewController: AuthenticationStepViewController {
         return stackView
     }()
 
-    private let loginButton: Button = {
+    private lazy var loginButton: Button = {
         let button = Button(style: .full, variant: .light, titleLabelFont: .smallSemiboldFont)
         button.accessibilityIdentifier = "Login"
         button.setTitle("landing.login.button.title".localized, for: .normal)
@@ -135,7 +135,7 @@ final class LandingViewController: AuthenticationStepViewController {
         return button
     }()
 
-    private let enterpriseLoginButton: Button = {
+    private lazy var enterpriseLoginButton: Button = {
         let button = Button(style: .empty,
                             variant: .light,
                             titleLabelFont: .smallSemiboldFont)
@@ -148,7 +148,7 @@ final class LandingViewController: AuthenticationStepViewController {
         return button
     }()
 
-    private let loginWithEmailButton: Button = {
+    private lazy var loginWithEmailButton: Button = {
         let button = Button(style: .full, variant: .light, titleLabelFont: .smallSemiboldFont)
         button.accessibilityIdentifier = "Login with email"
         button.setTitle("landing.login.email.button.title".localized, for: .normal)
@@ -159,7 +159,7 @@ final class LandingViewController: AuthenticationStepViewController {
         return button
     }()
 
-    private let loginWithSSOButton: Button = {
+    private lazy var loginWithSSOButton: Button = {
         let button = Button(style: .empty, variant: .light, titleLabelFont: .smallSemiboldFont)
         button.accessibilityIdentifier = "Log in with SSO"
         button.setTitle("landing.login.sso.button.title".localized, for: .normal)
@@ -183,7 +183,7 @@ final class LandingViewController: AuthenticationStepViewController {
         return label
     }()
 
-    private let createAccountButton: Button = {
+    private lazy var createAccountButton: Button = {
         let button = Button(style: .empty,
                             variant: .light,
                             titleLabelFont: .smallSemiboldFont)

--- a/Wire-iOS/Sources/Permissions/ShareContactsViewController.swift
+++ b/Wire-iOS/Sources/Permissions/ShareContactsViewController.swift
@@ -65,7 +65,7 @@ final class ShareContactsViewController: UIViewController {
     var notNowButtonHidden = false
     private(set) var showingAddressBookAccessDeniedViewController = false
 
-    private let notNowButton: UIButton = {
+    private lazy var notNowButton: UIButton = {
         let notNowButton = UIButton(type: .custom)
         notNowButton.titleLabel?.font = UIFont.smallLightFont
         notNowButton.setTitleColor(UIColor.from(scheme: .buttonFaded, variant: .dark), for: .normal)

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/FileTransfer/AudioMessageView.swift
@@ -68,7 +68,7 @@ final class AudioMessageView: UIView, TransferView {
 
         return waveformProgressView
     }()
-    
+
     private let loadingView = ThreeDotsLoadingView()
 
     private var allViews: [UIView] = []

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/NSAttributedString+Down.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/NSAttributedString+Down.swift
@@ -35,7 +35,7 @@ extension NSAttributedString {
         if result.string.last == "\n" {
             result.deleteCharacters(in: NSMakeRange(result.length - 1, 1))
         }
-        
+
         guard !result.string.isEmpty else {
             return .init(string: text)
         }

--- a/Wire-iOS/Sources/UserInterface/CustomAppLock/Unlock/UnlockViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/CustomAppLock/Unlock/UnlockViewController.swift
@@ -115,7 +115,7 @@ final class UnlockViewController: UIViewController {
         return label
     }()
 
-    private let wipeButton: UIButton = {
+    private lazy var wipeButton: UIButton = {
         let button = UIButton()
         button.titleLabel?.font = FontSpec(.medium, .medium).font!.withSize(14)
         button.setTitleColor(UIColor.from(scheme: .textForeground, variant: .dark), for: .normal)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

In this PR I fix SwiftLint warnings related to this rule:

**Self in Property Initialization Violation**: `self` refers to the unapplied `NSObject.self()` method, which is likely not expected. Make the variable `lazy` to be able to refer to the current instance or use `ClassName.self`. `(self_in_property_initialization)`

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
