### PR TITLE
refactor: process federation connection removed event - WPB-10187

### DIFF
--- a/WireAPI/Sources/WireAPI/Models/UpdateEvent/FederationEvent/FederationConnectionRemovedEvent.swift
+++ b/WireAPI/Sources/WireAPI/Models/UpdateEvent/FederationEvent/FederationConnectionRemovedEvent.swift
@@ -28,4 +28,8 @@ public struct FederationConnectionRemovedEvent: Equatable, Codable {
 
     public let domains: Set<String>
 
+    public init(domains: Set<String>) {
+        self.domains = domains
+    }
+
 }

--- a/WireDomain/Project/WireDomain Project.xcodeproj/project.pbxproj
+++ b/WireDomain/Project/WireDomain Project.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		59909A692C5BC001009C41DE /* WireAPI in Frameworks */ = {isa = PBXBuildFile; productRef = 59909A682C5BC001009C41DE /* WireAPI */; };
 		59909A6D2C5BC08B009C41DE /* WireAPISupport in Frameworks */ = {isa = PBXBuildFile; productRef = 59909A6C2C5BC08B009C41DE /* WireAPISupport */; };
 		59AAD2E32C763F6C0095E6C2 /* WireUtilitiesPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 59AAD2E22C763F6C0095E6C2 /* WireUtilitiesPackage */; };
+		C90E8B392C8B213E0017494F /* FederationConnectionRemovedEventProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90E8B382C8B213E0017494F /* FederationConnectionRemovedEventProcessorTests.swift */; };
 		C9E8A3AA2C7324D10093DD5C /* ConversationLabelsRepositoryError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9E8A3A92C7324D10093DD5C /* ConversationLabelsRepositoryError.swift */; };
 		C9E8A3AE2C73878B0093DD5C /* ConnectionsRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9E8A3AD2C73878B0093DD5C /* ConnectionsRepositoryTests.swift */; };
 		C9E8A3B52C738F0A0093DD5C /* ConversationLabelsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9E8A3B42C738F0A0093DD5C /* ConversationLabelsRepository.swift */; };
@@ -152,6 +153,7 @@
 		162356512C2B223B00C6666C /* UserRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserRepository.swift; sourceTree = "<group>"; };
 		162356522C2B223B00C6666C /* UserRepositoryError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserRepositoryError.swift; sourceTree = "<group>"; };
 		162356562C2B22A300C6666C /* UserModelMappings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserModelMappings.swift; sourceTree = "<group>"; };
+		C90E8B382C8B213E0017494F /* FederationConnectionRemovedEventProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FederationConnectionRemovedEventProcessorTests.swift; sourceTree = "<group>"; };
 		C9E8A3A92C7324D10093DD5C /* ConversationLabelsRepositoryError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationLabelsRepositoryError.swift; sourceTree = "<group>"; };
 		C9E8A3AD2C73878B0093DD5C /* ConnectionsRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionsRepositoryTests.swift; sourceTree = "<group>"; };
 		C9E8A3B42C738F0A0093DD5C /* ConversationLabelsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationLabelsRepository.swift; sourceTree = "<group>"; };
@@ -264,6 +266,7 @@
 		017F679A2C20801800B6E02D /* WireDomain */ = {
 			isa = PBXGroup;
 			children = (
+				C90E8B362C8B211A0017494F /* Event Processor */,
 				EEC410252C60D48900E89394 /* Synchronization */,
 				EE0E117C2C2C4076004BBD29 /* Helpers */,
 				EE57A7092C2A8B950096F242 /* Event Decryption */,
@@ -379,6 +382,22 @@
 			);
 			name = Tests;
 			path = ../Tests;
+			sourceTree = "<group>";
+		};
+		C90E8B362C8B211A0017494F /* Event Processor */ = {
+			isa = PBXGroup;
+			children = (
+				C90E8B372C8B21200017494F /* FederationEventProcessor */,
+			);
+			path = "Event Processor";
+			sourceTree = "<group>";
+		};
+		C90E8B372C8B21200017494F /* FederationEventProcessor */ = {
+			isa = PBXGroup;
+			children = (
+				C90E8B382C8B213E0017494F /* FederationConnectionRemovedEventProcessorTests.swift */,
+			);
+			path = FederationEventProcessor;
 			sourceTree = "<group>";
 		};
 		EE0E117C2C2C4076004BBD29 /* Helpers */ = {
@@ -776,6 +795,7 @@
 				CB7979162C738547006FBA58 /* TestSetup.swift in Sources */,
 				162356502C2B223100C6666C /* UserRepositoryTests.swift in Sources */,
 				EE3F97542C2ADC4C00668DF1 /* ProteusMessageDecryptorTests.swift in Sources */,
+				C90E8B392C8B213E0017494F /* FederationConnectionRemovedEventProcessorTests.swift in Sources */,
 				EE57A70B2C2A8BAA0096F242 /* UpdateEventDecryptorTests.swift in Sources */,
 				C9E8A3AE2C73878B0093DD5C /* ConnectionsRepositoryTests.swift in Sources */,
 				017F679C2C20801800B6E02D /* TeamRepositoryTests.swift in Sources */,

--- a/WireDomain/Sources/WireDomain/Event Processing/FederationEventProcessor/FederationConnectionRemovedEventProcessor.swift
+++ b/WireDomain/Sources/WireDomain/Event Processing/FederationEventProcessor/FederationConnectionRemovedEventProcessor.swift
@@ -45,7 +45,7 @@ struct FederationConnectionRemovedEventProcessor: FederationConnectionRemovedEve
             throw Error.missingDomains(event.domains)
         }
 
-        await repository.terminateFederationConnection(with: domain, and: otherDomain)
+        await repository.removeFederationConnection(between: domain, and: otherDomain)
     }
 
 }

--- a/WireDomain/Sources/WireDomain/Event Processing/FederationEventProcessor/FederationConnectionRemovedEventProcessor.swift
+++ b/WireDomain/Sources/WireDomain/Event Processing/FederationEventProcessor/FederationConnectionRemovedEventProcessor.swift
@@ -36,7 +36,7 @@ struct FederationConnectionRemovedEventProcessor: FederationConnectionRemovedEve
         case missingDomains(Set<String>)
     }
 
-    let repository: any UserRepositoryProtocol
+    let repository: any ConnectionsRepositoryProtocol
 
     func processEvent(_ event: FederationConnectionRemovedEvent) async throws {
         guard let domain = Array(event.domains).first,
@@ -45,7 +45,7 @@ struct FederationConnectionRemovedEventProcessor: FederationConnectionRemovedEve
             throw Error.missingDomains(event.domains)
         }
 
-        await repository.removeUsersFromFederatedConversations(on: domain, and: otherDomain)
+        await repository.terminateFederationConnection(with: domain, and: otherDomain)
     }
 
 }

--- a/WireDomain/Sources/WireDomain/Event Processing/FederationEventProcessor/FederationConnectionRemovedEventProcessor.swift
+++ b/WireDomain/Sources/WireDomain/Event Processing/FederationEventProcessor/FederationConnectionRemovedEventProcessor.swift
@@ -32,9 +32,20 @@ protocol FederationConnectionRemovedEventProcessorProtocol {
 
 struct FederationConnectionRemovedEventProcessor: FederationConnectionRemovedEventProcessorProtocol {
 
-    func processEvent(_: FederationConnectionRemovedEvent) async throws {
-        // TODO: [WPB-10187]
-        assertionFailure("not implemented yet")
+    enum Error: Swift.Error {
+        case missingDomains(Set<String>)
+    }
+
+    let repository: any UserRepositoryProtocol
+
+    func processEvent(_ event: FederationConnectionRemovedEvent) async throws {
+        guard let domain = Array(event.domains).first,
+              let otherDomain = Array(event.domains).last
+        else {
+            throw Error.missingDomains(event.domains)
+        }
+
+        await repository.removeUsersFromFederatedConversations(on: domain, and: otherDomain)
     }
 
 }

--- a/WireDomain/Sources/WireDomain/Repositories/ConnectionsRepositiory.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/ConnectionsRepositiory.swift
@@ -33,7 +33,7 @@ protocol ConnectionsRepositoryProtocol {
 
     /// Removes a federation connection between two domains.
     ///
-    /// - Parameter domain : The domain for which the connection was removed.
+    /// - Parameter domain: The domain for which the connection was removed.
     /// - Parameter otherDomain: The other domain for which the connection was removed.
 
     func removeFederationConnection(between domain: String, and otherDomain: String) async

--- a/WireDomain/Sources/WireDomain/Repositories/ConnectionsRepositiory.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/ConnectionsRepositiory.swift
@@ -110,7 +110,7 @@ struct ConnectionsRepository: ConnectionsRepositoryProtocol {
         forConversationsNotOwnedBy domains: Set<String>
     ) {
         let notHostedConversations = fetchNotHostedConversations(
-            on: domains,
+            excludedDomains: domains,
             withParticipantsOn: userDomains
         )
 
@@ -188,11 +188,11 @@ struct ConnectionsRepository: ConnectionsRepositoryProtocol {
     }
 
     private func fetchNotHostedConversations(
-        on domains: Set<String>,
+        excludedDomains: Set<String>,
         withParticipantsOn userDomains: Set<String>
     ) -> [ZMConversation] {
         let groupConversation = ZMConversation.groupConversations(
-            notHostedOnDomains: Array(domains),
+            notHostedOnDomains: Array(excludedDomains),
             in: context
         )
 

--- a/WireDomain/Sources/WireDomain/Repositories/ConnectionsRepositiory.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/ConnectionsRepositiory.swift
@@ -30,13 +30,24 @@ protocol ConnectionsRepositoryProtocol {
     /// Pull self team metadata frmo the server and store locally.
 
     func pullConnections() async throws
+    
+    /// Terminates a federation connection with specified domains.
+    ///
+    /// - Parameter domain : The domain for which the federation connection was removed.
+    /// - Parameter otherDomain: The other domain for which the federation connection was removed.
+
+    func terminateFederationConnection(with domain: String, and otherDomain: String) async
 }
 
 struct ConnectionsRepository: ConnectionsRepositoryProtocol {
 
+    // MARK: - Properties
+    
     private let connectionsAPI: any ConnectionsAPI
     private let context: NSManagedObjectContext
 
+    // MARK: - Object lifecycle
+    
     init(
         connectionsAPI: any ConnectionsAPI,
         context: NSManagedObjectContext
@@ -44,6 +55,8 @@ struct ConnectionsRepository: ConnectionsRepositoryProtocol {
         self.connectionsAPI = connectionsAPI
         self.context = context
     }
+    
+    // MARK: - Public
 
     /// Retrieve from backend and store connections locally
 
@@ -59,6 +72,153 @@ struct ConnectionsRepository: ConnectionsRepositoryProtocol {
                 }
             }
         }
+    }
+
+    public func terminateFederationConnection(
+        with domain: String,
+        and otherDomain: String
+    ) async {
+        await context.perform { [self] in
+            
+            /// For all conversations that are NOT owned by `domain` or `otherDomain` and contain users from `domain` and `otherDomain`, remove users from `domain` and `otherDomain` from those conversations.
+            
+            terminateFederationConnection(
+                with: [domain, otherDomain],
+                forConversationsNotOwnedBy: [domain, otherDomain]
+            )
+
+            /// For all conversations owned by `domain` that contains users from `otherDomain`, remove users from `otherDomain` from those conversations.
+            
+            terminateFederationConnection(
+                with: domain,
+                forConversationsOwnedBy: otherDomain
+            )
+
+            /// For all conversations owned by `otherDomain` that contains users from `domain`, remove users from `domain` from those conversations.
+            
+            terminateFederationConnection(
+                with: otherDomain,
+                forConversationsOwnedBy: domain
+            )
+        }
+    }
+    
+    // MARK: - Private
+    
+    private func terminateFederationConnection(
+        with userDomains: Set<String>,
+        forConversationsNotOwnedBy domains: Set<String>
+    ) {
+        let notHostedConversations = fetchNotHostedConversations(
+            on: domains,
+            withParticipantsOn: userDomains
+        )
+
+        for notHostedConversation in notHostedConversations {
+            let participants = getParticipants(from: notHostedConversation, on: userDomains)
+
+            terminateFederationConnection(
+                for: notHostedConversation,
+                with: participants,
+                on: userDomains
+            )
+        }
+    }
+
+    private func terminateFederationConnection(
+        with userDomain: String,
+        forConversationsOwnedBy domain: String
+    ) {
+        let hostedConversations = fetchHostedConversations(
+            on: domain,
+            withParticipantsOn: userDomain
+        )
+
+        for hostedConversation in hostedConversations {
+            let participants = getParticipants(from: hostedConversation, on: [userDomain])
+
+            terminateFederationConnection(
+                for: hostedConversation,
+                with: participants,
+                on: [userDomain, domain]
+            )
+        }
+    }
+
+    private func terminateFederationConnection(
+        for conversation: ZMConversation,
+        with participants: Set<ZMUser>,
+        on domains: Set<String>
+    ) {
+        let selfUser = ZMUser.selfUser(in: context)
+
+        conversation.appendFederationTerminationSystemMessage(
+            domains: Array(domains),
+            sender: selfUser,
+            at: .now
+        )
+
+        conversation.removeParticipantsLocally(participants)
+
+        conversation.appendParticipantsRemovedAnonymouslySystemMessage(
+            users: participants,
+            sender: selfUser,
+            removedReason: .federationTermination,
+            at: .now
+        )
+    }
+    
+    private func fetchHostedConversations(
+        on domain: String,
+        withParticipantsOn userDomain: String
+    ) -> [ZMConversation] {
+        let groupConversation = ZMConversation.groupConversations(
+            hostedOnDomain: domain,
+            in: context
+        )
+
+        return groupConversation.filter {
+            let localParticipants = Set($0.participantRoles.compactMap(\.user))
+            let localParticipantDomains = Set(localParticipants.compactMap(\.domain))
+
+            let userDomains = Set([userDomain])
+
+            return userDomains.isSubset(of: localParticipantDomains)
+        }
+    }
+
+    private func fetchNotHostedConversations(
+        on domains: Set<String>,
+        withParticipantsOn userDomains: Set<String>
+    ) -> [ZMConversation] {
+        let groupConversation = ZMConversation.groupConversations(
+            notHostedOnDomains: Array(domains),
+            in: context
+        )
+
+        return groupConversation.filter {
+            let localParticipants = Set($0.participantRoles.compactMap(\.user))
+            let localParticipantDomains = Set(localParticipants.compactMap(\.domain))
+
+            return userDomains.isSubset(of: localParticipantDomains)
+        }
+    }
+    
+    private func getParticipants(
+        from conversation: ZMConversation,
+        on domains: Set<String>
+    ) -> Set<ZMUser> {
+        let localParticipants = Set(conversation.participantRoles.compactMap(\.user))
+
+        let participants = localParticipants.filter { user in
+            if let domain = user.domain {
+                domain.isOne(of: domains)
+            } else {
+                false
+            }
+        }
+
+        return participants
     }
 
     /// Save connection and related objects to local storage.

--- a/WireDomain/Sources/WireDomain/Repositories/ConnectionsRepositiory.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/ConnectionsRepositiory.swift
@@ -30,7 +30,7 @@ protocol ConnectionsRepositoryProtocol {
     /// Pull self team metadata frmo the server and store locally.
 
     func pullConnections() async throws
-    
+
     /// Terminates a federation connection with specified domains.
     ///
     /// - Parameter domain : The domain for which the federation connection was removed.
@@ -42,12 +42,12 @@ protocol ConnectionsRepositoryProtocol {
 struct ConnectionsRepository: ConnectionsRepositoryProtocol {
 
     // MARK: - Properties
-    
+
     private let connectionsAPI: any ConnectionsAPI
     private let context: NSManagedObjectContext
 
     // MARK: - Object lifecycle
-    
+
     init(
         connectionsAPI: any ConnectionsAPI,
         context: NSManagedObjectContext
@@ -55,7 +55,7 @@ struct ConnectionsRepository: ConnectionsRepositoryProtocol {
         self.connectionsAPI = connectionsAPI
         self.context = context
     }
-    
+
     // MARK: - Public
 
     /// Retrieve from backend and store connections locally
@@ -79,32 +79,32 @@ struct ConnectionsRepository: ConnectionsRepositoryProtocol {
         and otherDomain: String
     ) async {
         await context.perform { [self] in
-            
+
             /// For all conversations that are NOT owned by `domain` or `otherDomain` and contain users from `domain` and `otherDomain`, remove users from `domain` and `otherDomain` from those conversations.
-            
+
             terminateFederationConnection(
                 with: [domain, otherDomain],
                 forConversationsNotOwnedBy: [domain, otherDomain]
             )
 
-            /// For all conversations owned by `domain` that contains users from `otherDomain`, remove users from `otherDomain` from those conversations.
-            
+            /// For all conversations owned by `otherDomain` that contains users from `domain`, remove users from `domain` from those conversations.
+
             terminateFederationConnection(
                 with: domain,
                 forConversationsOwnedBy: otherDomain
             )
 
-            /// For all conversations owned by `otherDomain` that contains users from `domain`, remove users from `domain` from those conversations.
-            
+            /// For all conversations owned by `domain` that contains users from `otherDomain`, remove users from `otherDomain` from those conversations.
+
             terminateFederationConnection(
                 with: otherDomain,
                 forConversationsOwnedBy: domain
             )
         }
     }
-    
+
     // MARK: - Private
-    
+
     private func terminateFederationConnection(
         with userDomains: Set<String>,
         forConversationsNotOwnedBy domains: Set<String>
@@ -167,7 +167,7 @@ struct ConnectionsRepository: ConnectionsRepositoryProtocol {
             at: .now
         )
     }
-    
+
     private func fetchHostedConversations(
         on domain: String,
         withParticipantsOn userDomain: String
@@ -203,7 +203,7 @@ struct ConnectionsRepository: ConnectionsRepositoryProtocol {
             return userDomains.isSubset(of: localParticipantDomains)
         }
     }
-    
+
     private func getParticipants(
         from conversation: ZMConversation,
         on domains: Set<String>

--- a/WireDomain/Sources/WireDomain/Repositories/UserRepository.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/UserRepository.swift
@@ -99,11 +99,11 @@ public final class UserRepository: UserRepositoryProtocol {
 
     private func persistUser(from user: WireAPI.User) {
         let persistedUser = ZMUser.fetchOrCreate(with: user.id.uuid, domain: user.id.domain, in: context)
-        
+
         guard user.deleted == false else {
             return persistedUser.markAccountAsDeleted(at: Date())
         }
-        
+
         persistedUser.name = user.name
         persistedUser.handle = user.handle
         persistedUser.teamIdentifier = user.teamID

--- a/WireDomain/Sources/WireDomain/Repositories/UserRepository.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/UserRepository.swift
@@ -43,11 +43,6 @@ public protocol UserRepositoryProtocol {
 
     func pullUsers(userIDs: [WireDataModel.QualifiedID]) async throws
 
-    func removeUsersFromFederatedConversations(
-        on domain: String,
-        and otherDomain: String
-    ) async
-
 }
 
 public final class UserRepository: UserRepositoryProtocol {
@@ -100,37 +95,15 @@ public final class UserRepository: UserRepositoryProtocol {
         }
     }
 
-    public func removeUsersFromFederatedConversations(
-        on domain: String,
-        and otherDomain: String
-    ) async {
-        await context.perform { [self] in
-            removeUsers(
-                with: [domain, otherDomain],
-                fromConversationsNotOwnedBy: [domain, otherDomain]
-            )
-
-            removeUsers(
-                with: domain,
-                fromConversationsOwnedBy: otherDomain
-            )
-
-            removeUsers(
-                with: otherDomain,
-                fromConversationsOwnedBy: domain
-            )
-        }
-    }
-
     // MARK: - Private
 
     private func persistUser(from user: WireAPI.User) {
         let persistedUser = ZMUser.fetchOrCreate(with: user.id.uuid, domain: user.id.domain, in: context)
-
+        
         guard user.deleted == false else {
             return persistedUser.markAccountAsDeleted(at: Date())
         }
-
+        
         persistedUser.name = user.name
         persistedUser.handle = user.handle
         persistedUser.teamIdentifier = user.teamID
@@ -143,121 +116,5 @@ public final class UserRepository: UserRepositoryProtocol {
         persistedUser.providerIdentifier = user.service?.provider.transportString()
         persistedUser.supportedProtocols = user.supportedProtocols?.toDomainModel() ?? [.proteus]
         persistedUser.needsToBeUpdatedFromBackend = false
-    }
-
-    private func removeUsers(
-        with userDomains: Set<String>,
-        fromConversationsNotOwnedBy domains: Set<String>
-    ) {
-        let notHostedConversations = fetchNotHostedConversations(
-            on: domains,
-            withParticipantsOn: userDomains
-        )
-
-        for notHostedConversation in notHostedConversations {
-            let participants = getParticipants(from: notHostedConversation, on: domains)
-
-            processFederatedConversation(
-                conversation: notHostedConversation,
-                participants: participants,
-                domains: userDomains
-            )
-        }
-    }
-
-    private func removeUsers(
-        with userDomain: String,
-        fromConversationsOwnedBy domain: String
-    ) {
-        let hostedConversations = fetchHostedConversations(
-            on: domain,
-            withParticipantsOn: userDomain
-        )
-
-        for hostedConversation in hostedConversations {
-            let participants = getParticipants(from: hostedConversation, on: [userDomain])
-
-            processFederatedConversation(
-                conversation: hostedConversation,
-                participants: participants,
-                domains: [userDomain, domain]
-            )
-        }
-    }
-
-    private func processFederatedConversation(
-        conversation: ZMConversation,
-        participants: Set<ZMUser>,
-        domains: Set<String>
-    ) {
-        let selfUser = ZMUser.selfUser(in: context)
-
-        conversation.appendFederationTerminationSystemMessage(
-            domains: Array(domains),
-            sender: selfUser,
-            at: .now
-        )
-
-        conversation.removeParticipantsLocally(participants)
-
-        conversation.appendParticipantsRemovedAnonymouslySystemMessage(
-            users: participants,
-            sender: selfUser,
-            removedReason: .federationTermination,
-            at: .now
-        )
-    }
-
-    private func getParticipants(
-        from conversation: ZMConversation,
-        on domains: Set<String>
-    ) -> Set<ZMUser> {
-        let localParticipants = Set(conversation.participantRoles.compactMap(\.user))
-
-        let participants = localParticipants.filter { user in
-            if let domain = user.domain {
-                domain.isOne(of: domains)
-            } else {
-                false
-            }
-        }
-
-        return participants
-    }
-
-    private func fetchHostedConversations(
-        on domain: String,
-        withParticipantsOn userDomain: String
-    ) -> [ZMConversation] {
-        let groupConversation = ZMConversation.groupConversations(
-            hostedOnDomain: domain,
-            in: context
-        )
-
-        return groupConversation.filter {
-            let localParticipants = Set($0.participantRoles.compactMap(\.user))
-            let localParticipantDomains = Set(localParticipants.compactMap(\.domain))
-
-            let userDomains = Set([userDomain])
-
-            return userDomains.isSubset(of: localParticipantDomains)
-        }
-    }
-
-    private func fetchNotHostedConversations(
-        on domains: Set<String>,
-        withParticipantsOn userDomains: Set<String>
-    ) -> [ZMConversation] {
-        let groupConversation = ZMConversation.groupConversations(
-            notHostedOnDomains: Array(domains),
-            in: context
-        )
-
-        return groupConversation.filter {
-            let localParticipants = Set($0.participantRoles.compactMap(\.user))
-            let localParticipantDomains = Set(localParticipants.compactMap(\.domain))
-
-            return userDomains.isSubset(of: localParticipantDomains)
-        }
     }
 }

--- a/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
+++ b/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
@@ -362,21 +362,6 @@ public class MockUserRepositoryProtocol: UserRepositoryProtocol {
         try await mock(userIDs)
     }
 
-    // MARK: - removeUsersFromFederatedConversations
-
-    public var removeUsersFromFederatedConversationsOnAnd_Invocations: [(domain: String, otherDomain: String)] = []
-    public var removeUsersFromFederatedConversationsOnAnd_MockMethod: ((String, String) async -> Void)?
-
-    public func removeUsersFromFederatedConversations(on domain: String, and otherDomain: String) async {
-        removeUsersFromFederatedConversationsOnAnd_Invocations.append((domain: domain, otherDomain: otherDomain))
-
-        guard let mock = removeUsersFromFederatedConversationsOnAnd_MockMethod else {
-            fatalError("no mock for `removeUsersFromFederatedConversationsOnAnd`")
-        }
-
-        await mock(domain, otherDomain)
-    }
-
 }
 
 // swiftlint:enable variable_name

--- a/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
+++ b/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
@@ -362,6 +362,21 @@ public class MockUserRepositoryProtocol: UserRepositoryProtocol {
         try await mock(userIDs)
     }
 
+    // MARK: - removeUsersFromFederatedConversations
+
+    public var removeUsersFromFederatedConversationsOnAnd_Invocations: [(domain: String, otherDomain: String)] = []
+    public var removeUsersFromFederatedConversationsOnAnd_MockMethod: ((String, String) async -> Void)?
+
+    public func removeUsersFromFederatedConversations(on domain: String, and otherDomain: String) async {
+        removeUsersFromFederatedConversationsOnAnd_Invocations.append((domain: domain, otherDomain: otherDomain))
+
+        guard let mock = removeUsersFromFederatedConversationsOnAnd_MockMethod else {
+            fatalError("no mock for `removeUsersFromFederatedConversationsOnAnd`")
+        }
+
+        await mock(domain, otherDomain)
+    }
+
 }
 
 // swiftlint:enable variable_name

--- a/WireDomain/Tests/WireDomainTests/Event Processor/FederationEventProcessor/FederationConnectionRemovedEventProcessorTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Event Processor/FederationEventProcessor/FederationConnectionRemovedEventProcessorTests.swift
@@ -39,18 +39,18 @@ final class FederationConnectionRemovedEventProcessorTests: XCTestCase {
     }
 
     override func setUp() async throws {
+        try await super.setUp()
         coreDataStack = try await coreDataStackHelper.createStack()
         sut = FederationConnectionRemovedEventProcessor(
             repository: ConnectionsRepository(connectionsAPI: mockAPI, context: context)
         )
-        try await super.setUp()
     }
 
     override func tearDown() async throws {
+        try await super.tearDown()
         coreDataStack = nil
         sut = nil
         try coreDataStackHelper.cleanupDirectory()
-        try await super.tearDown()
     }
 
     // MARK: - Tests

--- a/WireDomain/Tests/WireDomainTests/Event Processor/FederationEventProcessor/FederationConnectionRemovedEventProcessorTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Event Processor/FederationEventProcessor/FederationConnectionRemovedEventProcessorTests.swift
@@ -1,0 +1,252 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireAPI
+import WireAPISupport
+import WireDataModel
+import WireDataModelSupport
+import XCTest
+
+@testable import WireDomain
+
+final class FederationConnectionRemovedEventProcessorTests: XCTestCase {
+
+    var sut: FederationConnectionRemovedEventProcessor!
+
+    var coreDataStack: CoreDataStack!
+    let coreDataStackHelper = CoreDataStackHelper()
+    let modelHelper = ModelHelper()
+    let mockAPI = MockUsersAPI()
+
+    var context: NSManagedObjectContext {
+        coreDataStack.syncContext
+    }
+
+    override func setUp() async throws {
+        coreDataStack = try await coreDataStackHelper.createStack()
+        sut = FederationConnectionRemovedEventProcessor(
+            repository: UserRepository(context: context, usersAPI: mockAPI)
+        )
+        try await super.setUp()
+    }
+
+    override func tearDown() async throws {
+        coreDataStack = nil
+        sut = nil
+        try coreDataStackHelper.cleanupDirectory()
+        try await super.tearDown()
+    }
+
+    // MARK: - Tests
+
+    func testProcessEvent_It_Removes_Participants_From_Group_Conversations_On_Specified_Not_Hosted_Domains() async throws {
+        // Given
+
+        await context.perform { [self] in
+
+            let conversation = makeNotHostedConversation()
+
+            XCTAssertEqual(conversation.remoteIdentifier, Scaffolding.groupConversationID)
+            XCTAssertEqual(conversation.localParticipants.count, 2)
+        }
+
+        // When
+
+        try await sut.processEvent(Scaffolding.event)
+
+        // Then
+
+        try await context.perform { [context] in
+            let conversation = try XCTUnwrap(
+                ZMConversation.fetch(
+                    with: Scaffolding.groupConversationID,
+                    domain: Scaffolding.firstDomain,
+                    in: context
+                )
+            )
+
+            XCTAssertEqual(conversation.remoteIdentifier, Scaffolding.groupConversationID)
+            XCTAssertEqual(conversation.localParticipants.count, 0) /// All participants were removed from the conversation with domain name "domain.com".
+            XCTAssertEqual(conversation.allMessages.count, 2) /// A federation termination system message and a participant removed anonymously system message.
+        }
+    }
+
+    func testProcessEvent_It_Removes_Participants_From_Group_Conversations_On_Specified_Hosted_Domains() async throws {
+        // Given
+
+        await context.perform { [self] in
+
+            let conversation = makeHostedConversation()
+
+            XCTAssertEqual(conversation.remoteIdentifier, Scaffolding.groupConversationID)
+            XCTAssertEqual(conversation.localParticipants.count, 2)
+        }
+
+        // When
+
+        try await sut.processEvent(Scaffolding.event)
+
+        // Then
+
+        try await context.perform { [context] in
+            let conversation = try XCTUnwrap(
+                ZMConversation.fetch(
+                    with: Scaffolding.groupConversationID,
+                    domain: Scaffolding.firstDomain,
+                    in: context
+                )
+            )
+
+            XCTAssertEqual(conversation.remoteIdentifier, Scaffolding.groupConversationID)
+            XCTAssertEqual(conversation.localParticipants.count, 1) /// The user not part of the specified domain was removed from the conversation, the one remaining is part of the specified domain.
+            XCTAssertEqual(conversation.allMessages.count, 2) /// A federation termination system message and a participant removed anonymously system message.
+        }
+    }
+
+    /// Creates a conversation with domain "domain.com" with participants of "domain3.com" and "domain4.com",
+    /// The federation event domains are "domain3.com" and "domain4.com".
+    /// It enables testing that the participants are all removed from the conversation that is not hosted on these domains.
+    private func makeNotHostedConversation() -> ZMConversation {
+        var created = false
+
+        let user = ZMUser.fetchOrCreate(
+            with: Scaffolding.userID,
+            domain: nil,
+            in: context
+        )
+
+        let otherUser = ZMUser.fetchOrCreate(
+            with: Scaffolding.otherUserID,
+            domain: nil,
+            in: context
+        )
+
+        user.domain = Scaffolding.thirdDomain
+        otherUser.domain = Scaffolding.fourthDomain
+
+        let conversation = ZMConversation.fetchOrCreate(
+            with: Scaffolding.groupConversationID,
+            domain: Scaffolding.firstDomain,
+            in: context,
+            created: &created
+        )
+
+        conversation.conversationType = .group
+        conversation.domain = Scaffolding.firstDomain
+
+        let userRole = ParticipantRole.create(
+            managedObjectContext: context,
+            user: user,
+            conversation: conversation
+        )
+
+        let otherUserRole = ParticipantRole.create(
+            managedObjectContext: context,
+            user: otherUser,
+            conversation: conversation
+        )
+
+        userRole.conversation = conversation
+        otherUserRole.conversation = conversation
+
+        user.participantRoles = [userRole]
+        otherUser.participantRoles = [otherUserRole]
+
+        conversation.addParticipantsAndUpdateConversationState(
+            users: [user, otherUser]
+        )
+
+        return conversation
+    }
+
+    /// Creates a conversation with domain "domain4.com" with participants of "domain3.com" and "domain4.com",
+    /// The federation event domains are "domain3.com" and "domain4.com".
+    /// It enables testing that the participant with domain "domain3.com" is removed from the conversation that is hosted on "domain4.com"
+    private func makeHostedConversation() -> ZMConversation {
+        let user = ZMUser.fetchOrCreate(
+            with: Scaffolding.userID,
+            domain: nil,
+            in: context
+        )
+
+        let otherUser = ZMUser.fetchOrCreate(
+            with: Scaffolding.otherUserID,
+            domain: nil,
+            in: context
+        )
+
+        user.domain = Scaffolding.thirdDomain
+        otherUser.domain = Scaffolding.fourthDomain
+
+        var created = false
+
+        let conversation = ZMConversation.fetchOrCreate(
+            with: Scaffolding.groupConversationID,
+            domain: Scaffolding.fourthDomain,
+            in: context,
+            created: &created
+        )
+
+        conversation.domain = Scaffolding.fourthDomain
+        conversation.conversationType = .group
+
+        let userRole = ParticipantRole.create(
+            managedObjectContext: context,
+            user: user,
+            conversation: conversation
+        )
+
+        let otherUserRole = ParticipantRole.create(
+            managedObjectContext: context,
+            user: otherUser,
+            conversation: conversation
+        )
+
+        userRole.conversation = conversation
+        otherUserRole.conversation = conversation
+
+        user.participantRoles = [userRole]
+        otherUser.participantRoles = [otherUserRole]
+
+        conversation.addParticipantsAndUpdateConversationState(
+            users: [user, otherUser]
+        )
+
+        return conversation
+    }
+
+}
+
+// MARK: - Scaffolding
+
+private enum Scaffolding {
+
+    static let userID = UUID()
+    static let otherUserID = UUID()
+    static let groupConversationID = UUID()
+    static let firstDomain = "domain.com"
+    static let secondDomain = "domain2.com"
+    static let thirdDomain = "domain3.com"
+    static let fourthDomain = "domain4.com"
+
+    static let event = FederationConnectionRemovedEvent(
+        domains: Set([thirdDomain, fourthDomain])
+    )
+
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10187" title="WPB-10187" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-10187</a>  [iOS] Process FederationConnectionRemovedEvent
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Key points

This PR is part of the quick sync refactoring plan and is related to processing the multiple events we receive from the backend or the push channel.

Specifically, this PR is about porting the existing implementation of the `FederationConnectionRemovedEventProcessor` event.

Legacy code was using a FederationTerminationManager part of WireRequestStrategy framework to manage the storage logic. 

```
 federationTerminationManager.handleFederationTerminationBetween(firstDomain, otherDomain: secondDomain)
```

To avoid using this internal dependency, we now directly perform the storage logic operations in our dedicated ConnectionRepository object.

### Testing

UTs cover the following use cases:
- Federated participants are removed from the conversations that are not hosted on the given domains.
- A federated participant on a hosted conversation domain is removed from that conversation if he's not part of the same domain.

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
