### PR TITLE
fix: remove spacing between header and preview - WPB-24923

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/AttachmentsPreviewView/WireDriveLargeDocumentPreviewView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/AttachmentsPreviewView/WireDriveLargeDocumentPreviewView.swift
@@ -39,7 +39,7 @@ struct WireDriveLargeDocumentPreviewView: View {
 
     var body: some View {
         WireDriveAttachmentPreview {
-            VStack {
+            VStack(spacing: 0) {
                 WireDriveDocumentHeaderView(
                     headerIcon: headerIcon,
                     headerText: headerText,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24923" title="WPB-24923" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24923</a>  [iOS] Files Preview in Conversation - remove colored gap between header and thumbnail image
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Remove gap between Preview header and thumbnail (de gap mark with yellow on the picture)
<img width="375" height="134" alt="Wire 2026-04-22 at 09-06-04" src="https://github.com/user-attachments/assets/e99b0481-f824-44f9-9c6e-cf7b30afbe95" />

### Testing

Share a file (except for videos, images & audio)
Check the preview, it should be no gap between header with filename and thumbnail preview image.
 
---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
