### PR TITLE
fix: crashes when opening app to answer a call FS-1344

### DIFF
--- a/Wire-iOS/Sources/Analytics/Events/Analytics+CallEvents.swift
+++ b/Wire-iOS/Sources/Analytics/Events/Analytics+CallEvents.swift
@@ -90,11 +90,12 @@ extension Analytics {
     }
 
     private func attributesForUser(in conversation: ZMConversation) -> [String: Any] {
+        guard let selfUser = SelfUser.provider?.selfUser else { return [:] }
         var userType: String
 
-        if SelfUser.current.isWirelessUser {
+        if selfUser.isWirelessUser {
             userType = "temporary_guest"
-        } else if SelfUser.current.isGuest(in: conversation) {
+        } else if selfUser.isGuest(in: conversation) {
             userType = "guest"
         } else {
             userType = "user"

--- a/Wire-iOS/Sources/Analytics/Events/ZMConversation+Analytics.swift
+++ b/Wire-iOS/Sources/Analytics/Events/ZMConversation+Analytics.swift
@@ -95,9 +95,14 @@ extension ZMConversation {
             $0.isGuest(in: self)
         }).count
 
-        return [
-            "conversation_guests": numGuests.logRound(),
-            "user_type": SelfUser.current.isGuest(in: self) ? "guest" : "user"
+        var attributes: [String: Any] = [
+            "conversation_guests": numGuests.logRound()
         ]
+
+        if let selfUser = SelfUser.provider?.selfUser {
+            attributes["user_type"] = selfUser.isGuest(in: self) ? "guest" : "user"
+        }
+
+        return attributes
     }
 }

--- a/Wire-iOS/Sources/AppRootRouter.swift
+++ b/Wire-iOS/Sources/AppRootRouter.swift
@@ -413,7 +413,6 @@ extension AppRootRouter {
             presentAlertForDeletedAccountIfNeeded(error)
             sessionManager.processPendingURLActionDoesNotRequireAuthentication()
         case .authenticated:
-            authenticatedRouter?.updateActiveCallPresentationState()
             urlActionRouter.authenticatedRouter = authenticatedRouter
             ZClientViewController.shared?.legalHoldDisclosureController?.discloseCurrentState(cause: .appOpen)
             sessionManager.processPendingURLActionRequiresAuthentication()

--- a/Wire-iOS/Sources/AuthenticatedRouter.swift
+++ b/Wire-iOS/Sources/AuthenticatedRouter.swift
@@ -71,10 +71,13 @@ class AuthenticatedRouter: NSObject {
 
         super.init()
 
-        NotificationCenter.default.addObserver(forName: .featureDidChangeNotification,
-                                               object: nil,
-                                               queue: .main,
-                                               using: notifyFeatureChange)
+        NotificationCenter.default.addObserver(
+            forName: .featureDidChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            self?.notifyFeatureChange(notification)
+        }
     }
 
     private func notifyFeatureChange(_ note: Notification) {

--- a/Wire-iOS/Sources/UserInterface/Calling/CallController/CallController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallController/CallController.swift
@@ -42,6 +42,10 @@ final class CallController: NSObject {
         addObservers()
     }
 
+    deinit {
+        observerTokens.removeAll()
+    }
+
     // MARK: - Public Implementation
     func updateActiveCallPresentationState() {
         guard let priorityCallConversation = priorityCallConversation else {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1344" title="FS-1344" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1344</a>  [iOS] [Bund Col1] App crash upon starting call
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Given CallKit is disabled and I receive an incoming call while the app is the background, when I bring the app to the foreground, the app will sometimes crash.

### Causes

There seem to be a couple different crashes:
- Trying to access the self user when it is not yet available (in analytic events).
- Trying to constraint a call top overlay to an unrelated view.

The underlying cause of the top overlay crash is because:

- we try to present it twice, 
- because we have two instances of `CallController` that are listening to call state changes, 
- because we have two instances of `ActiveCallRouter`, 
- because there is a retain cycle between the `ActiveCallRouter` and the `NotificationCenter`, 
- because when we transition to the authenticated state we recreate a new `ActiveCallRouter` each time.

### Solutions

We can fix the self user crashes by safely unwrapping values.

We fix the call overlay issue by removing the retain cycle in `ActiveCallRouter`.

### Testing

#### How to Test

- Have EAR enabled (helps reproduce the issue)
- Disabled CallKit
- Put the app in the background
- Receive an incoming call
- Open the app

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
