### PR TITLE
fix: required debug builds option - WPB-24616

### DIFF
--- a/.github/workflows/_reusable_app_release.yml
+++ b/.github/workflows/_reusable_app_release.yml
@@ -26,7 +26,6 @@ on:
         required: true
       produce_debug_builds:
         type: boolean
-        required: true
         default: false
 
     secrets:


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24616" title="WPB-24616" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24616</a>  [iOS] Release iOS v3.120.9
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Following #4585, workflows needed to add produce_debug_build parameter, this PR removes this need.


### Testing

N/A

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
