### PR TITLE
fix: Nav bar color for country picker

### DIFF
--- a/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationCredentialsViewController.swift
+++ b/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationCredentialsViewController.swift
@@ -310,7 +310,7 @@ final class AuthenticationCredentialsViewController: AuthenticationStepControlle
         countryCodePicker.delegate = self
         countryCodePicker.modalPresentationStyle = .formSheet
 
-        let navigationController = countryCodePicker.wrapInNavigationController(navigationBarClass: LightNavigationBar.self)
+        let navigationController = countryCodePicker.wrapInNavigationController(navigationBarClass: LightNavigationBar.self, setBackgroundColor: true)
         present(navigationController, animated: true)
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR we fix the nav bar color for country picker

| BEFORE  | AFTER |
|---|---|
| ![Screenshot 2022-04-27 at 16 59 33](https://user-images.githubusercontent.com/10944108/165549532-8894ddb8-d1ae-4dca-b1e6-7aba2f504c46.png) | ![Screenshot 2022-04-27 at 17 00 59](https://user-images.githubusercontent.com/10944108/165549637-7f359400-765c-4ac7-8ec5-e7f4f2896926.png) |

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
