### PR TITLE
fix: call title cut on iPhone 14 ACC-390

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallHeaderBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallHeaderBar.swift
@@ -46,9 +46,9 @@ class CallHeaderBar: UIView {
     private func setupConstraints() {
         NSLayoutConstraint.activate([
             titleLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
-            titleLabel.centerYAnchor.constraint(equalTo: centerYAnchor, constant: 14.0),
+            titleLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
             minimalizeButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20.0),
-            minimalizeButton.centerYAnchor.constraint(equalTo: centerYAnchor, constant: 14.0),
+            minimalizeButton.centerYAnchor.constraint(equalTo: centerYAnchor),
             minimalizeButton.widthAnchor.constraint(equalToConstant: 32.0),
             minimalizeButton.heightAnchor.constraint(equalToConstant: 32.0),
             titleLabel.leadingAnchor.constraint(greaterThanOrEqualTo: minimalizeButton.trailingAnchor, constant: 6.0)

--- a/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingBottomSheetViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingBottomSheetViewController.swift
@@ -63,26 +63,31 @@ class CallingBottomSheetViewController: BottomSheetContainerViewController {
         participantsObserverToken = voiceChannel.addParticipantObserver(self)
         visibleVoiceChannelViewController.delegate = self
 
-        addTopBar()
+        view.addSubview(headerBar)
+        setupViews()
+        addConstraints()
     }
 
     required public init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    private func addTopBar() {
+    private func setupViews() {
+        view.backgroundColor = SemanticColors.View.backgroundDefault
+        headerBar.setTitle(title: voiceChannel.conversation?.displayName ?? "")
+        headerBar.minimalizeButton.addTarget(self, action: #selector(hideCallView), for: .touchUpInside)
+    }
+
+    private func addConstraints() {
         headerBar.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(headerBar)
 
         NSLayoutConstraint.activate([
             headerBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             headerBar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            headerBar.heightAnchor.constraint(equalToConstant: 74),
-            headerBar.topAnchor.constraint(equalTo: view.topAnchor),
+            headerBar.topAnchor.constraint(equalTo: view.safeTopAnchor),
+            headerBar.safeBottomAnchor.constraint(equalTo: view.safeTopAnchor, constant: 45.0),
             headerBar.bottomAnchor.constraint(equalTo: visibleVoiceChannelViewController.view.topAnchor).withPriority(.required)
         ])
-        headerBar.setTitle(title: voiceChannel.conversation?.displayName ?? "")
-        headerBar.minimalizeButton.addTarget(self, action: #selector(hideCallView), for: .touchUpInside)
     }
 
     // after rotating device recalculate bottom sheet max height


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-390" title="ACC-390" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />ACC-390</a>  [iOS] Conversation title on the top is little cut off on iPhone 14 pro due to dynamic island
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->


- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
