### PR TITLE
fix: calling UI layout issues FS-1501

### DIFF
--- a/Wire-iOS.xcodeproj/project.pbxproj
+++ b/Wire-iOS.xcodeproj/project.pbxproj
@@ -1185,6 +1185,7 @@
 		D35EEDC928C7E68100949F02 /* URLRequestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EEDC728C7E68100949F02 /* URLRequestable.swift */; };
 		D35EEDCB28C7E95F00949F02 /* CookieProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EEDCA28C7E95F00949F02 /* CookieProvider.swift */; };
 		D35EEDCC28C7E95F00949F02 /* CookieProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EEDCA28C7E95F00949F02 /* CookieProvider.swift */; };
+		D364822C299630CD009EEE4D /* UIDevice+Orientation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D364822B299630CD009EEE4D /* UIDevice+Orientation.swift */; };
 		D36E027829374EEA006C3E5A /* NSLayoutConstraint+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36E027729374EEA006C3E5A /* NSLayoutConstraint+Helper.swift */; };
 		D36E027A293758DD006C3E5A /* CallHeaderBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36E0279293758DD006C3E5A /* CallHeaderBar.swift */; };
 		D38BC97628BF8AA700EB928F /* NotificationServiceError.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE455DF28AFC443005ACD74 /* NotificationServiceError.swift */; };
@@ -3161,6 +3162,7 @@
 		D35EEDC428C2374300949F02 /* NetworkSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkSessionTests.swift; sourceTree = "<group>"; };
 		D35EEDC728C7E68100949F02 /* URLRequestable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLRequestable.swift; sourceTree = "<group>"; };
 		D35EEDCA28C7E95F00949F02 /* CookieProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CookieProvider.swift; sourceTree = "<group>"; };
+		D364822B299630CD009EEE4D /* UIDevice+Orientation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIDevice+Orientation.swift"; sourceTree = "<group>"; };
 		D36E027729374EEA006C3E5A /* NSLayoutConstraint+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSLayoutConstraint+Helper.swift"; sourceTree = "<group>"; };
 		D36E0279293758DD006C3E5A /* CallHeaderBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallHeaderBar.swift; sourceTree = "<group>"; };
 		D3A74DBC29432E8B00DD272F /* EstablishingCallStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EstablishingCallStatusView.swift; sourceTree = "<group>"; };
@@ -6957,6 +6959,7 @@
 				BFE41870209C8AFD00503C7C /* CallInfoConfiguration+Debug.swift */,
 				635BAFE5262DB34400B986A4 /* Array+CallParticipant.swift */,
 				D36E027729374EEA006C3E5A /* NSLayoutConstraint+Helper.swift */,
+				D364822B299630CD009EEE4D /* UIDevice+Orientation.swift */,
 			);
 			path = Helper;
 			sourceTree = "<group>";
@@ -8597,6 +8600,7 @@
 				1648EEF32049A6F800CC6B37 /* DirectorySectionController.swift in Sources */,
 				A96A21EF23D5AE6D005B5579 /* UIApplication+Permissions.swift in Sources */,
 				5E9E8A9D21621FEC0058D6E1 /* AuthenticationActioner.swift in Sources */,
+				D364822C299630CD009EEE4D /* UIDevice+Orientation.swift in Sources */,
 				BF8EE5561D62FBCD00B0D6D7 /* ConversationInputBarViewController+Editing.swift in Sources */,
 				16A94AEF2099DFEC008A5718 /* CallParticipantsListViewController.swift in Sources */,
 				F15650E121DD11CA00210504 /* SpinnerSubtitleView.swift in Sources */,

--- a/Wire-iOS/Generated/Strings+Generated.swift
+++ b/Wire-iOS/Generated/Strings+Generated.swift
@@ -5611,8 +5611,8 @@ internal enum L10n {
         internal static let title = L10n.tr("Localizable", "voice.network_error.title", fallback: "No Internet Connection")
       }
       internal enum PickUpButton {
-        /// Accept
-        internal static let title = L10n.tr("Localizable", "voice.pick_up_button.title", fallback: "Accept")
+        /// Pick Up
+        internal static let title = L10n.tr("Localizable", "voice.pick_up_button.title", fallback: "Pick Up")
       }
       internal enum SpeakerButton {
         /// Speaker

--- a/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -650,7 +650,7 @@
 "voice.cancel_button.title" = "Cancel";
 "voice.call_button.title" = "Call";
 "voice.end_call_button.title" = "End Call";
-"voice.pick_up_button.title" = "Accept";
+"voice.pick_up_button.title" = "Pick Up";
 "voice.calling.title" = "Calling...";
 "voice.call_error.unsupported_version.title" = "Please update Wire";
 "voice.call_error.unsupported_version.message" = "You received a call that isn't supported by this version of Wire.\nGet the latest version in the App Store.";

--- a/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallHeaderBar.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallHeaderBar.swift
@@ -64,7 +64,8 @@ class CallHeaderBar: UIView {
             minimalizeButton.centerYAnchor.constraint(equalTo: centerYAnchor),
             minimalizeButton.widthAnchor.constraint(equalToConstant: 32.0),
             minimalizeButton.heightAnchor.constraint(equalToConstant: 32.0),
-            verticalStackView.leadingAnchor.constraint(greaterThanOrEqualTo: minimalizeButton.trailingAnchor, constant: 6.0)
+            verticalStackView.leadingAnchor.constraint(greaterThanOrEqualTo: minimalizeButton.trailingAnchor, constant: 6.0),
+            verticalStackView.heightAnchor.constraint(greaterThanOrEqualToConstant: 32.0)
         ])
     }
 

--- a/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsInfoViewController/CallingActionsInfoViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsInfoViewController/CallingActionsInfoViewController.swift
@@ -129,7 +129,7 @@ class CallingActionsInfoViewController: UIViewController, UICollectionViewDelega
     }
 
     func updateActionViewHeight() {
-        guard UIDevice.current.orientation.isLandscape else {
+        guard UIDevice.current.twoDimensionOrientation.isLandscape else {
             actionsViewHeightConstraint.constant =  isIncomingCall ? 250 : 128
             actionsView.verticalStackView.alignment = .fill
             return

--- a/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsView/CallingActionsView.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsView/CallingActionsView.swift
@@ -178,7 +178,7 @@ class CallingActionsView: UIView {
             largeHangUpButton.leadingAnchor.constraint(equalTo: safeLeadingAnchor, constant: 20.0),
             largePickUpButton.trailingAnchor.constraint(equalTo: safeTrailingAnchor, constant: -20.0)
         ]
-        let isPortrait = !UIDevice.current.orientation.isLandscape
+        let isPortrait = UIDevice.current.twoDimensionOrientation.isPortrait
         NSLayoutConstraint.activate(
             isPortrait ? largeButtonsPortraitConstraints : largeButtonsLandscapeConstraints
         )

--- a/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingBottomSheetViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingBottomSheetViewController.swift
@@ -44,7 +44,7 @@ class CallingBottomSheetViewController: BottomSheetContainerViewController {
         var offset = 0.0
         switch voiceChannel.state {
         case .incoming:
-            offset = UIDevice.current.orientation.isLandscape ? 128.0 : 250.0
+            offset = UIDevice.current.twoDimensionOrientation.isLandscape ? 128.0 : 250.0
         default:
             offset = 128.0
         }
@@ -133,7 +133,7 @@ class CallingBottomSheetViewController: BottomSheetContainerViewController {
     // after rotating device recalculate bottom sheet max height
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
-        let isLandscape = UIDevice.current.orientation.isLandscape
+        let isLandscape = UIDevice.current.twoDimensionOrientation.isLandscape
         // if landscape then bottom sheet should take whole screen (without headerBar)
         let bottomSheetMaxHeight = isLandscape ? (size.height - headerBar.bounds.height) : bottomSheetMaxHeight
         let newConfiguration = BottomSheetConfiguration(height: bottomSheetMaxHeight, initialOffset: bottomSheetMinimalOffset)

--- a/Wire-iOS/Sources/UserInterface/Calling/Helper/UIDevice+Orientation.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/Helper/UIDevice+Orientation.swift
@@ -1,0 +1,31 @@
+//
+// Wire
+// Copyright (C) 2023 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import UIKit
+
+extension UIDevice {
+    var twoDimensionOrientation: UIDeviceOrientation {
+        if orientation.isPortrait || orientation.isLandscape {
+            return orientation
+        }
+        guard let interfaceOrientation = UIApplication.shared.firstKeyWindow?.windowScene?.interfaceOrientation else {
+            return .portrait
+        }
+        return interfaceOrientation.isLandscape ? .landscapeLeft : .portrait
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1501" title="FS-1501" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1501</a>  [iOS] Calling: not matching avatar is shown when receiving non-UI Kit call with different display name
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->


- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
