### PR TITLE
fix: SwiftLint warnings and errors for multiple rules (`reduce_boolean`, `compiler_protocol_init`, `closure_parameter_position`)

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -13,7 +13,6 @@ disabled_rules:
     - notification_center_detachment
     - discarded_notification_center_observer
     - cyclomatic_complexity
-    - closure_parameter_position
     - statement_position
     - weak_delegate
     - inclusive_language
@@ -25,8 +24,6 @@ disabled_rules:
     - nesting
     - function_parameter_count
     - xctfail_message
-    - compiler_protocol_init
-    - reduce_boolean
 
 included:
     - Wire-iOS/Sources

--- a/Wire-iOS Tests/AVAsset/AVURLAsset+conversionTests.swift
+++ b/Wire-iOS Tests/AVAsset/AVURLAsset+conversionTests.swift
@@ -30,8 +30,7 @@ final class AVURLAsset_conversionTests: XCTestCase {
 
         AVURLAsset.convertVideoToUploadFormat(at: videoURL,
                                               quality: AVAssetExportPresetLowQuality,
-                                              deleteSourceFile: false) {
-                                                url, asset, error in
+                                              deleteSourceFile: false) { url, asset, error in
                                                 // THEN
 
                                                 // exported file URL

--- a/Wire-iOS Tests/AccessoryTextField/AccessoryTextFieldValidationTests.swift
+++ b/Wire-iOS Tests/AccessoryTextField/AccessoryTextFieldValidationTests.swift
@@ -212,11 +212,12 @@ final class AccessoryTextFieldValidateionTests: XCTestCase {
         // GIVEN
         let type: ValidatedTextField.Kind = .password(isNew: true)
         let text = String(repeating: "a", count: 7)
+        let missingRequiredClassesSet: Set<PasswordCharacterClass> = [.uppercase, .special, .digits]
 
         // WHEN & THEN
         checkError(textFieldType: type, text: text, expectedError:
             .invalidPassword([.tooShort,
-                              .missingRequiredClasses(Set(arrayLiteral: .uppercase, .special, .digits))]))
+                              .missingRequiredClasses(missingRequiredClassesSet)]))
     }
 
     func testThat129CharacterPasswordIsInvalid_New() {

--- a/Wire-iOS Tests/CombinationTest.swift
+++ b/Wire-iOS Tests/CombinationTest.swift
@@ -113,7 +113,7 @@ class CombinationTestTest: XCTestCase {
         let test = CombinationTest(mutable: BoolPair(first: false, second: false), mutators: [firstMutator, secondMutator])
 
         XCTAssertEqual(test.testAll { (variation) -> (Bool?) in
-            return variation.result.calculate() == variation.combinationChain.reduce(true) { $0 && $1 }
+            return variation.result.calculate() == variation.combinationChain.allSatisfy { $0 }
         }.count, 0)
     }
 }

--- a/Wire-iOS/Sources/UserInterface/Overlay/CallTopOverlayController.swift
+++ b/Wire-iOS/Sources/UserInterface/Overlay/CallTopOverlayController.swift
@@ -187,8 +187,7 @@ final class CallTopOverlayController: UIViewController {
     private func startCallDurationTimer() {
         stopCallDurationTimer()
 
-        callDurationTimer = .scheduledTimer(withTimeInterval: 0.1, repeats: true) {
-            [weak self] _ in
+        callDurationTimer = .scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] _ in
             self?.updateCallDuration()
         }
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Started removing rules from the list. It's going to be a long process. For a start I fix warnings and errors for the rules below:

- **Closure Parameter Position Violation**: Closure parameters should be on the same line as opening brace. `(closure_parameter_position)`
- **Compiler Protocol Init Violation**: The initializers declared in compiler protocol ExpressibleByArrayLiteral shouldn't be called directly. `(compiler_protocol_init)`
- **Reduce Boolean Violation**: Use `allSatisfy` instead `(reduce_boolean)`

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
