### PR TITLE
fix: MockCoreCryptoProtocol broke after bump to 10.1.1 - WPB-27753

### DIFF
--- a/wire-ios-data-model/Support/Sources/MockCoreCryptoProtocol.swift
+++ b/wire-ios-data-model/Support/Sources/MockCoreCryptoProtocol.swift
@@ -400,4 +400,11 @@ public final class MockCoreCryptoProtocol: CoreCryptoProtocol {
         fatalError("not implemented")
     }
 
+    public func transactionFfiCancellable(
+        command: any WireCoreCryptoUniffi.CoreCryptoCommand,
+        cancellation: WireCoreCryptoUniffi.CoreCryptoCancellationToken
+    ) async throws {
+        fatalError("not implemented")
+    }
+
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27753" title="WPB-27753" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-27753</a>  [iOS] Update to Core Crypto 10.1.1
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
After merging #5094 the `MockCoreCryptoProtocol` broke due to a new (and missing) protocol method requirement. This PR fixes this by adding a "not implemented" fatal error. This is fine because clients don't actually invoke the ffi method, but rather a higher level transaction method (which is mocked).

### Testing
Compile and run WireDataModel tests.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
