### PR TITLE
fix: callSelfParticipantView bugs- ACC-143

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingBottomSheetViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingBottomSheetViewController.swift
@@ -51,7 +51,7 @@ class CallingBottomSheetViewController: BottomSheetContainerViewController {
         super.init(contentViewController: visibleVoiceChannelViewController, bottomSheetViewController: callingActionsInfoViewController, bottomSheetConfiguration: .init(height: bottomSheetMaxHeight, initialOffset: bottomSheetInitialOffset))
 
         callingActionsInfoViewController.actionsDelegate = visibleVoiceChannelViewController
-        visibleVoiceChannelViewController.configurationObserver = self
+        visibleVoiceChannelViewController.configurationObserver = callingActionsInfoViewController
         participantsObserverToken = voiceChannel.addParticipantObserver(self)
         visibleVoiceChannelViewController.delegate = self
 
@@ -122,19 +122,6 @@ class CallingBottomSheetViewController: BottomSheetContainerViewController {
         }
         visibleVoiceChannelViewController = CallViewController(voiceChannel: voiceChannel, selfUser: ZMUser.selfUser())
         visibleVoiceChannelViewController.delegate = self
-    }
-}
-
-extension CallingBottomSheetViewController: CallInfoConfigurationObserver {
-    func didUpdateConfiguration(configuration: CallInfoConfiguration) {
-        callingActionsInfoViewController.didUpdateConfiguration(configuration: configuration)
-        visibleVoiceChannelViewController.view.layoutSubviews()
-        guard let navigationBar  = self.navigationController?.navigationBar else { return }
-        navigationBar.tintColor = UIColor.from(scheme: .textForeground, variant: configuration.effectiveColorVariant)
-        navigationBar.isTranslucent = true
-        navigationBar.barTintColor = .clear
-        navigationBar.setBackgroundImage(UIImage.singlePixelImage(with: .clear), for: .default)
-
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingBottomSheetViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingBottomSheetViewController.swift
@@ -51,7 +51,7 @@ class CallingBottomSheetViewController: BottomSheetContainerViewController {
         super.init(contentViewController: visibleVoiceChannelViewController, bottomSheetViewController: callingActionsInfoViewController, bottomSheetConfiguration: .init(height: bottomSheetMaxHeight, initialOffset: bottomSheetInitialOffset))
 
         callingActionsInfoViewController.actionsDelegate = visibleVoiceChannelViewController
-        visibleVoiceChannelViewController.configurationObserver = callingActionsInfoViewController
+        visibleVoiceChannelViewController.configurationObserver = self
         participantsObserverToken = voiceChannel.addParticipantObserver(self)
         visibleVoiceChannelViewController.delegate = self
 
@@ -123,7 +123,19 @@ class CallingBottomSheetViewController: BottomSheetContainerViewController {
         visibleVoiceChannelViewController = CallViewController(voiceChannel: voiceChannel, selfUser: ZMUser.selfUser())
         visibleVoiceChannelViewController.delegate = self
     }
+}
 
+extension CallingBottomSheetViewController: CallInfoConfigurationObserver {
+    func didUpdateConfiguration(configuration: CallInfoConfiguration) {
+        callingActionsInfoViewController.didUpdateConfiguration(configuration: configuration)
+        visibleVoiceChannelViewController.view.layoutSubviews()
+        guard let navigationBar  = self.navigationController?.navigationBar else { return }
+        navigationBar.tintColor = UIColor.from(scheme: .textForeground, variant: configuration.effectiveColorVariant)
+        navigationBar.isTranslucent = true
+        navigationBar.barTintColor = .clear
+        navigationBar.setBackgroundImage(UIImage.singlePixelImage(with: .clear), for: .default)
+
+    }
 }
 
 extension CallingBottomSheetViewController: WireCallCenterCallParticipantObserver {
@@ -133,7 +145,7 @@ extension CallingBottomSheetViewController: WireCallCenterCallParticipantObserve
 }
 
 extension CallingBottomSheetViewController: WireCallCenterCallStateObserver {
-
+    // TODO: needed?
     func callCenterDidChange(callState: CallState, conversation: ZMConversation, caller: UserType, timestamp: Date?, previousCallState: CallState?) {
         updateVisibleVoiceChannelViewController()
     }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallParticipantViews/BaseCallParticipantView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallParticipantViews/BaseCallParticipantView.swift
@@ -126,6 +126,9 @@ class BaseCallParticipantView: OrientableView, AVSIdentifierProvider {
         avatarView.user = stream.user
         avatarView.userSession = userSession
         userDetailsView.alpha = DeveloperFlag.updatedCallingUI.isOn ? 1 : 0
+        guard DeveloperFlag.updatedCallingUI.isOn else { return }
+        layer.cornerRadius = 6
+        layer.masksToBounds = true
     }
 
     func createConstraints() {
@@ -202,7 +205,7 @@ class BaseCallParticipantView: OrientableView, AVSIdentifierProvider {
         let showBorderForActiveSpeaker = shouldShowActiveSpeakerFrame && stream.isParticipantUnmutedAndSpeakingNow
         let showBorderForAudioParticipant = shouldShowBorderWhenVideoIsStopped && !stream.isSharingVideo
 
-        layer.borderWidth = (showBorderForActiveSpeaker || showBorderForAudioParticipant) && !isMaximized ? 1 : 0
+        layer.borderWidth = (showBorderForActiveSpeaker || showBorderForAudioParticipant) && !isMaximized ? 2 : 0
         layer.borderColor = showBorderForActiveSpeaker ? UIColor.accent().cgColor : UIColor.black.cgColor
     }
 

--- a/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallParticipantViews/BaseCallParticipantView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallParticipantViews/BaseCallParticipantView.swift
@@ -205,7 +205,8 @@ class BaseCallParticipantView: OrientableView, AVSIdentifierProvider {
         let showBorderForActiveSpeaker = shouldShowActiveSpeakerFrame && stream.isParticipantUnmutedAndSpeakingNow
         let showBorderForAudioParticipant = shouldShowBorderWhenVideoIsStopped && !stream.isSharingVideo
 
-        layer.borderWidth = (showBorderForActiveSpeaker || showBorderForAudioParticipant) && !isMaximized ? 2 : 0
+        let borderWidth = DeveloperFlag.updatedCallingUI.isOn ? 2.0 : 1.0
+        layer.borderWidth = (showBorderForActiveSpeaker || showBorderForAudioParticipant) && !isMaximized ? borderWidth : 0
         layer.borderColor = showBorderForActiveSpeaker ? UIColor.accent().cgColor : UIColor.black.cgColor
     }
 

--- a/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallParticipantViews/CallParticipantDetailView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallParticipantViews/CallParticipantDetailView.swift
@@ -33,12 +33,13 @@ final class CallParticipantDetailsView: RoundedBlurView {
 
     private let labelContainerView = UIView()
     private let microphoneImageView = UIImageView()
+    private var microphoneWidth: NSLayoutConstraint!
 
     var microphoneIconStyle: MicrophoneIconStyle = .hidden {
         didSet {
             microphoneIconView.set(style: microphoneIconStyle)
             guard DeveloperFlag.updatedCallingUI.isOn else { return }
-            microphoneImageView.isHidden = true
+            makeMicrophone(hidden: true)
             labelContainerView.backgroundColor = .black
             nameLabel.textColor = .white
 
@@ -47,7 +48,7 @@ final class CallParticipantDetailsView: RoundedBlurView {
                 labelContainerView.backgroundColor = UIColor.accent()
                 nameLabel.textColor = SemanticColors.Label.textDefaultWhite
             case .muted:
-                microphoneImageView.isHidden = false
+                makeMicrophone(hidden: false)
             case .unmuted, .hidden:
                 break
             }
@@ -63,14 +64,13 @@ final class CallParticipantDetailsView: RoundedBlurView {
 
     override func setupViews() {
         super.setupViews()
-        setCornerRadius(12)
-
         if DeveloperFlag.updatedCallingUI.isOn {
             [microphoneImageView, labelContainerView].forEach {
                 $0.translatesAutoresizingMaskIntoConstraints = false
                 addSubview($0)
             }
             nameLabel.translatesAutoresizingMaskIntoConstraints = false
+            nameLabel.lineBreakMode = .byTruncatingTail
             labelContainerView.addSubview(nameLabel)
             labelContainerView.backgroundColor = .black
             labelContainerView.layer.cornerRadius = 3.0
@@ -83,6 +83,7 @@ final class CallParticipantDetailsView: RoundedBlurView {
             microphoneImageView.layer.masksToBounds = true
             blurView.alpha = 0
         } else {
+            setCornerRadius(12)
             microphoneIconView.set(size: .tiny, color: .white)
             [microphoneIconView, nameLabel].forEach {
                 $0.translatesAutoresizingMaskIntoConstraints = false
@@ -108,15 +109,24 @@ final class CallParticipantDetailsView: RoundedBlurView {
             microphoneIconView.heightAnchor.constraint(equalToConstant: 16)
         ])
     }
+
+    private func makeMicrophone(hidden: Bool) {
+            self.microphoneWidth.constant = hidden ? 0 : 22
+            self.setNeedsDisplay()
+    }
+
     private func createUpdatedUIContraints() {
+        labelContainerView.setContentCompressionResistancePriority(.required, for: .horizontal)
+        microphoneWidth = microphoneImageView.widthAnchor.constraint(equalToConstant: 22)
         NSLayoutConstraint.activate([
+            labelContainerView.centerXAnchor.constraint(equalTo: centerXAnchor).withPriority(.defaultLow),
             labelContainerView.centerYAnchor.constraint(equalTo: centerYAnchor),
-            labelContainerView.leadingAnchor.constraint(greaterThanOrEqualTo: microphoneImageView.trailingAnchor, constant: 4),
-            labelContainerView.centerXAnchor.constraint(equalTo: centerXAnchor),
+            labelContainerView.leadingAnchor.constraint(greaterThanOrEqualTo: microphoneImageView.trailingAnchor, constant: 2.0),
+            labelContainerView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor),
             microphoneImageView.centerYAnchor.constraint(equalTo: centerYAnchor),
-            microphoneImageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 6),
-            microphoneImageView.widthAnchor.constraint(equalToConstant: 22),
-            microphoneImageView.heightAnchor.constraint(equalToConstant: 22)
+            microphoneImageView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            microphoneImageView.heightAnchor.constraint(equalToConstant: 22),
+            microphoneWidth
         ])
         NSLayoutConstraint.activate(
             NSLayoutConstraint.forView(view: nameLabel,

--- a/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallParticipantViews/CallParticipantDetailView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallParticipantViews/CallParticipantDetailView.swift
@@ -70,7 +70,6 @@ final class CallParticipantDetailsView: RoundedBlurView {
                 addSubview($0)
             }
             nameLabel.translatesAutoresizingMaskIntoConstraints = false
-            nameLabel.lineBreakMode = .byTruncatingTail
             labelContainerView.addSubview(nameLabel)
             labelContainerView.backgroundColor = .black
             labelContainerView.layer.cornerRadius = 3.0

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoRootViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoRootViewController.swift
@@ -47,7 +47,7 @@ final class CallInfoRootViewController: UIViewController, UINavigationController
     var configuration: CallInfoViewControllerInput {
         didSet {
             guard !configuration.isEqual(toConfiguration: oldValue) else { return }
-            updateConfiguration(animated: true) //PPPPPPPP
+            updateConfiguration(animated: true)
         }
     }
 

--- a/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoRootViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/CallInfoRootViewController.swift
@@ -47,7 +47,7 @@ final class CallInfoRootViewController: UIViewController, UINavigationController
     var configuration: CallInfoViewControllerInput {
         didSet {
             guard !configuration.isEqual(toConfiguration: oldValue) else { return }
-            updateConfiguration(animated: true)
+            updateConfiguration(animated: true) //PPPPPPPP
         }
     }
 

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallGridConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallGridConfiguration.swift
@@ -17,6 +17,7 @@
 //
 
 import WireSyncEngine
+import WireCommonComponents
 
 struct CallGridConfiguration: CallGridViewControllerInput, Equatable {
 
@@ -192,6 +193,7 @@ extension VoiceChannel {
     }
 
     fileprivate var shouldShowActiveSpeakerFrame: Bool {
+        if DeveloperFlag.updatedCallingUI.isOn { return true }
         return connectedParticipants.count > 2 && videoGridPresentationMode == .allVideoStreams
     }
 

--- a/Wire-iOS/Sources/UserInterface/Calling/Thumbnail/PinnableThumbnailViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/Thumbnail/PinnableThumbnailViewController.swift
@@ -58,6 +58,7 @@ final class PinnableThumbnailViewController: UIViewController {
 
         self.thumbnailContentSize = contentSize
         updateThumbnailFrame(animated: false, parentSize: thumbnailContainerView.frame.size)
+        pinningBehavior.updateFields(in: thumbnailContainerView.bounds)
     }
 
     func updateThumbnailContentSize(_ newSize: CGSize, animated: Bool) {

--- a/Wire-iOS/Sources/UserInterface/Calling/Thumbnail/PinnableThumbnailViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/Thumbnail/PinnableThumbnailViewController.swift
@@ -17,6 +17,7 @@
 //
 
 import UIKit
+import WireCommonComponents
 
 final class PinnableThumbnailViewController: UIViewController {
 
@@ -109,7 +110,8 @@ final class PinnableThumbnailViewController: UIViewController {
         thumbnailContainerView.addSubview(thumbnailView)
         thumbnailView.autoresizingMask = []
         thumbnailView.clipsToBounds = true
-        thumbnailView.shape = .rounded(radius: 12)
+        let cornerRadius = DeveloperFlag.updatedCallingUI.isOn ? 6.0 : 12.0
+        thumbnailView.shape = .rounded(radius: cornerRadius)
 
         thumbnailContainerView.layer.shadowRadius = 30
         thumbnailContainerView.layer.shadowOpacity = 0.32


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-143" title="ACC-143" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />ACC-143</a>  Context change on focus (3.2.1)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
