### PR TITLE
chore: add Wire drive UI tests - WPB-24818

### DIFF
--- a/WireUI/Sources/WireLocators/Locators.swift
+++ b/WireUI/Sources/WireLocators/Locators.swift
@@ -396,7 +396,7 @@ public enum Locators {
 
         public enum FilesPage: String {
             case close
-            case createFolder = "Create folder"
+            case createFolder
             case createFile
             case recycleBin
             case sharedDrivePageHeader = "Shared Drive"

--- a/WireUI/Sources/WireLocators/Locators.swift
+++ b/WireUI/Sources/WireLocators/Locators.swift
@@ -396,7 +396,7 @@ public enum Locators {
 
         public enum FilesPage: String {
             case close
-            case createFolder
+            case createFolder = "Create folder"
             case createFile
             case recycleBin
             case sharedDrivePageHeader = "Shared Drive"
@@ -423,7 +423,9 @@ public enum Locators {
             case close
         }
 
+        /// UI elements for both file or folder creation.
         public enum CreateFilePage: String {
+            case createFolderPageHeader = "Create folder"
             case cancelButton
             case createButton
         }
@@ -469,6 +471,10 @@ public enum Locators {
         public enum FilesItemPage: String {
             case confirmDeleteButton
             case confirmRestoreButton
+        }
+
+        public enum RecycleBinPage: String {
+            case deletePermanently = "Delete Permanently"
         }
     }
 

--- a/wire-ios/WireUITests/Pages/FolderPage.swift
+++ b/wire-ios/WireUITests/Pages/FolderPage.swift
@@ -1,0 +1,54 @@
+//
+// Wire
+// Copyright (C) 2026 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import WireLocators
+import XCTest
+
+final class FolderPage: PageModel {
+
+    override var pageMainElement: XCUIElement {
+        createFolderPageHeader
+    }
+
+    var folderNameInputField: XCUIElement {
+        app.textFields.firstMatch
+    }
+
+    var createFolderPageHeader: XCUIElement {
+        app.staticTexts[Locators.WireDrive.CreateFilePage.createFolderPageHeader.rawValue]
+    }
+
+    var createFolderButton: XCUIElement {
+        app.buttons
+            .matching(identifier: Locators.WireDrive.CreateFilePage.createButton.rawValue)
+            .firstMatch
+    }
+
+    func waitForPageToDisappear() {
+        XCTAssertFalse(pageMainElement.waitForExistence(timeout: 3))
+    }
+
+    func enterFolderNameAndValidate(name: String = "Test") -> String {
+        folderNameInputField.tap()
+        folderNameInputField.typeText(name)
+        createFolderButton.tap()
+        waitForPageToDisappear()
+        return name
+    }
+
+}

--- a/wire-ios/WireUITests/Pages/RecycleBinPage.swift
+++ b/wire-ios/WireUITests/Pages/RecycleBinPage.swift
@@ -74,4 +74,25 @@ class RecycleBinPage: PageModel {
         closeRecycleBinButton.tap()
         return try SharedDriveFilesPage()
     }
+
+    var deletePermanentlyOnMenuContext: XCUIElement {
+        app.buttons[Locators.WireDrive.RecycleBinPage.deletePermanently.rawValue]
+    }
+
+    var deletePermanentlyOptionOnBottomSheet: XCUIElement {
+        app.buttons[Locators.WireDrive.RecycleBinPage.deletePermanently.rawValue].firstMatch
+    }
+
+    func deleteFilePermanently() -> Self {
+        moreButton.tap()
+        deletePermanentlyOnMenuContext.tap()
+        deletePermanentlyOptionOnBottomSheet.tap()
+        return self
+    }
+
+    func verifyRecycleBinIsEmpty() -> Bool {
+        let file = app.staticTexts[Locators.WireDrive.FilesContentPage.fileItem(0)]
+        return !file.waitForExistence(timeout: 3)
+    }
+
 }

--- a/wire-ios/WireUITests/Pages/SharedDriveFilesPage.swift
+++ b/wire-ios/WireUITests/Pages/SharedDriveFilesPage.swift
@@ -58,6 +58,10 @@ class SharedDriveFilesPage: PageModel {
         app.buttons[Locators.WireDrive.FilesPage.recycleBin.rawValue]
     }
 
+    var createFolderButton: XCUIElement {
+        app.buttons[Locators.WireDrive.FilesPage.createFolder.rawValue]
+    }
+
     var moreButton: XCUIElement {
         app.buttons
             .matching(identifier: Locators.WireDrive.FilesContentPage.fileItem(0))
@@ -96,6 +100,18 @@ class SharedDriveFilesPage: PageModel {
 
     func verifyFileMovedToSharedDrive(fileName: String) -> Bool {
         fileMetadataText.label.contains(fileName)
+    }
 
+    func createFolder() throws -> FolderPage {
+        moreOptionOnSharedDrive.tap()
+        createFolderButton.tap()
+        return try FolderPage()
+    }
+
+    func verifyFolderIsCreated(folderName: String) -> Bool {
+        app.staticTexts
+            .matching(identifier: folderName)
+            .element
+            .exists
     }
 }

--- a/wire-ios/WireUITests/WireDriveTests.swift
+++ b/wire-ios/WireUITests/WireDriveTests.swift
@@ -193,7 +193,6 @@ final class WireDriveTests: WireUITestCase {
             .group(UserGenerator.generateRandomConversationName())
         )
 
-        // WHEN
         var sharedDrivePage = try uploadSketchAndOpenSharedDrive(message: message, for: teamOwner)
 
         let sharedFileName = sharedDrivePage.fileNameText
@@ -206,6 +205,54 @@ final class WireDriveTests: WireUITestCase {
 
         // THEN
         XCTAssertTrue(sharedDrivePage.verifyFileMovedToSharedDrive(fileName: sharedFileName))
+    }
 
+    @MainActor
+    func testDeletingFilePermanentelyFromRecycleBin_TC_8960() async throws {
+
+        // GIVEN
+        let message = "Attachment with Text"
+        let teamOwner = try await createDriveEnabledConversation(
+            .group(UserGenerator.generateRandomConversationName())
+        )
+
+        // WHEN
+        let activeConversationPage = try loginAndOpenConversation(for: teamOwner)
+            .typeMessageAndAttachSketch(message)
+
+        activeConversationPage.waitToUploadToFinishAndSend()
+
+        let sharedDrivePage = try activeConversationPage
+            .openSharedDrive()
+
+        let recycleBinPage = try sharedDrivePage
+            .openMoreOptionsOnFileAndDelete()
+            .openRecycleBin()
+            .deleteFilePermanently()
+
+        // THEN
+        XCTAssertTrue(recycleBinPage.verifyRecycleBinIsEmpty())
+    }
+
+    @MainActor
+    func testCreatingFolder_TC_8961() async throws {
+
+        // GIVEN
+        let teamOwner = try await createDriveEnabledConversation(
+            .group(UserGenerator.generateRandomConversationName())
+        )
+
+        // WHEN
+        let activeConversationPage = try loginAndOpenConversation(for: teamOwner)
+        let sharedDrivePage = try activeConversationPage
+            .openSharedDrive()
+
+        let createFolderPage = try sharedDrivePage
+            .createFolder()
+
+        let folderName = createFolderPage.enterFolderNameAndValidate()
+
+        // THEN
+        XCTAssertTrue(sharedDrivePage.verifyFolderIsCreated(folderName: folderName))
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24818" title="WPB-24818" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24818</a>  [iOS] Add UI (flow) recycle bin tests for Wire drive
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR adds a couple of missing UI tests for Wire drive (folder creation and delete file permanently), as described here: https://app.testiny.io/IOS/testcases/tcf/1389/tc/8960

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
