### PR TITLE
fix: ExpirationActivityManager multiple resume continuation - WPB-24585

### DIFF
--- a/wire-ios-system/Source/ExpiringActivity.swift
+++ b/wire-ios-system/Source/ExpiringActivity.swift
@@ -50,6 +50,9 @@ actor ExpiringActivityManager {
 
     let api: any ExpiringActivityInterface
     var task: Task<Void, any Error>?
+    // Stored as actor state so resumeOnce() is serialised through the actor
+    // executor — no lock required, no threads blocked.
+    private var continuation: CheckedContinuation<Void, any Error>?
 
     init() {
         self.init(api: ProcessInfo.processInfo)
@@ -61,7 +64,11 @@ actor ExpiringActivityManager {
 
     func withExpiringActivity(reason: String, block: @escaping () async throws -> Void) async throws {
         try await withTaskCancellationHandler {
+            // withCheckedThrowingContinuation forwards the caller's actor
+            // isolation to its body closure, so the body runs on this actor's
+            // executor and may access isolated state directly.
             try await withCheckedThrowingContinuation { continuation in
+                self.continuation = continuation
                 api.performExpiringActivity(withReason: reason) { expiring in
                     if !expiring {
                         let semaphore = DispatchSemaphore(value: 0)
@@ -70,12 +77,11 @@ actor ExpiringActivityManager {
                                 WireLogger.backgroundActivity.debug("Start of activity: \(reason)")
                                 try await self.startWork(block: block, semaphore: semaphore).value
                                 WireLogger.backgroundActivity.debug("Expiring activity completed: \(reason)")
-                                continuation.resume()
+                                await self.resumeOnce()
                             } catch {
                                 WireLogger.backgroundActivity.warn("Expiring activity ended with an error: \(error)")
-                                continuation.resume(throwing: error)
+                                await self.resumeOnce(throwing: error)
                             }
-
                         }
                         semaphore.wait()
                     } else {
@@ -84,7 +90,7 @@ actor ExpiringActivityManager {
                             do {
                                 try await self.stopWork()
                             } catch {
-                                continuation.resume(throwing: error)
+                                await self.resumeOnce(throwing: error)
                             }
                         }
                     }
@@ -93,6 +99,16 @@ actor ExpiringActivityManager {
         } onCancel: {
             Task { try? await self.stopWork() }
         }
+    }
+
+    private func resumeOnce() {
+        continuation?.resume()
+        continuation = nil
+    }
+
+    private func resumeOnce(throwing error: any Error) {
+        continuation?.resume(throwing: error)
+        continuation = nil
     }
 
     func startWork(block: @escaping () async throws -> Void, semaphore: DispatchSemaphore) -> Task<Void, any Error> {

--- a/wire-ios-system/Tests/ExpiringActivityTests.swift
+++ b/wire-ios-system/Tests/ExpiringActivityTests.swift
@@ -110,6 +110,69 @@ class ExpiringActivityTests: XCTestCase {
         } catch {}
     }
 
+    // MARK: - Double-resume regression tests (crash: EXC_BREAKPOINT on CheckedContinuation.resume)
+
+    /// Regression test for the crash where outer-task cancellation and the expiry callback
+    /// both tried to resume the continuation:
+    ///   1. `onCancel` fires → `stopWork()` cancels the inner task, sets `self.task = nil`
+    ///   2. Inner task throws `CancellationError` → first resume
+    ///   3. `expiring = true` fires → `stopWork()` finds `self.task == nil`, throws,
+    ///      and previously tried to resume the continuation a second time → crash
+    func testNoCrash_WhenExpiryFires_AfterOuterTaskCancellation() async throws {
+        let api = MockExpiringActivityAPI()
+        let sut = ExpiringActivityManager(api: api)
+
+        let workStarted = expectation(description: "work started")
+        let expiryFired = expectation(description: "expiry fired")
+
+        api.method = { _, block in
+            self.concurrentQueue.async { block(false) }
+            // Expiry fires after work has started, racing with the outer cancellation below.
+            self.concurrentQueue.asyncAfter(deadline: .now() + 0.05) {
+                expiryFired.fulfill()
+                block(true)
+            }
+        }
+
+        let outerTask = Task {
+            try await sut.withExpiringActivity(reason: "regression test") {
+                workStarted.fulfill()
+                while true {
+                    await Task.yield()
+                    try Task.checkCancellation()
+                }
+            }
+        }
+
+        await fulfillment(of: [workStarted], timeout: 1)
+        outerTask.cancel()
+        await fulfillment(of: [expiryFired], timeout: 1)
+
+        // Must not crash (EXC_BREAKPOINT) regardless of which error is thrown.
+        do { try await outerTask.value } catch {}
+    }
+
+    /// Regression test for the race where the expiry callback fires *before* the
+    /// `expiring = false` callback has had a chance to call `startWork` on the actor:
+    ///   1. `expiring = true` reaches the actor first → `stopWork()` finds `task == nil`,
+    ///      throws, and previously resumed the continuation with that error
+    ///   2. `expiring = false` then runs `startWork`, work completes, and previously
+    ///      tried to resume the continuation a second time → crash
+    func testNoCrash_WhenExpiryCallbackFiresBeforeWorkStarts() async throws {
+        let api = MockExpiringActivityAPI()
+        let sut = ExpiringActivityManager(api: api)
+
+        api.method = { _, block in
+            // Deliver expiry before start to maximise the chance of the race.
+            self.concurrentQueue.async { block(true) }
+            self.concurrentQueue.async { block(false) }
+        }
+
+        // Must not crash. The error (ExpiringActivityNotAllowedToRun or
+        // CancellationError) is an expected outcome of the race.
+        do { try await sut.withExpiringActivity(reason: "regression test") {} } catch {}
+    }
+
     func testThatTaskEndsWithoutError_WhenActivityCompletes() async throws {
 
         // given


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24585" title="WPB-24585" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24585</a>  [iOS] Crash on ExpiringActivityManager
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


<!--do not remove the jira markers to link tickets automatically -->


### Issue

Porting fix to release #4669

### Testing

N/A

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
