### PR TITLE
feat: mark notifications as time sensitive SQCORE-1308

### DIFF
--- a/Wire Notification Service Extension/NotificationService.swift
+++ b/Wire Notification Service Extension/NotificationService.swift
@@ -80,12 +80,21 @@ public class NotificationService: UNNotificationServiceExtension, NotificationSe
         tearDown()
     }
 
-    public func notificationSessionDidGenerateNotification(_ notification: ZMLocalNotification?, unreadConversationCount: Int) {
+    public func notificationSessionDidGenerateNotification(
+        _ notification: ZMLocalNotification?,
+        unreadConversationCount: Int
+    ) {
         defer { tearDown() }
+
         guard let contentHandler = contentHandler else { return }
+
         guard let content = notification?.content as? UNMutableNotificationContent else {
             contentHandler(.empty)
             return
+        }
+
+        if #available(iOS 15, *) {
+            content.interruptionLevel = .timeSensitive
         }
 
         let badgeCount = totalUnreadCount(unreadConversationCount)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Mark notifications as time sensitive. This allows notifications to cut through notification summaries and focus modes.


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
