### PR TITLE
feat: update classification banner in conversation when allow guest toggle changed FS-467

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
@@ -823,6 +823,7 @@ extension ConversationInputBarViewController: ZMConversationObserver {
         if change.participantsChanged ||
             change.connectionStateChanged ||
             change.allowGuestsChanged {
+            // Sometime participantsChanged is not observed after allowGuestsChanged 
             updateInputBarVisibility()
             updateClassificationBanner()
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
@@ -821,7 +821,8 @@ extension ConversationInputBarViewController: InformalTextViewDelegate {
 extension ConversationInputBarViewController: ZMConversationObserver {
     func conversationDidChange(_ change: ConversationChangeInfo) {
         if change.participantsChanged ||
-            change.connectionStateChanged {
+            change.connectionStateChanged ||
+            change.allowGuestsChanged {
             updateInputBarVisibility()
             updateClassificationBanner()
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-467" title="FS-467" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-467</a>  iOS: I see "Not classified" label in the conversation on switching the value of Guest toggle to OFF 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Update the classification banner in the conversation screen when the allow guest toggle changed.
