### PR TITLE
chore: improve nse debugging

### DIFF
--- a/Wire Notification Service Extension/NotificationService.swift
+++ b/Wire Notification Service Extension/NotificationService.swift
@@ -72,6 +72,11 @@ public class NotificationService: UNNotificationServiceExtension, NotificationSe
         _ request: UNNotificationRequest,
         withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
     ) {
+        if DeveloperFlag.nseDebugEntryPoint.isOn {
+            contentHandler(request.debugContent)
+            return
+        }
+
         self.contentHandler = contentHandler
 
         guard
@@ -176,6 +181,24 @@ extension UNNotificationRequest {
 
     var mutableContent: UNMutableNotificationContent? {
         return content.mutableCopy() as? UNMutableNotificationContent
+    }
+
+    var debugContent: UNNotificationContent {
+        let content = UNMutableNotificationContent()
+        content.title = "DEBUG 👀"
+
+        guard
+            let notificationData = self.content.userInfo["data"] as? [String: Any],
+            let userID = notificationData["user"] as? String,
+            let data = notificationData["data"] as? [String: Any],
+            let eventID = data["id"] as? String
+        else {
+            content.body = "Received a push"
+            return content
+        }
+
+        content.body = "USER: \(userID), EVENT: \(eventID)"
+        return content
     }
 
 }

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1218,7 +1218,6 @@
 		DBF7235F1B5566B80036F4C5 /* a_lot_of_people.json in Resources */ = {isa = PBXBuildFile; fileRef = DBF7235E1B5566B80036F4C5 /* a_lot_of_people.json */; };
 		E52D5A7B2858C18600D0494E /* Colors+Generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = E52D5A7A2858C18600D0494E /* Colors+Generated.swift */; };
 		E52F448B2844E916008E11CB /* UITableViewCell+DisclosureIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E52F448A2844E916008E11CB /* UITableViewCell+DisclosureIndicator.swift */; };
-		E5436FAE285A1C83004D95EB /* SemanticColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = E56CA3762858A36500CD2045 /* SemanticColors.swift */; };
 		E5443393286192CF00F2E0ED /* SwitchStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5443392286192CF00F2E0ED /* SwitchStyle.swift */; };
 		E56CA37528588C4F00CD2045 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E56CA37428588C4F00CD2045 /* Colors.xcassets */; };
 		E57333CD2859CF840039EE02 /* Colors+Generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = E52D5A7A2858C18600D0494E /* Colors+Generated.swift */; };
@@ -1320,6 +1319,7 @@
 		EED92353278DA9D2002D4D9D /* AccentColorPickerSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EED92352278DA9D2002D4D9D /* AccentColorPickerSnapshotTests.swift */; };
 		EEDEA26823ED609C000EF7E3 /* ContactsViewController+Invite.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDEA26723ED609C000EF7E3 /* ContactsViewController+Invite.swift */; };
 		EEE104052126F68A003C779B /* CameraController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE104042126F68A003C779B /* CameraController.swift */; };
+		EEE5D981287E1CDA004E2D2B /* DeveloperFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE5D980287E1CDA004E2D2B /* DeveloperFlag.swift */; };
 		EEE60E2C2179D99100D03346 /* GroupDetailsNotificationOptionsCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE60E2B2179D99100D03346 /* GroupDetailsNotificationOptionsCellTests.swift */; };
 		EEE81E9223E028EA00A1D035 /* TopPeopleCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE81E9123E028EA00A1D035 /* TopPeopleCell.swift */; };
 		EEE81E9423E0467F00A1D035 /* TopPeopleLineCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE81E9323E0467F00A1D035 /* TopPeopleLineCollectionViewController.swift */; };
@@ -3201,6 +3201,7 @@
 		EED92352278DA9D2002D4D9D /* AccentColorPickerSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AccentColorPickerSnapshotTests.swift; path = "Wire-iOS Tests/AccentColorPickerSnapshotTests.swift"; sourceTree = SOURCE_ROOT; };
 		EEDEA26723ED609C000EF7E3 /* ContactsViewController+Invite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContactsViewController+Invite.swift"; sourceTree = "<group>"; };
 		EEE104042126F68A003C779B /* CameraController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraController.swift; sourceTree = "<group>"; };
+		EEE5D980287E1CDA004E2D2B /* DeveloperFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperFlag.swift; sourceTree = "<group>"; };
 		EEE60E2B2179D99100D03346 /* GroupDetailsNotificationOptionsCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupDetailsNotificationOptionsCellTests.swift; sourceTree = "<group>"; };
 		EEE81E9123E028EA00A1D035 /* TopPeopleCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopPeopleCell.swift; sourceTree = "<group>"; };
 		EEE81E9323E0467F00A1D035 /* TopPeopleLineCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopPeopleLineCollectionViewController.swift; sourceTree = "<group>"; };
@@ -7551,6 +7552,7 @@
 				E9EBE0D128194F2D0058C793 /* FontScheme.swift */,
 				E9EBE0D328194F890058C793 /* FontScheme+DynamicType.swift */,
 				E9EBE0D8281958BE0058C793 /* FontSpec.swift */,
+				EEE5D980287E1CDA004E2D2B /* DeveloperFlag.swift */,
 			);
 			path = WireCommonComponents;
 			sourceTree = "<group>";
@@ -8013,7 +8015,6 @@
 				5E144FFF213EA0EC00B65E14 /* PreviewImageView.swift in Sources */,
 				5EDD2538213FD5E200C0E254 /* SLComposeServiceViewController+Preview.swift in Sources */,
 				06F9864625CC146B005572C5 /* UIView+ConstraintFactory.swift in Sources */,
-				06717E5D2865183600AF442C /* Stylable.swift in Sources */,
 				BFBE45771E36205F009FBF60 /* Error+Logging.swift in Sources */,
 				543E0C681E23A7C3000E2161 /* NotSignedInViewController.swift in Sources */,
 				BF96A6CC1E2FD3BA0057974A /* NSItemProvider+Fetching.swift in Sources */,
@@ -9521,6 +9522,7 @@
 				EF3B26DC2370585700245701 /* AppCenter.swift in Sources */,
 				A98370BC2488101500515687 /* URL+FileSize.swift in Sources */,
 				E9EBE0D228194F2D0058C793 /* FontScheme.swift in Sources */,
+				EEE5D981287E1CDA004E2D2B /* DeveloperFlag.swift in Sources */,
 				5E3E1B732260DA200053AC59 /* StyleKitIcons.generated.swift in Sources */,
 				F15650C621DD0C5500210504 /* CGFloat+Hairline.swift in Sources */,
 				F15650A321DCF63300210504 /* FilePreviewGenerator.swift in Sources */,

--- a/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperFlags/DeveloperFlagsView.swift
+++ b/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperFlags/DeveloperFlagsView.swift
@@ -17,11 +17,10 @@
 //
 
 import SwiftUI
+import WireCommonComponents
 
 @available(iOS 14, *)
 struct DeveloperFlagsView: View {
-
-    typealias Flag = DeveloperFlagsViewModel.DeveloperFlag
 
     // MARK: - Properties
 
@@ -37,7 +36,7 @@ struct DeveloperFlagsView: View {
         }
     }
 
-    private func cell(for flag: Flag) -> some View {
+    private func cell(for flag: DeveloperFlag) -> some View {
         VStack(alignment: .leading, spacing: 10) {
             Toggle(flag.rawValue, isOn: binding(for: flag))
             Text(flag.description)
@@ -46,7 +45,7 @@ struct DeveloperFlagsView: View {
         }
     }
 
-    private func binding(for flag: Flag) -> Binding<Bool> {
+    private func binding(for flag: DeveloperFlag) -> Binding<Bool> {
         var flag = flag
         return Binding(
             get: { flag.isOn },

--- a/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperFlags/DeveloperFlagsViewModel.swift
+++ b/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperFlags/DeveloperFlagsViewModel.swift
@@ -17,43 +17,10 @@
 //
 
 import Foundation
+import WireCommonComponents
 
 @available(iOS 14, *)
 final class DeveloperFlagsViewModel: ObservableObject {
-
-    // MARK: - Models
-
-    enum DeveloperFlag: String, CaseIterable {
-
-        private static let storage = UserDefaults.applicationGroup
-
-        case showCreateMLSGroupToggle
-        case nseDebugging
-        case nseDebugEntryPoint
-        case useDevelopmentBackendAPI
-
-        var description: String {
-            switch self {
-            case .showCreateMLSGroupToggle:
-                return "Turn on to show the MLS toggle when creating a new group."
-
-            case .nseDebugging:
-                return "Turn on to make the notification service extension (NSE) display debug notifications."
-
-            case .nseDebugEntryPoint:
-                return "Turn on to display a notification immediately at the entry point of the notification service extension, skipping any further push processing."
-
-            case .useDevelopmentBackendAPI:
-                return "Turn on to use the developement backend API version instead of the latest production API version."
-            }
-        }
-
-        var isOn: Bool {
-            get { return Self.storage.bool(forKey: rawValue) }
-            set { Self.storage.set(newValue, forKey: rawValue) }
-        }
-
-    }
 
     // MARK: - State
 

--- a/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperFlags/DeveloperFlagsViewModel.swift
+++ b/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperFlags/DeveloperFlagsViewModel.swift
@@ -29,6 +29,7 @@ final class DeveloperFlagsViewModel: ObservableObject {
 
         case showCreateMLSGroupToggle
         case nseDebugging
+        case nseDebugEntryPoint
         case useDevelopmentBackendAPI
 
         var description: String {
@@ -38,6 +39,9 @@ final class DeveloperFlagsViewModel: ObservableObject {
 
             case .nseDebugging:
                 return "Turn on to make the notification service extension (NSE) display debug notifications."
+
+            case .nseDebugEntryPoint:
+                return "Turn on to display a notification immediately at the entry point of the notification service extension, skipping any further push processing."
 
             case .useDevelopmentBackendAPI:
                 return "Turn on to use the developement backend API version instead of the latest production API version."

--- a/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperFlags/DeveloperFlagsViewModel.swift
+++ b/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperFlags/DeveloperFlagsViewModel.swift
@@ -18,14 +18,14 @@
 
 import Foundation
 
-private let storage = UserDefaults(suiteName: "com.wire.developer-flags")!
-
 @available(iOS 14, *)
 final class DeveloperFlagsViewModel: ObservableObject {
 
     // MARK: - Models
 
     enum DeveloperFlag: String, CaseIterable {
+
+        private static let storage = UserDefaults.applicationGroup
 
         case showCreateMLSGroupToggle
         case nseDebugging
@@ -45,8 +45,8 @@ final class DeveloperFlagsViewModel: ObservableObject {
         }
 
         var isOn: Bool {
-            get { return storage.bool(forKey: rawValue) }
-            set { storage.set(newValue, forKey: rawValue) }
+            get { return Self.storage.bool(forKey: rawValue) }
+            set { Self.storage.set(newValue, forKey: rawValue) }
         }
 
     }

--- a/WireCommonComponents/DeveloperFlag.swift
+++ b/WireCommonComponents/DeveloperFlag.swift
@@ -1,0 +1,51 @@
+//
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+public enum DeveloperFlag: String, CaseIterable {
+
+    private static let storage = UserDefaults.applicationGroup
+
+    case showCreateMLSGroupToggle
+    case nseDebugging
+    case nseDebugEntryPoint
+    case useDevelopmentBackendAPI
+
+    public var description: String {
+        switch self {
+        case .showCreateMLSGroupToggle:
+            return "Turn on to show the MLS toggle when creating a new group."
+
+        case .nseDebugging:
+            return "Turn on to make the notification service extension (NSE) display debug notifications."
+
+        case .nseDebugEntryPoint:
+            return "Turn on to display a notification immediately at the entry point of the notification service extension, skipping any further push processing."
+
+        case .useDevelopmentBackendAPI:
+            return "Turn on to use the developement backend API version instead of the latest production API version."
+        }
+    }
+
+    public var isOn: Bool {
+        get { return Self.storage.bool(forKey: rawValue) }
+        set { Self.storage.set(newValue, forKey: rawValue) }
+    }
+
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We still have issues with the NSE not displaying notifications for periods of time. It's hard to know where the failure is happening because 1) notifications are just difficult to debug without a debugger, 2) the NSE is a separate process and our logging tools don't work in it, 3) it not easy to reproduce the issue.

### Solutions

Add two developer flags:

1. `nseDebugEntryPoint`, if on, will make the NSE display the contents of the push it receives at its entry point immediately and then return. This is useful to check whether the problem is if the NSE is receiving the push at all (eg. due to bad network) or if it's to do with our processing of the push.2. 
2. `nseDebugging`, if on, will display notifications with debug messages in all the failure points of the push processing, which would have otherwise resulted in a silent failure. This will be helpful to isolate specific code paths.3. 


### Notes 

These are just some attempt to isolate the cause(s) of the issues we're experiencing. Even if the debug notifications aren't being displayed, but we're sure that the entry point is being hit, then it would suggest something else going wrong such as memory budget violations or crashes.


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
