### PR TITLE
fix: change image size in incoming call FS-1501

### DIFF
--- a/Wire-iOS/Generated/Strings+Generated.swift
+++ b/Wire-iOS/Generated/Strings+Generated.swift
@@ -5611,8 +5611,8 @@ internal enum L10n {
         internal static let title = L10n.tr("Localizable", "voice.network_error.title", fallback: "No Internet Connection")
       }
       internal enum PickUpButton {
-        /// Pick Up
-        internal static let title = L10n.tr("Localizable", "voice.pick_up_button.title", fallback: "Pick Up")
+        /// Accept
+        internal static let title = L10n.tr("Localizable", "voice.pick_up_button.title", fallback: "Accept")
       }
       internal enum SpeakerButton {
         /// Speaker

--- a/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -330,10 +330,11 @@ final class CallViewController: UIViewController {
         ])
         guard let user = voiceChannel.getSecondParticipant(), let session = ZMUserSession.shared() else { return }
         user.fetchProfileImage(session: session,
-                                     imageCache: UIImage.defaultUserImageCache,
-                                     sizeLimit: UserImageView.Size.big.rawValue,
-                                     isDesaturated: false,
-                                     completion: { [weak self] (image, _) in
+                               imageCache: UIImage.defaultUserImageCache,
+                               sizeLimit: UserImageView.Size.normal.rawValue,
+                               isDesaturated: false,
+                               completion: { [weak self] (image, _) in
+            guard let image = image else { return }
             self?.establishingCallStatusView.setProfileImage(image: image)
         })
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1501" title="FS-1501" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1501</a>  [iOS] Calling: not matching avatar is shown when receiving non-UI Kit call with different display name
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
