### PR TITLE
chore: drop `topAndBottomEdgesToSuperviewEdges` IC - 81

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListAccessoryView.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListAccessoryView.swift
@@ -102,10 +102,12 @@ final class ConversationListAccessoryView: UIView {
             transparentIconViewLeading,
             transparentIconViewTrailing,
             expandTransparentIconViewWidthConstraint,
-            expandWidthConstraint
-            ] +
-            transparentIconView.topAndBottomEdgesToSuperviewEdges()
+            expandWidthConstraint,
+            transparentIconView.topAnchor.constraint(equalTo: topAnchor),
+            transparentIconView.bottomAnchor.constraint(equalTo: bottomAnchor)
+            ]
         )
+
         badgeView.fitInSuperview()
     }
 

--- a/Wire-iOS/Sources/UserInterface/Helpers/UIView+Constraints.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UIView+Constraints.swift
@@ -100,46 +100,6 @@ extension UIView {
         return constraint
     }
 
-    // MARK: - signal edge alignment
-
-    @discardableResult @available(iOS, introduced: 10.0, deprecated: 13.0, message: "Use the anchors API instead")
-    func pin(to view: UIView,
-             safely: Bool = false,
-             anchor: Anchor,
-             inset: CGFloat = 0,
-             activate: Bool = true) -> NSLayoutConstraint {
-        let constant: CGFloat
-        switch anchor {
-        case .top, .leading:
-            constant = inset
-        case .bottom, .trailing:
-            constant = -inset
-        }
-
-        var selfAnchor: NSObject!
-        var otherAnchor: NSObject!
-
-        switch anchor {
-        case .top:
-            selfAnchor = topAnchor
-            otherAnchor = safely ? view.safeTopAnchor: view.topAnchor
-        case .bottom:
-            selfAnchor = bottomAnchor
-            otherAnchor = safely ? view.safeBottomAnchor: view.bottomAnchor
-        case .leading:
-            selfAnchor = leadingAnchor
-            otherAnchor = safely ? view.safeLeadingAnchor: view.leadingAnchor
-        case .trailing:
-            selfAnchor = trailingAnchor
-            otherAnchor = safely ? view.safeTrailingAnchor: view.trailingAnchor
-        }
-
-        let constraint = (selfAnchor as! NSLayoutAnchor<AnyObject>).constraint(equalTo: (otherAnchor as! NSLayoutAnchor<AnyObject>), constant: constant)
-        constraint.isActive = activate
-
-        return constraint
-    }
-
     // MARK: - all edges alignment
 
     @discardableResult @available(iOS, introduced: 10.0, deprecated: 13.0, message: "Use the anchors API instead")

--- a/Wire-iOS/Sources/UserInterface/Helpers/UIView+Constraints.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UIView+Constraints.swift
@@ -208,18 +208,6 @@ extension UIView {
         return constraints
     }
 
-    // MARK: - dimensions
-
-    @discardableResult @available(iOS, introduced: 10.0, deprecated: 13.0, message: "Use the anchors API instead")
-    func topAndBottomEdgesToSuperviewEdges() -> [NSLayoutConstraint] {
-        guard let superview = superview else { return [] }
-
-        return [
-            superview.topAnchor.constraint(equalTo: topAnchor),
-            superview.bottomAnchor.constraint(equalTo: bottomAnchor)
-        ]
-    }
-
 }
 
 extension UIView {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR we drop `topAndBottomEdgesToSuperviewEdges`. We also remove `func pin(to view: UIView,` since it's not being used anywhere.

##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
