### PR TITLE
fix: incoming call UI horizontal ACC-361

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingBottomSheetViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingBottomSheetViewController.swift
@@ -26,14 +26,21 @@ protocol CallInfoConfigurationObserver: AnyObject {
 }
 
 class CallingBottomSheetViewController: BottomSheetContainerViewController {
-    private let bottomSheetInitialOffset = 124.0
     private let bottomSheetMaxHeight = UIScreen.main.bounds.height * 0.7
 
     weak var delegate: ActiveCallViewControllerDelegate?
     private var participantsObserverToken: Any?
     private let voiceChannel: VoiceChannel
     private let headerBar = CallHeaderBar()
-    
+
+    var bottomSheetMinimalOffset: CGFloat {
+        switch voiceChannel.state {
+        case .incoming(degradedUser: _):
+            return 230.0
+        default:
+            return 124.0
+        }
+    }
 
     let callingActionsInfoViewController: CallingActionsInfoViewController
     var visibleVoiceChannelViewController: CallViewController{
@@ -48,7 +55,7 @@ class CallingBottomSheetViewController: BottomSheetContainerViewController {
         visibleVoiceChannelViewController = CallViewController(voiceChannel: voiceChannel, selfUser: selfUser, isOverlayEnabled: false)
 
         callingActionsInfoViewController = CallingActionsInfoViewController(participants: voiceChannel.getParticipantsList(), selfUser: selfUser)
-        super.init(contentViewController: visibleVoiceChannelViewController, bottomSheetViewController: callingActionsInfoViewController, bottomSheetConfiguration: .init(height: bottomSheetMaxHeight, initialOffset: bottomSheetInitialOffset))
+        super.init(contentViewController: visibleVoiceChannelViewController, bottomSheetViewController: callingActionsInfoViewController, bottomSheetConfiguration: .init(height: bottomSheetMaxHeight, initialOffset: 124.0))
 
         callingActionsInfoViewController.actionsDelegate = visibleVoiceChannelViewController
         callingActionsInfoViewController.actionsView.bottomSheetScrollingDelegate = self
@@ -81,10 +88,10 @@ class CallingBottomSheetViewController: BottomSheetContainerViewController {
 
     @objc private func didChangeOrientation() {
         if UIDevice.current.orientation.isLandscape {
-            let newConfiguration = BottomSheetConfiguration(height: view.bounds.height, initialOffset: bottomSheetInitialOffset)
+            let newConfiguration = BottomSheetConfiguration(height: view.bounds.height, initialOffset: bottomSheetMinimalOffset)
             self.configuration = newConfiguration
         } else {
-            let newConfiguration = BottomSheetConfiguration(height: bottomSheetMaxHeight, initialOffset: bottomSheetInitialOffset)
+            let newConfiguration = BottomSheetConfiguration(height: bottomSheetMaxHeight, initialOffset: bottomSheetMinimalOffset)
             self.configuration = newConfiguration
         }
         hideBottomSheet()
@@ -124,16 +131,16 @@ class CallingBottomSheetViewController: BottomSheetContainerViewController {
         visibleVoiceChannelViewController = CallViewController(voiceChannel: voiceChannel, selfUser: ZMUser.selfUser())
         visibleVoiceChannelViewController.delegate = self
     }
+
 }
 
 extension CallingBottomSheetViewController: CallInfoConfigurationObserver {
     func didUpdateConfiguration(configuration: CallInfoConfiguration) {
         callingActionsInfoViewController.didUpdateConfiguration(configuration: configuration)
         panGesture.isEnabled = !configuration.state.isIncoming
-        let offset = configuration.state.isIncoming ? 230.0 : bottomSheetInitialOffset
-        guard self.configuration.initialOffset != offset else { return }
-        let height = configuration.state.isIncoming ? offset : view.bounds.height * 0.7
-        let newConfiguration = BottomSheetConfiguration(height: height, initialOffset: offset)
+        guard self.configuration.initialOffset != bottomSheetMinimalOffset else { return }
+        let height = view.bounds.height * 0.7//configuration.state.isIncoming ? bottomSheetInitialOffset : view.bounds.height * 0.7
+        let newConfiguration = BottomSheetConfiguration(height: height, initialOffset: bottomSheetMinimalOffset)
         self.configuration = newConfiguration
         hideBottomSheet()
     }

--- a/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingBottomSheetViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingBottomSheetViewController.swift
@@ -129,7 +129,8 @@ class CallingBottomSheetViewController: BottomSheetContainerViewController {
 extension CallingBottomSheetViewController: CallInfoConfigurationObserver {
     func didUpdateConfiguration(configuration: CallInfoConfiguration) {
         callingActionsInfoViewController.didUpdateConfiguration(configuration: configuration)
-        let offset = configuration.state.isIncoming ? 280.0 : bottomSheetInitialOffset
+        panGesture.isEnabled = !configuration.state.isIncoming
+        let offset = configuration.state.isIncoming ? 230.0 : bottomSheetInitialOffset
         guard self.configuration.initialOffset != offset else { return }
         let height = configuration.state.isIncoming ? offset : view.bounds.height * 0.7
         let newConfiguration = BottomSheetConfiguration(height: height, initialOffset: offset)

--- a/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingBottomSheetViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingBottomSheetViewController.swift
@@ -139,8 +139,7 @@ extension CallingBottomSheetViewController: CallInfoConfigurationObserver {
         callingActionsInfoViewController.didUpdateConfiguration(configuration: configuration)
         panGesture.isEnabled = !configuration.state.isIncoming
         guard self.configuration.initialOffset != bottomSheetMinimalOffset else { return }
-        let height = view.bounds.height * 0.7//configuration.state.isIncoming ? bottomSheetInitialOffset : view.bounds.height * 0.7
-        let newConfiguration = BottomSheetConfiguration(height: height, initialOffset: bottomSheetMinimalOffset)
+        let newConfiguration = BottomSheetConfiguration(height: bottomSheetMaxHeight, initialOffset: bottomSheetMinimalOffset)
         self.configuration = newConfiguration
         hideBottomSheet()
     }

--- a/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/EstablishingCallStatusView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/EstablishingCallStatusView.swift
@@ -81,6 +81,7 @@ class EstablishingCallStatusView: UIView {
     }
 
     private func setupConstraints() {
+        let spacerHeight = UIScreen.main.bounds.height / 9.0
         NSLayoutConstraint.activate([
             stackView.topAnchor.constraint(equalTo: topAnchor),
             stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
@@ -88,7 +89,7 @@ class EstablishingCallStatusView: UIView {
             stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
             profileImageView.widthAnchor.constraint(equalToConstant: 128.0),
             profileImageView.heightAnchor.constraint(equalToConstant: 128.0),
-            spaceView.heightAnchor.constraint(equalToConstant: 100.0)
+            spaceView.heightAnchor.constraint(equalToConstant: spacerHeight)
         ])
     }
     


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-361" title="ACC-361" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />ACC-361</a>  [iOS] Fix "pre calling UI" in the horizontal mode
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
