### PR TITLE
fix: unable to open attachment file second time [SQSERVICES-1624]

### DIFF
--- a/Wire-iOS/Sources/Helpers/syncengine/ZMMessage+Actions.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMMessage+Actions.swift
@@ -115,10 +115,7 @@ extension ZMConversationMessage {
               MediaShareRestrictionManager(sessionRestriction: ZMUserSession.shared()).canDownloadMedia else {
             return false
         }
-        return isFile
-            && fileMessageData.transferState == .uploaded
-            && fileMessageData.downloadState == .remote
-        && MediaShareRestrictionManager(sessionRestriction: ZMUserSession.shared()).canDownloadMedia
+        return isFile && fileMessageData.transferState == .uploaded
     }
 
     var canCancelDownload: Bool {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1624" title="SQSERVICES-1624" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQSERVICES-1624</a>  [iOS] Unable to open attachment files (pdf)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Fixed issue when user is unable to open file  for the second time. 
I removed condition that checks if file was already downloaded before opening. It won't cause downloading single file multiple times because before downloading files data we're checking if it's already stored on the device.