### PR TITLE
chore: remove iOS 11 or earlier dead code

### DIFF
--- a/Wire-iOS/Sources/Authentication/Landing/LandingViewController.swift
+++ b/Wire-iOS/Sources/Authentication/Landing/LandingViewController.swift
@@ -286,9 +286,7 @@ final class LandingViewController: AuthenticationStepViewController {
     }
 
     private func configureSubviews() {
-        if #available(iOS 11, *) {
-            additionalSafeAreaInsets.top = -44
-        }
+        additionalSafeAreaInsets.top = -44
 
         topStack.addArrangedSubview(logoView)
 

--- a/Wire-iOS/Sources/Components/CompanyLoginFlowOpener.swift
+++ b/Wire-iOS/Sources/Components/CompanyLoginFlowOpener.swift
@@ -77,11 +77,7 @@ final class CompanyLoginFlowHandler {
             return
         }
 
-        if #available(iOS 11, *) {
-            openSafariAuthenticationSession(at: authenticationURL)
-        } else {
-            openSafariEmbed(at: authenticationURL)
-        }
+        openSafariAuthenticationSession(at: authenticationURL)
     }
 
     private func startListeningToFlowCompletion() {

--- a/Wire-iOS/Sources/Components/CustomSpacingStackView.swift
+++ b/Wire-iOS/Sources/Components/CustomSpacingStackView.swift
@@ -26,18 +26,7 @@ final class CustomSpacingStackView: UIView {
      This initializer must be used if you intend to call wr_addCustomSpacing.
      */
     init(customSpacedArrangedSubviews subviews: [UIView]) {
-        if #available(iOS 11, *) {
-            stackView = UIStackView(arrangedSubviews: subviews)
-        } else {
-            var subviewsWithSpacers: [UIView] = []
-
-            subviews.forEach { view in
-                subviewsWithSpacers.append(view)
-                subviewsWithSpacers.append(SpacingView(0))
-            }
-
-            stackView = UIStackView(arrangedSubviews: subviewsWithSpacers)
-        }
+        stackView = UIStackView(arrangedSubviews: subviews)
 
         super.init(frame: .zero)
 
@@ -63,18 +52,7 @@ final class CustomSpacingStackView: UIView {
      On iOS 11, it uses the default system implementation.
      */
     func wr_addCustomSpacing(_ customSpacing: CGFloat, after view: UIView) {
-        if #available(iOS 11, *) {
-            return stackView.setCustomSpacing(customSpacing, after: view)
-        }
-
-        guard let spacerIndex = stackView.subviews.firstIndex(of: view)?.advanced(by: 1),
-            let spacer = stackView.subviews[spacerIndex] as? SpacingView else { return }
-
-        if view.isHidden || customSpacing < (stackView.spacing * 2) {
-            spacer.isHidden = true
-        } else {
-            spacer.size = customSpacing - stackView.spacing
-        }
+        return stackView.setCustomSpacing(customSpacing, after: view)
     }
 
     private func createConstraints() {

--- a/Wire-iOS/Sources/Components/TokenField/TokenField.swift
+++ b/Wire-iOS/Sources/Components/TokenField/TokenField.swift
@@ -517,9 +517,7 @@ final class TokenField: UIView {
         textView.delegate = self
         textView.translatesAutoresizingMaskIntoConstraints = false
         textView.backgroundColor = UIColor.clear
-        if #available(iOS 11, *) {
-            textView.textDragInteraction?.isEnabled = false
-        }
+        textView.textDragInteraction?.isEnabled = false
         addSubview(textView)
 
         toLabel.translatesAutoresizingMaskIntoConstraints = false

--- a/Wire-iOS/Sources/Helpers/UIScreen+SafeArea.swift
+++ b/Wire-iOS/Sources/Helpers/UIScreen+SafeArea.swift
@@ -21,21 +21,17 @@ import UIKit
 extension UIScreen {
 
     static var safeArea: UIEdgeInsets {
-        if #available(iOS 11, *), hasNotch {
+        if hasNotch {
             return UIApplication.shared.keyWindow!.safeAreaInsets
         }
         return UIEdgeInsets(top: 20.0, left: 0.0, bottom: 0.0, right: 0.0)
     }
 
     static var hasBottomInset: Bool {
-        if #available(iOS 11, *) {
-            guard let window = UIApplication.shared.keyWindow else { return false }
-            let insets = window.safeAreaInsets
+        guard let window = UIApplication.shared.keyWindow else { return false }
+        let insets = window.safeAreaInsets
 
-            return insets.bottom > 0
-        }
-
-        return false
+        return insets.bottom > 0
     }
 
     static var hasNotch: Bool {

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/CallQualityController/CallQualityViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/CallQualityController/CallQualityViewController.swift
@@ -162,13 +162,7 @@ final class CallQualityViewController: UIViewController, UIGestureRecognizerDele
         iphone_leadingConstraint = contentView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 8)
         iphone_trailingConstraint = contentView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -8)
 
-        let bottomAnchor: NSLayoutAnchor<NSLayoutYAxisAnchor>
-
-        if #available(iOS 11, *) {
-            bottomAnchor = view.safeAreaLayoutGuide.bottomAnchor
-        } else {
-            bottomAnchor = view.bottomAnchor
-        }
+        let bottomAnchor: NSLayoutAnchor<NSLayoutYAxisAnchor> = view.safeAreaLayoutGuide.bottomAnchor
 
         iphone_bottomConstraint = contentView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -8)
         ipad_centerYConstraint = contentView.centerYAnchor.constraint(equalTo: view.centerYAnchor)

--- a/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.swift
@@ -228,11 +228,7 @@ final class FullscreenImageViewController: UIViewController {
 
         scrollView.fitInSuperview()
 
-        if #available(iOS 11, *) {
-            scrollView.contentInsetAdjustmentBehavior = .never
-        } else {
-            automaticallyAdjustsScrollViewInsets = false
-        }
+        scrollView.contentInsetAdjustmentBehavior = .never
 
         scrollView.delegate = self
         scrollView.accessibilityIdentifier = "fullScreenPage"

--- a/Wire-iOS/Sources/UserInterface/Conversation/Create/SimpleTextField.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Create/SimpleTextField.swift
@@ -72,13 +72,7 @@ final class SimpleTextField: UITextField, Themeable {
     init() {
         let leftInset: CGFloat = 8
 
-        var topInset: CGFloat = 0
-        if #available(iOS 11, *) {
-            topInset = 0
-        } else {
-            /// Placeholder frame calculation is changed in iOS 11, therefore the TOP inset is not necessary
-            topInset = 8
-        }
+        let topInset: CGFloat = 0
         placeholderInsets = UIEdgeInsets(top: topInset, left: leftInset, bottom: 0, right: 16)
 
         super.init(frame: .zero)

--- a/Wire-iOS/Sources/UserInterface/Helpers/UIViewController+SafeArea.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UIViewController+SafeArea.swift
@@ -21,94 +21,50 @@ import UIKit
 extension UIViewController {
 
     var safeBottomAnchor: NSLayoutYAxisAnchor {
-        if #available(iOS 11, *) {
-            return self.view.safeAreaLayoutGuide.bottomAnchor
-        } else {
-            return self.bottomLayoutGuide.topAnchor
-        }
+        return self.view.safeAreaLayoutGuide.bottomAnchor
     }
 
     var safeTopAnchor: NSLayoutYAxisAnchor {
-        if #available(iOS 11, *) {
-            return self.view.safeAreaLayoutGuide.topAnchor
-        } else {
-            return self.topLayoutGuide.bottomAnchor
-        }
+        return self.view.safeAreaLayoutGuide.topAnchor
     }
 
     var safeCenterYAnchor: NSLayoutYAxisAnchor {
-        if #available(iOS 11, *) {
-            return view.safeAreaLayoutGuide.centerYAnchor
-        } else {
-            return view.centerYAnchor
-        }
+        return view.safeAreaLayoutGuide.centerYAnchor
     }
 
 }
 
 extension UIView {
     var safeAreaLayoutGuideOrFallback: UILayoutGuide {
-        if #available(iOS 11, *) {
-            return safeAreaLayoutGuide
-        } else {
-            return layoutMarginsGuide
-        }
+        return safeAreaLayoutGuide
     }
 
     var safeAreaInsetsOrFallback: UIEdgeInsets {
-        if #available(iOS 11, *) {
-            return safeAreaInsets
-        } else {
-            return .zero
-        }
+        return safeAreaInsets
     }
 
     var safeLeadingAnchor: NSLayoutXAxisAnchor {
-        if #available(iOS 11, *) {
-            return safeAreaLayoutGuide.leadingAnchor
-        } else {
-            return leadingAnchor
-        }
+        return safeAreaLayoutGuide.leadingAnchor
     }
 
     var safeTrailingAnchor: NSLayoutXAxisAnchor {
-        if #available(iOS 11, *) {
-            return safeAreaLayoutGuide.trailingAnchor
-        } else {
-            return trailingAnchor
-        }
+        return safeAreaLayoutGuide.trailingAnchor
     }
 
     var safeBottomAnchor: NSLayoutYAxisAnchor {
-        if #available(iOS 11, *) {
-            return safeAreaLayoutGuide.bottomAnchor
-        } else {
-            return bottomAnchor
-        }
+        return safeAreaLayoutGuide.bottomAnchor
     }
 
     var safeTopAnchor: NSLayoutYAxisAnchor {
-        if #available(iOS 11, *) {
-            return safeAreaLayoutGuide.topAnchor
-        } else {
-            return topAnchor
-        }
+        return safeAreaLayoutGuide.topAnchor
     }
 
     var safeCenterYAnchor: NSLayoutYAxisAnchor {
-        if #available(iOS 11, *) {
-            return safeAreaLayoutGuide.centerYAnchor
-        } else {
-            return centerYAnchor
-        }
+        return safeAreaLayoutGuide.centerYAnchor
     }
 
     var safeCenterXAnchor: NSLayoutXAxisAnchor {
-        if #available(iOS 11, *) {
-            return safeAreaLayoutGuide.centerXAnchor
-        } else {
-            return centerXAnchor
-        }
+        return safeAreaLayoutGuide.centerXAnchor
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.swift
@@ -120,14 +120,7 @@ final class ProfileViewController: UIViewController {
         updateTitleView()
 
         profileTitleView.translatesAutoresizingMaskIntoConstraints = false
-        if #available(iOS 11, *) {
-            navigationItem.titleView = profileTitleView
-        } else {
-            profileTitleView.setNeedsLayout()
-            profileTitleView.layoutIfNeeded()
-            profileTitleView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-            profileTitleView.translatesAutoresizingMaskIntoConstraints = true
-        }
+        navigationItem.titleView = profileTitleView
 
         navigationItem.titleView = profileTitleView
     }

--- a/WireCommonComponents/AccessoryTextField.swift
+++ b/WireCommonComponents/AccessoryTextField.swift
@@ -86,13 +86,7 @@ open class AccessoryTextField: UITextField {
          accessoryTrailingInset: CGFloat = 16,
          textFieldAttributes: Attributes) {
         
-        var topInset: CGFloat = 0
-        if #available(iOS 11, *) {
-            topInset = 0
-        } else {
-            /// Placeholder frame calculation is changed in iOS 11, therefore the TOP inset is not necessary
-            topInset = 8
-        }
+        let topInset: CGFloat = 0
 
         self.placeholderInsets = UIEdgeInsets(top: topInset, left: leftInset, bottom: 0, right: horizonalInset)
         self.textInsets = UIEdgeInsets(top: 0, left: horizonalInset, bottom: 0, right: horizonalInset)


### PR DESCRIPTION
# What's new in this PR?

### Issues

Since the project is support iOS 12+, the code specific for iOS 11 or lower becomes dead code


### Solutions

Remove code for iOS 11 or below and remove markers for `#available(iOS 11, *)` which is always true.