### PR TITLE
chore: Update string for `participants.services.remove_integration.button`

### DIFF
--- a/Wire-iOS/Generated/Strings+Generated.swift
+++ b/Wire-iOS/Generated/Strings+Generated.swift
@@ -3600,8 +3600,8 @@ internal enum L10n {
       }
       internal enum Services {
         internal enum RemoveIntegration {
-          /// Remove integration
-          internal static let button = L10n.tr("Localizable", "participants.services.remove_integration.button", fallback: "Remove integration")
+          /// Remove service
+          internal static let button = L10n.tr("Localizable", "participants.services.remove_integration.button", fallback: "Remove service")
         }
       }
     }

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -905,7 +905,7 @@
 "device.type.unknown" = "Unknown";
 
 // Bot
-"participants.services.remove_integration.button" = "Remove integration";
+"participants.services.remove_integration.button" = "Remove service";
 
 // Group details
 "group_details.guest_options_cell.title" = "Guests";

--- a/Wire-iOS/Sources/UserInterface/Services/ServiceDetailViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Services/ServiceDetailViewController.swift
@@ -215,16 +215,22 @@ final class ServiceDetailViewController: UIViewController {
 
 fileprivate extension Button {
 
+    typealias PeoplePickerServices = L10n.Localizable.Peoplepicker.Services
+
     static func openServiceConversationButton() -> Button {
-        return Button(style: .accentColorTextButtonStyle, title: "peoplepicker.services.open_conversation.item".localized)
+        return Button(style: .accentColorTextButtonStyle,
+                      title: PeoplePickerServices.OpenConversation.item.capitalized)
     }
 
     static func createAddServiceButton() -> Button {
-        return Button(style: .accentColorTextButtonStyle, title: "peoplepicker.services.add_service.button".localized)
+        return Button(style: .accentColorTextButtonStyle,
+                      title: PeoplePickerServices.AddService.button.capitalized)
     }
 
     static func createDestructiveServiceButton() -> Button {
-        let button = Button(style: .accentColorTextButtonStyle, title: "participants.services.remove_integration.button".localized)
+        let button = Button(style: .accentColorTextButtonStyle,
+                            title: L10n.Localizable.Participants.Services.RemoveIntegration.button.capitalized)
+
         return button
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR we update the string for `participants.services.remove_integration.button` from `Remove integration` to `Remove service`

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
