### PR TITLE
fix: Background color of Canvas - ACC - 306

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Sketchpad/CanvasViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Sketchpad/CanvasViewController.swift
@@ -74,7 +74,7 @@ final class CanvasViewController: UIViewController, UINavigationControllerDelega
         super.viewDidLoad()
 
         canvas.delegate = self
-        canvas.backgroundColor = SemanticColors.View.backgroundDefaultWhite
+        canvas.backgroundColor = .white
         canvas.isAccessibilityElement = true
         canvas.accessibilityIdentifier = "canvas"
 
@@ -88,7 +88,7 @@ final class CanvasViewController: UIViewController, UINavigationControllerDelega
         hintLabel.font = FontSpec.normalRegularFont.font
         hintLabel.textAlignment = .center
         hintLabel.textColor = SemanticColors.Label.textSettingsPasswordPlaceholder
-        self.view.backgroundColor = SemanticColors.View.backgroundDefaultWhite
+        self.view.backgroundColor = .white
 
         [canvas, hintLabel, hintImageView, toolbar].forEach(view.addSubview)
 


### PR DESCRIPTION
We need to set it to white on light and dark mode

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR we fix the background color of the canvas to be white in both light and dark mode.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
