### PR TITLE
fix: mls migration doesn't start after relaunch - WPB-27049

### DIFF
--- a/wire-ios-sync-engine/Source/SessionManager/UserSessionLoader.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/UserSessionLoader.swift
@@ -489,6 +489,7 @@ final class UserSessionLoader {
             apiVersion: WireTransport.APIVersion(rawValue: Int32(backendMetadata.apiVersion.rawValue))
         )
         let recurringActionService = RecurringActionService(
+            userID: accountID,
             storage: sharedUserDefaults,
             dateProvider: .system
         )

--- a/wire-ios-sync-engine/Source/Synchronization/RecurringActionService/RecurringAction.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/RecurringActionService/RecurringAction.swift
@@ -21,7 +21,7 @@ import Foundation
 struct RecurringAction {
 
     let id: String
-    let shouldRunOncePerLaunch: Bool
+    let shouldRunEveryLaunch: Bool
     let interval: TimeInterval
     let perform: () async -> Void
 

--- a/wire-ios-sync-engine/Source/Synchronization/RecurringActionService/RecurringAction.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/RecurringActionService/RecurringAction.swift
@@ -21,6 +21,7 @@ import Foundation
 struct RecurringAction {
 
     let id: String
+    let shouldRunOncePerLaunch: Bool
     let interval: TimeInterval
     let perform: () async -> Void
 

--- a/wire-ios-sync-engine/Source/Synchronization/RecurringActionService/RecurringActionService.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/RecurringActionService/RecurringActionService.swift
@@ -22,17 +22,28 @@ import WireUtilities
 
 final class RecurringActionService: RecurringActionServiceInterface {
 
+    private struct LastCheckDateKey: DefaultsKey {
+
+        let actionID: String
+
+        var rawValue: String {
+            "lastCheckDate_\(actionID)"
+        }
+
+    }
+
     // MARK: - Properties
 
     private(set) var actionsByID = [String: RecurringAction]()
-    private let storage: UserDefaults
+    private let storage: PrivateUserDefaults<LastCheckDateKey>
     private let dateProvider: CurrentDateProviding
 
     public init(
+        userID: UUID,
         storage: UserDefaults,
         dateProvider: CurrentDateProviding
     ) {
-        self.storage = storage
+        self.storage = PrivateUserDefaults(userID: userID, storage: storage)
         self.dateProvider = dateProvider
     }
 
@@ -72,8 +83,8 @@ final class RecurringActionService: RecurringActionServiceInterface {
 
     // MARK: - Helpers
 
-    private func key(for actionID: String) -> String {
-        "lastCheckDate_\(actionID)"
+    private func key(for actionID: String) -> LastCheckDateKey {
+        LastCheckDateKey(actionID: actionID)
     }
 
     private func lastCheckDate(for actionID: String) -> Date? {
@@ -82,5 +93,9 @@ final class RecurringActionService: RecurringActionServiceInterface {
 
     func persistLastCheckDate(for actionID: String) {
         storage.set(dateProvider.now, forKey: key(for: actionID))
+    }
+
+    private func clearLastCheckDate(for actionID: String) {
+        storage.removeObject(forKey: key(for: actionID))
     }
 }

--- a/wire-ios-sync-engine/Source/Synchronization/RecurringActionService/RecurringActionService.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/RecurringActionService/RecurringActionService.swift
@@ -40,6 +40,10 @@ final class RecurringActionService: RecurringActionServiceInterface {
 
     public func registerAction(_ action: RecurringAction) {
         actionsByID[action.id] = action
+
+        if action.shouldRunOncePerLaunch {
+            clearLastCheckDate(for: action.id)
+        }
     }
 
     public func performActionsIfNeeded() async {

--- a/wire-ios-sync-engine/Source/Synchronization/RecurringActionService/RecurringActionService.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/RecurringActionService/RecurringActionService.swift
@@ -52,7 +52,7 @@ final class RecurringActionService: RecurringActionServiceInterface {
     public func registerAction(_ action: RecurringAction) {
         actionsByID[action.id] = action
 
-        if action.shouldRunOncePerLaunch {
+        if action.shouldRunEveryLaunch {
             clearLastCheckDate(for: action.id)
         }
     }

--- a/wire-ios-sync-engine/Source/Use cases/SnoozeCertificateEnrollmentUseCase.swift
+++ b/wire-ios-sync-engine/Source/Use cases/SnoozeCertificateEnrollmentUseCase.swift
@@ -70,6 +70,7 @@ final class SnoozeCertificateEnrollmentUseCase: SnoozeCertificateEnrollmentUseCa
 
         let recurringAction = RecurringAction(
             id: actionId,
+            shouldRunOncePerLaunch: false,
             interval: interval
         ) {
             if isUpdateMode {

--- a/wire-ios-sync-engine/Source/Use cases/SnoozeCertificateEnrollmentUseCase.swift
+++ b/wire-ios-sync-engine/Source/Use cases/SnoozeCertificateEnrollmentUseCase.swift
@@ -70,7 +70,7 @@ final class SnoozeCertificateEnrollmentUseCase: SnoozeCertificateEnrollmentUseCa
 
         let recurringAction = RecurringAction(
             id: actionId,
-            shouldRunOncePerLaunch: false,
+            shouldRunEveryLaunch: false,
             interval: interval
         ) {
             if isUpdateMode {

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+RecurringAction.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+RecurringAction.swift
@@ -25,7 +25,7 @@ extension ZMUserSession {
     var updateProteusToMLSMigrationStatusAction: RecurringAction {
         .init(
             id: #function,
-            shouldRunOncePerLaunch: true,
+            shouldRunEveryLaunch: true,
             interval: .oneDay
         ) { [weak self] in
             guard
@@ -49,7 +49,7 @@ extension ZMUserSession {
     var refreshUsersMissingMetadataAction: RecurringAction {
         .init(
             id: #function,
-            shouldRunOncePerLaunch: false,
+            shouldRunEveryLaunch: false,
             interval: 3 * .oneHour
         ) { [weak self] in
             guard let context = self?.syncContext else {
@@ -72,7 +72,7 @@ extension ZMUserSession {
     var refreshConversationsMissingMetadataAction: RecurringAction {
         .init(
             id: #function,
-            shouldRunOncePerLaunch: false,
+            shouldRunEveryLaunch: false,
             interval: 3 * .oneHour
         ) { [weak self] in
             guard let context = self?.syncContext else {
@@ -96,7 +96,7 @@ extension ZMUserSession {
     var refreshTeamMetadataAction: RecurringAction {
         .init(
             id: #function,
-            shouldRunOncePerLaunch: false,
+            shouldRunEveryLaunch: false,
             interval: .oneDay
         ) { [weak self] in
             guard let context = self?.syncContext else {
@@ -115,7 +115,7 @@ extension ZMUserSession {
     var refreshFederationCertificatesAction: RecurringAction {
         .init(
             id: #function,
-            shouldRunOncePerLaunch: false,
+            shouldRunEveryLaunch: false,
             interval: .oneDay
         ) { [weak self] in
             do {

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+RecurringAction.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+RecurringAction.swift
@@ -23,7 +23,11 @@ import WireLogging
 extension ZMUserSession {
 
     var updateProteusToMLSMigrationStatusAction: RecurringAction {
-        .init(id: #function, interval: .oneDay) { [weak self] in
+        .init(
+            id: #function,
+            shouldRunOncePerLaunch: true,
+            interval: .oneDay
+        ) { [weak self] in
             guard
                 let self,
                 await viewContext.perform({ self.mlsFeature.isEnabled })
@@ -43,7 +47,11 @@ extension ZMUserSession {
     }
 
     var refreshUsersMissingMetadataAction: RecurringAction {
-        .init(id: #function, interval: 3 * .oneHour) { [weak self] in
+        .init(
+            id: #function,
+            shouldRunOncePerLaunch: false,
+            interval: 3 * .oneHour
+        ) { [weak self] in
             guard let context = self?.syncContext else {
                 return
             }
@@ -62,7 +70,11 @@ extension ZMUserSession {
     }
 
     var refreshConversationsMissingMetadataAction: RecurringAction {
-        .init(id: #function, interval: 3 * .oneHour) { [weak self] in
+        .init(
+            id: #function,
+            shouldRunOncePerLaunch: false,
+            interval: 3 * .oneHour
+        ) { [weak self] in
             guard let context = self?.syncContext else {
                 return
             }
@@ -82,7 +94,11 @@ extension ZMUserSession {
     }
 
     var refreshTeamMetadataAction: RecurringAction {
-        .init(id: #function, interval: .oneDay) { [weak self] in
+        .init(
+            id: #function,
+            shouldRunOncePerLaunch: false,
+            interval: .oneDay
+        ) { [weak self] in
             guard let context = self?.syncContext else {
                 return
             }
@@ -97,7 +113,11 @@ extension ZMUserSession {
     }
 
     var refreshFederationCertificatesAction: RecurringAction {
-        .init(id: #function, interval: .oneDay) { [weak self] in
+        .init(
+            id: #function,
+            shouldRunOncePerLaunch: false,
+            interval: .oneDay
+        ) { [weak self] in
             do {
                 guard let self else { return }
 

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSessionBuilder.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSessionBuilder.swift
@@ -256,6 +256,7 @@ struct ZMUserSessionBuilder {
             apiVersion: BackendInfo.apiVersion
         )
         let recurringActionService = recurringActionService ?? RecurringActionService(
+            userID: userId,
             storage: sharedUserDefaults,
             dateProvider: .system
         )

--- a/wire-ios-sync-engine/Support/Sources/Synchronization/RecurringActionService/RecurringAction+dummy.swift
+++ b/wire-ios-sync-engine/Support/Sources/Synchronization/RecurringActionService/RecurringAction+dummy.swift
@@ -21,6 +21,10 @@
 extension RecurringAction {
 
     static var dummy: Self {
-        .init(id: .randomAlphanumerical(length: 16), interval: .infinity) {}
+        .init(
+            id: .randomAlphanumerical(length: 16),
+            shouldRunOncePerLaunch: false,
+            interval: .infinity
+        ) {}
     }
 }

--- a/wire-ios-sync-engine/Support/Sources/Synchronization/RecurringActionService/RecurringAction+dummy.swift
+++ b/wire-ios-sync-engine/Support/Sources/Synchronization/RecurringActionService/RecurringAction+dummy.swift
@@ -23,7 +23,7 @@ extension RecurringAction {
     static var dummy: Self {
         .init(
             id: .randomAlphanumerical(length: 16),
-            shouldRunOncePerLaunch: false,
+            shouldRunEveryLaunch: false,
             interval: .infinity
         ) {}
     }

--- a/wire-ios-sync-engine/Tests/Source/UserSession/RecurringActionServiceTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/RecurringActionServiceTests.swift
@@ -52,9 +52,14 @@ final class RecurringActionServiceTests: XCTestCase {
     func testThatItPerformsActionInitially() async {
         // Given
         var actionPerformed = false
-        sut.registerAction(.init(id: .randomAlphanumerical(length: 5), interval: 1) {
-            actionPerformed = true
-        })
+        sut.registerAction(
+            .init(
+                id: .randomAlphanumerical(length: 5),
+                shouldRunOncePerLaunch: false,
+                interval: 1,
+                perform: { actionPerformed = true }
+            )
+        )
 
         // When
         await sut.performActionsIfNeeded()
@@ -66,9 +71,14 @@ final class RecurringActionServiceTests: XCTestCase {
     func testThatItDoesNotPerformActionTooEarly() async {
         // Given
         var actionPerformed = false
-        sut.registerAction(.init(id: .randomAlphanumerical(length: 5), interval: 3) {
-            actionPerformed = true
-        })
+        sut.registerAction(
+            .init(
+                id: .randomAlphanumerical(length: 5),
+                shouldRunOncePerLaunch: false,
+                interval: 3,
+                perform: { actionPerformed = true }
+            )
+        )
 
         // When
         await sut.performActionsIfNeeded()
@@ -86,9 +96,14 @@ final class RecurringActionServiceTests: XCTestCase {
         let actionID = String.randomAlphanumerical(length: 5)
 
         sut.persistLastCheckDate(for: actionID)
-        sut.registerAction(.init(id: actionID, interval: 100) {
-            actionPerformed = true
-        })
+        sut.registerAction(
+            .init(
+                id: actionID,
+                shouldRunOncePerLaunch: false,
+                interval: 100,
+                perform: { actionPerformed = true }
+            )
+        )
 
         XCTAssertFalse(actionPerformed)
 
@@ -102,9 +117,14 @@ final class RecurringActionServiceTests: XCTestCase {
     func testThatItPerformsActionAgain() async {
         // Given
         var actionPerformed = false
-        sut.registerAction(.init(id: .randomAlphanumerical(length: 5), interval: 3) {
-            actionPerformed = true
-        })
+        sut.registerAction(
+            .init(
+                id: .randomAlphanumerical(length: 5),
+                shouldRunOncePerLaunch: false,
+                interval: 3,
+                perform: { actionPerformed = true }
+            )
+        )
 
         // When
         await sut.performActionsIfNeeded()

--- a/wire-ios-sync-engine/Tests/Source/UserSession/RecurringActionServiceTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/RecurringActionServiceTests.swift
@@ -36,6 +36,7 @@ final class RecurringActionServiceTests: XCTestCase {
         dateProvider = .init()
         dateProvider.now = .now.addingTimeInterval(-.oneDay)
         sut = RecurringActionService(
+            userID: UUID(),
             storage: userDefaults,
             dateProvider: dateProvider
         )

--- a/wire-ios-sync-engine/Tests/Source/UserSession/RecurringActionServiceTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/RecurringActionServiceTests.swift
@@ -288,37 +288,6 @@ final class RecurringActionServiceTests: XCTestCase {
         // Then - User 2's action also performed (not blocked by user 1's action)
         XCTAssertEqual(user1ActionPerformedCount, 1)
         XCTAssertEqual(user2ActionPerformedCount, 1)
-
-        // When - User 1 tries again without time passing
-        await service1.performActionsIfNeeded()
-
-        // Then - User 1's action not performed again
-        XCTAssertEqual(user1ActionPerformedCount, 1)
-        XCTAssertEqual(user2ActionPerformedCount, 1)
-
-        // When - User 2 tries again without time passing
-        await service2.performActionsIfNeeded()
-
-        // Then - User 2's action not performed again
-        XCTAssertEqual(user1ActionPerformedCount, 1)
-        XCTAssertEqual(user2ActionPerformedCount, 1)
-
-        // When - Time passes over the interval
-        dateProvider.now += .oneDay + .fiveMinutes
-
-        // When - User 1 tries again
-        await service1.performActionsIfNeeded()
-
-        // Then - User 1's action is peformed again, but not User 2's
-        XCTAssertEqual(user1ActionPerformedCount, 2)
-        XCTAssertEqual(user2ActionPerformedCount, 1)
-
-        // When - User 2 tries again
-        await service2.performActionsIfNeeded()
-
-        // Then - User 2's action is peformed again as well
-        XCTAssertEqual(user1ActionPerformedCount, 2)
-        XCTAssertEqual(user2ActionPerformedCount, 2)
     }
 
     func testThatOncePerLaunchActionsAreScopedToUserID() async {

--- a/wire-ios-sync-engine/Tests/Source/UserSession/RecurringActionServiceTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/RecurringActionServiceTests.swift
@@ -56,7 +56,7 @@ final class RecurringActionServiceTests: XCTestCase {
         sut.registerAction(
             .init(
                 id: .randomAlphanumerical(length: 5),
-                shouldRunOncePerLaunch: false,
+                shouldRunEveryLaunch: false,
                 interval: 1,
                 perform: { actionPerformed = true }
             )
@@ -75,7 +75,7 @@ final class RecurringActionServiceTests: XCTestCase {
         sut.registerAction(
             .init(
                 id: .randomAlphanumerical(length: 5),
-                shouldRunOncePerLaunch: false,
+                shouldRunEveryLaunch: false,
                 interval: 3,
                 perform: { actionPerformed = true }
             )
@@ -100,7 +100,7 @@ final class RecurringActionServiceTests: XCTestCase {
         sut.registerAction(
             .init(
                 id: actionID,
-                shouldRunOncePerLaunch: false,
+                shouldRunEveryLaunch: false,
                 interval: 100,
                 perform: { actionPerformed = true }
             )
@@ -121,7 +121,7 @@ final class RecurringActionServiceTests: XCTestCase {
         sut.registerAction(
             .init(
                 id: .randomAlphanumerical(length: 5),
-                shouldRunOncePerLaunch: false,
+                shouldRunEveryLaunch: false,
                 interval: 3,
                 perform: { actionPerformed = true }
             )
@@ -137,15 +137,15 @@ final class RecurringActionServiceTests: XCTestCase {
         XCTAssertTrue(actionPerformed)
     }
 
-    // MARK: - Once Per Launch Tests
+    // MARK: - Run Every Launch Tests
 
-    func testThatItPerformsOncePerLaunchActionImmediately() async {
+    func testThatItPerformsRunEveryLaunchActionImmediately() async {
         // Given
         var actionPerformed = false
         sut.registerAction(
             .init(
                 id: .randomAlphanumerical(length: 5),
-                shouldRunOncePerLaunch: true,
+                shouldRunEveryLaunch: true,
                 interval: .oneDay,
                 perform: { actionPerformed = true }
             )
@@ -158,14 +158,14 @@ final class RecurringActionServiceTests: XCTestCase {
         XCTAssertTrue(actionPerformed)
     }
 
-    func testThatItPerformsOncePerLaunchActionOnlyOnceUntilIntervalPasses() async {
+    func testThatItPerformsRunEveryLaunchActionOnlyOnceUntilIntervalPasses() async {
         // Given
         var actionPerformedCount = 0
         let actionID = String.randomAlphanumerical(length: 5)
         sut.registerAction(
             .init(
                 id: actionID,
-                shouldRunOncePerLaunch: true,
+                shouldRunEveryLaunch: true,
                 interval: .oneDay,
                 perform: { actionPerformedCount += 1 }
             )
@@ -198,14 +198,14 @@ final class RecurringActionServiceTests: XCTestCase {
         XCTAssertEqual(actionPerformedCount, 2)
     }
 
-    func testThatOncePerLaunchActionRunsAgainAfterReinitialization() async {
+    func testThatRunEveryLaunchActionRunsAgainAfterReinitialization() async {
         // Given
         var actionPerformedCount = 0
         let actionID = String.randomAlphanumerical(length: 5)
         sut.registerAction(
             .init(
                 id: actionID,
-                shouldRunOncePerLaunch: true,
+                shouldRunEveryLaunch: true,
                 interval: .oneDay,
                 perform: { actionPerformedCount += 1 }
             )
@@ -226,7 +226,7 @@ final class RecurringActionServiceTests: XCTestCase {
         newSut.registerAction(
             .init(
                 id: actionID,
-                shouldRunOncePerLaunch: true,
+                shouldRunEveryLaunch: true,
                 interval: .oneDay,
                 perform: { actionPerformedCount += 1 }
             )
@@ -261,7 +261,7 @@ final class RecurringActionServiceTests: XCTestCase {
         service1.registerAction(
             .init(
                 id: actionID,
-                shouldRunOncePerLaunch: false,
+                shouldRunEveryLaunch: false,
                 interval: .oneDay,
                 perform: { user1ActionPerformedCount += 1 }
             )
@@ -269,7 +269,7 @@ final class RecurringActionServiceTests: XCTestCase {
         service2.registerAction(
             .init(
                 id: actionID,
-                shouldRunOncePerLaunch: false,
+                shouldRunEveryLaunch: false,
                 interval: .oneDay,
                 perform: { user2ActionPerformedCount += 1 }
             )
@@ -343,7 +343,7 @@ final class RecurringActionServiceTests: XCTestCase {
         service1.registerAction(
             .init(
                 id: actionID,
-                shouldRunOncePerLaunch: true,
+                shouldRunEveryLaunch: true,
                 interval: .oneDay,
                 perform: { user1ActionPerformedCount += 1 }
             )
@@ -351,7 +351,7 @@ final class RecurringActionServiceTests: XCTestCase {
         service2.registerAction(
             .init(
                 id: actionID,
-                shouldRunOncePerLaunch: true,
+                shouldRunEveryLaunch: true,
                 interval: .oneDay,
                 perform: { user2ActionPerformedCount += 1 }
             )
@@ -388,7 +388,7 @@ final class RecurringActionServiceTests: XCTestCase {
         newService1.registerAction(
             .init(
                 id: actionID,
-                shouldRunOncePerLaunch: true,
+                shouldRunEveryLaunch: true,
                 interval: .oneDay,
                 perform: { user1ActionPerformedCount += 1 }
             )
@@ -396,7 +396,7 @@ final class RecurringActionServiceTests: XCTestCase {
         newService2.registerAction(
             .init(
                 id: actionID,
-                shouldRunOncePerLaunch: true,
+                shouldRunEveryLaunch: true,
                 interval: .oneDay,
                 perform: { user2ActionPerformedCount += 1 }
             )

--- a/wire-ios-sync-engine/Tests/Source/UserSession/RecurringActionServiceTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/RecurringActionServiceTests.swift
@@ -25,18 +25,18 @@ import XCTest
 
 final class RecurringActionServiceTests: XCTestCase {
 
+    let userID = UUID()
     var userDefaults: UserDefaults!
     var dateProvider: CurrentDateProvidingMock!
     var sut: RecurringActionService!
 
     override func setUp() {
         super.setUp()
-
         userDefaults = .temporary()
         dateProvider = .init()
         dateProvider.now = .now.addingTimeInterval(-.oneDay)
         sut = RecurringActionService(
-            userID: UUID(),
+            userID: userID,
             storage: userDefaults,
             dateProvider: dateProvider
         )
@@ -135,5 +135,278 @@ final class RecurringActionServiceTests: XCTestCase {
 
         // Then
         XCTAssertTrue(actionPerformed)
+    }
+
+    // MARK: - Once Per Launch Tests
+
+    func testThatItPerformsOncePerLaunchActionImmediately() async {
+        // Given
+        var actionPerformed = false
+        sut.registerAction(
+            .init(
+                id: .randomAlphanumerical(length: 5),
+                shouldRunOncePerLaunch: true,
+                interval: .oneDay,
+                perform: { actionPerformed = true }
+            )
+        )
+
+        // When
+        await sut.performActionsIfNeeded()
+
+        // Then
+        XCTAssertTrue(actionPerformed)
+    }
+
+    func testThatItPerformsOncePerLaunchActionOnlyOnceUntilIntervalPasses() async {
+        // Given
+        var actionPerformedCount = 0
+        let actionID = String.randomAlphanumerical(length: 5)
+        sut.registerAction(
+            .init(
+                id: actionID,
+                shouldRunOncePerLaunch: true,
+                interval: .oneDay,
+                perform: { actionPerformedCount += 1 }
+            )
+        )
+
+        // When - First launch (should run immediately)
+        await sut.performActionsIfNeeded()
+
+        // Then
+        XCTAssertEqual(actionPerformedCount, 1)
+
+        // When - Run again immediately (should not run)
+        await sut.performActionsIfNeeded()
+
+        // Then
+        XCTAssertEqual(actionPerformedCount, 1)
+
+        // When - Advance time but not past interval (should not run)
+        dateProvider.now += .oneHour
+        await sut.performActionsIfNeeded()
+
+        // Then
+        XCTAssertEqual(actionPerformedCount, 1)
+
+        // When - Advance time past interval (should run)
+        dateProvider.now += .oneDay
+        await sut.performActionsIfNeeded()
+
+        // Then
+        XCTAssertEqual(actionPerformedCount, 2)
+    }
+
+    func testThatOncePerLaunchActionRunsAgainAfterReinitialization() async {
+        // Given
+        var actionPerformedCount = 0
+        let actionID = String.randomAlphanumerical(length: 5)
+        sut.registerAction(
+            .init(
+                id: actionID,
+                shouldRunOncePerLaunch: true,
+                interval: .oneDay,
+                perform: { actionPerformedCount += 1 }
+            )
+        )
+
+        // When - First launch
+        await sut.performActionsIfNeeded()
+
+        // Then
+        XCTAssertEqual(actionPerformedCount, 1)
+
+        // When - Simulate relaunch by creating new service instance
+        let newSut = RecurringActionService(
+            userID: userID, // Same user id
+            storage: userDefaults,
+            dateProvider: dateProvider
+        )
+        newSut.registerAction(
+            .init(
+                id: actionID,
+                shouldRunOncePerLaunch: true,
+                interval: .oneDay,
+                perform: { actionPerformedCount += 1 }
+            )
+        )
+        await newSut.performActionsIfNeeded()
+
+        // Then - Should run again on relaunch even though interval hasn't passed
+        XCTAssertEqual(actionPerformedCount, 2)
+    }
+
+    // MARK: - User Scoping Tests
+
+    func testThatRecurringActionChecksAreScopedToUserID() async {
+        // Given
+        let actionID = String.randomAlphanumerical(length: 5)
+        let userID1 = UUID()
+        let userID2 = UUID()
+        var user1ActionPerformedCount = 0
+        var user2ActionPerformedCount = 0
+
+        let service1 = RecurringActionService(
+            userID: userID1,
+            storage: userDefaults,
+            dateProvider: dateProvider
+        )
+        let service2 = RecurringActionService(
+            userID: userID2,
+            storage: userDefaults,
+            dateProvider: dateProvider
+        )
+
+        service1.registerAction(
+            .init(
+                id: actionID,
+                shouldRunOncePerLaunch: false,
+                interval: .oneDay,
+                perform: { user1ActionPerformedCount += 1 }
+            )
+        )
+        service2.registerAction(
+            .init(
+                id: actionID,
+                shouldRunOncePerLaunch: false,
+                interval: .oneDay,
+                perform: { user2ActionPerformedCount += 1 }
+            )
+        )
+
+        // When - User 1 performs action
+        await service1.performActionsIfNeeded()
+
+        // Then - Only user 1's action performed
+        XCTAssertEqual(user1ActionPerformedCount, 1)
+        XCTAssertEqual(user2ActionPerformedCount, 0)
+
+        // When - User 2 performs action
+        await service2.performActionsIfNeeded()
+
+        // Then - User 2's action also performed (not blocked by user 1's action)
+        XCTAssertEqual(user1ActionPerformedCount, 1)
+        XCTAssertEqual(user2ActionPerformedCount, 1)
+
+        // When - User 1 tries again without time passing
+        await service1.performActionsIfNeeded()
+
+        // Then - User 1's action not performed again
+        XCTAssertEqual(user1ActionPerformedCount, 1)
+        XCTAssertEqual(user2ActionPerformedCount, 1)
+
+        // When - User 2 tries again without time passing
+        await service2.performActionsIfNeeded()
+
+        // Then - User 2's action not performed again
+        XCTAssertEqual(user1ActionPerformedCount, 1)
+        XCTAssertEqual(user2ActionPerformedCount, 1)
+
+        // When - Time passes over the interval
+        dateProvider.now += .oneDay + .fiveMinutes
+
+        // When - User 1 tries again
+        await service1.performActionsIfNeeded()
+
+        // Then - User 1's action is peformed again, but not User 2's
+        XCTAssertEqual(user1ActionPerformedCount, 2)
+        XCTAssertEqual(user2ActionPerformedCount, 1)
+
+        // When - User 2 tries again
+        await service2.performActionsIfNeeded()
+
+        // Then - User 2's action is peformed again as well
+        XCTAssertEqual(user1ActionPerformedCount, 2)
+        XCTAssertEqual(user2ActionPerformedCount, 2)
+    }
+
+    func testThatOncePerLaunchActionsAreScopedToUserID() async {
+        // Given
+        let actionID = String.randomAlphanumerical(length: 5)
+        let userID1 = UUID()
+        let userID2 = UUID()
+        var user1ActionPerformedCount = 0
+        var user2ActionPerformedCount = 0
+
+        let service1 = RecurringActionService(
+            userID: userID1,
+            storage: userDefaults,
+            dateProvider: dateProvider
+        )
+        let service2 = RecurringActionService(
+            userID: userID2,
+            storage: userDefaults,
+            dateProvider: dateProvider
+        )
+
+        service1.registerAction(
+            .init(
+                id: actionID,
+                shouldRunOncePerLaunch: true,
+                interval: .oneDay,
+                perform: { user1ActionPerformedCount += 1 }
+            )
+        )
+        service2.registerAction(
+            .init(
+                id: actionID,
+                shouldRunOncePerLaunch: true,
+                interval: .oneDay,
+                perform: { user2ActionPerformedCount += 1 }
+            )
+        )
+
+        // When - Both users perform actions
+        await service1.performActionsIfNeeded()
+        await service2.performActionsIfNeeded()
+
+        // Then - Both actions performed independently
+        XCTAssertEqual(user1ActionPerformedCount, 1)
+        XCTAssertEqual(user2ActionPerformedCount, 1)
+
+        // When - Both try again immediately
+        await service1.performActionsIfNeeded()
+        await service2.performActionsIfNeeded()
+
+        // Then - Neither action performed again (interval not passed)
+        XCTAssertEqual(user1ActionPerformedCount, 1)
+        XCTAssertEqual(user2ActionPerformedCount, 1)
+
+        // When - Simulate relaunch for both users
+        let newService1 = RecurringActionService(
+            userID: userID1,
+            storage: userDefaults,
+            dateProvider: dateProvider
+        )
+        let newService2 = RecurringActionService(
+            userID: userID2,
+            storage: userDefaults,
+            dateProvider: dateProvider
+        )
+
+        newService1.registerAction(
+            .init(
+                id: actionID,
+                shouldRunOncePerLaunch: true,
+                interval: .oneDay,
+                perform: { user1ActionPerformedCount += 1 }
+            )
+        )
+        newService2.registerAction(
+            .init(
+                id: actionID,
+                shouldRunOncePerLaunch: true,
+                interval: .oneDay,
+                perform: { user2ActionPerformedCount += 1 }
+            )
+        )
+
+        await newService1.performActionsIfNeeded()
+        await newService2.performActionsIfNeeded()
+
+        // Then - Both actions run again on relaunch
+        XCTAssertEqual(user1ActionPerformedCount, 2)
+        XCTAssertEqual(user2ActionPerformedCount, 2)
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27049" title="WPB-27049" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-27049</a>  [iOS] App does not start the Proteus to MLS migration
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

According to the use case (see ticket), the app should periodically check to start the proteus to mls migration:

> On app startup and every 24 hours

Currently, the app only checks every 24 hours across app launches, which is not what the use case describes.

This PR corrects the check by making sure the proteus to mls migration check happens on every launch and every 24 hours thereafter:
- Add a `shouldRunOncePerLaunch` to `RecurringAction` (set `true` only for the proteus to mls recurring action)
- When registering the action, if `shouldRunOncePerLaunch` is `true`, then clear the last check date. The next time the check happens it will perform the action and set the last check date.

Additionally, this PR solves a problem where the instance of `RecurringActionService` for account A interferes with the instance for account B, because the last check dates are stored in the user defaults (which aren't scoped to the user):
- Scope the last check dates to the user id by using `PrivateUserDefaults`.

### AI
AI was used to generate the unit tests.

### Testing
1. Log in to an MLS enabled team that does not have the mls migration enabled yet.
2. Have one or more proteus groups.
3. Enable the mls migration with the start date in the past and end date in the future.
4. Assert that the mls migration doesn't begin yet (no system message in the proteus group)
5. Restart the app
6. Assert that all proteus groups now have a system message about the mls migration and the group details show a `mixed` protocol.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
