### PR TITLE
fix: The color of the navigation bar for SettingsClientViewController

### DIFF
--- a/Wire-iOS/Sources/UserInterface/UserProfile/Devices/ProfileClientViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Devices/ProfileClientViewController.swift
@@ -336,7 +336,7 @@ final class ProfileClientViewController: UIViewController, SpinnerCapable {
                                                                 fromConversation: fromConversation,
                                                                 variant: ColorScheme.default.variant)
 
-        let navigationControllerWrapper = selfClientController.wrapInNavigationController()
+        let navigationControllerWrapper = selfClientController.wrapInNavigationController(setBackgroundColor: true)
 
         navigationControllerWrapper.modalPresentationStyle = .currentContext
         present(navigationControllerWrapper, animated: true, completion: .none)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR we fix the color of the navigation bar for SettingsClientViewController.

| BEFORE |  AFTER |
|---|---|
| ![Screenshot 2022-06-20 at 10 24 14](https://user-images.githubusercontent.com/10944108/174562256-d26e2e74-d8b4-4461-9951-baf6af5bb775.png) | ![Screenshot 2022-06-20 at 10 39 07](https://user-images.githubusercontent.com/10944108/174562201-8e830de0-3b31-4467-8b7a-7b5ff5ff4985.png)  |



----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
