### PR TITLE
fix: join ongoing conference calls as muted - SQCALL-506

### DIFF
--- a/Wire-iOS/Sources/Helpers/syncengine/ZMConversation+Calling.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMConversation+Calling.swift
@@ -52,6 +52,9 @@ extension ZMConversation {
     }
 
     func joinCall() {
+        if conversationType == .group {
+            voiceChannel?.muted = true
+        }
         joinVoiceChannel(video: false)
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQCALL-506" title="SQCALL-506" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQCALL-506</a>  [iOS] User is joined as Unmuted on rejoining a group conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Re-joining conference calls would result in the user joining **not muted** instead of **muted**.

### Causes (Optional)

After leaving a call, AVS prepares for any new call by setting the mute state to its default **unmuted** state. If the client needs to join muted, it has to set the muted state itself before joining the call.

### Solutions

Explicitly set the muted state to **muted** when joining a conference call from the `join` button

### Testing

Couldn't find a way to assign a mock of the voice channel to the conversation in order to verify that the muted state is set properly

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
