### PR TITLE
chore: add flag to break notifications

### DIFF
--- a/Wire Notification Service Extension/NotificationService.swift
+++ b/Wire Notification Service Extension/NotificationService.swift
@@ -33,7 +33,11 @@ public class NotificationService: UNNotificationServiceExtension{
         _ request: UNNotificationRequest,
         withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
     ) {
-        if DeveloperFlag.useSimpleNSE.isOn {
+        if DeveloperFlag.breakMyNotifications.isOn {
+            // By doing nothing, we hope to get in a state where iOS will no
+            // longer deliver pushes to us.
+            return
+        } else if DeveloperFlag.useSimpleNSE.isOn {
             simpleService.didReceive(
                 request,
                 withContentHandler: contentHandler
@@ -47,7 +51,11 @@ public class NotificationService: UNNotificationServiceExtension{
     }
 
     public override func serviceExtensionTimeWillExpire() {
-        if DeveloperFlag.useSimpleNSE.isOn {
+        if DeveloperFlag.breakMyNotifications.isOn {
+            // By doing nothing, we hope to get in a state where iOS will no
+            // longer deliver pushes to us.
+            return
+        } else if DeveloperFlag.useSimpleNSE.isOn {
             simpleService.serviceExtensionTimeWillExpire()
         } else {
             legacyService.serviceExtensionTimeWillExpire()

--- a/WireCommonComponents/DeveloperFlag.swift
+++ b/WireCommonComponents/DeveloperFlag.swift
@@ -23,6 +23,7 @@ public enum DeveloperFlag: String, CaseIterable {
     private static let storage = UserDefaults.applicationGroup
 
     case showCreateMLSGroupToggle
+    case breakMyNotifications
     case useSimpleNSE
     case nseDebugging
     case nseDebugEntryPoint
@@ -32,6 +33,9 @@ public enum DeveloperFlag: String, CaseIterable {
         switch self {
         case .showCreateMLSGroupToggle:
             return "Turn on to show the MLS toggle when creating a new group."
+
+        case .breakMyNotifications:
+            return "Turn on to get your app in a state where it no longer receives notifications."
 
         case .useSimpleNSE:
             return "Turn on to use the new and simple implementation of the notification service extension."


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

We suspect that people still suffering from notification issues is because their app is in a bad state where iOS is no longer delivering notifications. To test this hypothesis, we're adding a flag to intentionally break the notification service. If the flag is on, we will not do anything in the service, which hopefully after receiving and ignoring enough pushes, the app will no longer show any notifications.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
