### PR TITLE
Revert "remove CODECOV_TOKEN from fastlane"

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,6 +75,7 @@ steps:
 - script: |
     fastlane post_test
   env:  
+    CODECOV_TOKEN: $(CODECOV_TOKEN)
     DEPENDENCIES_BASE_URL: "https://raw.githubusercontent.com/wireapp/wire-ios-shared-resources/master"
     GITHUB_ACCESS_TOKEN: $(GITHUB_ACCESS_TOKEN)   
   displayName: "Post Test"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -316,6 +316,9 @@ platform :ios do
         codecov = "./codecov -J '^Wire$' -D ../DerivedData"
 
         if ENV["BUILD_REASON"] == "PullRequest"
+            if ENV["CODECOV_TOKEN"].nil?
+                UI.user_error! "codecov.io token missing for current repository. Set it in CODECOV_TOKEN environment variable"
+            end
 
             if ENV["BUILD_SOURCEBRANCH"].nil?
                 UI.user_error! "Source branch env variable missing. Set BUILD_SOURCEBRANCH to fix it"
@@ -323,10 +326,11 @@ platform :ios do
 
             pull_request_number = ENV["BUILD_SOURCEBRANCH"].split("/")[2] # For PRs the branch is in format "refs/pull/1/merge"
 
-            codecov << " -P #{pull_request_number}"
+            codecov << " -t #{ENV["CODECOV_TOKEN"]} -P #{pull_request_number}"
         end
 
         sh codecov
+
     end
 end
 


### PR DESCRIPTION
Reverts wireapp/wire-ios#5057

Checked that other framework project still using `CODECOV_TOKEN` and produce codecov report. Undo the setup of codecov