### PR TITLE
fix: setup EAR permissions in login flow

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -28,8 +28,8 @@
 		065A5AF3279B083B002D4D1E /* WireDataModel.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A99EE1A5266657B000E713FC /* WireDataModel.xcframework */; };
 		065A5AF5279B0840002D4D1E /* WireSyncEngine.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A99EE19D266657AF00E713FC /* WireSyncEngine.xcframework */; };
 		065B7E842861F48500EF9595 /* Colors+Generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = E52D5A7A2858C18600D0494E /* Colors+Generated.swift */; };
-		0665DF7028EE366D0094482B /* ZMConversationMessage+Announcement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0665DF6F28EE366D0094482B /* ZMConversationMessage+Announcement.swift */; };
 		0665DF6E28E494360094482B /* ImagePickerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0665DF6D28E494360094482B /* ImagePickerManager.swift */; };
+		0665DF7028EE366D0094482B /* ZMConversationMessage+Announcement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0665DF6F28EE366D0094482B /* ZMConversationMessage+Announcement.swift */; };
 		0665DF7328F01D3B0094482B /* ProfileImagePickerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0665DF7228F01D3B0094482B /* ProfileImagePickerManager.swift */; };
 		0667FE312384237E00F75F93 /* UICollectionView+SetMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0667FE302384237E00F75F93 /* UICollectionView+SetMessage.swift */; };
 		06717E592865179000AF442C /* SemanticColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06717E582865178F00AF442C /* SemanticColors.swift */; };
@@ -1332,6 +1332,7 @@
 		EE8E926E2024F085000F4752 /* MarkdownTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8E926D2024F085000F4752 /* MarkdownTextView.swift */; };
 		EE948F1923E17778000A663E /* ContactsDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE948F1823E17778000A663E /* ContactsDataSource.swift */; };
 		EE94CA1925C2E490005F1155 /* ScreenCurtainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE94CA0B25C2E48B005F1155 /* ScreenCurtainTests.swift */; };
+		EE98A09E296ED46D0055E981 /* DeviceConfigurationEventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE98A09D296ED46D0055E981 /* DeviceConfigurationEventHandler.swift */; };
 		EE997A1A2507A851008336D2 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE997A192507A851008336D2 /* Logging.swift */; };
 		EE9EE24028DB12920009F144 /* JobTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE9EE23F28DB12920009F144 /* JobTests.swift */; };
 		EEA1ED7325BF430B006D07D3 /* AppLockModule.View.LockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8736F1831E4B67F0001CBA62 /* AppLockModule.View.LockView.swift */; };
@@ -1871,8 +1872,8 @@
 		065A5ADE279B07AC002D4D1E /* Wire Notification Service Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "Wire Notification Service Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		065A5AE0279B07AC002D4D1E /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		065A5AE2279B07AC002D4D1E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		0665DF6F28EE366D0094482B /* ZMConversationMessage+Announcement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversationMessage+Announcement.swift"; sourceTree = "<group>"; };
 		0665DF6D28E494360094482B /* ImagePickerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePickerManager.swift; sourceTree = "<group>"; };
+		0665DF6F28EE366D0094482B /* ZMConversationMessage+Announcement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversationMessage+Announcement.swift"; sourceTree = "<group>"; };
 		0665DF7228F01D3B0094482B /* ProfileImagePickerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileImagePickerManager.swift; sourceTree = "<group>"; };
 		0667FE302384237E00F75F93 /* UICollectionView+SetMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView+SetMessage.swift"; sourceTree = "<group>"; };
 		06717E582865178F00AF442C /* SemanticColors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SemanticColors.swift; sourceTree = "<group>"; };
@@ -3268,6 +3269,7 @@
 		EE8E926D2024F085000F4752 /* MarkdownTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownTextView.swift; sourceTree = "<group>"; };
 		EE948F1823E17778000A663E /* ContactsDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactsDataSource.swift; sourceTree = "<group>"; };
 		EE94CA0B25C2E48B005F1155 /* ScreenCurtainTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenCurtainTests.swift; sourceTree = "<group>"; };
+		EE98A09D296ED46D0055E981 /* DeviceConfigurationEventHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceConfigurationEventHandler.swift; sourceTree = "<group>"; };
 		EE997A192507A851008336D2 /* Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
 		EE9EE23F28DB12920009F144 /* JobTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JobTests.swift; sourceTree = "<group>"; };
 		EEA2E56F25B2385D00E726C3 /* AppLockModulePresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockModulePresenterTests.swift; sourceTree = "<group>"; };
@@ -4457,6 +4459,7 @@
 				5E8DA780211C3B7200360979 /* Pre-Login */,
 				5E8DA756211B04EA00360979 /* Post-Login */,
 				5EFD914021C9063E00080599 /* Input */,
+				EE98A0A3296ED4930055E981 /* Device Configuration */,
 			);
 			path = "Event Handlers";
 			sourceTree = "<group>";
@@ -7190,6 +7193,14 @@
 			path = Tests;
 			sourceTree = "<group>";
 		};
+		EE98A0A3296ED4930055E981 /* Device Configuration */ = {
+			isa = PBXGroup;
+			children = (
+				EE98A09D296ED46D0055E981 /* DeviceConfigurationEventHandler.swift */,
+			);
+			path = "Device Configuration";
+			sourceTree = "<group>";
+		};
 		EEA65C2525D27A8300AA7519 /* Generated */ = {
 			isa = PBXGroup;
 			children = (
@@ -8903,6 +8914,7 @@
 				A95DFDC124E6D2E30005DC0E /* CGSize+Const.swift in Sources */,
 				5EB45761204EA75300BA217A /* CallQualityDismissalTransition.swift in Sources */,
 				5EDD253C2140044D00C0E254 /* SettingsLicenseItem.swift in Sources */,
+				EE98A09E296ED46D0055E981 /* DeviceConfigurationEventHandler.swift in Sources */,
 				BF5DF5C520F4B0B8002BCB67 /* UICollectionView+GroupedSections.swift in Sources */,
 				546EEA8F2536DFAB00195097 /* SwitchingAccountRouter.swift in Sources */,
 				8742C2E21E51BD7900329FB6 /* TextSearchInputView.swift in Sources */,

--- a/Wire-iOS/Sources/Authentication/AuthenticationFlowStep.swift
+++ b/Wire-iOS/Sources/Authentication/AuthenticationFlowStep.swift
@@ -82,6 +82,9 @@ indirect enum AuthenticationFlowStep: Equatable {
     case incrementalUserCreation(UnregisteredUser, IntermediateRegistrationStep)
     case createUser(UnregisteredUser)
 
+    // Configuration
+    case configureDevice
+
     // MARK: - Properties
 
     /// Whether the authentication steps generates a user interface.
@@ -118,6 +121,9 @@ indirect enum AuthenticationFlowStep: Equatable {
         case .activateCredentials: return false
         case .incrementalUserCreation(_, let intermediateStep): return intermediateStep.needsInterface
         case .createUser: return false
+
+        // Configuration
+        case .configureDevice: return false
         }
     }
 

--- a/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
+++ b/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
@@ -364,6 +364,24 @@ extension AuthenticationCoordinator: AuthenticationActioner, SessionManagerCreat
 
             case .addEmailAndPassword(let newCredentials):
                 setEmailCredentialsForCurrentUser(newCredentials)
+
+            case .configureDevicePermissions:
+                guard
+                    let session = ZMUserSession.shared(),
+                    session.encryptMessagesAtRest
+                else {
+                    eventResponderChain.handleEvent(ofType: .deviceConfigurationComplete)
+                    return
+                }
+
+                session.appLockController.evaluateAuthentication(
+                    passcodePreference: .deviceOnly,
+                    description: L10n.Localizable.Self.Settings.PrivacySecurity.LockApp.description
+                ){ [weak self] _, _  in
+                    DispatchQueue.main.performAsync {
+                        self?.eventResponderChain.handleEvent(ofType: .deviceConfigurationComplete)
+                    }
+                }
             }
         }
     }

--- a/Wire-iOS/Sources/Authentication/Event Handlers/AuthenticationCoordinatorAction.swift
+++ b/Wire-iOS/Sources/Authentication/Event Handlers/AuthenticationCoordinatorAction.swift
@@ -57,6 +57,7 @@ enum AuthenticationCoordinatorAction {
     case startBackupFlow
     case signOut(warn: Bool)
     case addEmailAndPassword(ZMEmailCredentials)
+    case configureDevicePermissions
 
     var retainsModal: Bool {
         switch self {

--- a/Wire-iOS/Sources/Authentication/Event Handlers/AuthenticationEventResponderChain.swift
+++ b/Wire-iOS/Sources/Authentication/Event Handlers/AuthenticationEventResponderChain.swift
@@ -67,6 +67,7 @@ class AuthenticationEventResponderChain {
         case registrationStepSuccess
         case userProfileChange(UserChangeInfo)
         case userInput(Any)
+        case deviceConfigurationComplete
     }
 
     // MARK: - Properties
@@ -98,6 +99,7 @@ class AuthenticationEventResponderChain {
     var registrationSuccessHandlers: [AnyAuthenticationEventHandler<Void>] = []
     var userProfileChangeObservers: [AnyAuthenticationEventHandler<UserChangeInfo>] = []
     var userInputObservers: [AnyAuthenticationEventHandler<Any>] = []
+    var deviceConfigurationHandlers: [AnyAuthenticationEventHandler<Void>] = []
 
     /**
      * Configures the object with the given delegate and registers the default observers.
@@ -168,6 +170,9 @@ class AuthenticationEventResponderChain {
         registerHandler(AuthenticationButtonTapInputHandler(), to: &userInputObservers)
         registerHandler(AuthenticationAddEmailPasswordInputHandler(), to: &userInputObservers)
         registerHandler(AuthenticationReauthenticateInputHandler(), to: &userInputObservers)
+
+        // deviceConfigurationHandlers
+        registerHandler(DeviceConfigurationEventHandler(), to: &deviceConfigurationHandlers)
     }
 
     /// Registers a handler inside the specified type erased array.
@@ -209,6 +214,8 @@ class AuthenticationEventResponderChain {
             handleEvent(with: userProfileChangeObservers, context: changeInfo)
         case .userInput(let value):
             handleEvent(with: userInputObservers, context: value)
+        case .deviceConfigurationComplete:
+            handleEvent(with: deviceConfigurationHandlers, context: ())
         }
     }
 

--- a/Wire-iOS/Sources/Authentication/Event Handlers/Device Configuration/DeviceConfigurationEventHandler.swift
+++ b/Wire-iOS/Sources/Authentication/Event Handlers/Device Configuration/DeviceConfigurationEventHandler.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2018 Wire Swiss GmbH
+// Copyright (C) 2023 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -18,17 +18,18 @@
 
 import Foundation
 
-/**
- * Handles the notification informing that the user session has been created after the user registered.
- */
-
-class RegistrationSessionAvailableEventHandler: AuthenticationEventHandler {
+class DeviceConfigurationEventHandler: AuthenticationEventHandler {
 
     weak var statusProvider: AuthenticationStatusProvider?
 
     func handleEvent(currentStep: AuthenticationFlowStep, context: Void) -> [AuthenticationCoordinatorAction]? {
-        guard case .createUser = currentStep else { return nil }
-        return [.transition(.configureDevice, mode: .normal), .configureDevicePermissions]
+        guard case .configureDevice = currentStep else { return nil }
+
+        if statusProvider?.sharedUserSession?.hasCompletedInitialSync == true {
+            return [.hideLoadingView, postAction]
+        } else {
+            return [.transition(.pendingInitialSync(next: nil), mode: .normal)]
+        }
     }
 
 }

--- a/Wire-iOS/Sources/Authentication/Event Handlers/Post-Login/Success/AuthenticationSuccessEventHandler.swift
+++ b/Wire-iOS/Sources/Authentication/Event Handlers/Post-Login/Success/AuthenticationSuccessEventHandler.swift
@@ -28,11 +28,7 @@ class AuthenticationClientRegistrationSuccessHandler: AuthenticationEventHandler
     weak var statusProvider: AuthenticationStatusProvider?
 
     func handleEvent(currentStep: AuthenticationFlowStep, context: Void) -> [AuthenticationCoordinatorAction]? {
-        if ZMUserSession.shared()?.hasCompletedInitialSync == true {
-            return [.hideLoadingView, .completeLoginFlow]
-        } else {
-            return [.transition(.pendingInitialSync(next: nil), mode: .normal)]
-        }
+        return [.transition(.configureDevice, mode: .normal), .configureDevicePermissions]
     }
 
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After https://github.com/wireapp/wire-ios-sync-engine/commit/6b1675bb6cba6d4407e4c024bf9524ddbd16938a we no longer ask for FaceID permissions during the login flow.

### Causes

Previously we were migrating the DB to encryption at rest (this was unnecessary and causing issues so I removed the migration step), which then resulted In a locked DB. The user then needed to authenticate to unlock the DB, which causes the permission for FaceID to be requested. Since we skip the migration phase now, we don't need to unlock the DB and consequently no FaceID permission is needed during the login flow. 

### Solutions

- Add a step to the login flow to configure the device. 
- In this step, require local authentication (triggering biometric permission requests) if EAR is enabled.
- Insert this step before completing both the login and registration flows.

### Testing

#### How to Test

1. Configure the app to require EAR.
2. Log in, or sign up with a new account.
3. Verify that local authentication is required before completing the flow.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
