### PR TITLE
fix(mls-migration): attempt finalisation directly after migration started

### DIFF
--- a/wire-ios-data-model/Source/MLS/Migration/ProteusToMLSMigrationCoordinator.swift
+++ b/wire-ios-data-model/Source/MLS/Migration/ProteusToMLSMigrationCoordinator.swift
@@ -91,6 +91,7 @@ public class ProteusToMLSMigrationCoordinator: ProteusToMLSMigrationCoordinating
         switch storage.migrationStatus {
         case .notStarted:
             try await startMigrationIfNeeded()
+            try await finaliseMigrationIfNeeded()
         case .started:
             try await finaliseMigrationIfNeeded()
         default:


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Suggesting change to attempt to finalise the migration directly after it has been started instead of waiting 24 hours.
If there are any conversation that are ready to migrate from `mixed` to `mls`, they will migrate. The conversations that aren't ready will stay in `mixed` mode until every client in the conversation supports MLS or the migration finalisation time has been reached. 
