### PR TITLE
fix: trigger automatic repair for affected conversations - WPB-22447

### DIFF
--- a/WireDomain/Sources/WireDomain/Components/ClientSessionComponent.swift
+++ b/WireDomain/Sources/WireDomain/Components/ClientSessionComponent.swift
@@ -830,4 +830,10 @@ public final class ClientSessionComponent {
         }
     )
 
+    public lazy var repairFaultyMLSRemovalKeysGenerator = RepairFaultyMLSRemovalKeysGenerator(
+        journal: journal,
+        repairUseCase: repairFaultyRemovalKeysUsecase,
+        workAgent: workAgent
+    )
+
 }

--- a/WireDomain/Sources/WireDomain/Synchronization/RepairFaultyMLSRemovalKeysGenerator.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/RepairFaultyMLSRemovalKeysGenerator.swift
@@ -1,0 +1,63 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/// Generates and submits a work item to repair faulty MLS removal keys if needed.
+///
+/// This generator checks the journal flag and submits the repair work item
+/// to the work agent if repair is required. This pattern keeps the work item internal
+/// while allowing it to be triggered from the session initialization or after migrations.
+
+public final class RepairFaultyMLSRemovalKeysGenerator {
+
+    private let journal: any JournalProtocol
+    private let repairUseCase: any RepairRemovalKeysUseCaseProtocol
+    private let workAgent: WorkAgent
+
+    public init(
+        journal: any JournalProtocol,
+        repairUseCase: any RepairRemovalKeysUseCaseProtocol,
+        workAgent: WorkAgent
+    ) {
+        self.journal = journal
+        self.repairUseCase = repairUseCase
+        self.workAgent = workAgent
+    }
+
+    /// Checks if repair is needed and submits the work item if so.
+    ///
+    /// This method can be called multiple times safely - it only submits
+    /// the work item if the journal flag is set.
+
+    public func submitWorkItemIfNeeded() {
+        guard journal[.isRepairFaultyMLSRemovalKeysRequired] else {
+            return
+        }
+
+        let workItem = RepairFaultyMLSRemovalKeysWorkItem(
+            journal: journal,
+            repairUseCase: repairUseCase
+        )
+
+        Task { [workAgent] in
+            await workAgent.submitItem(workItem)
+        }
+    }
+
+}

--- a/WireDomain/Sources/WireDomain/Utilities/Journal/Journal.swift
+++ b/WireDomain/Sources/WireDomain/Utilities/Journal/Journal.swift
@@ -137,7 +137,8 @@ public extension Journal {
             JournalKey.isInitialSyncRequired,
             JournalKey.isSyncV2Enabled,
             JournalKey.isBackendMLSEnabled,
-            JournalKey.isFederationMigrationRequired
+            JournalKey.isFederationMigrationRequired,
+            JournalKey.isRepairFaultyMLSRemovalKeysRequired
 
         ].forEach {
             result[$0.name] = "\(self[$0] == true ? "Yes" : "No")"

--- a/WireDomain/Sources/WireDomain/Utilities/Journal/JournalKey.swift
+++ b/WireDomain/Sources/WireDomain/Utilities/Journal/JournalKey.swift
@@ -103,6 +103,13 @@ public extension JournalKey where Value == Bool {
         defaultValue: false
     )
 
+    /// Whether faulty MLS removal keys need to be repaired.
+
+    static let isRepairFaultyMLSRemovalKeysRequired = Self(
+        "isRepairFaultyMLSRemovalKeysRequired",
+        defaultValue: false
+    )
+
 }
 
 public extension JournalKey where Value == Set<String> {

--- a/WireDomain/Sources/WireDomain/WorkAgent/WorkItem/RepairFaultyMLSRemovalKeysWorkItem.swift
+++ b/WireDomain/Sources/WireDomain/WorkAgent/WorkItem/RepairFaultyMLSRemovalKeysWorkItem.swift
@@ -1,0 +1,82 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireLogging
+
+/// Repairs conversations with faulty MLS removal keys.
+///
+/// This work item checks if the journal flag `isRepairFaultyMLSRemovalKeysRequired`
+/// is set, and if so, invokes the repair use case. On successful completion,
+/// the flag is cleared so the repair only runs once per migration.
+
+struct RepairFaultyMLSRemovalKeysWorkItem: WorkItem {
+
+    let id = UUID()
+    var priority: WorkItemPriority {
+        .low
+    }
+
+    private let journal: any JournalProtocol
+    private let repairUseCase: any RepairRemovalKeysUseCaseProtocol
+
+    init(
+        journal: any JournalProtocol,
+        repairUseCase: any RepairRemovalKeysUseCaseProtocol
+    ) {
+        self.journal = journal
+        self.repairUseCase = repairUseCase
+    }
+
+    func start() async throws {
+        // Check if repair is needed
+        guard journal[.isRepairFaultyMLSRemovalKeysRequired] else {
+            WireLogger.mls.debug(
+                "faulty MLS removal keys repair not needed, skipping",
+                attributes: .safePublic
+            )
+            return
+        }
+
+        WireLogger.mls.info(
+            "starting faulty MLS removal keys repair",
+            attributes: .safePublic
+        )
+
+        do {
+            let result = try await repairUseCase.invoke()
+
+            WireLogger.mls.info(
+                "faulty MLS removal keys repair completed: found \(result.faultyConversationsFound), repaired \(result.conversationsRepaired)",
+                attributes: .safePublic
+            )
+
+            // Clear the flag on success
+            journal[.isRepairFaultyMLSRemovalKeysRequired] = false
+
+        } catch {
+            WireLogger.mls.error(
+                "faulty MLS removal keys repair failed: \(String(describing: error))",
+                attributes: .safePublic
+            )
+            // Don't clear the flag so it will be retried
+            throw error
+        }
+    }
+
+}

--- a/WireDomain/Tests/WireDomainTests/Utilities/JournalTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Utilities/JournalTests.swift
@@ -70,7 +70,7 @@ class JournalStoreTests {
     @Test("Values contain all declared values")
     func values() {
         // Given
-        let exhaustiveKeysCount = 10
+        let exhaustiveKeysCount = 11
         sut[.isSyncV2Enabled] = true
 
         // When

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/AppVersionMigrations/AppVersionMigration_4_11_1.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/AppVersionMigrations/AppVersionMigration_4_11_1.swift
@@ -1,0 +1,37 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireDomain
+
+/// **Issue:**: Faulty MLS removal keys need repair - [WPB-22447]
+struct AppVersionMigration_4_11_1: AppVersionMigration {
+
+    let version: SemanticVersion = "4.11.1"
+    let journal: any JournalProtocol
+    let repairGenerator: RepairFaultyMLSRemovalKeysGenerator?
+
+    func perform() async throws {
+        // Mark that faulty MLS removal keys need to be repaired
+        journal[.isRepairFaultyMLSRemovalKeysRequired] = true
+
+        // Submit the work item now that the flag is set
+        repairGenerator?.submitWorkItemIfNeeded()
+    }
+
+}

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -681,7 +681,7 @@ public final class ZMUserSession: NSObject {
             await clientSessionComponent.workAgent.start()
 
             // Initialize the generator to enqueue repair work item if needed
-            _ = clientSessionComponent.repairFaultyMLSRemovalKeysGenerator
+            clientSessionComponent.repairFaultyMLSRemovalKeysGenerator.submitWorkItemIfNeeded()
         }
     }
 

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -679,6 +679,9 @@ public final class ZMUserSession: NSObject {
         Task {
             await clientSessionComponent.workAgent.setAutoStartEnabled(true)
             await clientSessionComponent.workAgent.start()
+
+            // Initialize the generator to enqueue repair work item if needed
+            _ = clientSessionComponent.repairFaultyMLSRemovalKeysGenerator
         }
     }
 
@@ -1746,7 +1749,11 @@ extension ZMUserSession {
                 sessionManager: sessionManager
             ),
             AppVersionMigration_4_3_0(coreCryptoProvider: coreCryptoProvider),
-            AppVersionMigration_4_10_0(journal: journal)
+            AppVersionMigration_4_10_0(journal: journal),
+            AppVersionMigration_4_11_1(
+                journal: journal,
+                repairGenerator: clientSessionComponent?.repairFaultyMLSRemovalKeysGenerator
+            )
         ]
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22447" title="WPB-22447" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-22447</a>  [iOS] "Message could not be decrypted" from federated connection
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
This PR introduces an automatic trigger to repair conversations affected by faulty removal keys. Changes include:
- New 4.11.1 app version migration to flip a flag indicating the fix should be run
- If the flag is flip, a work item is submitted to the work agent that performs the fix and flips the flag off when successful. The fix will be attempted at most once per launch

### Testing
Update to 4.11.1 and verify the migration is run and that the repair is started (check logs).

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
