### PR TITLE
fix: traitCollection for tab bar ACC-414

### DIFF
--- a/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController.swift
@@ -417,7 +417,7 @@ extension UITabBar {
     // the UITabBar shows the UITabBarItem icon next to the text
     override open var traitCollection: UITraitCollection {
         if UIDevice.current.userInterfaceIdiom == .pad {
-            return UITraitCollection(horizontalSizeClass: .compact)
+            return UITraitCollection(traitsFrom: [super.traitCollection, UITraitCollection(horizontalSizeClass: .compact)])
         }
         return super.traitCollection
     }

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListTabBar.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListTabBar.swift
@@ -171,6 +171,11 @@ final class ConversationListTabBar: UITabBar {
         scalesLargeContentImage = true
     }
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        guard previousTraitCollection?.userInterfaceStyle != traitCollection.userInterfaceStyle else { return }
+    }
+
 }
 
 // MARK: - ConversationListViewModelRestorationDelegate

--- a/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListTabBar.swift
+++ b/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListTabBar.swift
@@ -171,11 +171,6 @@ final class ConversationListTabBar: UITabBar {
         scalesLargeContentImage = true
     }
 
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        guard previousTraitCollection?.userInterfaceStyle != traitCollection.userInterfaceStyle else { return }
-    }
-
 }
 
 // MARK: - ConversationListViewModelRestorationDelegate


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/ACC-414" title="ACC-414" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />ACC-414</a>  [iOS] iPad: Tab bar doesn't update colors when switching from Light to Dark mode
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
Wrong colors in dark mode for tab bar.

### Solutions

We need use `super.traitCollection` for TabBar.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
