### PR TITLE
feat: simple nse step2 cleanup, tests SQSERVICES-1700

### DIFF
--- a/Wire Notification Service Extension/Simple/Helpers/EventDecodingProtocol.swift
+++ b/Wire Notification Service Extension/Simple/Helpers/EventDecodingProtocol.swift
@@ -1,0 +1,37 @@
+//
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import WireDataModel
+import WireSyncEngine
+
+
+protocol EventDecodingProtocol {
+    func decryptAndStoreEvents(events: [ZMUpdateEvent]) async -> [ZMUpdateEvent]
+}
+
+
+extension EventDecoder: EventDecodingProtocol {
+
+    func decryptAndStoreEvents(events: [ZMUpdateEvent]) async -> [ZMUpdateEvent] {
+        return await withCheckedContinuation { continuation in
+            decryptAndStoreEvents(events) { decryptedEvents in
+                continuation.resume(with: .success(decryptedEvents))
+            }
+        }
+    }
+}

--- a/Wire Notification Service Extension/Simple/Helpers/EventMessageExtractor.swift
+++ b/Wire Notification Service Extension/Simple/Helpers/EventMessageExtractor.swift
@@ -16,20 +16,13 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
+import Foundation
 import WireDataModel
-import WireSyncEngine
 
-protocol EventDecodingProtocol {
-    func decryptAndStoreEvents(events: [ZMUpdateEvent]) async -> [ZMUpdateEvent]
-}
-
-extension EventDecoder: EventDecodingProtocol {
-
-    func decryptAndStoreEvents(events: [ZMUpdateEvent]) async -> [ZMUpdateEvent] {
-        return await withCheckedContinuation { continuation in
-            decryptAndStoreEvents(events) { decryptedEvents in
-                continuation.resume(with: .success(decryptedEvents))
-            }
-        }
+class EventMessageExtractor {
+    func extractMessage(fromDecodedEvent event: ZMUpdateEvent) throws -> String {
+        guard let message = GenericMessage(from: event) else { throw NotificationServiceError.noGenericMessage }
+        guard let messageContent = message.textData?.content else { throw NotificationServiceError.incorrectContent }
+        return messageContent
     }
 }

--- a/Wire Notification Service Extension/Simple/Job.swift
+++ b/Wire Notification Service Extension/Simple/Job.swift
@@ -100,7 +100,6 @@ final class Job: NSObject, Loggable {
     private func extractMessageContent(from event: ZMUpdateEvent) async throws -> String {
         guard let coreDataStack = coreDataStack else { throw NotificationServiceError.noAccount }
 
-        try await coreDataStack.loadStores()
         let eventDecoder = EventDecoder(eventMOC: coreDataStack.eventContext, syncMOC: coreDataStack.syncContext)
         let updatedEvents = await eventDecoder.decryptAndStoreEvents(events: [event])
 
@@ -142,21 +141,6 @@ final class Job: NSObject, Loggable {
 
 }
 
-extension CoreDataStack {
-
-    func loadStores() async throws {
-        return try await withCheckedThrowingContinuation { continuation in
-            loadStores {
-                if let error = $0 {
-                    continuation.resume(with: .failure(error))
-                } else {
-                    continuation.resume(with: .success(()))
-                }
-            }
-        }
-    }
-
-}
 
 extension EventDecoder {
 

--- a/Wire Notification Service Extension/Simple/Job.swift
+++ b/Wire Notification Service Extension/Simple/Job.swift
@@ -101,8 +101,7 @@ final class Job: NSObject, Loggable {
     }
 
     private func extractMessageContent(from event: ZMUpdateEvent) async throws -> String {
-        let updatedEvents = await eventDecoder.decryptAndStoreEvents(events: [event])
-        guard let updatedEvent = updatedEvents.first else { throw NotificationServiceError.noDecryptedEvent }
+        let updatedEvent =  try await eventDecoder.decryptAndStoreEvent(event)
         return try messageExtractor.extractMessage(fromDecodedEvent: updatedEvent)
     }
 

--- a/Wire Notification Service Extension/Simple/NotificationServiceError.swift
+++ b/Wire Notification Service Extension/Simple/NotificationServiceError.swift
@@ -23,11 +23,10 @@ enum NotificationServiceError: Error, Equatable {
     case invalidEnvironment
     case malformedPushPayload
     case userNotAuthenticated
-    case failedToFetchAccessToken
-    case notImplemented(String)
     case noAppGroupID
     case noAccount
-    case decryptionError
     case incorrectContent
+    case noDecryptedEvent
+    case noGenericMessage
 
 }

--- a/Wire Notification Service Extension/Simple/SimpleNotificationService.swift
+++ b/Wire Notification Service Extension/Simple/SimpleNotificationService.swift
@@ -61,7 +61,7 @@ final class SimpleNotificationService: UNNotificationServiceExtension, Loggable 
         let task = Task { [weak self] in
             do {
                 logger.trace("\(request.identifier, privacy: .public): initializing job")
-                guard let accountID = request.content.accountID else { throw NotificationServiceError.incorrectContent }
+                guard let accountID = request.content.accountID else { throw NotificationServiceError.noAccount }
                 let coreDataStack = try await dataStackForAccount(accountID: accountID)
                 let eventDecoder =   EventDecoder(eventMOC: coreDataStack.eventContext, syncMOC: coreDataStack.syncContext)
                 let job = try Job(request: request, eventDecoder: eventDecoder)

--- a/Wire Notification Service Extension/Simple/SimpleNotificationService.swift
+++ b/Wire Notification Service Extension/Simple/SimpleNotificationService.swift
@@ -63,7 +63,7 @@ final class SimpleNotificationService: UNNotificationServiceExtension, Loggable 
                 logger.trace("\(request.identifier, privacy: .public): initializing job")
                 guard let accountID = request.content.accountID else { throw NotificationServiceError.noAccount }
                 let coreDataStack = try await dataStackForAccount(accountID: accountID)
-                let eventDecoder =   EventDecoder(eventMOC: coreDataStack.eventContext, syncMOC: coreDataStack.syncContext)
+                let eventDecoder = EventDecoder(eventMOC: coreDataStack.eventContext, syncMOC: coreDataStack.syncContext)
                 let job = try Job(request: request, eventDecoder: eventDecoder)
                 let content = try await job.execute()
                 logger.trace("\(request.identifier, privacy: .public): showing notification")

--- a/Wire Notification Service Extension/Simple/SimpleNotificationService.swift
+++ b/Wire Notification Service Extension/Simple/SimpleNotificationService.swift
@@ -111,3 +111,19 @@ private extension SimpleNotificationService {
         return coreDataStack
     }
 }
+
+extension CoreDataStack {
+
+    func loadStores() async throws {
+        return try await withCheckedThrowingContinuation { continuation in
+            loadStores {
+                if let error = $0 {
+                    continuation.resume(with: .failure(error))
+                } else {
+                    continuation.resume(with: .success(()))
+                }
+            }
+        }
+    }
+
+}

--- a/Wire Notification Service Extension/Simple/SimpleNotificationService.swift
+++ b/Wire Notification Service Extension/Simple/SimpleNotificationService.swift
@@ -21,6 +21,7 @@ import UserNotifications
 import WireTransport
 import WireCommonComponents
 import WireDataModel
+import WireSyncEngine
 
 final class SimpleNotificationService: UNNotificationServiceExtension, Loggable {
 
@@ -62,7 +63,8 @@ final class SimpleNotificationService: UNNotificationServiceExtension, Loggable 
                 logger.trace("\(request.identifier, privacy: .public): initializing job")
                 guard let accountID = request.content.accountID else { throw NotificationServiceError.incorrectContent }
                 let coreDataStack = try await dataStackForAccount(accountID: accountID)
-                let job = try Job(request: request, coreDataStack: coreDataStack)
+                let eventDecoder =   EventDecoder(eventMOC: coreDataStack.eventContext, syncMOC: coreDataStack.syncContext)
+                let job = try Job(request: request, eventDecoder: eventDecoder)
                 let content = try await job.execute()
                 logger.trace("\(request.identifier, privacy: .public): showing notification")
                 contentHandler(content)

--- a/Wire-iOS Tests/Notification Service Extension/SimpleNotificationServiceExtension/JobTests.swift
+++ b/Wire-iOS Tests/Notification Service Extension/SimpleNotificationServiceExtension/JobTests.swift
@@ -86,13 +86,13 @@ class JobTests: XCTestCase {
                             ]
                         ]
 
-                        return [ZMUpdateEvent(
+                        return ZMUpdateEvent(
                             uuid: self.eventID,
                             payload: payload,
                             transient: false,
                             decrypted: true,
                             source: .pushNotification
-                        )!]
+                        )!
         }
         return decoder
     }()
@@ -223,9 +223,9 @@ class MockEventMessageExtractor: EventMessageExtractor {
 }
 
 class MockEventDecoder: EventDecodingProtocol {
-    var mockDecodeEvent: (() async -> [ZMUpdateEvent])?
+    var mockDecodeEvent: (() async -> ZMUpdateEvent)?
 
-    func decryptAndStoreEvents(events: [ZMUpdateEvent]) async -> [ZMUpdateEvent] {
+    func decryptAndStoreEvent(_ event: ZMUpdateEvent) async -> ZMUpdateEvent {
         guard let mock = mockDecodeEvent else {
             fatalError("no mock for `decodeEvent`")
         }

--- a/Wire-iOS Tests/Notification Service Extension/SimpleNotificationServiceExtension/JobTests.swift
+++ b/Wire-iOS Tests/Notification Service Extension/SimpleNotificationServiceExtension/JobTests.swift
@@ -162,27 +162,6 @@ class JobTests: XCTestCase {
                     ]
                 ]
             ]
-//            let payload: [String: Any] = ["from": "16b0c8ed-2026-4643-8c6e-4b7b7160890b",
-//                                          "type": "conversation.otr-message-add",
-//                                          "qualified_from": [
-//                                            "domain": "wire.com",
-//                                            "id": "16b0c8ed-2026-4643-8c6e-4b7b7160890b"
-//                                          ],
-//                                          "qualified_conversation": [
-//                                            "domain": "wire.com",
-//                                            "id": "d7174dca-488b-463b-bb64-2c2bec442deb"
-//                                          ],
-//                                          "conversation": "d7174dca-488b-463b-bb64-2c2bec442deb",
-//                                          "time": "2022-09-29T09:14:42.428Z",
-//                                          "data": [
-//                                            "data": "",
-//                                            "recipient": "ec9d18bc7d0909b0",
-//                                            "sender": "b7d8296a54a59151",
-//                                            "text": "CiRkY2JhMzA0OS05NzgxLTQzNjktYTQxMi1mMzZjNDhkZDRmMjQSCQoDWXl5MAA4AQ=="
-//                                          ],
-//                                          "external": ""]
-
-
             return ZMUpdateEvent(
                 uuid: eventID,
                 payload: payload,

--- a/Wire-iOS Tests/Notification Service Extension/SimpleNotificationServiceExtension/JobTests.swift
+++ b/Wire-iOS Tests/Notification Service Extension/SimpleNotificationServiceExtension/JobTests.swift
@@ -68,15 +68,13 @@ class JobTests: XCTestCase {
         )
     }()
 
-    lazy var dataStack: CoreDataStack? = {
-        guard let groupID = Bundle.main.applicationGroupIdentifier else {
-            return nil
-        }
+    lazy var dataStack: CoreDataStack = {
+        let groupID = Bundle.main.applicationGroupIdentifier!
         let sharedContainerURL = FileManager.sharedContainerDirectory(for: groupID)
-        let accountManager = AccountManager(sharedDirectory: sharedContainerURL)
-        guard let account = accountManager.account(with: userID) else {
-                  return nil
-        }
+//        let accountManager = AccountManager(sharedDirectory: sharedContainerURL)
+//        let account = accountManager.account(with: userID)!
+
+        let account = Account(userName: "", userIdentifier: userID)
         return CoreDataStack(
             account: account,
             applicationContainer: sharedContainerURL
@@ -127,40 +125,40 @@ class JobTests: XCTestCase {
     }
     
     // TODO: need to mock CoreDataStack to return correct message and check it
-    func test_Execute_NewMessageEvent_Content() async throws {
-        // Given
-        mockAccessAPIClient.mockFetchAccessToken = {
-            AccessToken(token: "12345", type: "Bearer", expiresInSeconds: 10)
-        }
-
-        mockNotificationsAPIClient.mockFetchEvent = { eventID in
-            XCTAssertEqual(eventID, self.eventID)
-
-            let payload: [String: Any] = [
-                "id": "cf51e6b1-39a6-11ed-8005-520924331b82",
-                "time": "2022-09-21T12:13:32.173Z",
-                "type": "conversation.otr-message-add",
-                "payload": [
-                    "conversation": "c06684dd-2865-4ff8-aef5-e0b07ae3a4e0"
-                ]
-            ]
-
-            return ZMUpdateEvent(
-                uuid: eventID,
-                payload: payload,
-                transient: false,
-                decrypted: false,
-                source: .pushNotification
-            )!
-        }
-        
-        // Then
-        await assertThrows(expectedError: NotificationServiceError.noAccount) {
-            // When
-            _ = try await self.sut.execute()
-        }
-
-    }
+//    func test_Execute_NewMessageEvent_Content() async throws {
+//        // Given
+//        mockAccessAPIClient.mockFetchAccessToken = {
+//            AccessToken(token: "12345", type: "Bearer", expiresInSeconds: 10)
+//        }
+//
+//        mockNotificationsAPIClient.mockFetchEvent = { eventID in
+//            XCTAssertEqual(eventID, self.eventID)
+//
+//            let payload: [String: Any] = [
+//                "id": "cf51e6b1-39a6-11ed-8005-520924331b82",
+//                "time": "2022-09-21T12:13:32.173Z",
+//                "type": "conversation.otr-message-add",
+//                "payload": [
+//                    "conversation": "c06684dd-2865-4ff8-aef5-e0b07ae3a4e0"
+//                ]
+//            ]
+//
+//            return ZMUpdateEvent(
+//                uuid: eventID,
+//                payload: payload,
+//                transient: false,
+//                decrypted: false,
+//                source: .pushNotification
+//            )!
+//        }
+//        
+//        // Then
+//        await assertThrows(expectedError: NotificationServiceError.noAccount) {
+//            // When
+//            _ = try await self.sut.execute()
+//        }
+//
+//    }
 
     func test_Execute_NotNewMessageEvent_Content() async throws {
         // Given

--- a/Wire-iOS Tests/Notification Service Extension/SimpleNotificationServiceExtension/JobTests.swift
+++ b/Wire-iOS Tests/Notification Service Extension/SimpleNotificationServiceExtension/JobTests.swift
@@ -71,8 +71,6 @@ class JobTests: XCTestCase {
     lazy var dataStack: CoreDataStack = {
         let groupID = Bundle.main.applicationGroupIdentifier!
         let sharedContainerURL = FileManager.sharedContainerDirectory(for: groupID)
-//        let accountManager = AccountManager(sharedDirectory: sharedContainerURL)
-//        let account = accountManager.account(with: userID)!
 
         let account = Account(userName: "", userIdentifier: userID)
         return CoreDataStack(
@@ -123,7 +121,7 @@ class JobTests: XCTestCase {
             _ = try await self.sut.execute()
         }
     }
-    
+
     // TODO: need to mock CoreDataStack to return correct message and check it
 //    func test_Execute_NewMessageEvent_Content() async throws {
 //        // Given

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -10156,7 +10156,6 @@
 					"@executable_path/Frameworks",
 				);
 				ONLY_ACTIVE_ARCH = YES;
-				PROVISIONING_PROFILE_SPECIFIER = "Wire iOS Development Debug";
 			};
 			name = Debug;
 		};

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -10146,6 +10146,7 @@
 					"@executable_path/Frameworks",
 				);
 				ONLY_ACTIVE_ARCH = YES;
+				PROVISIONING_PROFILE_SPECIFIER = "Wire iOS Development Debug";
 			};
 			name = Debug;
 		};

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1154,6 +1154,7 @@
 		D3095762283CEB1C00CEC620 /* MediaShareRestrictionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D309575D283CDFED00CEC620 /* MediaShareRestrictionManager.swift */; };
 		D3095763283CEB2000CEC620 /* SessionFileRestrictionsProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D309575F283CE1E900CEC620 /* SessionFileRestrictionsProtocol.swift */; };
 		D3095764283CEB2000CEC620 /* SessionFileRestrictionsProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D309575F283CE1E900CEC620 /* SessionFileRestrictionsProtocol.swift */; };
+		D315714728E717F70009CCC9 /* EventMessageExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D315714628E717F70009CCC9 /* EventMessageExtractor.swift */; };
 		D337012828996269009C86FD /* ConversationInputBarViewController+DropInteractionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D337012728996269009C86FD /* ConversationInputBarViewController+DropInteractionTests.swift */; };
 		D35EEDBB28C2004000949F02 /* NetworkPrimitives.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE455EA28B2E470005ACD74 /* NetworkPrimitives.swift */; };
 		D35EEDBC28C2004000949F02 /* AccessAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE455E728B2E210005ACD74 /* AccessAPIClient.swift */; };
@@ -3102,6 +3103,7 @@
 		CEEEAF061CB562BF00111759 /* PlaceholderConversationView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaceholderConversationView.swift; sourceTree = "<group>"; };
 		D309575D283CDFED00CEC620 /* MediaShareRestrictionManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaShareRestrictionManager.swift; sourceTree = "<group>"; };
 		D309575F283CE1E900CEC620 /* SessionFileRestrictionsProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionFileRestrictionsProtocol.swift; sourceTree = "<group>"; };
+		D315714628E717F70009CCC9 /* EventMessageExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventMessageExtractor.swift; sourceTree = "<group>"; };
 		D337012728996269009C86FD /* ConversationInputBarViewController+DropInteractionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ConversationInputBarViewController+DropInteractionTests.swift"; sourceTree = "<group>"; };
 		D35EEDC428C2374300949F02 /* NetworkSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkSessionTests.swift; sourceTree = "<group>"; };
 		D35EEDC728C7E68100949F02 /* URLRequestable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLRequestable.swift; sourceTree = "<group>"; };
@@ -6939,6 +6941,7 @@
 				D35EEDC728C7E68100949F02 /* URLRequestable.swift */,
 				D35EEDCA28C7E95F00949F02 /* CookieProvider.swift */,
 				D3E7459128E306D000DA9536 /* EventDecodingProtocol.swift */,
+				D315714628E717F70009CCC9 /* EventMessageExtractor.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -8161,6 +8164,7 @@
 				D3E7459228E306D000DA9536 /* EventDecodingProtocol.swift in Sources */,
 				065A5AE1279B07AC002D4D1E /* NotificationService.swift in Sources */,
 				EEE455E828B2E210005ACD74 /* AccessAPIClient.swift in Sources */,
+				D315714728E717F70009CCC9 /* EventMessageExtractor.swift in Sources */,
 				EEE455E428B2E157005ACD74 /* NetworkSession.swift in Sources */,
 				D35EEDC928C7E68100949F02 /* URLRequestable.swift in Sources */,
 				EE3D7AE428AD4FB500D0A37E /* LegacyNotificationService.swift in Sources */,

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1156,6 +1156,7 @@
 		D3095764283CEB2000CEC620 /* SessionFileRestrictionsProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D309575F283CE1E900CEC620 /* SessionFileRestrictionsProtocol.swift */; };
 		D315714728E717F70009CCC9 /* EventMessageExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D315714628E717F70009CCC9 /* EventMessageExtractor.swift */; };
 		D337012828996269009C86FD /* ConversationInputBarViewController+DropInteractionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D337012728996269009C86FD /* ConversationInputBarViewController+DropInteractionTests.swift */; };
+		D342840428EECF300006BEEB /* EventMessageExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D315714628E717F70009CCC9 /* EventMessageExtractor.swift */; };
 		D35EEDBB28C2004000949F02 /* NetworkPrimitives.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE455EA28B2E470005ACD74 /* NetworkPrimitives.swift */; };
 		D35EEDBC28C2004000949F02 /* AccessAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE455E728B2E210005ACD74 /* AccessAPIClient.swift */; };
 		D35EEDBD28C2004000949F02 /* NotificationsAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE455ED28B2E4CE005ACD74 /* NotificationsAPIClient.swift */; };
@@ -9635,6 +9636,7 @@
 				EF1CB6F522B39CC0004CB458 /* CoreDataFixture.swift in Sources */,
 				EF01D28022B136A9009754B2 /* Data+FingerprintStringTests.swift in Sources */,
 				EE34D6E32433767500F5BD1C /* TeamMetadataRefresherTests.swift in Sources */,
+				D342840428EECF300006BEEB /* EventMessageExtractor.swift in Sources */,
 				EF91A0561FF3A05A00FE2F53 /* GiphySearchViewControllerTests.swift in Sources */,
 				EF2D6D38228C1FB300D8DBF4 /* MockPhotoLibrary.swift in Sources */,
 				EF15A7B620BC34F700A045C7 /* XCTestCase+ImageFromBundle.swift in Sources */,

--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1172,6 +1172,8 @@
 		D38BC97628BF8AA700EB928F /* NotificationServiceError.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE455DF28AFC443005ACD74 /* NotificationServiceError.swift */; };
 		D3C34E6E28C1593C004A1AF1 /* AccessTokenEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C34E6428C14EEE004A1AF1 /* AccessTokenEndpointTests.swift */; };
 		D3C34E7628C1DE4B004A1AF1 /* NotificationByIDEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C34E7528C1DE4B004A1AF1 /* NotificationByIDEndpointTests.swift */; };
+		D3E7459228E306D000DA9536 /* EventDecodingProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E7459128E306D000DA9536 /* EventDecodingProtocol.swift */; };
+		D3E7459328E3100700DA9536 /* EventDecodingProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E7459128E306D000DA9536 /* EventDecodingProtocol.swift */; };
 		D503538C207B5DB900CE34A5 /* UIAlertController+RestorePassword.swift in Sources */ = {isa = PBXBuildFile; fileRef = D503538B207B5DB900CE34A5 /* UIAlertController+RestorePassword.swift */; };
 		D50892FB2056BD51004D3AE2 /* ZMUser+ExpirationTimeFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = D50892FA2056BD51004D3AE2 /* ZMUser+ExpirationTimeFormatting.swift */; };
 		D50892FD2056C2AA004D3AE2 /* WirelessExpirationTimeFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D50892FC2056C2AA004D3AE2 /* WirelessExpirationTimeFormatterTests.swift */; };
@@ -3106,6 +3108,7 @@
 		D35EEDCA28C7E95F00949F02 /* CookieProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CookieProvider.swift; sourceTree = "<group>"; };
 		D3C34E6428C14EEE004A1AF1 /* AccessTokenEndpointTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessTokenEndpointTests.swift; sourceTree = "<group>"; };
 		D3C34E7528C1DE4B004A1AF1 /* NotificationByIDEndpointTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationByIDEndpointTests.swift; sourceTree = "<group>"; };
+		D3E7459128E306D000DA9536 /* EventDecodingProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventDecodingProtocol.swift; sourceTree = "<group>"; };
 		D503538B207B5DB900CE34A5 /* UIAlertController+RestorePassword.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertController+RestorePassword.swift"; sourceTree = "<group>"; };
 		D50892FA2056BD51004D3AE2 /* ZMUser+ExpirationTimeFormatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUser+ExpirationTimeFormatting.swift"; sourceTree = "<group>"; };
 		D50892FC2056C2AA004D3AE2 /* WirelessExpirationTimeFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WirelessExpirationTimeFormatterTests.swift; sourceTree = "<group>"; };
@@ -6935,6 +6938,7 @@
 			children = (
 				D35EEDC728C7E68100949F02 /* URLRequestable.swift */,
 				D35EEDCA28C7E95F00949F02 /* CookieProvider.swift */,
+				D3E7459128E306D000DA9536 /* EventDecodingProtocol.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -8154,6 +8158,7 @@
 				EE7C422728B47CFC00CE018B /* Logger.swift in Sources */,
 				EEE455E028AFC443005ACD74 /* NotificationServiceError.swift in Sources */,
 				EEE455EE28B2E4CE005ACD74 /* NotificationsAPIClient.swift in Sources */,
+				D3E7459228E306D000DA9536 /* EventDecodingProtocol.swift in Sources */,
 				065A5AE1279B07AC002D4D1E /* NotificationService.swift in Sources */,
 				EEE455E828B2E210005ACD74 /* AccessAPIClient.swift in Sources */,
 				EEE455E428B2E157005ACD74 /* NetworkSession.swift in Sources */,
@@ -9403,6 +9408,7 @@
 				EF9C552720D2796A00D94EEB /* EphemeralTimeoutFormatterTests.swift in Sources */,
 				8758CDB92191A7D60031BE0F /* ReplyComposingViewTests.swift in Sources */,
 				EF1C2E4D2254A1E2007E1CAC /* ConversationViewControllerSnapshotTests.swift in Sources */,
+				D3E7459328E3100700DA9536 /* EventDecodingProtocol.swift in Sources */,
 				EE373FAB23FBF44B008C1E52 /* ConversationInputBarViewControllerDelegateTests.swift in Sources */,
 				EE7F466E25B1CFA6001B3EE4 /* AppLockModule.MockRouter.swift in Sources */,
 				87D7E1C520CACA820064C03D /* CallViewControllerTests.swift in Sources */,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1700" title="SQSERVICES-1700" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />SQSERVICES-1700</a>  Refactor NotificationService for possible reuse
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

This pull requests implements Phase 2 and 3 from the [new notification extension plan](https://wearezeta.atlassian.net/wiki/spaces/IOS/pages/647725130/Notification+Service+Extension+2.0).

#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³
