### PR TITLE
fix: Typos in Accessibility.strings

### DIFF
--- a/Wire-iOS/Generated/Strings+Generated.swift
+++ b/Wire-iOS/Generated/Strings+Generated.swift
@@ -430,10 +430,10 @@ internal enum L10n {
         /// Double tab to open all
         internal static let hint = L10n.tr("Accessibility", "conversationSearch.section.hint")
       }
-      internal enum SendBy {
-        /// Send by %@
+      internal enum SentBy {
+        /// Sent by %@
         internal static func description(_ p1: Any) -> String {
-          return L10n.tr("Accessibility", "conversationSearch.sendBy.description", String(describing: p1))
+          return L10n.tr("Accessibility", "conversationSearch.sentBy.description", String(describing: p1))
         }
       }
       internal enum VideoMessage {

--- a/Wire-iOS/Resources/Base.lproj/Accessibility.strings
+++ b/Wire-iOS/Resources/Base.lproj/Accessibility.strings
@@ -66,13 +66,13 @@
 "conversationSearch.filesSection.description" = "Files in this conversation";
 "conversationSearch.videosSection.description" = "Videos in this conversation";
 "conversationSearch.linksSection.description" = "Links in this conversation";
-"conversationSearch.section.hint" = "Double tab to open all";
+"conversationSearch.section.hint" = "Double tap to open all";
 "conversationSearch.emptyResult.description" = "No results";
 "conversationSearch.noItems.description" = "No items in collection";
 "conversationSearch.imageMessage.description" = "Image";
 "conversationSearch.videoMessage.description" = "Video";
 "conversationSearch.audioMessage.description" = "Audio";
-"conversationSearch.sendBy.description" = "Send by %@";
+"conversationSearch.sendBy.description" = "Sent by %@";
 "conversationSearch.fileName.description" = "File name";
 "conversationSearch.fileSize.description" = "Size";
 "conversationSearch.fileType.description" = "Type";

--- a/Wire-iOS/Resources/Base.lproj/Accessibility.strings
+++ b/Wire-iOS/Resources/Base.lproj/Accessibility.strings
@@ -72,7 +72,7 @@
 "conversationSearch.imageMessage.description" = "Image";
 "conversationSearch.videoMessage.description" = "Video";
 "conversationSearch.audioMessage.description" = "Audio";
-"conversationSearch.sendBy.description" = "Sent by %@";
+"conversationSearch.sentBy.description" = "Sent by %@";
 "conversationSearch.fileName.description" = "File name";
 "conversationSearch.fileSize.description" = "Size";
 "conversationSearch.fileType.description" = "Type";

--- a/Wire-iOS/Sources/UserInterface/Collections/CollectionAudioCell.swift
+++ b/Wire-iOS/Sources/UserInterface/Collections/CollectionAudioCell.swift
@@ -55,7 +55,7 @@ final class CollectionAudioCell: CollectionCell {
             restrictionView.configure()
         }
 
-        accessibilityLabel = ConversationSearch.SendBy.description(message.senderName)
+        accessibilityLabel = ConversationSearch.SentBy.description(message.senderName)
                             + ", \(message.serverTimestamp?.formattedDate ?? ""), "
                             + ConversationSearch.AudioMessage.description
         accessibilityHint = ConversationSearch.ItemPlay.hint


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR we fix two typos in `Accessibility.strings`

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
