### PR TITLE
fix: memory leak operation loop - WPB-18909

### DIFF
--- a/WireNetwork/Sources/WireNetwork/APIs/AuthenticationAPI/AuthenticationAPIError.swift
+++ b/WireNetwork/Sources/WireNetwork/APIs/AuthenticationAPI/AuthenticationAPIError.swift
@@ -44,6 +44,8 @@ public enum AuthenticationAPIError: Error {
 
     case serviceUnavailable
 
+    case tooManyRequests(_ message: String, retyAfter: TimeInterval?)
+    
     /// Thrown by `requestVerificationCode(for:)`.
 
     case invalidEmail
@@ -73,7 +75,6 @@ public extension AuthenticationAPIError {
         case userCreationRestricted
 
         case unauthorized
-
     }
 
 }

--- a/WireNetwork/Sources/WireNetwork/APIs/AuthenticationAPI/AuthenticationAPIV0.swift
+++ b/WireNetwork/Sources/WireNetwork/APIs/AuthenticationAPI/AuthenticationAPIV0.swift
@@ -73,41 +73,51 @@ class AuthenticationAPIV0: AuthenticationAPI, VersionedAPI {
             for: responseURL
         )
 
-        let accessToken = try ResponseParser()
-            .success(
-                code: .ok,
-                type: AccessTokenV0.self
-            )
-            .failure(
-                code: .forbidden,
-                label: "code-authentication-required",
-                error: AuthenticationAPIError.twoFactorAuthenticationRequired
-            )
-            .failure(
-                code: .forbidden,
-                label: "code-authentication-failed",
-                error: AuthenticationAPIError.twoFactorAuthenticationFailed
-            )
-            .failure(
-                code: .forbidden,
-                label: "pending-activation",
-                error: AuthenticationAPIError.accountPendingActivation
-            )
-            .failure(
-                code: .forbidden,
-                label: "suspended",
-                error: AuthenticationAPIError.accountSuspended
-            )
-            .failure(
-                code: .forbidden,
-                label: "invalid-credentials",
-                error: AuthenticationAPIError.invalidCredentials
-            )
-            .parse(
-                code: response.statusCode,
-                data: data
-            )
-
+        let accessToken: AccessToken
+        do {
+            accessToken = try ResponseParser()
+                .success(
+                    code: .ok,
+                    type: AccessTokenV0.self
+                )
+                .failure(
+                    code: .forbidden,
+                    label: "code-authentication-required",
+                    error: AuthenticationAPIError.twoFactorAuthenticationRequired
+                )
+                .failure(
+                    code: .forbidden,
+                    label: "code-authentication-failed",
+                    error: AuthenticationAPIError.twoFactorAuthenticationFailed
+                )
+                .failure(
+                    code: .forbidden,
+                    label: "pending-activation",
+                    error: AuthenticationAPIError.accountPendingActivation
+                )
+                .failure(
+                    code: .forbidden,
+                    label: "suspended",
+                    error: AuthenticationAPIError.accountSuspended
+                )
+                .failure(
+                    code: .forbidden,
+                    label: "invalid-credentials",
+                    error: AuthenticationAPIError.invalidCredentials
+                )
+                .failure(code: .tooManyRequests, decodableError: FailureResponseV0.self)
+                .parse(
+                    code: response.statusCode,
+                    data: data
+                )
+        } catch let error as FailureResponseV0 {
+            if error.code == HTTPStatusCode.tooManyRequests.rawValue && error.label == "client-error" {
+                let retryAfter = responseHeaders["retry-after"].flatMap { TimeInterval($0) }
+                throw AuthenticationAPIError.tooManyRequests(error.message, retyAfter: retryAfter)
+            }
+            throw error
+        }
+        
         return (cookies, accessToken)
     }
 

--- a/WireNetwork/Sources/WireNetwork/HTTP Client/HTTPStatusCode.swift
+++ b/WireNetwork/Sources/WireNetwork/HTTP Client/HTTPStatusCode.swift
@@ -61,6 +61,10 @@ enum HTTPStatusCode: Int {
     /// conflict - 409
 
     case conflict = 409
+    
+    // too many requests - 429
+    
+    case tooManyRequests = 429
 
     /// domain blocked - 451
 

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+Authentication.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+Authentication.swift
@@ -69,16 +69,18 @@ extension ZMUserSession {
 
     func close(deleteCookie: Bool, completion: @escaping () -> Void) {
         // Clear all notifications associated with the account from the notification center
-        syncManagedObjectContext.performGroupedBlock {
-            self.localNotificationDispatcher?.cancelAllNotifications()
+        
+        syncManagedObjectContext.performAndWait { [weak self] in
+            self?.syncManagedObjectContext.disableSaves()
+            self?.localNotificationDispatcher?.cancelAllNotifications()
         }
 
         if deleteCookie {
             deleteUserKeychainItems()
         }
 
-        syncManagedObjectContext.perform {
-            self.tearDown()
+        syncManagedObjectContext.performAndWait { [weak self] in
+            self?.tearDown()
         }
 
         completion()

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -655,7 +655,7 @@ public final class ZMUserSession: NSObject {
         operationLoop = nil
         transportSession.tearDown()
         notificationDispatcher.tearDown()
-        managedObjectContext.perform { [weak self] in
+        managedObjectContext.performAndWait { [weak self] in
             self?.callCenter?.tearDown()
         }
         coreDataStack.close()

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -655,7 +655,9 @@ public final class ZMUserSession: NSObject {
         operationLoop = nil
         transportSession.tearDown()
         notificationDispatcher.tearDown()
-        callCenter?.tearDown()
+        managedObjectContext.perform { [weak self] in
+            self?.callCenter?.tearDown()
+        }
         coreDataStack.close()
         contextStorage.clear()
 

--- a/wire-ios/Wire-iOS/Sources/Authentication/Helpers/LogOutHelper.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Helpers/LogOutHelper.swift
@@ -72,7 +72,7 @@ final class LogOutHelper {
         return viewController
     }
 
-    private func logout(password: String? = nil) {
+    func logout(password: String? = nil) {
         guard let selfUser = ZMUser.selfUser() else { return }
 
         if selfUser.usesCompanyLogin || password != nil {

--- a/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DebugActions/DeveloperDebugActionsViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DebugActions/DeveloperDebugActionsViewModel.swift
@@ -85,7 +85,9 @@ final class DeveloperDebugActionsViewModel: ObservableObject {
             .init(title: "Clear collapsed messages cache", action: clearCollapsedMessagesCache),
             .init(title: "Simulate access token failure", action: simulateAccessTokenFailure),
             .init(title: "Invalidate all conversations", action: invalidateAllConversations),
-            .init(title: "Set last app version migration", action: requestAppVersionInput)
+            .init(title: "Set last app version migration", action: requestAppVersionInput),
+            .init(title: "Logout", action: logout)
+
         ]
 
         let toggleItems: [DeveloperDebugActionsDisplayModel.ToggleItem] = [
@@ -147,6 +149,10 @@ final class DeveloperDebugActionsViewModel: ObservableObject {
 
     // MARK: - Forces logout
 
+    func logout() {
+        LogOutHelper(showLoading: {}, hideLoading: {}).logout()
+    }
+    
     private func simulateAccessTokenFailure() {
         guard let selfUserID = userSession?.managedObjectContext.performAndWait({
             userSession?.selfUser.remoteIdentifier


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18909" title="WPB-18909" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18909</a>  [iOS] ZMUserSession is still retained in memory after logout
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

When the user logs out the ZMUserSession is still retained in memory. Looking at it, the operation loop still waits for all dispatch groups to be empty. Not sure exactly sure why there are so much blocks left and why they can't be executed.

It would appear that there are 2 pending save (enqueueDelayedSaved)

Solution:
Disable the enqueuDelayedSaved when logging out

* Add debug action to logout without password

### Testing

1. login
2. logout
3. check memory
---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
