### PR TITLE
fix: duplicate green banner - WPB-23037

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCellDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCellDescription.swift
@@ -174,13 +174,15 @@ enum ConversationSystemMessageCellDescription {
         case .newConversation:
             var cells: [AnyConversationMessageCellDescription] = []
 
-            let welcomeCell = ConversationWelcomeSystemMessageCellDescription(
-                variant: (
-                    wireCells: conversation.isWireDriveEnabled,
-                    isChannel: conversation.isChannel
+            if conversation.conversationType != .oneOnOne {
+                let welcomeCell = ConversationWelcomeSystemMessageCellDescription(
+                    variant: (
+                        wireCells: conversation.isWireDriveEnabled,
+                        isChannel: conversation.isChannel
+                    )
                 )
-            )
-            cells.append(AnyConversationMessageCellDescription(welcomeCell))
+                cells.append(AnyConversationMessageCellDescription(welcomeCell))
+            }
 
             let startedConversationCell = ConversationStartedSystemMessageCellDescription(message: message)
             cells.append(AnyConversationMessageCellDescription(startedConversationCell))


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23037" title="WPB-23037" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23037</a>  [iOS] Duplicate initial system messages
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

For some 1:1 conversations, the green welcome banner is appearing twice.
The code for the 1:1 green banner is in a complete different place than the code for group and channel conversations.
This PR adds a check for 1:1 in the latter code (channels + groups) and only adds the green banner if the conversation type is not 1:1.
With the assumption that the banner is added twice because somehow both parts of the code were executed, the new check should prevent the second banner from being added.

### Testing

We couldn't figure out how to reliably reproduce the duplicate banners, but this code has fixed the issue locally in one of the 1:1 conversations for @jullianm 

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
