### PR TITLE
feat: Support multiple accounts SQSERVICES-1310

### DIFF
--- a/Wire Notification Service Extension/NotificationService.swift
+++ b/Wire Notification Service Extension/NotificationService.swift
@@ -21,6 +21,7 @@ import UserNotifications
 import WireNotificationEngine
 import WireCommonComponents
 import WireDataModel
+import WireSyncEngine
 import UIKit
 
 public class NotificationService: UNNotificationServiceExtension, NotificationSessionDelegate {
@@ -58,10 +59,8 @@ public class NotificationService: UNNotificationServiceExtension, NotificationSe
 
         contentAndHandler = (content, contentHandler)
 
-        // TODO: Check if we have accountID in request.content.userInfo
-        guard
-            let accountID = accountManager.selectedAccount?.userIdentifier,
-            let session = try? createSession(accountID: accountID)
+        guard let accountID = content.userInfo.accountId(),
+              let session = try? createSession(accountID: accountID)
         else {
             // TODO: what happens here?
             return

--- a/Wire Notification Service Extension/NotificationService.swift
+++ b/Wire Notification Service Extension/NotificationService.swift
@@ -54,8 +54,9 @@ public class NotificationService: UNNotificationServiceExtension, NotificationSe
     ) {
         self.contentHandler = contentHandler
 
-        guard let accountID = content.userInfo.accountId(),
-              let session = try? createSession(accountID: accountID)
+        guard
+            let accountID = request.content.userInfo.accountId(),
+            let session = try? createSession(accountID: accountID)
         else {
             // TODO: what happens here?
             return


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1310" title="SQSERVICES-1310" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />SQSERVICES-1310</a>  Support multiple accounts
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Get the account ID from the push payload and create a notification session with that ID.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
