### PR TITLE
chore: Drop pin method and use anchors API instead IC - 69

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Collections/ConversationImagesViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/ConversationImagesViewController.swift
@@ -151,7 +151,10 @@ final class ConversationImagesViewController: TintColorCorrectedViewController {
 
         pageViewController.view.fitInSuperview()
         buttonsBar.fitInSuperview(exclude: [.top])
-        overlay.pin(to: buttonsBar)
+        overlay.topAnchor.constraint(equalTo: buttonsBar.topAnchor).isActive = true
+        overlay.bottomAnchor.constraint(equalTo: buttonsBar.bottomAnchor).isActive = true
+        overlay.trailingAnchor.constraint(equalTo: buttonsBar.trailingAnchor).isActive = true
+        overlay.leadingAnchor.constraint(equalTo: buttonsBar.leadingAnchor).isActive = true
 
         separator.heightAnchor.constraint(equalToConstant: .hairline).isActive = true
         separator.pin(to: buttonsBar, exclude: [.bottom])

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ArticleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ArticleView.swift
@@ -116,7 +116,6 @@ final class ArticleView: UIView {
         obfuscationView.trailingAnchor.constraint(equalTo: imageView.trailingAnchor).isActive = true
         obfuscationView.leadingAnchor.constraint(equalTo: imageView.leadingAnchor).isActive = true
 
-
         NSLayoutConstraint.activate([
             imageHeightConstraint,
             messageLabel.topAnchor.constraint(equalTo: imageView.bottomAnchor, constant: 12),

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ArticleView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ArticleView.swift
@@ -111,7 +111,11 @@ final class ArticleView: UIView {
 
         messageLabel.fitInSuperview(with: EdgeInsets(margin: 12), exclude: [.bottom, .top])
         authorLabel.fitInSuperview(with: EdgeInsets(margin: 12), exclude: [.top])
-        obfuscationView.pin(to: imageView)
+        obfuscationView.topAnchor.constraint(equalTo: imageView.topAnchor).isActive = true
+        obfuscationView.bottomAnchor.constraint(equalTo: imageView.bottomAnchor).isActive = true
+        obfuscationView.trailingAnchor.constraint(equalTo: imageView.trailingAnchor).isActive = true
+        obfuscationView.leadingAnchor.constraint(equalTo: imageView.leadingAnchor).isActive = true
+
 
         NSLayoutConstraint.activate([
             imageHeightConstraint,

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/Cells/TopPeopleCell.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/Cells/TopPeopleCell.swift
@@ -118,7 +118,6 @@ final class TopPeopleCell: UICollectionViewCell {
             nameLabel.trailingAnchor.constraint(equalTo: avatarContainer.trailingAnchor).isActive = true
             nameLabel.leadingAnchor.constraint(equalTo: avatarContainer.leadingAnchor).isActive = true
 
-
             NSLayoutConstraint.activate(constraints)
             initialConstraintsCreated = true
 

--- a/Wire-iOS/Sources/UserInterface/StartUI/Common/Cells/TopPeopleCell.swift
+++ b/Wire-iOS/Sources/UserInterface/StartUI/Common/Cells/TopPeopleCell.swift
@@ -115,9 +115,9 @@ final class TopPeopleCell: UICollectionViewCell {
 
             constraints.append(nameLabel.topAnchor.constraint(equalTo: avatarContainer.bottomAnchor, constant: 8))
 
-            constraints.append(contentsOf: nameLabel.pin(to: avatarContainer,
-                                                         with: EdgeInsets(top: .nan, leading: 0, bottom: .nan, trailing: 0),
-                                                         exclude: [.top, .bottom], activate: false).values)
+            nameLabel.trailingAnchor.constraint(equalTo: avatarContainer.trailingAnchor).isActive = true
+            nameLabel.leadingAnchor.constraint(equalTo: avatarContainer.leadingAnchor).isActive = true
+
 
             NSLayoutConstraint.activate(constraints)
             initialConstraintsCreated = true


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

 Drop pin method and use anchors API instead IC - 69

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
