### PR TITLE
fix: Border Color of Search Icon in Conversation View when bringing the app from the background to foreground

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
@@ -186,6 +186,7 @@ final class ConversationViewController: UIViewController {
 
         if traitCollection.userInterfaceStyle != previousTraitCollection?.userInterfaceStyle {
             updateRightNavigationItemsButtons()
+            updateLeftNavigationBarItems()
         }
     }
 
@@ -536,10 +537,6 @@ extension ConversationViewController: ConversationInputBarViewControllerDelegate
         button.layer.cornerRadius = 12
         button.contentEdgeInsets = UIEdgeInsets(top: 8, left: 12, bottom: 8, right: 12)
         button.bounds.size = button.systemLayoutSizeFitting(CGSize(width: .max, height: 32))
-
-        if showingSearchResults {
-            button.tintColor = UIColor.accent()
-        }
 
         return UIBarButtonItem(customView: button)
     }


### PR DESCRIPTION

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

That issue is bugging me for a while. So when we bring the app from the background to the foreground and we're in the conversation view. Then the border color of the search icon is wrong. With this PR we fix that issue. 

Here's a video that explains that issue. 

https://user-images.githubusercontent.com/10944108/212669330-39b4ae33-b771-4c20-98c5-56a041e75edb.mp4

----

##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
