### PR TITLE
chore: add launch argument to keep overlay visible SQCALL-508

### DIFF
--- a/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
+++ b/Wire-iOS.xcodeproj/xcshareddata/xcschemes/Wire-iOS.xcscheme
@@ -214,6 +214,10 @@
             argument = "-FederationEnabled 1"
             isEnabled = "NO">
          </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--keep-calling-overlay-visible"
+            isEnabled = "NO">
+         </CommandLineArgument>
       </CommandLineArguments>
       <EnvironmentVariables>
          <EnvironmentVariable

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -19,6 +19,7 @@
 import UIKit
 import WireSyncEngine
 import avs
+import WireCommonComponents
 
 protocol CallViewControllerDelegate: AnyObject {
     func callViewControllerDidDisappear(_ callController: CallViewController,
@@ -467,20 +468,18 @@ extension CallViewController: CallGridViewControllerDelegate {
 
 extension CallViewController {
 
-    private var callingConfig: CallingConfiguration { .config }
-
     var isOverlayVisible: Bool {
         return callInfoRootViewController.view.alpha > 0
+    }
+
+    private var shouldOverlayStayVisibleForAutomation: Bool {
+        return AutomationHelper.sharedHelper.keepCallingOverlayVisible
     }
 
     fileprivate var canHideOverlay: Bool {
         guard case .established = callInfoConfiguration.state else { return false }
 
-        guard callingConfig.canAudioCallHideOverlay else {
-            return callInfoConfiguration.isVideoCall
-        }
-
-        return true
+        return !shouldOverlayStayVisibleForAutomation
     }
 
     fileprivate func toggleOverlayVisibility() {
@@ -518,6 +517,8 @@ extension CallViewController {
     }
 
     func startOverlayTimer() {
+        guard !shouldOverlayStayVisibleForAutomation else { return }
+
         stopOverlayTimer()
         overlayTimer = .scheduledTimer(withTimeInterval: 8, repeats: false) { [weak self] _ in
             self?.animateOverlay(show: false)

--- a/WireCommonComponents/AutomationHelper.swift
+++ b/WireCommonComponents/AutomationHelper.swift
@@ -101,6 +101,9 @@ public final class AutomationHelper: NSObject {
     /// Whether federation support should be enabled
     public let enableFederation: Bool
 
+    /// Whether the calling overlay should disappear automatically.
+    public let keepCallingOverlayVisible: Bool
+
     override init() {
         let url = URL(string: NSTemporaryDirectory())?.appendingPathComponent(fileArgumentsName)
         let arguments: ArgumentsType = url.flatMap(FileArguments.init) ?? CommandLineArguments()
@@ -112,6 +115,7 @@ public final class AutomationHelper: NSObject {
         shouldPersistBackendType = arguments.hasFlag(AutomationKey.persistBackendType)
         disableInteractiveKeyboardDismissal = arguments.hasFlag(AutomationKey.disableInteractiveKeyboardDismissal)
         enableFederation = arguments.hasFlag(AutomationKey.enableFederation)
+        keepCallingOverlayVisible = arguments.hasFlag(AutomationKey.keepCallingOverlayVisible)
         
         if let value = arguments.flagValueIfPresent(AutomationKey.useAppCenter.rawValue) {
             useAppCenterLaunchOption = (value != "0")
@@ -153,6 +157,7 @@ public final class AutomationHelper: NSObject {
         case disableInteractiveKeyboardDismissal = "disable-interactive-keyboard-dismissal"
         case useAppCenter = "use-app-center"
         case enableFederation = "enable-federation"
+        case keepCallingOverlayVisible = "keep-calling-overlay-visible"
     }
     
     /// Returns the login email and password credentials if set in the given arguments


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQCALL-508" title="SQCALL-508" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />SQCALL-508</a>  iOS: Add a launch argument to display the calling overlay 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Added a launch argument to keep the calling overlay visible for QA automation.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
