### PR TITLE
feat: new reachability for multibackend - WPB-20050

### DIFF
--- a/WireNetwork/Sources/WireNetwork/Network/NetworkStack/NetworkReachability.swift
+++ b/WireNetwork/Sources/WireNetwork/Network/NetworkStack/NetworkReachability.swift
@@ -1,0 +1,45 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+@preconcurrency import Combine
+import Foundation
+import Network
+
+public final class NetworkReachability: Sendable {
+
+    private let monitor = NWPathMonitor()
+    private let isReachableSubject = CurrentValueSubject<Bool, Never>(true)
+    private let queue = DispatchQueue(label: "NetworkReachabilityQueue")
+
+    public var isReachablePublisher: AnyPublisher<Bool, Never> {
+        isReachableSubject.eraseToAnyPublisher()
+    }
+
+    public init() {
+        monitor.pathUpdateHandler = { [weak self] path in
+            print("[DEBUG] reachability changed: \(path.status)")
+            self?.isReachableSubject.send(path.status == .satisfied)
+        }
+        monitor.start(queue: queue)
+    }
+
+    deinit {
+        monitor.cancel()
+    }
+
+}

--- a/WireNetwork/Sources/WireNetwork/Network/NetworkStack/NetworkReachability.swift
+++ b/WireNetwork/Sources/WireNetwork/Network/NetworkStack/NetworkReachability.swift
@@ -32,7 +32,6 @@ public final class NetworkReachability: Sendable {
 
     public init() {
         monitor.pathUpdateHandler = { [weak self] path in
-            print("[DEBUG] reachability changed: \(path.status)")
             self?.isReachableSubject.send(path.status == .satisfied)
         }
         monitor.start(queue: queue)

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -493,9 +493,10 @@ public final class ZMUserSession: NSObject {
         super.init()
 
         if DeveloperFlag.multibackend.isOn {
-            isNetworkReachableCancellable = networkReachability.isReachablePublisher.sink { [weak self] isReachable in
-                isReachable ? self?.didReceiveData() : self?.didGoOffline()
-            }
+            self.isNetworkReachableCancellable = networkReachability.isReachablePublisher
+                .sink { [weak self] isReachable in
+                    isReachable ? self?.didReceiveData() : self?.didGoOffline()
+                }
         }
     }
 

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -404,6 +404,9 @@ public final class ZMUserSession: NSObject {
     private let userSessionComponent: UserSessionComponent
     public private(set) var clientSessionComponent: ClientSessionComponent?
 
+    private let networkReachability = NetworkReachability()
+    private var isNetworkReachableCancellable: AnyCancellable?
+
     // MARK: - Initialize
 
     init(
@@ -489,6 +492,11 @@ public final class ZMUserSession: NSObject {
 
         super.init()
 
+        if DeveloperFlag.multibackend.isOn {
+            isNetworkReachableCancellable = networkReachability.isReachablePublisher.sink { [weak self] isReachable in
+                isReachable ? self?.didReceiveData() : self?.didGoOffline()
+            }
+        }
     }
 
     func trackAppOpenAnalyticEventWhenAppBecomesActive() {
@@ -698,7 +706,10 @@ public final class ZMUserSession: NSObject {
 
     private func configureTransportSession() {
         transportSession.pushChannel.clientID = selfUserClient?.remoteIdentifier
-        transportSession.setNetworkStateDelegate(self)
+        // When multibackend is on. we use another reachability.
+        if !DeveloperFlag.multibackend.isOn {
+            transportSession.setNetworkStateDelegate(self)
+        }
         transportSession.setAccessTokenRenewalFailureHandler { [weak self] response in
             self?.transportSessionAccessTokenDidFail(response: response)
         }

--- a/wire-ios/Wire-iOS Share Extension/Generated/Strings+Generated.swift
+++ b/wire-ios/Wire-iOS Share Extension/Generated/Strings+Generated.swift
@@ -49,8 +49,8 @@ internal enum L10n {
       internal enum UpdateRequired {
         /// Your Wire server needs to be updated. Please notify your system administrator.
         internal static let obsoleteBackend = L10n.tr("Localizable", "share_extension.error.update_required.obsolete_backend", fallback: "Your Wire server needs to be updated. Please notify your system administrator.")
-        /// You are missing out on new features. Get the latest version of  Wire to continue using the app with this account.
-        internal static let obsoleteClient = L10n.tr("Localizable", "share_extension.error.update_required.obsolete_client", fallback: "You are missing out on new features. Get the latest version of  Wire to continue using the app with this account.")
+        /// You are missing out on new features. Get the latest version of Wire to continue using the app with this account.
+        internal static let obsoleteClient = L10n.tr("Localizable", "share_extension.error.update_required.obsolete_client", fallback: "You are missing out on new features. Get the latest version of Wire to continue using the app with this account.")
         /// Update required
         internal static let title = L10n.tr("Localizable", "share_extension.error.update_required.title", fallback: "Update required")
       }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20050" title="WPB-20050" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20050</a>  [iOS] Check backend reachability per account
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
This PR introduces a new `NetworkReachability` that makes use of `NWPathMonitor` to report whether the app has an internet connection. This is in contrast to the old `ZMReachability` which is written in Objective C, uses a lower level C style network API, and checks reachability of specific hosts. 

A key difference between the two is that although `NetworkReachability` is much simpler, it only tells us if there is a connection available and not whether a connection to the Wire backends is available. However, I observed that we only use the existing reachability to hide and show the "no internet" banner, so I think this is fine. If we want to check host reachability, we could extend the code to also send pings to specific hosts.

### Testing
1. Enabled mutilbackend developer flag
2. Log in
3. For the phone in airplane mode, observe the "No internet" banner.
4. Reconnect to the internet, observe the banner goes away.


---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
