### PR TITLE
fix: User cannot resend code or change Email while creating a new personal wire account - ACC - 346

### DIFF
--- a/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationStepController.swift
+++ b/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationStepController.swift
@@ -199,12 +199,6 @@ class AuthenticationStepController: AuthenticationStepViewController {
         contentStack.distribution = .fill
         contentStack.alignment = .fill
 
-        let tapGesture = UITapGestureRecognizer(target: self,
-                                                action: #selector(dismissKeyboard))
-        
-        tapGesture.cancelsTouchesInView = false
-
-        view.addGestureRecognizer(tapGesture)
         view.addSubview(contentStack)
         view.addSubview(footerViewStackView)
     }
@@ -370,13 +364,16 @@ class AuthenticationStepController: AuthenticationStepViewController {
         mainView.becomeFirstResponderIfPossible()
     }
 
-    @objc
     func dismissKeyboard() {
         mainView.resignFirstResponder()
     }
 
     override func accessibilityPerformMagicTap() -> Bool {
         return (mainView as? MagicTappable)?.performMagicTap() == true
+    }
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        view.endEditing(true)
     }
 
 }

--- a/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationStepController.swift
+++ b/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationStepController.swift
@@ -101,6 +101,8 @@ class AuthenticationStepController: AuthenticationStepViewController {
         super.viewDidLoad()
         view.backgroundColor = SemanticColors.View.backgroundDefault
 
+
+
         createViews()
         createConstraints()
         updateBackButton()
@@ -110,6 +112,12 @@ class AuthenticationStepController: AuthenticationStepViewController {
         super.viewDidAppear(animated)
         configureObservers()
         showKeyboard()
+
+        let tapGesture = UITapGestureRecognizer(target: self,
+                                                action: #selector(dismissKeyboard))
+        tapGesture.cancelsTouchesInView = false
+
+        self.view.addGestureRecognizer(tapGesture)
         UIAccessibility.post(notification: .screenChanged, argument: headlineLabel)
     }
 
@@ -364,6 +372,7 @@ class AuthenticationStepController: AuthenticationStepViewController {
         mainView.becomeFirstResponderIfPossible()
     }
 
+    @objc
     func dismissKeyboard() {
         mainView.resignFirstResponder()
     }

--- a/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationStepController.swift
+++ b/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationStepController.swift
@@ -359,7 +359,6 @@ class AuthenticationStepController: AuthenticationStepViewController {
         showKeyboard()
     }
 
-    @objc
     func showKeyboard() {
         mainView.becomeFirstResponderIfPossible()
     }

--- a/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationStepController.swift
+++ b/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationStepController.swift
@@ -100,9 +100,6 @@ class AuthenticationStepController: AuthenticationStepViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = SemanticColors.View.backgroundDefault
-
-
-
         createViews()
         createConstraints()
         updateBackButton()
@@ -112,12 +109,6 @@ class AuthenticationStepController: AuthenticationStepViewController {
         super.viewDidAppear(animated)
         configureObservers()
         showKeyboard()
-
-        let tapGesture = UITapGestureRecognizer(target: self,
-                                                action: #selector(dismissKeyboard))
-        tapGesture.cancelsTouchesInView = false
-
-        self.view.addGestureRecognizer(tapGesture)
         UIAccessibility.post(notification: .screenChanged, argument: headlineLabel)
     }
 
@@ -208,6 +199,12 @@ class AuthenticationStepController: AuthenticationStepViewController {
         contentStack.distribution = .fill
         contentStack.alignment = .fill
 
+        let tapGesture = UITapGestureRecognizer(target: self,
+                                                action: #selector(dismissKeyboard))
+        
+        tapGesture.cancelsTouchesInView = false
+
+        view.addGestureRecognizer(tapGesture)
         view.addSubview(contentStack)
         view.addSubview(footerViewStackView)
     }
@@ -368,6 +365,7 @@ class AuthenticationStepController: AuthenticationStepViewController {
         showKeyboard()
     }
 
+    @objc
     func showKeyboard() {
         mainView.becomeFirstResponderIfPossible()
     }

--- a/Wire-iOS/Sources/UserInterface/Components/CharacterInputField.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/CharacterInputField.swift
@@ -191,7 +191,6 @@ final class CharacterInputField: UIControl, UITextInputTraits, TextContainer {
         storage = String()
     }
 
-
     private func createConstraints() {
         stackView.translatesAutoresizingMaskIntoConstraints = false
 

--- a/Wire-iOS/Sources/UserInterface/Components/CharacterInputField.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/CharacterInputField.swift
@@ -188,7 +188,18 @@ final class CharacterInputField: UIControl, UITextInputTraits, TextContainer {
                                                                       action: #selector(onLongPress(_:)))
         addGestureRecognizer(longPressGestureRecognizer)
 
+        let tapGesture = UITapGestureRecognizer(target: self,
+                                                action: #selector(hideKeyboard))
+        tapGesture.cancelsTouchesInView = false
+
+        addGestureRecognizer(tapGesture)
+
         storage = String()
+    }
+
+    @objc
+    private func hideKeyboard() {
+        self.endEditing(true)
     }
 
     private func createConstraints() {

--- a/Wire-iOS/Sources/UserInterface/Components/CharacterInputField.swift
+++ b/Wire-iOS/Sources/UserInterface/Components/CharacterInputField.swift
@@ -188,19 +188,9 @@ final class CharacterInputField: UIControl, UITextInputTraits, TextContainer {
                                                                       action: #selector(onLongPress(_:)))
         addGestureRecognizer(longPressGestureRecognizer)
 
-        let tapGesture = UITapGestureRecognizer(target: self,
-                                                action: #selector(hideKeyboard))
-        tapGesture.cancelsTouchesInView = false
-
-        addGestureRecognizer(tapGesture)
-
         storage = String()
     }
 
-    @objc
-    private func hideKeyboard() {
-        self.endEditing(true)
-    }
 
     private func createConstraints() {
         stackView.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR we fix a keyboard trap that we had during the sign-up flow, where the user couldn't dismiss the keyboard in any way. With the new implementation, the user can dismiss the keyboard by tapping anywhere on the screen

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
