### PR TITLE
fix: Broken link to german legal page SQSERVICES-1389

### DIFF
--- a/Wire-iOS/Generated/Strings+Generated.swift
+++ b/Wire-iOS/Generated/Strings+Generated.swift
@@ -2355,6 +2355,10 @@ internal enum L10n {
         }
       }
     }
+    internal enum Link {
+      /// legal
+      internal static let legal = L10n.tr("Localizable", "link.legal")
+    }
     internal enum List {
       /// ARCHIVE
       internal static let archivedConversations = L10n.tr("Localizable", "list.archived_conversations")

--- a/Wire-iOS/Generated/Strings+Generated.swift
+++ b/Wire-iOS/Generated/Strings+Generated.swift
@@ -2355,10 +2355,6 @@ internal enum L10n {
         }
       }
     }
-    internal enum Link {
-      /// legal
-      internal static let legal = L10n.tr("Localizable", "link.legal")
-    }
     internal enum List {
       /// ARCHIVE
       internal static let archivedConversations = L10n.tr("Localizable", "list.archived_conversations")

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -16,9 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-// Link Path strings
-"link.legal" = "legal";
-
 // General strings
 "general.ok" = "OK";
 "general.next" = "Next";

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -16,6 +16,8 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
+// Link Path strings
+"link.legal" = "legal";
 
 // General strings
 "general.ok" = "OK";

--- a/Wire-iOS/Resources/de.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/de.lproj/Localizable.strings
@@ -16,9 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-// Link Path strings
-"link.legal" = "datenschutz";
-
 // General strings
 "general.ok" = "OK";
 "general.next" = "Weiter";

--- a/Wire-iOS/Resources/de.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/de.lproj/Localizable.strings
@@ -15,9 +15,11 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
+
+// Link Path strings
+"link.legal" = "datenschutz";
+
 // General strings
-
-
 "general.ok" = "OK";
 "general.next" = "Weiter";
 "general.cancel" = "Abbrechen";

--- a/Wire-iOS/Sources/Helpers/URL+Wire.swift
+++ b/Wire-iOS/Sources/Helpers/URL+Wire.swift
@@ -181,7 +181,7 @@ extension URL {
     }
 
     static var wr_termsOfServicesURL: URL {
-        return BackendEnvironment.websiteLink(path: "datenschutz")
+        return BackendEnvironment.websiteLink(path: L10n.Localizable.Link.legal)
     }
 
     static var wr_legalHoldLearnMore: URL {

--- a/Wire-iOS/Sources/Helpers/URL+Wire.swift
+++ b/Wire-iOS/Sources/Helpers/URL+Wire.swift
@@ -23,6 +23,11 @@ import WireDataModel
 
 private let zmLog = ZMSLog(tag: "URL")
 
+enum WebsitePages {
+    case termsOfServices
+    case privacyPolicy
+}
+
 enum TeamSource: Int {
     case onboarding, settings
 
@@ -89,6 +94,17 @@ extension BackendEnvironment {
         return shared.websiteURL.appendingPathComponent(path)
     }
 
+    fileprivate static func localizedWebsiteLink(forPage: WebsitePages) -> URL {
+        switch forPage {
+        case .termsOfServices, .privacyPolicy:
+            if Locale.autoupdatingCurrent.languageCode == "de" {
+                return shared.websiteURL.appendingPathComponent("datenschutz")
+            } else {
+                return shared.websiteURL.appendingPathComponent("legal")
+            }
+        }
+    }
+
     fileprivate static func accountsLink(path: String) -> URL {
         return shared.accountsURL.appendingPathComponent(path)
     }
@@ -137,7 +153,7 @@ extension URL {
     }
 
     static var wr_privacyPolicy: URL {
-        return BackendEnvironment.websiteLink(path: L10n.Localizable.Link.legal)
+        return BackendEnvironment.localizedWebsiteLink(forPage: .privacyPolicy)
     }
 
     static var wr_licenseInformation: URL {

--- a/Wire-iOS/Sources/Helpers/URL+Wire.swift
+++ b/Wire-iOS/Sources/Helpers/URL+Wire.swift
@@ -197,7 +197,7 @@ extension URL {
     }
 
     static var wr_termsOfServicesURL: URL {
-        return BackendEnvironment.websiteLink(path: L10n.Localizable.Link.legal)
+        return BackendEnvironment.localizedWebsiteLink(forPage: .termsOfServices)
     }
 
     static var wr_legalHoldLearnMore: URL {

--- a/Wire-iOS/Sources/Helpers/URL+Wire.swift
+++ b/Wire-iOS/Sources/Helpers/URL+Wire.swift
@@ -23,7 +23,7 @@ import WireDataModel
 
 private let zmLog = ZMSLog(tag: "URL")
 
-enum WebsitePages {
+private enum WebsitePages {
     case termsOfServices
     case privacyPolicy
 }

--- a/Wire-iOS/Sources/Helpers/URL+Wire.swift
+++ b/Wire-iOS/Sources/Helpers/URL+Wire.swift
@@ -137,7 +137,7 @@ extension URL {
     }
 
     static var wr_privacyPolicy: URL {
-        return BackendEnvironment.websiteLink(path: "legal")
+        return BackendEnvironment.websiteLink(path: L10n.Localizable.Link.legal)
     }
 
     static var wr_licenseInformation: URL {
@@ -181,7 +181,7 @@ extension URL {
     }
 
     static var wr_termsOfServicesURL: URL {
-        return BackendEnvironment.websiteLink(path: "legal")
+        return BackendEnvironment.websiteLink(path: "datenschutz")
     }
 
     static var wr_legalHoldLearnMore: URL {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1389" title="SQSERVICES-1389" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQSERVICES-1389</a>  [iOS] Broken link to German legal page
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR we aim to fix the issue with the broken German legal page. But that problem also lead us to think how to treat URL's for different languages. Currently on the Wire website we support German and English. 

So when the Wire iOS app is in German we should redirect users to the German version of the website when it comes to "About", "Legal" and many other pages. 

The initial solution was to do something like:

```swift
static var wr_termsOfServicesURL: URL {
    if Locale.autoupdatingCurrent.languageCode == "de" {
        return BackendEnvironment.websiteLink(path: "datenschutz")
    } else {
        return BackendEnvironment.websiteLink(path: "legal")
    }
}
```

But Katerina and I didn't like it that much. The solution implemented in this PR (initially) was to use Localizable.strings. In our case it works fine but it would lead to more issues down the road and it's a good to not mix localisation and URL's.

As the third and final option implemented in this PR, we ended up created a enum `WebsitePages` and a method called

```swift
func localizedWebsiteLink(forPage: WebsitePages) -> URL
```

In that method we check for user's locale and then we pass the appropriate path for our link.

##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
