### PR TITLE
fix(mls): crash when tapping message protocol cell FS-880

### DIFF
--- a/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/MessageProtocolSectionController.swift
+++ b/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/MessageProtocolSectionController.swift
@@ -114,6 +114,13 @@ final class MessageProtocolSectionController: GroupDetailsSectionController {
         return size
     }
 
+    override func collectionView(
+        _ collectionView: UICollectionView,
+        didSelectItemAt indexPath: IndexPath
+    ) {
+        return
+    }
+
 }
 
 private extension MessageProtocol {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-880" title="FS-880" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />FS-880</a>  [IOS] Protocol and Cyphersuite indication in the Group properties
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

If I tap on the message protocol cell (in group details), the app crashes.

### Causes

The `MessageProtocolSectionController` doesn't override a method from super, that is expected to be overridden.

### Solutions

Override the method with an empty implementation.


### Testing

Tested manually.


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
