### PR TITLE
fix: remove exception for showing "Apps are active" info - WPB-24961

### DIFF
--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+ExternalParticipant.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+ExternalParticipant.swift
@@ -56,7 +56,7 @@ public extension ZMConversation {
 
     /// The state of external participants in the conversation.
     var externalParticipantsState: ExternalParticipantsState {
-        // Exception: We don't consider guests/apps as external participants in 1:1 conversations
+        // External-participant states are only reported for group conversations.
         guard conversationType == .group else { return [] }
 
         let participants = Set(localParticipants)

--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+ExternalParticipant.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+ExternalParticipant.swift
@@ -56,17 +56,12 @@ public extension ZMConversation {
 
     /// The state of external participants in the conversation.
     var externalParticipantsState: ExternalParticipantsState {
-        // Exception 1) We don't consider guests/apps as external participants in 1:1 conversations
+        // Exception: We don't consider guests/apps as external participants in 1:1 conversations
         guard conversationType == .group else { return [] }
 
-        // Exception 2) If there is only one user in the group and it's an app, we don't consider it as external
         let participants = Set(localParticipants)
         let selfUser = ZMUser.selfUser(in: managedObjectContext!)
         let otherUsers = participants.subtracting([selfUser])
-
-        if otherUsers.count == 1, otherUsers.first!.isAppOrBot {
-            return []
-        }
 
         // Calculate the external participants state
         let canDisplayGuests = selfUser.isTeamMember

--- a/wire-ios-data-model/Tests/Model/Conversation/ZMConversationExternalParticipantsStateTests.swift
+++ b/wire-ios-data-model/Tests/Model/Conversation/ZMConversationExternalParticipantsStateTests.swift
@@ -96,12 +96,9 @@ class ZMConversationExternalParticipantsStateTests: ZMConversationTestsBase {
         // None
         assertMatrixRow(.group, selfUser: .personal, otherUsers: [.personal], expectedResult: [])
         assertMatrixRow(.group, selfUser: .personal, otherUsers: [.memberOfHostingTeam], expectedResult: [])
-        assertMatrixRow(.group, selfUser: .personal, otherUsers: [.service], expectedResult: [])
         assertMatrixRow(.group, selfUser: .memberOfHostingTeam, otherUsers: [.memberOfHostingTeam], expectedResult: [])
-        assertMatrixRow(.group, selfUser: .memberOfHostingTeam, otherUsers: [.service], expectedResult: [])
         assertMatrixRow(.group, selfUser: .external, otherUsers: [.external], expectedResult: [])
         assertMatrixRow(.group, selfUser: .external, otherUsers: [.memberOfHostingTeam], expectedResult: [])
-        assertMatrixRow(.group, selfUser: .external, otherUsers: [.service], expectedResult: [])
 
         // Only Remotes
         assertMatrixRow(
@@ -122,6 +119,9 @@ class ZMConversationExternalParticipantsStateTests: ZMConversationTestsBase {
         assertMatrixRow(.group, selfUser: .external, otherUsers: [.personal], expectedResult: [.visibleGuests])
 
         // Only Services
+        assertMatrixRow(.group, selfUser: .personal, otherUsers: [.service], expectedResult: [.visibleApps])
+        assertMatrixRow(.group, selfUser: .memberOfHostingTeam, otherUsers: [.service], expectedResult: [.visibleApps])
+        assertMatrixRow(.group, selfUser: .external, otherUsers: [.service], expectedResult: [.visibleApps])
         assertMatrixRow(
             .group,
             selfUser: .memberOfHostingTeam,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24961" title="WPB-24961" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24961</a>  [iOS] Apps active banner not visible
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Currently we'll only show the banner "Apps are active" in a conversation if there are more participants than the self user and the app/bot. 
This PR changes the logic and now we will always show the banner if any app is present.

### Testing

Add an app to a conversation and see that the banner is visible.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
