### PR TITLE
chore: revert "feat: Non-Linear font scaling (#5677)"

### DIFF
--- a/Wire-iOS Tests/App Lock/Tests/AppLockModuleViewTests.swift
+++ b/Wire-iOS Tests/App Lock/Tests/AppLockModuleViewTests.swift
@@ -21,7 +21,7 @@ import XCTest
 import SnapshotTesting
 @testable import Wire
 
-final class AppLockModuleViewTests: ZMSnapshotTestCase {
+final class AppLockModuleViewTests: XCTestCase {
 
     private var sut: AppLockModule.View!
     private var presenter: AppLockModule.MockPresenter!

--- a/Wire-iOS Tests/App Lock/Tests/AppLockModuleViewTests.swift
+++ b/Wire-iOS Tests/App Lock/Tests/AppLockModuleViewTests.swift
@@ -21,7 +21,7 @@ import XCTest
 import SnapshotTesting
 @testable import Wire
 
-final class AppLockModuleViewTests: XCTestCase {
+final class AppLockModuleViewTests: ZMSnapshotTestCase {
 
     private var sut: AppLockModule.View!
     private var presenter: AppLockModule.MockPresenter!

--- a/Wire-iOS Tests/ConversationList/Container/ConversationListViewControllerTests.swift
+++ b/Wire-iOS Tests/ConversationList/Container/ConversationListViewControllerTests.swift
@@ -24,20 +24,19 @@ final class MockConversationList: ConversationListHelperType {
     static var hasArchivedConversations: Bool = false
 }
 
-final class ConversationListViewControllerTests: XCTestCase {
+final class ConversationListViewControllerTests: ZMSnapshotTestCase {
 
     var sut: ConversationListViewController!
 
     override func setUp() {
         super.setUp()
-
+        accentColor = .strongBlue
         MockConversationList.hasArchivedConversations = false
         let selfUser = MockUserType.createSelfUser(name: "Johannes Chrysostomus Wolfgangus Theophilus Mozart", inTeam: UUID())
         let account = Account.mockAccount(imageData: mockImageData)
         let viewModel = ConversationListViewController.ViewModel(account: account, selfUser: selfUser, conversationListType: MockConversationList.self)
         sut = ConversationListViewController(viewModel: viewModel)
         viewModel.viewController = sut
-
         sut.view.backgroundColor = .black
     }
 

--- a/Wire-iOS Tests/ConversationList/Container/ConversationListViewControllerTests.swift
+++ b/Wire-iOS Tests/ConversationList/Container/ConversationListViewControllerTests.swift
@@ -24,19 +24,20 @@ final class MockConversationList: ConversationListHelperType {
     static var hasArchivedConversations: Bool = false
 }
 
-final class ConversationListViewControllerTests: ZMSnapshotTestCase {
+final class ConversationListViewControllerTests: XCTestCase {
 
     var sut: ConversationListViewController!
 
     override func setUp() {
         super.setUp()
-        accentColor = .strongBlue
+
         MockConversationList.hasArchivedConversations = false
         let selfUser = MockUserType.createSelfUser(name: "Johannes Chrysostomus Wolfgangus Theophilus Mozart", inTeam: UUID())
         let account = Account.mockAccount(imageData: mockImageData)
         let viewModel = ConversationListViewController.ViewModel(account: account, selfUser: selfUser, conversationListType: MockConversationList.self)
         sut = ConversationListViewController(viewModel: viewModel)
         viewModel.viewController = sut
+
         sut.view.backgroundColor = .black
     }
 

--- a/Wire-iOS Tests/ShareContactsViewControllerSnapshotTests.swift
+++ b/Wire-iOS Tests/ShareContactsViewControllerSnapshotTests.swift
@@ -20,7 +20,7 @@ import XCTest
 @testable import Wire
 import SnapshotTesting
 
-final class ShareContactsViewControllerSnapshotTests: XCTestCase {
+final class ShareContactsViewControllerSnapshotTests: ZMSnapshotTestCase {
 
     var sut: ShareContactsViewController!
 

--- a/Wire-iOS Tests/ShareContactsViewControllerSnapshotTests.swift
+++ b/Wire-iOS Tests/ShareContactsViewControllerSnapshotTests.swift
@@ -20,7 +20,7 @@ import XCTest
 @testable import Wire
 import SnapshotTesting
 
-final class ShareContactsViewControllerSnapshotTests: ZMSnapshotTestCase {
+final class ShareContactsViewControllerSnapshotTests: XCTestCase {
 
     var sut: ShareContactsViewController!
 

--- a/Wire-iOS Tests/ShareViewControllerTests.swift
+++ b/Wire-iOS Tests/ShareViewControllerTests.swift
@@ -34,7 +34,7 @@ extension MockShareViewControllerConversation: StableRandomParticipantsProvider 
 	}
 }
 
-final class ShareViewControllerTests: ZMSnapshotTestCase {
+final class ShareViewControllerTests: XCTestCase {
     fileprivate var groupConversation: MockShareViewControllerConversation!
     fileprivate var oneToOneConversation: MockShareViewControllerConversation!
     fileprivate var sut: ShareViewController<MockShareViewControllerConversation, MockShareableMessage>!

--- a/Wire-iOS Tests/ShareViewControllerTests.swift
+++ b/Wire-iOS Tests/ShareViewControllerTests.swift
@@ -34,7 +34,7 @@ extension MockShareViewControllerConversation: StableRandomParticipantsProvider 
 	}
 }
 
-final class ShareViewControllerTests: XCTestCase {
+final class ShareViewControllerTests: ZMSnapshotTestCase {
     fileprivate var groupConversation: MockShareViewControllerConversation!
     fileprivate var oneToOneConversation: MockShareViewControllerConversation!
     fileprivate var sut: ShareViewController<MockShareViewControllerConversation, MockShareableMessage>!

--- a/Wire-iOS/Sources/Permissions/PermissionDeniedViewController.swift
+++ b/Wire-iOS/Sources/Permissions/PermissionDeniedViewController.swift
@@ -18,7 +18,6 @@
 
 import Foundation
 import UIKit
-import WireCommonComponents
 
 protocol PermissionDeniedViewControllerDelegate: AnyObject {
     func continueWithoutPermission(_ viewController: PermissionDeniedViewController)
@@ -50,10 +49,10 @@ final class PermissionDeniedViewController: UIViewController {
         let attributedText = text.withCustomParagraphSpacing()
 
         attributedText.addAttributes([
-            NSAttributedString.Key.font: FontSpec.largeThinFont.font!
+            NSAttributedString.Key.font: UIFont.largeThinFont
             ], range: (text as NSString).range(of: [paragraph1, paragraph2].joined(separator: "\u{2029}")))
         attributedText.addAttributes([
-            NSAttributedString.Key.font: FontSpec.largeSemiboldFont.font!
+            NSAttributedString.Key.font: UIFont.largeSemiboldFont
             ], range: (text as NSString).range(of: title))
         vc.heroLabel.attributedText = attributedText
 
@@ -74,10 +73,10 @@ final class PermissionDeniedViewController: UIViewController {
         let attributedText = text.withCustomParagraphSpacing()
 
         attributedText.addAttributes([
-            NSAttributedString.Key.font: FontSpec.largeThinFont.font!
+            NSAttributedString.Key.font: UIFont.largeThinFont
             ], range: (text as NSString).range(of: paragraph1))
         attributedText.addAttributes([
-            NSAttributedString.Key.font: FontSpec.largeSemiboldFont.font!
+            NSAttributedString.Key.font: UIFont.largeSemiboldFont
             ], range: (text as NSString).range(of: title))
         vc.heroLabel.attributedText = attributedText
 

--- a/Wire-iOS/Sources/Permissions/PermissionDeniedViewController.swift
+++ b/Wire-iOS/Sources/Permissions/PermissionDeniedViewController.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import UIKit
+import WireCommonComponents
 
 protocol PermissionDeniedViewControllerDelegate: AnyObject {
     func continueWithoutPermission(_ viewController: PermissionDeniedViewController)
@@ -49,10 +50,10 @@ final class PermissionDeniedViewController: UIViewController {
         let attributedText = text.withCustomParagraphSpacing()
 
         attributedText.addAttributes([
-            NSAttributedString.Key.font: UIFont.largeThinFont
+            NSAttributedString.Key.font: FontSpec.largeThinFont.font!
             ], range: (text as NSString).range(of: [paragraph1, paragraph2].joined(separator: "\u{2029}")))
         attributedText.addAttributes([
-            NSAttributedString.Key.font: UIFont.largeSemiboldFont
+            NSAttributedString.Key.font: FontSpec.largeSemiboldFont.font!
             ], range: (text as NSString).range(of: title))
         vc.heroLabel.attributedText = attributedText
 
@@ -73,10 +74,10 @@ final class PermissionDeniedViewController: UIViewController {
         let attributedText = text.withCustomParagraphSpacing()
 
         attributedText.addAttributes([
-            NSAttributedString.Key.font: UIFont.largeThinFont
+            NSAttributedString.Key.font: FontSpec.largeThinFont.font!
             ], range: (text as NSString).range(of: paragraph1))
         attributedText.addAttributes([
-            NSAttributedString.Key.font: UIFont.largeSemiboldFont
+            NSAttributedString.Key.font: FontSpec.largeSemiboldFont.font!
             ], range: (text as NSString).range(of: title))
         vc.heroLabel.attributedText = attributedText
 

--- a/Wire-iOS/Sources/Permissions/ShareContactsViewController.swift
+++ b/Wire-iOS/Sources/Permissions/ShareContactsViewController.swift
@@ -18,7 +18,6 @@
 
 import Foundation
 import UIKit
-import WireCommonComponents
 
 protocol ShareContactsViewControllerDelegate: AnyObject {
     func shareDidSkip(_ viewController: UIViewController)
@@ -68,7 +67,7 @@ final class ShareContactsViewController: UIViewController {
 
     private lazy var notNowButton: UIButton = {
         let notNowButton = UIButton(type: .custom)
-        notNowButton.titleLabel?.font = FontSpec.smallLightFont.font!
+        notNowButton.titleLabel?.font = UIFont.smallLightFont
         notNowButton.setTitleColor(UIColor.from(scheme: .buttonFaded, variant: .dark), for: .normal)
         notNowButton.setTitleColor(UIColor.from(scheme: .buttonFaded, variant: .dark).withAlphaComponent(0.2), for: .highlighted)
         notNowButton.setTitle("registration.share_contacts.skip_button.title".localized.uppercased(), for: .normal)
@@ -79,7 +78,7 @@ final class ShareContactsViewController: UIViewController {
 
     private let heroLabel: UILabel = {
         let heroLabel = UILabel.createHeroLabel()
-        heroLabel.font = FontSpec.largeSemiboldFont.font!
+        heroLabel.font = UIFont.largeSemiboldFont
         heroLabel.attributedText = ShareContactsViewController.attributedHeroText
 
         return heroLabel
@@ -111,7 +110,7 @@ final class ShareContactsViewController: UIViewController {
 
         attributedText.addAttributes([
             NSAttributedString.Key.foregroundColor: UIColor.from(scheme: .textForeground, variant: .dark),
-            NSAttributedString.Key.font: FontSpec.largeThinFont.font!
+            NSAttributedString.Key.font: UIFont.largeThinFont
             ], range: (text as NSString).range(of: paragraph))
 
         return attributedText

--- a/Wire-iOS/Sources/Permissions/ShareContactsViewController.swift
+++ b/Wire-iOS/Sources/Permissions/ShareContactsViewController.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import UIKit
+import WireCommonComponents
 
 protocol ShareContactsViewControllerDelegate: AnyObject {
     func shareDidSkip(_ viewController: UIViewController)
@@ -67,7 +68,7 @@ final class ShareContactsViewController: UIViewController {
 
     private lazy var notNowButton: UIButton = {
         let notNowButton = UIButton(type: .custom)
-        notNowButton.titleLabel?.font = UIFont.smallLightFont
+        notNowButton.titleLabel?.font = FontSpec.smallLightFont.font!
         notNowButton.setTitleColor(UIColor.from(scheme: .buttonFaded, variant: .dark), for: .normal)
         notNowButton.setTitleColor(UIColor.from(scheme: .buttonFaded, variant: .dark).withAlphaComponent(0.2), for: .highlighted)
         notNowButton.setTitle("registration.share_contacts.skip_button.title".localized.uppercased(), for: .normal)
@@ -78,7 +79,7 @@ final class ShareContactsViewController: UIViewController {
 
     private let heroLabel: UILabel = {
         let heroLabel = UILabel.createHeroLabel()
-        heroLabel.font = UIFont.largeSemiboldFont
+        heroLabel.font = FontSpec.largeSemiboldFont.font!
         heroLabel.attributedText = ShareContactsViewController.attributedHeroText
 
         return heroLabel
@@ -110,7 +111,7 @@ final class ShareContactsViewController: UIViewController {
 
         attributedText.addAttributes([
             NSAttributedString.Key.foregroundColor: UIColor.from(scheme: .textForeground, variant: .dark),
-            NSAttributedString.Key.font: UIFont.largeThinFont
+            NSAttributedString.Key.font: FontSpec.largeThinFont.font!
             ], range: (text as NSString).range(of: paragraph))
 
         return attributedText

--- a/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.View.LockView.swift
+++ b/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.View.LockView.swift
@@ -19,7 +19,6 @@
 import Foundation
 import UIKit
 import WireSystem
-import WireCommonComponents
 
 extension AppLockModule.View {
 
@@ -53,7 +52,8 @@ extension AppLockModule.View {
         private let blurView = UIVisualEffectView.blurView()
 
         private let messageLabel: UILabel = {
-            let label = DynamicFontLabel(fontSpec: .largeThinFont, color: .textForeground, variant: .dark)
+            let label = UILabel()
+            label.font = .largeThinFont
             label.textColor = .from(scheme: .textForeground, variant: .dark)
             return label
         }()

--- a/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.View.LockView.swift
+++ b/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.View.LockView.swift
@@ -19,6 +19,7 @@
 import Foundation
 import UIKit
 import WireSystem
+import WireCommonComponents
 
 extension AppLockModule.View {
 
@@ -52,8 +53,7 @@ extension AppLockModule.View {
         private let blurView = UIVisualEffectView.blurView()
 
         private let messageLabel: UILabel = {
-            let label = UILabel()
-            label.font = .largeThinFont
+            let label = DynamicFontLabel(fontSpec: .largeThinFont, color: .textForeground, variant: .dark)
             label.textColor = .from(scheme: .textForeground, variant: .dark)
             return label
         }()

--- a/Wire-iOS/Sources/UserInterface/Availability/AvailabilityStringBuilder.swift
+++ b/Wire-iOS/Sources/UserInterface/Availability/AvailabilityStringBuilder.swift
@@ -72,7 +72,7 @@ final class AvailabilityStringBuilder: NSObject {
         switch size {
         case .small:
             verticalCorrection = -1
-        case .medium, .large, .normal:
+        case .medium, .large, .normal, .navBar:
             verticalCorrection = 0
         }
 

--- a/Wire-iOS/Sources/UserInterface/Availability/AvailabilityStringBuilder.swift
+++ b/Wire-iOS/Sources/UserInterface/Availability/AvailabilityStringBuilder.swift
@@ -72,7 +72,7 @@ final class AvailabilityStringBuilder: NSObject {
         switch size {
         case .small:
             verticalCorrection = -1
-        case .medium, .large, .normal, .navBar:
+        case .medium, .large, .normal:
             verticalCorrection = 0
         }
 

--- a/Wire-iOS/Sources/UserInterface/Availability/AvailabilityTitleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Availability/AvailabilityTitleView.swift
@@ -130,7 +130,7 @@ final class AvailabilityTitleView: TitleView, Themeable, ZMUserObserver {
     /// Refreshes the appearance of the view, based on the options.
     private func updateAppearance() {
         if options.contains(.useLargeFont) {
-            titleFont = .navBarSemiboldFont
+            titleFont = .normalSemiboldFont
         } else {
             titleFont = .smallSemiboldFont
         }

--- a/Wire-iOS/Sources/UserInterface/Availability/AvailabilityTitleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Availability/AvailabilityTitleView.swift
@@ -130,7 +130,7 @@ final class AvailabilityTitleView: TitleView, Themeable, ZMUserObserver {
     /// Refreshes the appearance of the view, based on the options.
     private func updateAppearance() {
         if options.contains(.useLargeFont) {
-            titleFont = .normalSemiboldFont
+            titleFont = .navBarSemiboldFont
         } else {
             titleFont = .smallSemiboldFont
         }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/UserNameTakeOverViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/UserNameTakeOverViewController.swift
@@ -29,7 +29,10 @@ enum UserNameTakeOverViewControllerAction {
 
 final class UserNameTakeOverViewController: UIViewController {
 
-    public let displayNameLabel = UILabel()
+    public let displayNameLabel = DynamicFontLabel(
+        fontSpec: FontSpec.largeThinFont,
+        color: .textDimmed,
+        variant: .light)
     public let suggestedHandleLabel = UILabel()
     public let subtitleTextView = WebLinkTextView()
 
@@ -68,8 +71,6 @@ final class UserNameTakeOverViewController: UIViewController {
         [displayNameLabel, suggestedHandleLabel].forEach(topContainer.addSubview)
         [topContainer, subtitleTextView, chooseOwnButton, keepSuggestedButton].forEach(contentView.addSubview)
 
-        displayNameLabel.font = FontSpec(.large, .thin).font!
-        displayNameLabel.textColor = UIColor.from(scheme: .textDimmed, variant: .light)
         displayNameLabel.text = name
         displayNameLabel.textAlignment = .center
 

--- a/Wire-iOS/Sources/UserInterface/ConversationList/UserNameTakeOverViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/UserNameTakeOverViewController.swift
@@ -29,10 +29,7 @@ enum UserNameTakeOverViewControllerAction {
 
 final class UserNameTakeOverViewController: UIViewController {
 
-    public let displayNameLabel = DynamicFontLabel(
-        fontSpec: FontSpec.largeThinFont,
-        color: .textDimmed,
-        variant: .light)
+    public let displayNameLabel = UILabel()
     public let suggestedHandleLabel = UILabel()
     public let subtitleTextView = WebLinkTextView()
 
@@ -71,6 +68,8 @@ final class UserNameTakeOverViewController: UIViewController {
         [displayNameLabel, suggestedHandleLabel].forEach(topContainer.addSubview)
         [topContainer, subtitleTextView, chooseOwnButton, keepSuggestedButton].forEach(contentView.addSubview)
 
+        displayNameLabel.font = FontSpec(.large, .thin).font!
+        displayNameLabel.textColor = UIColor.from(scheme: .textDimmed, variant: .light)
         displayNameLabel.text = name
         displayNameLabel.textAlignment = .center
 

--- a/Wire-iOS/Sources/UserInterface/Settings/SettingsCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/SettingsCell.swift
@@ -51,6 +51,7 @@ class SettingsTableCell: UITableViewCell, SettingsCellType {
         label.numberOfLines = 0
         label.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
         label.setContentHuggingPriority(UILayoutPriority.required, for: .horizontal)
+        label.adjustsFontSizeToFitWidth = true
 
         return label
     }()

--- a/Wire-iOS/Sources/UserInterface/Settings/SettingsCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/SettingsCell.swift
@@ -51,7 +51,6 @@ class SettingsTableCell: UITableViewCell, SettingsCellType {
         label.numberOfLines = 0
         label.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
         label.setContentHuggingPriority(UILayoutPriority.required, for: .horizontal)
-        label.adjustsFontSizeToFitWidth = true
 
         return label
     }()

--- a/WireCommonComponents/FontScheme.swift
+++ b/WireCommonComponents/FontScheme.swift
@@ -29,6 +29,7 @@ public enum FontSize: String {
     case normal
     case medium
     case small
+    case navBar
 }
 
 public enum FontWeight: String, CaseIterable {
@@ -190,34 +191,52 @@ public enum FontScheme {
                                             contentSizeCategory: contentSizeCategory)
 
         /// fontTextStyle: none
+        let navBarPointSize = pointSize(fontSize: .navBar, contentSizeCategory: contentSizeCategory)
+        
+        fontsByFontSpec[FontSpec(.navBar, .none, .none)]      = .systemFont(ofSize: navBarPointSize, weight: .light)
+        fontsByFontSpec[FontSpec(.navBar, .bold, .none)]      = .systemFont(ofSize: navBarPointSize, weight: .bold)
+        fontsByFontSpec[FontSpec(.navBar, .medium, .none)]    = .systemFont(ofSize: navBarPointSize, weight: .medium)
+        fontsByFontSpec[FontSpec(.navBar, .semibold, .none)]  = .systemFont(ofSize: navBarPointSize, weight: .semibold)
+        fontsByFontSpec[FontSpec(.navBar, .regular, .none)]   = .systemFont(ofSize: navBarPointSize, weight: .regular)
+        fontsByFontSpec[FontSpec(.navBar, .light, .none)]     = .systemFont(ofSize: navBarPointSize, weight: .light)
+        fontsByFontSpec[FontSpec(.navBar, .thin, .none)]      = .systemFont(ofSize: navBarPointSize, weight: .thin)
+        
+        let largePointSize = pointSize(fontSize: .large, contentSizeCategory: contentSizeCategory)
+        
+        fontsByFontSpec[FontSpec(.large, .none, .none)]      = .systemFont(ofSize: largePointSize, weight: .light)
+        fontsByFontSpec[FontSpec(.large, .bold, .none)]      = .systemFont(ofSize: largePointSize, weight: .bold)
+        fontsByFontSpec[FontSpec(.large, .medium, .none)]    = .systemFont(ofSize: largePointSize, weight: .medium)
+        fontsByFontSpec[FontSpec(.large, .semibold, .none)]  = .systemFont(ofSize: largePointSize, weight: .semibold)
+        fontsByFontSpec[FontSpec(.large, .regular, .none)]   = .systemFont(ofSize: largePointSize, weight: .regular)
+        fontsByFontSpec[FontSpec(.large, .light, .none)]     = .systemFont(ofSize: largePointSize, weight: .light)
+        fontsByFontSpec[FontSpec(.large, .thin, .none)]      = .systemFont(ofSize: largePointSize, weight: .thin)
 
-        fontsByFontSpec[FontSpec(.large, .none, .none)]      = .systemFont(ofSize: 24, contentSizeCategory: contentSizeCategory, weight: .light)
-        fontsByFontSpec[FontSpec(.large, .medium, .none)]    = .systemFont(ofSize: 24, contentSizeCategory: contentSizeCategory, weight: .medium)
-        fontsByFontSpec[FontSpec(.large, .semibold, .none)]  = .systemFont(ofSize: 24, contentSizeCategory: contentSizeCategory, weight: .semibold)
-        fontsByFontSpec[FontSpec(.large, .regular, .none)]   = .systemFont(ofSize: 24, contentSizeCategory: contentSizeCategory, weight: .regular)
-        fontsByFontSpec[FontSpec(.large, .light, .none)]     = .systemFont(ofSize: 24, contentSizeCategory: contentSizeCategory, weight: .light)
-        fontsByFontSpec[FontSpec(.large, .thin, .none)]      = .systemFont(ofSize: 24, contentSizeCategory: contentSizeCategory, weight: .thin)
+        let normalPointSize = pointSize(fontSize: .normal, contentSizeCategory: contentSizeCategory)
+        
+        fontsByFontSpec[FontSpec(.normal, .none, .none)]      = .systemFont(ofSize: normalPointSize, weight: .light)
+        fontsByFontSpec[FontSpec(.normal, .bold, .none)]      = .systemFont(ofSize: normalPointSize, weight: .bold)
+        fontsByFontSpec[FontSpec(.normal, .medium, .none)]    = .systemFont(ofSize: normalPointSize, weight: .medium)
+        fontsByFontSpec[FontSpec(.normal, .semibold, .none)]  = .systemFont(ofSize: normalPointSize, weight: .semibold)
+        fontsByFontSpec[FontSpec(.normal, .regular, .none)]   = .systemFont(ofSize: normalPointSize, weight: .regular)
+        fontsByFontSpec[FontSpec(.normal, .light, .none)]     = .systemFont(ofSize: normalPointSize, weight: .light)
 
-        fontsByFontSpec[FontSpec(.normal, .none, .none)]     = .systemFont(ofSize: 16, contentSizeCategory: contentSizeCategory, weight: .light)
-        fontsByFontSpec[FontSpec(.normal, .light, .none)]    = .systemFont(ofSize: 16, contentSizeCategory: contentSizeCategory, weight: .light)
-        fontsByFontSpec[FontSpec(.normal, .thin, .none)]     = .systemFont(ofSize: 16, contentSizeCategory: contentSizeCategory, weight: .thin)
-        fontsByFontSpec[FontSpec(.normal, .regular, .none)]  = .systemFont(ofSize: 16, contentSizeCategory: contentSizeCategory, weight: .regular)
-        fontsByFontSpec[FontSpec(.normal, .semibold, .none)] = .systemFont(ofSize: 16, contentSizeCategory: contentSizeCategory, weight: .semibold)
-        fontsByFontSpec[FontSpec(.normal, .medium, .none)]   = .systemFont(ofSize: 16, contentSizeCategory: contentSizeCategory, weight: .medium)
-        fontsByFontSpec[FontSpec(.normal, .bold, .none)]     = .systemFont(ofSize: 16, contentSizeCategory: contentSizeCategory, weight: .bold)
+        let mediumPointSize = pointSize(fontSize: .medium, contentSizeCategory: contentSizeCategory)
+        
+        fontsByFontSpec[FontSpec(.medium, .none, .none)]      = .systemFont(ofSize: mediumPointSize, weight: .light)
+        fontsByFontSpec[FontSpec(.medium, .bold, .none)]      = .systemFont(ofSize: mediumPointSize, weight: .bold)
+        fontsByFontSpec[FontSpec(.medium, .medium, .none)]    = .systemFont(ofSize: mediumPointSize, weight: .medium)
+        fontsByFontSpec[FontSpec(.medium, .semibold, .none)]  = .systemFont(ofSize: mediumPointSize, weight: .semibold)
+        fontsByFontSpec[FontSpec(.medium, .regular, .none)]   = .systemFont(ofSize: mediumPointSize, weight: .regular)
+        fontsByFontSpec[FontSpec(.medium, .light, .none)]     = .systemFont(ofSize: mediumPointSize, weight: .light)
 
-        fontsByFontSpec[FontSpec(.medium, .none, .none)]     = .systemFont(ofSize: 12, contentSizeCategory: contentSizeCategory, weight: .light)
-        fontsByFontSpec[FontSpec(.medium, .bold, .none)]     = .systemFont(ofSize: 12, contentSizeCategory: contentSizeCategory, weight: .bold)
-        fontsByFontSpec[FontSpec(.medium, .medium, .none)]   = .systemFont(ofSize: 12, contentSizeCategory: contentSizeCategory, weight: .medium)
-        fontsByFontSpec[FontSpec(.medium, .semibold, .none)] = .systemFont(ofSize: 12, contentSizeCategory: contentSizeCategory, weight: .semibold)
-        fontsByFontSpec[FontSpec(.medium, .regular, .none)]  = .systemFont(ofSize: 12, contentSizeCategory: contentSizeCategory, weight: .regular)
-
-        fontsByFontSpec[FontSpec(.small, .none, .none)]      = .systemFont(ofSize: 11, contentSizeCategory: contentSizeCategory, weight: .light)
-        fontsByFontSpec[FontSpec(.small, .bold, .none)]      = .systemFont(ofSize: 11, contentSizeCategory: contentSizeCategory, weight: .bold)
-        fontsByFontSpec[FontSpec(.small, .medium, .none)]    = .systemFont(ofSize: 11, contentSizeCategory: contentSizeCategory, weight: .medium)
-        fontsByFontSpec[FontSpec(.small, .semibold, .none)]  = .systemFont(ofSize: 11, contentSizeCategory: contentSizeCategory, weight: .semibold)
-        fontsByFontSpec[FontSpec(.small, .regular, .none)]   = .systemFont(ofSize: 11, contentSizeCategory: contentSizeCategory, weight: .regular)
-        fontsByFontSpec[FontSpec(.small, .light, .none)]     = .systemFont(ofSize: 11, contentSizeCategory: contentSizeCategory, weight: .light)
+        let smallPointSize = pointSize(fontSize: .small, contentSizeCategory: contentSizeCategory)
+        
+        fontsByFontSpec[FontSpec(.small, .none, .none)]      = .systemFont(ofSize: smallPointSize, weight: .light)
+        fontsByFontSpec[FontSpec(.small, .bold, .none)]      = .systemFont(ofSize: smallPointSize, weight: .bold)
+        fontsByFontSpec[FontSpec(.small, .medium, .none)]    = .systemFont(ofSize: smallPointSize, weight: .medium)
+        fontsByFontSpec[FontSpec(.small, .semibold, .none)]  = .systemFont(ofSize: smallPointSize, weight: .semibold)
+        fontsByFontSpec[FontSpec(.small, .regular, .none)]   = .systemFont(ofSize: smallPointSize, weight: .regular)
+        fontsByFontSpec[FontSpec(.small, .light, .none)]     = .systemFont(ofSize: smallPointSize, weight: .light)
 
     }
 
@@ -226,3 +245,139 @@ public enum FontScheme {
     }
 }
 
+func pointSize(fontSize: FontSize, contentSizeCategory: UIContentSizeCategory) -> CGFloat {
+    switch (fontSize, contentSizeCategory) {
+    // SMALLL
+    case (.small, .extraSmall):
+        return 10
+    case (.small, .small):
+        return 10
+    case (.small, .medium):
+        return 11
+    case (.small, .large):
+        return 11
+    case (.small, .extraLarge):
+        return 13
+    case (.small, .extraExtraLarge):
+        return 15
+    case (.small, .extraExtraExtraLarge):
+        return 17
+    case (.small, .accessibilityMedium):
+        return 20
+    case (.small, .accessibilityLarge):
+        return 24
+    case (.small, .accessibilityExtraLarge):
+        return 29
+    case (.small, .accessibilityExtraExtraLarge):
+        return 34
+    case (.small, .accessibilityExtraExtraExtraLarge):
+        return 40
+        
+    // Normal
+    case (.normal, .extraSmall):
+        return 13
+    case (.normal, .small):
+        return 14
+    case (.normal, .medium):
+        return 15
+    case (.normal, .large):
+        return 16
+    case (.normal, .extraLarge):
+        return 18
+    case (.normal, .extraExtraLarge):
+        return 20
+    case (.normal, .extraExtraExtraLarge):
+        return 26
+    case (.normal, .accessibilityMedium):
+        return 32
+    case (.normal, .accessibilityLarge):
+        return 33
+    case (.normal, .accessibilityExtraLarge):
+        return 38
+    case (.normal, .accessibilityExtraExtraLarge):
+        return 44
+    case (.normal, .accessibilityExtraExtraExtraLarge):
+        return 51
+        
+    // Medium
+    case (.medium, .extraSmall):
+        return 11
+    case (.medium, .small):
+        return 11
+    case (.medium, .medium):
+        return 11
+    case (.medium, .large):
+        return 12
+    case (.medium, .extraLarge):
+        return 14
+    case (.medium, .extraExtraLarge):
+        return 16
+    case (.medium, .extraExtraExtraLarge):
+        return 18
+    case (.medium, .accessibilityMedium):
+        return 22
+    case (.medium, .accessibilityLarge):
+        return 26
+    case (.medium, .accessibilityExtraLarge):
+        return 32
+    case (.medium, .accessibilityExtraExtraLarge):
+        return 37
+    case (.medium, .accessibilityExtraExtraExtraLarge):
+        return 43
+        
+    // Large
+    case (.large, .extraSmall):
+        return 21
+    case (.large, .small):
+        return 22
+    case (.large, .medium):
+        return 23
+    case (.large, .large):
+        return 24
+    case (.large, .extraLarge):
+        return 27
+    case (.large, .extraExtraLarge):
+        return 29
+    case (.large, .extraExtraExtraLarge):
+        return 31
+    case (.large, .accessibilityMedium):
+        return 36
+    case (.large, .accessibilityLarge):
+        return 41
+    case (.large, .accessibilityExtraLarge):
+        return 46
+    case (.large, .accessibilityExtraExtraLarge):
+        return 50
+    case (.large, .accessibilityExtraExtraExtraLarge):
+        return 53
+        
+    // navBar
+    case (.navBar, .extraSmall):
+        return 13
+    case (.navBar, .small):
+        return 14
+    case (.navBar, .medium):
+        return 15
+    case (.navBar, .large):
+        return 16
+    case (.navBar, .extraLarge):
+        return 17
+    case (.navBar, .extraExtraLarge):
+        return 18
+    case (.navBar, .extraExtraExtraLarge):
+        return 20
+    case (.navBar, .accessibilityMedium):
+        return 22
+    case (.navBar, .accessibilityLarge):
+        return 24
+    case (.navBar, .accessibilityExtraLarge):
+        return 28
+    case (.navBar, .accessibilityExtraExtraLarge):
+        return 29
+    case (.navBar, .accessibilityExtraExtraExtraLarge):
+        return 30
+        
+    default:
+        return 10
+    }
+}

--- a/WireCommonComponents/FontScheme.swift
+++ b/WireCommonComponents/FontScheme.swift
@@ -29,7 +29,6 @@ public enum FontSize: String {
     case normal
     case medium
     case small
-    case navBar
 }
 
 public enum FontWeight: String, CaseIterable {
@@ -191,52 +190,34 @@ public enum FontScheme {
                                             contentSizeCategory: contentSizeCategory)
 
         /// fontTextStyle: none
-        let navBarPointSize = pointSize(fontSize: .navBar, contentSizeCategory: contentSizeCategory)
-        
-        fontsByFontSpec[FontSpec(.navBar, .none, .none)]      = .systemFont(ofSize: navBarPointSize, weight: .light)
-        fontsByFontSpec[FontSpec(.navBar, .bold, .none)]      = .systemFont(ofSize: navBarPointSize, weight: .bold)
-        fontsByFontSpec[FontSpec(.navBar, .medium, .none)]    = .systemFont(ofSize: navBarPointSize, weight: .medium)
-        fontsByFontSpec[FontSpec(.navBar, .semibold, .none)]  = .systemFont(ofSize: navBarPointSize, weight: .semibold)
-        fontsByFontSpec[FontSpec(.navBar, .regular, .none)]   = .systemFont(ofSize: navBarPointSize, weight: .regular)
-        fontsByFontSpec[FontSpec(.navBar, .light, .none)]     = .systemFont(ofSize: navBarPointSize, weight: .light)
-        fontsByFontSpec[FontSpec(.navBar, .thin, .none)]      = .systemFont(ofSize: navBarPointSize, weight: .thin)
-        
-        let largePointSize = pointSize(fontSize: .large, contentSizeCategory: contentSizeCategory)
-        
-        fontsByFontSpec[FontSpec(.large, .none, .none)]      = .systemFont(ofSize: largePointSize, weight: .light)
-        fontsByFontSpec[FontSpec(.large, .bold, .none)]      = .systemFont(ofSize: largePointSize, weight: .bold)
-        fontsByFontSpec[FontSpec(.large, .medium, .none)]    = .systemFont(ofSize: largePointSize, weight: .medium)
-        fontsByFontSpec[FontSpec(.large, .semibold, .none)]  = .systemFont(ofSize: largePointSize, weight: .semibold)
-        fontsByFontSpec[FontSpec(.large, .regular, .none)]   = .systemFont(ofSize: largePointSize, weight: .regular)
-        fontsByFontSpec[FontSpec(.large, .light, .none)]     = .systemFont(ofSize: largePointSize, weight: .light)
-        fontsByFontSpec[FontSpec(.large, .thin, .none)]      = .systemFont(ofSize: largePointSize, weight: .thin)
 
-        let normalPointSize = pointSize(fontSize: .normal, contentSizeCategory: contentSizeCategory)
-        
-        fontsByFontSpec[FontSpec(.normal, .none, .none)]      = .systemFont(ofSize: normalPointSize, weight: .light)
-        fontsByFontSpec[FontSpec(.normal, .bold, .none)]      = .systemFont(ofSize: normalPointSize, weight: .bold)
-        fontsByFontSpec[FontSpec(.normal, .medium, .none)]    = .systemFont(ofSize: normalPointSize, weight: .medium)
-        fontsByFontSpec[FontSpec(.normal, .semibold, .none)]  = .systemFont(ofSize: normalPointSize, weight: .semibold)
-        fontsByFontSpec[FontSpec(.normal, .regular, .none)]   = .systemFont(ofSize: normalPointSize, weight: .regular)
-        fontsByFontSpec[FontSpec(.normal, .light, .none)]     = .systemFont(ofSize: normalPointSize, weight: .light)
+        fontsByFontSpec[FontSpec(.large, .none, .none)]      = .systemFont(ofSize: 24, contentSizeCategory: contentSizeCategory, weight: .light)
+        fontsByFontSpec[FontSpec(.large, .medium, .none)]    = .systemFont(ofSize: 24, contentSizeCategory: contentSizeCategory, weight: .medium)
+        fontsByFontSpec[FontSpec(.large, .semibold, .none)]  = .systemFont(ofSize: 24, contentSizeCategory: contentSizeCategory, weight: .semibold)
+        fontsByFontSpec[FontSpec(.large, .regular, .none)]   = .systemFont(ofSize: 24, contentSizeCategory: contentSizeCategory, weight: .regular)
+        fontsByFontSpec[FontSpec(.large, .light, .none)]     = .systemFont(ofSize: 24, contentSizeCategory: contentSizeCategory, weight: .light)
+        fontsByFontSpec[FontSpec(.large, .thin, .none)]      = .systemFont(ofSize: 24, contentSizeCategory: contentSizeCategory, weight: .thin)
 
-        let mediumPointSize = pointSize(fontSize: .medium, contentSizeCategory: contentSizeCategory)
-        
-        fontsByFontSpec[FontSpec(.medium, .none, .none)]      = .systemFont(ofSize: mediumPointSize, weight: .light)
-        fontsByFontSpec[FontSpec(.medium, .bold, .none)]      = .systemFont(ofSize: mediumPointSize, weight: .bold)
-        fontsByFontSpec[FontSpec(.medium, .medium, .none)]    = .systemFont(ofSize: mediumPointSize, weight: .medium)
-        fontsByFontSpec[FontSpec(.medium, .semibold, .none)]  = .systemFont(ofSize: mediumPointSize, weight: .semibold)
-        fontsByFontSpec[FontSpec(.medium, .regular, .none)]   = .systemFont(ofSize: mediumPointSize, weight: .regular)
-        fontsByFontSpec[FontSpec(.medium, .light, .none)]     = .systemFont(ofSize: mediumPointSize, weight: .light)
+        fontsByFontSpec[FontSpec(.normal, .none, .none)]     = .systemFont(ofSize: 16, contentSizeCategory: contentSizeCategory, weight: .light)
+        fontsByFontSpec[FontSpec(.normal, .light, .none)]    = .systemFont(ofSize: 16, contentSizeCategory: contentSizeCategory, weight: .light)
+        fontsByFontSpec[FontSpec(.normal, .thin, .none)]     = .systemFont(ofSize: 16, contentSizeCategory: contentSizeCategory, weight: .thin)
+        fontsByFontSpec[FontSpec(.normal, .regular, .none)]  = .systemFont(ofSize: 16, contentSizeCategory: contentSizeCategory, weight: .regular)
+        fontsByFontSpec[FontSpec(.normal, .semibold, .none)] = .systemFont(ofSize: 16, contentSizeCategory: contentSizeCategory, weight: .semibold)
+        fontsByFontSpec[FontSpec(.normal, .medium, .none)]   = .systemFont(ofSize: 16, contentSizeCategory: contentSizeCategory, weight: .medium)
+        fontsByFontSpec[FontSpec(.normal, .bold, .none)]     = .systemFont(ofSize: 16, contentSizeCategory: contentSizeCategory, weight: .bold)
 
-        let smallPointSize = pointSize(fontSize: .small, contentSizeCategory: contentSizeCategory)
-        
-        fontsByFontSpec[FontSpec(.small, .none, .none)]      = .systemFont(ofSize: smallPointSize, weight: .light)
-        fontsByFontSpec[FontSpec(.small, .bold, .none)]      = .systemFont(ofSize: smallPointSize, weight: .bold)
-        fontsByFontSpec[FontSpec(.small, .medium, .none)]    = .systemFont(ofSize: smallPointSize, weight: .medium)
-        fontsByFontSpec[FontSpec(.small, .semibold, .none)]  = .systemFont(ofSize: smallPointSize, weight: .semibold)
-        fontsByFontSpec[FontSpec(.small, .regular, .none)]   = .systemFont(ofSize: smallPointSize, weight: .regular)
-        fontsByFontSpec[FontSpec(.small, .light, .none)]     = .systemFont(ofSize: smallPointSize, weight: .light)
+        fontsByFontSpec[FontSpec(.medium, .none, .none)]     = .systemFont(ofSize: 12, contentSizeCategory: contentSizeCategory, weight: .light)
+        fontsByFontSpec[FontSpec(.medium, .bold, .none)]     = .systemFont(ofSize: 12, contentSizeCategory: contentSizeCategory, weight: .bold)
+        fontsByFontSpec[FontSpec(.medium, .medium, .none)]   = .systemFont(ofSize: 12, contentSizeCategory: contentSizeCategory, weight: .medium)
+        fontsByFontSpec[FontSpec(.medium, .semibold, .none)] = .systemFont(ofSize: 12, contentSizeCategory: contentSizeCategory, weight: .semibold)
+        fontsByFontSpec[FontSpec(.medium, .regular, .none)]  = .systemFont(ofSize: 12, contentSizeCategory: contentSizeCategory, weight: .regular)
+
+        fontsByFontSpec[FontSpec(.small, .none, .none)]      = .systemFont(ofSize: 11, contentSizeCategory: contentSizeCategory, weight: .light)
+        fontsByFontSpec[FontSpec(.small, .bold, .none)]      = .systemFont(ofSize: 11, contentSizeCategory: contentSizeCategory, weight: .bold)
+        fontsByFontSpec[FontSpec(.small, .medium, .none)]    = .systemFont(ofSize: 11, contentSizeCategory: contentSizeCategory, weight: .medium)
+        fontsByFontSpec[FontSpec(.small, .semibold, .none)]  = .systemFont(ofSize: 11, contentSizeCategory: contentSizeCategory, weight: .semibold)
+        fontsByFontSpec[FontSpec(.small, .regular, .none)]   = .systemFont(ofSize: 11, contentSizeCategory: contentSizeCategory, weight: .regular)
+        fontsByFontSpec[FontSpec(.small, .light, .none)]     = .systemFont(ofSize: 11, contentSizeCategory: contentSizeCategory, weight: .light)
 
     }
 
@@ -245,139 +226,3 @@ public enum FontScheme {
     }
 }
 
-func pointSize(fontSize: FontSize, contentSizeCategory: UIContentSizeCategory) -> CGFloat {
-    switch (fontSize, contentSizeCategory) {
-    // SMALLL
-    case (.small, .extraSmall):
-        return 10
-    case (.small, .small):
-        return 10
-    case (.small, .medium):
-        return 11
-    case (.small, .large):
-        return 11
-    case (.small, .extraLarge):
-        return 13
-    case (.small, .extraExtraLarge):
-        return 15
-    case (.small, .extraExtraExtraLarge):
-        return 17
-    case (.small, .accessibilityMedium):
-        return 20
-    case (.small, .accessibilityLarge):
-        return 24
-    case (.small, .accessibilityExtraLarge):
-        return 29
-    case (.small, .accessibilityExtraExtraLarge):
-        return 34
-    case (.small, .accessibilityExtraExtraExtraLarge):
-        return 40
-        
-    // Normal
-    case (.normal, .extraSmall):
-        return 13
-    case (.normal, .small):
-        return 14
-    case (.normal, .medium):
-        return 15
-    case (.normal, .large):
-        return 16
-    case (.normal, .extraLarge):
-        return 18
-    case (.normal, .extraExtraLarge):
-        return 20
-    case (.normal, .extraExtraExtraLarge):
-        return 26
-    case (.normal, .accessibilityMedium):
-        return 32
-    case (.normal, .accessibilityLarge):
-        return 33
-    case (.normal, .accessibilityExtraLarge):
-        return 38
-    case (.normal, .accessibilityExtraExtraLarge):
-        return 44
-    case (.normal, .accessibilityExtraExtraExtraLarge):
-        return 51
-        
-    // Medium
-    case (.medium, .extraSmall):
-        return 11
-    case (.medium, .small):
-        return 11
-    case (.medium, .medium):
-        return 11
-    case (.medium, .large):
-        return 12
-    case (.medium, .extraLarge):
-        return 14
-    case (.medium, .extraExtraLarge):
-        return 16
-    case (.medium, .extraExtraExtraLarge):
-        return 18
-    case (.medium, .accessibilityMedium):
-        return 22
-    case (.medium, .accessibilityLarge):
-        return 26
-    case (.medium, .accessibilityExtraLarge):
-        return 32
-    case (.medium, .accessibilityExtraExtraLarge):
-        return 37
-    case (.medium, .accessibilityExtraExtraExtraLarge):
-        return 43
-        
-    // Large
-    case (.large, .extraSmall):
-        return 21
-    case (.large, .small):
-        return 22
-    case (.large, .medium):
-        return 23
-    case (.large, .large):
-        return 24
-    case (.large, .extraLarge):
-        return 27
-    case (.large, .extraExtraLarge):
-        return 29
-    case (.large, .extraExtraExtraLarge):
-        return 31
-    case (.large, .accessibilityMedium):
-        return 36
-    case (.large, .accessibilityLarge):
-        return 41
-    case (.large, .accessibilityExtraLarge):
-        return 46
-    case (.large, .accessibilityExtraExtraLarge):
-        return 50
-    case (.large, .accessibilityExtraExtraExtraLarge):
-        return 53
-        
-    // navBar
-    case (.navBar, .extraSmall):
-        return 13
-    case (.navBar, .small):
-        return 14
-    case (.navBar, .medium):
-        return 15
-    case (.navBar, .large):
-        return 16
-    case (.navBar, .extraLarge):
-        return 17
-    case (.navBar, .extraExtraLarge):
-        return 18
-    case (.navBar, .extraExtraExtraLarge):
-        return 20
-    case (.navBar, .accessibilityMedium):
-        return 22
-    case (.navBar, .accessibilityLarge):
-        return 24
-    case (.navBar, .accessibilityExtraLarge):
-        return 28
-    case (.navBar, .accessibilityExtraExtraLarge):
-        return 29
-    case (.navBar, .accessibilityExtraExtraExtraLarge):
-        return 30
-        
-    default:
-        return 10
-    }
-}

--- a/WireCommonComponents/FontSpec.swift
+++ b/WireCommonComponents/FontSpec.swift
@@ -117,5 +117,26 @@ public extension FontSpec {
     static var largeLightWithTextStyleFont: Self {
         return self.init(.large, .light, .largeTitle)
     }
+    
+    // MARK: - NavBarTitle
 
+    static var navBarThinFont: Self {
+        return self.init(.navBar, .thin)
+    }
+
+    static var navBarLightFont: Self {
+        return self.init(.navBar, .light)
+    }
+
+    static var navBarRegularFont: Self {
+        return self.init(.navBar, .regular)
+    }
+
+    static var navBarMediumFont: Self {
+        return self.init(.navBar, .medium)
+    }
+
+    static var navBarSemiboldFont: Self {
+        return self.init(.navBar, .semibold)
+    }
 }

--- a/WireCommonComponents/FontSpec.swift
+++ b/WireCommonComponents/FontSpec.swift
@@ -117,26 +117,5 @@ public extension FontSpec {
     static var largeLightWithTextStyleFont: Self {
         return self.init(.large, .light, .largeTitle)
     }
-    
-    // MARK: - NavBarTitle
 
-    static var navBarThinFont: Self {
-        return self.init(.navBar, .thin)
-    }
-
-    static var navBarLightFont: Self {
-        return self.init(.navBar, .light)
-    }
-
-    static var navBarRegularFont: Self {
-        return self.init(.navBar, .regular)
-    }
-
-    static var navBarMediumFont: Self {
-        return self.init(.navBar, .medium)
-    }
-
-    static var navBarSemiboldFont: Self {
-        return self.init(.navBar, .semibold)
-    }
 }


### PR DESCRIPTION
This reverts commit 60d358e4f45a816efa66617fabc29bb85a2cb1de.

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This introduced a lot of issues with dynamic type throughout the app and we would like to revert it for now.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
