### PR TITLE
fix: The color of navigation bar when profile view controller presented as a popover or a modal IC-44

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsContentViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsContentViewController.swift
@@ -314,7 +314,7 @@ extension MessageDetailsContentViewController {
 
     /// Presents a profile view controller as a popover or a modal depending on the context.
     fileprivate func presentDetailsViewController(_ controller: ProfileViewController, above cell: UserCell) {
-        let presentedController = controller.wrapInNavigationController()
+        let presentedController = controller.wrapInNavigationController(setBackgroundColor: true)
         presentedController.modalPresentationStyle = .formSheet
 
         if let popover = presentedController.popoverPresentationController {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/IC-44" title="IC-44" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />IC-44</a>  The colour of navigation bar is transparent when profile view controller presented as a popover or a modal
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR we fix the color of the navigation bar when  profile view controller presented as a popover or a modal depending on the context. 

|BEFORE | AFTER |
|---|---|
|<img width="586" alt="Screenshot 2022-04-25 at 10 01 32" src="https://user-images.githubusercontent.com/10944108/165052897-012409ff-322b-4a3e-86b4-e2cda3be7e1a.png"> | <img width="586" alt="Screenshot 2022-04-25 at 10 35 13" src="https://user-images.githubusercontent.com/10944108/165052947-febe92ff-e600-474f-8af2-bb71aac3c205.png"> |


----


##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
