### PR TITLE
chore: Revert "fix: app state transition deadlock - WPB-24530 🍒

### DIFF
--- a/wire-ios/Wire-iOS/Sources/AppRootRouter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppRootRouter.swift
@@ -251,7 +251,6 @@ extension AppRootRouter: AppStateCalculatorDelegate {
             showAppLock(userSession: userSession, completion: completion)
         case let .syncFailure(error, onRetry):
             presentSyncErrorAlert(error: error, onRetry: onRetry)
-            appStateTransitionGroup.leave()
         }
     }
 
@@ -269,8 +268,9 @@ extension AppRootRouter: AppStateCalculatorDelegate {
             UIAlertAction(
                 title: L10n.Localizable.Content.System.FailedtosendMessage.retry, // reusing retry string
                 style: .default
-            ) { _ in
+            ) { [weak self] _ in
                 onRetry()
+                self?.appStateTransitionGroup.leave()
             }
         )
 
@@ -278,7 +278,9 @@ extension AppRootRouter: AppStateCalculatorDelegate {
             UIAlertAction(
                 title: L10n.Localizable.General.cancel,
                 style: .destructive
-            ) { _ in }
+            ) { [weak self] _ in
+                self?.appStateTransitionGroup.leave()
+            }
         )
 
         rootViewController.present(alert, animated: true)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24530" title="WPB-24530" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24530</a>  [iOS] This message can not be displayed shown when phone is locked for a while
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Reverts wireapp/wire-ios#4602

This is temporary while we do a hotfix to 4.16.3