### PR TITLE
fix: Update SelfDeletingMessages button when enabled/disabled SQSERVICES-1752

### DIFF
--- a/Wire-iOS/Sources/Helpers/UIButton+RoundedCorners.swift
+++ b/Wire-iOS/Sources/Helpers/UIButton+RoundedCorners.swift
@@ -27,7 +27,7 @@ extension UIButton {
         case bottom
     }
 
-    func roundCorners(edge: Edge, radius: CGFloat) {
+    func roundCorners(edge: Edge, radius: CGFloat = 0) {
         layer.cornerRadius = radius
         clipsToBounds = true
 

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Ephemeral.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Ephemeral.swift
@@ -140,7 +140,7 @@ extension ConversationInputBarViewController {
 
     func updateViewsForSelfDeletingMessageChanges() {
         updateAccessoryViews()
-
+        updateInputBarButtons()
         inputBar.changeEphemeralState(to: ephemeralState)
 
         if conversation.hasSyncedMessageDestructionTimeout {

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
@@ -321,7 +321,7 @@ final class ConversationInputBarViewController: UIViewController,
 
     // MARK: - Input views handling
 
-    /// init with a InputBarConversationType objcet
+    /// init with a InputBarConversationType object
     /// - Parameter conversation: provide nil only for tests
     init(
         conversation: InputBarConversationType,

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
@@ -35,7 +35,7 @@ final class ConversationInputBarViewController: UIViewController,
 
     let mediaShareRestrictionManager = MediaShareRestrictionManager(sessionRestriction: ZMUserSession.shared())
 
-    // MARK: PopoverPresenter    
+    // MARK: PopoverPresenter
     var presentedPopover: UIPopoverPresentationController?
     var popoverPointToView: UIView?
 
@@ -219,18 +219,32 @@ final class ConversationInputBarViewController: UIViewController,
         switch mediaShareRestrictionManager.level {
 
         case .none:
-            return [
-                hourglassButton,
-                mentionButton,
-                photoButton,
-                sketchButton,
-                gifButton,
-                audioButton,
-                pingButton,
-                uploadFileButton,
-                locationButton,
-                videoButton
-            ]
+            if conversation.isSelfDeletingMessageSendingDisabled {
+                return [
+                    mentionButton,
+                    photoButton,
+                    sketchButton,
+                    gifButton,
+                    audioButton,
+                    pingButton,
+                    uploadFileButton,
+                    locationButton,
+                    videoButton
+                ]
+            } else {
+                return [
+                    hourglassButton,
+                    mentionButton,
+                    photoButton,
+                    sketchButton,
+                    gifButton,
+                    audioButton,
+                    pingButton,
+                    uploadFileButton,
+                    locationButton,
+                    videoButton
+                ]
+            }
         case .securityFlag:
             return [
                 photoButton,
@@ -858,7 +872,7 @@ extension ConversationInputBarViewController: ZMConversationObserver {
         if change.participantsChanged ||
             change.connectionStateChanged ||
             change.allowGuestsChanged {
-            // Sometime participantsChanged is not observed after allowGuestsChanged 
+            // Sometime participantsChanged is not observed after allowGuestsChanged
             updateInputBarVisibility()
             updateClassificationBanner()
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
@@ -660,7 +660,6 @@ final class ConversationInputBarViewController: UIViewController,
     private func giphyButtonPressed(_ sender: Any?) {
         guard !AppDelegate.isOffline,
                 let conversation = conversation as? ZMConversation else { return }
-              let conversation = conversation as? ZMConversation else { return }
 
         let giphySearchViewController = GiphySearchViewController(searchTerm: "", conversation: conversation)
         giphySearchViewController.delegate = self

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
@@ -216,37 +216,22 @@ final class ConversationInputBarViewController: UIViewController,
     private var typingObserverToken: Any?
 
     private var inputBarButtons: [IconButton] {
+        var buttonArray: [IconButton] = []
         switch mediaShareRestrictionManager.level {
-
         case .none:
-            if conversation.isSelfDeletingMessageSendingDisabled {
-                return [
-                    mentionButton,
-                    photoButton,
-                    sketchButton,
-                    gifButton,
-                    audioButton,
-                    pingButton,
-                    uploadFileButton,
-                    locationButton,
-                    videoButton
-                ]
-            } else {
-                return [
-                    hourglassButton,
-                    mentionButton,
-                    photoButton,
-                    sketchButton,
-                    gifButton,
-                    audioButton,
-                    pingButton,
-                    uploadFileButton,
-                    locationButton,
-                    videoButton
-                ]
-            }
+            buttonArray = [
+                mentionButton,
+                photoButton,
+                sketchButton,
+                gifButton,
+                audioButton,
+                pingButton,
+                uploadFileButton,
+                locationButton,
+                videoButton
+            ]
         case .securityFlag:
-            return [
+            buttonArray = [
                 photoButton,
                 mentionButton,
                 sketchButton,
@@ -256,12 +241,17 @@ final class ConversationInputBarViewController: UIViewController,
                 videoButton
             ]
         case .APIFlag:
-            return [
+            buttonArray = [
                 mentionButton,
                 pingButton,
                 locationButton
             ]
         }
+        if !conversation.isSelfDeletingMessageSendingDisabled {
+            buttonArray.insert(hourglassButton, at: buttonArray.startIndex)
+        }
+
+        return buttonArray
     }
 
     var mode: ConversationInputBarViewControllerMode = .textInput {
@@ -496,7 +486,7 @@ final class ConversationInputBarViewController: UIViewController,
     }
 
     func updateRightAccessoryView() {
-       updateEphemeralIndicatorButtonTitle(ephemeralIndicatorButton)
+        updateEphemeralIndicatorButtonTitle(ephemeralIndicatorButton)
 
         let trimmed = inputBar.textView.text.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
 
@@ -542,10 +532,10 @@ final class ConversationInputBarViewController: UIViewController,
 
     func updateAvailabilityPlaceholder() {
         guard ZMUser.selfUser().hasTeam,
-            conversation.conversationType == .oneOnOne,
-            let connectedUser = conversation.connectedUserType else {
-                return
-        }
+              conversation.conversationType == .oneOnOne,
+              let connectedUser = conversation.connectedUserType else {
+                  return
+              }
 
         inputBar.availabilityPlaceholder = AvailabilityStringBuilder.string(for: connectedUser, with: .placeholder, color: inputBar.placeholderColor)
     }
@@ -670,6 +660,7 @@ final class ConversationInputBarViewController: UIViewController,
     private func giphyButtonPressed(_ sender: Any?) {
         guard !AppDelegate.isOffline,
                 let conversation = conversation as? ZMConversation else { return }
+              let conversation = conversation as? ZMConversation else { return }
 
         let giphySearchViewController = GiphySearchViewController(searchTerm: "", conversation: conversation)
         giphySearchViewController.delegate = self

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarButtonsView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarButtonsView.swift
@@ -136,6 +136,7 @@ final class InputBarButtonsView: UIView {
 
         // Drop existing constraints
         buttons.forEach {
+            $0.roundCorners(edge: .trailing)
             $0.removeFromSuperview()
             buttonInnerContainer.addSubview($0)
         }

--- a/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarButtonsView.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarButtonsView.swift
@@ -136,6 +136,7 @@ final class InputBarButtonsView: UIView {
 
         // Drop existing constraints
         buttons.forEach {
+            $0.roundCorners(edge: .leading)
             $0.roundCorners(edge: .trailing)
             $0.removeFromSuperview()
             buttonInnerContainer.addSubview($0)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR we update the input bar buttons when self deleting messages is enabled/disabled. 

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
