### PR TITLE
chore: Use iOS 16+ standard directory URLs - WPB-11185

### DIFF
--- a/wire-ios-cryptobox/WireCryptoboxTests/ChaCha20StreamEncryptionTests.swift
+++ b/wire-ios-cryptobox/WireCryptoboxTests/ChaCha20StreamEncryptionTests.swift
@@ -86,8 +86,7 @@ class ChaCha20StreamEncryptionTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        let docments = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
-        directoryURL = docments.appendingPathComponent("ChaCha20EncryptionTests")
+        directoryURL = URL.documentsDirectory.appendingPathComponent("ChaCha20EncryptionTests")
 
         do {
             try FileManager.default.createDirectory(atPath: directoryURL.path, withIntermediateDirectories: true, attributes: nil)

--- a/wire-ios-data-model/Source/ManagedObjectContext/CoreDataStack+ClearStorage.swift
+++ b/wire-ios-data-model/Source/ManagedObjectContext/CoreDataStack+ClearStorage.swift
@@ -24,13 +24,12 @@ extension CoreDataStack {
 
     /// Locations where Wire is or has historically been storing data.
     private var storageLocations: [URL] {
-        var locations = [.cachesDirectory,
-                         .applicationSupportDirectory,
-                         .libraryDirectory].compactMap {
-                            FileManager.default.urls(for: $0, in: .userDomainMask).first
-                         }
-
-        locations.append(applicationContainer)
+        var locations = [
+            URL.cachesDirectory,
+            URL.applicationSupportDirectory,
+            URL.libraryDirectory,
+            applicationContainer
+        ]
 
         if let bundleIdentifier = Bundle.main.bundleIdentifier {
             locations.append(applicationContainer

--- a/wire-ios-data-model/Tests/OneOnOne/OneOnOneMigratorTests.swift
+++ b/wire-ios-data-model/Tests/OneOnOne/OneOnOneMigratorTests.swift
@@ -215,9 +215,7 @@ final class OneOnOneMigratorTests: XCTestCase {
         }
 
         // required to add be able to add images
-        let cacheLocation = try XCTUnwrap(
-            FileManager.default.randomCacheURL
-        )
+        let cacheLocation = FileManager.default.randomCacheURL
 
         await syncContext.perform {
             self.syncContext.zm_fileAssetCache = FileAssetCache(location: cacheLocation)

--- a/wire-ios-data-model/Tests/Source/ManagedObjectContext/BackupMetadataTests.swift
+++ b/wire-ios-data-model/Tests/Source/ManagedObjectContext/BackupMetadataTests.swift
@@ -24,8 +24,7 @@ class BackupMetadataTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        let documentsURL = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).first!
-        url = URL(fileURLWithPath: documentsURL).appendingPathComponent(name)
+        url = URL.documentsDirectory.appendingPathComponent(name)
     }
 
     override func tearDown() {

--- a/wire-ios-data-model/Tests/Source/ManagedObjectContext/CoreDataStackTests+ClearStorage.swift
+++ b/wire-ios-data-model/Tests/Source/ManagedObjectContext/CoreDataStackTests+ClearStorage.swift
@@ -24,10 +24,7 @@ class CoreDataStackTests_ClearStorage: ZMTBaseTest {
     let account: Account = Account(userName: "", userIdentifier: UUID())
 
     var applicationContainer: URL {
-        return FileManager.default
-            .urls(for: .applicationSupportDirectory, in: .userDomainMask)
-            .first!
-            .appendingPathComponent("CoreDataStackTests")
+        URL.applicationSupportDirectory.appendingPathComponent("CoreDataStackTests")
     }
 
     func testThatPersistentStoreIsCleared_WhenUpgradingFromLegacyInstallation() {
@@ -160,8 +157,8 @@ class CoreDataStackTests_ClearStorage: ZMTBaseTest {
         let bundleID = Bundle.main.bundleIdentifier!
 
         return [
-            FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!,
-            FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!,
+            URL.cachesDirectory,
+            URL.applicationSupportDirectory,
             applicationContainer,
             applicationContainer.appendingPathComponent(bundleID),
             applicationContainer.appendingPathComponent(bundleID).appendingPathComponent(accountID),

--- a/wire-ios-data-model/Tests/Source/ManagedObjectContext/DatabaseBaseTest.swift
+++ b/wire-ios-data-model/Tests/Source/ManagedObjectContext/DatabaseBaseTest.swift
@@ -25,9 +25,7 @@ class DatabaseBaseTest: ZMTBaseTest {
     var accountID: UUID = UUID.create()
 
     public static var applicationContainer: URL {
-        FileManager.default
-            .urls(for: .applicationSupportDirectory, in: .userDomainMask)
-            .first!
+        URL.applicationSupportDirectory
             .appendingPathComponent("StorageStackTests")
     }
 

--- a/wire-ios-data-model/Tests/Source/Model/AccountManagerTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/AccountManagerTests.swift
@@ -24,7 +24,7 @@ final class AccountManagerTests: ZMConversationTestsBase {
 
     override func setUp() {
         super.setUp()
-        let applicationSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let applicationSupport = URL.applicationSupportDirectory
         url = applicationSupport.appendingPathComponent("AccountManagerTests")
     }
 

--- a/wire-ios-data-model/Tests/Source/Model/AccountStoreTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/AccountStoreTests.swift
@@ -26,7 +26,7 @@ final class AccountStoreTests: ZMConversationTestsBase {
 
     override func setUp() {
         super.setUp()
-        let applicationSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let applicationSupport = URL.applicationSupportDirectory
         url = applicationSupport.appendingPathComponent("AccountStoreTests")
     }
 

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ConversationTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ConversationTests.swift
@@ -283,8 +283,7 @@ extension ConversationTests {
             let fileData = Data.secureRandomData(length: 100)
             let fileName = "foo.bar"
 
-            let documentsURL = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0]
-            let fileURL = URL(fileURLWithPath: documentsURL).appendingPathComponent(fileName)
+            let fileURL = URL.documentsDirectory.appendingPathComponent(fileName)
             try fileData.write(to: fileURL)
 
             XCTAssertNotNil(selfUserID)

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/SharedObjectStoreTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/SharedObjectStoreTests.swift
@@ -36,7 +36,7 @@ class ContextDidSaveNotificationPersistenceTests: BaseZMMessageTests {
 
     override func setUp() {
         super.setUp()
-        let url = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let url = URL.applicationSupportDirectory
         sut = ContextDidSaveNotificationPersistence(accountContainer: url)
     }
 
@@ -128,7 +128,7 @@ class ShareExtensionAnalyticsPersistenceTests: BaseZMMessageTests {
 
     override func setUp() {
         super.setUp()
-        let url = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let url = URL.applicationSupportDirectory
         sut = ShareExtensionAnalyticsPersistence(accountContainer: url)
     }
 
@@ -185,7 +185,7 @@ class ShareObjectStoreTests: ZMTBaseTest {
     }
 
     func createStore() -> SharedObjectStore<WireDataModel.SharedObjectTestClass> {
-        let url = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        let url = URL.cachesDirectory
         return SharedObjectStore(accountContainer: url, fileName: "store")
     }
 

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+Messages.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+Messages.swift
@@ -286,8 +286,7 @@ final class ZMConversationMessagesTests: ZMConversationTestsBase {
 
     func testThatWeCanInsertAFileMessage() {
         // given
-        let documents = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).first!
-        let fileURL = URL(fileURLWithPath: documents).appendingPathComponent("secret_file.txt")
+        let fileURL = URL.documentsDirectory.appendingPathComponent("secret_file.txt")
         let data = Data.randomEncryptionKey()
         let size = data.count
         try! data.write(to: fileURL)
@@ -318,8 +317,7 @@ final class ZMConversationMessagesTests: ZMConversationTestsBase {
 
     func testThatWeCanNotInsertAFileMessage_WhenFileSharingIsDisabled() {
         // given
-        let documents = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).first!
-        let fileURL = URL(fileURLWithPath: documents).appendingPathComponent("secret_file.txt")
+        let fileURL = URL.documentsDirectory.appendingPathComponent("secret_file.txt")
         let data = Data.randomEncryptionKey()
         try! data.write(to: fileURL)
         let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
@@ -356,8 +354,7 @@ final class ZMConversationMessagesTests: ZMConversationTestsBase {
     func testThatWeCanInsertAPassFileMessage() {
         // given
         let filename = "ticket.pkpass"
-        let documents = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).first!
-        let fileURL = URL(fileURLWithPath: documents).appendingPathComponent(filename)
+        let fileURL = URL.documentsDirectory.appendingPathComponent(filename)
         let data = Data.randomEncryptionKey()
         let size = data.count
         try! data.write(to: fileURL)
@@ -450,8 +447,7 @@ final class ZMConversationMessagesTests: ZMConversationTestsBase {
     func testThatWeCanInsertAVideoMessage() {
         // given
         let fileName = "video.mp4"
-        let documents = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).first!
-        let fileURL = URL(fileURLWithPath: documents).appendingPathComponent(fileName)
+        let fileURL = URL.documentsDirectory.appendingPathComponent(fileName)
         let videoData = Data.secureRandomData(length: 500)
         let thumbnailData = Data.secureRandomData(length: 250)
         let duration = 12333
@@ -501,8 +497,7 @@ final class ZMConversationMessagesTests: ZMConversationTestsBase {
 
         // given
         let fileName = "audio.m4a"
-        let documents = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).first!
-        let fileURL = URL(fileURLWithPath: documents).appendingPathComponent(fileName)
+        let fileURL = URL.documentsDirectory.appendingPathComponent(fileName)
         let videoData = Data.secureRandomData(length: 500)
         let thumbnailData = Data.secureRandomData(length: 250)
         let duration = 12333

--- a/wire-ios-data-model/Tests/Source/Model/Messages/FileAssetCacheTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Messages/FileAssetCacheTests.swift
@@ -47,9 +47,7 @@ class FileAssetCacheTests: XCTestCase {
             self.modelHelper.createSelfClient(in: self.context)
         }
 
-        location = try XCTUnwrap(
-            FileManager.default.randomCacheURL
-        )
+        location = FileManager.default.randomCacheURL
 
         try FileManager.default.removeItemIfExists(at: location!)
         sut = FileAssetCache(location: location!)

--- a/wire-ios-data-model/Tests/Source/Model/Messages/OtrBaseTest.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Messages/OtrBaseTest.swift
@@ -30,7 +30,7 @@ class OtrBaseTest: XCTestCase {
     }
 
     static var sharedContainerURL: URL {
-        return try! FileManager.default.url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+        URL.applicationSupportDirectory
     }
 
     static func otrDirectoryURL(accountIdentifier: UUID) -> URL {

--- a/wire-ios-data-model/Tests/Source/Model/Messages/ZMClientMessageTests+Deletion.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Messages/ZMClientMessageTests+Deletion.swift
@@ -100,7 +100,7 @@ class ZMClientMessageTests_Deletion: BaseZMClientMessageTests {
     func testThatItDeletesAnAssetMessage_File() {
         // given
         let data = Data("Hello World".utf8)
-        let documents = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).first!
+        let documents = URL.documentDirectory
         let url = URL(fileURLWithPath: documents).appendingPathComponent("file.dat")
 
         defer { try! FileManager.default.removeItem(at: url) }

--- a/wire-ios-data-model/Tests/Source/Model/ModelObjectsTests+Helpers.swift
+++ b/wire-ios-data-model/Tests/Source/Model/ModelObjectsTests+Helpers.swift
@@ -79,7 +79,7 @@ extension ModelObjectsTests {
     }
 
     func testURLWithFilename(_ filename: String) -> URL {
-        let documents = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).first!
+        let documents = URL.documentDirectory
         let documentsURL = URL(fileURLWithPath: documents)
         return documentsURL.appendingPathComponent(filename)
     }

--- a/wire-ios-data-model/Tests/Source/Model/Utils/FileManager+FileLocationTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Utils/FileManager+FileLocationTests.swift
@@ -22,7 +22,7 @@ class FileManager_CryptoboxTests: XCTestCase {
 
     func testThatItReturnsTheCryptoboxPath() {
         // given
-        let url = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        let url = URL.cachesDirectory
 
         // when
         let storeURL = FileManager.keyStoreURL(accountDirectory: url, createParentIfNeeded: false)
@@ -38,7 +38,7 @@ class FileManager_CryptoboxTests: XCTestCase {
 
     func testThatItCreatesTheParentDirectoryIfNeededAndExcludesItFromBackup() {
         // given
-        let url = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        let url = URL.cachesDirectory
 
         // when
         let storeURL = FileManager.keyStoreURL(accountDirectory: url, createParentIfNeeded: true)
@@ -58,7 +58,7 @@ class FileManager_CacheTests: XCTestCase {
 
     func testThatItReturnsTheCachesDirectory_WithAccountId() {
         // given
-        let url = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        let url = URL.cachesDirectory
         let accountId = UUID()
 
         // when
@@ -84,7 +84,7 @@ class FileManager_CacheTests: XCTestCase {
 
     func testThatItReturnsTheCachesDirectory_WithoutAccountId() {
         // given
-        let url = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        let url = URL.cachesDirectory
 
         // when
         let cachesURL = FileManager.default.cachesURLForAccount(with: nil, in: url)

--- a/wire-ios-data-model/Tests/Source/Model/ZMBaseManagedObjectTest.swift
+++ b/wire-ios-data-model/Tests/Source/Model/ZMBaseManagedObjectTest.swift
@@ -23,8 +23,7 @@ import XCTest
 extension ZMBaseManagedObjectTest {
 
     var storageDirectory: URL {
-        FileManager.default.urls(for: .documentDirectory,
-                                 in: .userDomainMask).first!
+        URL.documentsDirectory
     }
 
     func createClientTextMessage(in context: NSManagedObjectContext? = nil) -> ZMClientMessage? {

--- a/wire-ios-mocktransport/Source/Clients and OTR/MockUserClient.swift
+++ b/wire-ios-mocktransport/Source/Clients and OTR/MockUserClient.swift
@@ -206,7 +206,7 @@ extension MockUserClient {
 @objc extension MockUserClient {
 
     public static var mockEncryptionSessionDirectory: URL {
-        return FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!.appendingPathComponent("mocktransport-encryptionDirectory")
+        return URL.applicationSupportDirectory.appendingPathComponent("mocktransport-encryptionDirectory")
     }
 
     static func encryptionContext(for user: MockUser?, clientId: String?) -> EncryptionContext {

--- a/wire-ios-notification-engine/WireNotificationEngineTests/BaseNotificationSessionTests.swift
+++ b/wire-ios-notification-engine/WireNotificationEngineTests/BaseNotificationSessionTests.swift
@@ -53,12 +53,7 @@ class BaseTest: ZMTBaseTest {
 
         accountIdentifier = UUID.create()
         authenticationStatus = FakeAuthenticationStatus()
-        cachesDirectory = try! FileManager.default.url(
-            for: .cachesDirectory,
-               in: .userDomainMask,
-               appropriateFor: nil,
-               create: true
-        )
+        cachesDirectory = URL.cachesDirectory
 
         let account = Account(
             userName: "",

--- a/wire-ios-request-strategy/Sources/Helpers/ZMTBaseTests+CoreDataStack.swift
+++ b/wire-ios-request-strategy/Sources/Helpers/ZMTBaseTests+CoreDataStack.swift
@@ -22,7 +22,7 @@ import WireTesting
 extension ZMTBaseTest {
 
     var sharedContainerURL: URL {
-        FileManager.default.randomCacheURL!
+        FileManager.default.randomCacheURL
 
     }
 

--- a/wire-ios-request-strategy/Tests/Helpers/MessagingTest+Encryption.swift
+++ b/wire-ios-request-strategy/Tests/Helpers/MessagingTest+Encryption.swift
@@ -122,7 +122,7 @@ extension MessagingTestBase {
 
     /// Returns the folder where the encryption contexts for other test clients are stored
     var otherClientsEncryptionContextsURL: URL {
-        return FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!.appendingPathComponent("OtherClients")
+        return URL.cachesDirectory.appendingPathComponent("OtherClients")
     }
 
     /// Returns the encryption context to use for a given client. There are extra cryptobox sessions

--- a/wire-ios-request-strategy/Tests/Helpers/MessagingTestBase.swift
+++ b/wire-ios-request-strategy/Tests/Helpers/MessagingTestBase.swift
@@ -508,7 +508,7 @@ extension MessagingTestBase {
 extension MessagingTestBase {
 
     private var cacheFolder: URL {
-        return FileManager.default.randomCacheURL!
+        return FileManager.default.randomCacheURL
     }
 
     fileprivate func deleteAllFilesInCache() {

--- a/wire-ios-request-strategy/Tests/Sources/Notifications/PushNotifications/LocalNotificationContentTypeTest.swift
+++ b/wire-ios-request-strategy/Tests/Sources/Notifications/PushNotifications/LocalNotificationContentTypeTest.swift
@@ -182,9 +182,7 @@ class LocalNotificationContentTypeTest: ZMLocalNotificationTests {
     }
 
     private func testURLWithFilename(_ filename: String) -> URL {
-        let documents = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).first!
-        let documentsURL = URL(fileURLWithPath: documents)
-        return documentsURL.appendingPathComponent(filename)
+        return URL.documentsDirectory.appendingPathComponent(filename)
     }
 
     private func createTestFile(at url: URL) -> Data {

--- a/wire-ios-share-engine/WireShareEngineTests/BaseSharingSessionTests.swift
+++ b/wire-ios-share-engine/WireShareEngineTests/BaseSharingSessionTests.swift
@@ -70,12 +70,7 @@ class BaseTest: ZMTBaseTest {
 
         accountIdentifier = UUID.create()
         authenticationStatus = FakeAuthenticationStatus()
-        cachesDirectory = try! FileManager.default.url(
-            for: .cachesDirectory,
-               in: .userDomainMask,
-               appropriateFor: nil,
-               create: true
-        )
+        cachesDirectory = URL.cachesDirectory
 
         let account = Account(
             userName: "",

--- a/wire-ios-share-engine/WireShareEngineTests/OperationLoopTests.swift
+++ b/wire-ios-share-engine/WireShareEngineTests/OperationLoopTests.swift
@@ -40,11 +40,10 @@ final class OperationLoopTests: ZMTBaseTest {
     override func setUp() {
         super.setUp()
         let accountId = UUID()
-        let directoryURL = try! FileManager.default.url(for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
         let account = Account(userName: "", userIdentifier: accountId)
 
         let coreDataStack = CoreDataStack(account: account,
-                                          applicationContainer: directoryURL,
+                                          applicationContainer: .cachesDirectory,
                                           inMemoryStore: true,
                                           dispatchGroup: dispatchGroup)
         coreDataStack.loadStores { error in

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -302,9 +302,8 @@ public final class SessionManager: NSObject, SessionManagerType {
 
     let pushTokenService: PushTokenServiceInterface
 
-    var cachesDirectory: URL? {
-        let manager = FileManager.default
-        return manager.urls(for: .cachesDirectory, in: .userDomainMask).first
+    var cachesDirectory: URL {
+        URL.cachesDirectory
     }
 
     private let minTLSVersion: String?
@@ -965,9 +964,8 @@ public final class SessionManager: NSObject, SessionManagerType {
     }
 
     private func clearCacheDirectory() {
-        guard let cachesDirectoryPath = cachesDirectory else { return }
         let manager = FileManager.default
-        try? manager.removeItem(at: cachesDirectoryPath)
+        try? manager.removeItem(at: cachesDirectory)
     }
 
     fileprivate func deleteAccountData(for account: Account) {

--- a/wire-ios-sync-engine/Source/Synchronization/ZMHotFixDirectory+Swift.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/ZMHotFixDirectory+Swift.swift
@@ -131,7 +131,7 @@ import Foundation
 
     public static func purgePINCachesInHostBundle() {
         let fileManager = FileManager.default
-        guard let cachesDirectory = try? fileManager.url(for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: false) else { return }
+        let cachesDirectory = URL.cachesDirectory
         let PINCacheFolders = ["com.pinterest.PINDiskCache.images", "com.pinterest.PINDiskCache.largeUserImages", "com.pinterest.PINDiskCache.smallUserImages"]
 
         PINCacheFolders.forEach { PINCacheFolder in

--- a/wire-ios-sync-engine/Tests/Source/DatabaseTest.swift
+++ b/wire-ios-sync-engine/Tests/Source/DatabaseTest.swift
@@ -47,7 +47,7 @@ class DatabaseTest: ZMTBaseTest {
     }
 
     var cacheURL: URL {
-        return FileManager.default.randomCacheURL!
+        return FileManager.default.randomCacheURL
 
     }
 

--- a/wire-ios-sync-engine/Tests/Source/Use cases/ShareFileUseCaseTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Use cases/ShareFileUseCaseTests.swift
@@ -37,15 +37,8 @@ class ShareFileUseCaseTests: ZMTBaseTest {
         coreDataStackHelper = CoreDataStackHelper()
         coreDataStack = try await coreDataStackHelper.createStack()
 
-        let cacheLocation = try XCTUnwrap(
-            FileManager.default.urls(
-                for: .cachesDirectory,
-                in: .userDomainMask
-            ).first
-        )
-
         await coreDataStack.viewContext.perform {
-            self.coreDataStack.viewContext.zm_fileAssetCache = FileAssetCache(location: cacheLocation)
+            self.coreDataStack.viewContext.zm_fileAssetCache = FileAssetCache(location: .cachesDirectory)
         }
 
         sut = ShareFileUseCase(contextProvider: coreDataStack)

--- a/wire-ios-system/Source/UserDefaults+Temporary.swift
+++ b/wire-ios-system/Source/UserDefaults+Temporary.swift
@@ -55,8 +55,8 @@ private final class SuiteCleanUp {
         // ~/Library/Developer/CoreSimulator/Devices/<device id>/data/Containers/Data/Application/<app id>/Library/Preferences/<suiteName>.plist
         do {
             let fileManager = FileManager.default
-            let url = try fileManager
-                .url(for: .libraryDirectory, in: .userDomainMask, appropriateFor: .init(string: "/")!, create: false)
+            let url = URL
+                .libraryDirectory
                 .appendingPathComponent("Preferences")
                 .appendingPathComponent(suiteName + ".plist")
             if fileManager.fileExists(atPath: url.path) {

--- a/wire-ios-system/Source/ZMAssertionDumpFile.swift
+++ b/wire-ios-system/Source/ZMAssertionDumpFile.swift
@@ -27,20 +27,11 @@ public final class AssertionDumpFile: NSObject {
     }
 
     public static var url: URL {
-        get throws {
-            let applicationSupportDirectory = try FileManager.default.url(
-                for: .applicationSupportDirectory,
-                in: .userDomainMask,
-                appropriateFor: nil,
-                create: true
-            )
-
-            return applicationSupportDirectory.appendingPathComponent("last_assertion.log")
-        }
+        URL.applicationSupportDirectory.appendingPathComponent("last_assertion.log")
     }
 
     public static func write(content: String) throws {
-        var dumpFile = try url
+        var dumpFile = url
         try Data().write(to: dumpFile)
 
         var resourceValues = URLResourceValues()

--- a/wire-ios-system/Tests/ZMAssertionDumpFileTests.swift
+++ b/wire-ios-system/Tests/ZMAssertionDumpFileTests.swift
@@ -23,16 +23,16 @@ import XCTest
 final class ZMAssertionDumpFileTests: XCTestCase {
 
     override func setUpWithError() throws {
-        let url = try AssertionDumpFile.url
+        let url = AssertionDumpFile.url
         if FileManager.default.fileExists(atPath: url.path) {
-            try FileManager.default.removeItem(at: AssertionDumpFile.url)
+            try FileManager.default.removeItem(at: url)
         }
     }
 
     override func tearDownWithError() throws {
-        let url = try AssertionDumpFile.url
+        let url = AssertionDumpFile.url
         if FileManager.default.fileExists(atPath: url.path) {
-            try FileManager.default.removeItem(at: AssertionDumpFile.url)
+            try FileManager.default.removeItem(at: url)
         }
     }
 

--- a/wire-ios-system/Tests/ZMLogTests.swift
+++ b/wire-ios-system/Tests/ZMLogTests.swift
@@ -551,7 +551,7 @@ extension ZMLogTests {
         Thread.sleep(forTimeInterval: 0.2)
 
         // then
-        let path = try XCTUnwrap(ZMSLog.currentLogURL?.path)
+        let path = ZMSLog.currentLogURL.path
         XCTAssertFalse(FileManager.default.fileExists(atPath: path))
     }
 
@@ -682,8 +682,7 @@ extension ZMLogTests {
     func getLinesFromCurrentLog(file: StaticString = #file, line: UInt = #line) -> [String] {
 
         guard
-            let currentLog = ZMSLog.currentLogURL,
-            let data = FileManager.default.contents(atPath: currentLog.path)
+            let data = FileManager.default.contents(atPath: ZMSLog.currentLogURL.path)
         else {
             XCTFail(file: file, line: line)
             return []

--- a/wire-ios-testing/Source/Public/FileManger+RandomCacheURL.swift
+++ b/wire-ios-testing/Source/Public/FileManger+RandomCacheURL.swift
@@ -20,8 +20,8 @@ import Foundation
 
 public extension FileManager {
 
-    var randomCacheURL: URL? {
-        urls(for: .cachesDirectory, in: .userDomainMask).first?.appendingPathComponent(UUID().uuidString)
+    var randomCacheURL: URL {
+        URL.cachesDirectory.appendingPathComponent(UUID().uuidString)
     }
 
 }

--- a/wire-ios/Tests/Fixture/CoreDataFixture.swift
+++ b/wire-ios/Tests/Fixture/CoreDataFixture.swift
@@ -58,7 +58,7 @@ final class CoreDataFixture {
         return false
     }
 
-    var documentsDirectory: URL?
+    var documentsDirectory: URL
 
     init() {
         /// From ZMSnapshotTestCase
@@ -71,16 +71,12 @@ final class CoreDataFixture {
         UIView.setAnimationsEnabled(false)
         snapshotBackgroundColor = UIColor.clear
 
-        do {
-            documentsDirectory = try FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
-        } catch {
-            XCTAssertNil(error, "Unexpected error \(error)")
-        }
+        documentsDirectory = URL.documentsDirectory
 
         let account = Account(userName: "", userIdentifier: UUID())
         let group = ZMSDispatchGroup(dispatchGroup: dispatchGroup, label: "CoreDataStack")
         let coreDataStack = CoreDataStack(account: account,
-                                          applicationContainer: documentsDirectory!,
+                                          applicationContainer: documentsDirectory,
                                           inMemoryStore: true,
                                           dispatchGroup: group)
 
@@ -115,9 +111,8 @@ final class CoreDataFixture {
     }
 
     func setUpCaches() {
-        let cacheLocation = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
         uiMOC.zm_userImageCache = UserImageLocalCache(location: nil)
-        uiMOC.zm_fileAssetCache = FileAssetCache(location: cacheLocation)
+        uiMOC.zm_fileAssetCache = FileAssetCache(location: .cachesDirectory)
     }
 
     // MARK: – Setup

--- a/wire-ios/Wire-iOS Tests/Backup/BackupExcluderTests.swift
+++ b/wire-ios/Wire-iOS Tests/Backup/BackupExcluderTests.swift
@@ -43,16 +43,14 @@ final class BackupExcluderTests: XCTestCase {
     }
 
     func delete(fileNamed: String) {
-        guard let path = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).first else { return }
-        let file = URL(fileURLWithPath: path).appendingPathComponent(fileNamed)
+        let file = URL.documentsDirectory.appendingPathComponent(fileNamed)
 
         let fileManager = FileManager.default
         try? fileManager.removeItem(at: file)
     }
 
     func write(text: String, to fileNamed: String) {
-        guard let path = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).first else { return }
-        let file = URL(fileURLWithPath: path).appendingPathComponent(fileNamed)
+        let file = URL.documentsDirectory.appendingPathComponent(fileNamed)
         try? text.write(to: file, atomically: false, encoding: String.Encoding.utf8)
     }
 

--- a/wire-ios/Wire-iOS Tests/LoggingTest.swift
+++ b/wire-ios/Wire-iOS Tests/LoggingTest.swift
@@ -34,9 +34,8 @@ class LoggingTest: XCTestCase {
         // Assert that some logs have been written to the current log file, which is the file
         // that gets attached to debug reports.
         XCTAssertNotNil(ZMSLog.currentZipLog)
-        XCTAssertNotNil(ZMSLog.currentLogURL)
         XCTAssertFalse(ZMSLog.currentZipLog!.isEmpty)
-        XCTAssertFalse(FileManager.default.contents(atPath: ZMSLog.currentLogURL!.path)!.isEmpty)
+        XCTAssertFalse(FileManager.default.contents(atPath: ZMSLog.currentLogURL.path)!.isEmpty)
     }
 
 }

--- a/wire-ios/Wire-iOS Tests/Utils/ZMSnapshotTestCase.swift
+++ b/wire-ios/Wire-iOS Tests/Utils/ZMSnapshotTestCase.swift
@@ -35,7 +35,7 @@ class ZMSnapshotTestCase: XCTestCase {
         return false
     }
 
-    var documentsDirectory: URL?
+    var documentsDirectory: URL!
 
     override open func setUp() {
         super.setUp()
@@ -50,11 +50,7 @@ class ZMSnapshotTestCase: XCTestCase {
         accentColor = .red
         snapshotBackgroundColor = UIColor.clear
 
-        do {
-            documentsDirectory = try FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
-        } catch {
-            XCTAssertNil(error, "Unexpected error \(error)")
-        }
+        documentsDirectory = URL.documentsDirectory
 
         setupCoreDataStack()
         if needsCaches {
@@ -65,7 +61,7 @@ class ZMSnapshotTestCase: XCTestCase {
     func setupCoreDataStack() {
         let account = Account(userName: "", userIdentifier: UUID())
         let coreDataStack = CoreDataStack(account: account,
-                                          applicationContainer: documentsDirectory!,
+                                          applicationContainer: documentsDirectory,
                                           inMemoryStore: true)
 
         coreDataStack.loadStores(completionHandler: { error in
@@ -92,7 +88,7 @@ class ZMSnapshotTestCase: XCTestCase {
 
     func removeContentsOfDocumentsDirectory() {
         do {
-            let contents = try FileManager.default.contentsOfDirectory(at: documentsDirectory!, includingPropertiesForKeys: nil, options: .skipsHiddenFiles)
+            let contents = try FileManager.default.contentsOfDirectory(at: documentsDirectory, includingPropertiesForKeys: nil, options: .skipsHiddenFiles)
 
             for content: URL in contents {
                 do {
@@ -115,9 +111,8 @@ class ZMSnapshotTestCase: XCTestCase {
     }
 
     func setUpCaches() {
-        let cacheLocation = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
         uiMOC.zm_userImageCache = UserImageLocalCache(location: nil)
-        uiMOC.zm_fileAssetCache = FileAssetCache(location: cacheLocation)
+        uiMOC.zm_fileAssetCache = FileAssetCache(location: .cachesDirectory)
     }
 
 }

--- a/wire-ios/Wire-iOS/Sources/Helpers/FileDirectory/FileManager+Directory.swift
+++ b/wire-ios/Wire-iOS/Sources/Helpers/FileDirectory/FileManager+Directory.swift
@@ -22,8 +22,7 @@ import WireSystem
 private let zmLog = ZMSLog(tag: "FileManager")
 
 extension URL {
-    static func directoryURL(_ pathComponent: String) -> URL? {
-        let url = try? FileManager.default.url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
-        return url?.appendingPathComponent(pathComponent)
+    static func directoryURL(_ pathComponent: String) -> URL {
+        URL.applicationSupportDirectory.appendingPathComponent(pathComponent)
     }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+FilesPopover.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+FilesPopover.swift
@@ -37,11 +37,9 @@ extension ConversationInputBarViewController {
         #if targetEnvironment(simulator)
         let plistHandler: ((UIAlertAction) -> Void) = { _ in
             self.userSession.enqueue({
-                let paths = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)
-                guard let basePath = paths.first,
-                    let sourceLocation = Bundle.main.url(forResource: "CountryCodes", withExtension: "plist") else { return }
+                guard let sourceLocation = Bundle.main.url(forResource: "CountryCodes", withExtension: "plist") else { return }
 
-                let destLocation = URL(fileURLWithPath: basePath).appendingPathComponent(sourceLocation.lastPathComponent)
+                let destLocation = URL.documentsDirectory.appendingPathComponent(sourceLocation.lastPathComponent)
 
                 try? FileManager.default.copyItem(at: sourceLocation, to: destLocation)
                 self.uploadFile(at: destLocation)
@@ -151,13 +149,10 @@ extension ConversationInputBarViewController {
         return UIAlertAction(title: title, style: .default, handler: {_ in
             self.userSession.enqueue({
                 let randomData = Data.secureRandomData(length: UInt(size))
+                let fileURL = URL.documentsDirectory.appendingPathComponent(fileName)
 
-                if let dir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first {
-                    let fileURL = dir.appendingPathComponent(fileName)
-                    try? randomData.write(to: fileURL)
-
-                    self.uploadFile(at: fileURL)
-                }
+                try? randomData.write(to: fileURL)
+                self.uploadFile(at: fileURL)
             })
         })
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/EmojiRepository.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/EmojiRepository.swift
@@ -59,20 +59,12 @@ final class EmojiRepository: EmojiRepositoryInterface {
     // MARK: - Recently used
 
     func registerRecentlyUsedEmojis(_ emojis: [Emoji.ID]) {
-        guard
-            let emojiDirectory,
-            let recentlyUsedEmojisURL
-        else {
-            return
-        }
-
         try! FileManager.default.createAndProtectDirectory(at: emojiDirectory)
         (emojis as NSArray).write(to: recentlyUsedEmojisURL, atomically: true)
     }
 
     func fetchRecentlyUsedEmojis() -> [Emoji] {
         guard
-            let recentlyUsedEmojisURL,
             let emojiValues = NSArray(contentsOf: recentlyUsedEmojisURL) as? [String]
         else {
             return []
@@ -82,7 +74,7 @@ final class EmojiRepository: EmojiRepositoryInterface {
     }
 
     private lazy var emojiDirectory = URL.directoryURL("emoji")
-    private lazy var recentlyUsedEmojisURL = emojiDirectory?.appendingPathComponent("recently_used.plist")
+    private lazy var recentlyUsedEmojisURL = emojiDirectory.appendingPathComponent("recently_used.plist")
 
     // MARK: - Availability
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
@@ -585,9 +585,9 @@ final class ConversationListViewModel: NSObject {
 
         guard isFolderStatePersistenceEnabled,
               let jsonString = state.jsonString,
-              let persistentDirectory = ConversationListViewModel.persistentDirectory,
-              let directoryURL = URL.directoryURL(persistentDirectory) else { return }
+              let persistentDirectory = ConversationListViewModel.persistentDirectory else { return }
 
+        let directoryURL = URL.directoryURL(persistentDirectory)
         try! FileManager.default.createAndProtectDirectory(at: directoryURL)
 
         do {
@@ -611,7 +611,7 @@ final class ConversationListViewModel: NSObject {
     static var persistentURL: URL? {
         guard let persistentDirectory else { return nil }
 
-        return URL.directoryURL(persistentDirectory)?.appendingPathComponent(ConversationListViewModel.persistentFilename)
+        return URL.directoryURL(persistentDirectory).appendingPathComponent(ConversationListViewModel.persistentFilename)
     }
 }
 

--- a/wire-ios/WireCommonComponents/LogFileDestination.swift
+++ b/wire-ios/WireCommonComponents/LogFileDestination.swift
@@ -21,8 +21,8 @@ import WireSystem
 
 public enum LogFileDestination: CaseIterable, FileLoggerDestination {
 
-    private static var cachesDirectory: URL? {
-        FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
+    private static var cachesDirectory: URL {
+        URL.cachesDirectory
     }
 
     case nse
@@ -48,7 +48,7 @@ public enum LogFileDestination: CaseIterable, FileLoggerDestination {
             }
             return url.appendingPathComponent(filename)
         case .main:
-            return Self.cachesDirectory?.appendingPathComponent(filename)
+            return Self.cachesDirectory.appendingPathComponent(filename)
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11185" title="WPB-11185" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-11185</a>  [iOS] Remove optional URLs
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->

# WIP - Don't review

### Issue

With dropping support for iOS 15 we now have a much nicer API for getting the URL of standard directories which thankfully returns non optional results 🥳 

```diff
-let documents: URL? = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first // iOS 15
+let documents: URL = URL.documentsDirectory // iOS 16
```

This PR updates nearly all cases I have found to use the modern API

### Testing

Run unit tests

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---
