### PR TITLE
fix: incoming call landscape layout FS-1502

### DIFF
--- a/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsView/CallingActionsView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsView/CallingActionsView.swift
@@ -137,7 +137,8 @@ class CallingActionsView: UIView {
             handleView.heightAnchor.constraint(equalToConstant: 5),
             handleView.widthAnchor.constraint(equalToConstant: 130),
             topStackView.leadingAnchor.constraint(equalTo: verticalStackView.leadingAnchor, constant: 14),
-            topStackView.trailingAnchor.constraint(equalTo: verticalStackView.trailingAnchor, constant: -14)
+            topStackView.trailingAnchor.constraint(equalTo: verticalStackView.trailingAnchor, constant: -14),
+            topStackView.heightAnchor.constraint(equalToConstant: 85).withPriority(.required)
         ])
     }
 
@@ -163,20 +164,19 @@ class CallingActionsView: UIView {
             $0.subtitleTransformLabel.font = FontSpec(.small, .bold).font!
             addSubview($0)
         }
-        NSLayoutConstraint.activate([
-            largeHangUpButton.leadingAnchor.constraint(equalTo: safeLeadingAnchor, constant: 20.0),
-            largeHangUpButton.bottomAnchor.constraint(equalTo: safeBottomAnchor, constant: -34.0),
-            largePickUpButton.trailingAnchor.constraint(equalTo: safeTrailingAnchor, constant: -20.0),
-            largePickUpButton.bottomAnchor.constraint(equalTo: safeBottomAnchor, constant: -34.0)
-        ])
 
         largeButtonsPortraitConstraints = [
             largeHangUpButton.centerXAnchor.constraint(equalTo: microphoneButton.centerXAnchor).withPriority(.required),
-            largePickUpButton.centerXAnchor.constraint(equalTo: speakerButton.centerXAnchor).withPriority(.required)
+            largePickUpButton.centerXAnchor.constraint(equalTo: speakerButton.centerXAnchor).withPriority(.required),
+
+            largeHangUpButton.bottomAnchor.constraint(equalTo: safeBottomAnchor, constant: -34.0),
+            largePickUpButton.bottomAnchor.constraint(equalTo: safeBottomAnchor, constant: -34.0)
         ]
         largeButtonsLandscapeConstraints = [
             largeHangUpButton.centerYAnchor.constraint(equalTo: microphoneButton.centerYAnchor).withPriority(.required),
-            largePickUpButton.centerYAnchor.constraint(equalTo: largeHangUpButton.centerYAnchor).withPriority(.required)
+            largePickUpButton.centerYAnchor.constraint(equalTo: largeHangUpButton.centerYAnchor).withPriority(.required),
+            largeHangUpButton.leadingAnchor.constraint(equalTo: safeLeadingAnchor, constant: 20.0),
+            largePickUpButton.trailingAnchor.constraint(equalTo: safeTrailingAnchor, constant: -20.0),
         ]
         let isPortrait = !UIDevice.current.orientation.isLandscape
         NSLayoutConstraint.activate(

--- a/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsView/CallingActionsView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsView/CallingActionsView.swift
@@ -176,7 +176,7 @@ class CallingActionsView: UIView {
             largeHangUpButton.centerYAnchor.constraint(equalTo: microphoneButton.centerYAnchor).withPriority(.required),
             largePickUpButton.centerYAnchor.constraint(equalTo: largeHangUpButton.centerYAnchor).withPriority(.required),
             largeHangUpButton.leadingAnchor.constraint(equalTo: safeLeadingAnchor, constant: 20.0),
-            largePickUpButton.trailingAnchor.constraint(equalTo: safeTrailingAnchor, constant: -20.0),
+            largePickUpButton.trailingAnchor.constraint(equalTo: safeTrailingAnchor, constant: -20.0)
         ]
         let isPortrait = !UIDevice.current.orientation.isLandscape
         NSLayoutConstraint.activate(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1502" title="FS-1502" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1502</a>  [iOS] Calling: on non-UI KIT calls, the calling UI has different sizes of buttons
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->


#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
