### PR TITLE
fix: active call overlay is not presented when coming from background FS-1411

### DIFF
--- a/Wire-iOS/Sources/AppRootRouter.swift
+++ b/Wire-iOS/Sources/AppRootRouter.swift
@@ -413,6 +413,8 @@ extension AppRootRouter {
             presentAlertForDeletedAccountIfNeeded(error)
             sessionManager.processPendingURLActionDoesNotRequireAuthentication()
         case .authenticated:
+            // This is needed to display an ongoing call when coming from the background.
+            authenticatedRouter?.updateActiveCallPresentationState()
             urlActionRouter.authenticatedRouter = authenticatedRouter
             ZClientViewController.shared?.legalHoldDisclosureController?.discloseCurrentState(cause: .appOpen)
             sessionManager.processPendingURLActionRequiresAuthentication()

--- a/Wire-iOS/Sources/UserInterface/Calling/CallController/ActiveCallRouter.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallController/ActiveCallRouter.swift
@@ -42,7 +42,15 @@ protocol CallQualityRouterProtocol: AnyObject {
 class ActiveCallRouter: NSObject {
 
     // MARK: - Public Property
-    var isActiveCallShown = false
+    var isActiveCallShown = false {
+        didSet {
+            if isActiveCallShown {
+                isPresentingActiveCall = false
+            }
+        }
+    }
+
+    var isPresentingActiveCall = false
 
     // MARK: - Private Property
     private let rootViewController: RootViewController
@@ -81,7 +89,12 @@ class ActiveCallRouter: NSObject {
 extension ActiveCallRouter: ActiveCallRouterProtocol {
     // MARK: - ActiveCall
     func presentActiveCall(for voiceChannel: VoiceChannel, animated: Bool) {
-        guard !isActiveCallShown else { return }
+        guard
+            !isPresentingActiveCall,
+            !isActiveCallShown
+        else {
+            return
+        }
 
         // NOTE: We resign first reponder for the input bar since it will attempt to restore
         // first responder when the call overlay is interactively dismissed but canceled.
@@ -96,7 +109,7 @@ extension ActiveCallRouter: ActiveCallRouterProtocol {
             dismissPresentedAndPresentActiveCall(modalViewController: modalVC, animated: animated)
         } else {
             presentActiveCall(modalViewController: modalVC, animated: animated)
-        }   
+        }
     }
 
     func dismissActiveCall(animated: Bool = true, completion: Completion? = nil) {
@@ -156,6 +169,7 @@ extension ActiveCallRouter: ActiveCallRouterProtocol {
     }
 
     private func presentActiveCall(modalViewController: ModalPresentationViewController, animated: Bool) {
+        isPresentingActiveCall = true
         rootViewController.present(modalViewController, animated: animated, completion: { [weak self] in
             self?.isActiveCallShown = true
         })


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1411" title="FS-1411" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1411</a>  [iOS] Col1 RC 3.108(226): Moving app to background while in a call makes user unable to open calloverlay
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
… FS-1411

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Given there is an ongoing call, when I the app is put to the background and brought back to the foreground, then the call UI is not visible.

### Causes

In my last PR, I [deleted this line](https://github.com/wireapp/wire-ios/pull/6047/files#r1062564858). It's clear now that we need to present the call ui again after coming from the background, since it may have been torn down.

The reason why I deleted that line was because it was causing double presentation of the calling ui when there is an incoming call and the user brings the app to the foreground (presented once here, but also once when the incoming call event is processed).

### Solutions

Revert the deleted line, and additionally make sure double presentation doesn't occur by adding some more conditions when we present an active call.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
