### PR TITLE
fix: Border color for `Audio`, `Video` and `Search` buttons in `ConversationView` (Dark Mode)

### DIFF
--- a/Wire-iOS/Sources/Helpers/SemanticColors.swift
+++ b/Wire-iOS/Sources/Helpers/SemanticColors.swift
@@ -138,7 +138,7 @@ public enum SemanticColors {
         static let textEmptyEnabled = UIColor(light: Asset.black, dark: Asset.white)
         static let textBottomBarNormal = UIColor(light: Asset.gray90, dark: Asset.gray50)
         static let textBottomBarSelected = UIColor(light: Asset.white, dark: Asset.black)
-        static let borderBarItem = UIColor(light: Asset.gray40, dark: Asset.gray90)
+        static let borderBarItem = UIColor(light: Asset.gray40, dark: Asset.gray100)
         static let backgroundLikeEnabled = UIColor(light: Asset.gray70, dark: Asset.gray60)
         static let backgroundLikeHighlighted = UIColor(light: Asset.red500Light, dark: Asset.red500Dark)
         static let backgroundSendDisabled = UIColor(light: Asset.gray70, dark: Asset.gray70)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR we replace `Asset.gray90` with `Asset.gray100` for the border color of the Audio, Video and Search Buttons in conversation View.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
