### PR TITLE
feat: add option force disable CallKit via build time flag FS-1321

### DIFF
--- a/Wire-iOS Tests/MessageReplyPreviewViewTests.swift
+++ b/Wire-iOS Tests/MessageReplyPreviewViewTests.swift
@@ -33,7 +33,7 @@ extension UIView {
     }
 }
 
-final class MessageReplyPreviewViewTests: XCTestCase {
+final class MessageReplyPreviewViewTests: ZMSnapshotTestCase {
     override func setUp() {
         super.setUp()
     }

--- a/Wire-iOS/Sources/Helpers/Bundle+SecurityFlags.swift
+++ b/Wire-iOS/Sources/Helpers/Bundle+SecurityFlags.swift
@@ -26,6 +26,7 @@ enum SecurityFlags {
     case backup
     case maxNumberAccounts
     case fileSharing
+    case forceCallKitDisabled
 
     /// Whether encryption at rest is enabled and can't be disabled.
 
@@ -49,6 +50,8 @@ enum SecurityFlags {
             return "ForceEncryptionAtRestEnabled"
         case .fileSharing:
             return "FileSharingEnabled"
+        case .forceCallKitDisabled:
+            return "ForceCallKitDisabled"
         }
     }
 

--- a/Wire-iOS/Sources/Helpers/syncengine/SessionManager+Convenience.swift
+++ b/Wire-iOS/Sources/Helpers/syncengine/SessionManager+Convenience.swift
@@ -51,7 +51,8 @@ extension SessionManager {
     }
 
     func updateCallNotificationStyleFromSettings() {
-        let isCallKitEnabled: Bool = !(Settings.shared[.disableCallKit] ?? false)
+        let isCallKitDisabled = Settings.shared[.disableCallKit] == true || SecurityFlags.forceCallKitDisabled.isEnabled
+        let isCallKitEnabled = !isCallKitDisabled
         let hasAudioPermissions = AVCaptureDevice.authorizationStatus(for: AVMediaType.audio) == AVAuthorizationStatus.authorized
         let isCallKitSupported = !UIDevice.isSimulator
 

--- a/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Options.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Options.swift
@@ -125,7 +125,7 @@ extension SettingsCellDescriptorFactory {
             cellDescriptors: [callKitToggle],
             header: "self.settings.callkit.title".localized,
             footer: "self.settings.callkit.description".localized,
-            visibilityAction: .none
+            visibilityAction: { _ in !SecurityFlags.forceCallKitDisabled.isEnabled }
         )
     }
 
@@ -135,8 +135,14 @@ extension SettingsCellDescriptorFactory {
             inverse: false
         )
 
+        // FIXME: Headers
+        // The header of the CallKit section is used as a generic "Calls" section header, not
+        // only for the CallKit toggle but also for the other call settings. The CallKit toggle
+        // is sometimes hidden, which means if it is, we need to add the header to the next section.
+
         return SettingsSectionDescriptor(
             cellDescriptors: [muteCallToggle],
+            header: SecurityFlags.forceCallKitDisabled.isEnabled ? L10n.Localizable.Self.Settings.Callkit.title : .none,
             footer: L10n.Localizable.Self.Settings.MuteOtherCall.description,
             visibilityAction: .none
         )

--- a/Wire-iOS/Wire-Info.plist
+++ b/Wire-iOS/Wire-Info.plist
@@ -78,6 +78,8 @@
 	<string>${MAX_NUMBER_ACCOUNTS}</string>
 	<key>FileSharingEnabled</key>
 	<string>${FILE_SHARING_ENABLED}</string>
+	<key>ForceCallKitDisabled</key>
+	<string>${FORCE_CALLKIT_DISABLED}</string>
 	<key>CountlyAppKey</key>
 	<string>$(COUNTLY_APP_KEY)</string>
 	<key>CountlyHost</key>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1321" title="FS-1321" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />FS-1321</a>  [iOS] Create Bund build with CallKit force disabled
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Add an option to force disable CallKit via a build time flag. The default is CallKit is not disabled.
- If disabled, then the setting in user options is hidden, and the session manager is configure appropriately to disable CallKit.


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
