### PR TITLE
feat:  Make possible to initiate reset for 1 on 1 conversations in dev menu - WPB-19633

### DIFF
--- a/wire-ios-data-model/Source/MLS/BackendMLSPublicKeys.swift
+++ b/wire-ios-data-model/Source/MLS/BackendMLSPublicKeys.swift
@@ -41,7 +41,7 @@ public struct BackendMLSPublicKeys: Equatable {
             removal.p521
         }
 
-        return [externalSenderData].compactMap { $0 }.map(ExternalSenderKey.init)
+        return [externalSenderData].compactMap(\.self).map(ExternalSenderKey.init)
     }
 
     public struct MLSPublicKeys: Equatable {

--- a/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DebugActions/DeveloperDebugActionsViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DebugActions/DeveloperDebugActionsViewModel.swift
@@ -156,7 +156,12 @@ final class DeveloperDebugActionsViewModel: ObservableObject {
         else { return }
 
         Task { @MainActor in
-            guard let conversation = await firstGroupConversation(of: selfClient, in: context, isMLS: true),
+            guard let conversation = await firstConversation(
+                of: selfClient,
+                in: context,
+                isMLS: true,
+                onlyGroups: false
+            ),
                   let mlsGroupID = conversation.mlsGroupID else {
                 WireLogger.mls.info("No MLS conversation to trigger initiate reset")
 
@@ -325,7 +330,7 @@ final class DeveloperDebugActionsViewModel: ObservableObject {
         else { return }
 
         Task { @MainActor in
-            guard let qualifiedID = await firstGroupConversation(of: selfClient, in: context)?.qualifiedID else {
+            guard let qualifiedID = await firstConversation(of: selfClient, in: context, onlyGroups: true)?.qualifiedID else {
                 assertionFailure("no conversation found to update protocol change")
                 return
             }
@@ -345,14 +350,18 @@ final class DeveloperDebugActionsViewModel: ObservableObject {
         }
     }
 
-    private func firstGroupConversation(
+    private func firstConversation(
         of userClient: UserClient,
         in context: NSManagedObjectContext,
-        isMLS: Bool? = nil
+        isMLS: Bool? = nil,
+        onlyGroups: Bool
     ) async -> ZMConversation? {
         await context.perform {
             userClient.user?.conversations
-                .filter { $0.conversationType == .group }
+                .filter {
+                    onlyGroups ? $0.conversationType == .group : true
+                }
+                .filter { !$0.isSelfConversation }
                 .filter {
                     !$0.isDeleted && !$0.isArchived && !$0.isDeletedRemotely
                 }

--- a/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DebugActions/DeveloperDebugActionsViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DebugActions/DeveloperDebugActionsViewModel.swift
@@ -162,7 +162,7 @@ final class DeveloperDebugActionsViewModel: ObservableObject {
                 isMLS: true,
                 onlyGroups: false
             ),
-                  let mlsGroupID = conversation.mlsGroupID else {
+                let mlsGroupID = conversation.mlsGroupID else {
                 WireLogger.mls.info("No MLS conversation to trigger initiate reset")
 
                 return
@@ -330,7 +330,8 @@ final class DeveloperDebugActionsViewModel: ObservableObject {
         else { return }
 
         Task { @MainActor in
-            guard let qualifiedID = await firstConversation(of: selfClient, in: context, onlyGroups: true)?.qualifiedID else {
+            guard let qualifiedID = await firstConversation(of: selfClient, in: context, onlyGroups: true)?.qualifiedID
+            else {
                 assertionFailure("no conversation found to update protocol change")
                 return
             }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19633" title="WPB-19633" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19633</a>  [iOS] not possible to reset 1:1 with debug options
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

Be able to initiate reset MLS 1:1 conversation

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
