### PR TITLE
fix: photo library permission copy does not have an example

### DIFF
--- a/Wire-iOS/Resources/Base.lproj/InfoPlist.strings
+++ b/Wire-iOS/Resources/Base.lproj/InfoPlist.strings
@@ -23,7 +23,7 @@
 /* Showed after taking a picture with camera, but only when NSPhotoLibraryUsageDescription permission was declined. Asks permission for only writing to photo library. */
 "NSPhotoLibraryAddUsageDescription" = "Allow Wire to store pictures you take in the photo library.";
 /* Showed when trying to send picture from conversaiton list. Asks permissions for reading and writing to photo library */
-"NSPhotoLibraryUsageDescription" = "Allow Wire to access pictures stored in photo library.";
+"NSPhotoLibraryUsageDescription" = "Allow Wire to access pictures stored in photo library so you can send pictures and videos to others.";
 /* Is shown to the user when app is locked with AppLock feature on the phone that supports Face ID */
 "NSFaceIDUsageDescription" = "In order to authenticate in the app allow Wire to access the Face ID feature.";
 

--- a/Wire-iOS/Resources/ar.lproj/InfoPlist.strings
+++ b/Wire-iOS/Resources/ar.lproj/InfoPlist.strings
@@ -23,6 +23,6 @@
 /* Showed after taking a picture with camera, but only when NSPhotoLibraryUsageDescription permission was declined. Asks permission for only writing to photo library. */
 "NSPhotoLibraryAddUsageDescription" = "اسمح لـWire بحفظ الصور الملتقطة في مكتبك الصور.";
 /* Showed when trying to send picture from conversaiton list. Asks permissions for reading and writing to photo library */
-"NSPhotoLibraryUsageDescription" = "اسمح لـWire بالوصول للصور المخزنة في مكتبة الصور.";
+"NSPhotoLibraryUsageDescription" = "Allow Wire to access pictures stored in photo library so you can send pictures and videos to others.";
 /* Is shown to the user when app is locked with AppLock feature on the phone that supports Face ID */
 "NSFaceIDUsageDescription" = "In order to authenticate in the app allow Wire to access the Face ID feature.";

--- a/Wire-iOS/Resources/da.lproj/InfoPlist.strings
+++ b/Wire-iOS/Resources/da.lproj/InfoPlist.strings
@@ -23,6 +23,6 @@
 /* Showed after taking a picture with camera, but only when NSPhotoLibraryUsageDescription permission was declined. Asks permission for only writing to photo library. */
 "NSPhotoLibraryAddUsageDescription" = "Allow Wire to store pictures you take in the photo library.";
 /* Showed when trying to send picture from conversaiton list. Asks permissions for reading and writing to photo library */
-"NSPhotoLibraryUsageDescription" = "Allow Wire to access pictures stored in photo library.";
+"NSPhotoLibraryUsageDescription" = "Allow Wire to access pictures stored in photo library so you can send pictures and videos to others.";
 /* Is shown to the user when app is locked with AppLock feature on the phone that supports Face ID */
 "NSFaceIDUsageDescription" = "In order to authenticate in the app allow Wire to access the Face ID feature.";

--- a/Wire-iOS/Resources/de.lproj/InfoPlist.strings
+++ b/Wire-iOS/Resources/de.lproj/InfoPlist.strings
@@ -23,6 +23,6 @@
 /* Showed after taking a picture with camera, but only when NSPhotoLibraryUsageDescription permission was declined. Asks permission for only writing to photo library. */
 "NSPhotoLibraryAddUsageDescription" = "Erlauben Sie Wire, die von Ihnen aufgenommenen Bilder im Fotoarchiv zu speichern.";
 /* Showed when trying to send picture from conversaiton list. Asks permissions for reading and writing to photo library */
-"NSPhotoLibraryUsageDescription" = "Erlauben Sie Wire Zugriff auf die im Fotoarchiv gespeicherten Bilder.";
+"NSPhotoLibraryUsageDescription" = "Erlauben Sie Wire den Zugriff auf gespeicherte Bilder in der Fotomediathek, damit Sie Bilder und Videos an andere senden können.";
 /* Is shown to the user when app is locked with AppLock feature on the phone that supports Face ID */
 "NSFaceIDUsageDescription" = "Um sich in der App zu authentifizieren, erlauben Sie Wire Zugriff auf die Face ID-Funktion.";

--- a/Wire-iOS/Resources/es.lproj/InfoPlist.strings
+++ b/Wire-iOS/Resources/es.lproj/InfoPlist.strings
@@ -23,6 +23,6 @@
 /* Showed after taking a picture with camera, but only when NSPhotoLibraryUsageDescription permission was declined. Asks permission for only writing to photo library. */
 "NSPhotoLibraryAddUsageDescription" = "Permite a Wire que guarde las fotos que tomas en la galería de fotos.";
 /* Showed when trying to send picture from conversaiton list. Asks permissions for reading and writing to photo library */
-"NSPhotoLibraryUsageDescription" = "Permite a Wire acceder a las imágenes almacenadas en la galería de fotos.";
+"NSPhotoLibraryUsageDescription" = "Allow Wire to access pictures stored in photo library so you can send pictures and videos to others.";
 /* Is shown to the user when app is locked with AppLock feature on the phone that supports Face ID */
 "NSFaceIDUsageDescription" = "Para autentificarse en la aplicación, permite a Wire acceder a la función Face ID.";

--- a/Wire-iOS/Resources/et.lproj/InfoPlist.strings
+++ b/Wire-iOS/Resources/et.lproj/InfoPlist.strings
@@ -23,6 +23,6 @@
 /* Showed after taking a picture with camera, but only when NSPhotoLibraryUsageDescription permission was declined. Asks permission for only writing to photo library. */
 "NSPhotoLibraryAddUsageDescription" = "Luba Wire’l salvestada pildistatud fotod sinu pildikogusse.";
 /* Showed when trying to send picture from conversaiton list. Asks permissions for reading and writing to photo library */
-"NSPhotoLibraryUsageDescription" = "Luba Wire’le ligipääs sinu pildikogus olevatele fotodele.";
+"NSPhotoLibraryUsageDescription" = "Allow Wire to access pictures stored in photo library so you can send pictures and videos to others.";
 /* Is shown to the user when app is locked with AppLock feature on the phone that supports Face ID */
 "NSFaceIDUsageDescription" = "Audentimiseks luba Wire'e juurdepääs Face ID funktsioonile.";

--- a/Wire-iOS/Resources/fi.lproj/InfoPlist.strings
+++ b/Wire-iOS/Resources/fi.lproj/InfoPlist.strings
@@ -23,6 +23,6 @@
 /* Showed after taking a picture with camera, but only when NSPhotoLibraryUsageDescription permission was declined. Asks permission for only writing to photo library. */
 "NSPhotoLibraryAddUsageDescription" = "Allow Wire to store pictures you take in the photo library.";
 /* Showed when trying to send picture from conversaiton list. Asks permissions for reading and writing to photo library */
-"NSPhotoLibraryUsageDescription" = "Allow Wire to access pictures stored in photo library.";
+"NSPhotoLibraryUsageDescription" = "Allow Wire to access pictures stored in photo library so you can send pictures and videos to others.";
 /* Is shown to the user when app is locked with AppLock feature on the phone that supports Face ID */
 "NSFaceIDUsageDescription" = "In order to authenticate in the app allow Wire to access the Face ID feature.";

--- a/Wire-iOS/Resources/fr.lproj/InfoPlist.strings
+++ b/Wire-iOS/Resources/fr.lproj/InfoPlist.strings
@@ -23,6 +23,6 @@
 /* Showed after taking a picture with camera, but only when NSPhotoLibraryUsageDescription permission was declined. Asks permission for only writing to photo library. */
 "NSPhotoLibraryAddUsageDescription" = "Autorisez Wire à enregistrer les photos que vous prenez dans la bibliothèque de photos.";
 /* Showed when trying to send picture from conversaiton list. Asks permissions for reading and writing to photo library */
-"NSPhotoLibraryUsageDescription" = "Autorisez Wire à accéder aux images enregistrées dans la bibliothèque de photos.";
+"NSPhotoLibraryUsageDescription" = "Autorisez Wire à accéder aux images enregistrées dans la bibliothèque de photos pour pouvoir envoyer des photos et vidéos aux autres utilisateurs.";
 /* Is shown to the user when app is locked with AppLock feature on the phone that supports Face ID */
 "NSFaceIDUsageDescription" = "Pour vous authentifier dans l'application, veuillez autoriser Wire à utiliser Face ID.";

--- a/Wire-iOS/Resources/it.lproj/InfoPlist.strings
+++ b/Wire-iOS/Resources/it.lproj/InfoPlist.strings
@@ -23,6 +23,6 @@
 /* Showed after taking a picture with camera, but only when NSPhotoLibraryUsageDescription permission was declined. Asks permission for only writing to photo library. */
 "NSPhotoLibraryAddUsageDescription" = "Consenti a Wire di memorizzare le foto scattate nella libreria foto.";
 /* Showed when trying to send picture from conversaiton list. Asks permissions for reading and writing to photo library */
-"NSPhotoLibraryUsageDescription" = "Consenti a Wire di accedere alle foto memorizzate nella libreria foto.";
+"NSPhotoLibraryUsageDescription" = "Allow Wire to access pictures stored in photo library so you can send pictures and videos to others.";
 /* Is shown to the user when app is locked with AppLock feature on the phone that supports Face ID */
 "NSFaceIDUsageDescription" = "Al fine di autenticarsi nell'app consenti a Wire di accedere alla funzione Face ID.";

--- a/Wire-iOS/Resources/ja.lproj/InfoPlist.strings
+++ b/Wire-iOS/Resources/ja.lproj/InfoPlist.strings
@@ -23,6 +23,6 @@
 /* Showed after taking a picture with camera, but only when NSPhotoLibraryUsageDescription permission was declined. Asks permission for only writing to photo library. */
 "NSPhotoLibraryAddUsageDescription" = "写真を保存するために、Wireがあなたのフォトライブラリにアクセスすることを許可してください。";
 /* Showed when trying to send picture from conversaiton list. Asks permissions for reading and writing to photo library */
-"NSPhotoLibraryUsageDescription" = "Wire に フォトライブラリに保存された画像へのアクセスを許可します。";
+"NSPhotoLibraryUsageDescription" = "Allow Wire to access pictures stored in photo library so you can send pictures and videos to others.";
 /* Is shown to the user when app is locked with AppLock feature on the phone that supports Face ID */
 "NSFaceIDUsageDescription" = "アプリで認証するために、Wire が Face ID にアクセスするのを許可します。";

--- a/Wire-iOS/Resources/lt.lproj/InfoPlist.strings
+++ b/Wire-iOS/Resources/lt.lproj/InfoPlist.strings
@@ -23,6 +23,6 @@
 /* Showed after taking a picture with camera, but only when NSPhotoLibraryUsageDescription permission was declined. Asks permission for only writing to photo library. */
 "NSPhotoLibraryAddUsageDescription" = "Suteikite „Wire“ galimybę išsaugoti padarytas nuotraukas paveikslėlių bibliotekoje.";
 /* Showed when trying to send picture from conversaiton list. Asks permissions for reading and writing to photo library */
-"NSPhotoLibraryUsageDescription" = "Suteikite „Wire“ galimybę prisijungti prie paveikslėlių saugomų bibliotekoje.";
+"NSPhotoLibraryUsageDescription" = "Allow Wire to access pictures stored in photo library so you can send pictures and videos to others.";
 /* Is shown to the user when app is locked with AppLock feature on the phone that supports Face ID */
 "NSFaceIDUsageDescription" = "Norėdami nustatyti tapatybę programėlėje leiskite „Wire“ naudoti „Face ID“ galimybę.";

--- a/Wire-iOS/Resources/nl.lproj/InfoPlist.strings
+++ b/Wire-iOS/Resources/nl.lproj/InfoPlist.strings
@@ -23,6 +23,6 @@
 /* Showed after taking a picture with camera, but only when NSPhotoLibraryUsageDescription permission was declined. Asks permission for only writing to photo library. */
 "NSPhotoLibraryAddUsageDescription" = "Sta Wire toe om afbeeldingen op te slaan in je foto bibliotheek.";
 /* Showed when trying to send picture from conversaiton list. Asks permissions for reading and writing to photo library */
-"NSPhotoLibraryUsageDescription" = "Sta Wire toe om de afbeeldingen in je foto bibliotheek te zien.";
+"NSPhotoLibraryUsageDescription" = "Allow Wire to access pictures stored in photo library so you can send pictures and videos to others.";
 /* Is shown to the user when app is locked with AppLock feature on the phone that supports Face ID */
 "NSFaceIDUsageDescription" = "Voor het ontgrendelen van de Wire app met Face ID, heeft wire toegang nodig tot Face ID.";

--- a/Wire-iOS/Resources/pl.lproj/InfoPlist.strings
+++ b/Wire-iOS/Resources/pl.lproj/InfoPlist.strings
@@ -23,6 +23,6 @@
 /* Showed after taking a picture with camera, but only when NSPhotoLibraryUsageDescription permission was declined. Asks permission for only writing to photo library. */
 "NSPhotoLibraryAddUsageDescription" = "Zezwól Wire na przechowywanie zdjęć, które robisz, w bibliotece zdjęć.";
 /* Showed when trying to send picture from conversaiton list. Asks permissions for reading and writing to photo library */
-"NSPhotoLibraryUsageDescription" = "Zezwól Wire na dostęp do zdjęć przechowywanych w bibliotece zdjęć.";
+"NSPhotoLibraryUsageDescription" = "Allow Wire to access pictures stored in photo library so you can send pictures and videos to others.";
 /* Is shown to the user when app is locked with AppLock feature on the phone that supports Face ID */
 "NSFaceIDUsageDescription" = "Aby uwierzytelnić się w aplikacji, zezwól Wire na dostęp do funkcji Face ID.";

--- a/Wire-iOS/Resources/pt-BR.lproj/InfoPlist.strings
+++ b/Wire-iOS/Resources/pt-BR.lproj/InfoPlist.strings
@@ -23,6 +23,6 @@
 /* Showed after taking a picture with camera, but only when NSPhotoLibraryUsageDescription permission was declined. Asks permission for only writing to photo library. */
 "NSPhotoLibraryAddUsageDescription" = "Permitir que o Wire armazene fotos que você tirar na biblioteca de fotos.";
 /* Showed when trying to send picture from conversaiton list. Asks permissions for reading and writing to photo library */
-"NSPhotoLibraryUsageDescription" = "Permitir que o Wire acesse imagens guardadas na biblioteca de fotos.";
+"NSPhotoLibraryUsageDescription" = "Allow Wire to access pictures stored in photo library so you can send pictures and videos to others.";
 /* Is shown to the user when app is locked with AppLock feature on the phone that supports Face ID */
 "NSFaceIDUsageDescription" = "Para autenticar no aplicativo, permita que o Wire acesse o recurso Face ID.";

--- a/Wire-iOS/Resources/ru.lproj/InfoPlist.strings
+++ b/Wire-iOS/Resources/ru.lproj/InfoPlist.strings
@@ -23,6 +23,6 @@
 /* Showed after taking a picture with camera, but only when NSPhotoLibraryUsageDescription permission was declined. Asks permission for only writing to photo library. */
 "NSPhotoLibraryAddUsageDescription" = "Разрешить Wire сохранять снимки в галерею.";
 /* Showed when trying to send picture from conversaiton list. Asks permissions for reading and writing to photo library */
-"NSPhotoLibraryUsageDescription" = "Разрешить Wire доступ к изображениям, хранящимся в галерее.";
+"NSPhotoLibraryUsageDescription" = "Allow Wire to access pictures stored in photo library so you can send pictures and videos to others.";
 /* Is shown to the user when app is locked with AppLock feature on the phone that supports Face ID */
 "NSFaceIDUsageDescription" = "Для аутентификации в приложении разрешите Wire доступ к функции Face ID.";

--- a/Wire-iOS/Resources/sl.lproj/InfoPlist.strings
+++ b/Wire-iOS/Resources/sl.lproj/InfoPlist.strings
@@ -23,6 +23,6 @@
 /* Showed after taking a picture with camera, but only when NSPhotoLibraryUsageDescription permission was declined. Asks permission for only writing to photo library. */
 "NSPhotoLibraryAddUsageDescription" = "Allow Wire to store pictures you take in the photo library.";
 /* Showed when trying to send picture from conversaiton list. Asks permissions for reading and writing to photo library */
-"NSPhotoLibraryUsageDescription" = "Allow Wire to access pictures stored in photo library.";
+"NSPhotoLibraryUsageDescription" = "Allow Wire to access pictures stored in photo library so you can send pictures and videos to others.";
 /* Is shown to the user when app is locked with AppLock feature on the phone that supports Face ID */
 "NSFaceIDUsageDescription" = "In order to authenticate in the app allow Wire to access the Face ID feature.";

--- a/Wire-iOS/Resources/tr.lproj/InfoPlist.strings
+++ b/Wire-iOS/Resources/tr.lproj/InfoPlist.strings
@@ -23,6 +23,6 @@
 /* Showed after taking a picture with camera, but only when NSPhotoLibraryUsageDescription permission was declined. Asks permission for only writing to photo library. */
 "NSPhotoLibraryAddUsageDescription" = "Wire'ın fotoğraf galerinde resim depolamasına izin ver.";
 /* Showed when trying to send picture from conversaiton list. Asks permissions for reading and writing to photo library */
-"NSPhotoLibraryUsageDescription" = "Wire'ın fotoğraf galerinde resim depolama erişimine izin ver.";
+"NSPhotoLibraryUsageDescription" = "Allow Wire to access pictures stored in photo library so you can send pictures and videos to others.";
 /* Is shown to the user when app is locked with AppLock feature on the phone that supports Face ID */
 "NSFaceIDUsageDescription" = "Uygulamada kimlik doğrulaması için Wire'ın Face ID özelliğine erişmesine izin ver.";

--- a/Wire-iOS/Resources/uk.lproj/InfoPlist.strings
+++ b/Wire-iOS/Resources/uk.lproj/InfoPlist.strings
@@ -23,6 +23,6 @@
 /* Showed after taking a picture with camera, but only when NSPhotoLibraryUsageDescription permission was declined. Asks permission for only writing to photo library. */
 "NSPhotoLibraryAddUsageDescription" = "Дозволити Wire зберігати картинки у вашій фототеці.";
 /* Showed when trying to send picture from conversaiton list. Asks permissions for reading and writing to photo library */
-"NSPhotoLibraryUsageDescription" = "Надати Wire доступ до картинок, збережених у вашій фототеці.";
+"NSPhotoLibraryUsageDescription" = "Allow Wire to access pictures stored in photo library so you can send pictures and videos to others.";
 /* Is shown to the user when app is locked with AppLock feature on the phone that supports Face ID */
 "NSFaceIDUsageDescription" = "Дозволити Wire доступ до функції Face ID, щоб авторизуватися в додатку.";

--- a/Wire-iOS/Resources/zh-Hans.lproj/InfoPlist.strings
+++ b/Wire-iOS/Resources/zh-Hans.lproj/InfoPlist.strings
@@ -23,6 +23,6 @@
 /* Showed after taking a picture with camera, but only when NSPhotoLibraryUsageDescription permission was declined. Asks permission for only writing to photo library. */
 "NSPhotoLibraryAddUsageDescription" = "允许Wire存储图片到照片库。";
 /* Showed when trying to send picture from conversaiton list. Asks permissions for reading and writing to photo library */
-"NSPhotoLibraryUsageDescription" = "允许Wire访问存储照片库。";
+"NSPhotoLibraryUsageDescription" = "Allow Wire to access pictures stored in photo library so you can send pictures and videos to others.";
 /* Is shown to the user when app is locked with AppLock feature on the phone that supports Face ID */
 "NSFaceIDUsageDescription" = "为了进行身份验证, 允许Wire访问 \"Face ID\" 功能。";

--- a/Wire-iOS/Resources/zh-Hant.lproj/InfoPlist.strings
+++ b/Wire-iOS/Resources/zh-Hant.lproj/InfoPlist.strings
@@ -23,6 +23,6 @@
 /* Showed after taking a picture with camera, but only when NSPhotoLibraryUsageDescription permission was declined. Asks permission for only writing to photo library. */
 "NSPhotoLibraryAddUsageDescription" = "允許Wire存儲圖片到照片庫。";
 /* Showed when trying to send picture from conversaiton list. Asks permissions for reading and writing to photo library */
-"NSPhotoLibraryUsageDescription" = "允許Wire讀取照片庫。";
+"NSPhotoLibraryUsageDescription" = "Allow Wire to access pictures stored in photo library so you can send pictures and videos to others.";
 /* Is shown to the user when app is locked with AppLock feature on the phone that supports Face ID */
 "NSFaceIDUsageDescription" = "為了在應用程式中驗證身份，請允許Wire使用Face ID權限。";


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The photo library access permission alert does not explain to the user for what reason we need access.

### Solutions

Change the copy to include an example why we need access to the photo library.


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
