### PR TITLE
feat: 5min time window for chat bubble grouping - WPB-20517

### DIFF
--- a/wire-ios/Wire-iOS Tests/ConversationMessageCell/ConversationMessageSectionControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationMessageCell/ConversationMessageSectionControllerTests.swift
@@ -40,7 +40,7 @@ final class ConversationMessageSectionControllerTests: XCTestCase {
         userSession = UserSessionMock(mockUser: mockSelfUser)
         context = ConversationMessageContext(
             isSameSenderAsPrevious: false,
-            isTimestampInSameMinuteAsPreviousMessage: false,
+            isGroupedWithPreviousMessage: false,
             isFirstMessageOfTheDay: false,
             isFirstUnreadMessage: false,
             isLastMessage: false,
@@ -121,7 +121,7 @@ final class ConversationMessageSectionControllerTests: XCTestCase {
         let message = MockMessageFactory.textMessage(withText: "Welcome to Dub Dub")
         let context = ConversationMessageContext(
             isSameSenderAsPrevious: true,
-            isTimestampInSameMinuteAsPreviousMessage: true
+            isGroupedWithPreviousMessage: true
         )
 
         // WHEN
@@ -161,7 +161,7 @@ final class ConversationMessageSectionControllerTests: XCTestCase {
         let message = MockMessageFactory.textMessage(withText: "Hello")
         let context = ConversationMessageContext(
             isSameSenderAsPrevious: true,
-            isTimestampInSameMinuteAsPreviousMessage: false
+            isGroupedWithPreviousMessage: false
         )
         // WHEN
         let section = makeSUT(message: message, context: context)
@@ -181,7 +181,7 @@ final class ConversationMessageSectionControllerTests: XCTestCase {
         let message = MockMessageFactory.textMessage(withText: "Hello")
         let context = ConversationMessageContext(
             isSameSenderAsPrevious: true,
-            isTimestampInSameMinuteAsPreviousMessage: false
+            isGroupedWithPreviousMessage: false
         )
         // WHEN
         let section = makeSUT(message: message, context: context)

--- a/wire-ios/Wire-iOS Tests/ConversationMessageCell/ConversationMessageSnapshotTestCase.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationMessageCell/ConversationMessageSnapshotTestCase.swift
@@ -24,7 +24,7 @@ import XCTest
 private extension ConversationMessageContext {
     static let defaultContext = ConversationMessageContext(
         isSameSenderAsPrevious: false,
-        isTimestampInSameMinuteAsPreviousMessage: false,
+        isGroupedWithPreviousMessage: false,
         isFirstMessageOfTheDay: false,
         isFirstUnreadMessage: false,
         isLastMessage: false,

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
@@ -22,7 +22,7 @@ import WireSyncEngine
 
 struct ConversationMessageContext: Equatable {
     var isSameSenderAsPrevious: Bool = false
-    var isTimestampInSameMinuteAsPreviousMessage: Bool = false
+    var isGroupedWithPreviousMessage: Bool = false
     var isFirstMessageOfTheDay: Bool = false
     var isFirstUnreadMessage: Bool = false
     var isLastMessage: Bool = false
@@ -561,8 +561,8 @@ final class ConversationMessageSectionController: NSObject, ZMMessageObserver {
             return true
         }
 
-        // This message is from the same sender but in a different minute.
-        if !context.isTimestampInSameMinuteAsPreviousMessage {
+        // This message is from the same sender and is visually grouped with the previous message.
+        if !context.isGroupedWithPreviousMessage {
             return true
         }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
@@ -561,7 +561,7 @@ final class ConversationMessageSectionController: NSObject, ZMMessageObserver {
             return true
         }
 
-        // This message is from the same sender and is visually grouped with the previous message.
+        // This message is from the same sender but is not visually grouped with the previous message.
         if !context.isGroupedWithPreviousMessage {
             return true
         }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
@@ -766,24 +766,24 @@ extension ConversationTableViewDataSource {
         messages: [ZMMessage]
     ) -> ConversationMessageContext {
 
-        let isTimestampInSameMinuteAsPreviousMessage: Bool
+        let isGroupedWithPreviousMessage: Bool
 
         let previousMessage = messageBeforeMessage(at: index, messages: messages)
 
         if let currentMessage = message.serverTimestamp, let prevMessage = previousMessage?.serverTimestamp {
             if isChatBubbleSimpleEnabled {
-                isTimestampInSameMinuteAsPreviousMessage = currentMessage.isWithin(minutes: 5, fromDate: prevMessage)
+                isGroupedWithPreviousMessage = currentMessage.isWithin(minutes: 5, fromDate: prevMessage)
             } else {
-                isTimestampInSameMinuteAsPreviousMessage = currentMessage.isInSameMinute(asDate: prevMessage)
+                isGroupedWithPreviousMessage = currentMessage.isInSameMinute(asDate: prevMessage)
             }
         } else {
-            isTimestampInSameMinuteAsPreviousMessage = false
+            isGroupedWithPreviousMessage = false
         }
 
         let isLastMessage = (index == 0) && !hasNewerMessagesToLoad
         return ConversationMessageContext(
             isSameSenderAsPrevious: isPreviousSenderSame(forMessage: message, at: index, messages: messages),
-            isTimestampInSameMinuteAsPreviousMessage: isTimestampInSameMinuteAsPreviousMessage,
+            isGroupedWithPreviousMessage: isGroupedWithPreviousMessage,
             isFirstMessageOfTheDay: isFirstMessageOfTheDay(for: message, at: index, messages: messages),
             isFirstUnreadMessage: message.nonce == firstUnreadMessageNonce,
             isLastMessage: isLastMessage,

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
@@ -771,7 +771,11 @@ extension ConversationTableViewDataSource {
         let previousMessage = messageBeforeMessage(at: index, messages: messages)
 
         if let currentMessage = message.serverTimestamp, let prevMessage = previousMessage?.serverTimestamp {
-            isTimestampInSameMinuteAsPreviousMessage = currentMessage.isInSameMinute(asDate: prevMessage)
+            if isChatBubbleSimpleEnabled {
+                isTimestampInSameMinuteAsPreviousMessage = currentMessage.isWithin(minutes: 5, fromDate: prevMessage)
+            } else {
+                isTimestampInSameMinuteAsPreviousMessage = currentMessage.isInSameMinute(asDate: prevMessage)
+            }
         } else {
             isTimestampInSameMinuteAsPreviousMessage = false
         }
@@ -984,6 +988,10 @@ extension Date {
         let components = calendar.dateComponents([.year, .month, .day, .hour, .minute], from: self)
         let otherComponents = calendar.dateComponents([.year, .month, .day, .hour, .minute], from: date)
         return components == otherComponents
+    }
+
+    func isWithin(minutes: Double, fromDate date: Date) -> Bool {
+        date.addingTimeInterval(minutes * 60) > self
     }
 
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20517" title="WPB-20517" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20517</a>  [iOS] Chat message grouping longer time window
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Instead of grouping chat messages by the same minute on the clock, the time window is now 5 minutes.
When a message is less than 5 minutes apart from the previous one, it belongs to the same group.

### Testing

Write chat messages which are sometimes less than 5 minutes apart and sometimes more than 5 minutes apart. 
