### PR TITLE
fix: colors in UserClientCell

### DIFF
--- a/Wire-iOS/Sources/UserInterface/UserProfile/Devices/UserClientCell.swift
+++ b/Wire-iOS/Sources/UserInterface/UserProfile/Devices/UserClientCell.swift
@@ -44,6 +44,7 @@ final class UserClientCell: SeparatorCollectionViewCell {
 
         accessibilityIdentifier = "device_cell"
         shouldGroupAccessibilityChildren = true
+        backgroundColor = SemanticColors.View.backgroundUserCell
 
         setUpDeviceIconView()
 
@@ -58,13 +59,17 @@ final class UserClientCell: SeparatorCollectionViewCell {
 
         accessoryIconView.translatesAutoresizingMaskIntoConstraints = false
         accessoryIconView.contentMode = .center
+        accessoryIconView.setTemplateIcon(.disclosureIndicator, size: 12)
+        accessoryIconView.tintColor = SemanticColors.Icon.foregroundDefault
 
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         titleLabel.font = .smallSemiboldFont
+        titleLabel.textColor = SemanticColors.Label.textCellTitle
         titleLabel.accessibilityIdentifier = "device_cell.name"
 
         subtitleLabel.translatesAutoresizingMaskIntoConstraints = false
         subtitleLabel.font = .smallRegularFont
+        subtitleLabel.textColor = SemanticColors.Label.textCellSubtitle
         subtitleLabel.accessibilityIdentifier = "device_cell.identifier"
 
         iconStackView = UIStackView(arrangedSubviews: [verifiedIconView, accessoryIconView])
@@ -93,6 +98,14 @@ final class UserClientCell: SeparatorCollectionViewCell {
         createConstraints()
     }
 
+    override var isHighlighted: Bool {
+        didSet {
+            backgroundColor = isHighlighted
+            ? SemanticColors.View.backgroundUserCellHightLighted
+            : SemanticColors.View.backgroundUserCell
+        }
+    }
+
     private func setUpDeviceIconView() {
         deviceTypeIconView.setTemplateIcon(.devices, size: .tiny)
         deviceTypeIconView.tintColor = SemanticColors.Icon.foregroundDefault
@@ -107,18 +120,6 @@ final class UserClientCell: SeparatorCollectionViewCell {
             contentStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
             contentStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16)
         ])
-    }
-
-    override func applyColorScheme(_ colorSchemeVariant: ColorSchemeVariant) {
-        super.applyColorScheme(colorSchemeVariant)
-
-        backgroundColor = SemanticColors.View.backgroundUserCell
-        accessoryIconView.setTemplateIcon(.disclosureIndicator, size: 12)
-        accessoryIconView.tintColor = SemanticColors.Icon.foregroundDefault
-        titleLabel.textColor = SemanticColors.Label.textCellTitle
-        subtitleLabel.textColor = SemanticColors.Label.textCellSubtitle
-
-        updateDeviceIcon()
     }
 
     func configure(with client: UserClientType) {
@@ -139,7 +140,8 @@ final class UserClientCell: SeparatorCollectionViewCell {
     private func updateDeviceIcon() {
         switch client?.deviceClass {
         case .legalHold?:
-            deviceTypeIconView.image = StyleKitIcon.legalholdactive.makeImage(size: .tiny, color: SemanticColors.LegacyColors.vividRed)
+            deviceTypeIconView.setTemplateIcon(.legalholdactive, size: .tiny)
+            deviceTypeIconView.tintColor = SemanticColors.LegacyColors.vividRed
             deviceTypeIconView.accessibilityIdentifier = "img.device_class.legalhold"
         default:
             setUpDeviceIconView()


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

There would be an instance where the color of one of the cells wouldn't be the correct one. That's because we didn't override isHighlighted. Now that we do, we fix the issue once and for all.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
