### PR TITLE
fix: make writing databaseKey on context async, fix UTs - WPB-16374

### DIFF
--- a/wire-ios-data-model/Source/Authentication/EAR/EARService.swift
+++ b/wire-ios-data-model/Source/Authentication/EAR/EARService.swift
@@ -558,9 +558,9 @@ public class EARService: EARServiceInterface {
         }
     }
 
-    private func performInAllContexts(_ block: (NSManagedObjectContext) -> Void) {
+    private func performInAllContexts(_ block: @escaping (NSManagedObjectContext) -> Void) {
         for context in databaseContexts {
-            context.performAndWait {
+            context.perform {
                 block(context)
             }
         }

--- a/wire-ios-data-model/Tests/Authentication/EAR/EARServiceTests.swift
+++ b/wire-ios-data-model/Tests/Authentication/EAR/EARServiceTests.swift
@@ -243,6 +243,8 @@ final class EARServiceTests: ZMBaseManagedObjectTest, EARServiceDelegate {
         // Then EAR is enabled on the context
         XCTAssertTrue(uiMOC.encryptMessagesAtRest)
 
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
         // Then all contexts have the database key.
         XCTAssertNotNil(uiMOC.databaseKey)
         syncMOC.performAndWait { XCTAssertNotNil(syncMOC.databaseKey) }
@@ -319,6 +321,8 @@ final class EARServiceTests: ZMBaseManagedObjectTest, EARServiceDelegate {
         // When
         XCTAssertNoThrow(try sut.enableEncryptionAtRest(context: uiMOC))
 
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
         // Then migration was run
         XCTAssertEqual(prepareForMigrationCalls, 1)
         XCTAssertTrue(messageData.isEncrypted)
@@ -381,6 +385,7 @@ final class EARServiceTests: ZMBaseManagedObjectTest, EARServiceDelegate {
         XCTAssertNoThrow(try sut.enableEncryptionAtRest(context: uiMOC))
 
         // Then
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         XCTAssertTrue(conversation.hasEncryptedDraftMessageData)
         XCTAssertEqual(conversation.unencryptedDraftMessageContent, "Beep bloop")
         XCTAssertTrue(uiMOC.encryptMessagesAtRest)
@@ -444,6 +449,7 @@ final class EARServiceTests: ZMBaseManagedObjectTest, EARServiceDelegate {
         XCTAssertFalse(uiMOC.encryptMessagesAtRest)
 
         // Then all contexts no longer have the database key
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         XCTAssertNil(uiMOC.databaseKey)
         syncMOC.performAndWait { XCTAssertNil(syncMOC.databaseKey) }
     }
@@ -591,6 +597,7 @@ final class EARServiceTests: ZMBaseManagedObjectTest, EARServiceDelegate {
         sut.lockDatabase()
 
         // Then
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         XCTAssertNil(uiMOC.databaseKey)
 
         syncMOC.performAndWait {
@@ -617,6 +624,7 @@ final class EARServiceTests: ZMBaseManagedObjectTest, EARServiceDelegate {
         XCTAssertNoThrow(try sut.unlockDatabase())
 
         // Then
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         XCTAssertEqual(uiMOC.databaseKey?._storage, decryptedDatabaseKey)
 
         syncMOC.performAndWait {
@@ -809,6 +817,7 @@ final class EARServiceTests: ZMBaseManagedObjectTest, EARServiceDelegate {
         sut.setDatabaseKeyInAllContexts(databaseKey)
 
         // Then
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         XCTAssertEqual(uiMOC.databaseKey, databaseKey)
 
         syncMOC.performAndWait {
@@ -819,6 +828,7 @@ final class EARServiceTests: ZMBaseManagedObjectTest, EARServiceDelegate {
         sut.setDatabaseKeyInAllContexts(nil)
 
         // Then
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         XCTAssertNil(uiMOC.databaseKey)
 
         syncMOC.performAndWait {
@@ -883,6 +893,7 @@ final class EARServiceTests: ZMBaseManagedObjectTest, EARServiceDelegate {
         try sut.enableEncryptionAtRest(context: uiMOC, skipMigration: true)
 
         // Then
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         XCTAssertFalse(uiMOC.isLocked)
 
         let newPublicKeys = try XCTUnwrap(sut.fetchPublicKeys())


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16374" title="WPB-16374" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16374</a>  [iOS] cannot switch EAR on current internal builds
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

**Context**: when enabling/disabling EAR, we're stuck on loading screen
**Reason**: when doing the database migration, we're writing the databaseKey from the context and waiting for the operation to complete, this never completes.
**Solution**: make the writing operation async

### Testing

Enable/disable EAR on the settings screen. App should not be stuck anymore.

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.
