### PR TITLE
fix: added back to setHandle which removed accidentally - WPB-24695

### DIFF
--- a/wire-ios/WireUITests/Helper/UserHelper.swift
+++ b/wire-ios/WireUITests/Helper/UserHelper.swift
@@ -299,6 +299,10 @@ final class UserHelper {
             email: teamOwner.email,
             password: teamOwner.password
         )
+
+        // Set username
+        try await selfUserAPI.updateHandle(handle: teamOwner.username)
+
         createdUsers.append(teamOwner)
         return (qualifiedID: qualifiedId, owner: teamOwner)
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24695" title="WPB-24695" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24695</a>  [iOS] Fix critical flow failures
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

teamOwner handle is not set but in UITest flow it it should be set. So added back. It has removed by mistake here https://github.com/wireapp/wire-ios/pull/4525/changes#diff-994cf6437438208c28c47582ec419a9e11f0af321fa110bf113cf6c0487ad82a

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
