### PR TITLE
fix: Fix the layout issue of guest link copy SQSERVICES-1439

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation Options/GuestLinkInfoCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation Options/GuestLinkInfoCell.swift
@@ -63,7 +63,7 @@ final class GuestLinkInfoCell: UITableViewCell, CellConfigurationConfigurable {
 
             label.leadingAnchor.constraint(equalTo: imageContainer.trailingAnchor),
             label.topAnchor.constraint(equalTo: contentView.topAnchor),
-            label.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            label.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -8),
             label.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
         ])
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1439" title="SQSERVICES-1439" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQSERVICES-1439</a>  [iOS] Update copy when other team has guest links disabled and I look into guest link options
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR we fix the layout issue of guest link copy.  We've added a bit of padding so the copy isn't so close to the edge of the screen.

|   BEFORE |  AFTER |
|---|---|
| ![image-20220407-101555](https://user-images.githubusercontent.com/10944108/162203886-d33b1d06-fc5e-44eb-8336-a23cb479c8d7.png) | <img width="555" alt="Screenshot 2022-04-07 at 14 46 44" src="https://user-images.githubusercontent.com/10944108/162203362-9af6e407-a6c4-4b59-a7c0-1c69d717c34f.png"> |




##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
