### PR TITLE
fix: sync is suspended when call ends in foreground - WPB-25064

### DIFF
--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager+CallKitManagerDelegate.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager+CallKitManagerDelegate.swift
@@ -99,7 +99,14 @@ extension SessionManager: CallKitManagerDelegate {
     }
 
     func didEndAllCalls() {
-        WireLogger.calling.info("all calls ended, suspending background tasks", attributes: .safePublic)
+        guard UIApplication.shared.applicationState == .background else {
+            return
+        }
+
+        WireLogger.calling.info(
+            "all calls ended in background, suspending all syncs",
+            attributes: .safePublic
+        )
         Task {
             for userSession in backgroundUserSessions.values {
                 await userSession.syncAgent?.suspend()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25064" title="WPB-25064" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-25064</a>  [iOS] [Sync] Push channel is closed when ending a call and does not restart
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
When participating in a call while in the foreground and then leaving that call, the app no longer receives and processes update events. When the app is brought to the background and then foreground, the problem is resolved.

This bug is a combination of a few issues that only first surfaced with https://github.com/wireapp/wire-ios/pull/4477 which introduced new task cancellation checks in the sync.

The cause of the bug begins with code introduced in December last year (https://github.com/wireapp/wire-ios/pull/4000) which solved a problem of the web socket closing during an ongoing call when bring the call to the background, by not suspending the sync during an ongoing call but only when all calls had finished. However, it suspended the sync at the end of calls regardless of whether the app was in the foreground or background. The sequence of events is thus:

- Call is ongoing in the foreground
- Call ends in the foreground
- CallKit informs its delegate that the call ends, this triggers a new sync to start (not clear why, this is another issue)
- The sync restarts
- The call is successfully ended, all syncs are not suspended (erroneously in the foreground)
- Now that there is additional task cancellation checks, this suspension actually cancels the newly started sync
- The code responsible for restarting syncs while in the foreground doesn't run because the cancelled sync never reached completion
- The app is now idle

This PR proposes a very small and simple fix which is intended to resolve the immediate problem of suspending the sync at the end of the call while in the foreground. The change is to only perform this suspension when the app is in the background, so that the websocket is closed correctly in the BG and not incorrectly while in the FG.

A more robust and general solution is needed to improve sync management and stability which will be addressed separately.

### Testing
1. Open the app and be synced
2. Start a call and connect
3. While in the foreground, leave the call and stay in the foreground
4. Assert you still receive messages and other update events
5. Start a new call, assert it works fine.
6. Move call to background, then end the call
7. Receive messages, assert you see notifications for these messages without delay.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
