### PR TITLE
fix: restore testSoundCloudMediaPreviewAttachment with fail expected SQPIT-799

### DIFF
--- a/Wire-iOS Tests/ConversationMessageCell/ConversationTextMessageTests.swift
+++ b/Wire-iOS Tests/ConversationMessageCell/ConversationTextMessageTests.swift
@@ -139,7 +139,7 @@ final class ConversationTextMessageTests: XCTestCase {
         verify(message: message, waitForTextViewToLoad: true)
     }
 
-    func disabled_testSoundCloudMediaPreviewAttachment() {
+    func testSoundCloudMediaPreviewAttachment() {
         // GIVEN
         let message = MockMessageFactory.textMessage(withText: "https://soundcloud.com/bridgitmendler/bridgit-mendler-atlantis-feat-kaiydo")
         message.senderUser = mockOtherUser
@@ -150,7 +150,12 @@ final class ConversationTextMessageTests: XCTestCase {
         ]
 
         // THEN
-        verify(message: message, waitForTextViewToLoad: true)
+        let options = XCTExpectedFailure.Options()
+        options.isStrict = false
+        XCTExpectFailure("This test is flaky, may be related to sound cloud preview text view?", options: options) {
+            verify(message: message, waitForTextViewToLoad: true)
+        }
+
     }
 
     func testSoundCloudSetMediaPreviewAttachment() {

--- a/Wire-iOS Tests/ConversationMessageCell/ConversationTextMessageTests.swift
+++ b/Wire-iOS Tests/ConversationMessageCell/ConversationTextMessageTests.swift
@@ -195,5 +195,4 @@ final class ConversationTextMessageTests: XCTestCase {
         // THEN
         verify(message: message)
     }
-
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQPIT-799" title="SQPIT-799" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/secure/viewavatar?size=medium&avatarId=10818&avatarType=issuetype" />SQPIT-799</a>  fix: flaky test on wire-ios
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Restore `testSoundCloudMediaPreviewAttachment` with fail expected to make sure sound cloud preview is covered in test.