### PR TITLE
fix: SwiftLint warnings for statement position Part 2

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/EphemeralKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/EphemeralKeyboardViewController.swift
@@ -113,8 +113,7 @@ final class EphemeralKeyboardViewController: UIViewController {
         self.conversation = conversation
         if Bundle.developerModeEnabled {
             timeouts = MessageDestructionTimeoutValue.all + [nil]
-        }
-        else {
+        } else {
             timeouts = MessageDestructionTimeoutValue.all
         }
         super.init(nibName: nil, bundle: nil)
@@ -281,8 +280,7 @@ extension EphemeralKeyboardViewController: UIPickerViewDelegate, UIPickerViewDat
         let timeout = timeouts[row]
         if let actualTimeout = timeout, let title = actualTimeout.displayString {
             return title && font && color
-        }
-        else {
+        } else {
             return "Custom" && font && color
         }
     }
@@ -292,8 +290,7 @@ extension EphemeralKeyboardViewController: UIPickerViewDelegate, UIPickerViewDat
 
         if let actualTimeout = timeout {
             delegate?.ephemeralKeyboard(self, didSelectMessageTimeout: actualTimeout.rawValue)
-        }
-        else {
+        } else {
             displayCustomPicker()
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
@@ -377,12 +377,10 @@ final class InputBar: UIView {
             if super.point(inside: point, with: event) {
                 let locationInButtonRow = buttonInnerContainer.convert(point, from: self)
                 return locationInButtonRow.y < buttonInnerContainer.bounds.height / 1.3
-            }
-            else {
+            } else {
                 return false
             }
-        }
-        else {
+        } else {
             return super.point(inside: point, with: event)
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/RecordingDotView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/RecordingDotView.swift
@@ -44,8 +44,7 @@ final class RecordingDotView: UIView {
 
             if animating {
                 self.startAnimation()
-            }
-            else {
+            } else {
                 self.stopAnimation()
             }
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ReplyComposingView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ReplyComposingView.swift
@@ -31,23 +31,17 @@ fileprivate extension ZMConversationMessage {
 
         if let textData = textMessageData {
             contentDescriptionText = textData.messageText ?? ""
-        }
-        else if isImage {
+        } else if isImage {
             contentDescriptionText = "conversation.input_bar.message_preview.accessibility.image_message".localized
-        }
-        else if let locationData = locationMessageData {
+        } else if let locationData = locationMessageData {
             contentDescriptionText = locationData.name ?? "conversation.input_bar.message_preview.accessibility.location_message".localized
-        }
-        else if isVideo {
+        } else if isVideo {
             contentDescriptionText = "conversation.input_bar.message_preview.accessibility.video_message".localized
-        }
-        else if isAudio {
+        } else if isAudio {
             contentDescriptionText = "conversation.input_bar.message_preview.accessibility.audio_message".localized
-        }
-        else if let fileData = fileMessageData {
+        } else if let fileData = fileMessageData {
             contentDescriptionText = String(format: "conversation.input_bar.message_preview.accessibility.file_message".localized, fileData.filename ?? "")
-        }
-        else {
+        } else {
             contentDescriptionText = "conversation.input_bar.message_preview.accessibility.unknown_message".localized
         }
 

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListAccessoryView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListAccessoryView.swift
@@ -139,8 +139,7 @@ final class ConversationListAccessoryView: UIView {
             if let mediaPlayer = activeMediaPlayer, mediaPlayer.state == .playing {
                 iconView.setIcon(.pause, size: iconSize, color: .white)
                 accessibilityValue = "conversation_list.voiceover.status.pause_media".localized
-            }
-            else {
+            } else {
                 iconView.setIcon(.play, size: iconSize, color: .white)
                 accessibilityValue = "conversation_list.voiceover.status.play_media".localized
             }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListAvatarView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListAvatarView.swift
@@ -148,8 +148,7 @@ final public class ConversationListAvatarView: UIView {
 
             if mode == .one {
                 layer.borderWidth = 0
-            }
-            else {
+            } else {
                 layer.borderWidth = .hairline
                 layer.borderColor = UIColor(white: 1, alpha: 0.24).cgColor
             }
@@ -227,8 +226,7 @@ final public class ConversationListAvatarView: UIView {
             if xPosition + size.width >= containerSize.width {
                 xPosition = 0
                 yPosition += size.height + inset
-            }
-            else {
+            } else {
                 xPosition += size.width + inset
             }
         }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ZMConversation+Status.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ZMConversation+Status.swift
@@ -133,44 +133,32 @@ extension StatusMessageType {
         if message.isText, let textMessage = message.textMessageData {
             if textMessage.isMentioningSelf {
                 self = .mention
-            }
-            else if textMessage.isQuotingSelf {
+            } else if textMessage.isQuotingSelf {
                 self = .reply
-            }
-            else if textMessage.linkPreview != nil {
+            } else if textMessage.linkPreview != nil {
                 self = .link
-            }
-            else {
+            } else {
                 self = .text
             }
-        }
-        else if message.isImage {
+        } else if message.isImage {
             self = .image
-        }
-        else if message.isLocation {
+        } else if message.isLocation {
             self = .location
-        }
-        else if message.isAudio {
+        } else if message.isAudio {
             self = .audio
-        }
-        else if message.isVideo {
+        } else if message.isVideo {
             self = .video
-        }
-        else if message.isFile {
+        } else if message.isFile {
             self = .file
-        }
-        else if message.isKnock {
+        } else if message.isKnock {
             self = .knock
-        }
-        else if message.isSystem, let system = message.systemMessageData {
+        } else if message.isSystem, let system = message.systemMessageData {
             if let statusMessageType = StatusMessageType.conversationSystemMessageTypeToStatusMessageType[system.systemMessageType] {
                 self = statusMessageType
-            }
-            else {
+            } else {
                 return nil
             }
-        }
-        else {
+        } else {
             return nil
         }
     }
@@ -394,8 +382,7 @@ final class TypingMatcher: ConversationStatusMatcher {
             let resultString = String(format: "conversation.status.typing.group".localized, typingUsersString)
             let intermediateString = NSAttributedString(string: resultString, attributes: type(of: self).regularStyle)
             statusString = self.addEmphasis(to: intermediateString, for: typingUsersString)
-        }
-        else {
+        } else {
             statusString = "conversation.status.typing".localized && type(of: self).regularStyle
         }
         return statusString
@@ -528,8 +515,7 @@ final class NewMessagesMatcher: TypedConversationStatusMatcher {
 
             let resultString = localizedMatchedItems.joined(separator: ", ")
             return resultString.capitalizingFirstLetter() && type(of: self).regularStyle
-        }
-        else {
+        } else {
             guard let message = status.messagesRequiringAttention.reversed().first(where: {
                     if $0.senderUser != nil,
                        let type = StatusMessageType(message: $0),
@@ -559,8 +545,7 @@ final class NewMessagesMatcher: TypedConversationStatusMatcher {
                     typeSuffix += ".group"
                 }
                 messageDescription = (localizationRootPath + typeSuffix).localized
-            }
-            else {
+            } else {
                 var format = localizationRootPath + "." + localizationKey
 
                 if status.isGroup && type == .missedCall {
@@ -574,8 +559,7 @@ final class NewMessagesMatcher: TypedConversationStatusMatcher {
             if status.isGroup && !message.isEphemeral {
                 return (((sender.name ?? "") + ": ") && Swift.type(of: self).emphasisStyle) +
                         (messageDescription && Swift.type(of: self).regularStyle)
-            }
-            else {
+            } else {
                 return messageDescription && Swift.type(of: self).regularStyle
             }
         }
@@ -594,8 +578,7 @@ final class NewMessagesMatcher: TypedConversationStatusMatcher {
                    let type = StatusMessageType(message: $0),
                    matchedTypesDescriptions[type] != nil {
                     return true
-                }
-                else {
+                } else {
                     return false
                 }
             }),

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationAction.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationAction.swift
@@ -100,8 +100,7 @@ extension ZMConversation {
         if !isReadOnly {
             if ZMUser.selfUser()?.isTeamMember ?? false {
                 actions.append(.configureNotifications)
-            }
-            else {
+            } else {
                 let isSilenced = mutedMessageTypes != .none
                 actions.append(.silence(isSilenced: isSilenced))
             }

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+Notifications.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+Notifications.swift
@@ -66,8 +66,7 @@ enum NotificationResult: CaseIterable {
 
         if let mutedMessageTypes = self.mutedMessageTypes, conversation.mutedMessageTypes == mutedMessageTypes {
             checkmarkText = " ✓"
-        }
-        else {
+        } else {
             checkmarkText = ""
         }
 

--- a/Wire-iOS/Sources/UserInterface/Helpers/UIViewController+SafeArea.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UIViewController+SafeArea.swift
@@ -23,8 +23,7 @@ extension UIViewController {
     var safeBottomAnchor: NSLayoutYAxisAnchor {
         if #available(iOS 11, *) {
             return self.view.safeAreaLayoutGuide.bottomAnchor
-        }
-        else {
+        } else {
             return self.bottomLayoutGuide.topAnchor
         }
     }
@@ -32,8 +31,7 @@ extension UIViewController {
     var safeTopAnchor: NSLayoutYAxisAnchor {
         if #available(iOS 11, *) {
             return self.view.safeAreaLayoutGuide.topAnchor
-        }
-        else {
+        } else {
             return self.topLayoutGuide.bottomAnchor
         }
     }
@@ -41,8 +39,7 @@ extension UIViewController {
     var safeCenterYAnchor: NSLayoutYAxisAnchor {
         if #available(iOS 11, *) {
             return view.safeAreaLayoutGuide.centerYAnchor
-        }
-        else {
+        } else {
             return view.centerYAnchor
         }
     }
@@ -85,8 +82,7 @@ extension UIView {
     var safeBottomAnchor: NSLayoutYAxisAnchor {
         if #available(iOS 11, *) {
             return safeAreaLayoutGuide.bottomAnchor
-        }
-        else {
+        } else {
             return bottomAnchor
         }
     }
@@ -102,8 +98,7 @@ extension UIView {
     var safeCenterYAnchor: NSLayoutYAxisAnchor {
         if #available(iOS 11, *) {
             return safeAreaLayoutGuide.centerYAnchor
-        }
-        else {
+        } else {
             return centerYAnchor
         }
     }
@@ -111,8 +106,7 @@ extension UIView {
     var safeCenterXAnchor: NSLayoutXAxisAnchor {
         if #available(iOS 11, *) {
             return safeAreaLayoutGuide.centerXAnchor
-        }
-        else {
+        } else {
             return centerXAnchor
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Location/NSUserDefaults+Location.swift
+++ b/Wire-iOS/Sources/UserInterface/Location/NSUserDefaults+Location.swift
@@ -45,13 +45,11 @@ extension LocationData {
             let longitudeFloatUnwrap = longitude as? Float {
             latitudeFloat = latitudeFloatUnwrap
             longitudeFloat = longitudeFloatUnwrap
-        }
-        else if let latitudeDoubleUnwrap = latitude as? Double,
+        } else if let latitudeDoubleUnwrap = latitude as? Double,
                 let longitudeDoubleUnwrap = longitude as? Double {
             latitudeFloat = Float(latitudeDoubleUnwrap)
             longitudeFloat = Float(longitudeDoubleUnwrap)
-        }
-        else {
+        } else {
             return nil
         }
 

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -607,8 +607,7 @@ final class ZClientViewController: UIViewController {
                     heightConstraint.isActive = false
                     self.view.layoutIfNeeded()
                 })
-            }
-            else {
+            } else {
                 topOverlayViewController = viewController
                 updateSplitViewTopConstraint()
             }

--- a/Wire-iOS/Sources/UserInterface/SelfProfile/ProfileHeaderViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/ProfileHeaderViewController.swift
@@ -294,8 +294,7 @@ final class ProfileHeaderViewController: UIViewController, Themeable {
         if let handle = user.handle, !handle.isEmpty, !options.contains(.hideHandle) {
             handleLabel.text = "@" + handle
             handleLabel.accessibilityValue = handleLabel.text
-        }
-        else {
+        } else {
             handleLabel.isHidden = true
         }
     }

--- a/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController+NewDeviceAlert.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController+NewDeviceAlert.swift
@@ -29,8 +29,7 @@ extension SelfProfileViewController {
         if clientsRequiringUserAttention.count > 0 {
             self.presentNewLoginAlertController(clientsRequiringUserAttention)
             return true
-        }
-        else {
+        } else {
             return false
         }
     }

--- a/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController+SettingsChangeAlert.swift
+++ b/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController+SettingsChangeAlert.swift
@@ -28,8 +28,7 @@ extension SelfProfileViewController {
             self.presentReadReceiptsChangedAlert(with: currentValue)
 
             return true
-        }
-        else {
+        } else {
             return false
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsButtonCellDescriptor.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsButtonCellDescriptor.swift
@@ -29,8 +29,7 @@ class SettingsButtonCellDescriptor: SettingsCellDescriptorType {
     var visible: Bool {
         if let visibilityAction = self.visibilityAction {
             return visibilityAction(self)
-        }
-        else {
+        } else {
             return true
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
@@ -306,8 +306,7 @@ extension SettingsCellDescriptorFactory {
             presentationAction: {
                 if ZMUser.selfUser().hasValidEmail || ZMUser.selfUser()!.usesCompanyLogin {
                     return BackupViewController.init(backupSource: SessionManager.shared!)
-                }
-                else {
+                } else {
                     let alert = UIAlertController(
                         title: "self.settings.history_backup.set_email.title".localized,
                         message: "self.settings.history_backup.set_email.message".localized,

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
@@ -71,8 +71,7 @@ class SettingsCellDescriptorFactory {
 
             if SessionManager.shared?.accountManager.accounts.count < SessionManager.maxNumberAccounts {
                 SessionManager.shared?.addAccount()
-            }
-            else {
+            } else {
                 if let controller = UIApplication.shared.topmostViewController(onlyFullScreen: false) {
                     let alert = UIAlertController(
                         title: "self.settings.add_account.error.title".localized,
@@ -159,8 +158,7 @@ class SettingsCellDescriptorFactory {
             if let stringValue = value.value() as? String,
                 let enumValue = ZMSound(rawValue: stringValue) {
                 return .text(enumValue.descriptionLocalizationKey.localized)
-            }
-            else {
+            } else {
                 return .text(defaultSound.descriptionLocalizationKey.localized)
             }
         }

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsPropertyTextValueCellDescriptor.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsPropertyTextValueCellDescriptor.swift
@@ -62,8 +62,7 @@ class SettingsPropertyTextValueCellDescriptor: SettingsPropertyCellDescriptorTyp
 
             do {
                 try self.settingsProperty << SettingsPropertyValue.string(value: stringValue)
-            }
-            catch let error as NSError {
+            } catch let error as NSError {
 
                 // specific error message for name string is too short
                 if error.domain == ZMObjectValidationErrorDomain &&
@@ -77,8 +76,7 @@ class SettingsPropertyTextValueCellDescriptor: SettingsPropertyCellDescriptorTyp
                     UIApplication.shared.topmostViewController(onlyFullScreen: false)?.showAlert(for: error)
                 }
 
-            }
-            catch let generalError {
+            } catch let generalError {
                 zmLog.error("Error setting property: \(generalError)")
             }
         }

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsPropertyToggleCellDescriptor.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsPropertyToggleCellDescriptor.swift
@@ -49,8 +49,7 @@ final class SettingsPropertyToggleCellDescriptor: SettingsPropertyCellDescriptor
             var boolValue = false
             if let value = self.settingsProperty.value().value() as? NSNumber {
                 boolValue = value.boolValue
-            }
-            else {
+            } else {
                 boolValue = false
             }
 

--- a/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ConfirmEmailViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ConfirmEmailViewController.swift
@@ -45,8 +45,7 @@ extension UITableView {
 
                 self.tableHeaderView?.layoutIfNeeded()
                 self.tableHeaderView = newHeader
-            }
-            else {
+            } else {
                 self.tableHeaderView = nil
             }
         }

--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientTableViewCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientTableViewCell.swift
@@ -177,12 +177,10 @@ class ClientTableViewCell: UITableViewCell {
 
             if userClient.verified {
                 verifiedLabel.text = NSLocalizedString("device.verified", comment: "")
-            }
-            else {
+            } else {
                 verifiedLabel.text = NSLocalizedString("device.not_verified", comment: "")
             }
-        }
-        else {
+        } else {
             verifiedLabel.text = ""
         }
     }
@@ -204,8 +202,7 @@ class ClientTableViewCell: UITableViewCell {
     func updateLabel() {
         if let userClientLabel = userClient?.label, showLabel {
             labelLabel.text = userClientLabel
-        }
-        else {
+        } else {
             labelLabel.text = ""
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/FingerprintTableViewCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/FingerprintTableViewCell.swift
@@ -118,8 +118,7 @@ final class FingerprintTableViewCell: UITableViewCell {
 
                     fingerprintLabel.attributedText = attributedFingerprint
                     spinner.stopAnimating()
-        }
-        else {
+        } else {
             fingerprintLabel.attributedText = .none
             spinner.startAnimating()
         }

--- a/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/SettingsClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/SettingsClientViewController.swift
@@ -211,8 +211,7 @@ final class SettingsClientViewController: UIViewController,
         case .fingerprintAndVerify:
             if self.userClient == ZMUserSession.shared()?.selfUserClient {
                 return 1
-            }
-            else {
+            } else {
                 return 2
             }
         case .resetSession:
@@ -247,8 +246,7 @@ final class SettingsClientViewController: UIViewController,
                         cell.variant = self.variant
                     return cell
                 }
-            }
-            else {
+            } else {
                 if let cell = tableView.dequeueReusableCell(withIdentifier: type(of: self).verifiedCellReuseIdentifier, for: indexPath) as? SettingsToggleCell {
                     cell.titleText = NSLocalizedString("device.verified", comment: "")
                     cell.cellNameLabel.accessibilityIdentifier = "device verified label"

--- a/Wire-iOS/Sources/UserInterface/Settings/SettingsCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/SettingsCell.swift
@@ -318,8 +318,7 @@ class SettingsTableCell: UITableViewCell, SettingsCellType {
             backgroundColor = UIColor(white: 0, alpha: 0.2)
             badge.backgroundColor = UIColor.white
             badgeLabel.textColor = UIColor.black
-        }
-        else {
+        } else {
             backgroundColor = UIColor.clear
         }
     }
@@ -456,8 +455,7 @@ final class SettingsTextCell: SettingsTableCell,
         if string.rangeOfCharacter(from: CharacterSet.newlines) != .none {
             textField.resignFirstResponder()
             return false
-        }
-        else {
+        } else {
             return true
         }
     }

--- a/Wire-iOS/Sources/UserInterface/SkeletonViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/SkeletonViewController.swift
@@ -259,8 +259,7 @@ final class SkeletonViewController: UIViewController {
 
         if let fromUnwrapped = from, to.imageData == nil, to.teamName == nil {
             account = fromUnwrapped
-        }
-        else {
+        } else {
             account = to
         }
 

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/EmptySearchResultsView.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/EmptySearchResultsView.swift
@@ -57,8 +57,7 @@ final class EmptySearchResultsView: UIView {
             if let action = self.buttonAction {
                 actionButton.isHidden = false
                 actionButton.setTitle(action.title, for: .normal)
-            }
-            else {
+            } else {
                 actionButton.isHidden = true
             }
         }

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/Services/SearchServicesSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/SectionControllers/Services/SearchServicesSectionController.swift
@@ -48,8 +48,7 @@ final class SearchServicesSectionController: SearchSectionController {
     override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         if canSelfUserManageTeam {
             return services.count + 1
-        }
-        else {
+        } else {
             return services.count
         }
     }
@@ -61,8 +60,7 @@ final class SearchServicesSectionController: SearchSectionController {
     func service(for indexPath: IndexPath) -> ServiceUser {
         if canSelfUserManageTeam {
             return services[indexPath.row - 1]
-        }
-        else {
+        } else {
             return services[indexPath.row]
         }
     }
@@ -74,8 +72,7 @@ final class SearchServicesSectionController: SearchSectionController {
     override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         if canSelfUserManageTeam && indexPath.row == 0 {
             return collectionView.dequeueReusableCell(withReuseIdentifier: OpenServicesAdminCell.zm_reuseIdentifier, for: indexPath)
-        }
-        else {
+        } else {
             let service = self.service(for: indexPath)
 
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: UserCell.zm_reuseIdentifier, for: indexPath) as! UserCell
@@ -91,8 +88,7 @@ final class SearchServicesSectionController: SearchSectionController {
     override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if canSelfUserManageTeam && indexPath.row == 0 {
             delegate?.addServicesSectionDidRequestOpenServicesAdmin()
-        }
-        else {
+        } else {
             let service = self.service(for: indexPath)
             delegate?.searchSectionController(self, didSelectUser: service, at: indexPath)
         }

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsView.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsView.swift
@@ -120,8 +120,7 @@ final class SearchResultsView: UIView {
                     accessoryView.trailingAnchor.constraint(equalTo: accessoryContainer.trailingAnchor),
                     accessoryView.bottomAnchor.constraint(equalTo: accessoryContainer.bottomAnchor)
                 ])
-            }
-            else {
+            } else {
                 accessoryContainerHeightConstraint?.isActive = true
             }
 

--- a/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+SearchResults.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+SearchResults.swift
@@ -116,8 +116,7 @@ extension StartUIViewController: SearchResultsViewControllerDelegate {
             let avoiding = KeyboardAvoidingViewController(viewController: controller)
             self.navigationController?.pushViewController(avoiding, animated: true) {
             }
-        }
-        else {
+        } else {
             let embeddedNavigationController = controller.wrapInNavigationController()
             embeddedNavigationController.modalPresentationStyle = .formSheet
             self.present(embeddedNavigationController, animated: true)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Wanted to break this PR in two separate ones so it's easier for review. Since #5466 is now merged, it's time to open a new PR and fix the rest of the warnings produced by that rule.

- Statement Position Violation: Else and catch should be on the same line, one space after the previous declaration. (statement_position)

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
