### PR TITLE
fix: seed video fails as simulator not booted - WPB-24695

### DIFF
--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -154,23 +154,31 @@ jobs:
         run: |
           bundle exec fastlane generate_env
 
-      - name: Seed simulator with test video file
-        if: ${{ inputs.run_critical_flows }}
-        run: |
-          VIDEO_PATH="${REPO_ROOT}/wire-ios/WireUITests/TestServicesData/Video/testVideo.mp4"
-
-          if [ ! -f "$VIDEO_PATH" ]; then
-            echo "Missing test video: $VIDEO_PATH"
-            exit 1
-          fi
-
-          xcrun simctl addmedia booted "$VIDEO_PATH"
-          
       - name: Setup Kalium Testservice
         if: ${{ inputs.run_critical_flows && inputs.branch != 'release/cycle-4.16' && inputs.branch != 'release/cycle-4.17' }}
         uses: ./.github/actions/kalium-testservice/setup
         with:
           kalium_ref: ${{ inputs.kalium_ref }}
+
+      - name: Seed simulator with test video file
+        if: ${{ inputs.run_critical_flows }}
+        continue-on-error: true
+        run: |
+          VIDEO_PATH="${REPO_ROOT}/wire-ios/WireUITests/TestServicesData/Video/testVideo.mp4"
+
+          if [ ! -f "$VIDEO_PATH" ]; then
+            echo "::warning::Missing test video: $VIDEO_PATH. Skipping simulator media seeding."
+            exit 0
+          fi
+
+          BOOTED_DEVICE_ID=$(xcrun simctl list devices booted | awk -F '[()]' '/Booted/ { print $2; exit }')
+          if [ -z "$BOOTED_DEVICE_ID" ]; then
+            echo "::warning::No booted simulator found. Skipping simulator media seeding."
+            exit 0
+          fi
+
+          xcrun simctl addmedia "$BOOTED_DEVICE_ID" "$VIDEO_PATH" || \
+            echo "::warning::Failed to seed simulator with test video"
 
       - name: "Test new critical flows"
         if: ${{ inputs.run_critical_flows }}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24695" title="WPB-24695" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24695</a>  [iOS] Fix critical flow failures
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

In recent run: https://github.com/wireapp/wire-ios/actions/runs/25440492284
It failed the step due to not able to addMedia video file as simulator is not booted. 

Changes:

Changes the order of this step to buy more time to see if simulator can be booted to apply.
Also continuing on error.

### Testing


---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
