### PR TITLE
WPB-27890: fix: resolve original caller for call-end "called" message

### DIFF
--- a/WireDomain/Sources/WireDomain/Notifications/Builders/Conversation/ConversationCallingEventNotificationBuilder.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Builders/Conversation/ConversationCallingEventNotificationBuilder.swift
@@ -119,16 +119,20 @@ struct ConversationCallingEventNotificationBuilder: ConversationCallingEventNoti
         conversationID: ConversationID
     ) async -> UserNotification {
         let conversation = await context.getConversation(conversationID: conversationID)
-        let caller = await context.getCaller(senderID: senderID)
+        let callerID = context.callerID(callContent: callContent)
         let selfUser = await context.getSelfUser()
         let selfUserID = await context.selfUserID(selfUser: selfUser)
-        let callerID = context.callerID(callContent: callContent)
-        let senderName = await context.callerName(caller: caller)
         let conversationName = await context.conversationName(conversation: conversation)
         let teamName = await context.teamName(selfUser: selfUser)
         let isGroupConversation = await context.isGroupConversation(conversation: conversation)
 
         if callContent.isIncomingCall {
+            // SETUP-triggered: the OTR envelope sender IS the original
+            // caller (server-authenticated), so resolve the displayed name
+            // from the envelope sender rather than the self-declared
+            // src_userid.
+            let caller = await context.getCaller(senderID: senderID)
+            let senderName = await context.callerName(caller: caller)
             return buildIncomingCallNotification(
                 selfUserID: selfUserID,
                 senderID: senderID.id,
@@ -142,6 +146,11 @@ struct ConversationCallingEventNotificationBuilder: ConversationCallingEventNoti
                 isVideo: callContent.isVideo
             )
         } else { // Missed call
+            // End-message-triggered: the envelope sender may not be the
+            // caller, so prefer the originator declared in the payload
+            // (src_userid), falling back to the envelope sender when absent.
+            let caller = await context.getCallStarter(callerID: callerID, senderID: senderID)
+            let senderName = await context.callerName(caller: caller)
             return await buildMissedCallNotification(
                 selfUserID: selfUserID,
                 senderID: senderID.id,
@@ -497,6 +506,26 @@ extension ConversationCallingEventNotificationBuilder {
                 id: senderID.id,
                 domain: senderID.domain
             )
+        }
+        /// Resolves the user whose name labels the call notification.
+        ///
+        /// Prefers the original caller declared in the payload
+        /// (`src_userid`) over the OTR envelope sender, so a missed or
+        /// group-incoming call is attributed to the caller rather than
+        /// the participant whose message triggered the notification.
+        /// Falls back to the envelope sender when `src_userid` is absent
+        /// (older clients / 1:1 calls, where the sender is the caller).
+        func getCallStarter(
+            callerID: UUID?,
+            senderID: UserID
+        ) async -> ZMUser {
+            if let callerID {
+                return await userLocalStore.fetchOrCreateUser(
+                    id: callerID,
+                    domain: senderID.domain
+                )
+            }
+            return await getCaller(senderID: senderID)
         }
 
         func isGroupConversation(conversation: ZMConversation) async -> Bool {

--- a/WireDomain/Sources/WireDomain/Notifications/Builders/Conversation/ConversationCallingEventNotificationBuilder.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Builders/Conversation/ConversationCallingEventNotificationBuilder.swift
@@ -119,7 +119,8 @@ struct ConversationCallingEventNotificationBuilder: ConversationCallingEventNoti
         conversationID: ConversationID
     ) async -> UserNotification {
         let conversation = await context.getConversation(conversationID: conversationID)
-        let callerID = context.callerID(callContent: callContent)
+        let callerIdentity = context.callerIdentity(callContent: callContent)
+        let callerID = callerIdentity?.id
         let selfUser = await context.getSelfUser()
         let selfUserID = await context.selfUserID(selfUser: selfUser)
         let conversationName = await context.conversationName(conversation: conversation)
@@ -149,7 +150,10 @@ struct ConversationCallingEventNotificationBuilder: ConversationCallingEventNoti
             // End-message-triggered: the envelope sender may not be the
             // caller, so prefer the originator declared in the payload
             // (src_userid), falling back to the envelope sender when absent.
-            let caller = await context.getCallStarter(callerID: callerID, senderID: senderID)
+            let caller = await context.fetchNotificationCaller(
+                callerIdentity: callerIdentity,
+                senderID: senderID
+            )
             let senderName = await context.callerName(caller: caller)
             return await buildMissedCallNotification(
                 selfUserID: selfUserID,
@@ -507,22 +511,25 @@ extension ConversationCallingEventNotificationBuilder {
                 domain: senderID.domain
             )
         }
-        /// Resolves the user whose name labels the call notification.
+        /// Resolves the user whose name labels a missed-call notification.
         ///
-        /// Prefers the original caller declared in the payload
-        /// (`src_userid`) over the OTR envelope sender, so a missed or
-        /// group-incoming call is attributed to the caller rather than
-        /// the participant whose message triggered the notification.
-        /// Falls back to the envelope sender when `src_userid` is absent
-        /// (older clients / 1:1 calls, where the sender is the caller).
-        func getCallStarter(
-            callerID: UUID?,
+        /// The call-end message that triggers a missed-call notification is often
+        /// sent by a participant other than the caller, so the name is resolved from
+        /// the original caller declared in the payload (`src_userid`) rather than the
+        /// envelope sender. `src_userid` carries the caller's own domain when
+        /// federation is enabled (`UUID@domain`), so that domain — not the sender's —
+        /// is used to fetch the user. Falls back to the envelope sender when
+        /// `src_userid` is absent (older clients / 1:1 calls, where the sender is the
+        /// caller); the name reflects this best-effort contract rather than claiming
+        /// the user always started the call.
+        func fetchNotificationCaller(
+            callerIdentity: (id: UUID, domain: String?)?,
             senderID: UserID
         ) async -> ZMUser {
-            if let callerID {
+            if let callerIdentity {
                 return await userLocalStore.fetchOrCreateUser(
-                    id: callerID,
-                    domain: senderID.domain
+                    id: callerIdentity.id,
+                    domain: callerIdentity.domain
                 )
             }
             return await getCaller(senderID: senderID)
@@ -554,10 +561,23 @@ extension ConversationCallingEventNotificationBuilder {
             await userLocalStore.teamName(for: selfUser)
         }
 
-        func callerID(
+        /// Parses the original caller from the AVS payload `src_userid`.
+        ///
+        /// AVS serializes the caller as a bare `UUID` (federation disabled) or
+        /// `UUID@domain` (federation enabled). Returning the caller's own domain —
+        /// rather than borrowing the envelope sender's — keeps cross-domain callers
+        /// attributable in federated conversations. The store layer ignores the
+        /// domain when federation is off, so passing it through unconditionally is
+        /// safe. Returns nil when `src_userid` is absent or malformed.
+        func callerIdentity(
             callContent: CallContent
-        ) -> UUID? {
-            callContent.callerUserID.flatMap(UUID.init(transportString:))
+        ) -> (id: UUID, domain: String?)? {
+            guard let raw = callContent.callerUserID else { return nil }
+            let parts = raw.components(separatedBy: "@")
+            guard (1 ... 2).contains(parts.count),
+                let id = UUID(uuidString: parts[0])
+            else { return nil }
+            return (id: id, domain: parts.count == 2 ? parts[1] : nil)
         }
 
         func increaseReadCount(

--- a/WireDomain/Sources/WireDomain/Notifications/Builders/Conversation/ConversationCallingEventNotificationBuilder.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Builders/Conversation/ConversationCallingEventNotificationBuilder.swift
@@ -511,6 +511,7 @@ extension ConversationCallingEventNotificationBuilder {
                 domain: senderID.domain
             )
         }
+
         /// Resolves the user whose name labels a missed-call notification.
         ///
         /// The call-end message that triggers a missed-call notification is often
@@ -575,7 +576,7 @@ extension ConversationCallingEventNotificationBuilder {
             guard let raw = callContent.callerUserID else { return nil }
             let parts = raw.components(separatedBy: "@")
             guard (1 ... 2).contains(parts.count),
-                let id = UUID(uuidString: parts[0])
+                  let id = UUID(uuidString: parts[0])
             else { return nil }
             return (id: id, domain: parts.count == 2 ? parts[1] : nil)
         }

--- a/WireDomain/Tests/WireDomainTests/Notifications/Conversations/ConversationCallingEventNotificationBuilderTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Notifications/Conversations/ConversationCallingEventNotificationBuilderTests.swift
@@ -479,6 +479,128 @@ final class ConversationCallingEventNotificationBuilderTests: XCTestCase {
         XCTAssertNil(userNotification)
     }
 
+    // MARK: - Caller resolution (src_userid) tests
+
+    func testMissedCall_UsesCallerDomainFromQualifiedSrcUserid() async throws {
+        await setupCallerResolutionMock()
+
+        // A qualified src_userid whose domain differs from the envelope sender's.
+        let qualifiedSrcUserid = "\(Scaffolding.callerID.uuidString)@\(Scaffolding.callerDomain)"
+        let notification = try await buildMissedCall(callerID: qualifiedSrcUserid)
+
+        let content = try XCTUnwrap(notification)
+        guard case let .text(notificationContent) = content else { return XCTFail() }
+
+        // The caller's own domain — not the sender's — is used to fetch the user.
+        XCTAssertTrue(
+            userLocalStore.fetchOrCreateUserIdDomain_Invocations.contains(where: {
+                $0.id == Scaffolding.callerID && $0.domain == Scaffolding.callerDomain
+            })
+        )
+
+        // The sender's (id, domain) is fetched once, by validation only; the
+        // missed-call name resolution must not fall back to it.
+        let senderFetchCount = userLocalStore.fetchOrCreateUserIdDomain_Invocations
+            .filter { $0.id == Scaffolding.userID.id && $0.domain == Scaffolding.userID.domain }
+            .count
+        XCTAssertEqual(senderFetchCount, 1)
+
+        // The notification is attributed to the caller, not the envelope sender.
+        XCTAssertEqual(notificationContent.title, Scaffolding.callerName)
+        XCTAssertEqual(notificationContent.userInfo["senderIDString"] as? String, Scaffolding.callerID.uuidString)
+    }
+
+    func testMissedCall_ParsesBareUuidSrcUserid() async throws {
+        await setupCallerResolutionMock()
+
+        let notification = try await buildMissedCall(callerID: Scaffolding.callerID.uuidString)
+
+        let content = try XCTUnwrap(notification)
+        guard case let .text(notificationContent) = content else { return XCTFail() }
+
+        // A bare UUID carries no domain; the caller is fetched with domain nil,
+        // never the sender's domain.
+        XCTAssertTrue(
+            userLocalStore.fetchOrCreateUserIdDomain_Invocations.contains(where: {
+                $0.id == Scaffolding.callerID && $0.domain == nil
+            })
+        )
+
+        XCTAssertEqual(notificationContent.title, Scaffolding.callerName)
+        XCTAssertEqual(notificationContent.userInfo["senderIDString"] as? String, Scaffolding.callerID.uuidString)
+    }
+
+    func testMissedCall_FallsBackToSenderWhenSrcUseridAbsent() async throws {
+        await setupCallerResolutionMock()
+
+        let notification = try await buildMissedCall(callerID: nil)
+
+        let content = try XCTUnwrap(notification)
+        guard case let .text(notificationContent) = content else { return XCTFail() }
+
+        // Without src_userid, the name resolves from the envelope sender.
+        XCTAssertEqual(notificationContent.title, Scaffolding.senderName)
+        XCTAssertNil(notificationContent.userInfo["senderIDString"])
+
+        // The sender is fetched both by validation and by the missed-call fallback.
+        let senderFetchCount = userLocalStore.fetchOrCreateUserIdDomain_Invocations
+            .filter { $0.id == Scaffolding.userID.id && $0.domain == Scaffolding.userID.domain }
+            .count
+        XCTAssertEqual(senderFetchCount, 2)
+    }
+
+    // MARK: - Caller resolution helpers
+
+    /// Shared setup for src_userid tests: disables CallKit so the regular
+    /// notification path runs, and routes `fetchOrCreateUser` / `name(for:)`
+    /// to distinct caller vs. sender users so the resolved identity is observable.
+    private func setupCallerResolutionMock() async {
+        await setupMock(isGroup: false, isTeam: false)
+        defaults.set(false, forKey: "isCallKitAvailable")
+
+        let callerUser = await context.perform { [self] in
+            modelHelper.createUser(in: context)
+        }
+        let senderUser = await context.perform { [self] in
+            modelHelper.createUser(in: context)
+        }
+
+        userLocalStore.fetchOrCreateUserIdDomain_MockMethod = { id, _ in
+            id == Scaffolding.callerID ? callerUser : senderUser
+        }
+        userLocalStore.nameFor_MockMethod = { user in
+            if user === callerUser { return Scaffolding.callerName }
+            if user === senderUser { return Scaffolding.senderName }
+            return nil
+        }
+    }
+
+    /// Builds a missed-call (CANCEL) notification carrying the given `src_userid`.
+    private func buildMissedCall(callerID: String?) async throws -> UserNotification? {
+        var calling = Calling()
+        calling.content = setupCallingContentMock(type: "CANCEL", callerID: callerID)
+
+        sut = ConversationCallingEventNotificationBuilder(
+            context: .init(
+                conversationLocalStore: conversationLocalStore,
+                userLocalStore: userLocalStore
+            ),
+            validator: .init(
+                userLocalStore: userLocalStore,
+                conversationLocalStore: conversationLocalStore,
+                userDefaults: defaults
+            ),
+            accountID: .mockID1
+        )
+
+        return await sut.buildContent(
+            calling: calling,
+            at: .now,
+            conversationID: Scaffolding.conversationID,
+            senderID: Scaffolding.userID
+        )
+    }
+
     // MARK: - Internal tests assertion helpers
 
     private func internalCallKitTest_assertNotificationContent(
@@ -639,14 +761,16 @@ final class ConversationCallingEventNotificationBuilderTests: XCTestCase {
 
     private func setupCallingContentMock(
         type: String,
-        isVideo: Bool = false
+        isVideo: Bool = false,
+        callerID: String? = nil
     ) -> String {
-        """
+        let srcUserid = callerID.map { ",\n            \"src_userid\": \"\($0)\"" } ?? ""
+        return """
         {
             "type": "\(type)",
             "src_clientid": "clientid",
             "resp": false,
-            "props": { "videosend": "\(isVideo)" }
+            "props": { "videosend": "\(isVideo)" }\(srcUserid)
         }
         """
     }
@@ -726,6 +850,9 @@ final class ConversationCallingEventNotificationBuilderTests: XCTestCase {
         static let teamName = "Team1"
         static let conversationID = WireNetwork.QualifiedID(id: .mockID2, domain: "domain.com")
         static let userID = UserID(id: .mockID3, domain: "domain.com")
+        static let callerID = UUID.mockID4
+        static let callerDomain = "federation.wire.com"
+        static let callerName = "CallerName"
         static let accountID = UUID.mockID10
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27890" title="WPB-27890" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-27890</a>  NSE call notification shows the messenger instead of the original caller
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-27890

The NSE notification labelled missed and group-incoming calls with the OTR envelope sender (the participant whose message triggered the notification) instead of the original caller.

For an incoming call the notification is triggered by the SETUP, whose envelope sender IS the original caller, so the displayed name is resolved from the envelope sender. For a missed call the notification is triggered by the end message, whose sender may not be the caller, so the name is resolved from the payload's src_userid (callContent.callerUserID) when present, falling back to the envelope sender when absent.

It's LLM-generated, please, review it carefully.
