### PR TITLE
feat: introduce WireMacros - no ticket

### DIFF
--- a/WireAPI/Package.swift
+++ b/WireAPI/Package.swift
@@ -27,7 +27,8 @@ let package = Package(
             url: "https://github.com/pointfreeco/swift-snapshot-testing",
             from: "1.16.0"
         ),
-        .package(path: "../SourceryPlugin")
+        .package(path: "../SourceryPlugin"),
+        .package(path: "../WireMacros")
     ],
     targets: [
         .target(
@@ -47,6 +48,7 @@ let package = Package(
             name: "WireAPITests",
             dependencies: [
                 "WireAPI",
+                "WireMacros",
                 .product(
                     name: "SnapshotTesting",
                     package: "swift-snapshot-testing"

--- a/WireAPI/Tests/WireAPITests/APIs/ConversationsAPI/ConversationsAPITests.swift
+++ b/WireAPI/Tests/WireAPITests/APIs/ConversationsAPI/ConversationsAPITests.swift
@@ -16,6 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
+import WireMacros
 import XCTest
 
 @testable import WireAPI
@@ -107,7 +108,7 @@ final class ConversationsAPITests: XCTestCase {
         ]
 
         let expectedIDs: [UUID] = [
-            try XCTUnwrap(UUID(uuidString: "14c3f0ff-1a46-4e66-8845-ae084f09c483"))
+            #UUID("14c3f0ff-1a46-4e66-8845-ae084f09c483")
         ]
 
         let api = ConversationsAPIV0(httpClient: httpClient)
@@ -175,7 +176,7 @@ final class ConversationsAPITests: XCTestCase {
 
         let expectedIDs: [QualifiedID] = [
             QualifiedID(
-                uuid: try XCTUnwrap(UUID(uuidString: "14c3f0ff-1a46-4e66-8845-ae084f09c483")),
+                uuid: #UUID("14c3f0ff-1a46-4e66-8845-ae084f09c483"),
                 domain: "staging.zinfra.io"
             )
         ]
@@ -220,7 +221,7 @@ final class ConversationsAPITests: XCTestCase {
         let apiVersions = APIVersion.allCases
 
         let qualifiedID = QualifiedID(
-            uuid: try XCTUnwrap(UUID(uuidString: "213248a1-5499-418f-8173-5010d1c1e506")),
+            uuid: #UUID("213248a1-5499-418f-8173-5010d1c1e506"),
             domain: "wire.com"
         )
 

--- a/WireMacros/.gitignore
+++ b/WireMacros/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/WireMacros/.swiftpm/xcode/xcshareddata/xcschemes/WireMacros.xcscheme
+++ b/WireMacros/.swiftpm/xcode/xcshareddata/xcschemes/WireMacros.xcscheme
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1540"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "WireMacros"
+               BuildableName = "WireMacros"
+               BlueprintName = "WireMacros"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:Tests/WireMacrosTests/WireMacros.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "WireMacros"
+            BuildableName = "WireMacros"
+            BlueprintName = "WireMacros"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/WireMacros/.swiftpm/xcode/xcshareddata/xcschemes/WireMacrosClient.xcscheme
+++ b/WireMacros/.swiftpm/xcode/xcshareddata/xcschemes/WireMacrosClient.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1540"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "WireMacrosClient"
+               BuildableName = "WireMacrosClient"
+               BlueprintName = "WireMacrosClient"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "WireMacrosClient"
+            BuildableName = "WireMacrosClient"
+            BlueprintName = "WireMacrosClient"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "WireMacrosClient"
+            BuildableName = "WireMacrosClient"
+            BlueprintName = "WireMacrosClient"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/WireMacros/Package.swift
+++ b/WireMacros/Package.swift
@@ -1,0 +1,51 @@
+// swift-tools-version: 5.10
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+import CompilerPluginSupport
+
+let package = Package(
+    name: "WireMacros",
+    platforms: [.macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6), .macCatalyst(.v13)],
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "WireMacros",
+            targets: ["WireMacros"]
+        ),
+        .executable(
+            name: "WireMacrosClient",
+            targets: ["WireMacrosClient"]
+        ),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        // Macro implementation that performs the source transformation of a macro.
+        .macro(
+            name: "WireMacrosMacros",
+            dependencies: [
+                .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+                .product(name: "SwiftCompilerPlugin", package: "swift-syntax")
+            ]
+        ),
+
+        // Library that exposes a macro as part of its API, which is used in client programs.
+        .target(name: "WireMacros", dependencies: ["WireMacrosMacros"]),
+
+        // A client of the library, which is able to use the macro in its own code.
+        .executableTarget(name: "WireMacrosClient", dependencies: ["WireMacros"]),
+
+        // A test target used to develop the macro implementation.
+        .testTarget(
+            name: "WireMacrosTests",
+            dependencies: [
+                "WireMacrosMacros",
+                .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
+            ]
+        ),
+    ]
+)

--- a/WireMacros/Sources/WireMacros/WireMacros.swift
+++ b/WireMacros/Sources/WireMacros/WireMacros.swift
@@ -1,9 +1,10 @@
 // The Swift Programming Language
 // https://docs.swift.org/swift-book
 
-/// A macro that, when attached to
-/// a protocol declaration, produces a companion "provider" protocol
-/// that can be used inject dependencies.
+import Foundation
+
+/// A macro that, when attached to a protocol declaration, produces a
+/// companion "provider" protocol that can be used inject dependencies.
 ///
 /// For example:
 ///
@@ -46,4 +47,27 @@
 ///     }
 
 @attached(peer, names: suffixed(Provider))
-public macro Provided() = #externalMacro(module: "WireMacrosMacros", type: "ProvidedMacro")
+public macro Provided() = #externalMacro(
+    module: "WireMacrosMacros",
+    type: "ProvidedMacro"
+)
+
+/// A macro that validates UUID strings.
+///
+/// For example:
+///
+///     let validUUID = #UUID("7411ca17-ba08-4905-92d2-0617a8c810ca")
+///
+/// will compile and produce a non-optional `UUID`. On the otherhand:
+///
+///     let invalidUUID = #UUID("foo")
+///
+/// will throw a compile time error.
+
+@freestanding(expression)
+public macro UUID(
+    _ stringLiteral: String
+) -> UUID = #externalMacro(
+    module: "WireMacrosMacros",
+    type: "UUIDMacro"
+)

--- a/WireMacros/Sources/WireMacros/WireMacros.swift
+++ b/WireMacros/Sources/WireMacros/WireMacros.swift
@@ -1,5 +1,20 @@
-// The Swift Programming Language
-// https://docs.swift.org/swift-book
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
 
 import Foundation
 

--- a/WireMacros/Sources/WireMacros/WireMacros.swift
+++ b/WireMacros/Sources/WireMacros/WireMacros.swift
@@ -1,0 +1,49 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book
+
+/// A macro that, when attached to
+/// a protocol declaration, produces a companion "provider" protocol
+/// that can be used inject dependencies.
+///
+/// For example:
+///
+///     @Provided
+///     protocol MyUseCase {
+///         func invoke()
+///     }
+///
+/// will expand to:
+///
+///     protocol MyUseCase {
+///         func invoke()
+///     }
+///
+///     protocol MyUseCaseProvider {
+///         func makeMyUseCase() -> any MyUseCase
+///     }
+///
+/// Any object that is capable of providing the use case can
+/// conform to the provider protocol:
+///
+///     extension Factory: MyUseCaseProvider {
+///         func makeMyUseCase() -> any MyUseCase {
+///             MyUseCase(...)
+///         }
+///     }
+///
+/// Instead of injecting a concrete `Factory`, we can now inject
+/// some provider:
+///
+///     class MyViewModel {
+///
+///         let provider: some MyUseCaseProvider
+///
+///         func doSomething() {
+///             let useCase = provider.makeMyUseCase()
+///             useCase.invoke()
+///         }
+///
+///     }
+
+@attached(peer, names: suffixed(Provider))
+public macro Provided() = #externalMacro(module: "WireMacrosMacros", type: "ProvidedMacro")

--- a/WireMacros/Sources/WireMacrosClient/main.swift
+++ b/WireMacros/Sources/WireMacrosClient/main.swift
@@ -1,3 +1,21 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
 import Foundation
 import WireMacros
 

--- a/WireMacros/Sources/WireMacrosClient/main.swift
+++ b/WireMacros/Sources/WireMacrosClient/main.swift
@@ -1,3 +1,4 @@
+import Foundation
 import WireMacros
 
 @Provided
@@ -22,3 +23,6 @@ struct FooUseCaseProvider: FooUseCaseProtocolProvider {
     }
 
 }
+
+let uuid = #UUID("7411ca17-ba08-4905-92d2-0617a8c810ca")
+print(uuid)

--- a/WireMacros/Sources/WireMacrosClient/main.swift
+++ b/WireMacros/Sources/WireMacrosClient/main.swift
@@ -1,0 +1,24 @@
+import WireMacros
+
+@Provided
+public protocol FooUseCaseProtocol {
+
+    func invoke()
+
+}
+
+struct FooUseCase: FooUseCaseProtocol {
+
+    func invoke() {
+
+    }
+
+}
+
+struct FooUseCaseProvider: FooUseCaseProtocolProvider {
+
+    func makeFooUseCaseProtocol() -> any FooUseCaseProtocol {
+        FooUseCase()
+    }
+
+}

--- a/WireMacros/Sources/WireMacrosMacros/Provided/ProvidedMacro.swift
+++ b/WireMacros/Sources/WireMacrosMacros/Provided/ProvidedMacro.swift
@@ -1,0 +1,59 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public struct ProvidedMacro: PeerMacro {
+
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingPeersOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        guard let protocolDeclaration = declaration.as(ProtocolDeclSyntax.self) else {
+            throw ProvidedMacroError.notAttachedToProtocol
+        }
+
+        let isPrivate = protocolDeclaration.modifiers.contains {
+            $0.name.tokenKind == .keyword(.private)
+        }
+
+        guard !isPrivate else {
+            throw ProvidedMacroError.privateProtocol
+        }
+
+        let isPublic = protocolDeclaration.modifiers.contains {
+            $0.name.tokenKind == .keyword(.public)
+        }
+
+        let name = protocolDeclaration.name.text
+
+        let output = """
+        \(isPublic ? "public " : "")protocol \(name)Provider {
+
+            func make\(name)() -> any \(name)
+
+        }
+        """
+
+        return [DeclSyntax(stringLiteral: output)]
+    }
+
+}

--- a/WireMacros/Sources/WireMacrosMacros/Provided/ProvidedMacroError.swift
+++ b/WireMacros/Sources/WireMacrosMacros/Provided/ProvidedMacroError.swift
@@ -16,13 +16,19 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import SwiftCompilerPlugin
-import SwiftSyntaxMacros
+public enum ProvidedMacroError: Error, CustomStringConvertible {
 
-@main
-struct WireMacrosPlugin: CompilerPlugin {
-    let providingMacros: [Macro.Type] = [
-        ProvidedMacro.self,
-        UUIDMacro.self
-    ]
+    case notAttachedToProtocol
+    case privateProtocol
+
+    public var description: String {
+        switch self {
+        case .notAttachedToProtocol:
+            "@Provided can only be attached to a protocol"
+
+        case .privateProtocol:
+            "@Provided can not be attached to a private protocol"
+        }
+    }
+
 }

--- a/WireMacros/Sources/WireMacrosMacros/UUID/UUIDMacro.swift
+++ b/WireMacros/Sources/WireMacrosMacros/UUID/UUIDMacro.swift
@@ -1,0 +1,48 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public struct UUIDMacro: ExpressionMacro {
+
+    public static func expansion(
+        of node: some FreestandingMacroExpansionSyntax,
+        in context: some MacroExpansionContext
+    ) throws -> ExprSyntax {
+        // Ensure a single string literal argument.
+        guard
+            let argument = node.argumentList.first?.expression,
+            let segments = argument.as(StringLiteralExprSyntax.self)?.segments,
+            segments.count == 1,
+            case .stringSegment(let literalSegment)? = segments.first
+        else {
+            throw UUIDMacroError.requiresStringLiteralArgument
+        }
+
+        // Validate.
+        guard let _ = UUID(uuidString: literalSegment.content.text) else {
+            throw UUIDMacroError.invalidUUID("\(argument)")
+        }
+
+        return "UUID(uuidString: \(argument))!"
+    }
+
+}

--- a/WireMacros/Sources/WireMacrosMacros/UUID/UUIDMacroError.swift
+++ b/WireMacros/Sources/WireMacrosMacros/UUID/UUIDMacroError.swift
@@ -16,13 +16,19 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import SwiftCompilerPlugin
-import SwiftSyntaxMacros
+public enum UUIDMacroError: Error, CustomStringConvertible {
 
-@main
-struct WireMacrosPlugin: CompilerPlugin {
-    let providingMacros: [Macro.Type] = [
-        ProvidedMacro.self,
-        UUIDMacro.self
-    ]
+    case requiresStringLiteralArgument
+    case invalidUUID(String)
+
+    public var description: String {
+        switch self {
+        case .requiresStringLiteralArgument:
+            "#UUID requires a string literal argument."
+        case .invalidUUID(let string):
+            "\(string) is not a valid UUID."
+        }
+    }
+
 }
+

--- a/WireMacros/Sources/WireMacrosMacros/WireMacrosMacro.swift
+++ b/WireMacros/Sources/WireMacrosMacros/WireMacrosMacro.swift
@@ -1,0 +1,66 @@
+import SwiftCompilerPlugin
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+@main
+struct WireMacrosPlugin: CompilerPlugin {
+    let providingMacros: [Macro.Type] = [
+        ProvidedMacro.self,
+    ]
+}
+
+public enum ProvidedMacroError: Error, CustomStringConvertible {
+
+    case notAttachedToProtocol
+    case privateProtocol
+
+    public var description: String {
+        switch self {
+        case .notAttachedToProtocol:
+            "@Provided can only be attached to a protocol"
+
+        case .privateProtocol:
+            "@Provided can not be attached to a private protocol"
+        }
+    }
+
+}
+
+public struct ProvidedMacro: PeerMacro {
+
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingPeersOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        guard let protocolDeclaration = declaration.as(ProtocolDeclSyntax.self) else {
+            throw ProvidedMacroError.notAttachedToProtocol
+        }
+
+        let isPrivate = protocolDeclaration.modifiers.contains {
+            $0.name.tokenKind == .keyword(.private)
+        }
+
+        guard !isPrivate else {
+            throw ProvidedMacroError.privateProtocol
+        }
+
+        let isPublic = protocolDeclaration.modifiers.contains {
+            $0.name.tokenKind == .keyword(.public)
+        }
+
+        let name = protocolDeclaration.name.text
+
+        let output = """
+        \(isPublic ? "public " : "")protocol \(name)Provider {
+
+            func make\(name)() -> any \(name)
+
+        }
+        """
+
+        return [DeclSyntax(stringLiteral: output)]
+    }
+
+}

--- a/WireMacros/Tests/WireMacrosTests/ProvidedMacroTests.swift
+++ b/WireMacros/Tests/WireMacrosTests/ProvidedMacroTests.swift
@@ -1,22 +1,42 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
 import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest
 
-// Macro implementations build for the host, so the corresponding module is not available when cross-compiling. Cross-compiled tests may still make use of the macro itself in end-to-end tests.
+// Macro implementations build for the host, so the corresponding module is not available 
+// when cross-compiling. Cross-compiled tests may still make use of the macro itself in
+// end-to-end tests.
 #if canImport(WireMacrosMacros)
 import WireMacrosMacros
 
-let testMacros: [String: Macro.Type] = [
-    "Provided": ProvidedMacro.self,
+private let testMacros: [String: Macro.Type] = [
+    "Provided": ProvidedMacro.self
 ]
 #endif
 
-final class WireMacrosTests: XCTestCase {
-    
+final class ProvidedMacrosTests: XCTestCase {
+
     func testItCreatesPublicProviderProtocol() throws {
-        #if canImport(ProviderMacroMacros)
+        #if canImport(WireMacrosMacros)
         assertMacroExpansion(
             """
             @Provided
@@ -43,7 +63,7 @@ final class WireMacrosTests: XCTestCase {
     }
 
     func testItCreatesInternalProviderProtocol() throws {
-        #if canImport(ProviderMacroMacros)
+        #if canImport(WireMacrosMacros)
         assertMacroExpansion(
             """
             @Provided
@@ -70,7 +90,7 @@ final class WireMacrosTests: XCTestCase {
     }
 
     func testItDoesNotCreatePrivateProviderProtocol() throws {
-        #if canImport(ProviderMacroMacros)
+        #if canImport(WireMacrosMacros)
         assertMacroExpansion(
             """
             @Provided
@@ -98,7 +118,7 @@ final class WireMacrosTests: XCTestCase {
     }
 
     func testItThrowsErrorIfNotAttachedToProtocol() throws {
-        #if canImport(ProviderMacroMacros)
+        #if canImport(WireMacrosMacros)
         assertMacroExpansion(
             """
             @Provided
@@ -126,3 +146,4 @@ final class WireMacrosTests: XCTestCase {
     }
 
 }
+

--- a/WireMacros/Tests/WireMacrosTests/UUIDMacroTests.swift
+++ b/WireMacros/Tests/WireMacrosTests/UUIDMacroTests.swift
@@ -1,0 +1,101 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+
+// Macro implementations build for the host, so the corresponding module is not available
+// when cross-compiling. Cross-compiled tests may still make use of the macro itself in
+// end-to-end tests.
+
+#if canImport(WireMacrosMacros)
+import WireMacrosMacros
+
+private let testMacros: [String: Macro.Type] = [
+    "UUID": UUIDMacro.self
+]
+#endif
+
+final class UUIDMacrosTests: XCTestCase {
+
+    func testItExpandsAValidUUID() throws {
+        #if canImport(WireMacrosMacros)
+        assertMacroExpansion("""
+            let uuid = #UUID("7411ca17-ba08-4905-92d2-0617a8c810ca")
+            """,
+            expandedSource: """
+            let uuid = UUID(uuidString: "7411ca17-ba08-4905-92d2-0617a8c810ca")!
+            """,
+            macros: testMacros
+        )
+        #else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    func testItThrowsErrorWithInvalidUUID() throws {
+        #if canImport(WireMacrosMacros)
+        assertMacroExpansion("""
+            let uuid = #UUID("foo")
+            """,
+            expandedSource: """
+            let uuid = #UUID("foo")
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "\"foo\" is not a valid UUID.",
+                    line: 1,
+                    column: 12
+                )
+            ],
+            macros: testMacros
+        )
+        #else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    func testItThrowsErrorIfNotPassedAStringLiteral() throws {
+        #if canImport(WireMacrosMacros)
+        assertMacroExpansion("""
+            let string = "7411ca17-ba08-4905-92d2-0617a8c810ca"
+            let uuid = #UUID(string)
+            """,
+            expandedSource: """
+            let string = "7411ca17-ba08-4905-92d2-0617a8c810ca"
+            let uuid = #UUID(string)
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "#UUID requires a string literal argument.",
+                    line: 2,
+                    column: 12
+                )
+            ],
+            macros: testMacros
+        )
+        #else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+}
+

--- a/WireMacros/Tests/WireMacrosTests/WireMacros.xctestplan
+++ b/WireMacros/Tests/WireMacrosTests/WireMacros.xctestplan
@@ -1,0 +1,24 @@
+{
+  "configurations" : [
+    {
+      "id" : "A6812806-2731-4498-8D38-338B8651511D",
+      "name" : "Test Scheme Action",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "WireMacrosTests",
+        "name" : "WireMacrosTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/WireMacros/Tests/WireMacrosTests/WireMacrosTests.swift
+++ b/WireMacros/Tests/WireMacrosTests/WireMacrosTests.swift
@@ -1,0 +1,128 @@
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+
+// Macro implementations build for the host, so the corresponding module is not available when cross-compiling. Cross-compiled tests may still make use of the macro itself in end-to-end tests.
+#if canImport(WireMacrosMacros)
+import WireMacrosMacros
+
+let testMacros: [String: Macro.Type] = [
+    "Provided": ProvidedMacro.self,
+]
+#endif
+
+final class WireMacrosTests: XCTestCase {
+    
+    func testItCreatesPublicProviderProtocol() throws {
+        #if canImport(ProviderMacroMacros)
+        assertMacroExpansion(
+            """
+            @Provided
+            public protocol MyUseCaseProtocol {
+                func invoke()
+            }
+            """,
+            expandedSource: """
+            public protocol MyUseCaseProtocol {
+                func invoke()
+            }
+
+            public protocol MyUseCaseProtocolProvider {
+
+                func makeMyUseCaseProtocol() -> any MyUseCaseProtocol
+
+            }
+            """,
+            macros: testMacros
+        )
+        #else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    func testItCreatesInternalProviderProtocol() throws {
+        #if canImport(ProviderMacroMacros)
+        assertMacroExpansion(
+            """
+            @Provided
+            protocol MyUseCaseProtocol {
+                func invoke()
+            }
+            """,
+            expandedSource: """
+            protocol MyUseCaseProtocol {
+                func invoke()
+            }
+
+            protocol MyUseCaseProtocolProvider {
+
+                func makeMyUseCaseProtocol() -> any MyUseCaseProtocol
+
+            }
+            """,
+            macros: testMacros
+        )
+        #else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    func testItDoesNotCreatePrivateProviderProtocol() throws {
+        #if canImport(ProviderMacroMacros)
+        assertMacroExpansion(
+            """
+            @Provided
+            private protocol MyUseCaseProtocol {
+                func invoke()
+            }
+            """,
+            expandedSource: """
+            private protocol MyUseCaseProtocol {
+                func invoke()
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "@Provided can not be attached to a private protocol",
+                    line: 1,
+                    column: 1
+                )
+            ],
+            macros: testMacros
+        )
+        #else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    func testItThrowsErrorIfNotAttachedToProtocol() throws {
+        #if canImport(ProviderMacroMacros)
+        assertMacroExpansion(
+            """
+            @Provided
+            enum MyEnum {
+                case foo
+            }
+            """,
+            expandedSource: """
+            enum MyEnum {
+                case foo
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "@Provided can only be attached to a protocol",
+                    line: 1,
+                    column: 1
+                )
+            ],
+            macros: testMacros
+        )
+        #else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+}

--- a/wire-ios-mono.xcworkspace/contents.xcworkspacedata
+++ b/wire-ios-mono.xcworkspace/contents.xcworkspacedata
@@ -127,4 +127,7 @@
    <FileRef
       location = "group:SourceryPlugin">
    </FileRef>
+   <FileRef
+      location = "group:WireMacros/Tests/WireMacrosTests/WireMacros.xctestplan">
+   </FileRef>
 </Workspace>

--- a/wire-ios-mono.xcworkspace/contents.xcworkspacedata
+++ b/wire-ios-mono.xcworkspace/contents.xcworkspacedata
@@ -122,6 +122,9 @@
       location = "group:WireAPI">
    </FileRef>
    <FileRef
+      location = "group:WireMacros">
+   </FileRef>
+   <FileRef
       location = "group:SourceryPlugin">
    </FileRef>
 </Workspace>

--- a/wire-ios-mono.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/wire-ios-mono.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -65,6 +65,24 @@
         }
       },
       {
+        "package": "PINCache",
+        "repositoryURL": "https://github.com/pinterest/PINCache",
+        "state": {
+          "branch": null,
+          "revision": "2fb85948463292c2e824148cf17dc62a4c217a94",
+          "version": "3.0.4"
+        }
+      },
+      {
+        "package": "PINOperation",
+        "repositoryURL": "https://github.com/pinterest/PINOperation.git",
+        "state": {
+          "branch": null,
+          "revision": "a74f978733bdaf982758bfa23d70a189f4b4c1b6",
+          "version": "1.2.3"
+        }
+      },
+      {
         "package": "PLCrashReporter",
         "repositoryURL": "https://github.com/microsoft/plcrashreporter.git",
         "state": {
@@ -138,7 +156,7 @@
       },
       {
         "package": "swift-log",
-        "repositoryURL": "https://github.com/apple/swift-log.git",
+        "repositoryURL": "https://github.com/apple/swift-log",
         "state": {
           "branch": null,
           "revision": "e97a6fcb1ab07462881ac165fdbb37f067e205d5",
@@ -222,8 +240,8 @@
         "repositoryURL": "https://github.com/apple/swift-syntax",
         "state": {
           "branch": null,
-          "revision": "303e5c5c36d6a558407d364878df131c3546fad8",
-          "version": "510.0.2"
+          "revision": "64889f0c732f210a935a0ad7cda38f77f876262d",
+          "version": "509.1.1"
         }
       },
       {


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

Create a `WireMacros` package:
- `@Provided` generates a "provider" companion protocol for other protocols.
- `#UUID` validates uuid strings at compile time.
- new macros can be created and tested here too.

**Open question:** is the [potential overhead of using macros](https://forums.swift.org/t/swift-macros-build-time-overhead-concerns/70443/10) a concern? 

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

