### PR TITLE
fix: colors of calling actions buttons on mode change ACC-362

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsInfoViewController/CallingActionsInfoViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsInfoViewController/CallingActionsInfoViewController.swift
@@ -20,7 +20,6 @@ import UIKit
 import WireDataModel
 
 class CallingActionsInfoViewController: UIViewController, UICollectionViewDelegateFlowLayout {
-    private let actionsViewHeight = 150.0
     private let participantsHeaderHeight: CGFloat = 42
     private let cellHeight: CGFloat = 56
     private var topConstraint: NSLayoutConstraint?

--- a/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsView/CallingActionButton.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsView/CallingActionButton.swift
@@ -41,7 +41,7 @@ class CallingActionButton: IconLabelButton {
         iconButton.setIconColor(SemanticColors.Button.iconCallingNormal, for: .normal)
         iconButton.setBackgroundImageColor(SemanticColors.Button.backgroundCallingNormal, for: .normal)
 
-        setTitleColor(SemanticColors.Button.textCallingNormal, for: .normal)
+        setTitleColor(SemanticColors.Button.textCallingNormal, for: . selected)
         iconButton.setBorderColor(SemanticColors.Button.borderCallingSelected, for: .selected)
         iconButton.setIconColor(SemanticColors.Button.iconCallingSelected, for: .selected)
         iconButton.setBackgroundImageColor(SemanticColors.Button.backgroundCallingSelected, for: .selected)

--- a/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsView/CallingActionButton.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsView/CallingActionButton.swift
@@ -47,7 +47,7 @@ class CallingActionButton: IconLabelButton {
         iconButton.setBackgroundImageColor(SemanticColors.Button.backgroundCallingSelected, for: .selected)
 
 
-        setTitleColor(configuration.textColorDisabled, for: .disabled)
+        setTitleColor(SemanticColors.Button.textCallingDisabled, for: .disabled)
         iconButton.setBorderColor(SemanticColors.Button.borderCallingDisabled, for: .disabled)
         iconButton.setIconColor(SemanticColors.Button.iconCallingDisabled, for: .disabled)
         iconButton.setBackgroundImageColor(SemanticColors.Button.backgroundCallingDisabled, for: .disabled)

--- a/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsView/CallingActionButton.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsView/CallingActionButton.swift
@@ -36,12 +36,12 @@ class CallingActionButton: IconLabelButton {
     override func apply(_ configuration: CallActionAppearance) {
         iconButton.borderWidth = 1
 
-        setTitleColor(configuration.textColorNormal, for: .normal)
+        setTitleColor(SemanticColors.Button.textCallingNormal, for: .normal)
         iconButton.setBorderColor(SemanticColors.Button.borderCallingNormal, for: .normal)
         iconButton.setIconColor(SemanticColors.Button.iconCallingNormal, for: .normal)
         iconButton.setBackgroundImageColor(SemanticColors.Button.backgroundCallingNormal, for: .normal)
 
-        setTitleColor(configuration.textColorNormal, for: .selected)
+        setTitleColor(SemanticColors.Button.textCallingNormal, for: .normal)
         iconButton.setBorderColor(SemanticColors.Button.borderCallingSelected, for: .selected)
         iconButton.setIconColor(SemanticColors.Button.iconCallingSelected, for: .selected)
         iconButton.setBackgroundImageColor(SemanticColors.Button.backgroundCallingSelected, for: .selected)

--- a/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsView/CallingActionsView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsView/CallingActionsView.swift
@@ -108,7 +108,7 @@ class CallingActionsView: UIView {
             verticalStackView.topAnchor.constraint(equalTo: topAnchor, constant: 8),
             verticalStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16.0),
             verticalStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16.0),
-            verticalStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -8),
+            verticalStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -12),
             topStackView.widthAnchor.constraint(equalTo: verticalStackView.widthAnchor),
             handleView.widthAnchor.constraint(equalToConstant: 129),
             handleView.heightAnchor.constraint(equalToConstant: 5)
@@ -117,9 +117,7 @@ class CallingActionsView: UIView {
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        guard traitCollection.didSizeClassChange(from: previousTraitCollection) else { return }
-        setNeedsLayout()
-        layoutIfNeeded()
+        allButtons.forEach( { $0.updateState() })
     }
 
     // MARK: - State Input

--- a/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingBottomSheetViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingBottomSheetViewController.swift
@@ -38,7 +38,7 @@ class CallingBottomSheetViewController: BottomSheetContainerViewController {
         case .incoming(degradedUser: _):
             return 230.0
         default:
-            return 124.0
+            return 128.0
         }
     }
 
@@ -55,7 +55,7 @@ class CallingBottomSheetViewController: BottomSheetContainerViewController {
         visibleVoiceChannelViewController = CallViewController(voiceChannel: voiceChannel, selfUser: selfUser, isOverlayEnabled: false)
 
         callingActionsInfoViewController = CallingActionsInfoViewController(participants: voiceChannel.getParticipantsList(), selfUser: selfUser)
-        super.init(contentViewController: visibleVoiceChannelViewController, bottomSheetViewController: callingActionsInfoViewController, bottomSheetConfiguration: .init(height: bottomSheetMaxHeight, initialOffset: 124.0))
+        super.init(contentViewController: visibleVoiceChannelViewController, bottomSheetViewController: callingActionsInfoViewController, bottomSheetConfiguration: .init(height: bottomSheetMaxHeight, initialOffset: 128.0))
 
         callingActionsInfoViewController.actionsDelegate = visibleVoiceChannelViewController
         callingActionsInfoViewController.actionsView.bottomSheetScrollingDelegate = self

--- a/Wire-iOS/Sources/UserInterface/Calling/CallActionsView/IconLabelButton.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallActionsView/IconLabelButton.swift
@@ -94,12 +94,10 @@ class IconLabelButton: ButtonWithLargerHitArea {
         ])
     }
 
-    private func updateState() {
-        if !DeveloperFlag.isUpdatedCallingUI {
+    func updateState() {
             apply(appearance)
             subtitleTransformLabel.font = titleLabel?.font
             subtitleTransformLabel.textColor = titleColor(for: state)
-        }
     }
 
     override var isHighlighted: Bool {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-362" title="ACC-362" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />ACC-362</a>  [iOS] Fix button colors on the "pre calling UI"
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
