### PR TITLE
chore: don't cache APNS push tokens - WPB-27383

### DIFF
--- a/wire-ios-sync-engine/Source/Notifications/VoIPPushManager.swift
+++ b/wire-ios-sync-engine/Source/Notifications/VoIPPushManager.swift
@@ -38,7 +38,6 @@ public final class VoIPPushManager: NSObject, PKPushRegistryDelegate {
 
     public let callKitManager: CallKitManager
 
-    private let pushTokenService: PushTokenServiceInterface
     private let backgroundActivityFactory: BackgroundActivityFactory
     private let registry: PKPushRegistry
 
@@ -50,11 +49,9 @@ public final class VoIPPushManager: NSObject, PKPushRegistryDelegate {
 
     public init(
         application: ZMApplication,
-        pushTokenService: PushTokenServiceInterface,
         backgroundActivityFactory: BackgroundActivityFactory = .shared
     ) {
         Self.logger.debug("init VoIPPushManager")
-        self.pushTokenService = pushTokenService
         self.backgroundActivityFactory = backgroundActivityFactory
 
         self.registry = PKPushRegistry(queue: Self.pushRegistryQueue)

--- a/wire-ios-sync-engine/Source/SessionManager/PushTokenService.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/PushTokenService.swift
@@ -29,8 +29,6 @@ public final class PushTokenService: PushTokenServiceInterface {
     }
 
     public var onTokenChange: ((PushToken?) -> Void)?
-    public var onRegistrationComplete: (() -> Void)?
-    public var onUnregistrationComplete: (() -> Void)?
 
     // MARK: - Life cycle
 
@@ -62,8 +60,6 @@ public final class PushTokenService: PushTokenServiceInterface {
             WireLogger.push.error("registering push token failed: \(error)")
             throw error
         }
-
-        onRegistrationComplete?()
     }
 
     public func unregisterRemoteTokens(
@@ -97,8 +93,6 @@ public final class PushTokenService: PushTokenServiceInterface {
             WireLogger.push.error("unregister remote tokens, failed: \(error)")
             throw error
         }
-
-        onUnregistrationComplete?()
     }
 
 }
@@ -110,8 +104,6 @@ public protocol PushTokenServiceInterface: AnyObject {
     var localToken: PushToken? { get }
 
     var onTokenChange: ((PushToken?) -> Void)? { get set }
-    var onRegistrationComplete: (() -> Void)? { get set }
-    var onUnregistrationComplete: (() -> Void)? { get set }
 
     func storeLocalToken(_ token: PushToken?)
 

--- a/wire-ios-sync-engine/Source/SessionManager/PushTokenService.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/PushTokenService.swift
@@ -45,6 +45,9 @@ public final class PushTokenService: PushTokenServiceInterface {
         if DeveloperFlag.noAPNSTokenCache.isOn {
             inMemoryToken = token
             onTokenChange?(token)
+
+            // Avoid stale cache in the case where the user later disables the developer flag.
+            PushTokenStorage.pushToken = nil
             return
         }
 

--- a/wire-ios-sync-engine/Source/SessionManager/PushTokenService.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/PushTokenService.swift
@@ -67,6 +67,7 @@ public final class PushTokenService: PushTokenServiceInterface {
 
         do {
             try await action.perform(in: context)
+            WireLogger.push.info("Did register push token: \(clientID)")
         } catch let error as RegisterPushTokenAction.Failure {
             WireLogger.push.error("registering push token failed: \(error)")
             throw error

--- a/wire-ios-sync-engine/Source/SessionManager/PushTokenService.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/PushTokenService.swift
@@ -168,7 +168,7 @@ extension EntityAction {
     ///
     /// - Parameters:
     ///   - context the notification context in which to send the action's notification.
-    ///   - resultHandler a closure to recieve the action's result.
+    ///   - resultHandler a closure to receive the action's result.
 
     @available(*, renamed: "perform(in:)")
     mutating func perform(

--- a/wire-ios-sync-engine/Source/SessionManager/PushTokenService.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/PushTokenService.swift
@@ -25,10 +25,15 @@ public final class PushTokenService: PushTokenServiceInterface {
     // MARK: - Properties
 
     public var localToken: PushToken? {
-        PushTokenStorage.pushToken
+        if DeveloperFlag.noAPNSTokenCache.isOn {
+            return inMemoryToken
+        }
+        return PushTokenStorage.pushToken
     }
 
     public var onTokenChange: ((PushToken?) -> Void)?
+
+    private var inMemoryToken: PushToken?
 
     // MARK: - Life cycle
 
@@ -37,6 +42,12 @@ public final class PushTokenService: PushTokenServiceInterface {
     // MARK: - Methods
 
     public func storeLocalToken(_ token: PushToken?) {
+        if DeveloperFlag.noAPNSTokenCache.isOn {
+            inMemoryToken = token
+            onTokenChange?(token)
+            return
+        }
+
         if PushTokenStorage.pushToken != nil, token != PushTokenStorage.pushToken {
             WireLogger.push.info("updating token \(token == nil ? "to nil" : "")", attributes: .safePublic)
         }

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager+PushToken.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager+PushToken.swift
@@ -102,7 +102,7 @@ extension SessionManager {
             }
 
             do {
-                try await pushTokenService.syncLocalTokenWithRemote(
+                try await syncLocalTokenWithRemote(
                     clientID: clientID,
                     in: session.notificationContext
                 )
@@ -117,6 +117,11 @@ extension SessionManager {
                 )
             }
         }
+    }
+
+    @concurrent
+    private func syncLocalTokenWithRemote(clientID: String, in context: NotificationContext) async throws {
+        try await pushTokenService.syncLocalTokenWithRemote(clientID: clientID, in: context)
     }
 
 }

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager+PushToken.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager+PushToken.swift
@@ -44,7 +44,7 @@ extension SessionManager {
             return
         }
 
-        guard let localToken = pushTokenService.localToken else {
+        guard pushTokenService.localToken != nil else {
             WireLogger.push.info("no local token, will generate one")
             generateLocalToken(session: session)
             return

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager+PushToken.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager+PushToken.swift
@@ -91,4 +91,32 @@ extension SessionManager {
         }
     }
 
+    @MainActor
+    func uploadPushToken(sessions: [ZMUserSession]) async {
+        WireLogger.push.info("uploadPushToken: uploading for \(sessions.count) sessions", attributes: .safePublic)
+
+        for (index, session) in sessions.enumerated() {
+            guard let clientID = session.selfUserClient?.remoteIdentifier else {
+                WireLogger.push.warn("uploadPushToken: session \(index) has no client id", attributes: .safePublic)
+                continue
+            }
+
+            do {
+                try await pushTokenService.syncLocalTokenWithRemote(
+                    clientID: clientID,
+                    in: session.notificationContext
+                )
+
+                WireLogger.push.info("uploadPushToken: success for session \(index)", attributes: .safePublic)
+            } catch {
+                let error = error as NSError
+
+                WireLogger.push.error(
+                    "uploadPushToken: failed for session \(index): \(error.safeForLoggingDescription)",
+                    attributes: .safePublic
+                )
+            }
+        }
+    }
+
 }

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager+PushToken.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager+PushToken.swift
@@ -38,6 +38,14 @@ extension SessionManager {
     // MARK: - Token registration
 
     public func configurePushToken(session: ZMUserSession) {
+        if DeveloperFlag.noAPNSTokenCache.isOn {
+            WireLogger.push.info("configurePushToken: requesting fresh token from iOS")
+            session.managedObjectContext.performGroupedBlock {
+                self.application.registerForRemoteNotifications()
+            }
+            return
+        }
+
         guard let localToken = pushTokenService.localToken else {
             WireLogger.push.info("no local token, will generate one")
             generateLocalToken(session: session)

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager+PushToken.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager+PushToken.swift
@@ -40,9 +40,7 @@ extension SessionManager {
     public func configurePushToken(session: ZMUserSession) {
         if DeveloperFlag.noAPNSTokenCache.isOn {
             WireLogger.push.info("configurePushToken: requesting fresh token from iOS")
-            session.managedObjectContext.performGroupedBlock {
-                self.application.registerForRemoteNotifications()
-            }
+            application.registerForRemoteNotifications()
             return
         }
 

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -634,14 +634,17 @@ public final class SessionManager: NSObject, SessionManagerType {
         updateCallNotificationStyle()
 
         pushTokenService.onTokenChange = { [weak self] _ in
-            guard
-                let self,
-                let session = activeUserSession ?? backgroundUserSessions.values.first
-            else {
+            guard let self else { return }
+
+            if DeveloperFlag.noAPNSTokenCache.isOn {
+                // Upload push token for all loaded sessions. Correct behavior would be to upload it for all accounts
+                // but we don't yet have a means to do that without loading all sessions into memory.
+                Task { await self.uploadPushToken(sessions: Array(self.backgroundUserSessions.values)) }
                 return
             }
 
-            syncLocalTokenWithRemote(session: session)
+            guard let activeUserSession else { return }
+            syncLocalTokenWithRemote(session: activeUserSession)
         }
 
         self.deleteAccountToken = AccountDeletedNotification.addObserver(observer: self, queue: groupQueue)

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -436,7 +436,7 @@ public final class SessionManager: NSObject, SessionManagerType {
         environment: WireTransport.BackendEnvironment,
         configuration: SessionManagerConfiguration = SessionManagerConfiguration(),
         detector: JailbreakDetectorProtocol = JailbreakDetector(),
-        pushTokenService: PushTokenServiceInterface = PushTokenService(),
+        pushTokenService: PushTokenServiceInterface,
         callKitManager: CallKitManagerInterface,
         isDeveloperModeEnabled: Bool = false,
         isUnauthenticatedTransportSessionReady: Bool = false,
@@ -547,7 +547,7 @@ public final class SessionManager: NSObject, SessionManagerType {
         environment: WireTransport.BackendEnvironment,
         configuration: SessionManagerConfiguration = SessionManagerConfiguration(),
         detector: JailbreakDetectorProtocol = JailbreakDetector(),
-        pushTokenService: PushTokenServiceInterface = PushTokenService(),
+        pushTokenService: PushTokenServiceInterface,
         callKitManager: CallKitManagerInterface,
         isDeveloperModeEnabled: Bool = false,
         proxyCredentials: WireTransport.ProxyCredentials?,
@@ -636,7 +636,7 @@ public final class SessionManager: NSObject, SessionManagerType {
         pushTokenService.onTokenChange = { [weak self] _ in
             guard
                 let self,
-                let session = activeUserSession
+                let session = activeUserSession ?? backgroundUserSessions.values.first
             else {
                 return
             }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+Push.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+Push.swift
@@ -70,9 +70,9 @@ struct PushTokenMetadata {
 
 // MARK: - Register current push token
 
-public extension ZMUserSession {
+extension ZMUserSession {
 
-    internal func registerCurrentPushToken() {
+    func registerCurrentPushToken() {
         managedObjectContext.performGroupedBlock {
             self.sessionManager?.configurePushToken(session: self)
         }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+Push.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+Push.swift
@@ -72,18 +72,6 @@ struct PushTokenMetadata {
 
 public extension ZMUserSession {
 
-    @objc static let registerCurrentPushTokenNotificationName = Notification
-        .Name(rawValue: "ZMUserSessionResetPushTokensNotification")
-
-    func registerForRegisteringPushTokenNotification() {
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(ZMUserSession.registerCurrentPushToken),
-            name: ZMUserSession.registerCurrentPushTokenNotificationName,
-            object: nil
-        )
-    }
-
     internal func registerCurrentPushToken() {
         managedObjectContext.performGroupedBlock {
             self.sessionManager?.configurePushToken(session: self)

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -598,7 +598,6 @@ public final class ZMUserSession: NSObject {
         setupCertificateRevocationLists()
 
         registerForCalculateBadgeCountNotification()
-        registerForRegisteringPushTokenNotification()
         registerForBackgroundNotifications()
 
         enableBackgroundFetch()

--- a/wire-ios-sync-engine/Tests/Source/Mocks/MockPushTokenService.swift
+++ b/wire-ios-sync-engine/Tests/Source/Mocks/MockPushTokenService.swift
@@ -25,8 +25,6 @@ final class MockPushTokenService: NSObject, PushTokenServiceInterface {
 
     var localToken: PushToken?
     var onTokenChange: ((PushToken?) -> Void)?
-    var onRegistrationComplete: (() -> Void)?
-    var onUnregistrationComplete: (() -> Void)?
 
     var registeredTokensByClientID = [String: [PushToken]]()
 
@@ -45,7 +43,6 @@ final class MockPushTokenService: NSObject, PushTokenServiceInterface {
         var existingTokens = registeredTokensByClientID[clientID] ?? []
         existingTokens.append(token)
         registeredTokensByClientID[clientID] = existingTokens
-        onRegistrationComplete?()
     }
 
     func unregisterRemoteTokens(
@@ -55,8 +52,6 @@ final class MockPushTokenService: NSObject, PushTokenServiceInterface {
     ) async throws {
         let existingTokens = registeredTokensByClientID[clientID] ?? []
         registeredTokensByClientID[clientID] = existingTokens.filter { $0 == token }
-        onUnregistrationComplete?()
-
     }
 
 }

--- a/wire-ios-utilities/Source/DeveloperFlag.swift
+++ b/wire-ios-utilities/Source/DeveloperFlag.swift
@@ -87,7 +87,7 @@ public enum DeveloperFlag: String, CaseIterable {
             "Turn on to use the new registration flow"
 
         case .noAPNSTokenCache:
-            "Turn on to always request the APNS token from iOS on session configure instead of reading a cached one"
+            "Turn on to always request the APNS token from the system instead of reading a cached one"
 
         case .preventAdminlessGroups:
             "Turn on to prevent last admins from leaving groups without promoting someone else"

--- a/wire-ios-utilities/Source/DeveloperFlag.swift
+++ b/wire-ios-utilities/Source/DeveloperFlag.swift
@@ -33,6 +33,7 @@ public enum DeveloperFlag: String, CaseIterable {
     case forceDatabaseLoadingFailure
     case ignoreIncomingEvents
     case newRegistration
+    case noAPNSTokenCache
     case preventAdminlessGroups
     case showCreateMLSGroupToggle
     case showUnreadConversationsFilter
@@ -84,6 +85,9 @@ public enum DeveloperFlag: String, CaseIterable {
 
         case .newRegistration:
             "Turn on to use the new registration flow"
+
+        case .noAPNSTokenCache:
+            "Turn on to always request the APNS token from iOS on session configure instead of reading a cached one"
 
         case .preventAdminlessGroups:
             "Turn on to prevent last admins from leaving groups without promoting someone else"

--- a/wire-ios/Wire-iOS/Sources/AppDelegate.swift
+++ b/wire-ios/Wire-iOS/Sources/AppDelegate.swift
@@ -151,6 +151,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         AppDependencies.pushTokenService.storeLocalToken(.createAPNSToken(from: deviceToken))
     }
 
+    func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: any Error) {
+        let errorDescription = (error as NSError).safeForLoggingDescription
+        WireLogger.push.error(
+            "application did fail to register for remote notifications with error: \(errorDescription)",
+            attributes: .safePublic
+        )
+    }
+
     func application(
         _ application: UIApplication,
         didReceiveRemoteNotification userInfo: [AnyHashable: Any],

--- a/wire-ios/Wire-iOS/Sources/AppDependencies.swift
+++ b/wire-ios/Wire-iOS/Sources/AppDependencies.swift
@@ -29,6 +29,6 @@ enum AppDependencies {
 
     static let cookieStorage = CookieStorage(cookieEncryptionKey: UserDefaults.cookiesKey())
     static let pushTokenService = PushTokenService()
-    static let voIPPushManager = VoIPPushManager(application: UIApplication.shared, pushTokenService: pushTokenService)
+    static let voIPPushManager = VoIPPushManager(application: UIApplication.shared)
 
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Advanced.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Advanced.swift
@@ -65,7 +65,7 @@ extension SettingsCellDescriptorFactory {
             header: SelfSettingsAdvancedLocale.Troubleshooting.title,
             footer: SelfSettingsAdvancedLocale.ResetPushToken.subtitle,
             visibilityAction: { _ in
-                true
+                !DeveloperFlag.noAPNSTokenCache.isOn
             }
         )
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27383" title="WPB-27383" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-27383</a>  [iOS] Handle APNS device token invalidation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR enables the APNS push registration flow without caching. Apple explicitly states that clients should not cache push tokens as they may change at any time. If they were to change for a given client, push notifications would be broken for that client.

We are quite paranoid here. Therefore I'm making these changes behind a DeveloperFlag. We can first test it some time before enabling in a future production build.

Some decisions I have taken:

- Do minimal changes at this time. Rely on the existing code paths.
- Avoid changes to the legacy flow. There should be no behavior changes when the DeveloperFlag is disabled.
- The basic concept is to call `UIApplication.registerForRemoteNotifications()` whenever a new ZMUserSession is created. Then respond to `application(_:didRegisterForRemoteNotificationsWithDeviceToken:)` by uploading the device token for *all* loaded `ZMUserSession`. This is still not quite correct behavior. The correct behavior would be to upload this for all logged in accounts, no matter whether they have a loaded user session or not. But currently our network stack is coupled to `ZMUserSession` so this would require a big change.

Additionally this PR hides the `Reset Push Notification Tool` button in Settings > Advanced in the case of push notifications being enabled as that tool will have no effect without a cache.

### Testing

1. Install the app
2. Enable the developer flag - `noAPNSTokenCache`
3. Log into multiple accounts
4. Confirm push notifications are working for all accounts (working means we are receiving them)
5. Confirm there is no `Reset Push Notification Tool` in Settings > Advanced

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.