### PR TITLE
chore: [Part1] test calling on multiple account - WPB-27068

### DIFF
--- a/wire-ios/WireUITests/Helper/CallingManager.swift
+++ b/wire-ios/WireUITests/Helper/CallingManager.swift
@@ -99,6 +99,11 @@ final class CallingManager {
         try await client.switchScreenSharingOff(instanceId: instanceId, callId: callId)
     }
 
+    func stopCurrentCall(instanceId: String) async throws {
+        let callId = try await requireCurrentCallId(instanceId: instanceId)
+        try await client.stopCall(instanceId: instanceId, callId: callId)
+    }
+
     func verifyPeerConnections(
         instanceIds: [String],
         expectedCount: Int,

--- a/wire-ios/WireUITests/Helper/CallingServiceClient.swift
+++ b/wire-ios/WireUITests/Helper/CallingServiceClient.swift
@@ -373,6 +373,10 @@ final class CallingServiceClient {
         return call
     }
 
+    func stopCall(instanceId: String, callId: String) async throws {
+        try await performCallPut(instanceId: instanceId, pathComponents: ["call", callId, "stop"])
+    }
+
     func switchVideoOn(instanceId: String, callId: String) async throws {
         try await performCallPut(instanceId: instanceId, pathComponents: ["call", callId, "switchVideoOn"])
     }

--- a/wire-ios/WireUITests/ZCallingTests.swift
+++ b/wire-ios/WireUITests/ZCallingTests.swift
@@ -427,16 +427,16 @@ final class ZCallingTests: WireUITestCase {
             email: user1InactiveCallSetup.appUserReceivingCall.email,
             password: user1InactiveCallSetup.appUserReceivingCall.password
         )
-            .acceptPopup()
-            .openUserProfilePage()
-            .tapAddAccountOrTeamButton()
+        .acceptPopup()
+        .openUserProfilePage()
+        .tapAddAccountOrTeamButton()
 
         // Second user login - which will be active.
         _ = try app.loginUser(
             email: user2ActiveAccountSetup.appUserReceivingCall.email,
             password: user2ActiveAccountSetup.appUserReceivingCall.password
         )
-            .acceptPopup()
+        .acceptPopup()
 
         // WHEN
         let user1InactiveOwnerInstances = try await createCallingServiceInstances(

--- a/wire-ios/WireUITests/ZCallingTests.swift
+++ b/wire-ios/WireUITests/ZCallingTests.swift
@@ -90,16 +90,11 @@ final class ZCallingTests: WireUITestCase {
         return ongoingCallPage
     }
 
-    private func tapIncomingCallNotification(conversationName: String, callerName: String) {
+    private func tapIncomingCallNotification(conversationName: String) {
         let incomingCallPredicate = NSPredicate(
-            format: """
-            (label CONTAINS[c] %@ OR value CONTAINS[c] %@) AND
-            (label CONTAINS[c] %@ OR value CONTAINS[c] %@)
-            """,
+            format: "label CONTAINS[c] %@ OR value CONTAINS[c] %@",
             conversationName,
-            conversationName,
-            callerName,
-            callerName
+            conversationName
         )
         let springboardNotification = springboard.descendants(matching: .any)
             .matching(incomingCallPredicate)
@@ -422,15 +417,15 @@ final class ZCallingTests: WireUITestCase {
             email: user1InactiveAccountSetup.appUserReceivingCall.email,
             password: user1InactiveAccountSetup.appUserReceivingCall.password
         )
-            .acceptPopup()
-            .openUserProfilePage()
-            .tapAddAccountOrTeamButton()
+        .acceptPopup()
+        .openUserProfilePage()
+        .tapAddAccountOrTeamButton()
 
         _ = try app.loginUser(
             email: user2ActiveAccountSetup.appUserReceivingCall.email,
             password: user2ActiveAccountSetup.appUserReceivingCall.password
         )
-            .acceptPopup()
+        .acceptPopup()
 
         let user1InactiveOwnerInstances = try await createCallingServiceInstances(
             users: [user1InactiveAccountSetup.teamOwner]
@@ -443,22 +438,13 @@ final class ZCallingTests: WireUITestCase {
             conversationId: user1InactiveAccountSetup.conversationId
         )
 
-        // Tapping the incoming call notification switches from active account to inactive account while joining the call.
-        tapIncomingCallNotification(
-            conversationName: user1InactiveAccountSetup.groupName,
-            callerName: user1InactiveAccountSetup.teamOwner.name
-        )
+        // Tapping the incoming call notification switches from active account to inactive account while joining the
+        // call.
+        tapIncomingCallNotification(conversationName: user1InactiveAccountSetup.groupName)
         let ongoingCallPage = try acceptIncomingCall(groupName: user1InactiveAccountSetup.groupName)
 
         // THEN
         XCTAssertTrue(ongoingCallPage.timeLabel.waitForExistence(timeout: 10), "Call timer did not appear")
-        let groupCallTitle = app.staticTexts.matching(
-            NSPredicate(format: "label CONTAINS[c] %@", user1InactiveAccountSetup.groupName)
-        ).firstMatch
-        XCTAssertTrue(
-            groupCallTitle.exists,
-            "Call did not join to expected \(user1InactiveAccountSetup.groupName)"
-        )
 
         ongoingCallPage.endCallButton.tapAndWait()
         XCTAssertTrue(ongoingCallPage.timeLabel.waitForNonExistence(timeout: 5), "Call timer still visible")

--- a/wire-ios/WireUITests/ZCallingTests.swift
+++ b/wire-ios/WireUITests/ZCallingTests.swift
@@ -137,7 +137,6 @@ final class ZCallingTests: WireUITestCase {
     }
 
     /// Team Owner creates group conversation and initiates a group call with members via calling service
-    /// [critical]
     @MainActor
     func testMultipleUsersJoiningGroupCall_TC_8910_TC_8880() async throws {
 
@@ -291,7 +290,7 @@ final class ZCallingTests: WireUITestCase {
     }
 
     /// Call participant switches from audio call to video call and back
-    /// [critical]
+
     @MainActor
     func testSwitchBetweenAudioAndVideoCallAndShowsParticipantVideo_TC_8888_TC_9497() async throws {
 
@@ -361,7 +360,6 @@ final class ZCallingTests: WireUITestCase {
         )
     }
 
-    /// [critical]
     @MainActor
     func testParticipantCanSeeSharedScreen_TC_8891() async throws {
         // GIVEN
@@ -403,6 +401,7 @@ final class ZCallingTests: WireUITestCase {
             )
     }
 
+    /// [critical]
     @MainActor
     func testJoinCallForInactiveAndActiveAccountWhenAppInForeground_TC_8900_8897() async throws {
         // GIVEN

--- a/wire-ios/WireUITests/ZCallingTests.swift
+++ b/wire-ios/WireUITests/ZCallingTests.swift
@@ -137,6 +137,7 @@ final class ZCallingTests: WireUITestCase {
     }
 
     /// Team Owner creates group conversation and initiates a group call with members via calling service
+    /// [critical]
     @MainActor
     func testMultipleUsersJoiningGroupCall_TC_8910_TC_8880() async throws {
 
@@ -290,7 +291,7 @@ final class ZCallingTests: WireUITestCase {
     }
 
     /// Call participant switches from audio call to video call and back
-
+    /// [critical]
     @MainActor
     func testSwitchBetweenAudioAndVideoCallAndShowsParticipantVideo_TC_8888_TC_9497() async throws {
 
@@ -360,6 +361,7 @@ final class ZCallingTests: WireUITestCase {
         )
     }
 
+    /// [critical]
     @MainActor
     func testParticipantCanSeeSharedScreen_TC_8891() async throws {
         // GIVEN
@@ -401,7 +403,6 @@ final class ZCallingTests: WireUITestCase {
             )
     }
 
-    /// [critical]
     @MainActor
     func testJoinCallForInactiveAndActiveAccountWhenAppInForeground_TC_8900_8897() async throws {
         // GIVEN

--- a/wire-ios/WireUITests/ZCallingTests.swift
+++ b/wire-ios/WireUITests/ZCallingTests.swift
@@ -90,13 +90,16 @@ final class ZCallingTests: WireUITestCase {
         return ongoingCallPage
     }
 
-    private func tapIncomingCallNotification(conversationName: String) {
+    private func tapIncomingCallNotification(conversationName: String, callerName: String) {
         let incomingCallPredicate = NSPredicate(
-            format: "label CONTAINS[c] %@ OR value CONTAINS[c] %@ OR label CONTAINS[c] %@ OR value CONTAINS[c] %@",
+            format: """
+            (label CONTAINS[c] %@ OR value CONTAINS[c] %@) AND
+            (label CONTAINS[c] %@ OR value CONTAINS[c] %@)
+            """,
             conversationName,
             conversationName,
-            "calling",
-            "calling"
+            callerName,
+            callerName
         )
         let springboardNotification = springboard.descendants(matching: .any)
             .matching(incomingCallPredicate)
@@ -406,22 +409,28 @@ final class ZCallingTests: WireUITestCase {
     @MainActor
     func testJoinCallForInactiveAndActiveAccountWhenAppInForeground_TC_8900_8897() async throws {
         // GIVEN
-        let user1InactiveAccountSetup = try await makeTeamAndGroupCallSetup(memberCount: 1)
-        let user2ActiveAccountSetup = try await makeTeamAndGroupCallSetup(memberCount: 1)
+        let user1InactiveAccountSetup = try await makeTeamAndGroupCallSetup(
+            memberCount: 1,
+            groupName: "InactiveUserGroup"
+        )
+        let user2ActiveAccountSetup = try await makeTeamAndGroupCallSetup(
+            memberCount: 1,
+            groupName: "ActiveUserGroup"
+        )
 
         _ = try app.loginUser(
             email: user1InactiveAccountSetup.appUserReceivingCall.email,
             password: user1InactiveAccountSetup.appUserReceivingCall.password
         )
-        .acceptPopup()
-        .openUserProfilePage()
-        .tapAddAccountOrTeamButton()
+            .acceptPopup()
+            .openUserProfilePage()
+            .tapAddAccountOrTeamButton()
 
         _ = try app.loginUser(
             email: user2ActiveAccountSetup.appUserReceivingCall.email,
             password: user2ActiveAccountSetup.appUserReceivingCall.password
         )
-        .acceptPopup()
+            .acceptPopup()
 
         let user1InactiveOwnerInstances = try await createCallingServiceInstances(
             users: [user1InactiveAccountSetup.teamOwner]
@@ -434,11 +443,22 @@ final class ZCallingTests: WireUITestCase {
             conversationId: user1InactiveAccountSetup.conversationId
         )
 
-        tapIncomingCallNotification(conversationName: user1InactiveAccountSetup.groupName)
+        // Tapping the incoming call notification switches from active account to inactive account while joining the call.
+        tapIncomingCallNotification(
+            conversationName: user1InactiveAccountSetup.groupName,
+            callerName: user1InactiveAccountSetup.teamOwner.name
+        )
         let ongoingCallPage = try acceptIncomingCall(groupName: user1InactiveAccountSetup.groupName)
 
         // THEN
         XCTAssertTrue(ongoingCallPage.timeLabel.waitForExistence(timeout: 10), "Call timer did not appear")
+        let groupCallTitle = app.staticTexts.matching(
+            NSPredicate(format: "label CONTAINS[c] %@", user1InactiveAccountSetup.groupName)
+        ).firstMatch
+        XCTAssertTrue(
+            groupCallTitle.exists,
+            "Call did not join to expected \(user1InactiveAccountSetup.groupName)"
+        )
 
         ongoingCallPage.endCallButton.tapAndWait()
         XCTAssertTrue(ongoingCallPage.timeLabel.waitForNonExistence(timeout: 5), "Call timer still visible")

--- a/wire-ios/WireUITests/ZCallingTests.swift
+++ b/wire-ios/WireUITests/ZCallingTests.swift
@@ -116,19 +116,6 @@ final class ZCallingTests: WireUITestCase {
         )
     }
 
-    private func startCallAndAccept(
-        ownerInstanceId: String,
-        conversationId: String,
-        groupName: String
-    ) async throws -> OngoingCallPage {
-        _ = try await callingServiceClient.startCall(
-            instanceId: ownerInstanceId,
-            conversationId: conversationId
-        )
-
-        return try acceptIncomingCall(groupName: groupName)
-    }
-
     private func verifyOngoingCallBannerAndResume(
         ongoingCallPage: OngoingCallPage,
         conversationName: String
@@ -417,42 +404,55 @@ final class ZCallingTests: WireUITestCase {
     }
 
     @MainActor
-    func testJoinCallForInactiveAccountWhenOtherAccountIsActiveInForeground_TC_8900() async throws {
+    func testJoinCallForInactiveAndActiveAccountWhenAppInForeground_TC_8900_8897() async throws {
         // GIVEN
-        let user1InactiveCallSetup = try await makeTeamAndGroupCallSetup(memberCount: 1)
+        let user1InactiveAccountSetup = try await makeTeamAndGroupCallSetup(memberCount: 1)
         let user2ActiveAccountSetup = try await makeTeamAndGroupCallSetup(memberCount: 1)
 
-        // First user login - which will be inactive.
         _ = try app.loginUser(
-            email: user1InactiveCallSetup.appUserReceivingCall.email,
-            password: user1InactiveCallSetup.appUserReceivingCall.password
+            email: user1InactiveAccountSetup.appUserReceivingCall.email,
+            password: user1InactiveAccountSetup.appUserReceivingCall.password
         )
         .acceptPopup()
         .openUserProfilePage()
         .tapAddAccountOrTeamButton()
 
-        // Second user login - which will be active.
         _ = try app.loginUser(
             email: user2ActiveAccountSetup.appUserReceivingCall.email,
             password: user2ActiveAccountSetup.appUserReceivingCall.password
         )
         .acceptPopup()
 
-        // WHEN
         let user1InactiveOwnerInstances = try await createCallingServiceInstances(
-            users: [user1InactiveCallSetup.teamOwner]
+            users: [user1InactiveAccountSetup.teamOwner]
         )
         let user1InactiveOwnerInstanceId = try requireOwnerInstanceId(from: user1InactiveOwnerInstances)
 
+        // WHEN - inactive account receives a call while app is in foreground.
         _ = try await callingServiceClient.startCall(
             instanceId: user1InactiveOwnerInstanceId,
-            conversationId: user1InactiveCallSetup.conversationId
+            conversationId: user1InactiveAccountSetup.conversationId
         )
 
-        tapIncomingCallNotification(conversationName: user1InactiveCallSetup.groupName)
-        let ongoingCallPage = try acceptIncomingCall(groupName: user1InactiveCallSetup.groupName)
+        tapIncomingCallNotification(conversationName: user1InactiveAccountSetup.groupName)
+        let ongoingCallPage = try acceptIncomingCall(groupName: user1InactiveAccountSetup.groupName)
 
         // THEN
         XCTAssertTrue(ongoingCallPage.timeLabel.waitForExistence(timeout: 10), "Call timer did not appear")
+
+        ongoingCallPage.endCallButton.tapAndWait()
+        XCTAssertTrue(ongoingCallPage.timeLabel.waitForNonExistence(timeout: 5), "Call timer still visible")
+        try await callingManager.stopCurrentCall(instanceId: user1InactiveOwnerInstanceId)
+
+        // WHEN - same account receives a call while active and app is in foreground.
+        _ = try await callingServiceClient.startCall(
+            instanceId: user1InactiveOwnerInstanceId,
+            conversationId: user1InactiveAccountSetup.conversationId
+        )
+
+        let activeAccountOngoingCallPage = try acceptIncomingCall(groupName: user1InactiveAccountSetup.groupName)
+
+        // THEN
+        XCTAssertTrue(activeAccountOngoingCallPage.timeLabel.waitForExistence(timeout: 10), "Call timer did not appear")
     }
 }

--- a/wire-ios/WireUITests/ZCallingTests.swift
+++ b/wire-ios/WireUITests/ZCallingTests.swift
@@ -90,6 +90,32 @@ final class ZCallingTests: WireUITestCase {
         return ongoingCallPage
     }
 
+    private func tapIncomingCallNotification(conversationName: String) {
+        let incomingCallPredicate = NSPredicate(
+            format: "label CONTAINS[c] %@ OR value CONTAINS[c] %@ OR label CONTAINS[c] %@ OR value CONTAINS[c] %@",
+            conversationName,
+            conversationName,
+            "calling",
+            "calling"
+        )
+        let springboardNotification = springboard.descendants(matching: .any)
+            .matching(incomingCallPredicate)
+            .firstMatch
+
+        if springboardNotification.waitAndTap(timeout: 15) {
+            return
+        }
+
+        let appNotification = app.descendants(matching: .any)
+            .matching(incomingCallPredicate)
+            .firstMatch
+
+        XCTAssertTrue(
+            appNotification.waitAndTap(timeout: 3),
+            "Incoming call notification did not appear"
+        )
+    }
+
     private func startCallAndAccept(
         ownerInstanceId: String,
         conversationId: String,
@@ -396,12 +422,6 @@ final class ZCallingTests: WireUITestCase {
         let backgroundCallSetup = try await makeTeamAndGroupCallSetup(memberCount: 1)
         let foregroundCallSetup = try await makeTeamAndGroupCallSetup(memberCount: 1)
 
-        let backgroundOwnerInstances = try await createCallingServiceInstances(users: [backgroundCallSetup.teamOwner])
-        let backgroundOwnerInstanceId = try requireOwnerInstanceId(from: backgroundOwnerInstances)
-
-        let foregroundOwnerInstances = try await createCallingServiceInstances(users: [foregroundCallSetup.teamOwner])
-        let foregroundOwnerInstanceId = try requireOwnerInstanceId(from: foregroundOwnerInstances)
-
         _ = try app.loginUser(
             email: backgroundCallSetup.appUserReceivingCall.email,
             password: backgroundCallSetup.appUserReceivingCall.password
@@ -416,47 +436,64 @@ final class ZCallingTests: WireUITestCase {
         )
             .acceptPopup()
 
-        XCTAssertTrue(
-            try ConversationsPage()
-                .conversationCell(named: foregroundCallSetup.groupName)
-                .waitForExistence(timeout: 10),
-            "Foreground account group conversation did not appear"
-        )
-
-        // WHEN - inactive account receives a call while the app is in background.
-        await XCUIDevice.shared.press(.home)
-        try await Task.sleep(for: .seconds(2))
+        let backgroundOwnerInstances = try await createCallingServiceInstances(users: [backgroundCallSetup.teamOwner])
+        let backgroundOwnerInstanceId = try requireOwnerInstanceId(from: backgroundOwnerInstances)
 
         _ = try await callingServiceClient.startCall(
             instanceId: backgroundOwnerInstanceId,
             conversationId: backgroundCallSetup.conversationId
         )
 
-        await app.activate()
-        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 5), "App did not return to foreground")
-
+        tapIncomingCallNotification(conversationName: backgroundCallSetup.groupName)
         var ongoingCallPage = try acceptIncomingCall(groupName: backgroundCallSetup.groupName)
 
-        // THEN
-        ongoingCallPage = try verifyOngoingCallBannerAndResume(
-            ongoingCallPage: ongoingCallPage,
-            conversationName: backgroundCallSetup.groupName
-        )
-        let activeConversationPage = try ongoingCallPage.hangUpOngoingCall()
-        try activeConversationPage.verifyNoCallOngoingAfterHangUp()
+        XCTAssertTrue(ongoingCallPage.timeLabel.waitForExistence(timeout: 10), "Call timer did not appear")
+//        XCTAssertTrue(
+//            ongoingCallPage.conversationTitleButton.label.contains(conversationName),
+//            "Account did not switch to the expected call conversation"
+//        )
 
-        // WHEN - inactive account receives a call while the app is in foreground.
-        ongoingCallPage = try await startCallAndAccept(
-            ownerInstanceId: foregroundOwnerInstanceId,
-            conversationId: foregroundCallSetup.conversationId,
-            groupName: foregroundCallSetup.groupName
-        )
+//        let foregroundOwnerInstances = try await createCallingServiceInstances(users: [foregroundCallSetup.teamOwner])
+//        let foregroundOwnerInstanceId = try requireOwnerInstanceId(from: foregroundOwnerInstances)
 
-        // THEN
-        ongoingCallPage = try verifyOngoingCallBannerAndResume(
-            ongoingCallPage: ongoingCallPage,
-            conversationName: foregroundCallSetup.groupName
-        )
-        _ = try ongoingCallPage.hangUpOngoingCall()
+//        XCTAssertTrue(
+//            try ConversationsPage()
+//                .conversationCell(named: foregroundCallSetup.groupName)
+//                .waitForExistence(timeout: 10),
+//            "Foreground account group conversation did not appear"
+//        )
+
+        // WHEN - inactive account receives a call while the app is in background.
+//        await XCUIDevice.shared.press(.home)
+//        try await Task.sleep(for: .seconds(2))
+//
+//
+//
+//        await app.activate()
+//        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 5), "App did not return to foreground")
+
+
+
+//        // THEN
+//        ongoingCallPage = try verifyOngoingCallBannerAndResume(
+//            ongoingCallPage: ongoingCallPage,
+//            conversationName: backgroundCallSetup.groupName
+//        )
+//        let activeConversationPage = try ongoingCallPage.hangUpOngoingCall()
+//        try activeConversationPage.verifyNoCallOngoingAfterHangUp()
+//
+//        // WHEN - inactive account receives a call while the app is in foreground.
+//        ongoingCallPage = try await startCallAndAccept(
+//            ownerInstanceId: foregroundOwnerInstanceId,
+//            conversationId: foregroundCallSetup.conversationId,
+//            groupName: foregroundCallSetup.groupName
+//        )
+//
+//        // THEN
+//        ongoingCallPage = try verifyOngoingCallBannerAndResume(
+//            ongoingCallPage: ongoingCallPage,
+//            conversationName: foregroundCallSetup.groupName
+//        )
+//        _ = try ongoingCallPage.hangUpOngoingCall()
     }
 }

--- a/wire-ios/WireUITests/ZCallingTests.swift
+++ b/wire-ios/WireUITests/ZCallingTests.swift
@@ -417,83 +417,42 @@ final class ZCallingTests: WireUITestCase {
     }
 
     @MainActor
-    func testJoinCallForInactiveAccountInForegroundAndActiveAccountInBackground_TC_8900_TC_8898() async throws {
+    func testJoinCallForInactiveAccountWhenOtherAccountIsActiveInForeground_TC_8900() async throws {
         // GIVEN
-        let backgroundCallSetup = try await makeTeamAndGroupCallSetup(memberCount: 1)
-        let foregroundCallSetup = try await makeTeamAndGroupCallSetup(memberCount: 1)
+        let user1InactiveCallSetup = try await makeTeamAndGroupCallSetup(memberCount: 1)
+        let user2ActiveAccountSetup = try await makeTeamAndGroupCallSetup(memberCount: 1)
 
+        // First user login - which will be inactive.
         _ = try app.loginUser(
-            email: backgroundCallSetup.appUserReceivingCall.email,
-            password: backgroundCallSetup.appUserReceivingCall.password
+            email: user1InactiveCallSetup.appUserReceivingCall.email,
+            password: user1InactiveCallSetup.appUserReceivingCall.password
         )
             .acceptPopup()
             .openUserProfilePage()
             .tapAddAccountOrTeamButton()
 
+        // Second user login - which will be active.
         _ = try app.loginUser(
-            email: foregroundCallSetup.appUserReceivingCall.email,
-            password: foregroundCallSetup.appUserReceivingCall.password
+            email: user2ActiveAccountSetup.appUserReceivingCall.email,
+            password: user2ActiveAccountSetup.appUserReceivingCall.password
         )
             .acceptPopup()
 
-        let backgroundOwnerInstances = try await createCallingServiceInstances(users: [backgroundCallSetup.teamOwner])
-        let backgroundOwnerInstanceId = try requireOwnerInstanceId(from: backgroundOwnerInstances)
+        // WHEN
+        let user1InactiveOwnerInstances = try await createCallingServiceInstances(
+            users: [user1InactiveCallSetup.teamOwner]
+        )
+        let user1InactiveOwnerInstanceId = try requireOwnerInstanceId(from: user1InactiveOwnerInstances)
 
         _ = try await callingServiceClient.startCall(
-            instanceId: backgroundOwnerInstanceId,
-            conversationId: backgroundCallSetup.conversationId
+            instanceId: user1InactiveOwnerInstanceId,
+            conversationId: user1InactiveCallSetup.conversationId
         )
 
-        tapIncomingCallNotification(conversationName: backgroundCallSetup.groupName)
-        var ongoingCallPage = try acceptIncomingCall(groupName: backgroundCallSetup.groupName)
+        tapIncomingCallNotification(conversationName: user1InactiveCallSetup.groupName)
+        let ongoingCallPage = try acceptIncomingCall(groupName: user1InactiveCallSetup.groupName)
 
+        // THEN
         XCTAssertTrue(ongoingCallPage.timeLabel.waitForExistence(timeout: 10), "Call timer did not appear")
-//        XCTAssertTrue(
-//            ongoingCallPage.conversationTitleButton.label.contains(conversationName),
-//            "Account did not switch to the expected call conversation"
-//        )
-
-//        let foregroundOwnerInstances = try await createCallingServiceInstances(users: [foregroundCallSetup.teamOwner])
-//        let foregroundOwnerInstanceId = try requireOwnerInstanceId(from: foregroundOwnerInstances)
-
-//        XCTAssertTrue(
-//            try ConversationsPage()
-//                .conversationCell(named: foregroundCallSetup.groupName)
-//                .waitForExistence(timeout: 10),
-//            "Foreground account group conversation did not appear"
-//        )
-
-        // WHEN - inactive account receives a call while the app is in background.
-//        await XCUIDevice.shared.press(.home)
-//        try await Task.sleep(for: .seconds(2))
-//
-//
-//
-//        await app.activate()
-//        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 5), "App did not return to foreground")
-
-
-
-//        // THEN
-//        ongoingCallPage = try verifyOngoingCallBannerAndResume(
-//            ongoingCallPage: ongoingCallPage,
-//            conversationName: backgroundCallSetup.groupName
-//        )
-//        let activeConversationPage = try ongoingCallPage.hangUpOngoingCall()
-//        try activeConversationPage.verifyNoCallOngoingAfterHangUp()
-//
-//        // WHEN - inactive account receives a call while the app is in foreground.
-//        ongoingCallPage = try await startCallAndAccept(
-//            ownerInstanceId: foregroundOwnerInstanceId,
-//            conversationId: foregroundCallSetup.conversationId,
-//            groupName: foregroundCallSetup.groupName
-//        )
-//
-//        // THEN
-//        ongoingCallPage = try verifyOngoingCallBannerAndResume(
-//            ongoingCallPage: ongoingCallPage,
-//            conversationName: foregroundCallSetup.groupName
-//        )
-//        _ = try ongoingCallPage.hangUpOngoingCall()
     }
 }

--- a/wire-ios/WireUITests/ZCallingTests.swift
+++ b/wire-ios/WireUITests/ZCallingTests.swift
@@ -82,9 +82,45 @@ final class ZCallingTests: WireUITestCase {
         XCTAssertTrue(incomingCallPage.acceptButton.exists, "Expected call not received")
 
         let ongoingCallPage = try incomingCallPage.acceptIncommingCall()
-        XCTAssertTrue(app.staticTexts[groupName].waitForExistence(timeout: 10), "Conversation title mismatch")
+        let conversationTitle = app.staticTexts.matching(
+            NSPredicate(format: "label CONTAINS[c] %@", groupName)
+        ).firstMatch
+        XCTAssertTrue(conversationTitle.waitForExistence(timeout: 10), "Conversation title mismatch")
 
         return ongoingCallPage
+    }
+
+    private func startCallAndAccept(
+        ownerInstanceId: String,
+        conversationId: String,
+        groupName: String
+    ) async throws -> OngoingCallPage {
+        _ = try await callingServiceClient.startCall(
+            instanceId: ownerInstanceId,
+            conversationId: conversationId
+        )
+
+        return try acceptIncomingCall(groupName: groupName)
+    }
+
+    private func verifyOngoingCallBannerAndResume(
+        ongoingCallPage: OngoingCallPage,
+        conversationName: String
+    ) throws -> OngoingCallPage {
+        XCTAssertTrue(ongoingCallPage.timeLabel.waitForExistence(timeout: 10), "Call timer did not appear")
+
+        let activeConversationPage = try ongoingCallPage.minimizeCallUI()
+
+        XCTAssertTrue(
+            activeConversationPage.openOngoingCallButton.waitForExistence(timeout: 5),
+            "Ongoing call banner did not appear"
+        )
+        XCTAssertTrue(
+            activeConversationPage.conversationTitleButton.label.contains(conversationName),
+            "Account did not switch to the expected call conversation"
+        )
+
+        return try activeConversationPage.resumeCallUI()
     }
 
     /// Team Owner creates group conversation and initiates a group call with members via calling service
@@ -352,5 +388,75 @@ final class ZCallingTests: WireUITestCase {
                     "http://screen-bottom"
                 ]
             )
+    }
+
+    @MainActor
+    func testJoinCallForInactiveAccountInForegroundAndActiveAccountInBackground_TC_8900_TC_8898() async throws {
+        // GIVEN
+        let backgroundCallSetup = try await makeTeamAndGroupCallSetup(memberCount: 1)
+        let foregroundCallSetup = try await makeTeamAndGroupCallSetup(memberCount: 1)
+
+        let backgroundOwnerInstances = try await createCallingServiceInstances(users: [backgroundCallSetup.teamOwner])
+        let backgroundOwnerInstanceId = try requireOwnerInstanceId(from: backgroundOwnerInstances)
+
+        let foregroundOwnerInstances = try await createCallingServiceInstances(users: [foregroundCallSetup.teamOwner])
+        let foregroundOwnerInstanceId = try requireOwnerInstanceId(from: foregroundOwnerInstances)
+
+        _ = try app.loginUser(
+            email: backgroundCallSetup.appUserReceivingCall.email,
+            password: backgroundCallSetup.appUserReceivingCall.password
+        )
+            .acceptPopup()
+            .openUserProfilePage()
+            .tapAddAccountOrTeamButton()
+
+        _ = try app.loginUser(
+            email: foregroundCallSetup.appUserReceivingCall.email,
+            password: foregroundCallSetup.appUserReceivingCall.password
+        )
+            .acceptPopup()
+
+        XCTAssertTrue(
+            try ConversationsPage()
+                .conversationCell(named: foregroundCallSetup.groupName)
+                .waitForExistence(timeout: 10),
+            "Foreground account group conversation did not appear"
+        )
+
+        // WHEN - inactive account receives a call while the app is in background.
+        await XCUIDevice.shared.press(.home)
+        try await Task.sleep(for: .seconds(2))
+
+        _ = try await callingServiceClient.startCall(
+            instanceId: backgroundOwnerInstanceId,
+            conversationId: backgroundCallSetup.conversationId
+        )
+
+        await app.activate()
+        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 5), "App did not return to foreground")
+
+        var ongoingCallPage = try acceptIncomingCall(groupName: backgroundCallSetup.groupName)
+
+        // THEN
+        ongoingCallPage = try verifyOngoingCallBannerAndResume(
+            ongoingCallPage: ongoingCallPage,
+            conversationName: backgroundCallSetup.groupName
+        )
+        let activeConversationPage = try ongoingCallPage.hangUpOngoingCall()
+        try activeConversationPage.verifyNoCallOngoingAfterHangUp()
+
+        // WHEN - inactive account receives a call while the app is in foreground.
+        ongoingCallPage = try await startCallAndAccept(
+            ownerInstanceId: foregroundOwnerInstanceId,
+            conversationId: foregroundCallSetup.conversationId,
+            groupName: foregroundCallSetup.groupName
+        )
+
+        // THEN
+        ongoingCallPage = try verifyOngoingCallBannerAndResume(
+            ongoingCallPage: ongoingCallPage,
+            conversationName: foregroundCallSetup.groupName
+        )
+        _ = try ongoingCallPage.hangUpOngoingCall()
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27068" title="WPB-27068" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-27068</a>  [iOS] Automate - calling test - multiple account and accepting call on inactive account
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

TC-8900  As a user, I can join the call on inactive account and app foreground with other account as active in case of multiple account added

TC-8897 As a user, I can join the call on active account and app foreground when multiple account added


------
1. Two team setups, distinct groupName (Inactive/Active) 
2. Login user1 → add account → login user2 (user2 becomes active, user1 inactive).
3. Call rings on user1 (inactive) while app foreground → tap notification (switches active account to user1) → accept → assert.
4. End call, stop instance. user1 now the active account due to switch.
5. Second call on same user1 (now active) → acceptIncomingCall -> assert


### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._


https://github.com/user-attachments/assets/fcfd539c-7b12-4cc4-9b7b-90d5fdc98dd7

CI: https://github.com/wireapp/wire-ios/actions/runs/31170975679
<img width="1767" height="814" alt="image" src="https://github.com/user-attachments/assets/023617ba-ffe4-4a96-8571-d36771cb02cc" />


---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
