### PR TITLE
feat: update classifications banner in call when participants changed FS-100

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -38,7 +38,8 @@ final class CallViewController: UIViewController {
     fileprivate let hapticsController = CallHapticsController()
     fileprivate var classification: SecurityClassification = .none
 
-    private var observerTokens: [Any] = []
+    private var voiceChannelObserverTokens: [Any] = []
+    private var conversationObserverToken: Any?
     private var callGridConfiguration: CallGridConfiguration
     private let callGridViewController: CallGridViewController
     private var cameraType: CaptureDevice = .front
@@ -92,12 +93,9 @@ final class CallViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
         callInfoRootViewController.delegate = self
         callGridViewController.delegate = self
-        observerTokens += [voiceChannel.addCallStateObserver(self),
-                           voiceChannel.addParticipantObserver(self),
-                           voiceChannel.addConstantBitRateObserver(self),
-                           voiceChannel.addNetworkQualityObserver(self),
-                           voiceChannel.addMuteStateObserver(self),
-                           voiceChannel.addActiveSpeakersObserver(self)]
+
+        setupObservers()
+
         proximityMonitorManager?.stateChanged = { [weak self] raisedToEar in
             self?.proximityStateDidChange(raisedToEar)
         }
@@ -208,6 +206,19 @@ final class CallViewController: UIViewController {
         [callGridViewController, callInfoRootViewController].forEach { $0.view.fitInSuperview() }
     }
 
+    private func setupObservers() {
+        voiceChannelObserverTokens += [voiceChannel.addCallStateObserver(self),
+                           voiceChannel.addParticipantObserver(self),
+                           voiceChannel.addConstantBitRateObserver(self),
+                           voiceChannel.addNetworkQualityObserver(self),
+                           voiceChannel.addMuteStateObserver(self),
+                           voiceChannel.addActiveSpeakersObserver(self)]
+
+        guard let conversation = conversation else { return }
+
+        conversationObserverToken = ConversationChangeInfo.add(observer: self, for: conversation)
+    }
+
     fileprivate func minimizeOverlay() {
         delegate?.callViewControllerDidDisappear(self, for: conversation)
     }
@@ -310,6 +321,14 @@ final class CallViewController: UIViewController {
         }
     }
 
+}
+
+extension CallViewController: ZMConversationObserver {
+    func conversationDidChange(_ changeInfo: ConversationChangeInfo) {
+        guard changeInfo.participantsChanged else { return }
+
+        updateConfiguration()
+    }
 }
 
 extension CallViewController: WireCallCenterCallStateObserver {

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -239,6 +239,11 @@ final class CallViewController: UIViewController {
     }
 
     fileprivate func updateConfiguration() {
+        if let userSession = ZMUserSession.shared(),
+           let participants = conversation?.participants {
+            classification = userSession.classification(with: participants)
+        }
+
         callInfoConfiguration = CallInfoConfiguration(voiceChannel: voiceChannel,
                                                       preferedVideoPlaceholderState: preferedVideoPlaceholderState,
                                                       permissions: permissions,

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -214,7 +214,12 @@ final class CallViewController: UIViewController {
                            voiceChannel.addMuteStateObserver(self),
                            voiceChannel.addActiveSpeakersObserver(self)]
 
-        guard let conversation = conversation else { return }
+        guard
+            let conversation = conversation,
+            conversation.managedObjectContext != nil
+        else {
+            return
+        }
 
         conversationObserverToken = ConversationChangeInfo.add(observer: self, for: conversation)
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-100" title="FS-100" target="_blank"><img alt="Sub-task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />FS-100</a>  [iOS] Show classified banner in calls
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Update the classification banner in call status screen when the conversation participants changed.
