### PR TITLE
fix: prevent MLS group read receipts - WPB-27764

### DIFF
--- a/wire-ios-data-model/Source/Model/Message/ZMOTRMessage+Confirmations.swift
+++ b/wire-ios-data-model/Source/Model/Message/ZMOTRMessage+Confirmations.swift
@@ -68,7 +68,7 @@ extension ZMOTRMessage {
             return expectsReadConfirmation && readReceiptsEnabled
 
         } else if conversation.conversationType == .group {
-            return expectsReadConfirmation
+            return conversation.messageProtocol != .mls && expectsReadConfirmation
         }
 
         return false

--- a/wire-ios-data-model/Tests/Model/Messages/ZMMessageTests+Confirmation.swift
+++ b/wire-ios-data-model/Tests/Model/Messages/ZMMessageTests+Confirmation.swift
@@ -57,6 +57,32 @@ extension ZMMessageTests_Confirmation {
         XCTAssertFalse(message.needsReadConfirmation)
     }
 
+    func testThatMessageDoesntNeedReadConfirmation_InAnMLSGroup_WhenItExpectsReadConfirmation() {
+        // given
+        let user = createUser(in: uiMOC)
+        let conversation = createConversation(in: uiMOC)
+        conversation.messageProtocol = .mls
+
+        let message = insertMessage(conversation, fromSender: user, timestamp: Date()) as! ZMClientMessage
+        message.expectsReadConfirmation = true
+
+        // then
+        XCTAssertFalse(message.needsReadConfirmation)
+    }
+
+    func testThatMessageNeedsReadConfirmation_InAMixedGroup_WhenItExpectsReadConfirmation() {
+        // given
+        let user = createUser(in: uiMOC)
+        let conversation = createConversation(in: uiMOC)
+        conversation.messageProtocol = .mixed
+
+        let message = insertMessage(conversation, fromSender: user, timestamp: Date()) as! ZMClientMessage
+        message.expectsReadConfirmation = true
+
+        // then
+        XCTAssertTrue(message.needsReadConfirmation)
+    }
+
     func testThatMessageDoesntExpectReadConfirmation_InAGroup_ForMessagesSentBySelfUser() {
         // given
         let conversation = createConversation(in: uiMOC)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27764" title="WPB-27764" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-27764</a>  [iOS] Read receipts are still enable after migration to mls
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Summary

- Stop read receipts at the final eligibility check for MLS group conversations.
- Preserve existing behavior for Proteus and mixed groups, as well as one-to-one conversations.
- Add regression coverage for MLS and mixed group conversations.

## Why

MLS group read receipts require targeted messages, which this client version does not support. Relying only on the backend receipt mode can allow older messages that already expect confirmation to produce untargeted read receipts after migration.

## User impact

iOS no longer sends read receipts after a group conversation migrates to MLS, including for previously stored messages whose confirmation flag is already set.

## Validation

The focused WireDataModel confirmation suite passes with 22 tests and no failures.

[WPB-27764](https://wearezeta.atlassian.net/browse/WPB-27764)


[WPB-27764]: https://wearezeta.atlassian.net/browse/WPB-27764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ