### PR TITLE
fix: flaky FilesViewModelTests in WireMessaging - WPB-25557

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Common/NetworkMonitor.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Common/NetworkMonitor.swift
@@ -34,15 +34,17 @@ package final class NetworkMonitor: Observable, ObservableObject {
 
     private var monitor: any NWPathMonitoring
     private let queue = DispatchQueue(label: "NetworkMonitorQueue")
-    private let subject = CurrentValueSubject<NetworkStatus, Never>(.disconnected)
+    private let subject: CurrentValueSubject<NetworkStatus, Never>
     private var cancellables = Set<AnyCancellable>()
 
     @Published var currentStatus: NetworkStatus?
 
     init(
         monitor: any NWPathMonitoring = NWPathMonitor(),
+        initialStatus: NetworkStatus = .disconnected
     ) {
         self.monitor = monitor
+        self.subject = CurrentValueSubject(initialStatus)
 
         subject
             .debounce(for: .seconds(0.5), scheduler: DispatchQueue.main)
@@ -57,7 +59,7 @@ package final class NetworkMonitor: Observable, ObservableObject {
             guard let self else { return }
             Task { @MainActor in
                 let status: NetworkStatus = path.status == .satisfied ? .connected : .disconnected
-                subject.send(status)
+                self.subject.send(status)
             }
         }
 

--- a/WireMessaging/Tests/WireMessagingTests/WireDrive/UITests/Components/Files/FilesViewModelTests.swift
+++ b/WireMessaging/Tests/WireMessagingTests/WireDrive/UITests/Components/Files/FilesViewModelTests.swift
@@ -35,7 +35,7 @@ final class FilesViewModelTests {
     private let sut: FilesViewModel
     private var itemsUpdates: [[FilesViewItem]] = []
     private var cancellables = Set<AnyCancellable>()
-    private var networkMonitor = NetworkMonitor(monitor: MockNWPathMonitoring())
+    private var networkMonitor = NetworkMonitor(monitor: MockNWPathMonitoring(), initialStatus: .connected)
 
     init() {
         let nodesApi = MockNodesAPIProtocol()

--- a/WireMessaging/Tests/WireMessagingTests/WireDrive/UITests/Components/Files/FilesViewTests.swift
+++ b/WireMessaging/Tests/WireMessagingTests/WireDrive/UITests/Components/Files/FilesViewTests.swift
@@ -118,7 +118,7 @@ final class FilesViewTests: XCTestCase {
             localAssetRepository: localAssetsRepository
         )
 
-        networkMonitor = NetworkMonitor(monitor: MockNWPathMonitoring())
+        networkMonitor = NetworkMonitor(monitor: MockNWPathMonitoring(), initialStatus: .connected)
         networkMonitor.currentStatus = .connected
     }
 

--- a/WireMessaging/Tests/WireMessagingTests/WireDrive/UITests/Components/Files/FilesViewTests.swift
+++ b/WireMessaging/Tests/WireMessagingTests/WireDrive/UITests/Components/Files/FilesViewTests.swift
@@ -17,6 +17,7 @@
 //
 
 import Combine
+import Network
 import SwiftUI
 import WireDesign
 import WireFoundation
@@ -48,6 +49,7 @@ final class FilesViewTests: XCTestCase {
     private var makeAssetAvailableOfflineUseCase: WireDriveMakeAssetAvailableOfflineUseCase!
     private var removeAssetAvailableOfflineUseCase: WireDriveRemoveAssetAvailableOfflineUseCase!
     private var fetchOfflineAvailableAssetsUseCase: WireDriveFetchOfflineAvailableAssetsUseCase!
+    private var networkMonitor: NetworkMonitor!
 
     private let record: Bool? = nil
 
@@ -115,6 +117,9 @@ final class FilesViewTests: XCTestCase {
         fetchOfflineAvailableAssetsUseCase = WireDriveFetchOfflineAvailableAssetsUseCase(
             localAssetRepository: localAssetsRepository
         )
+
+        networkMonitor = NetworkMonitor(monitor: MockNWPathMonitoring())
+        networkMonitor.currentStatus = .connected
     }
 
     @MainActor
@@ -132,6 +137,7 @@ final class FilesViewTests: XCTestCase {
         updatePublicLinkExpiration = nil
         updatePublicLinkPassword = nil
         driveConversationsUseCase = nil
+        networkMonitor = nil
     }
 
     @MainActor
@@ -391,7 +397,8 @@ final class FilesViewTests: XCTestCase {
             nodesRepository: nodesRepository,
             fileCache: MockFileCache(),
             isBrowsing: false,
-            accentColorProvider: { .default }
+            accentColorProvider: { .default },
+            networkMonitor: networkMonitor
         )
 
         filesViewModel.state = state
@@ -432,4 +439,10 @@ private extension FilesItemViewModel {
         )
     }
 
+}
+
+private final class MockNWPathMonitoring: NWPathMonitoring {
+    var pathUpdateHandler: (@Sendable (NWPath) -> Void)?
+
+    func start(queue: DispatchQueue) {}
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25557" title="WPB-25557" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-25557</a>  [iOS] Flaky tests on FilesViewModelTests
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

The following tests are flaky depending on network they will end up on the wrong code path where no mock method is setup and then crash:

<img width="1215" height="482" alt="Screenshot 2026-05-11 at 15 38 50" src="https://github.com/user-attachments/assets/b5966894-b6fb-4c47-9a17-f3791e48ad50" />

### Testing

Run tests

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
