### PR TITLE
chore: Re-enable DD crash reporting - WPB-27522

### DIFF
--- a/WireAnalytics/Sources/WireDatadog/WireDatadog.swift
+++ b/WireAnalytics/Sources/WireDatadog/WireDatadog.swift
@@ -21,6 +21,7 @@ public import WireLogging
 
 import CryptoKit
 import DatadogCore
+import DatadogCrashReporting
 import DatadogLogs
 import DatadogTrace
 import UIKit
@@ -64,6 +65,8 @@ public final class WireDatadog {
             with: configuration,
             trackingConsent: .granted
         )
+
+        CrashReporting.enable()
 
         let logsConfiguration = Logs.Configuration()
         Logs.enable(with: logsConfiguration)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -234,6 +234,7 @@ platform :ios do
     lane :development do |options|
         options[:build_type] = "Development"
         options[:upload_testflight] = true
+        options[:upload_dsyms_to_datadog] = true
         options[:extra_distribution_groups] = ["Wire Employees"]
         options[:produce_debug_builds] = true
         options[:countly_api_key] = ENV['COUNTLY_INTERNAL_KEY']
@@ -246,6 +247,7 @@ platform :ios do
     lane :playground do |options|
         options[:build_type] = "Playground"
         options[:upload_testflight] = true
+        options[:upload_dsyms_to_datadog] = true
         options[:extra_distribution_groups] = ["Wire Employees", "Externals - Non Wire Employees"]
         options[:produce_debug_builds] = true
         options[:countly_api_key] = ENV['COUNTLY_INTERNAL_KEY']
@@ -258,6 +260,7 @@ platform :ios do
     lane :testflight_beta do |options|
         options[:build_type] = "Beta"
         options[:upload_testflight] = true
+        options[:upload_dsyms_to_datadog] = true
         options[:produce_debug_builds] = true
         options[:countly_api_key] = ENV['COUNTLY_INTERNAL_KEY']
         options[:extra_distribution_groups] = ["Wire Employees", "Externals - Non Wire Employees"]
@@ -424,6 +427,10 @@ platform :ios do
         sha256(options)
         upload_s3(options)
         save_changelog_to_env(options)
+       
+        if options[:upload_dsyms_to_datadog] || false
+            upload_dsyms_to_datadog(options)
+        end
     end
 
     def save_app_name(name)
@@ -918,6 +925,19 @@ platform :ios do
         build = Build.new(options: options)
         changelog = changelog(build)
         `export TEMP='RELEASE_NOTES=#{Base64.strict_encode64(changelog)}' && echo $TEMP >> ./.post_build/.env`
+    end
+
+    # Upload dsyms to Datadog
+    def upload_dsyms_to_datadog(options)
+        build = Build.new(options: options)
+        
+        upload_symbols_to_datadog(
+            api_key: ENV["DATADOG_API_KEY"],
+            dsym_paths: [
+                "#{build.artifact_path(with_filename: true)}.app.dSYM.zip"
+            ],
+            site: "datadoghq.eu"
+        )
     end
 end
 

--- a/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperToolsViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperToolsViewModel.swift
@@ -251,7 +251,8 @@ final class DeveloperToolsViewModel: ObservableObject {
             sections.append(Section(
                 header: "Datadog",
                 items: [
-                    .text(TextItem(title: "User ID", value: datadogUserIdentifier))
+                    .text(TextItem(title: "User ID", value: datadogUserIdentifier)),
+                    .button(.init(title: "Crash Report Test", action: { fatal("crash app") }))
                 ]
             ))
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27522" title="WPB-27522" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-27522</a>  [iOS] Enable error tracking in DataDog
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR re-enables DD crash reporting without RUM. It partially reverts https://github.com/wireapp/wire-ios/pull/4407/

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.
