### PR TITLE
fix: Fix passing values for channel creation - WPB-17195

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Create/WireConversationChannelCreationFormViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Create/WireConversationChannelCreationFormViewController.swift
@@ -132,6 +132,9 @@ final class WireConversationChannelCreationFormViewController: UIViewController 
         }
 
         values.name = channelCreationSettings.channelName
+        values.allowGuests = channelCreationSettings.guestsAllowed
+        values.allowServices = channelCreationSettings.servicesAllowed
+        values.enableReceipts = channelCreationSettings.readReceiptsEnabled
 
         let participantsController = AddParticipantsViewController(
             context: .create(values),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17195" title="WPB-17195" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17195</a>  [iOS] Incorrect guest and services settings after creating a group
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Fix passing config values for channel creation

### Testing

Pass allow guests on and off and check in conversation details

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
