### PR TITLE
fix: Spacing issue between markdown buttons in Conversation View ACC - 333

### DIFF
--- a/Wire-iOS/Sources/UserInterface/MarkdownBarView.swift
+++ b/Wire-iOS/Sources/UserInterface/MarkdownBarView.swift
@@ -71,7 +71,7 @@ final class MarkdownBarView: UIView {
     private func setupViews() {
 
         stackView.axis = .horizontal
-        stackView.distribution = .equalSpacing
+         stackView.distribution = .fillEqually
         stackView.alignment = .center
         stackView.layoutMargins = UIEdgeInsets(top: 0, left: buttonMargin, bottom: 0, right: buttonMargin)
         stackView.isLayoutMarginsRelativeArrangement = true
@@ -113,12 +113,22 @@ final class MarkdownBarView: UIView {
 
         addSubview(stackView)
 
+         let buttonMaxWidth = 100
+         let stackViewMaxWidth = CGFloat(buttonMaxWidth * buttons.count)
+
+         let stackViewWidth = stackView.widthAnchor.constraint(lessThanOrEqualToConstant: stackViewMaxWidth)
+         stackViewWidth.priority = .defaultHigh
+
+         let stackViewTrailingConstraint = stackView.trailingAnchor.constraint(equalTo: trailingAnchor)
+         stackViewTrailingConstraint.priority = .defaultLow
+
         stackView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
           stackView.topAnchor.constraint(equalTo: topAnchor),
           stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
-          stackView.leftAnchor.constraint(equalTo: leftAnchor),
-          stackView.rightAnchor.constraint(equalTo: rightAnchor)
+          stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+          stackViewWidth,
+          stackViewTrailingConstraint
         ])
 
         headerButton.itemIcons = [.markdownH1, .markdownH2, .markdownH3]


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR we fix the spacing issue between the markdown buttons in Conversation View. The spacing was way too big and occurred on devices such as the iPad, and phones like the iPhone Pro Max etc.

----

##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
