### PR TITLE
feat: add hardware keyboard navigation from input fields - WPB-14697

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+UITextViewDelegate.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+UITextViewDelegate.swift
@@ -84,6 +84,8 @@ extension ConversationInputBarViewController: UITextViewDelegate {
         }
 
         if text == "\t" {
+            setNeedsFocusUpdate()
+            updateFocusIfNeeded()
             textView.resignFirstResponder()
             UIAccessibility.post(
                 notification: .layoutChanged,

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController/ConversationInputBarViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController/ConversationInputBarViewController.swift
@@ -192,6 +192,16 @@ final class ConversationInputBarViewController: UIViewController,
         return inputBar
     }()
 
+    override var preferredFocusEnvironments: [any UIFocusEnvironment] {
+        guard isViewLoaded, inputBar.textView.isFirstResponder else {
+            return super.preferredFocusEnvironments
+        }
+
+        return ([sendButton, ephemeralIndicatorButton] + inputBar.buttonsView.buttons)
+            .filter { !$0.isHidden && $0.isEnabled && $0.isUserInteractionEnabled && $0.alpha > 0 }
+            + super.preferredFocusEnvironments
+    }
+
     lazy var typingIndicatorView: TypingIndicatorView = {
         let view = TypingIndicatorView()
         view.accessibilityIdentifier = "typingIndicator"

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController+UISearchBarDelegate.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController+UISearchBarDelegate.swift
@@ -19,6 +19,20 @@
 import UIKit
 
 extension ConversationListViewController: UISearchBarDelegate {
+    func searchBar(
+        _ searchBar: UISearchBar,
+        shouldChangeTextIn range: NSRange,
+        replacementText text: String
+    ) -> Bool {
+        guard text == "\t" else { return true }
+
+        let focusEnvironment = navigationController ?? self
+        focusEnvironment.setNeedsFocusUpdate()
+        focusEnvironment.updateFocusIfNeeded()
+        searchBar.searchTextField.resignFirstResponder()
+        return false
+    }
+
     func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
         searchBar.text = ""
         applySearchText()

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController.swift
@@ -309,6 +309,14 @@ final class ConversationListViewController: UIViewController {
         .portrait
     }
 
+    override var preferredFocusEnvironments: [any UIFocusEnvironment] {
+        guard navigationItem.searchController?.searchBar.searchTextField.isFirstResponder == true else {
+            return super.preferredFocusEnvironments
+        }
+
+        return [listContentController.collectionView] + super.preferredFocusEnvironments
+    }
+
     // MARK: - Setup UI
 
     private func setupObservers() {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
@@ -150,6 +150,7 @@ final class ConversationListContentController: UICollectionViewController {
         collectionView.register(ConversationListCell.self, forCellWithReuseIdentifier: CellReuseIdConversation)
 
         collectionView.alwaysBounceVertical = true
+        collectionView.allowsFocus = true
         collectionView.allowsSelection = true
         collectionView.allowsMultipleSelection = false
         collectionView.contentInset = .zero


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14697" title="WPB-14697" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-14697</a>  [iOS] Keyboard trapped in input field #55
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Moves focus out of the message composer and conversation search when Tab is pressed, while preserving VoiceOver behavior. Conversation list cells are now keyboard-focusable.

---

### Checklist

- [X] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [X] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
