### PR TITLE
chore: Fix SwiftLint warnings for statement position Part 1

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -13,7 +13,6 @@ disabled_rules:
     - notification_center_detachment
     - discarded_notification_center_observer
     - cyclomatic_complexity
-    - statement_position
     - weak_delegate
     - inclusive_language
     - class_delegate_protocol

--- a/Wire-iOS Tests/DateFormatterTests.swift
+++ b/Wire-iOS Tests/DateFormatterTests.swift
@@ -134,8 +134,7 @@ final class DateFormatterTests: XCTestCase {
         if hour > 12 {
             hour -= 12
             meridiem = "PM"
-        }
-        else if hour == 12 {
+        } else if hour == 12 {
             meridiem = "PM"
         }
 

--- a/Wire-iOS Tests/Settings/SettingsPropertyTests.swift
+++ b/Wire-iOS Tests/Settings/SettingsPropertyTests.swift
@@ -78,8 +78,7 @@ final class SettingsPropertyTests: XCTestCase {
                     expected: true
                 )
             }
-        }
-        else {
+        } else {
             recordFailure(
                 withDescription: "Unable to read property value",
                 inFile: file,

--- a/Wire-iOS/Sources/Components/Settings/SettingsPropertyFactory.swift
+++ b/Wire-iOS/Sources/Components/Settings/SettingsPropertyFactory.swift
@@ -201,8 +201,7 @@ final class SettingsPropertyFactory {
             let getAction: GetAction = { [unowned self] _ in
                 if let mediaManager = self.mediaManager {
                     return SettingsPropertyValue(mediaManager.intensityLevel.rawValue)
-                }
-                else {
+                } else {
                     return SettingsPropertyValue(0)
                 }
             }
@@ -213,8 +212,7 @@ final class SettingsPropertyFactory {
                     if let intensivityLevel = AVSIntensityLevel(rawValue: UInt(truncating: intValue)),
                         var mediaManager = self.mediaManager {
                         mediaManager.intensityLevel = intensivityLevel
-                    }
-                    else {
+                    } else {
                         throw SettingsPropertyError.WrongValue("Cannot use value \(intValue) for AVSIntensivityLevel at \(propertyName)")
                     }
                 default:
@@ -227,8 +225,7 @@ final class SettingsPropertyFactory {
             let getAction: GetAction = { [unowned self] _ in
                 if let tracking = self.tracking {
                     return SettingsPropertyValue(tracking.disableAnalyticsSharing)
-                }
-                else {
+                } else {
                     return SettingsPropertyValue(false)
                 }
             }
@@ -248,8 +245,7 @@ final class SettingsPropertyFactory {
             let getAction: GetAction = { [unowned self] _ in
                 if let tracking = self.tracking {
                     return SettingsPropertyValue(tracking.disableCrashSharing)
-                }
-                else {
+                } else {
                     return SettingsPropertyValue(false)
                 }
             }

--- a/Wire-iOS/Sources/Components/ShareViewController/ShareViewController.swift
+++ b/Wire-iOS/Sources/Components/ShareViewController/ShareViewController.swift
@@ -135,8 +135,7 @@ final class ShareViewController<D: ShareDestination & NSObjectProtocol, S: Share
                     let name = $0.displayName
                     return name.range(of: filterString, options: .caseInsensitive) != nil
                 }
-            }
-            else {
+            } else {
                 self.filteredDestinations = self.destinations
             }
 

--- a/Wire-iOS/Sources/Helpers/AttributedStringOperators.swift
+++ b/Wire-iOS/Sources/Helpers/AttributedStringOperators.swift
@@ -217,8 +217,7 @@ extension String {
 
         if povVersion != povPath, !povVersion.isEmpty {
             return povVersion
-        }
-        else {
+        } else {
             return self.localized
         }
     }

--- a/Wire-iOS/Sources/Helpers/NSAttributedString+Highlight.swift
+++ b/Wire-iOS/Sources/Helpers/NSAttributedString+Highlight.swift
@@ -90,8 +90,7 @@ extension NSAttributedString {
         // There is no prior whitespace
         if previousSpace.location == NSNotFound {
             return self.attributedSubstring(from: NSRange(location: from, length: self.length - from)).prefixedWithEllipsis()
-        }
-        else {
+        } else {
             // Check if we accidentally jumped to the previous line
             let textSkipped = text.substring(with: NSRange(location: previousSpace.location + previousSpace.length, length: from - previousSpace.location))
             let skippedNewline = textSkipped.containsCharacters(from: .newlines)
@@ -107,8 +106,7 @@ extension NSAttributedString {
         // There is no whitespace before the previousSpace
         if prePreviousSpace.location == NSNotFound {
             prePreviousSpace = previousSpace
-        }
-        else {
+        } else {
             // Check if we accidentally jumped to the previous line
             let textSkipped = text.substring(with: NSRange(location: prePreviousSpace.location + prePreviousSpace.length, length: from - prePreviousSpace.location))
             let preSkippedNewline = textSkipped.containsCharacters(from: .newlines)
@@ -127,8 +125,7 @@ extension NSAttributedString {
 
         if textSize.width > fittingIntoWidth {
             return self.attributedSubstring(from: NSRange(location: from, length: self.length - from)).prefixedWithEllipsis()
-        }
-        else {
+        } else {
             let rangeFromPrePreviousSpaceToEnd = NSRange(location: prePreviousSpace.location + prePreviousSpace.length,
                                                          length: self.length - (prePreviousSpace.location + prePreviousSpace.length))
 
@@ -167,8 +164,7 @@ extension NSAttributedString {
 
                 if upToWidth == 0 || substring.layoutSize().width < upToWidth {
                     attributedText.addAttributes(attributes, range: currentRange)
-                }
-                else {
+                } else {
                     break
                 }
             }

--- a/Wire-iOS/Sources/Helpers/syncengine/SessionManager+Convenience.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/SessionManager+Convenience.swift
@@ -56,8 +56,7 @@ extension SessionManager {
 
         if isCallKitEnabled && isCallKitSupported && hasAudioPermissions {
             self.callNotificationStyle = .callKit
-        }
-        else {
+        } else {
             self.callNotificationStyle = .pushNotifications
         }
     }

--- a/Wire-iOS/Sources/Helpers/syncengine/ZMMessage+Actions.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMMessage+Actions.swift
@@ -133,17 +133,13 @@ extension ZMConversationMessage {
 
         if isImage {
             return true
-        }
-        else if isVideo {
+        } else if isVideo {
             return videoCanBeSavedToCameraRoll()
-        }
-        else if isAudio {
+        } else if isAudio {
             return audioCanBeSaved()
-        }
-        else if isFile, let fileMessageData = self.fileMessageData {
+        } else if isFile, let fileMessageData = self.fileMessageData {
             return fileMessageData.fileURL != nil
-        }
-        else {
+        } else {
             return false
         }
     }
@@ -156,8 +152,7 @@ extension ZMConversationMessage {
 
         if isFile, let fileMessageData = self.fileMessageData {
             return fileMessageData.fileURL != nil
-        }
-        else {
+        } else {
             return (isText || isImage || isLocation || isFile)
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionCell.swift
@@ -83,8 +83,7 @@ class CollectionCell: UICollectionViewCell {
             newFrame.size.width = cachedSize.width
             newFrame.size.height = cachedSize.height
             layoutAttributes.frame = newFrame
-        }
-        else {
+        } else {
             setNeedsLayout()
             layoutIfNeeded()
             var desiredSize = layoutAttributes.size

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionLinkCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionLinkCell.swift
@@ -72,8 +72,7 @@ final class CollectionLinkCell: CollectionCell {
 
         if changeInfo == nil {
             shouldReload = true
-        }
-        else {
+        } else {
             shouldReload = changeInfo!.imageChanged
         }
 

--- a/Wire-iOS/Sources/UserInterface/Components/CharacterInputField.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/CharacterInputField.swift
@@ -70,8 +70,7 @@ final class CharacterInputField: UIControl, UITextInputTraits, TextContainer {
 
             if let character = storage.count > index ? storage[storage.index(storage.startIndex, offsetBy: index)] : nil {
                 characterView.character = character
-            }
-            else {
+            } else {
                 characterView.character = .none
             }
         }
@@ -107,8 +106,7 @@ final class CharacterInputField: UIControl, UITextInputTraits, TextContainer {
                 if let character = self.character {
                     label.text = String(character)
                     label.isHidden = false
-                }
-                else {
+                } else {
                     label.isHidden = true
                 }
             }

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/RotationAwareNavigationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/RotationAwareNavigationController.swift
@@ -31,8 +31,7 @@ final class RotationAwareNavigationController: UINavigationController, PopoverPr
     override var shouldAutorotate: Bool {
         if let topController = self.viewControllers.last {
             return topController.shouldAutorotate
-        }
-        else {
+        } else {
             return super.shouldAutorotate
         }
     }
@@ -40,8 +39,7 @@ final class RotationAwareNavigationController: UINavigationController, PopoverPr
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         if let topController = self.viewControllers.last {
             return topController.supportedInterfaceOrientations
-        }
-        else {
+        } else {
             return super.supportedInterfaceOrientations
         }
     }
@@ -49,8 +47,7 @@ final class RotationAwareNavigationController: UINavigationController, PopoverPr
     override var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
         if let topController = self.viewControllers.last {
             return topController.preferredInterfaceOrientationForPresentation
-        }
-        else {
+        } else {
             return super.preferredInterfaceOrientationForPresentation
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Components/MessagePreviewView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/MessagePreviewView.swift
@@ -32,8 +32,7 @@ extension ZMConversationMessage {
     func preparePreviewView(shouldDisplaySender: Bool = true) -> UIView {
         if self.isImage || self.isVideo {
             return MessageThumbnailPreviewView(message: self, displaySender: shouldDisplaySender)
-        }
-        else {
+        } else {
             return MessagePreviewView(message: self, displaySender: shouldDisplaySender)
         }
     }
@@ -152,8 +151,7 @@ final class MessageThumbnailPreviewView: UIView, Themeable {
     private func editIcon() -> NSAttributedString {
         if message.updatedAt != nil {
             return "  " + NSAttributedString(attachment: NSTextAttachment.textAttachment(for: .pencil, with: .from(scheme: .textForeground, variant: colorSchemeVariant), iconSize: 8))
-        }
-        else {
+        } else {
             return NSAttributedString()
         }
     }
@@ -176,15 +174,13 @@ final class MessageThumbnailPreviewView: UIView, Themeable {
             if let imageResource = message.imageMessageData?.image {
                 imagePreview.setImageResource(imageResource)
             }
-        }
-        else if message.isVideo, let fileMessageData = message.fileMessageData {
+        } else if message.isVideo, let fileMessageData = message.fileMessageData {
             let imageIcon = NSTextAttachment.textAttachment(for: .camera, with: .from(scheme: .textForeground, variant: colorSchemeVariant), verticalCorrection: -1)
             let initialString = NSAttributedString(attachment: imageIcon) + "  " + MessagePreview.video.localizedUppercase
             contentTextView.attributedText = initialString && attributes
 
             imagePreview.setImageResource(fileMessageData.thumbnailImage)
-        }
-        else {
+        } else {
             fatal("Unknown message for preview: \(message)")
         }
     }
@@ -285,8 +281,7 @@ final class MessagePreviewView: UIView, Themeable {
     private func editIcon() -> NSAttributedString {
         if message.updatedAt != nil {
             return "  " + NSAttributedString(attachment: NSTextAttachment.textAttachment(for: .pencil, with: .from(scheme: .textForeground, variant: colorSchemeVariant), iconSize: 8))
-        }
-        else {
+        } else {
             return NSAttributedString()
         }
     }
@@ -299,19 +294,16 @@ final class MessagePreviewView: UIView, Themeable {
 
         if let textMessageData = message.textMessageData {
             contentTextView.attributedText = NSAttributedString.formatForPreview(message: textMessageData, inputMode: true, variant: colorSchemeVariant)
-        }
-        else if let location = message.locationMessageData {
+        } else if let location = message.locationMessageData {
 
             let imageIcon = NSTextAttachment.textAttachment(for: .locationPin, with: .from(scheme: .textForeground, variant: colorSchemeVariant), verticalCorrection: -1)
             let initialString = NSAttributedString(attachment: imageIcon) + "  " + (location.name ?? "conversation.input_bar.message_preview.location".localized).localizedUppercase
             contentTextView.attributedText = initialString && attributes
-        }
-        else if message.isAudio {
+        } else if message.isAudio {
             let imageIcon = NSTextAttachment.textAttachment(for: .microphone, with: .from(scheme: .textForeground, variant: colorSchemeVariant), verticalCorrection: -1)
             let initialString = NSAttributedString(attachment: imageIcon) + "  " + "conversation.input_bar.message_preview.audio".localized.localizedUppercase
             contentTextView.attributedText = initialString && attributes
-        }
-        else if let fileData = message.fileMessageData {
+        } else if let fileData = message.fileMessageData {
             let imageIcon = NSTextAttachment.textAttachment(for: .document, with: .from(scheme: .textForeground, variant: colorSchemeVariant), verticalCorrection: -1)
             let initialString = NSAttributedString(attachment: imageIcon) + "  " + (fileData.filename ?? "conversation.input_bar.message_preview.file".localized).localizedUppercase
             contentTextView.attributedText = initialString && attributes

--- a/Wire-iOS/Sources/UserInterface/Components/RoundedView/ContinuousMaskLayer.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/RoundedView/ContinuousMaskLayer.swift
@@ -73,8 +73,7 @@ final class ContinuousMaskLayer: CALayer {
         if let otherMaskLayer = layer as? ContinuousMaskLayer {
             self.shape = otherMaskLayer.shape
             self.roundedCorners = otherMaskLayer.roundedCorners
-        }
-        else {
+        } else {
             fatal("Cannot init with \(layer)")
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Components/Views/SearchResultLabel.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/SearchResultLabel.swift
@@ -106,16 +106,14 @@ final public class SearchResultLabel: UILabel, Copyable {
                                                                              with: highlightedAttributes,
                                                                              upToWidth: self.bounds.width,
                                                                              totalMatches: &estimatedMatchesCount)
-            }
-            else {
+            } else {
                 self.attributedText = attributedText.cutAndPrefixedWithEllipsis(from: nsRange.location, fittingIntoWidth: self.bounds.width)
                     .highlightingAppearances(of: queries,
                                              with: highlightedAttributes,
                                              upToWidth: self.bounds.width,
                                              totalMatches: &estimatedMatchesCount)
             }
-        }
-        else {
+        } else {
             self.attributedText = attributedText
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/LikeButton.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/LikeButton.swift
@@ -42,8 +42,7 @@ final class LikeButton: IconButton {
             let prevState: UIControl.State
             if self.isSelected {
                 prevState = .selected
-            }
-            else {
+            } else {
                 prevState = []
             }
 
@@ -77,8 +76,7 @@ final class LikeButton: IconButton {
                         imageView.alpha = 1
                         self.isSelected = selected
                     })
-            }
-            else {
+            } else {
 
                 UIView.animate(easing: .easeInExpo, duration: 0.35, animations: {
                     animationImageView.transform = CGAffineTransform(scaleX: 6.3, y: 6.3)
@@ -95,8 +93,7 @@ final class LikeButton: IconButton {
             }
 
             UIImpactFeedbackGenerator(style: .light).impactOccurred()
-        }
-        else {
+        } else {
             self.isSelected = selected
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxDataSource.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxDataSource.swift
@@ -193,12 +193,10 @@ class MessageToolboxDataSource {
         if let timestampString = self.timestampString(message), message.isSent {
             if let deliveryStateString = deliveryStateString, message.shouldShowDeliveryState {
                 return (timestampString && attributes, deliveryStateString, countdownStatus)
-            }
-            else {
+            } else {
                 return (timestampString && attributes, nil, countdownStatus)
             }
-        }
-        else {
+        } else {
             return (nil, deliveryStateString, countdownStatus)
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/NSAttributedString+Mentions.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/NSAttributedString+Mentions.swift
@@ -79,8 +79,7 @@ extension NSMutableAttributedString {
         if user.isSelfUser {
             color = ColorScheme.default.color(named: .textForeground)
             backgroundColor = ColorScheme.default.color(named: .selfMentionHighlight)
-        }
-        else {
+        } else {
             color = .accent()
             backgroundColor = .clear
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ProgressView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ProgressView.swift
@@ -93,8 +93,7 @@ final class ProgressView: UIView {
 
         if animated {
             UIView.animate(withDuration: 0.35, delay: 0.0, options: [.beginFromCurrentState], animations: setBlock, completion: .none)
-        }
-        else {
+        } else {
             setBlock()
         }
     }
@@ -104,8 +103,7 @@ final class ProgressView: UIView {
             self.progressView.isHidden = false
             self.spinner.isHidden = true
             self.spinner.animating = false
-        }
-        else {
+        } else {
             self.progressView.isHidden = true
             self.spinner.isHidden = false
             self.spinner.animating = true

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ZMConversationMessage+AudioMessage.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ZMConversationMessage+AudioMessage.swift
@@ -24,8 +24,7 @@ extension ZMConversationMessage {
             fileMessageData.fileURL != nil,
             fileMessageData.isAudio {
             return true
-        }
-        else {
+        } else {
             return false
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ZMConversationMessage+File.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ZMConversationMessage+File.swift
@@ -23,8 +23,7 @@ extension ZMConversationMessage {
     public func isFileDownloaded() -> Bool {
         if self.fileMessageData?.fileURL != nil {
             return true
-        }
-        else {
+        } else {
             return false
         }
     }
@@ -35,8 +34,7 @@ extension ZMConversationMessage {
             let fileURL = fileMessageData.fileURL,
             UIVideoAtPathIsCompatibleWithSavedPhotosAlbum(fileURL.path) && fileMessageData.isVideo {
             return true
-        }
-        else {
+        } else {
             return false
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
@@ -279,8 +279,7 @@ final class ConversationTableViewDataSource: NSObject {
     func index(of message: ZMConversationMessage) -> Int? {
         if let indexPath = fetchController?.indexPath(forObject: message as! ZMMessage) {
             return indexPath.row
-        }
-        else {
+        } else {
             return nil
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Create/SimpleTextFieldValidator.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Create/SimpleTextFieldValidator.swift
@@ -50,8 +50,7 @@ final class SimpleTextFieldValidator: NSObject {
                                                     minimumStringLength: 1,
                                                     maximumStringLength: 64,
                                                     maximumByteLength: 256)
-        }
-        catch let stringValidationError as NSError {
+        } catch let stringValidationError as NSError {
 
             switch stringValidationError.code {
             case Int(ZMManagedObjectValidationErrorCode.tooLong.rawValue):

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioEffect.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioEffect.swift
@@ -27,8 +27,7 @@ extension String {
     @discardableResult func deleteFileAtPath() -> Bool {
         do {
             try FileManager.default.removeItem(atPath: self)
-        }
-        catch {
+        } catch {
             zmLog.error("Cannot delete file: \(self): \(error)")
             return false
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioEffectsPickerViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioEffectsPickerViewController.swift
@@ -57,8 +57,7 @@ final class AudioEffectsPickerViewController: UIViewController {
         didSet {
             if selectedAudioEffect == .reverse {
                 progressView.samples = normalizedLoudness.reversed()
-            }
-            else {
+            } else {
                 progressView.samples = normalizedLoudness
             }
 
@@ -85,8 +84,7 @@ final class AudioEffectsPickerViewController: UIViewController {
 
                     self.playMedia(effectPath)
                 }
-            }
-            else {
+            } else {
                 delegate?.audioEffectsPickerDidPickEffect(self, effect: .none, resultFilePath: recordingPath)
                 playMedia(recordingPath)
             }
@@ -245,8 +243,7 @@ final class AudioEffectsPickerViewController: UIViewController {
             let duration: Int
             if let player = audioPlayerController?.player {
                 duration = Int(ceil(player.duration))
-            }
-            else {
+            } else {
                 duration = Int(ceil(self.duration))
             }
 
@@ -267,8 +264,7 @@ final class AudioEffectsPickerViewController: UIViewController {
         if animated {
             let options: UIView.AnimationOptions = (state == .playing) ? .transitionFlipFromTop : .transitionFlipFromBottom
             UIView.transition(with: statusBoxView, duration: 0.35, options: options, animations: change, completion: .none)
-        }
-        else {
+        } else {
             change()
         }
     }
@@ -298,8 +294,7 @@ final class AudioEffectsPickerViewController: UIViewController {
 
             NSObject.cancelPreviousPerformRequests(withTarget: self, selector: selector, object: .none)
             perform(selector, with: .none, afterDelay: 0.05)
-        }
-        else {
+        } else {
             NSObject.cancelPreviousPerformRequests(withTarget: self, selector: selector, object: .none)
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordViewController.swift
@@ -313,8 +313,7 @@ final class AudioRecordViewController: UIViewController, AudioRecordBaseViewCont
         if recordingState == .recording {
             NSLayoutConstraint.deactivate(recordingDotViewHidden)
             NSLayoutConstraint.activate(recordingDotViewVisible)
-        }
-        else {
+        } else {
             NSLayoutConstraint.deactivate(recordingDotViewVisible)
             NSLayoutConstraint.activate(recordingDotViewHidden)
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/AssetCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/AssetCell.swift
@@ -105,8 +105,7 @@ final class AssetCell: UICollectionViewCell {
                 let (seconds, minutes) = (duration % 60, duration / 60)
                 durationView.text = String(format: "%d:%02d", minutes, seconds)
                 durationView.isHidden = false
-            }
-            else {
+            } else {
                 durationView.text = ""
                 durationView.isHidden = true
             }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/AssetLibrary.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/AssetLibrary.swift
@@ -67,8 +67,7 @@ class AssetLibrary: NSObject, PHPhotoLibraryChangeObserver {
 
         if synchronous {
             syncOperation()
-        }
-        else {
+        } else {
             DispatchQueue(label: "WireAssetLibrary", qos: DispatchQoS.background, attributes: [], autoreleaseFrequency: DispatchQueue.AutoreleaseFrequency.inherit, target: .none).async(execute: syncOperation)
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+UITextViewDelegate.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+UITextViewDelegate.swift
@@ -69,8 +69,7 @@ extension ConversationInputBarViewController: UITextViewDelegate {
             if UIDevice.current.type == .iPad,
                 canInsertMention {
                 insertBestMatchMention()
-            }
-            else {
+            } else {
                 inputBar.textView.autocorrectLastWord()
                 sendText()
             }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR I fix SwiftLint Warnings for the rule below:

- **Statement Position Violation**: Else and catch should be on the same line, one space after the previous declaration. `(statement_position)`

Since the changed files are 60 I decided to split this change into 2 PRs. The 2nd PR is going to be opened as soon we merge this one.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
