### PR TITLE
chore: disable team migration banner - WPB-19695

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
@@ -128,11 +128,12 @@ final class SelfProfileViewController: UIViewController {
             let backendInfoApiVersion = BackendInfo.apiVersion,
             let apiVersion = WireNetwork.APIVersion(rawValue: UInt(backendInfoApiVersion.rawValue)),
             apiVersion >= .v7 {
-            self.teamMigrationBanner = SelfProfileViewCallToActionBannerHostingController(
-                actionCallback: { [weak self] action in
-                    self?.onTeamCreationBannerInteraction(action, apiVersion: apiVersion)
-                }
-            )
+            // MARK: [WPB-19696] Re-enable team migration banner
+//            self.teamMigrationBanner = SelfProfileViewCallToActionBannerHostingController(
+//                actionCallback: { [weak self] action in
+//                    self?.onTeamCreationBannerInteraction(action, apiVersion: apiVersion)
+//                }
+//            )
         }
 
         if DeveloperFlag.multibackend.isOn {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
@@ -128,7 +128,7 @@ final class SelfProfileViewController: UIViewController {
             let backendInfoApiVersion = BackendInfo.apiVersion,
             let apiVersion = WireNetwork.APIVersion(rawValue: UInt(backendInfoApiVersion.rawValue)),
             apiVersion >= .v7 {
-            // MARK: [WPB-19696] Re-enable team migration banner
+            // FIXME: [WPB-19696] Re-enable team migration banner
 //            self.teamMigrationBanner = SelfProfileViewCallToActionBannerHostingController(
 //                actionCallback: { [weak self] action in
 //                    self?.onTeamCreationBannerInteraction(action, apiVersion: apiVersion)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
@@ -101,7 +101,7 @@ struct SettingsCellDescriptorFactory {
         }
 
         return SettingsExternalScreenCellDescriptor(
-            title: L10n.Localizable.Self.Settings.AddAccountOrTeam.title,
+            title: L10n.Localizable.Self.Settings.AddAccount.title, // MARK: [WPB-19696] Re-enable AddAccountOrTeam
             isDestructive: false,
             presentationStyle: .modal,
             identifier: nil,

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
@@ -101,7 +101,7 @@ struct SettingsCellDescriptorFactory {
         }
 
         return SettingsExternalScreenCellDescriptor(
-            title: L10n.Localizable.Self.Settings.AddAccount.title, // MARK: [WPB-19696] Re-enable AddAccountOrTeam
+            title: L10n.Localizable.Self.Settings.AddAccount.title, // FIXME: [WPB-19696] Re-enable AddAccountOrTeam
             isDestructive: false,
             presentationStyle: .modal,
             identifier: nil,

--- a/wire-ios/WireUITests/TeamManageTests.swift
+++ b/wire-ios/WireUITests/TeamManageTests.swift
@@ -22,6 +22,8 @@ final class TeamManageTests: WireUITestCase {
 
     @MainActor
     func test_Migrate_PersonalUserToTeam() async throws {
+        throw XCTSkip("Enable with WPB-19696")
+
         let user = try await userManager.createPersonalUser()
 
         let welcomePage = try WelcomePage()


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

This PR disables showing the team migration banner as this appears to have caused an app store rejection. As this may only be a temporary measure until we better understand the situation, this PR doesn't delete any code.

Additionally this PR updates some copy to remove the `Team` part.

| Before | After |
| --- | --- |
| <img width="1284" height="2778" alt="IMG_0305" src="https://github.com/user-attachments/assets/772cdaa8-dbeb-40eb-a855-6c21a7feb30b" /> | <img width="1284" height="2778" alt="IMG_0304" src="https://github.com/user-attachments/assets/f08c92aa-0ac3-4cba-bc9a-bc7a0d0e0302" /> |


### Testing

1. Navigate to the "Account" screen using a **non-team** user.
2. Ensure that there is no team migration banner.
3. Ensure that the add account button doesn't mention a team.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
