### PR TITLE
fix: Fix disappearing group when reseting it - WPB-19631

### DIFF
--- a/WireDomain/Sources/WireDomain/Helpers/InitiateResetMLSConversationUseCase.swift
+++ b/WireDomain/Sources/WireDomain/Helpers/InitiateResetMLSConversationUseCase.swift
@@ -95,10 +95,8 @@ public class InitiateResetMLSConversationUseCase: InitiateResetMLSConversationUs
             )?.0 else {
                 throw Failure.noRefreshedConversationFound
             }
-
-            // re-create group and re-add all participants
-            let users = await conversationLocalStore.localParticipantsExcludingSelfAsMLSUsers(in: refreshedConversation)
-            _ = try await mlsService.establishGroup(for: newGroupID, with: users, removalKeys: nil)
+                        
+            try await mlsService.establishPendingGroup(groupID: newGroupID)
 
             WireLogger.mls.info(
                 "Initiate reset broken MLS conversation use case finished",

--- a/WireDomain/Sources/WireDomain/Helpers/InitiateResetMLSConversationUseCase.swift
+++ b/WireDomain/Sources/WireDomain/Helpers/InitiateResetMLSConversationUseCase.swift
@@ -95,7 +95,7 @@ public class InitiateResetMLSConversationUseCase: InitiateResetMLSConversationUs
             )?.0 else {
                 throw Failure.noRefreshedConversationFound
             }
-                        
+
             try await mlsService.establishPendingGroup(groupID: newGroupID)
 
             WireLogger.mls.info(

--- a/WireDomain/Sources/WireDomain/Repositories/Conversations/LocalStore/ConversationLocalStore.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Conversations/LocalStore/ConversationLocalStore.swift
@@ -867,15 +867,6 @@ public final class ConversationLocalStore: ConversationLocalStoreProtocol {
         }
     }
 
-    public func localParticipantsExcludingSelfAsMLSUsers(
-        in conversation: ZMConversation
-    ) async -> [MLSUser] {
-        await context.perform {
-            conversation.localParticipantsExcludingSelf
-                .map { MLSUser(from: $0) }
-        }
-    }
-
     public func conversationName(
         conversation: ZMConversation
     ) async -> String? {

--- a/WireDomain/Sources/WireDomain/Repositories/Conversations/Protocols/ConversationLocalStoreProtocol.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Conversations/Protocols/ConversationLocalStoreProtocol.swift
@@ -256,13 +256,6 @@ public protocol ConversationLocalStoreProtocol {
         in conversation: ZMConversation
     ) async -> Set<ZMUser>
 
-    /// Fetches local participants from a conversation and maps to [MLSUser].
-    /// - parameter conversation: The related conversation.
-    /// - returns: A list of MLSUser participants.
-    func localParticipantsExcludingSelfAsMLSUsers(
-        in conversation: ZMConversation
-    ) async -> [MLSUser]
-
     /// Whether the conversation is a group conversation.
     /// - parameter conversation: The given conversation.
     /// - returns: A flag indicating whether the conversation is a group one.

--- a/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
+++ b/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
@@ -939,24 +939,6 @@ public class MockConversationLocalStoreProtocol: ConversationLocalStoreProtocol 
         }
     }
 
-    // MARK: - localParticipantsExcludingSelfAsMLSUsers
-
-    public var localParticipantsExcludingSelfAsMLSUsersIn_Invocations: [ZMConversation] = []
-    public var localParticipantsExcludingSelfAsMLSUsersIn_MockMethod: ((ZMConversation) async -> [MLSUser])?
-    public var localParticipantsExcludingSelfAsMLSUsersIn_MockValue: [MLSUser]?
-
-    public func localParticipantsExcludingSelfAsMLSUsers(in conversation: ZMConversation) async -> [MLSUser] {
-        localParticipantsExcludingSelfAsMLSUsersIn_Invocations.append(conversation)
-
-        if let mock = localParticipantsExcludingSelfAsMLSUsersIn_MockMethod {
-            return await mock(conversation)
-        } else if let mock = localParticipantsExcludingSelfAsMLSUsersIn_MockValue {
-            return mock
-        } else {
-            fatalError("no mock for `localParticipantsExcludingSelfAsMLSUsersIn`")
-        }
-    }
-
     // MARK: - isGroupConversation
 
     public var isGroupConversation_Invocations: [ZMConversation] = []

--- a/WireDomain/Tests/WireDomainTests/Helpers/InitiateResetMLSConversationUseCaseTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Helpers/InitiateResetMLSConversationUseCaseTests.swift
@@ -42,9 +42,7 @@ final class InitiateResetMLSConversationUseCaseTests: XCTestCase {
 
         mockAPI.resetMLSConversationEpochGroupID_MockMethod = { _, _ in }
         mockMLSService.wipeGroup_MockMethod = { _ in }
-        mockMLSService.establishGroupForWithRemovalKeys_MockMethod = { _, _, _ in
-            MLSCipherSuite.MLS_256_DHKEMP521_AES256GCM_SHA512_P521
-        }
+        mockMLSService.establishPendingGroupGroupID_MockMethod = { _ in }
 
         coreDataStack = try await coreDataStackHelper.createStack()
         let conversation = await coreDataStack.syncContext.perform { [self] in
@@ -64,8 +62,6 @@ final class InitiateResetMLSConversationUseCaseTests: XCTestCase {
         mockConversationLocalStore.fetchMLSConversationGroupID_MockValue = conversation
         mockConversationLocalStore.fetchConversationIdDomain_MockValue = conversation
         mockConversationLocalStore.qualifiedIDFor_MockValue = conversationID
-        mockConversationLocalStore
-            .localParticipantsExcludingSelfAsMLSUsersIn_MockValue = [MLSUser(WireDataModel.QualifiedID.random())]
         mockConversationLocalStore.mlsConversationInfoConversation_MockValue = (
             newGroupID, true
         )
@@ -95,7 +91,7 @@ final class InitiateResetMLSConversationUseCaseTests: XCTestCase {
         XCTAssertEqual(mockAPI.resetMLSConversationEpochGroupID_Invocations.count, 1)
         XCTAssertEqual(mockMLSService.wipeGroup_Invocations.first, groupID)
         XCTAssertEqual(
-            mockMLSService.establishGroupForWithRemovalKeys_Invocations.first?.groupID,
+            mockMLSService.establishPendingGroupGroupID_Invocations.first,
             newGroupID
         )
         XCTAssertEqual(
@@ -120,7 +116,7 @@ final class InitiateResetMLSConversationUseCaseTests: XCTestCase {
         XCTAssertEqual(mockConversationLocalStore.fetchMLSConversationGroupID_Invocations.count, 1)
         XCTAssertEqual(mockAPI.resetMLSConversationEpochGroupID_Invocations.count, 0)
         XCTAssertEqual(mockMLSService.wipeGroup_Invocations.count, 0)
-        XCTAssertEqual(mockMLSService.establishGroupForWithRemovalKeys_Invocations.count, 0)
+        XCTAssertEqual(mockMLSService.establishPendingGroupGroupID_Invocations.count, 0)
         XCTAssertEqual(mockResetLockRepository.setInitiatedResetConversationID_Invocations.count, 0)
     }
 

--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -797,7 +797,7 @@ public final class MLSService: MLSServiceInterface {
     }
 
     typealias PendingJoin = (groupID: MLSGroupID, epoch: UInt64)
-    
+
     public func establishPendingGroup(groupID: MLSGroupID) async throws {
         guard let context else {
             return
@@ -805,20 +805,20 @@ public final class MLSService: MLSServiceInterface {
         let conversation = await context.perform {
             ZMConversation.fetch(with: groupID, in: context)
         }
-        
+
         guard let conversation else {
             throw MLSServiceError.conversationNotFound
         }
-        
+
         try await internalEstablishPendingGroup(
             groupID: groupID,
             pendingGroup: conversation,
             context: context
         )
-        
-        await saveContext(context)
+
+        await save(context)
     }
-    
+
     private func internalEstablishPendingGroup(
         groupID: MLSGroupID,
         pendingGroup: ZMConversation,
@@ -828,7 +828,7 @@ public final class MLSService: MLSServiceInterface {
             pendingGroup.localParticipants.map(MLSUser.init)
         }
 
-        let ciphersuite = try await self.establishGroup(
+        let ciphersuite = try await establishGroup(
             for: groupID,
             with: mlsUsers
         )
@@ -889,7 +889,7 @@ public final class MLSService: MLSServiceInterface {
                     }
                 }
             }
-            
+
             var needToSave = false
             for await groupResult in group {
                 needToSave = needToSave || groupResult
@@ -897,15 +897,14 @@ public final class MLSService: MLSServiceInterface {
             return needToSave
         }
         if needToSave {
-            await saveContext(context)
+            await save(context)
         }
     }
-    
-    private func saveContext(_ context: NSManagedObjectContext) async {
+
+    private func save(_ context: NSManagedObjectContext) async {
         _ = await context.perform { [context] in
             context.saveOrRollback()
         }
-
     }
 
     // MARK: - Out-of-sync conversations

--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -797,6 +797,47 @@ public final class MLSService: MLSServiceInterface {
     }
 
     typealias PendingJoin = (groupID: MLSGroupID, epoch: UInt64)
+    
+    public func establishPendingGroup(groupID: MLSGroupID) async throws {
+        guard let context else {
+            return
+        }
+        let conversation = await context.perform {
+            ZMConversation.fetch(with: groupID, in: context)
+        }
+        
+        guard let conversation else {
+            throw MLSServiceError.conversationNotFound
+        }
+        
+        try await internalEstablishPendingGroup(
+            groupID: groupID,
+            pendingGroup: conversation,
+            context: context
+        )
+        
+        await saveContext(context)
+    }
+    
+    private func internalEstablishPendingGroup(
+        groupID: MLSGroupID,
+        pendingGroup: ZMConversation,
+        context: NSManagedObjectContext
+    ) async throws {
+        let mlsUsers = await context.perform {
+            pendingGroup.localParticipants.map(MLSUser.init)
+        }
+
+        let ciphersuite = try await self.establishGroup(
+            for: groupID,
+            with: mlsUsers
+        )
+
+        await context.perform {
+            pendingGroup.ciphersuite = ciphersuite
+            pendingGroup.mlsStatus = .ready
+        }
+    }
 
     public func performPendingJoins() async throws {
         guard let context else {
@@ -812,11 +853,11 @@ public final class MLSService: MLSServiceInterface {
 
         logger.info("joining \(pendingGroups.count) group(s)")
 
-        await withTaskGroup(of: Void.self) { group in
+        let needToSave = await withTaskGroup(of: Bool.self) { group in
             for pendingGroup in pendingGroups {
                 group.addTask {
                     guard let mlsGroupID = await context.perform({ pendingGroup.mlsGroupID }) else {
-                        return
+                        return false
                     }
 
                     do {
@@ -829,33 +870,42 @@ public final class MLSService: MLSServiceInterface {
                         let shouldEstablishGroup = epoch == 0 && isSelfConversation && !conversationExists
 
                         if shouldEstablishGroup {
-
-                            let mlsUsers = await context.perform {
-                                pendingGroup.localParticipants.map(MLSUser.init)
-                            }
-
-                            let ciphersuite = try await self.establishGroup(
-                                for: mlsGroupID,
-                                with: mlsUsers
+                            try await self.internalEstablishPendingGroup(
+                                groupID: mlsGroupID,
+                                pendingGroup: pendingGroup,
+                                context: context
                             )
-
-                            await context.perform {
-                                pendingGroup.ciphersuite = ciphersuite
-                                pendingGroup.mlsStatus = .ready
-                            }
-
+                            return true
                         } else {
                             try await self.joinByExternalCommit(groupID: mlsGroupID)
+                            return false
                         }
                     } catch {
                         WireLogger.mls.error(
                             "Failed to join pending group: \(error)",
                             attributes: [.mlsGroupID: mlsGroupID.safeForLoggingDescription]
                         )
+                        return false
                     }
                 }
             }
+            
+            var needToSave = false
+            for await groupResult in group {
+                needToSave = needToSave || groupResult
+            }
+            return needToSave
         }
+        if needToSave {
+            await saveContext(context)
+        }
+    }
+    
+    private func saveContext(_ context: NSManagedObjectContext) async {
+        _ = await context.perform { [context] in
+            context.saveOrRollback()
+        }
+
     }
 
     // MARK: - Out-of-sync conversations
@@ -1154,7 +1204,7 @@ public final class MLSService: MLSServiceInterface {
         })
     }
 
-    enum MLSSendExternalCommitError: Error {
+    enum MLSServiceError: Error {
         case conversationNotFound
     }
 
@@ -1177,7 +1227,7 @@ public final class MLSService: MLSServiceInterface {
                 with: parentID,
                 in: context
             ) else {
-                throw MLSSendExternalCommitError.conversationNotFound
+                throw MLSServiceError.conversationNotFound
             }
 
             let groupInfo = try await actionsProvider.fetchConversationGroupInfo(

--- a/wire-ios-data-model/Source/MLS/MLSServiceInterface.swift
+++ b/wire-ios-data-model/Source/MLS/MLSServiceInterface.swift
@@ -77,7 +77,7 @@ public protocol MLSServiceInterface: MLSEncryptionServiceInterface, MLSDecryptio
     /// [confluence use case](https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/791412993/Use+case+join+self+conversation+MLS)
 
     func createSelfGroup(for groupID: MLSGroupID) async throws -> MLSCipherSuite
-    
+
     /// Creates a new group with the given ID and adds users to it
     ///
     /// - Parameters:
@@ -99,8 +99,7 @@ public protocol MLSServiceInterface: MLSEncryptionServiceInterface, MLSDecryptio
         with users: [MLSUser],
         removalKeys: BackendMLSPublicKeys?
     ) async throws -> MLSCipherSuite
-    
-    
+
     /// Establishes group and sets its status to 'ready'
     /// - Parameters:
     ///   - groupID: The ID of the group to create

--- a/wire-ios-data-model/Source/MLS/MLSServiceInterface.swift
+++ b/wire-ios-data-model/Source/MLS/MLSServiceInterface.swift
@@ -77,6 +77,7 @@ public protocol MLSServiceInterface: MLSEncryptionServiceInterface, MLSDecryptio
     /// [confluence use case](https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/791412993/Use+case+join+self+conversation+MLS)
 
     func createSelfGroup(for groupID: MLSGroupID) async throws -> MLSCipherSuite
+    
     /// Creates a new group with the given ID and adds users to it
     ///
     /// - Parameters:
@@ -98,6 +99,14 @@ public protocol MLSServiceInterface: MLSEncryptionServiceInterface, MLSDecryptio
         with users: [MLSUser],
         removalKeys: BackendMLSPublicKeys?
     ) async throws -> MLSCipherSuite
+    
+    
+    /// Establishes group and sets its status to 'ready'
+    /// - Parameters:
+    ///   - groupID: The ID of the group to create
+    func establishPendingGroup(
+        groupID: MLSGroupID
+    ) async throws
 
     /// Joins a group by external commit, for the self client.
     ///

--- a/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
@@ -4229,6 +4229,26 @@ public class MockMLSServiceInterface: MLSServiceInterface {
         }
     }
 
+    // MARK: - establishPendingGroup
+
+    public var establishPendingGroupGroupID_Invocations: [MLSGroupID] = []
+    public var establishPendingGroupGroupID_MockError: Error?
+    public var establishPendingGroupGroupID_MockMethod: ((MLSGroupID) async throws -> Void)?
+
+    public func establishPendingGroup(groupID: MLSGroupID) async throws {
+        establishPendingGroupGroupID_Invocations.append(groupID)
+
+        if let error = establishPendingGroupGroupID_MockError {
+            throw error
+        }
+
+        guard let mock = establishPendingGroupGroupID_MockMethod else {
+            fatalError("no mock for `establishPendingGroupGroupID`")
+        }
+
+        try await mock(groupID)
+    }
+
     // MARK: - joinGroup
 
     public var joinGroupWith_Invocations: [MLSGroupID] = []


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19631" title="WPB-19631" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19631</a>  [iOS] Conversation disappearing from conversation list once reset
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
When you tried to initiate reset from a device, for this device conversation was disappearing. 
This fixes it by making correct CC comands and setting+saving a conversation mls status

### Testing

Initiate reset from dev menu
