### PR TITLE
fix: links aren't shared via share extension - WPB-24816

### DIFF
--- a/wire-ios/Wire-iOS Share Extension/Sources/View Controllers/ShareExtensionViewController.swift
+++ b/wire-ios/Wire-iOS Share Extension/Sources/View Controllers/ShareExtensionViewController.swift
@@ -162,12 +162,12 @@ final class ShareExtensionViewController: SLComposeServiceViewController {
         currentAccount = accountManager?.selectedAccount
         ExtensionBackupExcluder.exclude()
 
+        if let sortedAttachments = extensionContext?.attachments.sorted {
+            attachments = sortedAttachments
+        }
+
         Task { @MainActor in
             await updateAccount(currentAccount)
-
-            if let sortedAttachments = extensionContext?.attachments.sorted {
-                attachments = sortedAttachments
-            }
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24816" title="WPB-24816" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24816</a>  [iOS] [Share ext] Sharing website from Safari doesn't include link
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
When sharing a webpage via the share extension (such as from Safari) only the webpage title is included in the message and not the link.

This is because the webpage is the default text content and we must extract the url and append it to the text content, but a change introduced in https://github.com/wireapp/wire-ios/pull/3373 causes the attachments to be loaded later than usual due to being put inside a `Task`. As a result, when the view appears and we check to append any possible urls, there are no attachments loaded yet and nothing is appended.

The solution is to move the loading of attachments outside of the Task (it's not necessary to have it in the task) so that it is done synchronously before the view appears.

### Testing
1. Be logged in.
2. Open safari and try to share a webpage, such as www.apple.com
3. Before sending the message, assert that the text content includes the link.
4. Send the message, and check in the main app (sender or receiver) that the link is included in the sent message.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
