### PR TITLE
fix: use app groups id not being recognized SQSERVICE-1107

### DIFF
--- a/Wire Notification Service Extension/Wire Notification Extension.entitlements
+++ b/Wire Notification Service Extension/Wire Notification Extension.entitlements
@@ -10,7 +10,7 @@
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.${WIRE_BUNDLE_ID}</string>
+		<string>group.$(WIRE_BUNDLE_ID)</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When building the app for internal, the notification service extension can't be build.

### Causes

It complains about the provisioning profile relating tot he app groups capability. I've checked the profile, it appears to be correct. After some local testing, it seems that the entitlements file doesn't specify the app group id correctly.

### Solutions

Uses parenthesis when setting the app group identifier. (Not sure if this will work, but seems to fix it locally.)


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
