### PR TITLE
feat: new developer tools screen

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1262,6 +1262,8 @@
 		EE52989026B7FB21001A6D03 /* ZClientViewController+ConferenceCallingAvailabilty.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE52988F26B7FB21001A6D03 /* ZClientViewController+ConferenceCallingAvailabilty.swift */; };
 		EE571C032175ED7B0011B59C /* GroupDetailsNotificationOptionsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE571C022175ED7B0011B59C /* GroupDetailsNotificationOptionsCell.swift */; };
 		EE5F54D2259B77DD00F11F3C /* Viper+Interfaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5F54D0259B77DD00F11F3C /* Viper+Interfaces.swift */; };
+		EE742AB6284DE57900A6B5F3 /* DeveloperToolsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE742AB5284DE57900A6B5F3 /* DeveloperToolsView.swift */; };
+		EE742AB8284DE66400A6B5F3 /* DeveloperToolsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE742AB7284DE66400A6B5F3 /* DeveloperToolsViewModel.swift */; };
 		EE75B774203C6F5300855099 /* MarkdownTextStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE75B773203C6F5300855099 /* MarkdownTextStorageTests.swift */; };
 		EE7905F627F326EB00FCBF8C /* Wire Share Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 168A16A91D9597C2005CFA6C /* Wire Share Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		EE7E0E762109FE9200787C65 /* ParticipantsStringFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE7E0E752109FE9200787C65 /* ParticipantsStringFormatter.swift */; };
@@ -3132,6 +3134,8 @@
 		EE571C022175ED7B0011B59C /* GroupDetailsNotificationOptionsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupDetailsNotificationOptionsCell.swift; sourceTree = "<group>"; };
 		EE5F54D0259B77DD00F11F3C /* Viper+Interfaces.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Viper+Interfaces.swift"; sourceTree = "<group>"; };
 		EE5F54D1259B77DD00F11F3C /* Viper+Relationships.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Viper+Relationships.swift"; sourceTree = "<group>"; };
+		EE742AB5284DE57900A6B5F3 /* DeveloperToolsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperToolsView.swift; sourceTree = "<group>"; };
+		EE742AB7284DE66400A6B5F3 /* DeveloperToolsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperToolsViewModel.swift; sourceTree = "<group>"; };
 		EE75B773203C6F5300855099 /* MarkdownTextStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownTextStorageTests.swift; sourceTree = "<group>"; };
 		EE7C919727B40EBD00595977 /* Wire Notification Extension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Wire Notification Extension.entitlements"; sourceTree = "<group>"; };
 		EE7E0E752109FE9200787C65 /* ParticipantsStringFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantsStringFormatter.swift; sourceTree = "<group>"; };
@@ -5703,6 +5707,7 @@
 			children = (
 				54AB765B1DB7AB77008D19C8 /* DeveloperOptionsController.swift */,
 				54FF9E271E813BA500323D2E /* DebugAlert.swift */,
+				EE742AB9284DE67300A6B5F3 /* DeveloperTools */,
 			);
 			path = Developer;
 			sourceTree = "<group>";
@@ -6922,6 +6927,15 @@
 			path = Viper;
 			sourceTree = "<group>";
 		};
+		EE742AB9284DE67300A6B5F3 /* DeveloperTools */ = {
+			isa = PBXGroup;
+			children = (
+				EE742AB5284DE57900A6B5F3 /* DeveloperToolsView.swift */,
+				EE742AB7284DE66400A6B5F3 /* DeveloperToolsViewModel.swift */,
+			);
+			path = DeveloperTools;
+			sourceTree = "<group>";
+		};
 		EE7F465425B0F65E001B3EE4 /* App Lock */ = {
 			isa = PBXGroup;
 			children = (
@@ -7994,6 +8008,7 @@
 				551CD27822BA288B00EE9AE5 /* LegalHoldDisclosureController.swift in Sources */,
 				876B94821D7D8C870063AE89 /* UIView+SlideInState.swift in Sources */,
 				5E35F736217F417200D3F4FE /* BurstTimestampTableViewCell.swift in Sources */,
+				EE742AB8284DE66400A6B5F3 /* DeveloperToolsViewModel.swift in Sources */,
 				BFAF4CAD1CEB670F00780537 /* AudioRecordViewController.swift in Sources */,
 				1682AEC3204840E7003A052A /* SectionCollectionViewController.swift in Sources */,
 				637387C326443364004FEF79 /* AVSIdentifierProvider.swift in Sources */,
@@ -8520,6 +8535,7 @@
 				BFC0673D2099DD7D00204179 /* CallInfoViewController.swift in Sources */,
 				EF2E2F6F223BB6560038D7D9 /* ScreenCurtain.RootViewController.swift in Sources */,
 				EFEE97C1232271FF007A4702 /* ConversationViewController+ViewLifeCycle.swift in Sources */,
+				EE742AB6284DE57900A6B5F3 /* DeveloperToolsView.swift in Sources */,
 				879718921D1C109900163C07 /* AudioRecordKeyboardViewController.swift in Sources */,
 				F1A989D01FD1630300B8A82E /* SecondaryViewDescription.swift in Sources */,
 				550C63B422C36985005CE9FC /* FormattedText.swift in Sources */,

--- a/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperToolsView.swift
+++ b/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperToolsView.swift
@@ -42,11 +42,22 @@ struct DeveloperToolsView: View {
         }
     }
 
+    @ViewBuilder
     private func itemView(for item: DeveloperToolsViewModel.Item) -> some View {
-        Cell(title: item.title, value: item.value)
-            .onTapGesture {
+        switch item {
+        case let .button(buttonItem):
+            SwiftUI.Button {
                 viewModel.handleEvent(.itemTapped(item))
+            } label: {
+                Text(buttonItem.title)
             }
+
+        case let .text(textItem):
+            TextItemCell(title: textItem.title, value: textItem.value)
+                .onTapGesture {
+                    viewModel.handleEvent(.itemTapped(item))
+                }
+        }
     }
 
     private var dismissButton: some View {
@@ -61,7 +72,7 @@ struct DeveloperToolsView: View {
 // MARK: - Subviews
 
 @available(iOS 14, *)
-private struct Cell: View {
+private struct TextItemCell: View {
 
     let title: String
     let value: String

--- a/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperToolsView.swift
+++ b/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperToolsView.swift
@@ -1,0 +1,95 @@
+//
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import SwiftUI
+
+@available(iOS 14, *)
+struct DeveloperToolsView: View {
+
+    // MARK: - Properties
+
+    @StateObject
+    var viewModel: DeveloperToolsViewModel
+
+    // MARK: - Views
+
+    var body: some View {
+        List(viewModel.sections, rowContent: sectionView(for:))
+            .navigationTitle("Developer tools")
+            .navigationBarItems(trailing: dismissButton)
+    }
+
+    private func sectionView(for section: DeveloperToolsViewModel.Section) -> some View {
+        Section {
+            ForEach(section.items, content: itemView(for:))
+        } header: {
+            Text(section.header)
+        }
+    }
+
+    private func itemView(for item: DeveloperToolsViewModel.Item) -> some View {
+        Cell(title: item.title, value: item.value)
+            .onTapGesture {
+                viewModel.handleEvent(.itemTapped(item))
+            }
+    }
+
+    private var dismissButton: some View {
+        SwiftUI.Button(
+            action: { viewModel.handleEvent(.dismissButtonTapped) },
+            label: { Text("Close") }
+        )
+    }
+
+}
+
+// MARK: - Subviews
+
+@available(iOS 14, *)
+private struct Cell: View {
+
+    let title: String
+    let value: String
+
+    var body: some View {
+        HStack {
+            Text(title)
+
+            Spacer()
+
+            Text(value)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .foregroundColor(.secondary)
+        }
+    }
+
+}
+
+// MARK: - Previews
+
+@available(iOS 14, *)
+struct DeveloperToolsView_Previews: PreviewProvider {
+
+    static var previews: some View {
+        NavigationView {
+            DeveloperToolsView(viewModel: DeveloperToolsViewModel())
+        }
+    }
+
+}

--- a/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperToolsViewModel.swift
+++ b/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperToolsViewModel.swift
@@ -1,0 +1,174 @@
+//
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireSyncEngine
+import WireTransport
+import UIKit
+
+@available(iOS 14, *)
+final class DeveloperToolsViewModel: ObservableObject {
+
+    // MARK: - Models
+
+    struct Section: Identifiable {
+
+        let id = UUID()
+        var header: String
+        var items: [Item]
+
+    }
+
+    struct Item: Identifiable {
+
+        let id = UUID()
+        let title: String
+        let value: String
+
+    }
+
+    enum Event {
+
+        case dismissButtonTapped
+        case itemTapped(Item)
+
+    }
+
+    // MARK: - Properties
+
+    var onDismiss: (() -> Void)?
+
+    // MARK: - State
+
+    var sections: [Section]
+
+    // MARK: - Life cycle
+
+    init(onDismiss: (() -> Void)? = nil) {
+        self.onDismiss = onDismiss
+        sections = []
+
+        sections.append(Section(
+            header: "App info",
+            items: [
+                Item(title: "App version", value: appVersion),
+                Item(title: "Build number", value: buildNumber)
+            ]
+        ))
+
+        sections.append(Section(
+            header: "Backend info",
+            items: [
+                Item(title: "Name", value: backendName),
+                Item(title: "Domain", value: backendDomain),
+                Item(title: "API version", value: apiVersion),
+                Item(title: "Is federation enabled?", value: isFederationEnabled)
+            ]
+        ))
+
+        if let selfUser = selfUser {
+            sections.append(Section(
+                header: "Self user",
+                items: [
+                    Item(title: "Handle", value: selfUser.handle ?? "None"),
+                    Item(title: "Email", value: selfUser.emailAddress ?? "None"),
+                    Item(title: "User ID", value: selfUser.remoteIdentifier.uuidString),
+                    Item(title: "Analytics ID", value: selfUser.analyticsIdentifier?.uppercased() ?? "None"),
+                    Item(title: "Client ID", value: selfClient?.remoteIdentifier?.uppercased() ?? "None")
+                ]
+            ))
+        }
+
+        if let pushToken = PushTokenStorage.pushToken {
+            sections.append(Section(
+                header: "Push token",
+                items: [
+                    Item(title: "Token type", value: String(describing: pushToken.tokenType)),
+                    Item(title: "Token data", value: pushToken.deviceTokenString)
+                ]
+            ))
+        }
+    }
+
+    // MARK: - Events
+
+    func handleEvent(_ event: Event) {
+        switch event {
+        case .dismissButtonTapped:
+            onDismiss?()
+
+        case let .itemTapped(item):
+            UIPasteboard.general.string = item.value
+        }
+    }
+
+    // MARK: - Helpers
+
+    private var appVersion: String {
+        return Bundle.main.shortVersionString ?? "Unknown"
+    }
+
+    private var buildNumber: String {
+        return Bundle.main.infoDictionary?[kCFBundleVersionKey as String] as? String ?? "Unknown"
+    }
+
+    private var backendName: String {
+        return BackendEnvironment.shared.title
+    }
+
+    private var backendDomain: String {
+        return APIVersion.domain ?? "None"
+    }
+
+    private var apiVersion: String {
+        guard let version = APIVersion.current else { return "None" }
+        return String(describing: version.rawValue)
+    }
+
+    private var isFederationEnabled: String {
+        return String(describing: APIVersion.isFederationEnabled)
+    }
+
+    private var selfUser: ZMUser? {
+        guard let session = ZMUserSession.shared() else { return nil }
+        return ZMUser.selfUser(inUserSession: session)
+    }
+
+    private var selfClient: UserClient? {
+        guard let session = ZMUserSession.shared() else { return nil }
+        return session.selfUserClient
+    }
+
+}
+
+extension PushToken.TokenType: CustomStringConvertible {
+
+    public var description: String {
+        switch self {
+        case .standard:
+            return "Standard"
+
+        case .voip:
+            return "VoIP"
+
+        @unknown default:
+            return "Uknown type"
+        }
+    }
+
+}

--- a/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperToolsViewModel.swift
+++ b/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperToolsViewModel.swift
@@ -34,7 +34,32 @@ final class DeveloperToolsViewModel: ObservableObject {
 
     }
 
-    struct Item: Identifiable {
+    enum Item: Identifiable {
+
+        case button(ButtonItem)
+        case text(TextItem)
+
+        var id: UUID {
+            switch self {
+            case .button(let buttonItem):
+                return buttonItem.id
+
+            case .text(let textItem):
+                return textItem.id
+            }
+        }
+
+    }
+
+    struct ButtonItem: Identifiable {
+
+        let id = UUID()
+        let title: String
+        let action: () -> Void
+
+    }
+
+    struct TextItem: Identifiable {
 
         let id = UUID()
         let title: String
@@ -64,20 +89,27 @@ final class DeveloperToolsViewModel: ObservableObject {
         sections = []
 
         sections.append(Section(
+            header: "Logs",
+            items: [
+                .button(ButtonItem(title: "Send debug logs", action: sendDebugLogs))
+            ]
+        ))
+
+        sections.append(Section(
             header: "App info",
             items: [
-                Item(title: "App version", value: appVersion),
-                Item(title: "Build number", value: buildNumber)
+                .text(TextItem(title: "App version", value: appVersion)),
+                .text(TextItem(title: "Build number", value: buildNumber))
             ]
         ))
 
         sections.append(Section(
             header: "Backend info",
             items: [
-                Item(title: "Name", value: backendName),
-                Item(title: "Domain", value: backendDomain),
-                Item(title: "API version", value: apiVersion),
-                Item(title: "Is federation enabled?", value: isFederationEnabled)
+                .text(TextItem(title: "Name", value: backendName)),
+                .text(TextItem(title: "Domain", value: backendDomain)),
+                .text(TextItem(title: "API version", value: apiVersion)),
+                .text(TextItem(title: "Is federation enabled?", value: isFederationEnabled))
             ]
         ))
 
@@ -85,11 +117,11 @@ final class DeveloperToolsViewModel: ObservableObject {
             sections.append(Section(
                 header: "Self user",
                 items: [
-                    Item(title: "Handle", value: selfUser.handle ?? "None"),
-                    Item(title: "Email", value: selfUser.emailAddress ?? "None"),
-                    Item(title: "User ID", value: selfUser.remoteIdentifier.uuidString),
-                    Item(title: "Analytics ID", value: selfUser.analyticsIdentifier?.uppercased() ?? "None"),
-                    Item(title: "Client ID", value: selfClient?.remoteIdentifier?.uppercased() ?? "None")
+                    .text(TextItem(title: "Handle", value: selfUser.handle ?? "None")),
+                    .text(TextItem(title: "Email", value: selfUser.emailAddress ?? "None")),
+                    .text(TextItem(title: "User ID", value: selfUser.remoteIdentifier.uuidString)),
+                    .text(TextItem(title: "Analytics ID", value: selfUser.analyticsIdentifier?.uppercased() ?? "None")),
+                    .text(TextItem(title: "Client ID", value: selfClient?.remoteIdentifier?.uppercased() ?? "None"))
                 ]
             ))
         }
@@ -98,8 +130,8 @@ final class DeveloperToolsViewModel: ObservableObject {
             sections.append(Section(
                 header: "Push token",
                 items: [
-                    Item(title: "Token type", value: String(describing: pushToken.tokenType)),
-                    Item(title: "Token data", value: pushToken.deviceTokenString)
+                    .text(TextItem(title: "Token type", value: String(describing: pushToken.tokenType))),
+                    .text(TextItem(title: "Token data", value: pushToken.deviceTokenString))
                 ]
             ))
         }
@@ -112,9 +144,18 @@ final class DeveloperToolsViewModel: ObservableObject {
         case .dismissButtonTapped:
             onDismiss?()
 
-        case let .itemTapped(item):
-            UIPasteboard.general.string = item.value
+        case let .itemTapped(.text(textItem)):
+            UIPasteboard.general.string = textItem.value
+
+        case let .itemTapped(.button(buttonItem)):
+            buttonItem.action()
         }
+    }
+
+    // MARK: - Actions
+
+    private func sendDebugLogs() {
+        DebugLogSender.sendLogsByEmail(message: "Send logs yo!")
     }
 
     // MARK: - Helpers

--- a/Wire-iOS/Sources/WireApplication.swift
+++ b/Wire-iOS/Sources/WireApplication.swift
@@ -26,7 +26,7 @@ final class WireApplication: UIApplication {
     override func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
         guard motion == .motionShake else { return }
 
-        if #available(iOS 14, *) {
+        if #available(iOS 14, *), Bundle.developerModeEnabled {
             let developerTools = UIHostingController(
                 rootView: NavigationView {
                     DeveloperToolsView(viewModel: DeveloperToolsViewModel(onDismiss: { [weak self] in

--- a/Wire-iOS/Sources/WireApplication.swift
+++ b/Wire-iOS/Sources/WireApplication.swift
@@ -19,14 +19,28 @@
 import UIKit
 import WireCommonComponents
 import WireSyncEngine
+import SwiftUI
 
 final class WireApplication: UIApplication {
 
     override func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
         guard motion == .motionShake else { return }
-        DebugAlert.showSendLogsMessage(
-            message: "You have performed a shake motion, please confirm sending debug logs."
-        )
+
+        if #available(iOS 14, *) {
+            let developerTools = UIHostingController(
+                rootView: NavigationView {
+                    DeveloperToolsView(viewModel: DeveloperToolsViewModel(onDismiss: { [weak self] in
+                        self?.topmostViewController()?.dismissIfNeeded()
+                    }))
+                }
+            )
+
+            topmostViewController()?.present(developerTools, animated: true)
+        } else {
+            DebugAlert.showSendLogsMessage(
+                message: "You have performed a shake motion, please confirm sending debug logs."
+            )
+        }
     }
 }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

With recent work on federation and API versioning, it's increasingly difficult to diagnose why the app may not be behaving as you expect. For example, you might not be able to log in with your credentials, but you're sure they're correct. Sometimes the app is connected to the wrong backend, but it's hard to identify that. Wouldn't it be great to find out quickly what backend you're connected to? Wouldn't it be great to quickly access other useful info, such as the current API version, whether federation is enabled, the ids of the self user, what your push token is,  etc?

### Solutions

We already have a developer options menu in the account settings, but this not accessible until the user has logged in. Also, it doesn't have a lot of this info that we need. So, I've created a new (SwiftUI!) screen that shows this info. We can add to it as needed, but for now it contains some basic info about the app, backend, self user and push token. 

To open the screen, simply shake the phone (or simulator) and it will appear as a modal. Previously, the shake motion was used to send debug logs, for this reason I've also included a button to send the logs.

These tools are only available when developer mode is enabled.

**Tip:** tap on a value to save it to the clipboard.

![Simulator Screen Shot - iPhone 13 Pro - 2022-06-06 at 14 15 12](https://user-images.githubusercontent.com/28632506/172330691-3a9fba8a-ce84-4bd3-9ebf-a2c9bfcf7d1d.png)

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
