### PR TITLE
fix: remove deprecated flags SQPIT-847

### DIFF
--- a/Wire-iOS/Wire-Info.plist
+++ b/Wire-iOS/Wire-Info.plist
@@ -86,10 +86,6 @@
 	<string>${CUSTOM_BACKEND_ENABLED}</string>
 	<key>EnableDeveloperMenu</key>
 	<string>${DEVELOPER_MODE_ENABLED}</string>
-	<key>ExternalFilePickerEnabled</key>
-	<string>${EXTERNAL_FILE_PICKER_ACTION_ENABLED}</string>
-	<key>FileGifActionEnabled</key>
-	<string>${FILE_GIF_ACTION_ENABLED}</string>
 	<key>ForceCBREnabled</key>
 	<string>${FORCE_CBR_ENABLED}</string>
 	<key>ForceEncryptionAtRestEnabled</key>
@@ -147,12 +143,6 @@
 	<string>Allow Wire to store pictures you take in the photo library.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Allow Wire to access pictures stored in photo library.</string>
-	<key>OpenFilePreviewEnabled</key>
-	<string>${OPEN_FILE_PREVIEW_ENABLED}</string>
-	<key>SaveMessageEnabled</key>
-	<string>${SAVE_MESSAGE_ENABLED}</string>
-	<key>ShareExtensionEnabled</key>
-	<string>${SHARE_EXTENSION_ENABLED}</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>RedactedScript-Regular.ttf</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQPIT-847" title="SQPIT-847" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />SQPIT-847</a>  Bund app: check why EXTERNAL_FILE_PICKER_ACTION_ENABLED/SHARE_EXTENSION_ENABLED are ignored
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# What's new in this PR?

after https://github.com/wireapp/wire-ios/pull/5210, `FILE_GIF_ACTION_ENABLED`, `SAVE_MESSAGE_ENABLED`, `EXTERNAL_FILE_PICKER_ACTION_ENABLED`, `OPEN_FILE_PREVIEW_ENABLED`, `SHARE_EXTENSION_ENABLED` flags no longer read from the source code. Remove them from the .plist.