### PR TITLE
fix: Fix the bug that the downloaded file cannot be previewed

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/MessagePresenter.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/MessagePresenter.swift
@@ -66,7 +66,7 @@ final class MessagePresenter: NSObject {
         }
 
         // Need to create temporary hardlink to make sure the UIDocumentInteractionController shows the correct filename
-        var tmpPath = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(message.fileMessageData?.filename ?? "").absoluteString
+        var tmpPath = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(message.fileMessageData?.filename ?? "").path
 
         let path = fileURL.path
 
@@ -166,7 +166,7 @@ final class MessagePresenter: NSObject {
             openLocationMessage(message)
         } else if Message.isVideo(message), message.canBeShared {
             openFileMessage(message, targetView: targetView)
-        } else if Message.isFileTransfer(message), message.canBeDownloaded {
+        } else if Message.isFileTransfer(message) {
             openFileMessage(message, targetView: targetView)
         } else if Message.isImage(message), message.canBeShared {
             openImageMessage(message, actionResponder: delegate)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Once a file has been downloaded, it is not possible to click on the preview

### Causes (Optional)

There should be no more determination of canBeDownloaded

### Solutions

We do not determine here whether it can be downloaded or not, because he has already been downloaded before entering the current condition

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
