### PR TITLE
fix: profile pic visible when camera on ACC-356

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/EstablishingCallStatusView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/EstablishingCallStatusView.swift
@@ -104,6 +104,9 @@ class EstablishingCallStatusView: UIView {
         callStateLabel.text = state.displayString
     }
 
+    func setProfileImage(hidden: Bool) {
+        profileImageView.isHidden = hidden
+    }
 }
 
 // MARK: - Helper

--- a/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallGridViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallGridViewController.swift
@@ -278,6 +278,7 @@ final class CallGridViewController: SpinnerCapableViewController {
         updateGridViewAxis()
         updateHint(for: .configurationChanged)
         requestVideoStreamsIfNeeded(forPage: gridView.currentPage)
+        selfCallParticipantView?.avatarView.isHidden = !configuration.isConnected
     }
 
     private func displaySpinnerIfNeeded() {

--- a/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallGridViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallGridViewController.swift
@@ -278,7 +278,9 @@ final class CallGridViewController: SpinnerCapableViewController {
         updateGridViewAxis()
         updateHint(for: .configurationChanged)
         requestVideoStreamsIfNeeded(forPage: gridView.currentPage)
-        selfCallParticipantView?.avatarView.isHidden = !configuration.isConnected
+        if DeveloperFlag.updatedCallingUI.isOn {
+            selfCallParticipantView?.avatarView.isHidden = !configuration.isConnected
+        }
     }
 
     private func displaySpinnerIfNeeded() {

--- a/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallGridViewControllerInput.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallGridViewControllerInput.swift
@@ -28,6 +28,7 @@ protocol CallGridViewControllerInput {
     var shouldShowActiveSpeakerFrame: Bool { get }
     var presentationMode: VideoGridPresentationMode { get }
     var callHasTwoParticipants: Bool { get }
+    var isConnected: Bool { get }
 
     func isEqual(to other: CallGridViewControllerInput) -> Bool
 }

--- a/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallParticipantViews/BaseCallParticipantView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallParticipantViews/BaseCallParticipantView.swift
@@ -67,6 +67,7 @@ class BaseCallParticipantView: OrientableView, AVSIdentifierProvider {
     var avatarView = UserImageView(size: .normal)
     var userSession = ZMUserSession.shared()
     private(set) var videoView: AVSVideoViewProtocol?
+    private var borderLayer = CALayer()
 
     // MARK: - Private Properties
 
@@ -149,6 +150,12 @@ class BaseCallParticipantView: OrientableView, AVSIdentifierProvider {
         guard DeveloperFlag.updatedCallingUI.isOn else { return }
         layer.cornerRadius = 6
         layer.masksToBounds = true
+
+        guard DeveloperFlag.updatedCallingUI.isOn else { return }
+        borderLayer.borderColor = SemanticColors.View.backgroundDefaultWhite.cgColor
+        borderLayer.borderWidth = 5.0
+        borderLayer.cornerRadius = 6
+        layer.insertSublayer(borderLayer, above: layer)
     }
 
     func createConstraints() {
@@ -225,9 +232,15 @@ class BaseCallParticipantView: OrientableView, AVSIdentifierProvider {
         let showBorderForActiveSpeaker = shouldShowActiveSpeakerFrame && stream.isParticipantUnmutedAndSpeakingNow
         let showBorderForAudioParticipant = shouldShowBorderWhenVideoIsStopped && !stream.isSharingVideo
 
-        let borderWidth = DeveloperFlag.updatedCallingUI.isOn ? 2.0 : 1.0
-        layer.borderWidth = (showBorderForActiveSpeaker || showBorderForAudioParticipant) && !isMaximized ? borderWidth : 0
-        layer.borderColor = showBorderForActiveSpeaker ? UIColor.accent().cgColor : UIColor.black.cgColor
+        guard DeveloperFlag.updatedCallingUI.isOn else {
+            layer.borderWidth = (showBorderForActiveSpeaker || showBorderForAudioParticipant) && !isMaximized ? 1 : 0
+            layer.borderColor = showBorderForActiveSpeaker ? UIColor.accent().cgColor : UIColor.black.cgColor
+            return
+        }
+
+        layer.borderWidth = showBorderForActiveSpeaker ? 2 : 0
+        layer.borderColor = showBorderForActiveSpeaker ? UIColor.accent().cgColor : UIColor.clear.cgColor
+        borderLayer.isHidden = !showBorderForActiveSpeaker
     }
 
     // MARK: - Orientation & Layout
@@ -235,6 +248,7 @@ class BaseCallParticipantView: OrientableView, AVSIdentifierProvider {
     override func layoutSubviews() {
         super.layoutSubviews()
         detailsConstraints?.updateEdges(with: adjustedInsets)
+        borderLayer.frame = bounds
     }
 
     func layout(forInterfaceOrientation interfaceOrientation: UIInterfaceOrientation,

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallGridConfiguration.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallGridConfiguration.swift
@@ -30,6 +30,7 @@ struct CallGridConfiguration: CallGridViewControllerInput, Equatable {
     let shouldShowActiveSpeakerFrame: Bool
     let presentationMode: VideoGridPresentationMode
     let callHasTwoParticipants: Bool
+    let isConnected: Bool
 
     init(voiceChannel: VoiceChannel) {
         let videoStreamArrangment = voiceChannel.createStreamArrangment()
@@ -41,6 +42,7 @@ struct CallGridConfiguration: CallGridViewControllerInput, Equatable {
         shouldShowActiveSpeakerFrame = voiceChannel.shouldShowActiveSpeakerFrame
         presentationMode = voiceChannel.videoGridPresentationMode
         callHasTwoParticipants = voiceChannel.callHasTwoParticipants
+        isConnected = voiceChannel.state.isConnected
     }
 }
 

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -294,6 +294,7 @@ final class CallViewController: UIViewController {
             establishingCallStatusView.removeFromSuperview()
             return
         }
+        establishingCallStatusView.setProfileImage(hidden: configuration.mediaState.isSendingVideo)
         establishingCallStatusView.updateState(state: state)
         establishingCallStatusView.setTitle(title: configuration.title)
         guard establishingCallStatusView.superview == nil else { return }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-356" title="ACC-356" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />ACC-356</a>  [iOS] Fix: other user profile pic still shows when the camera is ON
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
