### PR TITLE
feat: Dynamic Type Support for Profile View

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Components/Views/DetailsCollectionViewCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/DetailsCollectionViewCell.swift
@@ -20,11 +20,8 @@ import UIKit
 import WireCommonComponents
 
 class DetailsCollectionViewCell: SeparatorCollectionViewCell, DynamicTypeCapable {
-    func redrawFont() {
-        statusLabel.font = FontSpec.smallRegularFont.font
 
-        titleLabel.font = titleBolded ? FontSpec.normalSemiboldFont.font : FontSpec.normalLightFont.font
-    }
+    // MARK: - Properties
 
     private let leftIconView = UIImageView()
     private let titleLabel = UILabel()
@@ -37,8 +34,6 @@ class DetailsCollectionViewCell: SeparatorCollectionViewCell, DynamicTypeCapable
 
     /// The leading offset of the content when `icon` is nil.
     var contentLeadingOffset: CGFloat = 24
-
-    // MARK: - Properties
 
     var titleBolded: Bool {
         get {
@@ -71,7 +66,7 @@ class DetailsCollectionViewCell: SeparatorCollectionViewCell, DynamicTypeCapable
         }
     }
 
-    // MARK: - Configuration
+    // MARK: - Configuration - Override Methods
 
     override func setUp() {
         super.setUp()
@@ -166,6 +161,12 @@ class DetailsCollectionViewCell: SeparatorCollectionViewCell, DynamicTypeCapable
 
     private func updateDisabledState() {
         titleLabel.textColor = UIColor.from(scheme: disabled ? .textPlaceholder : .textForeground, variant: colorSchemeVariant)
+    }
+
+    func redrawFont() {
+        statusLabel.font = FontSpec.smallRegularFont.font
+
+        titleLabel.font = titleBolded ? FontSpec.normalSemiboldFont.font : FontSpec.normalLightFont.font
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/Components/Views/UserCellSubtitleProtocol.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/Views/UserCellSubtitleProtocol.swift
@@ -57,7 +57,7 @@ extension UserCellSubtitleProtocol where Self: UIView & Themeable {
         }
 
         let color = UIColor.from(scheme: .sectionText, variant: colorSchemeVariant)
-        let formatter = AddressBookCorrelationFormatter(lightFont: lightFont.font!, boldFont: boldFont.font!, color: color)
+        let formatter = AddressBookCorrelationFormatter(lightFont: lightFont, boldFont: boldFont, color: color)
 
         correlationFormatters[colorSchemeVariant] = formatter
 

--- a/Wire-iOS/Sources/UserInterface/ConnectRequests/IncomingConnectionView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConnectRequests/IncomingConnectionView.swift
@@ -24,8 +24,8 @@ final class IncomingConnectionView: UIView {
 
     static private var correlationFormatter: AddressBookCorrelationFormatter = {
         return AddressBookCorrelationFormatter(
-            lightFont: FontSpec(.small, .light).font!,
-            boldFont: FontSpec(.small, .medium).font!,
+            lightFont: FontSpec(.small, .light),
+            boldFont: FontSpec(.small, .medium),
             color: UIColor.from(scheme: .textDimmed)
         )
     }()

--- a/Wire-iOS/Sources/UserInterface/ConnectRequests/UserConnectionView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConnectRequests/UserConnectionView.swift
@@ -29,8 +29,8 @@ final class UserConnectionView: UIView, Copyable {
 
     static private var correlationFormatter: AddressBookCorrelationFormatter = {
         return AddressBookCorrelationFormatter(
-            lightFont: FontSpec(.small, .light).font!,
-            boldFont: FontSpec(.small, .medium).font!,
+            lightFont: FontSpec(.small, .light),
+            boldFont: FontSpec(.small, .medium),
             color: UIColor.from(scheme: .textDimmed)
         )
     }()

--- a/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationDetailFooterView.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationDetailFooterView.swift
@@ -26,6 +26,7 @@ import WireSystem
 
 class ConversationDetailFooterView: UIView {
 
+    // MARK: - Properties
     private let variant: ColorSchemeVariant
     let rightButton = IconButton()
     var leftButton: IconButton
@@ -55,6 +56,7 @@ class ConversationDetailFooterView: UIView {
         }
     }
 
+    // MARK: - Initialization
     init() {
         self.variant = ColorScheme.default.variant
         self.leftButton = IconButton(fontSpec: .smallRegularFont)
@@ -68,6 +70,7 @@ class ConversationDetailFooterView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
+    // MARK: - Layout
     private func setupViews() {
         let configureButton = { (button: IconButton) in
             self.containerView.addSubview(button)
@@ -83,9 +86,8 @@ class ConversationDetailFooterView: UIView {
         configureButton(rightButton)
 
         leftButton.setTitleImageSpacing(16)
-        leftButton.titleLabel?.font = FontSpec(.small, .regular).font
-        leftButton.addTarget(self, action: #selector(leftButtonTapped), for: .touchUpInside)
 
+        leftButton.addTarget(self, action: #selector(leftButtonTapped), for: .touchUpInside)
         rightButton.addTarget(self, action: #selector(rightButtonTapped), for: .touchUpInside)
 
         backgroundColor = UIColor.from(scheme: .barBackground)

--- a/Wire-iOS/Sources/UserInterface/UserProfile/Views/ProfileTitleView.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Views/ProfileTitleView.swift
@@ -23,7 +23,7 @@ import WireDataModel
 final class ProfileTitleView: UIView {
 
     let verifiedImageView = UIImageView(image: WireStyleKit.imageOfShieldverified)
-    private let titleLabel = UILabel()
+    private let titleLabel = DynamicFontLabel(fontSpec: .normalMediumFont, color: .textForeground)
 
     var showVerifiedShield = false {
         didSet {
@@ -70,7 +70,6 @@ final class ProfileTitleView: UIView {
     func configure(with user: UserType, variant: ColorSchemeVariant) {
         let attributedTitle = user.nameIncludingAvailability(color: UIColor.from(scheme: .textForeground, variant: variant), selfUser: ZMUser.selfUser())
         titleLabel.attributedText = attributedTitle
-        titleLabel.font = FontSpec(.normal, .medium).font!
     }
 
     private func updateVerifiedShield() {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR, we're adding support for two Profile views. One with the tabs and the one without the tabs.

## Profile View with Tabs

| iPhone 8 - English  | iPhone 8 - German  |  iPhone SE - English  |  iPhone SE - German |
|---|---|---|---|
| ![Screenshot 2022-05-31 at 11 11 54](https://user-images.githubusercontent.com/10944108/171138744-9fd72f7a-dbe3-45b0-a869-448de632053a.png)  | ![Screenshot 2022-05-31 at 11 05 43](https://user-images.githubusercontent.com/10944108/171138903-f159d68c-6299-46e2-828d-18d91d4fe77e.png)  | ![Screenshot 2022-05-31 at 11 08 01](https://user-images.githubusercontent.com/10944108/171138791-904092c1-15c7-4dc7-bd32-ea486e9ecfff.png)  | ![Screenshot 2022-05-31 at 11 06 53](https://user-images.githubusercontent.com/10944108/171138846-4c88de65-f8e7-4d68-9bcb-10d525c570bf.png)  |

## Profile View without Tabs

| iPhone 8 - English  | iPhone 8 - German  |  iPhone SE - English  |  iPhone SE - German |
|---|---|---|---|
| ![Screenshot 2022-05-31 at 10 43 27](https://user-images.githubusercontent.com/10944108/171139615-8d576d4e-d71a-4225-a780-c8806b82ea44.png)  | ![Screenshot 2022-05-31 at 10 51 18](https://user-images.githubusercontent.com/10944108/171139729-2b77593d-121c-4cb6-9e79-175c2e026874.png)  | ![Screenshot 2022-05-31 at 10 45 24](https://user-images.githubusercontent.com/10944108/171139267-bf4f2da9-d121-4e43-afc6-35d4d23357b7.png)  | ![Screenshot 2022-05-31 at 10 46 33](https://user-images.githubusercontent.com/10944108/171139401-ca4871ab-8cce-46cc-8e4a-60ba856c6cd3.png) |













----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
