### PR TITLE
chore: add UI test for logging out - WPB-24964

### DIFF
--- a/wire-ios/WireUITests/WireAuthenticationTests.swift
+++ b/wire-ios/WireUITests/WireAuthenticationTests.swift
@@ -43,4 +43,46 @@ final class WireAuthenticationTests: WireUITestCase {
         XCTAssertTrue(loginPage.nextButton.waitForExistence(timeout: 2.0))
         XCTAssertFalse(loginPage.nextButton.isEnabled, "nextButton should be disabled if no password")
     }
+
+    @MainActor
+    func testLogout_TC_8946() async throws {
+        // Login user A
+        let userA = try await UserHelper.default.createPersonalUser()
+        _ = try app
+            .loginUser(email: userA.email, password: userA.password)
+            .acceptPopup()
+
+        // Login to user B
+        let userB = try await UserHelper.default.createPersonalUser()
+        _ = try ConversationsPage()
+            .openUserProfilePage()
+            .tapAddAccountOrTeamButton()
+
+        _ = try app
+            .loginUser(email: userB.email, password: userB.password)
+            .acceptPopup()
+
+        // Verify that user B is logged in and selected
+        let accountSettingsB = try ConversationsPage()
+            .openSettings()
+            .openAccountSettings()
+        XCTAssertEqual(accountSettingsB.getAccountName(), userB.name, "User B should be selected")
+
+        // Logout user B
+        try accountSettingsB
+            .logout()
+            .enterPassword(userB.password, expectWelcomePage: false)
+
+        // Verify that user A is logged in and selected
+        let accountSettingsA = try ConversationsPage()
+            .openSettings()
+            .openAccountSettings()
+        XCTAssertEqual(accountSettingsA.getAccountName(), userA.name, "User A should be selected")
+
+        // Logout user A
+        try accountSettingsA
+            .logout()
+            .enterPassword(userA.password, expectWelcomePage: true)
+    }
+
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24964" title="WPB-24964" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24964</a>  [iOS] Automation - TC-8946 - As a user, I am able to logout from the application.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR adds a UI test for logging out covering https://app.testiny.io/IOS/testcases/tc/8946/edit.

As the test steps were not written in the test case I implemented the following which tests logging out both when multiple users are logged in and when a single is logged in:

1. Login with user A
2. Login with user B
3. Logout with user B
4. Logout with user A

https://github.com/user-attachments/assets/ea1a2ac9-9682-4377-a490-6cecaea2d0f7

### Testing

Run automated tests

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.