### PR TITLE
fix: mls migration doesn't start after relaunch - WPB-27049 🍒

### DIFF
--- a/wire-ios-sync-engine/Source/SessionManager/UserSessionLoader.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/UserSessionLoader.swift
@@ -493,6 +493,7 @@ final class UserSessionLoader {
             apiVersion: WireTransport.APIVersion(rawValue: Int32(backendMetadata.apiVersion.rawValue))
         )
         let recurringActionService = RecurringActionService(
+            userID: accountID,
             storage: sharedUserDefaults,
             dateProvider: .system
         )

--- a/wire-ios-sync-engine/Source/Synchronization/RecurringActionService/RecurringAction.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/RecurringActionService/RecurringAction.swift
@@ -21,6 +21,7 @@ import Foundation
 struct RecurringAction {
 
     let id: String
+    let shouldRunEveryLaunch: Bool
     let interval: TimeInterval
     let perform: () async -> Void
 

--- a/wire-ios-sync-engine/Source/Synchronization/RecurringActionService/RecurringActionService.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/RecurringActionService/RecurringActionService.swift
@@ -22,17 +22,28 @@ import WireUtilities
 
 final class RecurringActionService: RecurringActionServiceInterface {
 
+    private struct LastCheckDateKey: DefaultsKey {
+
+        let actionID: String
+
+        var rawValue: String {
+            "lastCheckDate_\(actionID)"
+        }
+
+    }
+
     // MARK: - Properties
 
     private(set) var actionsByID = [String: RecurringAction]()
-    private let storage: UserDefaults
+    private let storage: PrivateUserDefaults<LastCheckDateKey>
     private let dateProvider: CurrentDateProviding
 
     public init(
+        userID: UUID,
         storage: UserDefaults,
         dateProvider: CurrentDateProviding
     ) {
-        self.storage = storage
+        self.storage = PrivateUserDefaults(userID: userID, storage: storage)
         self.dateProvider = dateProvider
     }
 
@@ -40,6 +51,10 @@ final class RecurringActionService: RecurringActionServiceInterface {
 
     public func registerAction(_ action: RecurringAction) {
         actionsByID[action.id] = action
+
+        if action.shouldRunEveryLaunch {
+            clearLastCheckDate(for: action.id)
+        }
     }
 
     public func performActionsIfNeeded() async {
@@ -68,8 +83,8 @@ final class RecurringActionService: RecurringActionServiceInterface {
 
     // MARK: - Helpers
 
-    private func key(for actionID: String) -> String {
-        "lastCheckDate_\(actionID)"
+    private func key(for actionID: String) -> LastCheckDateKey {
+        LastCheckDateKey(actionID: actionID)
     }
 
     private func lastCheckDate(for actionID: String) -> Date? {
@@ -78,5 +93,9 @@ final class RecurringActionService: RecurringActionServiceInterface {
 
     func persistLastCheckDate(for actionID: String) {
         storage.set(dateProvider.now, forKey: key(for: actionID))
+    }
+
+    private func clearLastCheckDate(for actionID: String) {
+        storage.removeObject(forKey: key(for: actionID))
     }
 }

--- a/wire-ios-sync-engine/Source/Use cases/SnoozeCertificateEnrollmentUseCase.swift
+++ b/wire-ios-sync-engine/Source/Use cases/SnoozeCertificateEnrollmentUseCase.swift
@@ -70,6 +70,7 @@ final class SnoozeCertificateEnrollmentUseCase: SnoozeCertificateEnrollmentUseCa
 
         let recurringAction = RecurringAction(
             id: actionId,
+            shouldRunEveryLaunch: false,
             interval: interval
         ) {
             if isUpdateMode {

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+RecurringAction.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+RecurringAction.swift
@@ -23,7 +23,11 @@ import WireLogging
 extension ZMUserSession {
 
     var updateProteusToMLSMigrationStatusAction: RecurringAction {
-        .init(id: #function, interval: .oneDay) { [weak self] in
+        .init(
+            id: #function,
+            shouldRunEveryLaunch: true,
+            interval: .oneDay
+        ) { [weak self] in
             guard
                 let self,
                 await viewContext.perform({ self.mlsFeature.isEnabled })
@@ -43,7 +47,11 @@ extension ZMUserSession {
     }
 
     var refreshUsersMissingMetadataAction: RecurringAction {
-        .init(id: #function, interval: 3 * .oneHour) { [weak self] in
+        .init(
+            id: #function,
+            shouldRunEveryLaunch: false,
+            interval: 3 * .oneHour
+        ) { [weak self] in
             guard let context = self?.syncContext else {
                 return
             }
@@ -62,7 +70,11 @@ extension ZMUserSession {
     }
 
     var refreshConversationsMissingMetadataAction: RecurringAction {
-        .init(id: #function, interval: 3 * .oneHour) { [weak self] in
+        .init(
+            id: #function,
+            shouldRunEveryLaunch: false,
+            interval: 3 * .oneHour
+        ) { [weak self] in
             guard let context = self?.syncContext else {
                 return
             }
@@ -82,7 +94,11 @@ extension ZMUserSession {
     }
 
     var refreshTeamMetadataAction: RecurringAction {
-        .init(id: #function, interval: .oneDay) { [weak self] in
+        .init(
+            id: #function,
+            shouldRunEveryLaunch: false,
+            interval: .oneDay
+        ) { [weak self] in
             guard let context = self?.syncContext else {
                 return
             }
@@ -97,7 +113,11 @@ extension ZMUserSession {
     }
 
     var refreshFederationCertificatesAction: RecurringAction {
-        .init(id: #function, interval: .oneDay) { [weak self] in
+        .init(
+            id: #function,
+            shouldRunEveryLaunch: false,
+            interval: .oneDay
+        ) { [weak self] in
             do {
                 guard let self else { return }
 

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSessionBuilder.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSessionBuilder.swift
@@ -272,6 +272,7 @@ struct ZMUserSessionBuilder {
             apiVersion: BackendInfo.apiVersion
         )
         let recurringActionService = recurringActionService ?? RecurringActionService(
+            userID: userId,
             storage: sharedUserDefaults,
             dateProvider: .system
         )

--- a/wire-ios-sync-engine/Support/Sources/Synchronization/RecurringActionService/RecurringAction+dummy.swift
+++ b/wire-ios-sync-engine/Support/Sources/Synchronization/RecurringActionService/RecurringAction+dummy.swift
@@ -21,6 +21,10 @@
 extension RecurringAction {
 
     static var dummy: Self {
-        .init(id: .randomAlphanumerical(length: 16), interval: .infinity) {}
+        .init(
+            id: .randomAlphanumerical(length: 16),
+            shouldRunEveryLaunch: false,
+            interval: .infinity
+        ) {}
     }
 }

--- a/wire-ios-sync-engine/Tests/Source/UserSession/RecurringActionServiceTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/RecurringActionServiceTests.swift
@@ -25,17 +25,18 @@ import XCTest
 
 final class RecurringActionServiceTests: XCTestCase {
 
+    let userID = UUID()
     var userDefaults: UserDefaults!
     var dateProvider: CurrentDateProvidingMock!
     var sut: RecurringActionService!
 
     override func setUp() {
         super.setUp()
-
         userDefaults = .temporary()
         dateProvider = .init()
         dateProvider.now = .now.addingTimeInterval(-.oneDay)
         sut = RecurringActionService(
+            userID: userID,
             storage: userDefaults,
             dateProvider: dateProvider
         )
@@ -52,9 +53,14 @@ final class RecurringActionServiceTests: XCTestCase {
     func testThatItPerformsActionInitially() async {
         // Given
         var actionPerformed = false
-        sut.registerAction(.init(id: .randomAlphanumerical(length: 5), interval: 1) {
-            actionPerformed = true
-        })
+        sut.registerAction(
+            .init(
+                id: .randomAlphanumerical(length: 5),
+                shouldRunEveryLaunch: false,
+                interval: 1,
+                perform: { actionPerformed = true }
+            )
+        )
 
         // When
         await sut.performActionsIfNeeded()
@@ -66,9 +72,14 @@ final class RecurringActionServiceTests: XCTestCase {
     func testThatItDoesNotPerformActionTooEarly() async {
         // Given
         var actionPerformed = false
-        sut.registerAction(.init(id: .randomAlphanumerical(length: 5), interval: 3) {
-            actionPerformed = true
-        })
+        sut.registerAction(
+            .init(
+                id: .randomAlphanumerical(length: 5),
+                shouldRunEveryLaunch: false,
+                interval: 3,
+                perform: { actionPerformed = true }
+            )
+        )
 
         // When
         await sut.performActionsIfNeeded()
@@ -86,9 +97,14 @@ final class RecurringActionServiceTests: XCTestCase {
         let actionID = String.randomAlphanumerical(length: 5)
 
         sut.persistLastCheckDate(for: actionID)
-        sut.registerAction(.init(id: actionID, interval: 100) {
-            actionPerformed = true
-        })
+        sut.registerAction(
+            .init(
+                id: actionID,
+                shouldRunEveryLaunch: false,
+                interval: 100,
+                perform: { actionPerformed = true }
+            )
+        )
 
         XCTAssertFalse(actionPerformed)
 
@@ -102,9 +118,14 @@ final class RecurringActionServiceTests: XCTestCase {
     func testThatItPerformsActionAgain() async {
         // Given
         var actionPerformed = false
-        sut.registerAction(.init(id: .randomAlphanumerical(length: 5), interval: 3) {
-            actionPerformed = true
-        })
+        sut.registerAction(
+            .init(
+                id: .randomAlphanumerical(length: 5),
+                shouldRunEveryLaunch: false,
+                interval: 3,
+                perform: { actionPerformed = true }
+            )
+        )
 
         // When
         await sut.performActionsIfNeeded()
@@ -114,5 +135,247 @@ final class RecurringActionServiceTests: XCTestCase {
 
         // Then
         XCTAssertTrue(actionPerformed)
+    }
+
+    // MARK: - Run Every Launch Tests
+
+    func testThatItPerformsRunEveryLaunchActionImmediately() async {
+        // Given
+        var actionPerformed = false
+        sut.registerAction(
+            .init(
+                id: .randomAlphanumerical(length: 5),
+                shouldRunEveryLaunch: true,
+                interval: .oneDay,
+                perform: { actionPerformed = true }
+            )
+        )
+
+        // When
+        await sut.performActionsIfNeeded()
+
+        // Then
+        XCTAssertTrue(actionPerformed)
+    }
+
+    func testThatItPerformsRunEveryLaunchActionOnlyOnceUntilIntervalPasses() async {
+        // Given
+        var actionPerformedCount = 0
+        let actionID = String.randomAlphanumerical(length: 5)
+        sut.registerAction(
+            .init(
+                id: actionID,
+                shouldRunEveryLaunch: true,
+                interval: .oneDay,
+                perform: { actionPerformedCount += 1 }
+            )
+        )
+
+        // When - First launch (should run immediately)
+        await sut.performActionsIfNeeded()
+
+        // Then
+        XCTAssertEqual(actionPerformedCount, 1)
+
+        // When - Run again immediately (should not run)
+        await sut.performActionsIfNeeded()
+
+        // Then
+        XCTAssertEqual(actionPerformedCount, 1)
+
+        // When - Advance time but not past interval (should not run)
+        dateProvider.now += .oneHour
+        await sut.performActionsIfNeeded()
+
+        // Then
+        XCTAssertEqual(actionPerformedCount, 1)
+
+        // When - Advance time past interval (should run)
+        dateProvider.now += .oneDay
+        await sut.performActionsIfNeeded()
+
+        // Then
+        XCTAssertEqual(actionPerformedCount, 2)
+    }
+
+    func testThatRunEveryLaunchActionRunsAgainAfterReinitialization() async {
+        // Given
+        var actionPerformedCount = 0
+        let actionID = String.randomAlphanumerical(length: 5)
+        sut.registerAction(
+            .init(
+                id: actionID,
+                shouldRunEveryLaunch: true,
+                interval: .oneDay,
+                perform: { actionPerformedCount += 1 }
+            )
+        )
+
+        // When - First launch
+        await sut.performActionsIfNeeded()
+
+        // Then
+        XCTAssertEqual(actionPerformedCount, 1)
+
+        // When - Simulate relaunch by creating new service instance
+        let newSut = RecurringActionService(
+            userID: userID, // Same user id
+            storage: userDefaults,
+            dateProvider: dateProvider
+        )
+        newSut.registerAction(
+            .init(
+                id: actionID,
+                shouldRunEveryLaunch: true,
+                interval: .oneDay,
+                perform: { actionPerformedCount += 1 }
+            )
+        )
+        await newSut.performActionsIfNeeded()
+
+        // Then - Should run again on relaunch even though interval hasn't passed
+        XCTAssertEqual(actionPerformedCount, 2)
+    }
+
+    // MARK: - User Scoping Tests
+
+    func testThatRecurringActionChecksAreScopedToUserID() async {
+        // Given
+        let actionID = String.randomAlphanumerical(length: 5)
+        let userID1 = UUID()
+        let userID2 = UUID()
+        var user1ActionPerformedCount = 0
+        var user2ActionPerformedCount = 0
+
+        let service1 = RecurringActionService(
+            userID: userID1,
+            storage: userDefaults,
+            dateProvider: dateProvider
+        )
+        let service2 = RecurringActionService(
+            userID: userID2,
+            storage: userDefaults,
+            dateProvider: dateProvider
+        )
+
+        service1.registerAction(
+            .init(
+                id: actionID,
+                shouldRunEveryLaunch: false,
+                interval: .oneDay,
+                perform: { user1ActionPerformedCount += 1 }
+            )
+        )
+        service2.registerAction(
+            .init(
+                id: actionID,
+                shouldRunEveryLaunch: false,
+                interval: .oneDay,
+                perform: { user2ActionPerformedCount += 1 }
+            )
+        )
+
+        // When - User 1 performs action
+        await service1.performActionsIfNeeded()
+
+        // Then - Only user 1's action performed
+        XCTAssertEqual(user1ActionPerformedCount, 1)
+        XCTAssertEqual(user2ActionPerformedCount, 0)
+
+        // When - User 2 performs action
+        await service2.performActionsIfNeeded()
+
+        // Then - User 2's action also performed (not blocked by user 1's action)
+        XCTAssertEqual(user1ActionPerformedCount, 1)
+        XCTAssertEqual(user2ActionPerformedCount, 1)
+    }
+
+    func testThatOncePerLaunchActionsAreScopedToUserID() async {
+        // Given
+        let actionID = String.randomAlphanumerical(length: 5)
+        let userID1 = UUID()
+        let userID2 = UUID()
+        var user1ActionPerformedCount = 0
+        var user2ActionPerformedCount = 0
+
+        let service1 = RecurringActionService(
+            userID: userID1,
+            storage: userDefaults,
+            dateProvider: dateProvider
+        )
+        let service2 = RecurringActionService(
+            userID: userID2,
+            storage: userDefaults,
+            dateProvider: dateProvider
+        )
+
+        service1.registerAction(
+            .init(
+                id: actionID,
+                shouldRunEveryLaunch: true,
+                interval: .oneDay,
+                perform: { user1ActionPerformedCount += 1 }
+            )
+        )
+        service2.registerAction(
+            .init(
+                id: actionID,
+                shouldRunEveryLaunch: true,
+                interval: .oneDay,
+                perform: { user2ActionPerformedCount += 1 }
+            )
+        )
+
+        // When - Both users perform actions
+        await service1.performActionsIfNeeded()
+        await service2.performActionsIfNeeded()
+
+        // Then - Both actions performed independently
+        XCTAssertEqual(user1ActionPerformedCount, 1)
+        XCTAssertEqual(user2ActionPerformedCount, 1)
+
+        // When - Both try again immediately
+        await service1.performActionsIfNeeded()
+        await service2.performActionsIfNeeded()
+
+        // Then - Neither action performed again (interval not passed)
+        XCTAssertEqual(user1ActionPerformedCount, 1)
+        XCTAssertEqual(user2ActionPerformedCount, 1)
+
+        // When - Simulate relaunch for both users
+        let newService1 = RecurringActionService(
+            userID: userID1,
+            storage: userDefaults,
+            dateProvider: dateProvider
+        )
+        let newService2 = RecurringActionService(
+            userID: userID2,
+            storage: userDefaults,
+            dateProvider: dateProvider
+        )
+
+        newService1.registerAction(
+            .init(
+                id: actionID,
+                shouldRunEveryLaunch: true,
+                interval: .oneDay,
+                perform: { user1ActionPerformedCount += 1 }
+            )
+        )
+        newService2.registerAction(
+            .init(
+                id: actionID,
+                shouldRunEveryLaunch: true,
+                interval: .oneDay,
+                perform: { user2ActionPerformedCount += 1 }
+            )
+        )
+
+        await newService1.performActionsIfNeeded()
+        await newService2.performActionsIfNeeded()
+
+        // Then - Both actions run again on relaunch
+        XCTAssertEqual(user1ActionPerformedCount, 2)
+        XCTAssertEqual(user2ActionPerformedCount, 2)
     }
 }

--- a/wire-ios/Wire-iOS/Resources/Configuration/Version.xcconfig
+++ b/wire-ios/Wire-iOS/Resources/Configuration/Version.xcconfig
@@ -16,5 +16,5 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-WIRE_SHORT_VERSION = 4.16.4
+WIRE_SHORT_VERSION = 4.16.5
 MAJOR_VERSION = 4


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27049" title="WPB-27049" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-27049</a>  [iOS] App does not start the Proteus to MLS migration
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue
Cherry pick of #5113 plus a version bump to 4.16.5.

### Testing
See original PR

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
