### PR TITLE
fix: Accessibility visibility for Navigation Bar items

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationRootViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationRootViewController.swift
@@ -111,13 +111,13 @@ final class ConversationRootViewController: UIViewController {
         ])
 
         navBarContainer.navigationBar.pushItem(conversationViewController.navigationItem, animated: false)
-        navBarContainer.navigationBar.accessibilityElementsHidden = false
     }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
         shouldAnimateNetworkStatusView = true
+        navBarContainer.navigationBar.accessibilityElementsHidden = false
     }
 
     override func viewDidDisappear(_ animated: Bool) {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Appium does not see locators for items in the navigation bar after user shared the video.
![Wire 2022-10-13 at 11_41 AM](https://user-images.githubusercontent.com/57407805/195595600-d16ce577-d6d7-47bf-824e-2f339fea89b7.png)


### Causes (Optional)

I made accessibility elements hidden in the `viewDidDisappear()` method because those items were available to VoiceOver in the conversation list view.

### Solutions

Make accessibility elements visible after the conversation view appears again.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
