### PR TITLE
fix: frame on active speaker acc-355

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallParticipantViews/BaseCallParticipantView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallParticipantViews/BaseCallParticipantView.swift
@@ -67,6 +67,7 @@ class BaseCallParticipantView: OrientableView, AVSIdentifierProvider {
     var avatarView = UserImageView(size: .normal)
     var userSession = ZMUserSession.shared()
     private(set) var videoView: AVSVideoViewProtocol?
+    private var borderLayer = CALayer()
 
     // MARK: - Private Properties
 
@@ -149,6 +150,12 @@ class BaseCallParticipantView: OrientableView, AVSIdentifierProvider {
         guard DeveloperFlag.updatedCallingUI.isOn else { return }
         layer.cornerRadius = 6
         layer.masksToBounds = true
+
+        guard DeveloperFlag.updatedCallingUI.isOn else { return }
+        borderLayer.borderColor = SemanticColors.View.backgroundDefaultWhite.cgColor
+        borderLayer.borderWidth = 5.0
+        borderLayer.cornerRadius = 6
+        layer.insertSublayer(borderLayer, above: layer)
     }
 
     func createConstraints() {
@@ -225,9 +232,15 @@ class BaseCallParticipantView: OrientableView, AVSIdentifierProvider {
         let showBorderForActiveSpeaker = shouldShowActiveSpeakerFrame && stream.isParticipantUnmutedAndSpeakingNow
         let showBorderForAudioParticipant = shouldShowBorderWhenVideoIsStopped && !stream.isSharingVideo
 
-        let borderWidth = DeveloperFlag.updatedCallingUI.isOn ? 2.0 : 1.0
-        layer.borderWidth = (showBorderForActiveSpeaker || showBorderForAudioParticipant) && !isMaximized ? borderWidth : 0
-        layer.borderColor = showBorderForActiveSpeaker ? UIColor.accent().cgColor : UIColor.black.cgColor
+        guard DeveloperFlag.updatedCallingUI.isOn else {
+            layer.borderWidth = (showBorderForActiveSpeaker || showBorderForAudioParticipant) && !isMaximized ? 1 : 0
+            layer.borderColor = showBorderForActiveSpeaker ? UIColor.accent().cgColor : UIColor.black.cgColor
+            return
+        }
+
+        layer.borderWidth = showBorderForActiveSpeaker ? 2 : 0
+        layer.borderColor = showBorderForActiveSpeaker ? UIColor.accent().cgColor : UIColor.clear.cgColor
+        borderLayer.isHidden = !showBorderForActiveSpeaker
     }
 
     // MARK: - Orientation & Layout
@@ -235,6 +248,7 @@ class BaseCallParticipantView: OrientableView, AVSIdentifierProvider {
     override func layoutSubviews() {
         super.layoutSubviews()
         detailsConstraints?.updateEdges(with: adjustedInsets)
+        borderLayer.frame = bounds
     }
 
     func layout(forInterfaceOrientation interfaceOrientation: UIInterfaceOrientation,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-355" title="ACC-355" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />ACC-355</a>  [iOS] Fix the highlight outline
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
