### PR TITLE
chore: Add new strings SQSERVICES-1138

### DIFF
--- a/Wire-iOS/Generated/Strings+Generated.swift
+++ b/Wire-iOS/Generated/Strings+Generated.swift
@@ -3746,6 +3746,16 @@ internal enum L10n {
               }
             }
           }
+          internal enum ProfileLink {
+            /// Profile link
+            internal static let title = L10n.tr("Localizable", "self.settings.account_section.profile_link.title")
+            internal enum Actions {
+              /// Profile Link Copied!
+              internal static let copiedLink = L10n.tr("Localizable", "self.settings.account_section.profile_link.actions.copied_link")
+              /// Copy Profile Link
+              internal static let copyLink = L10n.tr("Localizable", "self.settings.account_section.profile_link.actions.copy_link")
+            }
+          }
           internal enum Team {
             /// Team
             internal static let title = L10n.tr("Localizable", "self.settings.account_section.team.title")

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -1015,6 +1015,9 @@
 "self.settings.account_section.add_handle.title" = "Add username";
 "self.settings.account_section.team.title" = "Team";
 "self.settings.account_section.domain.title" = "Domain";
+"self.settings.account_section.profile_link.title" = "Profile link";
+"self.settings.account_section.profile_link.actions.copy_link" = "Copy Profile Link";
+"self.settings.account_section.profile_link.actions.copied_link" = "Profile Link Copied!";
 
 "self.settings.account_details_group.info.footer" = "People can find you with these details.";
 "self.settings.account_details_group.personal.footer" = "This information is not visible .";


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1138" title="SQSERVICES-1138" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />SQSERVICES-1138</a>  [iOS] Display user link in self user profile
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Add new strings for this feature: https://wearezeta.atlassian.net/browse/SQSERVICES-1138

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
