### PR TITLE
fix: Layout for the UsernameTakeOver view IC - 101

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/UserNameTakeOverViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/UserNameTakeOverViewController.swift
@@ -159,7 +159,7 @@ final class UserNameTakeOverViewController: UIViewController {
         NSLayoutConstraint.activate([
             keepSuggestedButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: edgeInsets.leading),
             keepSuggestedButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -edgeInsets.trailing),
-            keepSuggestedButton.bottomAnchor.constraint(equalTo: contentView.topAnchor, constant: -edgeInsets.bottom)
+            keepSuggestedButton.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -edgeInsets.bottom)
         ])
 
         NSLayoutConstraint.activate([


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR we fix the layout issue for the UsernameTakeOver View Controller. 

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
