### PR TITLE
chore: Drop key window deprecation warnings IC - 74

### DIFF
--- a/Wire-iOS Tests/CharacterInputFieldTests.swift
+++ b/Wire-iOS Tests/CharacterInputFieldTests.swift
@@ -55,7 +55,7 @@ final class CharacterInputFieldTests: XCTestCase {
 
     func testThatItCanBecomeFirstResponder() {
         // when
-        UIApplication.shared.keyWindow?.rootViewController?.view.addSubview(sut)
+        UIApplication.shared.windows.first { $0.isKeyWindow }?.rootViewController?.view.addSubview(sut)
         // then
         XCTAssertTrue(sut.canBecomeFocused)
         XCTAssertTrue(sut.becomeFirstResponder())
@@ -223,7 +223,7 @@ final class CharacterInputFieldScreenshotTests: XCTestCase {
 
     func testFocusedState() {
         // given
-        UIApplication.shared.keyWindow?.rootViewController?.view.addSubview(sut)
+        UIApplication.shared.windows.first { $0.isKeyWindow }?.rootViewController?.view.addSubview(sut)
 
         // when
         sut.becomeFirstResponder()
@@ -234,7 +234,7 @@ final class CharacterInputFieldScreenshotTests: XCTestCase {
 
     func testFocusedDeFocusedState() {
         // given
-        UIApplication.shared.keyWindow?.rootViewController?.view.addSubview(sut)
+        UIApplication.shared.windows.first { $0.isKeyWindow }?.rootViewController?.view.addSubview(sut)
 
         // when
         sut.becomeFirstResponder()

--- a/Wire-iOS Tests/MessagePresenterTests.swift
+++ b/Wire-iOS Tests/MessagePresenterTests.swift
@@ -34,7 +34,7 @@ final class MessagePresenterTests: XCTestCase {
         UIView.setAnimationsEnabled(false)
 
         if originalRootViewConttoller == nil {
-            originalRootViewConttoller = UIApplication.shared.keyWindow?.rootViewController
+            originalRootViewConttoller = UIApplication.shared.windows.first { $0.isKeyWindow }?.rootViewController
         }
     }
 
@@ -43,7 +43,7 @@ final class MessagePresenterTests: XCTestCase {
         mediaPlaybackManager = nil
         super.tearDown()
         UIView.setAnimationsEnabled(true)
-        UIApplication.shared.keyWindow?.rootViewController = originalRootViewConttoller
+        UIApplication.shared.windows.first { $0.isKeyWindow }?.rootViewController = originalRootViewConttoller
     }
 
     // MARK: - Video
@@ -54,7 +54,7 @@ final class MessagePresenterTests: XCTestCase {
         message.backingFileMessageData?.fileURL = fileURL
 
         let targetViewController = UIViewController()
-        UIApplication.shared.keyWindow?.rootViewController = targetViewController
+        UIApplication.shared.windows.first { $0.isKeyWindow }?.rootViewController = targetViewController
         sut.targetViewController = targetViewController
         _ = targetViewController.view
 

--- a/Wire-iOS/Sources/AppRootRouter.swift
+++ b/Wire-iOS/Sources/AppRootRouter.swift
@@ -458,7 +458,7 @@ extension AppRootRouter {
         let colorScheme = ColorScheme.default
         colorScheme.accentColor = .accent()
         colorScheme.variant = Settings.shared.colorSchemeVariant
-        UIApplication.shared.keyWindow?.rootViewController?.overrideUserInterfaceStyle = Settings.shared.colorScheme.userInterfaceStyle
+        UIApplication.shared.windows.first { $0.isKeyWindow }?.rootViewController?.overrideUserInterfaceStyle = Settings.shared.colorScheme.userInterfaceStyle
 
     }
 
@@ -537,7 +537,7 @@ extension AppRootRouter: ApplicationStateObserving {
         if let size = size {
             screenCurtain.frame.size = size
         } else {
-            screenCurtain.frame = UIApplication.shared.keyWindow?.frame ?? UIScreen.main.bounds
+            screenCurtain.frame = UIApplication.shared.windows.first { $0.isKeyWindow }?.frame ?? UIScreen.main.bounds
         }
     }
 }

--- a/Wire-iOS/Sources/Authentication/Interface/Descriptions/ViewDescriptions/VerificationCodeFieldDescription.swift
+++ b/Wire-iOS/Sources/Authentication/Interface/Descriptions/ViewDescriptions/VerificationCodeFieldDescription.swift
@@ -69,7 +69,8 @@ extension ResponderContainer: TextContainer where Child: TextContainer {
 extension VerificationCodeFieldDescription: ViewDescriptor {
     func create() -> UIView {
         /// get the with from keyWindow for iPad non full screen modes.
-        let width = UIApplication.shared.keyWindow?.frame.width ?? UIScreen.main.bounds.size.width
+        let window = UIApplication.shared.windows.first { $0.isKeyWindow }
+        let width = window?.frame.width ?? UIScreen.main.bounds.size.width
         let size = CGSize(width: width, height: AuthenticationStepController.mainViewHeight)
 
         let inputField = CharacterInputField(maxLength: 6, characterSet: .decimalDigits, size: size)

--- a/Wire-iOS/Sources/Authentication/Interface/Helpers/UIAlertController+Newsletter.swift
+++ b/Wire-iOS/Sources/Authentication/Interface/Helpers/UIAlertController+Newsletter.swift
@@ -62,7 +62,7 @@ extension UIAlertController {
 
         UIAlertController.newsletterSubscriptionDialogWasDisplayed = true
         viewController.present(alertController, animated: true) {
-            UIApplication.shared.keyWindow?.endEditing(true)
+            UIApplication.shared.windows.first { $0.isKeyWindow }?.endEditing(true)
         }
     }
 

--- a/Wire-iOS/Sources/Helpers/UIActivityViewController+FileSaving.swift
+++ b/Wire-iOS/Sources/Helpers/UIActivityViewController+FileSaving.swift
@@ -37,7 +37,7 @@ extension UIViewController {
     /// On iPad, UIActivityViewController must be presented in a popover and the popover's source view must be set
     ///
     /// - Parameter pointToView: the view which the popover points to
-    func configPopover(pointToView: UIView, popoverPresenter: PopoverPresenterViewController? = UIApplication.shared.keyWindow?.rootViewController as? PopoverPresenterViewController) {
+    func configPopover(pointToView: UIView, popoverPresenter: PopoverPresenterViewController? = UIApplication.shared.windows.first { $0.isKeyWindow }?.rootViewController as? PopoverPresenterViewController) {
         guard let popover = popoverPresentationController,
             let popoverPresenter = popoverPresenter else { return }
 

--- a/Wire-iOS/Sources/Helpers/UIScreen+SafeArea.swift
+++ b/Wire-iOS/Sources/Helpers/UIScreen+SafeArea.swift
@@ -22,13 +22,13 @@ extension UIScreen {
 
     static var safeArea: UIEdgeInsets {
         if hasNotch {
-            return UIApplication.shared.keyWindow!.safeAreaInsets
+            return UIApplication.shared.windows.first { $0.isKeyWindow }!.safeAreaInsets
         }
         return UIEdgeInsets(top: 20.0, left: 0.0, bottom: 0.0, right: 0.0)
     }
 
     static var hasBottomInset: Bool {
-        guard let window = UIApplication.shared.keyWindow else { return false }
+        guard let window = UIApplication.shared.windows.first(where: { $0.isKeyWindow }) else { return false }
         let insets = window.safeAreaInsets
 
         return insets.bottom > 0
@@ -37,7 +37,7 @@ extension UIScreen {
     static var hasNotch: Bool {
         // On iOS12 insets.top == 20 on device without notch.
         // insets.top == 44 on device with notch.
-        guard let window = UIApplication.shared.keyWindow else { return false }
+        guard let window = UIApplication.shared.windows.first(where: { $0.isKeyWindow }) else { return false }
         let insets = window.safeAreaInsets
 
         return insets.top > 20 || insets.bottom > 0

--- a/Wire-iOS/Sources/Helpers/UITraitEnvironment+LayoutMargins.swift
+++ b/Wire-iOS/Sources/Helpers/UITraitEnvironment+LayoutMargins.swift
@@ -45,7 +45,8 @@ extension UITraitEnvironment {
         return conversationHorizontalMargins()
     }
 
-    func conversationHorizontalMargins(windowWidth: CGFloat? = UIApplication.shared.keyWindow?.frame.width) -> HorizontalMargins {
+    func conversationHorizontalMargins(windowWidth: CGFloat? = UIApplication.shared.windows.first { $0.isKeyWindow }?.frame.width
+) -> HorizontalMargins {
 
         let userInterfaceSizeClass: UIUserInterfaceSizeClass
 

--- a/Wire-iOS/Sources/Managers/ColorSchemeController.swift
+++ b/Wire-iOS/Sources/Managers/ColorSchemeController.swift
@@ -50,7 +50,8 @@ final class ColorSchemeController: NSObject {
 
     @objc
     private func settingsColorSchemeDidChange() {
-        UIApplication.shared.keyWindow?.rootViewController?.overrideUserInterfaceStyle = Settings.shared.colorScheme.userInterfaceStyle
+        let window = UIApplication.shared.windows.first { $0.isKeyWindow }
+        window?.rootViewController?.overrideUserInterfaceStyle = Settings.shared.colorScheme.userInterfaceStyle
 
         ColorScheme.default.variant = Settings.shared.colorSchemeVariant
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
@@ -158,7 +158,7 @@ extension ConversationContentViewController {
     }
 
     func updatePopover() {
-        guard let rootViewController = UIApplication.shared.keyWindow?.rootViewController as? PopoverPresenterViewController else { return }
+        guard let rootViewController = UIApplication.shared.windows.first(where: { $0.isKeyWindow })?.rootViewController as? PopoverPresenterViewController else { return }
 
         rootViewController.updatePopoverSourceRect()
     }
@@ -185,7 +185,7 @@ extension ConversationContentViewController: UIAdaptivePresentationControllerDel
         keyboardAvoiding.preferredContentSize = CGSize.IPadPopover.preferredContentSize
         keyboardAvoiding.modalPresentationCapturesStatusBarAppearance = true
 
-        let presenter: PopoverPresenterViewController? = (presentedViewController ?? UIApplication.shared.keyWindow?.rootViewController) as? PopoverPresenterViewController
+        let presenter: PopoverPresenterViewController? = (presentedViewController ?? UIApplication.shared.windows.first { $0.isKeyWindow }) as? PopoverPresenterViewController
 
         if let presenter = presenter,
            let pointToView = (view as? SelectableView)?.selectionView ?? view ?? self.view {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
@@ -106,7 +106,7 @@ final class AudioRecordKeyboardViewController: UIViewController, AudioRecordBase
     public override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         recorder.stopRecording()
-        if isAppLockActive { UIApplication.shared.keyWindow?.endEditing(true) }
+        if isAppLockActive { UIApplication.shared.windows.first { $0.isKeyWindow }?.endEditing(true) }
     }
 
     // MARK: - View Configuration

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/AssetCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/CameraKeyboard/AssetCell.swift
@@ -86,7 +86,8 @@ final class AssetCell: UICollectionViewCell {
                 return
             }
 
-            let maxDimensionRetina = max(bounds.size.width, bounds.size.height) * (window ?? UIApplication.shared.keyWindow!).screen.scale
+            guard let keyWindow = UIApplication.shared.windows.first(where: { $0.isKeyWindow }) else { return }
+            let maxDimensionRetina = max(bounds.size.width, bounds.size.height) * (window ?? keyWindow).screen.scale
 
             representedAssetIdentifier = asset.localIdentifier
             imageRequestTag = manager.requestImage(for: asset,

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+ImagePicker.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+ImagePicker.swift
@@ -29,7 +29,7 @@ extension ConversationInputBarViewController {
                             allowsEditing: Bool,
                             pointToView: UIView?) {
 
-        guard let rootViewController = UIApplication.shared.keyWindow?.rootViewController as? PopoverPresenterViewController else { return }
+        guard let rootViewController = UIApplication.shared.windows.first(where: { $0.isKeyWindow })?.rootViewController as? PopoverPresenterViewController else { return }
 
         if !UIImagePickerController.isSourceTypeAvailable(sourceType) {
             if UIDevice.isSimulator {

--- a/Wire-iOS/Sources/UserInterface/Helpers/UIApplication+StatusBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Helpers/UIApplication+StatusBar.swift
@@ -65,7 +65,7 @@ extension UIApplication {
     }
 
     static var userInterfaceStyle: UIUserInterfaceStyle? {
-        UIApplication.shared.keyWindow?.rootViewController?.traitCollection.userInterfaceStyle
+        UIApplication.shared.windows.first { $0.isKeyWindow }?.rootViewController?.traitCollection.userInterfaceStyle
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController+ZMUserObserver.swift
+++ b/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController+ZMUserObserver.swift
@@ -22,7 +22,7 @@ extension ZClientViewController: ZMUserObserver {
 
     public func userDidChange(_ changeInfo: UserChangeInfo) {
         if changeInfo.accentColorValueChanged {
-            UIApplication.shared.keyWindow?.tintColor = UIColor.accent()
+            UIApplication.shared.windows.first { $0.isKeyWindow }?.tintColor = UIColor.accent()
         }
     }
 

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Advanced.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Advanced.swift
@@ -138,7 +138,7 @@ extension SettingsCellDescriptorFactory {
     private var presentVersionAction: (SettingsCellDescriptorType) -> Void {
         return { _ in
             let versionInfoViewController = VersionInfoViewController()
-            var superViewController = UIApplication.shared.keyWindow?.rootViewController
+            var superViewController = UIApplication.shared.windows.first { $0.isKeyWindow }?.rootViewController
 
             if let presentedViewController = superViewController?.presentedViewController {
                 superViewController = presentedViewController


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR we drop keyWindow and fix all deprecation warnings

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
