### PR TITLE
fix: incorrect capitalization - WPB-24867

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Debug Report/SettingsDebugReportViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Debug Report/SettingsDebugReportViewController.swift
@@ -55,14 +55,14 @@ class SettingsDebugReportViewController: UIViewController {
     }()
 
     private lazy var sendReportButton = createButton(
-        title: Strings.TechnicalReport.sendReport.capitalized,
+        title: Strings.TechnicalReport.sendReport,
         action: UIAction { [weak self] action in
             self?.didTapSendReport(sender: action.sender as! UIButton)
         }
     )
 
     private lazy var shareReportButton: UIButton = createButton(
-        title: Strings.TechnicalReport.shareReport.capitalized,
+        title: Strings.TechnicalReport.shareReport,
         action: UIAction { [weak self] _ in self?.didTapShareReport() }
     )
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24867" title="WPB-24867" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24867</a>  [iOS] [Localization] German spelling mistakes are displayed when sending an error report by user
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

In German, the button titles for sending the debug report had incorrect capitalization:
<img width="591" height="1280" alt="image" src="https://github.com/user-attachments/assets/29e02429-b139-4672-9912-8e15770232de" />

This PR removes the `capitalization` modifier as it shouldn't be used for localized content and isn't even necessary since the localized strings are already capitalized correctly:

<img width="1206" height="2622" alt="Simulator Screenshot - A - 2026-04-20 at 21 40 47" src="https://github.com/user-attachments/assets/53bf4252-dfc7-47f1-8162-e4671a1506ef" />


### Testing

- Switch to German
- Go to settings > Advanced > Debug report
- Check the button titles

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
