### PR TITLE
fix: cast always fails when setting core crypto callbacks FS-703

### DIFF
--- a/Wire-iOS/Sources/MLS/CoreCrypto.swift
+++ b/Wire-iOS/Sources/MLS/CoreCrypto.swift
@@ -20,14 +20,28 @@ import Foundation
 import WireDataModel
 import WireCoreCrypto
 
+class CoreCryptoCallbacksWrapper: WireCoreCrypto.CoreCryptoCallbacks {
+
+    let callbacks: WireDataModel.CoreCryptoCallbacks
+
+    init(callbacks: WireDataModel.CoreCryptoCallbacks) {
+        self.callbacks = callbacks
+    }
+
+    func authorize(conversationId: [UInt8], clientId: String) -> Bool {
+        return callbacks.authorize(conversationId: conversationId, clientId: clientId)
+    }
+
+    func isUserInGroup(identity: [UInt8], otherClients: [[UInt8]]) -> Bool {
+        return callbacks.isUserInGroup(identity: identity, otherClients: otherClients)
+    }
+
+}
+
 extension CoreCrypto: WireDataModel.CoreCryptoProtocol {
 
     public func wire_setCallbacks(callbacks: WireDataModel.CoreCryptoCallbacks) throws {
-        guard let callbacks = callbacks as? WireCoreCrypto.CoreCryptoCallbacks else {
-            fatalError("`callbacks` does not conform to `WireCoreCrypto.CoreCryptoCallbacks`")
-        }
-
-        try setCallbacks(callbacks: callbacks)
+        try setCallbacks(callbacks: CoreCryptoCallbacksWrapper(callbacks: callbacks))
     }
 
     public func wire_clientPublicKey() throws -> [UInt8] {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-703" title="FS-703" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />FS-703</a>  [iOS] Automatically Commit PendingProposals
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Calling `wire_setCallbacks` always fails

### Causes

It attempts to cast from  `WireDataModel.CoreCryptoCallbacks` to `WireCoreCrypto.CoreCryptoCallbacks` which always fails since they are different types.

### Solutions

Introduce a wrapper around WireDataModel.CoreCryptoCallbacks.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
