### PR TITLE
chore: remove datadog flag

### DIFF
--- a/Wire Notification Service Extension/LegacyNotificationService.swift
+++ b/Wire Notification Service Extension/LegacyNotificationService.swift
@@ -232,7 +232,7 @@ extension UNNotificationContent {
   }
 
   static func debugMessageIfNeeded(message: String) -> UNNotificationContent {
-      DatadogWrapper.shared()?.log(level: .debug, message: message)
+      DatadogWrapper.shared?.log(level: .debug, message: message)
       guard DeveloperFlag.nseDebugging.isOn else { return .empty }
       return debug(message: message)
   }

--- a/Wire Notification Service Extension/NotificationService.swift
+++ b/Wire Notification Service Extension/NotificationService.swift
@@ -36,8 +36,8 @@ public class NotificationService: UNNotificationServiceExtension{
         _ request: UNNotificationRequest,
         withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
     ) {
-        DatadogWrapper.shared()?.startMonitoring()
-        DatadogWrapper.shared()?.log(level: .debug, message: "request: \(request.debugDescription)")
+        DatadogWrapper.shared?.startMonitoring()
+        DatadogWrapper.shared?.log(level: .debug, message: "request: \(request.debugDescription)")
         if DeveloperFlag.breakMyNotifications.isOn {
             // By doing nothing, we hope to get in a state where iOS will no
             // longer deliver pushes to us.

--- a/Wire-iOS/Sources/AppDelegate.swift
+++ b/Wire-iOS/Sources/AppDelegate.swift
@@ -107,8 +107,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication,
                      willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         zmLog.info("application:willFinishLaunchingWithOptions \(String(describing: launchOptions)) (applicationState = \(application.applicationState.rawValue))")
-        DatadogWrapper.shared()?.startMonitoring()
-        DatadogWrapper.shared()?.log(level: .info, message: "start app")
+        DatadogWrapper.shared?.startMonitoring()
+        DatadogWrapper.shared?.log(level: .info, message: "start app")
         // Initial log line to indicate the client version and build
         zmLog.info("Wire-ios version \(String(describing: Bundle.main.shortVersionString)) (\(String(describing: Bundle.main.infoDictionary?[kCFBundleVersionKey as String])))")
 

--- a/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperToolsViewModel.swift
+++ b/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperToolsViewModel.swift
@@ -165,7 +165,7 @@ final class DeveloperToolsViewModel: ObservableObject {
             ))
         }
 
-        if let dataDogUserId = DatadogWrapper.shared()?.datadogUserId {
+        if let dataDogUserId = DatadogWrapper.shared?.datadogUserId {
             sections.append(Section(
                 header: "Datadog",
                 items: [

--- a/Wire-iOS/Sources/Managers/DatadogWrapper.swift
+++ b/Wire-iOS/Sources/Managers/DatadogWrapper.swift
@@ -24,33 +24,35 @@ import UIKit
 
 public class DatadogWrapper {
 
-    /// Get shared instance only if Developer Flag is on
-    public static func shared() -> DatadogWrapper? {
-        guard let appID = Bundle(for: DatadogWrapper.self).infoForKey("DatadogAppId"),
-              let clientToken = Bundle(for: DatadogWrapper.self).infoForKey("DatadogClientToken")
-              else {
-                  print("missing Datadog appID and clientToken - logging disabled")
-                  return nil
-              }
-        if sharedInstance == nil {
-            sharedInstance = DatadogWrapper(appID: appID, clientToken: clientToken)
+    /// Get shared instance only if Developer Flag is on.
+
+    public static lazy var shared: DatadogWrapper? = {
+        let bundle = Bundle(for: DatadogWrapper.self)
+
+        guard
+            let appID = bundle.infoForKey("DatadogAppId"),
+            let clientToken = bundle.infoForKey("DatadogClientToken")
+        else {
+            print("missing Datadog appID and clientToken - logging disabled")
+            return nil
         }
-        return sharedInstance
-    }
 
-    static var sharedInstance: DatadogWrapper?
+        return DatadogWrapper(appID: appID, clientToken: clientToken)
+    }()
 
-    /// SHA256 string to identify current Device across app and extensions
+    /// SHA256 string to identify current Device across app and extensions.
+
     public var datadogUserId: String
 
     var logger: Logger?
     var defaultLevel: LogLevel
 
-    private init(appID: String,
-                 clientToken: String,
-                 environment: BackendEnvironmentProvider = BackendEnvironment.shared,
-                 level: LogLevel = .debug) {
-
+    private init(
+        appID: String,
+        clientToken: String,
+        environment: BackendEnvironmentProvider = BackendEnvironment.shared,
+        level: LogLevel = .debug
+    ) {
         Datadog.initialize(
             appContext: .init(),
             trackingConsent: .granted,
@@ -69,6 +71,7 @@ public class DatadogWrapper {
                 .trackRUMLongTasks()
                 .build()
         )
+
         defaultLevel = level
         logger = Logger.builder
             .sendNetworkInfo(true)
@@ -90,36 +93,65 @@ public class DatadogWrapper {
           )
         Datadog.setUserInfo(id: datadogUserId)
         RemoteMonitoring.remoteLogger = self
-        log(level: defaultLevel, message: "Datadog startMonitoring for device: \(datadogUserId)")
+
+        log(
+            level: defaultLevel,
+            message: "Datadog startMonitoring for device: \(datadogUserId)"
+        )
     }
 
-    public func log(level: LogLevel,
-                    message: String,
-                    error: Error? = nil,
-                    attributes: [String: Encodable]? = nil) {
-        logger?.log(level: level, message: message, error: error, attributes: attributes)
+    public func log(
+        level: LogLevel,
+        message: String,
+        error: Error? = nil,
+        attributes: [String: Encodable]? = nil
+    ) {
+        logger?.log(
+            level: level,
+            message: message,
+            error: error,
+            attributes: attributes
+        )
     }
 }
 
 extension DatadogWrapper: RemoteLogger {
-    public func log(message: String, error: Error?, attributes: [String: Encodable]?, level: RemoteMonitoring.Level) {
-        log(level: level.logLevel, message: message, error: error, attributes: attributes)
+
+    public func log(
+        message: String,
+        error: Error?,
+        attributes: [String: Encodable]?,
+        level: RemoteMonitoring.Level
+    ) {
+        log(
+            level: level.logLevel,
+            message: message,
+            error: error,
+            attributes: attributes
+        )
     }
+
 }
 
 extension RemoteMonitoring.Level {
+
     var logLevel: LogLevel {
         switch self {
         case .debug:
             return .debug
+
         case .info:
             return .info
+
         case .notice:
             return .notice
+
         case .warn:
             return .warn
+
         case .error:
             return .error
+
         case .critical:
             return .critical
         }
@@ -131,6 +163,7 @@ extension RemoteMonitoring.Level {
 import CryptoKit
 
 extension String {
+
     var sha256String: String {
         let inputData = Data(self.utf8)
         let hashed = SHA256.hash(data: inputData)
@@ -146,24 +179,29 @@ extension String {
 #else
 
 public enum LogLevel {
+
     case debug
     case critical
     case info
     case warn
-}
-// no op interface
-public class DatadogWrapper {
-    public static func shared() -> DatadogWrapper? {
-        return nil
-    }
 
-    public func log(level: LogLevel,
-                    message: String,
-                    error: Error? = nil,
-                    attributes: [String: Encodable]? = nil) {}
+}
+
+
+public class DatadogWrapper {
+
+    public static let shared: DatadogWrapper? = nil
+
+    public func log(
+        level: LogLevel,
+        message: String,
+        error: Error? = nil,
+        attributes: [String: Encodable]? = nil
+    ) {}
 
     public func startMonitoring() {}
 
     public var datadogUserId: String = "NONE"
 }
+
 #endif

--- a/Wire-iOS/Sources/Managers/DatadogWrapper.swift
+++ b/Wire-iOS/Sources/Managers/DatadogWrapper.swift
@@ -97,7 +97,6 @@ public class DatadogWrapper {
                     message: String,
                     error: Error? = nil,
                     attributes: [String: Encodable]? = nil) {
-        guard DeveloperFlag.datadogEnabled.isOn else { return }
         logger?.log(level: level, message: message, error: error, attributes: attributes)
     }
 }

--- a/Wire-iOS/Sources/Managers/DatadogWrapper.swift
+++ b/Wire-iOS/Sources/Managers/DatadogWrapper.swift
@@ -26,7 +26,7 @@ public class DatadogWrapper {
 
     /// Get shared instance only if Developer Flag is on.
 
-    public static lazy var shared: DatadogWrapper? = {
+    public static var shared: DatadogWrapper? = {
         let bundle = Bundle(for: DatadogWrapper.self)
 
         guard

--- a/Wire-iOS/Sources/Managers/DatadogWrapper.swift
+++ b/Wire-iOS/Sources/Managers/DatadogWrapper.swift
@@ -186,8 +186,6 @@ public enum LogLevel {
     case warn
 
 }
-
-
 public class DatadogWrapper {
 
     public static let shared: DatadogWrapper? = nil

--- a/WireCommonComponents/DeveloperFlag.swift
+++ b/WireCommonComponents/DeveloperFlag.swift
@@ -28,7 +28,6 @@ public enum DeveloperFlag: String, CaseIterable {
     case nseDebugging
     case nseDebugEntryPoint
     case useDevelopmentBackendAPI
-    case datadogEnabled
 
     public var description: String {
         switch self {
@@ -49,8 +48,6 @@ public enum DeveloperFlag: String, CaseIterable {
 
         case .useDevelopmentBackendAPI:
             return "Turn on to use the developement backend API version instead of the latest production API version."
-        case .datadogEnabled:
-            return "Turn on to use the use Datadog logs in extension or app."
         }
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Remove the developer flag to enabled DataDog so that it is always enabled (for internal builds only). This PR also contains some formatting improvements.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
