### PR TITLE
chore(mls): fix QA automation helper

### DIFF
--- a/Wire-iOS/Sources/LaunchSequenceOperation.swift
+++ b/Wire-iOS/Sources/LaunchSequenceOperation.swift
@@ -201,6 +201,10 @@ final class APIVersionOperation: LaunchSequenceOperation {
 
     func execute() {
         APIVersion.storage = .applicationGroup
+
+        if let preferredVersion = AutomationHelper.sharedHelper.preferredAPIversion {
+            APIVersion.preferredVersion = preferredVersion
+        }
     }
 
 }

--- a/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
@@ -120,8 +120,20 @@ final class ConversationCreationController: UIViewController {
         guestsSection,
         servicesSection,
         receiptsSection,
-        selfUser.canCreateMLSGroups || DeveloperFlag.showCreateMLSGroupToggle.isOn ? encryptionProtocolSection : nil
+        shouldIncludeEncryptionProtocolSection ? encryptionProtocolSection : nil
     ].compactMap(\.self)
+
+    private var shouldIncludeEncryptionProtocolSection: Bool {
+        if DeveloperFlag.showCreateMLSGroupToggle.isOn {
+            return true
+        }
+
+        if AutomationHelper.sharedHelper.allowMLSGroupCreation == true {
+            return true
+        }
+
+        return selfUser.canCreateMLSGroups
+    }
 
     private lazy var guestsSection: ConversationCreateGuestsSectionController = {
         let section = ConversationCreateGuestsSectionController(values: values)

--- a/WireCommonComponents/AutomationHelper.swift
+++ b/WireCommonComponents/AutomationHelper.swift
@@ -85,6 +85,9 @@ public final class AutomationHelper: NSObject {
     /// Whether the calling overlay should disappear automatically.
     public let keepCallingOverlayVisible: Bool
 
+    public var preferredAPIversion: APIVersion?
+    public var allowMLSGroupCreation: Bool?
+
     override init() {
         let url = URL(string: NSTemporaryDirectory())?.appendingPathComponent(fileArgumentsName)
         let arguments: ArgumentsType = url.flatMap(FileArguments.init) ?? CommandLineArguments()
@@ -121,8 +124,10 @@ public final class AutomationHelper: NSObject {
             let value = arguments.flagValueIfPresent(AutomationKey.preferredAPIversion.rawValue),
             let apiVersion = Int32(value)
         {
-            APIVersion.preferredVersion = APIVersion(rawValue: apiVersion)
+            preferredAPIversion = APIVersion(rawValue: apiVersion)
         }
+
+        allowMLSGroupCreation = arguments.hasFlag(AutomationKey.allowMLSGroupCreation.rawValue)
 
         super.init()
     }
@@ -144,6 +149,7 @@ public final class AutomationHelper: NSObject {
         case useAppCenter = "use-app-center"
         case keepCallingOverlayVisible = "keep-calling-overlay-visible"
         case preferredAPIversion = "preferred-api-version"
+        case allowMLSGroupCreation = "allow-mls-group-creation"
     }
     /// Returns the login email and password credentials if set in the given arguments
     fileprivate static func credentials(_ arguments: ArgumentsType) -> AutomationEmailCredentials? {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

QA couldn't set the preferred api version with the existing argument. They also want to be able to toggle the message protocol option when creating a group.

### Causes

I think the helper wasn't being run when we needed it to be.

### Solutions

- Explicitly set the preferred api version in the api version launch operation.
- Add an option to control the message protocol toggle

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
