### PR TITLE
fix: Swiftlint warnings related to legacy_random

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
@@ -162,7 +162,7 @@ final class AudioRecordKeyboardViewController: UIViewController, AudioRecordBase
         if atRange.location != NSNotFound {
             let effects = AVSAudioEffectType.displayedEffects.filter { $0 != .none }
             let max = UInt32(effects.count)
-            let effect = effects[Int(arc4random_uniform(max))]
+            let effect = effects[Int.random(in: 0..<Int(max))]
             let image = effect.icon.makeImage(size: 14, color: color)
 
             let attachment = NSTextAttachment()

--- a/Wire-iOS/Sources/UserInterface/SkeletonViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/SkeletonViewController.swift
@@ -164,7 +164,7 @@ final class ListSkeletonContentView: UITableView, UITableViewDataSource {
         let cell = dequeueReusableCell(withIdentifier: "ListSkeletonCell")
 
         if let skeletonCell = cell as? ListSkeletonCell {
-            skeletonCell.lineInset =  randomizeDummyItem ? Float(arc4random() % 200) : 0
+            skeletonCell.lineInset =  randomizeDummyItem ? Float.random(in: 0..<200) : 0
         }
 
         return cell!


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Fix SwiftLint warnings related to legacy_random

- Legacy Random Violation: Prefer using type.random(in:) over legacy functions. (legacy_random)

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
