### PR TITLE
chore: Add 'updatedCallingUI' key to the QA automation helper ACC-143

### DIFF
--- a/Wire-iOS Tests/Calling/CallGridViewControllerSnapshotTests.swift
+++ b/Wire-iOS Tests/Calling/CallGridViewControllerSnapshotTests.swift
@@ -36,6 +36,8 @@ struct MockCallGridViewControllerInput: CallGridViewControllerInput, Equatable {
     var presentationMode: VideoGridPresentationMode = .allVideoStreams
 
     var callHasTwoParticipants: Bool = false
+
+    var isConnected: Bool = false
 }
 
 final class CallGridViewControllerSnapshotTests: ZMSnapshotTestCase {

--- a/Wire-iOS Tests/Calling/CallGridViewControllerSnapshotTests.swift
+++ b/Wire-iOS Tests/Calling/CallGridViewControllerSnapshotTests.swift
@@ -73,7 +73,7 @@ final class CallGridViewControllerSnapshotTests: ZMSnapshotTestCase {
         )
 
         CallingConfiguration.config = .largeConferenceCalls
-        UserDefaults.applicationGroup.set(false, forKey: DeveloperFlag.updatedCallingUI.rawValue)
+        UserDefaults.applicationGroup.set(true, forKey: DeveloperFlag.deprecatedCallingUI.rawValue)
     }
 
     override func tearDown() {

--- a/Wire-iOS Tests/Calling/CallInfoRootViewControllerSnapshotTests.swift
+++ b/Wire-iOS Tests/Calling/CallInfoRootViewControllerSnapshotTests.swift
@@ -25,7 +25,7 @@ final class CallInfoViewControllerSnapshotTests: ZMSnapshotTestCase {
     override func setUp() {
         super.setUp()
         CallingConfiguration.config = .largeConferenceCalls
-        UserDefaults.applicationGroup.set(false, forKey: DeveloperFlag.updatedCallingUI.rawValue)
+        UserDefaults.applicationGroup.set(true, forKey: DeveloperFlag.deprecatedCallingUI.rawValue)
     }
 
     override func tearDown() {

--- a/Wire-iOS Tests/Calling/CallInfoRootViewControllerTests.swift
+++ b/Wire-iOS Tests/Calling/CallInfoRootViewControllerTests.swift
@@ -37,7 +37,7 @@ final class CallInfoRootViewControllerTests: ZMSnapshotTestCase {
         mockUsers = SwiftMockLoader.mockUsers()
         defaultFixture = CallInfoTestFixture(otherUser: mockOtherUser, selfUser: mockSelfUser, mockUsers: mockUsers)
         CallingConfiguration.config = .largeConferenceCalls
-        UserDefaults.applicationGroup.set(false, forKey: DeveloperFlag.updatedCallingUI.rawValue)
+        UserDefaults.applicationGroup.set(true, forKey: DeveloperFlag.deprecatedCallingUI.rawValue)
     }
 
     override func tearDown() {

--- a/Wire-iOS Tests/Calling/CallParticipantsListViewControllerTests.swift
+++ b/Wire-iOS Tests/Calling/CallParticipantsListViewControllerTests.swift
@@ -49,7 +49,7 @@ final class CallParticipantsListViewControllerTests: ZMSnapshotTestCase {
     override func setUp() {
         super.setUp()
         mockParticipants = CallParticipantsListHelper.participants(count: 10, mockUsers: SwiftMockLoader.mockUsers())
-        UserDefaults.applicationGroup.set(false, forKey: DeveloperFlag.updatedCallingUI.rawValue)
+        UserDefaults.applicationGroup.set(true, forKey: DeveloperFlag.deprecatedCallingUI.rawValue)
     }
 
     override func tearDown() {

--- a/Wire-iOS Tests/IconLabelButtonTests.swift
+++ b/Wire-iOS Tests/IconLabelButtonTests.swift
@@ -30,7 +30,7 @@ final class IconLabelButtonTests: ZMSnapshotTestCase {
         button.translatesAutoresizingMaskIntoConstraints = false
         button.setNeedsLayout()
         button.layoutIfNeeded()
-        UserDefaults.applicationGroup.set(false, forKey: DeveloperFlag.updatedCallingUI.rawValue)
+        UserDefaults.applicationGroup.set(true, forKey: DeveloperFlag.deprecatedCallingUI.rawValue)
     }
 
     override func tearDown() {

--- a/Wire-iOS Tests/UserCellTests.swift
+++ b/Wire-iOS Tests/UserCellTests.swift
@@ -36,7 +36,7 @@ final class UserCellTests: ZMSnapshotTestCase {
         mockUser.handle = "james_hetfield_1"
 
         conversation = MockGroupDetailsConversation()
-        UserDefaults.applicationGroup.set(false, forKey: DeveloperFlag.updatedCallingUI.rawValue)
+        UserDefaults.applicationGroup.set(true, forKey: DeveloperFlag.deprecatedCallingUI.rawValue)
     }
 
     override func tearDown() {

--- a/Wire-iOS/Sources/AppDelegate.swift
+++ b/Wire-iOS/Sources/AppDelegate.swift
@@ -139,7 +139,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         zmLog.info("application:didFinishLaunchingWithOptions END \(String(describing: launchOptions))")
         zmLog.info("Application was launched with arguments: \(ProcessInfo.processInfo.arguments)")
-        UserDefaults.applicationGroup.set(true, forKey: DeveloperFlag.updatedCallingUI.rawValue)
         return true
     }
 

--- a/Wire-iOS/Sources/UserInterface/Calling/CallActionsView/CallActionIconType.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallActionsView/CallActionIconType.swift
@@ -42,8 +42,8 @@ enum CallActionIconType: IconLabelButtonInput {
         case .microphone: return Voice.MuteButton.title
         case .camera: return Voice.VideoButton.title
         case .speaker: return Voice.SpeakerButton.title
-        case .flipCamera: return DeveloperFlag.updatedCallingUI.isOn ? Voice.FlipCameraButton.title : Voice.FlipVideoButton.title
-        case .endCall:  return DeveloperFlag.updatedCallingUI.isOn ? Voice.HangUpButton.title : Voice.EndCallButton.title
+        case .flipCamera: return DeveloperFlag.isUpdatedCallingUI ? Voice.FlipCameraButton.title : Voice.FlipVideoButton.title
+        case .endCall:  return DeveloperFlag.isUpdatedCallingUI ? Voice.HangUpButton.title : Voice.EndCallButton.title
         case .pickUp: return Voice.PickUpButton.title
         }
     }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallActionsView/IconLabelButton.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallActionsView/IconLabelButton.swift
@@ -95,7 +95,7 @@ class IconLabelButton: ButtonWithLargerHitArea {
     }
 
     private func updateState() {
-        if !DeveloperFlag.updatedCallingUI.isOn {
+        if !DeveloperFlag.isUpdatedCallingUI {
             apply(appearance)
             subtitleTransformLabel.font = titleLabel?.font
             subtitleTransformLabel.textColor = titleColor(for: state)

--- a/Wire-iOS/Sources/UserInterface/Calling/CallController/ActiveCallRouter.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallController/ActiveCallRouter.swift
@@ -89,7 +89,7 @@ extension ActiveCallRouter: ActiveCallRouterProtocol {
         UIResponder.currentFirst?.resignFirstResponder()
 
         var activeCallViewController: UIViewController!
-        if DeveloperFlag.updatedCallingUI.isOn {
+        if DeveloperFlag.isUpdatedCallingUI {
             let bottomSheetActiveCallViewController = CallingBottomSheetViewController(voiceChannel: voiceChannel)
             bottomSheetActiveCallViewController.delegate = callController
             activeCallViewController = bottomSheetActiveCallViewController

--- a/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallGridViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallGridViewController.swift
@@ -82,9 +82,9 @@ final class CallGridViewController: SpinnerCapableViewController {
     }
 
     /// Update view visibility when this view controller is covered or not
-    var isCovered: Bool = !DeveloperFlag.updatedCallingUI.isOn {
+    var isCovered: Bool = !DeveloperFlag.isUpdatedCallingUI {
         didSet {
-            if DeveloperFlag.updatedCallingUI.isOn { isCovered = false }
+            if DeveloperFlag.isUpdatedCallingUI { isCovered = false }
             guard isCovered != oldValue else { return }
             notifyVisibilityChanged()
             displayIndicatorViewsIfNeeded()
@@ -126,7 +126,7 @@ final class CallGridViewController: SpinnerCapableViewController {
     // MARK: - Setup
 
     private func setupViews() {
-        if DeveloperFlag.updatedCallingUI.isOn {
+        if DeveloperFlag.isUpdatedCallingUI {
             gridView.backgroundColor = SemanticColors.View.backgroundCallGrid
         }
 

--- a/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallParticipantViews/BaseCallParticipantView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallParticipantViews/BaseCallParticipantView.swift
@@ -145,8 +145,8 @@ class BaseCallParticipantView: OrientableView, AVSIdentifierProvider {
         backgroundColor = .graphite
         avatarView.user = stream.user
         avatarView.userSession = userSession
-        userDetailsView.alpha = DeveloperFlag.updatedCallingUI.isOn ? 1 : 0
-        guard DeveloperFlag.updatedCallingUI.isOn else { return }
+        userDetailsView.alpha = DeveloperFlag.isUpdatedCallingUI ? 1 : 0
+        guard DeveloperFlag.isUpdatedCallingUI else { return }
         layer.cornerRadius = 6
         layer.masksToBounds = true
     }
@@ -225,7 +225,7 @@ class BaseCallParticipantView: OrientableView, AVSIdentifierProvider {
         let showBorderForActiveSpeaker = shouldShowActiveSpeakerFrame && stream.isParticipantUnmutedAndSpeakingNow
         let showBorderForAudioParticipant = shouldShowBorderWhenVideoIsStopped && !stream.isSharingVideo
 
-        let borderWidth = DeveloperFlag.updatedCallingUI.isOn ? 2.0 : 1.0
+        let borderWidth = DeveloperFlag.isUpdatedCallingUI ? 2.0 : 1.0
         layer.borderWidth = (showBorderForActiveSpeaker || showBorderForAudioParticipant) && !isMaximized ? borderWidth : 0
         layer.borderColor = showBorderForActiveSpeaker ? UIColor.accent().cgColor : UIColor.black.cgColor
     }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallParticipantViews/CallParticipantDetailView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallParticipantViews/CallParticipantDetailView.swift
@@ -38,7 +38,7 @@ final class CallParticipantDetailsView: RoundedBlurView {
     var microphoneIconStyle: MicrophoneIconStyle = .hidden {
         didSet {
             microphoneIconView.set(style: microphoneIconStyle)
-            guard DeveloperFlag.updatedCallingUI.isOn else { return }
+            guard DeveloperFlag.isUpdatedCallingUI else { return }
             makeMicrophone(hidden: true)
             labelContainerView.backgroundColor = .black
             nameLabel.textColor = .white
@@ -56,7 +56,7 @@ final class CallParticipantDetailsView: RoundedBlurView {
     }
 
     override init() {
-        nameLabel = DeveloperFlag.updatedCallingUI.isOn
+        nameLabel = DeveloperFlag.isUpdatedCallingUI
                     ? DynamicFontLabel(fontSpec: .mediumRegularFont, color: .white)
                     : UILabel(key: nil, size: .medium, weight: .semibold, color: .textForeground, variant: .dark)
         super.init()
@@ -64,7 +64,7 @@ final class CallParticipantDetailsView: RoundedBlurView {
 
     override func setupViews() {
         super.setupViews()
-        if DeveloperFlag.updatedCallingUI.isOn {
+        if DeveloperFlag.isUpdatedCallingUI {
             [microphoneImageView, labelContainerView].forEach {
                 $0.translatesAutoresizingMaskIntoConstraints = false
                 addSubview($0)
@@ -93,7 +93,7 @@ final class CallParticipantDetailsView: RoundedBlurView {
 
     override func createConstraints() {
         super.createConstraints()
-        if DeveloperFlag.updatedCallingUI.isOn {
+        if DeveloperFlag.isUpdatedCallingUI {
             createUpdatedUIContraints()
             return
         }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallGridView/RoundedPageIndicator.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallGridView/RoundedPageIndicator.swift
@@ -31,7 +31,7 @@ class RoundedPageIndicator: RoundedBlurView {
 
         addSubview(pageControl)
         pageControl.currentPageIndicatorTintColor = .accent()
-        if DeveloperFlag.updatedCallingUI.isOn {
+        if DeveloperFlag.isUpdatedCallingUI {
             pageControl.pageIndicatorTintColor = SemanticColors.View.backgroundDefaultWhite
             blurView.isHidden = true
         }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallParticipantsListView/CallParticipantsListView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallParticipantsListView/CallParticipantsListView.swift
@@ -137,7 +137,7 @@ extension UserCell: CallParticipantsListCellConfigurable {
         )
         videoIconView.set(style: VideoIconStyle(state: videoState))
         configure(with: user.value, selfUser: selfUser)
-        guard DeveloperFlag.updatedCallingUI.isOn else { return }
+        guard DeveloperFlag.isUpdatedCallingUI else { return }
         backgroundColor = SemanticColors.View.backgroundDefaultWhite
     }
 

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallGridConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallGridConfiguration.swift
@@ -193,7 +193,7 @@ extension VoiceChannel {
     }
 
     fileprivate var shouldShowActiveSpeakerFrame: Bool {
-        if DeveloperFlag.updatedCallingUI.isOn { return true }
+        if DeveloperFlag.isUpdatedCallingUI { return true }
         return connectedParticipants.count > 2 && videoGridPresentationMode == .allVideoStreams
     }
 

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -284,7 +284,7 @@ final class CallViewController: UIViewController {
         updateAppearance()
         updateIdleTimer()
         configurationObserver?.didUpdateConfiguration(configuration: callInfoConfiguration)
-        guard DeveloperFlag.updatedCallingUI.isOn else { return }
+        guard DeveloperFlag.isUpdatedCallingUI else { return }
         showIncomingCallStatusViewIfNeeded(forConfiguration: callInfoConfiguration)
     }
 

--- a/Wire-iOS/Sources/UserInterface/Calling/Thumbnail/PinnableThumbnailViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/Thumbnail/PinnableThumbnailViewController.swift
@@ -111,7 +111,7 @@ final class PinnableThumbnailViewController: UIViewController {
         thumbnailContainerView.addSubview(thumbnailView)
         thumbnailView.autoresizingMask = []
         thumbnailView.clipsToBounds = true
-        let cornerRadius = DeveloperFlag.updatedCallingUI.isOn ? 6.0 : 12.0
+        let cornerRadius = DeveloperFlag.isUpdatedCallingUI ? 6.0 : 12.0
         thumbnailView.shape = .rounded(radius: cornerRadius)
 
         thumbnailContainerView.layer.shadowRadius = 30

--- a/WireCommonComponents/AutomationHelper.swift
+++ b/WireCommonComponents/AutomationHelper.swift
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
+//
 
 import Foundation
 import WireSystem

--- a/WireCommonComponents/AutomationHelper.swift
+++ b/WireCommonComponents/AutomationHelper.swift
@@ -86,8 +86,8 @@ public final class AutomationHelper: NSObject {
     /// Whether the calling overlay should disappear automatically.
     public let keepCallingOverlayVisible: Bool
 
-    /// Whether to use the new calling overlay.
-    public let updatedCallingUI: Bool
+    /// Whether to use the old calling overlay.
+    public let deprecatedCallingUI: Bool
 
     override init() {
         let url = URL(string: NSTemporaryDirectory())?.appendingPathComponent(fileArgumentsName)
@@ -127,7 +127,7 @@ public final class AutomationHelper: NSObject {
         {
             BackendInfo.preferredAPIVersion = APIVersion(rawValue: apiVersion)
         }
-        updatedCallingUI = arguments.hasFlag(AutomationKey.updatedCallingUI)
+        deprecatedCallingUI = arguments.hasFlag(AutomationKey.deprecatedCallingUI)
 
         super.init()
     }
@@ -149,7 +149,7 @@ public final class AutomationHelper: NSObject {
         case useAppCenter = "use-app-center"
         case keepCallingOverlayVisible = "keep-calling-overlay-visible"
         case preferredAPIversion = "preferred-api-version"
-        case updatedCallingUI = "updated-calling-ui"
+        case deprecatedCallingUI = "deprecated-calling-ui"
     }
     /// Returns the login email and password credentials if set in the given arguments
     fileprivate static func credentials(_ arguments: ArgumentsType) -> AutomationEmailCredentials? {

--- a/WireCommonComponents/AutomationHelper.swift
+++ b/WireCommonComponents/AutomationHelper.swift
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-//
+// 
 
 import Foundation
 import WireSystem

--- a/WireCommonComponents/AutomationHelper.swift
+++ b/WireCommonComponents/AutomationHelper.swift
@@ -86,6 +86,9 @@ public final class AutomationHelper: NSObject {
     /// Whether the calling overlay should disappear automatically.
     public let keepCallingOverlayVisible: Bool
 
+    /// Whether to use the new calling overlay.
+    public let updatedCallingUI: Bool
+
     override init() {
         let url = URL(string: NSTemporaryDirectory())?.appendingPathComponent(fileArgumentsName)
         let arguments: ArgumentsType = url.flatMap(FileArguments.init) ?? CommandLineArguments()
@@ -124,6 +127,7 @@ public final class AutomationHelper: NSObject {
         {
             BackendInfo.preferredAPIVersion = APIVersion(rawValue: apiVersion)
         }
+        updatedCallingUI = arguments.hasFlag(AutomationKey.updatedCallingUI)
 
         super.init()
     }
@@ -145,6 +149,7 @@ public final class AutomationHelper: NSObject {
         case useAppCenter = "use-app-center"
         case keepCallingOverlayVisible = "keep-calling-overlay-visible"
         case preferredAPIversion = "preferred-api-version"
+        case updatedCallingUI = "updated-calling-ui"
     }
     /// Returns the login email and password credentials if set in the given arguments
     fileprivate static func credentials(_ arguments: ArgumentsType) -> AutomationEmailCredentials? {

--- a/WireCommonComponents/DeveloperFlag.swift
+++ b/WireCommonComponents/DeveloperFlag.swift
@@ -28,7 +28,7 @@ public enum DeveloperFlag: String, CaseIterable {
     case nseDebugging
     case nseDebugEntryPoint
     case useDevelopmentBackendAPI
-    case updatedCallingUI
+    case deprecatedCallingUI
 
     public var description: String {
         switch self {
@@ -49,8 +49,8 @@ public enum DeveloperFlag: String, CaseIterable {
 
         case .useDevelopmentBackendAPI:
             return "Turn on to use the developement backend API version instead of the latest production API version."
-        case .updatedCallingUI:
-            return "Turn on to use new calling UI with bottom sheet"
+        case .deprecatedCallingUI:
+            return "Turn on to use deprecated calling UI"
         }
     }
 
@@ -70,7 +70,7 @@ public enum DeveloperFlag: String, CaseIterable {
 public extension DeveloperFlag {
 
     static var isUpdatedCallingUI: Bool {
-        return DeveloperFlag.updatedCallingUI.isOn || AutomationHelper.sharedHelper.updatedCallingUI
+        return !(DeveloperFlag.deprecatedCallingUI.isOn || AutomationHelper.sharedHelper.deprecatedCallingUI)
     }
 
 }

--- a/WireCommonComponents/DeveloperFlag.swift
+++ b/WireCommonComponents/DeveloperFlag.swift
@@ -66,3 +66,11 @@ public enum DeveloperFlag: String, CaseIterable {
     }
 
 }
+
+public extension DeveloperFlag {
+
+    static var isUpdatedCallingUI: Bool {
+        return DeveloperFlag.updatedCallingUI.isOn || AutomationHelper.sharedHelper.updatedCallingUI
+    }
+
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-143" title="ACC-143" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />ACC-143</a>  Context change on focus (3.2.1)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We have a developer flag that we use to test the new and old calling overlay. But automation tests cannot change this flag.

### Solutions

Add a flag to the QA automation helper that can be used inside tests.

@Marcin-Ratajczak we should use` DeveloperFlag.isUpdatedCallingUI`

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
