### PR TITLE
chore: revert joined muted indication SQCALL-186

### DIFF
--- a/Wire-iOS Tests/Calling/CallInfoRootViewControllerTests.swift
+++ b/Wire-iOS Tests/Calling/CallInfoRootViewControllerTests.swift
@@ -48,6 +48,7 @@ final class CallInfoRootViewControllerTests: XCTestCase {
 
         super.tearDown()
     }
+
     // MARK: - OneToOne Audio
 
     func testOneToOneOutgoingAudioRinging() {
@@ -276,4 +277,5 @@ final class CallInfoRootViewControllerTests: XCTestCase {
         // then
         verify(matching: sut)
     }
+
 }

--- a/Wire-iOS/Generated/Strings+Generated.swift
+++ b/Wire-iOS/Generated/Strings+Generated.swift
@@ -346,12 +346,6 @@ internal enum L10n {
           }
         }
       }
-      internal enum Toast {
-        internal enum MutedOnJoin {
-          /// When you join a conference call, you are initially muted
-          internal static let message = L10n.tr("Localizable", "call.toast.muted_on_join.message")
-        }
-      }
       internal enum Video {
         /// Video paused
         internal static let paused = L10n.tr("Localizable", "call.video.paused")

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -720,8 +720,6 @@
 "call.alert.ongoing.start.button" = "Call anyway";
 "call.alert.ongoing.join.button" = "Join anyway";
 
-"call.toast.muted_on_join.message" = "When you join a conference call, you are initially muted";
-
 "call.quality.indicator.message" = "Your calling relay is not reachable. This may affect your call experience.";
 "call.quality.indicator.more_info.button.text" = "More info";
 

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoRootViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoRootViewController.swift
@@ -140,14 +140,3 @@ final class CallInfoRootViewController: UIViewController, UINavigationController
     }
 
 }
-// MARK: - Test Helpers
-
-extension CallInfoRootViewController {
-    // used by snapshot tests
-    func dismissToastView() {
-        Toast.hide()
-    }
-    func presentToastView(config: ToastConfiguration) {
-        Toast.show(with: config)
-    }
-}

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoViewController.swift
@@ -69,7 +69,7 @@ final class CallInfoViewController: UIViewController, CallActionsViewDelegate, C
     private let statusViewController: CallStatusViewController
     private let accessoryViewController: CallAccessoryViewController
     private let actionsView = CallActionsView()
-    private var hasMutedToastBeenShown: Bool = false
+
     var configuration: CallInfoViewControllerInput {
         didSet {
             updateState()
@@ -125,27 +125,7 @@ final class CallInfoViewController: UIViewController, CallActionsViewDelegate, C
         [statusViewController.view, accessoryViewController.view, actionsView].forEach(stackView.addArrangedSubview)
         statusViewController.didMove(toParent: self)
     }
-    private func showMutedToastMessageIfNeeded() {
-        guard
-            case .established(let duration) = configuration.state,
-            duration <= 5.0,
-            configuration.isMuted,
-            !hasMutedToastBeenShown
-        else {
-            return
-        }
 
-        let toastConfig = ToastConfiguration(
-            message: L10n.Localizable.Call.Toast.MutedOnJoin.message,
-            colorScheme: ColorSchemeColor.utilityNeutral,
-            variant: ColorSchemeVariant.light,
-            dismissable: true,
-            moreInfoAction: nil,
-            accessibilityIdentifier: "toast.mutedOnJoin"
-        )
-        Toast.show(with: toastConfig)
-        hasMutedToastBeenShown = true
-    }
     private func createConstraints() {
         NSLayoutConstraint.activate([
             stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
@@ -186,7 +166,7 @@ final class CallInfoViewController: UIViewController, CallActionsViewDelegate, C
         accessoryViewController.configuration = configuration
         backgroundViewController.view.isHidden = configuration.videoPlaceholderState == .hidden
         updateAccessoryView()
-        showMutedToastMessageIfNeeded()
+
         if configuration.networkQuality.isNormal {
             navigationItem.titleView = nil
         } else {

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoViewController.swift
@@ -105,11 +105,6 @@ final class CallInfoViewController: UIViewController, CallActionsViewDelegate, C
         updateState()
     }
 
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        Toast.hide()
-    }
-
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         guard traitCollection.didSizeClassChange(from: previousTraitCollection) else { return }
@@ -130,12 +125,7 @@ final class CallInfoViewController: UIViewController, CallActionsViewDelegate, C
         [statusViewController.view, accessoryViewController.view, actionsView].forEach(stackView.addArrangedSubview)
         statusViewController.didMove(toParent: self)
     }
-
     private func showMutedToastMessageIfNeeded() {
-        guard configuration.state != .terminating else {
-            Toast.hide()
-            return
-        }
         guard
             case .established(let duration) = configuration.state,
             duration <= 5.0,
@@ -156,7 +146,6 @@ final class CallInfoViewController: UIViewController, CallActionsViewDelegate, C
         Toast.show(with: toastConfig)
         hasMutedToastBeenShown = true
     }
-
     private func createConstraints() {
         NSLayoutConstraint.activate([
             stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQCALL-186" title="SQCALL-186" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />SQCALL-186</a>  [iOS] Inform the user they joined the call in muted state
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This feature has several issues that need to be addressed before it can be released (see reports in the ticket)
Therefore we will revert it for now

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
