### PR TITLE
chore: Remove deprecated message types `.usingNewDevice` and `. reactivatedDevice`

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCell.swift
@@ -917,10 +917,6 @@ final class ConversationNewDeviceSystemMessageCellDescription: ConversationMessa
 
         if !systemMessage.addedUserTypes.isEmpty {
             return configureForAddedUsers(in: conversation, attributes: textAttributes)
-        } else if systemMessage.systemMessageType == .reactivatedDevice {
-            return configureForReactivatedSelfClient(SelfUser.current, link: View.userClientURL)
-        } else if let user = users.first, user.isSelfUser && systemMessage.systemMessageType == .usingNewDevice {
-            return configureForNewCurrentDeviceOfSelfUser(user, link: View.userClientURL)
         } else if users.count == 1, let user = users.first, user.isSelfUser {
             return configureForNewClientOfSelfUser(user, clients: clients, link: View.userClientURL)
         } else {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR we remove deprecated message types such as `.usingNewDevice` and `. reactivatedDevice`.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
