### PR TITLE
fix: sync is suspended when call ends in foreground - WPB-25064 🍒

### DIFF
--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager+CallKitManagerDelegate.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager+CallKitManagerDelegate.swift
@@ -108,7 +108,14 @@ extension SessionManager: CallKitManagerDelegate {
     }
 
     func didEndAllCalls() {
-        WireLogger.calling.info("all calls ended, suspending background tasks", attributes: .safePublic)
+        guard UIApplication.shared.applicationState == .background else {
+            return
+        }
+
+        WireLogger.calling.info(
+            "all calls ended in background, suspending all syncs",
+            attributes: .safePublic
+        )
         Task {
             for userSession in backgroundUserSessions.values {
                 await userSession.syncAgent?.suspend()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25064" title="WPB-25064" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-25064</a>  [iOS] [Sync] Push channel is closed when ending a call and does not restart
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR cherry picks https://github.com/wireapp/wire-ios/pull/4637 into release/cycle-4.16