### PR TITLE
fix: Merged testServices tests together to avoid timeout while creating instance - WPB-24695

### DIFF
--- a/wire-ios/WireUITests/Helper/TestServicesClient.swift
+++ b/wire-ios/WireUITests/Helper/TestServicesClient.swift
@@ -23,6 +23,7 @@ class TestServicesClient {
     let testServiceURL = "http://localhost:8080"
     let CONNECT_TIMEOUT: TimeInterval = 120
     let RESPONSE_TIMEOUT: TimeInterval = 120
+    private var instanceCache: [String: String] = [:]
 
     func sendHttpRequest(url: String, body: [String: Any], requestType: String) async throws -> (Data, URLResponse) {
         guard let requestUrl = URL(string: url) else { fatalError("Invalid URL") }
@@ -50,6 +51,10 @@ class TestServicesClient {
         verificationCode: String?
     ) async throws -> String {
 
+        if let cachedInstanceId = instanceCache[email] {
+            return cachedInstanceId
+        }
+
         let url = URL(string: "\(testServiceURL)/api/v1/instance")
         guard let requestUrl = url else { fatalError() }
 
@@ -76,6 +81,7 @@ class TestServicesClient {
             CreateInstanceResponse.self,
             from: responseData
         )
+        instanceCache[email] = instanceResponse.instanceId
         return instanceResponse.instanceId
     }
 

--- a/wire-ios/WireUITests/Pages/MessagingTests.swift
+++ b/wire-ios/WireUITests/Pages/MessagingTests.swift
@@ -22,7 +22,7 @@ import XCTest
 final class MessagingTests: WireUITestCase {
 
     @MainActor
-    func testSendAndReceiveTextInGroupConversation_TC_8833_8840() async throws {
+    func testSendAndReceiveTextAndAudioInGroupConversation_TC_8833_8840_8835_8842() async throws {
 
         // GIVEN
         let groupName = UserGenerator.generateRandomConversationName()
@@ -35,18 +35,33 @@ final class MessagingTests: WireUITestCase {
             )
 
         let conversationId = try XCTUnwrap(conversationID, "conversationId is nil")
-
         let conversationDomain = BackendContext.current.domainInfo
 
         let firstTimePage = try app.loginUser(email: teamOwner.email, password: teamOwner.password)
         let conversationsPage = try firstTimePage.acceptPopup()
 
-        // WHEN member send text
+        let durationInMillis = 5000
+        let normalizedLoudness = (0 ..< 10).map { _ in Int.random(in: 0 ... 255) }
+
+        // WHEN member sends text and audio file
         try await testServicesClient.sendText(
             user: teamMembers[0],
             text: messageFromMember1,
             conversationId: conversationId,
             domain: conversationDomain
+        )
+
+        try await testServicesClient.sendFile(
+            type: "audio",
+            user: teamMembers[0],
+            fileName: "audio-message",
+            filepath: nil,
+            convoId: conversationId,
+            domain: conversationDomain,
+            audio: [
+                "durationInMillis": durationInMillis,
+                "normalizedLoudness": normalizedLoudness
+            ]
         )
 
         XCTAssertTrue(
@@ -63,16 +78,16 @@ final class MessagingTests: WireUITestCase {
             "Expected message '\(messageFromMember1)' not found in sent messages: \(receivedMessages)"
         )
 
-        let senderName = activeConversationPage.getSenderName()
-        XCTAssertEqual(
-            senderName,
-            teamMembers[0].name,
-            "Sender info didn't match expected value \(teamMembers[0].name)"
+        verifyMessageReceivedAndSenderInfo(
+            attachment: activeConversationPage.fileTypeIcons.firstMatch,
+            on: activeConversationPage,
+            expectedSenderName: teamMembers[0].name,
+            failureMessage: "Expected audio attachment not found"
         )
     }
 
     @MainActor
-    func testSendAndReceiveImageInGroupConversation_TC_8834_8841() async throws {
+    func testSendAndReceiveImageAndVideoInGroupConversation_TC_8834_8841_8836_8843() async throws {
 
         // GIVEN
         let groupName = UserGenerator.generateRandomConversationName()
@@ -83,18 +98,24 @@ final class MessagingTests: WireUITestCase {
             )
 
         let conversationId = try XCTUnwrap(conversationID, "conversationId is nil")
-
         let conversationDomain = BackendContext.current.domainInfo
 
         let firstTimePage = try app.loginUser(email: teamOwner.email, password: teamOwner.password)
         let conversationsPage = try firstTimePage.acceptPopup()
+
         let imageURL = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .appendingPathComponent("TestServicesData/Img/testImage.jpg")
         let imageExtension = imageURL.pathExtension
 
-        // WHEN member send image
+        let videoURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("TestServicesData/Video/testVideo.mp4")
+        let videoExtension = videoURL.pathExtension
+
+        // WHEN member sends image and video files
         try await testServicesClient.sendImage(
             user: teamMembers[0],
             fileURL: imageURL,
@@ -102,97 +123,6 @@ final class MessagingTests: WireUITestCase {
             conversationId: conversationId,
             domain: conversationDomain
         )
-
-        XCTAssertTrue(
-            conversationsPage.unreadMessagesCount.waitForExistence(timeout: 2),
-            "Unread messages count element did not appear"
-        )
-
-        let activeConversationPage = try conversationsPage.openConversation()
-
-        // THEN
-        verifyMessageReceivedAndSenderInfo(
-            attachment: activeConversationPage.fileTypeIcons.firstMatch,
-            on: activeConversationPage,
-            expectedSenderName: teamMembers[0].name,
-            failureMessage: "Expected image attachment not found"
-        )
-    }
-
-    @MainActor
-    func testSendAndReceiveAudioInGroupConversation_TC_8835_8842() async throws {
-
-        // GIVEN
-        let groupName = UserGenerator.generateRandomConversationName()
-        let (teamOwner, teamMembers, _, conversationID) = try await userHelper
-            .registerTeam(
-                withMemberCount: 1,
-                conversation: .group(groupName)
-            )
-
-        let conversationId = try XCTUnwrap(conversationID, "conversationId is nil")
-
-        let conversationDomain = BackendContext.current.domainInfo
-
-        let firstTimePage = try app.loginUser(email: teamOwner.email, password: teamOwner.password)
-        let conversationsPage = try firstTimePage.acceptPopup()
-
-        let durationInMillis = 5000
-        let normalizedLoudness = (0 ..< 10).map { _ in Int.random(in: 0 ... 255) }
-
-        // WHEN member sends audio file
-        try await testServicesClient.sendFile(
-            type: "audio",
-            user: teamMembers[0],
-            fileName: "audio-message",
-            filepath: nil,
-            convoId: conversationId,
-            domain: conversationDomain,
-            audio: [
-                "durationInMillis": durationInMillis,
-                "normalizedLoudness": normalizedLoudness
-            ]
-        )
-        XCTAssertTrue(
-            conversationsPage.unreadMessagesCount.waitForExistence(timeout: 2),
-            "Unread messages count element did not appear"
-        )
-
-        let activeConversationPage = try conversationsPage.openConversation()
-
-        // THEN
-        verifyMessageReceivedAndSenderInfo(
-            attachment: activeConversationPage.fileTypeIcons.firstMatch,
-            on: activeConversationPage,
-            expectedSenderName: teamMembers[0].name,
-            failureMessage: "Expected file attachment not found"
-        )
-    }
-
-    @MainActor
-    func testSendAndReceiveVideoFileInGroupConversation_TC_8836_8843() async throws {
-
-        // GIVEN
-        let groupName = UserGenerator.generateRandomConversationName()
-        let (teamOwner, teamMembers, _, conversationID) = try await userHelper
-            .registerTeam(
-                withMemberCount: 1,
-                conversation: .group(groupName)
-            )
-
-        let conversationId = try XCTUnwrap(conversationID, "conversationId is nil")
-
-        let conversationDomain = BackendContext.current.domainInfo
-
-        let firstTimePage = try app.loginUser(email: teamOwner.email, password: teamOwner.password)
-        let conversationsPage = try firstTimePage.acceptPopup()
-
-        // WHEN member sends video file
-        let videoURL = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .appendingPathComponent("TestServicesData/Video/testVideo.mp4")
-        let videoExtension = videoURL.pathExtension
 
         try await testServicesClient.sendFile(
             type: videoExtension,
@@ -202,6 +132,7 @@ final class MessagingTests: WireUITestCase {
             convoId: conversationId,
             domain: conversationDomain
         )
+
         XCTAssertTrue(
             conversationsPage.unreadMessagesCount.waitForExistence(timeout: 2),
             "Unread messages count element did not appear"
@@ -210,6 +141,11 @@ final class MessagingTests: WireUITestCase {
         let activeConversationPage = try conversationsPage.openConversation()
 
         // THEN
+        XCTAssertTrue(
+            activeConversationPage.fileTypeIcons.firstMatch.waitForExistence(timeout: 5),
+            "Expected image attachment not found"
+        )
+
         verifyMessageReceivedAndSenderInfo(
             attachment: activeConversationPage.fileAttachment(name: "TESTVIDEO", type: "MP4"),
             on: activeConversationPage,

--- a/wire-ios/WireUITests/WireDriveTests.swift
+++ b/wire-ios/WireUITests/WireDriveTests.swift
@@ -41,7 +41,7 @@ final class WireDriveTests: WireUITestCase {
     }
 
     private func verifyDriveEnabledConversation(on activeConversationPage: ActiveConversationPage) {
-        XCTAssertTrue(activeConversationPage.labelSharedDriveIsOn.exists)
+        XCTAssertTrue(activeConversationPage.labelSharedDriveIsOn.waitForExistence(timeout: 2))
         XCTAssertTrue(activeConversationPage.labelSelfDeletingMessageIsOFF.exists)
         XCTAssertFalse(activeConversationPage.selfDeletingMessageButton.isHittable)
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24695" title="WPB-24695" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24695</a>  [iOS] Fix critical flow failures
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

Test failing due to instance not being created.
https://github.com/wireapp/wire-ios/actions/runs/25054147648

Changes:
 Merged tests together to reduce time for login and using same instance for sending 2 types of messages.
 
**Just as a Note**: In another PR this is handled with send and received multiple type of messages separated
### Testing

Locally worked fine but will check by running on CI as well

<img width="522" height="89" alt="image" src="https://github.com/user-attachments/assets/fff71aaf-a1ca-49ca-a43f-ab2c90c0bfbe" />


---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
