### PR TITLE
fix: Disable iOS suggestions and message forward action SQSERVICES-1654

### DIFF
--- a/Wire-iOS/Sources/Helpers/MediaShareRestrictionManager.swift
+++ b/Wire-iOS/Sources/Helpers/MediaShareRestrictionManager.swift
@@ -88,6 +88,14 @@ class MediaShareRestrictionManager {
         return canUploadMedia(from: .clipboard)
     }
 
+    var canUseSpellChecking: Bool {
+        return canUploadMedia(from: .clipboard)
+    }
+
+    var canUseAutoCorrect: Bool {
+        return canUploadMedia(from: .clipboard)
+    }
+
     var hasAccessToCameraRoll: Bool {
         switch level {
         case .none:

--- a/Wire-iOS/Sources/Helpers/MediaShareRestrictionManager.swift
+++ b/Wire-iOS/Sources/Helpers/MediaShareRestrictionManager.swift
@@ -57,7 +57,7 @@ class MediaShareRestrictionManager {
 
     // MARK: - Public Properties
 
-    var mediaShareRestrictionLevel: MediaShareRestrictionLevel {
+    var level: MediaShareRestrictionLevel {
         if let sessionRestriction = sessionRestriction, !sessionRestriction.isFileSharingEnabled {
             return .APIFlag
         }
@@ -65,7 +65,7 @@ class MediaShareRestrictionManager {
     }
 
     func canUploadMedia(from source: ShareableMediaSource) -> Bool {
-        switch mediaShareRestrictionLevel {
+        switch level {
         case .none:
             return true
         case .securityFlag:
@@ -76,7 +76,7 @@ class MediaShareRestrictionManager {
     }
 
     var canDownloadMedia: Bool {
-        switch mediaShareRestrictionLevel {
+        switch level {
         case .none:
             return true
         case .APIFlag, .securityFlag:
@@ -89,7 +89,7 @@ class MediaShareRestrictionManager {
     }
 
     var hasAccessToCameraRoll: Bool {
-        switch mediaShareRestrictionLevel {
+        switch level {
         case .none:
             return true
         case .APIFlag, .securityFlag:

--- a/Wire-iOS/Sources/Helpers/syncengine/ZMMessage+Actions.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/ZMMessage+Actions.swift
@@ -22,6 +22,10 @@ import WireDataModel
 
 extension ZMConversationMessage {
 
+    var mediaShareRestrictionManager: MediaShareRestrictionManager {
+        return MediaShareRestrictionManager(sessionRestriction: ZMUserSession.shared())
+    }
+
     /// Whether the message can be digitally signed in.
     var canBeDigitallySigned: Bool {
         guard
@@ -40,7 +44,7 @@ extension ZMConversationMessage {
         guard canBeShared else {
             return false
         }
-        return MediaShareRestrictionManager(sessionRestriction: ZMUserSession.shared()).canUseClipboard &&
+        return mediaShareRestrictionManager.canUseClipboard &&
                !isEphemeral &&
                (isText || isImage || isLocation)
     }
@@ -111,7 +115,7 @@ extension ZMConversationMessage {
     var canBeDownloaded: Bool {
         guard let fileMessageData = self.fileMessageData,
               canBeShared,
-              MediaShareRestrictionManager(sessionRestriction: ZMUserSession.shared()).canDownloadMedia else {
+              mediaShareRestrictionManager.canDownloadMedia else {
             return false
         }
         return isFile && fileMessageData.transferState == .uploaded
@@ -128,7 +132,7 @@ extension ZMConversationMessage {
     var canBeSaved: Bool {
         guard canBeShared,
               !isEphemeral,
-              MediaShareRestrictionManager(sessionRestriction: ZMUserSession.shared()).canDownloadMedia else {
+              mediaShareRestrictionManager.canDownloadMedia else {
                   return false
               }
 
@@ -147,9 +151,11 @@ extension ZMConversationMessage {
 
     /// Whether it should be possible to forward given message to another conversation.
     var canBeForwarded: Bool {
-        if isEphemeral || !canBeShared {
-            return false
-        }
+        guard !isEphemeral,
+              canBeShared,
+              mediaShareRestrictionManager.canUseClipboard else {
+                  return false
+              }
 
         if isFile, let fileMessageData = self.fileMessageData {
             return fileMessageData.fileURL != nil

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
@@ -32,6 +32,9 @@ enum ConversationInputBarViewControllerMode {
 final class ConversationInputBarViewController: UIViewController,
                                                 UIPopoverPresentationControllerDelegate,
                                                 PopoverPresenter {
+
+    let mediaShareRestrictionManager = MediaShareRestrictionManager(sessionRestriction: ZMUserSession.shared())
+
     // MARK: PopoverPresenter    
     var presentedPopover: UIPopoverPresentationController?
     var popoverPointToView: UIView?
@@ -151,7 +154,12 @@ final class ConversationInputBarViewController: UIViewController,
 
     // MARK: subviews
     lazy var inputBar: InputBar = {
-        return InputBar(buttons: inputBarButtons)
+        let inputBar = InputBar(buttons: inputBarButtons)
+        if !mediaShareRestrictionManager.canUseClipboard {
+            inputBar.textView.spellCheckingType = .no
+            inputBar.textView.autocorrectionType = .no
+        }
+        return inputBar
     }()
 
     lazy var typingIndicatorView: TypingIndicatorView = {
@@ -199,7 +207,7 @@ final class ConversationInputBarViewController: UIViewController,
     private var typingObserverToken: Any?
 
     private var inputBarButtons: [IconButton] {
-        switch MediaShareRestrictionManager(sessionRestriction: ZMUserSession.shared()).mediaShareRestrictionLevel {
+        switch mediaShareRestrictionManager.level {
 
         case .none:
             return [
@@ -760,7 +768,7 @@ extension ConversationInputBarViewController: UIImagePickerControllerDelegate {
             if let image = image,
                let jpegData = image.jpegData(compressionQuality: 0.9) {
                 if picker.sourceType == UIImagePickerController.SourceType.camera {
-                    if MediaShareRestrictionManager(sessionRestriction: ZMUserSession.shared()).hasAccessToCameraRoll {
+                    if mediaShareRestrictionManager.hasAccessToCameraRoll {
                         UIImageWriteToSavedPhotosAlbum(image, self, #selector(image(_:didFinishSavingWithError:contextInfo:)), nil)
                     }
                     // In case of picking from the camera, the iOS controller is showing it's own confirmation screen.

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
@@ -155,8 +155,10 @@ final class ConversationInputBarViewController: UIViewController,
     // MARK: subviews
     lazy var inputBar: InputBar = {
         let inputBar = InputBar(buttons: inputBarButtons)
-        if !mediaShareRestrictionManager.canUseClipboard {
+        if !mediaShareRestrictionManager.canUseSpellChecking {
             inputBar.textView.spellCheckingType = .no
+        }
+        if !mediaShareRestrictionManager.canUseAutoCorrect {
             inputBar.textView.autocorrectionType = .no
         }
         return inputBar


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1654" title="SQSERVICES-1654" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />SQSERVICES-1654</a>  [ios] Bund: Create iOS column 1 clients that block the user from using spellcheck, translation tools and lookup from iOS
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

As a part of the restriction file sharing for Bund, we should also disable iOS suggestions and message forward action (the ability to forward a message to other Wire conversations).

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
