### PR TITLE
fix: Update font size for navigation bar items in `BackupPasswordViewController`

### DIFF
--- a/Wire-iOS/Sources/Helpers/UIBarButtonItem+StyleKit.swift
+++ b/Wire-iOS/Sources/Helpers/UIBarButtonItem+StyleKit.swift
@@ -78,4 +78,38 @@ extension UIBarButtonItem {
             return rightBarButtonItem
 
         }
+
+    static func createNavigationLeftBarButtonItem(
+        title: String? = nil,
+        systemImage: Bool,
+        target buttonTarget: Any?,
+        action buttonAction: Selector?,
+        font buttonFont: FontSpec = .headerRegularFont) -> UIBarButtonItem {
+
+            var leftBarButtonItem: UIBarButtonItem
+            if systemImage {
+                leftBarButtonItem = UIBarButtonItem(
+                    barButtonSystemItem: .done,
+                    target: buttonTarget,
+                    action: buttonAction)
+            } else {
+                leftBarButtonItem = UIBarButtonItem(
+                    title: title,
+                    style: .plain,
+                    target: buttonTarget,
+                    action: buttonAction)
+            }
+
+            let buttonStates: [UIControl.State] = [.normal, .highlighted, .disabled, .selected, .focused, .application, .reserved]
+
+            if let buttonFont = buttonFont.font {
+                buttonStates.forEach { buttonState in
+                    leftBarButtonItem.setTitleTextAttributes(
+                        [NSAttributedString.Key.font: buttonFont],
+                        for: buttonState)
+                }
+            }
+            return leftBarButtonItem
+
+        }
 }

--- a/Wire-iOS/Sources/Helpers/UIBarButtonItem+StyleKit.swift
+++ b/Wire-iOS/Sources/Helpers/UIBarButtonItem+StyleKit.swift
@@ -50,7 +50,7 @@ extension UIBarButtonItem {
         systemImage: Bool,
         target buttonTarget: Any?,
         action buttonAction: Selector?,
-        font buttonFont: FontSpec = .headerRegularFont) -> UIBarButtonItem {
+        font buttonFont: UIFont = .preferredFont(forTextStyle: .body)) -> UIBarButtonItem {
 
             var rightBarButtonItem: UIBarButtonItem
             if systemImage {
@@ -68,12 +68,10 @@ extension UIBarButtonItem {
 
             let buttonStates: [UIControl.State] = [.normal, .highlighted, .disabled, .selected, .focused, .application, .reserved]
 
-            if let buttonFont = buttonFont.font {
-                buttonStates.forEach { buttonState in
-                    rightBarButtonItem.setTitleTextAttributes(
-                        [NSAttributedString.Key.font: buttonFont],
-                        for: buttonState)
-                }
+            buttonStates.forEach { buttonState in
+                rightBarButtonItem.setTitleTextAttributes(
+                    [NSAttributedString.Key.font: buttonFont],
+                    for: buttonState)
             }
             return rightBarButtonItem
 
@@ -84,7 +82,7 @@ extension UIBarButtonItem {
         systemImage: Bool,
         target buttonTarget: Any?,
         action buttonAction: Selector?,
-        font buttonFont: FontSpec = .headerRegularFont) -> UIBarButtonItem {
+        font buttonFont: UIFont = .preferredFont(forTextStyle: .body)) -> UIBarButtonItem {
 
             var leftBarButtonItem: UIBarButtonItem
             if systemImage {
@@ -102,12 +100,10 @@ extension UIBarButtonItem {
 
             let buttonStates: [UIControl.State] = [.normal, .highlighted, .disabled, .selected, .focused, .application, .reserved]
 
-            if let buttonFont = buttonFont.font {
-                buttonStates.forEach { buttonState in
-                    leftBarButtonItem.setTitleTextAttributes(
-                        [NSAttributedString.Key.font: buttonFont],
-                        for: buttonState)
-                }
+            buttonStates.forEach { buttonState in
+                leftBarButtonItem.setTitleTextAttributes(
+                    [NSAttributedString.Key.font: buttonFont],
+                    for: buttonState)
             }
             return leftBarButtonItem
 

--- a/Wire-iOS/Sources/UserInterface/Settings/BackupPasswordViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/BackupPasswordViewController.swift
@@ -143,20 +143,24 @@ final class BackupPasswordViewController: UIViewController {
 
         navigationItem.setupNavigationBarTitle(title: HistoryBackup.Password.title.capitalized)
 
-        navigationItem.leftBarButtonItem = UIBarButtonItem(
-            title: HistoryBackup.Password.cancel.capitalized,
-            style: .plain,
+        let cancelButtonItem: UIBarButtonItem = .createNavigationRightBarButtonItem(
+            title: HistoryBackup.Password.next.capitalized,
+            systemImage: false,
             target: self,
             action: #selector(cancel)
         )
-        navigationItem.rightBarButtonItem = UIBarButtonItem(
+
+        let nextButtonItem: UIBarButtonItem = .createNavigationRightBarButtonItem(
             title: HistoryBackup.Password.next.capitalized,
-            style: .done,
+            systemImage: false,
             target: self,
             action: #selector(completeWithCurrentResult)
-        )
-        navigationItem.rightBarButtonItem?.tintColor = .accent()
-        navigationItem.rightBarButtonItem?.isEnabled = false
+       )
+        nextButtonItem.tintColor = UIColor.accent()
+        nextButtonItem.isEnabled = false
+
+        navigationItem.leftBarButtonItem = cancelButtonItem
+        navigationItem.rightBarButtonItem = nextButtonItem
     }
 
     fileprivate func updateState(with text: String) {

--- a/Wire-iOS/Sources/UserInterface/Settings/BackupPasswordViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Settings/BackupPasswordViewController.swift
@@ -143,8 +143,8 @@ final class BackupPasswordViewController: UIViewController {
 
         navigationItem.setupNavigationBarTitle(title: HistoryBackup.Password.title.capitalized)
 
-        let cancelButtonItem: UIBarButtonItem = .createNavigationRightBarButtonItem(
-            title: HistoryBackup.Password.next.capitalized,
+        let cancelButtonItem: UIBarButtonItem = .createNavigationLeftBarButtonItem(
+            title: HistoryBackup.Password.cancel.capitalized,
             systemImage: false,
             target: self,
             action: #selector(cancel)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR we update the font size of the NavigationBarItems in BackupPasswordViewController. 

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
