### PR TITLE
fix: freezed video ACC-359

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallParticipantViews/SelfCallParticipantView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallParticipantViews/SelfCallParticipantView.swift
@@ -27,7 +27,7 @@ final class SelfCallParticipantView: BaseCallParticipantView {
 
     override var stream: Stream {
         didSet {
-            guard stream != oldValue else { return }
+            guard stream.videoState != self.videoState else { return }
             updateCaptureState(with: stream.videoState)
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-359" title="ACC-359" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />ACC-359</a>  [iOS] Fix: "the video gets stuck"
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

fix bug that freezes selfParticipant video when you start audio call and then enable, disable and enable again camera

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
