### PR TITLE
fix: The color of the navigation bar of the FolderPickerViewController

### DIFF
--- a/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+Folders.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+Folders.swift
@@ -26,7 +26,7 @@ extension ConversationActionController {
         guard let directory = ZMUserSession.shared()?.conversationDirectory else { return }
         let folderPicker = FolderPickerViewController(conversation: conversation, directory: directory)
         folderPicker.delegate = self
-        self.present(folderPicker.wrapInNavigationController(navigationBarClass: DefaultNavigationBar.self))
+        self.present(folderPicker.wrapInNavigationController(navigationBarClass: DefaultNavigationBar.self, setBackgroundColor: true))
     }
 }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR, we fix the color of the navigation bar of the FolderPickerViewController.

| BEFORE  | AFTER  |
|---|---|
| <img width="548" alt="Screenshot 2022-05-20 at 10 46 17" src="https://user-images.githubusercontent.com/10944108/169493542-3cac8e26-a276-4816-94f3-d17d70717129.png">  | <img width="548" alt="Screenshot 2022-05-20 at 10 56 34" src="https://user-images.githubusercontent.com/10944108/169493561-dfe95541-c102-4098-a9d4-92d8c2025906.png">  |



----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
