### PR TITLE
chore: add automation helper to set preferred api version

### DIFF
--- a/Wire-iOS/Sources/AppDelegate.swift
+++ b/Wire-iOS/Sources/AppDelegate.swift
@@ -51,7 +51,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         FileBackupExcluderOperation(),
         APIVersionOperation(),
         FontSchemeOperation(),
-        VoIPPushHelperOperation()
+        VoIPPushHelperOperation(),
+        CleanUpDebugStateOperation()
     ]
     private var appStateCalculator = AppStateCalculator()
 

--- a/Wire-iOS/Sources/LaunchSequenceOperation.swift
+++ b/Wire-iOS/Sources/LaunchSequenceOperation.swift
@@ -220,3 +220,25 @@ final class VoIPPushHelperOperation: LaunchSequenceOperation {
     }
 
 }
+
+/// This operation cleans up any state that may have been set in debug builds so that
+/// release builds don't exhibit any debugging behaviour.
+///
+/// This is a safety precaution: users of release builds likely won't ever run a debug
+/// build, but it's better to be sure.
+
+final class CleanUpDebugStateOperation: LaunchSequenceOperation {
+
+    func execute() {
+        guard !Bundle.developerModeEnabled else { return }
+
+        // Clearing this ensures that the api version is negotiated with the backend
+        // and not set explicitly.
+        APIVersion.preferredVersion = nil
+
+        // Clearing all developer flags ensures that no custom behavior is
+        // present in the app.
+        DeveloperFlag.clearAllFlags()
+    }
+
+}

--- a/WireCommonComponents/AutomationHelper.swift
+++ b/WireCommonComponents/AutomationHelper.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import WireSystem
+import WireDataModel
 
 final public class AutomationEmailCredentials: NSObject {
     public var email: String
@@ -115,6 +116,14 @@ public final class AutomationHelper: NSObject {
             self.debugDataToInstall = nil
         }
         self.delayInAddressBookRemoteSearch = AutomationHelper.addressBookSearchDelay(arguments)
+
+        if
+            let value = arguments.flagValueIfPresent(AutomationKey.preferredAPIversion.rawValue),
+            let apiVersion = Int32(value)
+        {
+            APIVersion.preferredVersion = APIVersion(rawValue: apiVersion)
+        }
+
         super.init()
     }
 
@@ -134,6 +143,7 @@ public final class AutomationHelper: NSObject {
         case disableInteractiveKeyboardDismissal = "disable-interactive-keyboard-dismissal"
         case useAppCenter = "use-app-center"
         case keepCallingOverlayVisible = "keep-calling-overlay-visible"
+        case preferredAPIversion = "preferred-api-version"
     }
     /// Returns the login email and password credentials if set in the given arguments
     fileprivate static func credentials(_ arguments: ArgumentsType) -> AutomationEmailCredentials? {

--- a/WireCommonComponents/DeveloperFlag.swift
+++ b/WireCommonComponents/DeveloperFlag.swift
@@ -48,4 +48,10 @@ public enum DeveloperFlag: String, CaseIterable {
         set { Self.storage.set(newValue, forKey: rawValue) }
     }
 
+    static public func clearAllFlags() {
+        allCases.forEach {
+            storage.set(nil, forKey: $0.rawValue)
+        }
+    }
+
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

QA would like to be able to set the preferred api version via command line argument rather than through the app via automation.

### Solutions

Add the option to set the command line argument `preferred-api-version` with a numerical string value which will set the preferred api version of the app.

Additionally, I've added a safety measure to clear any debug / dev state when the app is in release mode, just to make sure that no custom behavior is run in release mode due to persisted data set in debug modes.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
