### PR TITLE
fix: Transparent Navigation Bar when creating a Group Conversation from the Profile View Controller

### DIFF
--- a/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.swift
@@ -138,7 +138,7 @@ final class ProfileViewController: UIViewController {
         let controller = ConversationCreationController(preSelectedParticipants: viewModel.userSet, selfUser: ZMUser.selfUser())
         controller.delegate = self
 
-        let wrappedController = controller.wrapInNavigationController()
+        let wrappedController = controller.wrapInNavigationController(setBackgroundColor: true)
         wrappedController.modalPresentationStyle = .formSheet
         present(wrappedController, animated: true)
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR we fix the transparent navigation bar when we try to create a group conversation from the Profile View Controller.

| BEFORE  |  AFTER  |
|---|---|
| ![Screenshot 2022-04-21 at 16 21 23](https://user-images.githubusercontent.com/10944108/164480306-b92b8e77-ccef-42df-bd3f-de192cbc0588.png)  | ![Screenshot 2022-04-21 at 16 29 03](https://user-images.githubusercontent.com/10944108/164480560-ec5dc275-a3bc-4a77-9157-74faf3e3a154.png)  |

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
