### PR TITLE
feat: folders screen - dynamic type support ACC-92

### DIFF
--- a/Wire-iOS Tests/AppStateCalculatorTests.swift
+++ b/Wire-iOS Tests/AppStateCalculatorTests.swift
@@ -156,7 +156,7 @@ final class AppStateCalculatorTests: XCTestCase {
             XCTAssertEqual(sut.appState, .authenticated(completedRegistration: false))
         } else {
             guard case let .unauthenticated(error: error) = sut.appState else {
-                return XCTFail()
+                return XCTFail("Error - unauthenticated")
             }
 
             XCTAssertEqual(error?.userSessionErrorCode, .needsAuthenticationAfterMigration)

--- a/Wire-iOS/Sources/Helpers/ColorScheme.swift
+++ b/Wire-iOS/Sources/Helpers/ColorScheme.swift
@@ -119,7 +119,6 @@ enum ColorSchemeColor: Int {
     case textSecurityNotClassified
     case backgroundSecurityNotClassified
     case white
-    
     fileprivate func colorPair(accentColor: UIColor) -> ColorPair {
         switch self {
         case .textForeground:
@@ -232,32 +231,24 @@ enum ColorSchemeColor: Int {
             return ColorPair(light: .graphite, dark: .white)
         case .white:
             return ColorPair(light: .white, dark: .white)
-            
         }
     }
 }
 
 final class ColorScheme: NSObject {
     private(set) var colors: [AnyHashable: Any]?
-    
     var variant: ColorSchemeVariant = .light
-    
     private(set) var defaultColorScheme: ColorScheme?
     var accentColor: UIColor = .red
-    
     var keyboardAppearance: UIKeyboardAppearance {
         return ColorScheme.keyboardAppearance(for: variant)
     }
-    
     class func keyboardAppearance(for variant: ColorSchemeVariant) -> UIKeyboardAppearance {
         return variant == .light ? .light : .dark
     }
-    
     static let `default`: ColorScheme = ColorScheme()
-    
     func color(named: ColorSchemeColor, variant: ColorSchemeVariant? = nil) -> UIColor {
         let colorSchemeVariant = variant ?? self.variant
-        
         let colorPair = named.colorPair(accentColor: accentColor)
         switch colorSchemeVariant {
         case .dark:
@@ -266,11 +257,9 @@ final class ColorScheme: NSObject {
             return colorPair.light
         }
     }
-    
     func nameAccent(for color: ZMAccentColor, variant: ColorSchemeVariant) -> UIColor {
         return UIColor.nameColor(for: color, variant: variant)
     }
-    
 }
 
 private struct ColorPair {
@@ -285,16 +274,13 @@ private extension ColorPair {
 }
 
 extension UIColor {
-    
     static func from(scheme: ColorSchemeColor, variant: ColorSchemeVariant? = nil) -> UIColor {
         return ColorScheme.default.color(named: scheme, variant: variant)
     }
-    
     /// Creates UIColor instance with color corresponding to @p accentColor that can be used to display the name.
     // NB: the order of coefficients must match ZMAccentColor enum ordering
     private static let accentColorNameColorBlendingCoefficientsDark: [CGFloat] = [0.8, 0.8, 0.72, 1.0, 0.8, 0.8, 0.8, 0.64]
     private static let accentColorNameColorBlendingCoefficientsLight: [CGFloat] = [0.8, 0.8, 0.72, 1.0, 0.8, 0.8, 0.64, 1.0]
-    
     /// Creates UIColor instance with color corresponding to @p accentColor that can be used to display the name.
     class func nameColor(for accentColor: ZMAccentColor, variant: ColorSchemeVariant) -> UIColor {
         let accentColor = AccentColor(ZMAccentColor: accentColor) ?? .strongBlue

--- a/Wire-iOS/Sources/Helpers/ColorScheme.swift
+++ b/Wire-iOS/Sources/Helpers/ColorScheme.swift
@@ -32,9 +32,7 @@ extension UIColor {
     static var graphiteAlpha8: UIColor = UIColor(rgba: (51, 55, 58, 0.08))
     static var graphiteAlpha16: UIColor = UIColor(rgba: (51, 55, 58, 0.16))
     static var graphiteAlpha40: UIColor = UIColor(rgba: (51, 55, 58, 0.4))
-
     static var backgroundLightGraphite: UIColor = UIColor(rgb: (30, 32, 33))
-
     static var lightGraphite: UIColor = UIColor(rgb: (141, 152, 159))
     static var lightGraphiteAlpha8: UIColor = UIColor(rgba: (141, 152, 159, 0.08))
     static var lightGraphiteAlpha24: UIColor = UIColor(rgba: (141, 152, 159, 0.24))
@@ -42,16 +40,12 @@ extension UIColor {
     static var lightGraphiteAlpha64: UIColor = UIColor(rgba: (141, 152, 159, 0.64))
     static var lightGraphiteWhite: UIColor = lightGraphiteAlpha8.removeAlphaByBlending(with: .white98)
     static var lightGraphiteDark: UIColor = lightGraphiteAlpha8.removeAlphaByBlending(with: .backgroundGraphite)
-
     static var graphiteDark: UIColor = UIColor(rgb: (50, 54, 57))
-
     static var backgroundGraphite: UIColor = UIColor(rgb: (22, 24, 25))
     static var backgroundGraphiteAlpha40: UIColor = UIColor(rgba: (22, 24, 25, 0.4))
     static var backgroundGraphiteAlpha12: UIColor = UIColor(rgba: (22, 24, 25, 0.12))
-
     static var white97: UIColor = UIColor(white: 0.97, alpha: 1)
     static var white98: UIColor = UIColor(white: 0.98, alpha: 1)
-
     static var whiteAlpha8: UIColor = UIColor(white: 1.0, alpha: 0.08)
     static var whiteAlpha16: UIColor = UIColor(white: 1.0, alpha: 0.16)
     static var whiteAlpha24: UIColor = UIColor(white: 1.0, alpha: 0.24)
@@ -59,7 +53,6 @@ extension UIColor {
     static var whiteAlpha56: UIColor = UIColor(white: 1.0, alpha: 0.56)
     static var whiteAlpha64: UIColor = UIColor(white: 1.0, alpha: 0.64)
     static var whiteAlpha80: UIColor = UIColor(white: 1.0, alpha: 0.8)
-
     static var blackAlpha4: UIColor = UIColor(white: 0.0, alpha: 0.04)
     static var blackAlpha8: UIColor = UIColor(white: 0.0, alpha: 0.08)
     static var blackAlpha16: UIColor = UIColor(white: 0, alpha: 0.16)
@@ -67,7 +60,6 @@ extension UIColor {
     static var blackAlpha48: UIColor = UIColor(white: 0.0, alpha: 0.48)
     static var blackAlpha40: UIColor = UIColor(white: 0.0, alpha: 0.4)
     static var blackAlpha80: UIColor = UIColor(white: 0.0, alpha: 0.8)
-
     static var amberAlpha48: UIColor = UIColor(rgba: (254, 191, 2, 0.48))
     static var amberAlpha80: UIColor = UIColor(rgba: (254, 191, 2, 0.8))
 }
@@ -78,7 +70,6 @@ enum ColorSchemeColor: Int {
     case textDimmed
     case textPlaceholder
     case textInBadge
-
     case iconNormal
     case iconSelected
     case iconHighlighted
@@ -87,17 +78,13 @@ enum ColorSchemeColor: Int {
     case iconShadow
     case iconHighlight
     case iconGuest
-
     case popUpButtonOverlayShadow
-
     case buttonHighlighted
     case buttonEmptyText
     case buttonFaded
-
     case tabNormal
     case tabSelected
     case tabHighlighted
-
     case background
     case contentBackground
     case barBackground
@@ -110,39 +97,29 @@ enum ColorSchemeColor: Int {
     case avatarBorder
     case loadingDotActive
     case loadingDotInactive
-
     case paleSeparator
     case listAvatarInitials
     case audioButtonOverlay
-
     case sectionBackground
     case sectionBackgroundHighlighted
     case sectionText
-
     case tokenFieldBackground
     case tokenFieldTextPlaceHolder
-
     case selfMentionHighlight
     case cellHighlight
-
     case replyBorder
     case replyHighlight
-
     case secondaryAction
     case secondaryActionDimmed
-
     case errorIndicator
-
     case landingScreen
-
     case utilityError
     case utilityNeutral
     case utilitySuccess
-
     case textSecurityNotClassified
     case backgroundSecurityNotClassified
     case white
-
+    
     fileprivate func colorPair(accentColor: UIColor) -> ColorPair {
         switch self {
         case .textForeground:
@@ -235,57 +212,52 @@ enum ColorSchemeColor: Int {
         case .replyHighlight:
             return ColorPair(light: UIColor(rgb: 0x33373A, alpha: 0.24),
                              dark: UIColor(white: 1, alpha: 0.24))
-
         case .secondaryAction:
             return ColorPair(light: UIColor(rgb: 0xE8ECEE), dark: .backgroundLightGraphite)
         case .secondaryActionDimmed:
             return ColorPair(light: UIColor(rgb: 0xE8ECEE, alpha: 0.24), dark: UIColor.backgroundLightGraphite.withAlphaComponent(0.24))
-
         case .errorIndicator:
             return ColorPair(light: UIColor(rgb: 0xE60606), dark: UIColor(rgb: 0xFC3E37))
-
         case .landingScreen:
             return ColorPair(light: .graphiteDark, dark: .white)
-
         case .utilityError:
             return ColorPair(light: UIColor(rgb: 0xE41734), dark: UIColor(rgb: 0xFC7887))
         case .utilityNeutral:
             return ColorPair(light: UIColor(rgb: 0x0772DE), dark: UIColor(rgb: 0x26BDFF))
         case .utilitySuccess:
             return ColorPair(light: UIColor(rgb: 0x148545), dark: UIColor(rgb: 0x35C763))
-
         case .textSecurityNotClassified:
             return ColorPair(light: .white, dark: .graphite)
         case .backgroundSecurityNotClassified:
             return ColorPair(light: .graphite, dark: .white)
         case .white:
             return ColorPair(light: .white, dark: .white)
-
+            
         }
     }
 }
 
 final class ColorScheme: NSObject {
     private(set) var colors: [AnyHashable: Any]?
-
+    
     var variant: ColorSchemeVariant = .light
-
+    
     private(set) var defaultColorScheme: ColorScheme?
     var accentColor: UIColor = .red
-
+    
     var keyboardAppearance: UIKeyboardAppearance {
         return ColorScheme.keyboardAppearance(for: variant)
     }
-
+    
     class func keyboardAppearance(for variant: ColorSchemeVariant) -> UIKeyboardAppearance {
         return variant == .light ? .light : .dark
     }
-
+    
     static let `default`: ColorScheme = ColorScheme()
-
+    
     func color(named: ColorSchemeColor, variant: ColorSchemeVariant? = nil) -> UIColor {
         let colorSchemeVariant = variant ?? self.variant
-
+        
         let colorPair = named.colorPair(accentColor: accentColor)
         switch colorSchemeVariant {
         case .dark:
@@ -294,11 +266,11 @@ final class ColorScheme: NSObject {
             return colorPair.light
         }
     }
-
+    
     func nameAccent(for color: ZMAccentColor, variant: ColorSchemeVariant) -> UIColor {
         return UIColor.nameColor(for: color, variant: variant)
     }
-
+    
 }
 
 private struct ColorPair {
@@ -313,16 +285,16 @@ private extension ColorPair {
 }
 
 extension UIColor {
-
+    
     static func from(scheme: ColorSchemeColor, variant: ColorSchemeVariant? = nil) -> UIColor {
         return ColorScheme.default.color(named: scheme, variant: variant)
     }
-
+    
     /// Creates UIColor instance with color corresponding to @p accentColor that can be used to display the name.
     // NB: the order of coefficients must match ZMAccentColor enum ordering
     private static let accentColorNameColorBlendingCoefficientsDark: [CGFloat] = [0.8, 0.8, 0.72, 1.0, 0.8, 0.8, 0.8, 0.64]
     private static let accentColorNameColorBlendingCoefficientsLight: [CGFloat] = [0.8, 0.8, 0.72, 1.0, 0.8, 0.8, 0.64, 1.0]
-
+    
     /// Creates UIColor instance with color corresponding to @p accentColor that can be used to display the name.
     class func nameColor(for accentColor: ZMAccentColor, variant: ColorSchemeVariant) -> UIColor {
         let accentColor = AccentColor(ZMAccentColor: accentColor) ?? .strongBlue

--- a/Wire-iOS/Sources/Helpers/ColorScheme.swift
+++ b/Wire-iOS/Sources/Helpers/ColorScheme.swift
@@ -141,6 +141,7 @@ enum ColorSchemeColor: Int {
 
     case textSecurityNotClassified
     case backgroundSecurityNotClassified
+    case white
 
     fileprivate func colorPair(accentColor: UIColor) -> ColorPair {
         switch self {
@@ -257,6 +258,8 @@ enum ColorSchemeColor: Int {
             return ColorPair(light: .white, dark: .graphite)
         case .backgroundSecurityNotClassified:
             return ColorPair(light: .graphite, dark: .white)
+        case .white:
+            return ColorPair(light: .white, dark: .white)
 
         }
     }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListHeaderView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListHeaderView.swift
@@ -71,9 +71,9 @@ final class ConversationListHeaderView: UICollectionReusableView {
     private var badgeWidthConstraint: NSLayoutConstraint?
 
     private let titleLabel: UILabel = {
-        let label = UILabel()
-        label.font = .smallRegularFont
-        label.textColor = .white
+        let label = DynamicFontLabel(
+            fontSpec: .smallRegularFont,
+            color: .white)
         label.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
 
         return label


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-92" title="ACC-92" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />ACC-92</a>  [iOS] Folders Screen: Dynamic Type Support (Partially implemented)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

# What's new in this PR?

In this PR I have implemented dynamic type correctly to make sure that the tableView heading's font is scalable.

| iPhone 8 - English  | iPhone 8 - German  |  iPhone SE - English | iPhone SE - German  |
|---|---|---|---|
| <img width="548" alt="Screenshot 2022-05-12 at 08 21 49" src="https://user-images.githubusercontent.com/50630878/171859380-bc7d20de-0846-49c0-9478-0ddad6297ed4.gif">  | <img width="548" alt="Screenshot 2022-05-12 at 08 26 22" src="https://user-images.githubusercontent.com/50630878/171859361-1882792b-f6ba-4f44-add9-8080b5122272.gif">  | <img width="548" alt="Screenshot 2022-05-12 at 09 54 36" src="https://user-images.githubusercontent.com/50630878/171859373-ca024b60-500c-4c1d-b4fc-6996947b7b35.gif"> | <img width="548" alt="Screenshot 2022-05-12 at 08 25 21" src="https://user-images.githubusercontent.com/50630878/171859378-1bd80496-7c32-420e-bc97-72ce3a4af71e.gif">  |

### Issues

The label was a regular UILabel and because of that, it hasn't been scaling properly. I have switched it to the dynamic type.


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
