### PR TITLE
fix: Colors in Share View Controller

### DIFF
--- a/Wire-iOS/Sources/Components/ShareViewController/ShareDestinationCell.swift
+++ b/Wire-iOS/Sources/Components/ShareViewController/ShareDestinationCell.swift
@@ -115,7 +115,7 @@ final class ShareDestinationCell<D: ShareDestination>: UITableViewCell {
         [avatarViewContainer, shieldView, guestUserIcon, legalHoldIcon, stackView, titleLabel, checkImageView].prepareForLayout()
 
         titleLabel.backgroundColor = .clear
-        titleLabel.textColor = .white
+        titleLabel.textColor = SemanticColors.Label.textDefault
         titleLabel.font = .normalLightFont
         titleLabel.setContentCompressionResistancePriority(UILayoutPriority.defaultLow, for: .horizontal)
 
@@ -123,7 +123,7 @@ final class ShareDestinationCell<D: ShareDestination>: UITableViewCell {
             stackView.addArrangedSubview($0)
         }
 
-        checkImageView.layer.borderColor = UIColor.white.cgColor
+        checkImageView.layer.borderColor = SemanticColors.Icon.borderCheckMark.cgColor
         checkImageView.layer.borderWidth = 2
         checkImageView.contentMode = .center
         checkImageView.layer.cornerRadius = checkmarkSize / 2.0
@@ -154,6 +154,16 @@ final class ShareDestinationCell<D: ShareDestination>: UITableViewCell {
 
     }
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        guard previousTraitCollection?.userInterfaceStyle != traitCollection.userInterfaceStyle else { return }
+        //  Border colors are not dynamically updating for Dark Mode
+        //  When you use adaptive colors with CALayers you’ll notice that these colors,
+        // are not updating when switching appearance live in the app.
+        // That's why we use the traitCollectionDidChange(_:) method.
+        checkImageView.layer.borderColor = SemanticColors.Icon.borderCheckMark.cgColor
+    }
+
     @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
@@ -162,7 +172,9 @@ final class ShareDestinationCell<D: ShareDestination>: UITableViewCell {
     override func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)
 
-        checkImageView.image = selected ? StyleKitIcon.checkmark.makeImage(size: 12, color: .white) : nil
-        checkImageView.backgroundColor = selected ? .accent() : .clear
+        checkImageView.image = selected ? StyleKitIcon.checkmark.makeImage(size: 12, color: .white).withRenderingMode(.alwaysTemplate) : nil
+        checkImageView.tintColor = selected ? SemanticColors.Icon.foregroundCheckMarkSelected : .clear
+        checkImageView.backgroundColor = selected ? SemanticColors.Icon.backgroundCheckMarkSelected : SemanticColors.Icon.backgroundCheckMark
+        checkImageView.layer.borderColor = selected ? UIColor.clear.cgColor : SemanticColors.Icon.borderCheckMark.cgColor
     }
 }

--- a/Wire-iOS/Sources/Components/ShareViewController/ShareViewController+Views.swift
+++ b/Wire-iOS/Sources/Components/ShareViewController/ShareViewController+Views.swift
@@ -41,14 +41,13 @@ extension ShareViewController {
     }
 
     func createViews() {
-
+        containerView.backgroundColor = SemanticColors.View.backgroundDefault
         createShareablePreview()
-
         self.tokenField.tokenTitleVerticalAdjustment = 1
         self.tokenField.textView.placeholderTextAlignment = .natural
         self.tokenField.textView.accessibilityIdentifier = "textViewSearch"
-        self.tokenField.textView.placeholder = "content.message.forward.to".localized(uppercased: true)
-        self.tokenField.textView.keyboardAppearance = .dark
+        self.tokenField.textView.placeholder = "content.message.forward.to".localized
+        self.tokenField.textView.keyboardAppearance = .default
         self.tokenField.textView.returnKeyType = .done
         self.tokenField.textView.autocorrectionType = .no
         self.tokenField.textView.textContainerInset = UIEdgeInsets(top: 9, left: 40, bottom: 11, right: 40)
@@ -71,15 +70,22 @@ extension ShareViewController {
 
         self.closeButton.accessibilityLabel = "close"
         self.closeButton.setIcon(.cross, size: .tiny, for: .normal)
+        self.closeButton.setIconColor(SemanticColors.Icon.foregroundDefault, for: .normal)
         self.closeButton.addTarget(self, action: #selector(ShareViewController.onCloseButtonPressed(sender:)), for: .touchUpInside)
+
+        let sendButtonIconColor = SemanticColors.Icon.foregroundDefaultWhite
 
         self.sendButton.accessibilityLabel = "send"
         self.sendButton.isEnabled = false
         self.sendButton.setIcon(.send, size: .tiny, for: .normal)
-        self.sendButton.setBackgroundImageColor(UIColor.white, for: .normal)
-        self.sendButton.setBackgroundImageColor(UIColor(white: 0.64, alpha: 1), for: .disabled)
-        self.sendButton.setBorderColor(.clear, for: .normal)
-        self.sendButton.setBorderColor(.clear, for: .disabled)
+        self.sendButton.setBackgroundImageColor(UIColor.accent(), for: .normal)
+        self.sendButton.setBackgroundImageColor(UIColor.accentDarken, for: .highlighted)
+        self.sendButton.setBackgroundImageColor(SemanticColors.Button.backgroundSendDisabled, for: .disabled)
+
+        self.sendButton.setIconColor(sendButtonIconColor, for: .normal)
+        self.sendButton.setIconColor(sendButtonIconColor, for: .highlighted)
+        self.sendButton.setIconColor(sendButtonIconColor, for: .disabled)
+
         self.sendButton.circular = true
         self.sendButton.addTarget(self, action: #selector(ShareViewController.onSendButtonPressed(sender:)), for: .touchUpInside)
 
@@ -95,7 +101,7 @@ extension ShareViewController {
             self.bottomSeparatorLine.isHidden = true
         }
 
-        [self.blurView, self.containerView].forEach(self.view.addSubview)
+        [self.containerView].forEach(self.view.addSubview)
 
         [self.tokenField, self.destinationsTableView, self.closeButton, self.sendButton, self.bottomSeparatorLine, self.topSeparatorView, self.searchIcon, self.clearButton].forEach(self.containerView.addSubview)
 
@@ -112,7 +118,6 @@ extension ShareViewController {
         }
 
         [view,
-         blurView,
          containerView,
          shareablePreviewWrapper,
          shareablePreviewView,
@@ -162,10 +167,6 @@ extension ShareViewController {
         }
 
         NSLayoutConstraint.activate([
-            blurView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            blurView.topAnchor.constraint(equalTo: view.topAnchor),
-            blurView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            blurView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
 
             containerView.topAnchor.constraint(equalTo: view.topAnchor),
             bottomConstraint,

--- a/Wire-iOS/Sources/Components/ShareViewController/ShareViewController.swift
+++ b/Wire-iOS/Sources/Components/ShareViewController/ShareViewController.swift
@@ -34,7 +34,7 @@ protocol Shareable {
     func previewView() -> UIView?
 }
 
-final class ShareViewController<D: ShareDestination & NSObjectProtocol, S: Shareable>: UIViewController, UITableViewDelegate, UITableViewDataSource, UIViewControllerTransitioningDelegate {
+final class ShareViewController<D: ShareDestination & NSObjectProtocol, S: Shareable>: UIViewController, UITableViewDelegate, UITableViewDataSource {
     let destinations: [D]
     let shareable: S
     private(set) var selectedDestinations: Set<D> = Set() {
@@ -78,7 +78,6 @@ final class ShareViewController<D: ShareDestination & NSObjectProtocol, S: Share
         self.showPreview = showPreview
         self.allowsMultipleSelection = allowsMultipleSelection
         super.init(nibName: nil, bundle: nil)
-        transitioningDelegate = self
 
         let messagePreviewAppearance = MessagePreviewView.appearance(whenContainedInInstancesOf: [ShareViewController.self])
         messagePreviewAppearance.colorSchemeVariant = .light
@@ -103,27 +102,22 @@ final class ShareViewController<D: ShareDestination & NSObjectProtocol, S: Share
         fatalError("init(coder:) has not been implemented")
     }
 
-    let blurView = UIVisualEffectView(effect: UIBlurEffect(style: .dark))
     let containerView  = UIView()
     var shareablePreviewView: UIView?
     var shareablePreviewWrapper: UIView?
     let searchIcon = UIImageView()
     let topSeparatorView = OverflowSeparatorView()
     let destinationsTableView = UITableView()
-    let closeButton = IconButton(style: .default, variant: .dark)
-    let sendButton = IconButton(style: .default, variant: .light)
+    let closeButton = IconButton(style: .default)
+    let sendButton = IconButton(style: .default)
 
     let clearButton = IconButton(style: .default)
     let tokenField = TokenField()
     let bottomSeparatorLine: UIView = {
         let view = UIView()
-        view.backgroundColor = UIColor.from(scheme: .separator)
+        view.backgroundColor = SemanticColors.View.backgroundSeparatorCell
         return view
     }()
-
-    override var preferredStatusBarStyle: UIStatusBarStyle {
-        return .lightContent
-    }
 
     // MARK: - Search
 
@@ -218,16 +212,6 @@ final class ShareViewController<D: ShareDestination & NSObjectProtocol, S: Share
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         self.topSeparatorView.scrollViewDidScroll(scrollView: scrollView)
-    }
-
-    // MARK: - UIViewControllerTransitioningDelegate
-
-    func animationController(forPresented presented: UIViewController, presenting: UIViewController, source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
-        return BlurEffectTransition(visualEffectView: blurView, crossfadingViews: [containerView], reverse: false)
-    }
-
-    func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
-        return BlurEffectTransition(visualEffectView: blurView, crossfadingViews: [containerView], reverse: true)
     }
 
     @objc

--- a/Wire-iOS/Sources/Components/ShareViewController/ShareViewController.swift
+++ b/Wire-iOS/Sources/Components/ShareViewController/ShareViewController.swift
@@ -79,12 +79,6 @@ final class ShareViewController<D: ShareDestination & NSObjectProtocol, S: Share
         self.allowsMultipleSelection = allowsMultipleSelection
         super.init(nibName: nil, bundle: nil)
 
-        let messagePreviewAppearance = MessagePreviewView.appearance(whenContainedInInstancesOf: [ShareViewController.self])
-        messagePreviewAppearance.colorSchemeVariant = .light
-
-        let messageThumbnailPreviewAppearance = MessageThumbnailPreviewView.appearance(whenContainedInInstancesOf: [ShareViewController.self])
-        messageThumbnailPreviewAppearance.colorSchemeVariant = .light
-
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(keyboardFrameWillChange(notification:)),
                                                name: UIResponder.keyboardWillChangeFrameNotification,
@@ -118,6 +112,10 @@ final class ShareViewController<D: ShareDestination & NSObjectProtocol, S: Share
         view.backgroundColor = SemanticColors.View.backgroundSeparatorCell
         return view
     }()
+
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return .lightContent
+    }
 
     // MARK: - Search
 

--- a/Wire-iOS/Sources/UserInterface/Components/MessagePreviewView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/MessagePreviewView.swift
@@ -51,7 +51,7 @@ extension UITextView {
         textView.isSelectable = true
 
         textView.backgroundColor = .clear
-        textView.textColor = .from(scheme: .textForeground)
+        textView.textColor = SemanticColors.SearchBar.textInputView
 
         textView.setContentCompressionResistancePriority(.required, for: .vertical)
 
@@ -247,7 +247,7 @@ final class MessagePreviewView: UIView, Themeable {
         if displaySender {
             allViews.append(senderLabel)
             senderLabel.font = .mediumSemiboldFont
-            senderLabel.textColor = .from(scheme: .textForeground, variant: colorSchemeVariant)
+            senderLabel.textColor = SemanticColors.Label.textDefault
             senderLabel.setContentCompressionResistancePriority(.required, for: .vertical)
             senderLabel.isAccessibilityElement = true
             senderLabel.accessibilityIdentifier = "SenderLabel_ReplyPreview"

--- a/Wire-iOS/Sources/UserInterface/Components/MessagePreviewView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/MessagePreviewView.swift
@@ -60,21 +60,15 @@ extension UITextView {
     }
 }
 
-final class MessageThumbnailPreviewView: UIView, Themeable {
+final class MessageThumbnailPreviewView: UIView {
     private let senderLabel = UILabel()
     private let contentTextView = UITextView.previewTextView()
     private let imagePreview = ImageResourceView()
     private var observerToken: Any?
     private let displaySender: Bool
+    private let iconColor = SemanticColors.Icon.foregroundDefault
 
     let message: ZMConversationMessage
-
-    @objc dynamic var colorSchemeVariant: ColorSchemeVariant = ColorScheme.default.variant {
-        didSet {
-            guard oldValue != colorSchemeVariant else { return }
-            applyColorScheme(colorSchemeVariant)
-        }
-    }
 
     init(message: ZMConversationMessage, displaySender: Bool = true) {
         require(message.canBeQuoted || !displaySender)
@@ -150,7 +144,7 @@ final class MessageThumbnailPreviewView: UIView, Themeable {
 
     private func editIcon() -> NSAttributedString {
         if message.updatedAt != nil {
-            return "  " + NSAttributedString(attachment: NSTextAttachment.textAttachment(for: .pencil, with: .from(scheme: .textForeground, variant: colorSchemeVariant), iconSize: 8))
+            return "  " + NSAttributedString(attachment: NSTextAttachment.textAttachment(for: .pencil, with: iconColor, iconSize: 8))
         } else {
             return NSAttributedString()
         }
@@ -159,15 +153,15 @@ final class MessageThumbnailPreviewView: UIView, Themeable {
     private func updateForMessage() {
         typealias MessagePreview = L10n.Localizable.Conversation.InputBar.MessagePreview
         let attributes: [NSAttributedString.Key: Any] = [.font: UIFont.smallSemiboldFont,
-                                                         .foregroundColor: UIColor.from(scheme: .textForeground, variant: colorSchemeVariant)]
+                                                         .foregroundColor: SemanticColors.Label.textDefault]
 
         senderLabel.attributedText = (message.senderName && attributes) + self.editIcon()
         imagePreview.isHidden = !message.canBeShared
 
         if message.isImage {
             let attributes: [NSAttributedString.Key: Any] = [.font: UIFont.smallSemiboldFont,
-                                                             .foregroundColor: UIColor.from(scheme: .textForeground, variant: colorSchemeVariant)]
-            let imageIcon = NSTextAttachment.textAttachment(for: .photo, with: .from(scheme: .textForeground, variant: colorSchemeVariant), verticalCorrection: -1)
+                                                             .foregroundColor: SemanticColors.Label.textDefault]
+            let imageIcon = NSTextAttachment.textAttachment(for: .photo, with: iconColor, verticalCorrection: -1)
             let initialString = NSAttributedString(attachment: imageIcon) + "  " + MessagePreview.image.localizedUppercase
             contentTextView.attributedText = initialString && attributes
 
@@ -175,7 +169,7 @@ final class MessageThumbnailPreviewView: UIView, Themeable {
                 imagePreview.setImageResource(imageResource)
             }
         } else if message.isVideo, let fileMessageData = message.fileMessageData {
-            let imageIcon = NSTextAttachment.textAttachment(for: .camera, with: .from(scheme: .textForeground, variant: colorSchemeVariant), verticalCorrection: -1)
+            let imageIcon = NSTextAttachment.textAttachment(for: .camera, with: iconColor, verticalCorrection: -1)
             let initialString = NSAttributedString(attachment: imageIcon) + "  " + MessagePreview.video.localizedUppercase
             contentTextView.attributedText = initialString && attributes
 
@@ -185,7 +179,9 @@ final class MessageThumbnailPreviewView: UIView, Themeable {
         }
     }
 
-    func applyColorScheme(_ colorSchemeVariant: ColorSchemeVariant) {
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        guard previousTraitCollection?.userInterfaceStyle != traitCollection.userInterfaceStyle else { return }
         updateForMessage()
     }
 
@@ -211,8 +207,7 @@ final class MessagePreviewView: UIView {
     private let contentTextView = UITextView.previewTextView()
     private var observerToken: Any?
     private let displaySender: Bool
-    let iconColor = SemanticColors.Icon.foregroundDefault
-
+    private let iconColor = SemanticColors.Icon.foregroundDefault
 
     let message: ZMConversationMessage
 

--- a/Wire-iOS/Sources/UserInterface/Components/MessagePreviewView.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/MessagePreviewView.swift
@@ -20,6 +20,7 @@ import Foundation
 import UIKit
 import WireDataModel
 import WireSyncEngine
+import WireCommonComponents
 
 extension ZMConversationMessage {
     func replyPreview() -> UIView? {
@@ -102,8 +103,8 @@ final class MessageThumbnailPreviewView: UIView, Themeable {
 
         if displaySender {
             allViews.append(senderLabel)
-            senderLabel.font = .mediumSemiboldFont
-            senderLabel.textColor = .from(scheme: .textForeground, variant: colorSchemeVariant)
+            senderLabel.font = FontSpec.mediumSemiboldFont.font!
+            senderLabel.textColor = SemanticColors.Label.textDefault
             senderLabel.setContentCompressionResistancePriority(.required, for: .vertical)
             senderLabel.isAccessibilityElement = true
             senderLabel.accessibilityIdentifier = "SenderLabel_ReplyPreview"
@@ -115,7 +116,6 @@ final class MessageThumbnailPreviewView: UIView, Themeable {
         imagePreview.layer.cornerRadius = 4
         imagePreview.isAccessibilityElement = true
         imagePreview.accessibilityIdentifier = "ThumbnailImage_ReplyPreview"
-
         allViews.prepareForLayout()
         allViews.forEach(addSubview)
     }
@@ -205,21 +205,16 @@ extension MessageThumbnailPreviewView: ZMMessageObserver {
     }
 }
 
-final class MessagePreviewView: UIView, Themeable {
+final class MessagePreviewView: UIView {
 
     private let senderLabel = UILabel()
     private let contentTextView = UITextView.previewTextView()
     private var observerToken: Any?
     private let displaySender: Bool
+    let iconColor = SemanticColors.Icon.foregroundDefault
+
 
     let message: ZMConversationMessage
-
-    @objc dynamic var colorSchemeVariant: ColorSchemeVariant = ColorScheme.default.variant {
-        didSet {
-            guard oldValue != colorSchemeVariant else { return }
-            applyColorScheme(colorSchemeVariant)
-        }
-    }
 
     init(message: ZMConversationMessage, displaySender: Bool = true) {
         require(message.canBeQuoted || !displaySender)
@@ -243,16 +238,14 @@ final class MessagePreviewView: UIView, Themeable {
 
     private func setupSubviews() {
         var allViews: [UIView] = [contentTextView]
-
         if displaySender {
             allViews.append(senderLabel)
-            senderLabel.font = .mediumSemiboldFont
+            senderLabel.font = FontSpec.mediumSemiboldFont.font!
             senderLabel.textColor = SemanticColors.Label.textDefault
             senderLabel.setContentCompressionResistancePriority(.required, for: .vertical)
             senderLabel.isAccessibilityElement = true
             senderLabel.accessibilityIdentifier = "SenderLabel_ReplyPreview"
         }
-
         allViews.prepareForLayout()
         allViews.forEach(self.addSubview)
     }
@@ -280,37 +273,39 @@ final class MessagePreviewView: UIView, Themeable {
 
     private func editIcon() -> NSAttributedString {
         if message.updatedAt != nil {
-            return "  " + NSAttributedString(attachment: NSTextAttachment.textAttachment(for: .pencil, with: .from(scheme: .textForeground, variant: colorSchemeVariant), iconSize: 8))
+            return "  " + NSAttributedString(attachment: NSTextAttachment.textAttachment(for: .pencil, with: iconColor, iconSize: 8))
         } else {
             return NSAttributedString()
         }
     }
 
     private func updateForMessage() {
-        let attributes: [NSAttributedString.Key: Any] = [.font: UIFont.smallSemiboldFont,
-                                                         .foregroundColor: UIColor.from(scheme: .textForeground, variant: colorSchemeVariant)]
+        let attributes: [NSAttributedString.Key: Any] = [.font: FontSpec.smallSemiboldFont.font!,
+                                                         .foregroundColor: SemanticColors.Label.textDefault]
 
         senderLabel.attributedText = (message.senderName && attributes) + self.editIcon()
 
         if let textMessageData = message.textMessageData {
-            contentTextView.attributedText = NSAttributedString.formatForPreview(message: textMessageData, inputMode: true, variant: colorSchemeVariant)
+            contentTextView.attributedText = NSAttributedString.formatForPreview(message: textMessageData, inputMode: true)
         } else if let location = message.locationMessageData {
 
-            let imageIcon = NSTextAttachment.textAttachment(for: .locationPin, with: .from(scheme: .textForeground, variant: colorSchemeVariant), verticalCorrection: -1)
+            let imageIcon = NSTextAttachment.textAttachment(for: .locationPin, with: iconColor, verticalCorrection: -1)
             let initialString = NSAttributedString(attachment: imageIcon) + "  " + (location.name ?? "conversation.input_bar.message_preview.location".localized).localizedUppercase
             contentTextView.attributedText = initialString && attributes
         } else if message.isAudio {
-            let imageIcon = NSTextAttachment.textAttachment(for: .microphone, with: .from(scheme: .textForeground, variant: colorSchemeVariant), verticalCorrection: -1)
+            let imageIcon = NSTextAttachment.textAttachment(for: .microphone, with: iconColor, verticalCorrection: -1)
             let initialString = NSAttributedString(attachment: imageIcon) + "  " + "conversation.input_bar.message_preview.audio".localized.localizedUppercase
             contentTextView.attributedText = initialString && attributes
         } else if let fileData = message.fileMessageData {
-            let imageIcon = NSTextAttachment.textAttachment(for: .document, with: .from(scheme: .textForeground, variant: colorSchemeVariant), verticalCorrection: -1)
+            let imageIcon = NSTextAttachment.textAttachment(for: .document, with: iconColor, verticalCorrection: -1)
             let initialString = NSAttributedString(attachment: imageIcon) + "  " + (fileData.filename ?? "conversation.input_bar.message_preview.file".localized).localizedUppercase
             contentTextView.attributedText = initialString && attributes
         }
     }
 
-    func applyColorScheme(_ colorSchemeVariant: ColorSchemeVariant) {
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        guard previousTraitCollection?.userInterfaceStyle != traitCollection.userInterfaceStyle else { return }
         updateForMessage()
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/NSAttributedString+MessageFormatting.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/NSAttributedString+MessageFormatting.swift
@@ -102,7 +102,7 @@ extension NSAttributedString {
     }
 
     @objc
-    static func formatForPreview(message: ZMTextMessageData, inputMode: Bool, variant: ColorSchemeVariant = ColorScheme.default.variant) -> NSAttributedString {
+    static func formatForPreview(message: ZMTextMessageData, inputMode: Bool) -> NSAttributedString {
         var plainText = message.messageText ?? ""
 
         // Substitute mentions with text markers
@@ -128,7 +128,7 @@ extension NSAttributedString {
         }
 
         markdownText.removeAttribute(.link, range: NSRange(location: 0, length: markdownText.length))
-        markdownText.addAttribute(.foregroundColor, value: UIColor.from(scheme: .textForeground, variant: variant), range: NSRange(location: 0, length: markdownText.length))
+        markdownText.addAttribute(.foregroundColor, value: SemanticColors.Label.textDefault, range: NSRange(location: 0, length: markdownText.length))
         return markdownText
     }
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+Forward.swift
@@ -125,7 +125,7 @@ extension ZMConversationMessage {
     func previewView() -> UIView? {
         let view = preparePreviewView(shouldDisplaySender: false)
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = .white
+        view.backgroundColor = SemanticColors.View.backgroundUserCell
         return view
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR we fix the colors in ShareViewController as well as removing Color Scheme variant from those two classes.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
