### PR TITLE
feat: remove preview error when url is nil - WPB-24272

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/AttachmentsPreviewView/WireDriveAttachmentsPreviewItemViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/AttachmentsPreviewView/WireDriveAttachmentsPreviewItemViewModel.swift
@@ -128,7 +128,7 @@ final class WireDriveAttachmentsPreviewItemViewModel: ObservableObject {
     }
 
     private var preview: WireDriveNodePreview? {
-        node?.previews.sorted(by: { $0.dimension < $1.dimension }).last
+        node?.previews.max(by: { $0.dimension < $1.dimension })
     }
 
     private var isProcessing: Bool {

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/AttachmentsPreviewView/WireDriveLargeDocumentPreviewView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/AttachmentsPreviewView/WireDriveLargeDocumentPreviewView.swift
@@ -50,14 +50,14 @@ struct WireDriveLargeDocumentPreviewView: View {
                 .background(ColorTheme.Backgrounds.surfaceVariant.color)
                 .frame(maxWidth: .infinity)
 
-                previewContainer {
-                    if case .failed = state {
+                if case .failed = state {
+                    previewContainer {
                         errorView(text: Self.downloadErrorMessage)
-                    } else {
-                        if let url {
+                    }
+                } else {
+                    if let url {
+                        previewContainer {
                             asyncImage(url: url)
-                        } else {
-                            errorView(text: Self.errorMessage)
                         }
                     }
                 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24272" title="WPB-24272" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24272</a>  [iOS] Non-preview Enabled files are displaying as big card with an error
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

For some file types there is no preview to be shown. In those cases we were showing an error view to the user.
This PR updates the code so it will not try to load the image from url if url is nil.

Would be nice to consider for the future to add a "generic" type for file types that have no preview, right now we are just assuming that when url is nil there is no preview.

### Testing

Upload a Zip file for example and no preview or error when loading the preview should be shown.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
