### PR TITLE
chore: remove @available(iOS 13, *) checks

### DIFF
--- a/Wire-iOS Tests/Calling/CallParticipantsListViewControllerTests.swift
+++ b/Wire-iOS Tests/Calling/CallParticipantsListViewControllerTests.swift
@@ -40,7 +40,6 @@ final class CallParticipantsListHelper {
 
 }
 
-@available(iOS 13.0, *)
 final class CallParticipantsListViewControllerTests: ZMSnapshotTestCase {
 
     var sut: CallParticipantsListViewController!

--- a/Wire-iOS Tests/CheckmarkCellTests.swift
+++ b/Wire-iOS Tests/CheckmarkCellTests.swift
@@ -20,7 +20,6 @@ import XCTest
 import SnapshotTesting
 @testable import Wire
 
-@available(iOS 13.0, *)
 final class CheckmarkCellTests: XCTestCase {
 
     var cell: CheckmarkCell!

--- a/Wire-iOS Tests/ContactsCellSnapshotTests.swift
+++ b/Wire-iOS Tests/ContactsCellSnapshotTests.swift
@@ -19,7 +19,6 @@
 import XCTest
 @testable import Wire
 
-@available(iOS 13.0, *)
 final class ContactsCellSnapshotTests: ZMSnapshotTestCase {
 
     var sut: ContactsCell!

--- a/Wire-iOS Tests/ConversationCreationControllerSnapshotTests.swift
+++ b/Wire-iOS Tests/ConversationCreationControllerSnapshotTests.swift
@@ -20,7 +20,6 @@ import SnapshotTesting
 import XCTest
 @testable import Wire
 
-@available(iOS 13.0, *)
 final class ConversationCreationControllerSnapshotTests: ZMSnapshotTestCase {
 
     var sut: ConversationCreationController!

--- a/Wire-iOS Tests/ConversationMessageCell/ConversationMessageSenderSnapshotTests.swift
+++ b/Wire-iOS Tests/ConversationMessageCell/ConversationMessageSenderSnapshotTests.swift
@@ -42,9 +42,7 @@ final class ConversationMessageSenderSnapshotTests: ZMSnapshotTestCase {
         sut = SenderCellComponent(frame: CGRect(x: 0, y: 0, width: 320, height: 64))
 
         ColorScheme.default.variant = .light
-        if #available(iOS 13.0, *) {
-            sut.overrideUserInterfaceStyle = .light
-        }
+        sut.overrideUserInterfaceStyle = .light
         sut.backgroundColor = UIColor.from(scheme: .contentBackground)
     }
 
@@ -72,10 +70,8 @@ final class ConversationMessageSenderSnapshotTests: ZMSnapshotTestCase {
 
     func test_SenderIsExternal_OneOnOneConversation_DarkMode() {
         // GIVEN
-        if #available(iOS 13.0, *) {
-            sut.overrideUserInterfaceStyle = .dark
-        }
         ColorScheme.default.variant = .dark
+        sut.overrideUserInterfaceStyle = .dark
         sut.backgroundColor = UIColor.from(scheme: .contentBackground)
 
         mockUser.teamRole = .partner
@@ -150,10 +146,8 @@ final class ConversationMessageSenderSnapshotTests: ZMSnapshotTestCase {
 
     func test_SenderIsGuest_GroupConversation_DarkMode() {
         // GIVEN
-        if #available(iOS 13.0, *) {
-            sut.overrideUserInterfaceStyle = .dark
-        }
         ColorScheme.default.variant = .dark
+        sut.overrideUserInterfaceStyle = .dark
         sut.backgroundColor = UIColor.from(scheme: .contentBackground)
         mockUser.teamIdentifier = nil
 

--- a/Wire-iOS Tests/CustomAppLock/AppLockChangeWarningViewControllerTests.swift
+++ b/Wire-iOS Tests/CustomAppLock/AppLockChangeWarningViewControllerTests.swift
@@ -20,7 +20,6 @@ import XCTest
 @testable import Wire
 import SnapshotTesting
 
-@available(iOS 13.0, *)
 class AppLockChangeWarningViewControllerTests: XCTestCase {
 
     func testWarningThatAppLockIsActive() {

--- a/Wire-iOS Tests/CustomAppLock/WipeDatabaseViewControllerTests.swift
+++ b/Wire-iOS Tests/CustomAppLock/WipeDatabaseViewControllerTests.swift
@@ -19,7 +19,6 @@ import XCTest
 import SnapshotTesting
 @testable import Wire
 
-@available(iOS 13.0, *)
 final class WipeDatabaseViewControllerTests: ZMSnapshotTestCase {
     var sut: WipeDatabaseViewController!
 

--- a/Wire-iOS Tests/GroupConversationCellTests.swift
+++ b/Wire-iOS Tests/GroupConversationCellTests.swift
@@ -19,7 +19,6 @@
 import XCTest
 @testable import Wire
 
-@available(iOS 13.0, *)
 final class GroupConversationCellTests: XCTestCase {
 
     var sut: GroupConversationCell!

--- a/Wire-iOS Tests/LegalHoldDetailsViewControllerSnapshotTests.swift
+++ b/Wire-iOS Tests/LegalHoldDetailsViewControllerSnapshotTests.swift
@@ -20,7 +20,6 @@ import XCTest
 import SnapshotTesting
 @testable import Wire
 
-@available(iOS 13.0, *)
 final class LegalHoldDetailsViewControllerSnapshotTests: ZMSnapshotTestCase {
 
     var sut: LegalHoldDetailsViewController!

--- a/Wire-iOS Tests/SwiftSnapshotTesting/XCTestCase+SnapshotTesting.swift
+++ b/Wire-iOS Tests/SwiftSnapshotTesting/XCTestCase+SnapshotTesting.swift
@@ -193,7 +193,6 @@ extension XCTestCase {
 			   line: line)
 	}
 
-    @available(iOS 13.0, *)
     func verifyInAllColorSchemes(createSut: () -> UIViewController,
                                  file: StaticString = #file,
                                  testName: String = #function,
@@ -226,7 +225,6 @@ extension XCTestCase {
 			   line: line)
 	}
 
-    @available(iOS 13.0, *)
     func verifyInDarkScheme(createSut: () -> UIViewController,
                             name: String? = nil,
                             file: StaticString = #file,
@@ -244,7 +242,6 @@ extension XCTestCase {
                line: line)
     }
 
-    @available(iOS 13.0, *)
     func verifyInLightScheme(createSut: () -> UIViewController,
                              name: String? = nil,
                              file: StaticString = #file,
@@ -262,7 +259,6 @@ extension XCTestCase {
                line: line)
     }
 
-    @available(iOS 13.0, *)
     func verifyInAllColorSchemes(matching: UIView,
                                  file: StaticString = #file,
                                  testName: String = #function,
@@ -553,13 +549,12 @@ extension XCTestCase {
                                       snapshotBackgroundColor: snapshotBackgroundColor)
         _ = container.addWidthConstraint(width: width)
 
-        if #available(iOS 13.0, *) {
             if ColorScheme.default.variant == .light {
                 container.overrideUserInterfaceStyle = .light
             } else {
                 container.overrideUserInterfaceStyle = .dark
             }
-        }
+
 
         verifyWithWidthInName(matching: container,
                               width: width,

--- a/Wire-iOS Tests/UserCellTests.swift
+++ b/Wire-iOS Tests/UserCellTests.swift
@@ -19,7 +19,6 @@
 import XCTest
 @testable import Wire
 
-@available(iOS 13.0, *)
 final class UserCellTests: ZMSnapshotTestCase {
 
     var sut: UserCell!

--- a/Wire-iOS Tests/UserSearchResultsViewControllerTests.swift
+++ b/Wire-iOS Tests/UserSearchResultsViewControllerTests.swift
@@ -19,7 +19,6 @@
 import XCTest
 @testable import Wire
 
-@available(iOS 13.0, *)
 final class UserSearchResultsViewControllerTests: ZMSnapshotTestCase {
 
     var sut: UserSearchResultsViewController!


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Since our base OS is iOS 13 we don't need those checks anymore. 

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
