### PR TITLE
fix: buttons disappearing in ConversationView Navigation bar because of the length of the title

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
@@ -78,19 +78,19 @@ extension ConversationViewController {
     }
 
     private var audioAndVideoCallButtons: UIView {
-            let buttonStack = UIStackView(arrangedSubviews: [videoCallButton, audioCallButton])
-            buttonStack.distribution = .fillEqually
-            buttonStack.spacing = 0
-            buttonStack.axis = .horizontal
+        let buttonStack = UIStackView(frame: CGRect(x: 0, y: 0, width: 80, height: 32))
+        buttonStack.distribution = .fillEqually
+        buttonStack.spacing = 0
+        buttonStack.axis = .horizontal
 
-            let buttonsView = UIView(frame: CGRect(x: 0, y: 0, width: 80, height: 32))
-            buttonsView.addSubview(buttonStack)
+        buttonStack.addArrangedSubview(videoCallButton)
+        buttonStack.addArrangedSubview(audioCallButton)
 
-            buttonStack.translatesAutoresizingMaskIntoConstraints = false
-            buttonStack.fitIn(view: buttonsView)
+        let buttonsView = UIView(frame: CGRect(x: 0, y: 0, width: 80, height: 32))
+        buttonsView.addSubview(buttonStack)
 
-            return buttonsView
-        }
+        return buttonsView
+    }
 
     var joinCallButton: UIBarButtonItem {
         let button = IconButton(fontSpec: .smallSemiboldFont)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR we fix the issue that popped up where the icons will disappear if the title conversation is a long one.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
