### PR TITLE
fix: it's possible to bypass blacklist FS-519

### DIFF
--- a/Wire-iOS Tests/AppStateCalculatorTests.swift
+++ b/Wire-iOS Tests/AppStateCalculatorTests.swift
@@ -201,6 +201,21 @@ final class AppStateCalculatorTests: XCTestCase {
         // THEN
         XCTAssertTrue(delegate.wasNotified)
     }
+
+    func testThatItDoesntTransitionAwayFromBlacklisted_IfThereIsNoCurrentAPIVersion() {
+        // GIVEN
+        sut.applicationDidBecomeActive()
+        APIVersion.current = nil
+        
+        let blacklistState = AppState.blacklisted(reason: .clientAPIVersionObsolete)
+        sut.testHelper_setAppState(blacklistState)
+
+        // WHEN
+        sut.sessionManagerDidReportLockChange(forSession: MockZMUserSession())
+
+        // THEN
+        XCTAssertEqual(sut.appState, blacklistState)
+    }
 }
 
 class MockAppStateCalculatorDelegate: AppStateCalculatorDelegate {

--- a/Wire-iOS/Sources/AppStateCalculator.swift
+++ b/Wire-iOS/Sources/AppStateCalculator.swift
@@ -108,6 +108,11 @@ class AppStateCalculator {
             return
         }
 
+        if case .blacklisted = self.appState, APIVersion.current == nil {
+            completion?()
+            return
+        }
+
         self.appState = appState
         self.pendingAppState = nil
         ZMSLog(tag: "AppState").debug("transitioning to app state: \(appState)")

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
@@ -267,6 +267,12 @@ class SettingsCellDescriptorFactory {
                    selectAction: DebugActions.showAnalyticsIdentifier)
         )
 
+        developerCellDescriptors.append(
+            Button(title: "What's the api version?",
+                   isDestructive: false,
+                   selectAction: DebugActions.showAPIVersionInfo)
+        )
+
         return SettingsGroupCellDescriptor(items: [SettingsSectionDescriptor(cellDescriptors: developerCellDescriptors)],
                                            title: L10n.Localizable.`Self`.Settings.DeveloperOptions.title,
                                            icon: .robot)

--- a/Wire-iOS/Sources/UserInterface/Settings/DebugActions.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/DebugActions.swift
@@ -170,6 +170,27 @@ enum DebugActions {
         controller.present(alert, animated: true)
     }
 
+    static func showAPIVersionInfo(_ type: SettingsCellDescriptorType) {
+        guard let controller = UIApplication.shared.topmostViewController(onlyFullScreen: false) else {
+            return
+        }
+
+        let message = """
+        Max supported version: \((APIVersion.allCases.max()?.rawValue).description(else: "None"))
+        Currently selected version: \((APIVersion.current?.rawValue).description(else: "None"))
+        Local domain: \(APIVersion.domain.description(else: "None"))
+        Is federation enabled: \(APIVersion.isFederationEnabled)
+        """
+
+        let alert = UIAlertController(
+            title: "API Version info",
+            message: message,
+            alertAction: .ok(style: .cancel)
+        )
+
+        controller.present(alert, animated: true)
+    }
+
     static func generateTestCrash(_ type: SettingsCellDescriptorType) {
         Crashes.generateTestCrash()
     }
@@ -303,4 +324,13 @@ enum DebugActions {
         }
         while (currentCount > 0)
     }
+}
+
+private extension Optional {
+
+    func description(else defaultDescription: String) -> String {
+        guard let value = self else { return defaultDescription }
+        return String(describing: value)
+    }
+
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

If you're already logged into the app, then the app get's blacklisted due to no api version being available, then it's possible to get to the conversation list by simply opening the app.

### Causes

When a user is already logged in and the app comes to the foreground, the session manager will inform its delegate that the active session changed. The delegate is responsible for transitioning to different app states (such as the blacklist state and the authenticated state).

But when the app comes to the foreground, we attempt to resolve the api version. In the case that none could be resolved, the session manager will inform its delegate to transition to the blacklist state, as expected. But because we're already logged in, the session manager will shortly ask the delegate to transition to the authenticated state. Thus we move out to the blacklist ui and to the conversation list.

### Solutions

A simple solution is to not transition away from the blacklist state if there is no selected api version. I think there may be a better solution, but likely it would take a lot more changes and could be risky. For now I think it's acceptable, and I will consider alternatives in the future.

### Testing

Added a unit test.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
