### PR TITLE
chore: test re-login with multiple backends - WPB-24958

### DIFF
--- a/wire-ios/WireUITests/FederationTests.swift
+++ b/wire-ios/WireUITests/FederationTests.swift
@@ -23,9 +23,6 @@ final class FederationTests: WireUITestCase {
     @MainActor
     func testConnectFederatedUsers_TC_9459() async throws {
 
-        defer {
-            BackendContext.current = .staging
-        }
         userHelper = UserHelper(environment: .bella)
         try switchBackend(target: .bella)
         let bellaTeam = try await userHelper.registerTeam(withMemberCount: 0)

--- a/wire-ios/WireUITests/Helper/WireUITestCase.swift
+++ b/wire-ios/WireUITests/Helper/WireUITestCase.swift
@@ -64,6 +64,7 @@ class WireUITestCase: XCTestCase {
         await callingServiceClient.destroyCreatedInstances()
         await userHelper.deleteCreatedUsers()
         userHelper = nil
+        BackendContext.current = .staging
     }
 
     func setCustomBackend(byDeeplink deeplink: URL, timeout: TimeInterval = 5, domainInfo: String) {

--- a/wire-ios/WireUITests/MultiBackendSupportTests.swift
+++ b/wire-ios/WireUITests/MultiBackendSupportTests.swift
@@ -77,6 +77,67 @@ final class MultiBackendSupportTests: WireUITestCase {
         )
     }
 
+    @MainActor
+    func testReLoginWhenMultipleBackends_TC_10550() async throws {
+        // Login to account A
+        let userA = try await UserHelper(environment: .staging).createPersonalUser()
+        _ = try app
+            .loginUser(email: userA.email, password: userA.password)
+            .acceptPopup()
+
+        // Go to Anta login
+        _ = try ConversationsPage()
+            .openUserProfilePage()
+            .tapAddAccountOrTeamButton()
+
+        try switchBackend(target: .anta)
+
+        // Login to account B
+        let userB = try await UserHelper(environment: .anta).createPersonalUser()
+        _ = try app
+            .loginUser(email: userB.email, password: userB.password)
+            .acceptPopup()
+
+        // Switch to account A
+        _ = try ConversationsPage()
+            .openUserProfilePage()
+            .switchUserAccountForUser(withName: userA.name)
+
+        // Switch to account B
+        _ = try ConversationsPage()
+            .openUserProfilePage()
+            .switchUserAccountForUser(withName: userB.name)
+
+        // Logout account B
+        _ = try ConversationsPage()
+            .openSettings()
+            .openAccountSettings()
+            .logout()
+            .enterPassword(userB.password, expectWelcomePage: false)
+
+        // Go to Anta login
+        _ = try ConversationsPage()
+            .openUserProfilePage()
+            .tapAddAccountOrTeamButton()
+
+        try switchBackend(target: .anta)
+
+        // Re-login to account B
+        _ = try app
+            .loginUser(email: userB.email, password: userB.password)
+
+        // Verify logged into account B
+        let accountSettingsPage = try ConversationsPage()
+            .openSettings()
+            .openAccountSettings()
+
+        try verifySwitchingAccount(
+            accountPage: accountSettingsPage,
+            expectedUser: userB,
+            expectedDomain: BackendTarget.anta.domainInfo
+        )
+    }
+
     private func verifySwitchingAccount(
         accountPage: AccountSettingsPage,
         expectedUser: UserInfo,

--- a/wire-ios/WireUITests/MultiBackendSupportTests.swift
+++ b/wire-ios/WireUITests/MultiBackendSupportTests.swift
@@ -47,8 +47,6 @@ final class MultiBackendSupportTests: WireUITestCase {
     @MainActor
     func testAddMultiBackendAccounts_TC_8940() async throws {
 
-        defer { BackendContext.current = .staging }
-
         var (accountPageBackend1, userBackend1) = try await testLoginToBackend(.staging)
 
         _ = try accountPageBackend1


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24958" title="WPB-24958" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24958</a>  [iOS] UI Test re-login on multiple backend
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR implements UI automation tests for re-login when multiple accounts are logged into different backends. 

It automates https://app.testiny.io/IOS/testcases/tcf/1602/tc/10550 

### Testing

Run UI tests

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.
