### PR TITLE
Fix: Broken links SQSERVICES-1292

### DIFF
--- a/Wire-iOS Tests/Bundle/URL+WireTests.swift
+++ b/Wire-iOS Tests/Bundle/URL+WireTests.swift
@@ -41,14 +41,13 @@ final class URL_WireTests: XCTestCase {
         let websiteURL = URL(string: "https://wire.com")!
         XCTAssertEqual(be.websiteURL, websiteURL)
         XCTAssertEqual(URL.wr_usernameLearnMore, websiteURL.appendingPathComponent("support/username"))
-        XCTAssertEqual(URL.wr_privacyPolicy, websiteURL.appendingPathComponent("legal/terms-of-use-personal"))
+        XCTAssertEqual(URL.wr_privacyPolicy, websiteURL.appendingPathComponent("legal"))
         XCTAssertEqual(URL.wr_licenseInformation, websiteURL.appendingPathComponent("legal/licenses/embed"))
         XCTAssertEqual(URL.wr_cannotDecryptHelp, websiteURL.appendingPathComponent("privacy/error-1"))
         XCTAssertEqual(URL.wr_cannotDecryptNewRemoteIDHelp, websiteURL.appendingPathComponent("privacy/error-2"))
         XCTAssertEqual(URL.wr_createTeamFeatures, websiteURL.appendingPathComponent("teams/learnmore"))
         XCTAssertEqual(URL.wr_emailInUseLearnMore, websiteURL.appendingPathComponent("support/email-in-use"))
-        XCTAssertEqual(URL.wr_termsOfServicesURL, websiteURL.appendingPathComponent("legal/terms-of-use-personal"))
-        XCTAssertEqual(URL.wr_termsOfServicesURL, websiteURL.appendingPathComponent("legal/terms-of-use-personal"))
+        XCTAssertEqual(URL.wr_termsOfServicesURL, websiteURL.appendingPathComponent("legal"))
     }
 
     func testThatSupportURLsAreLoadedCorrectly() {

--- a/Wire-iOS/Sources/Helpers/URL+Wire.swift
+++ b/Wire-iOS/Sources/Helpers/URL+Wire.swift
@@ -137,7 +137,7 @@ extension URL {
     }
 
     static var wr_privacyPolicy: URL {
-        return BackendEnvironment.websiteLink(path: "legal/terms-of-use-personal")
+        return BackendEnvironment.websiteLink(path: "legal")
     }
 
     static var wr_licenseInformation: URL {
@@ -181,7 +181,7 @@ extension URL {
     }
 
     static var wr_termsOfServicesURL: URL {
-        return BackendEnvironment.websiteLink(path: "legal/terms-of-use-personal")
+        return BackendEnvironment.websiteLink(path: "legal")
     }
 
     static var wr_legalHoldLearnMore: URL {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1292" title="SQSERVICES-1292" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQSERVICES-1292</a>  [iOS] Link to ToC is broken in the public account signup flow
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Links for `Terms of use` and `Privacy Policy` have been changed.

### Solutions

Fix links. 

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
