### PR TITLE
fix: flaky UITests failures - WPB-28014

### DIFF
--- a/WireUI/Sources/WireLocators/Locators.swift
+++ b/WireUI/Sources/WireLocators/Locators.swift
@@ -460,6 +460,7 @@ public enum Locators {
     public enum ShareExtensionPage: String {
 
         case sendButtonOnShareExtension
+        case messageField
         case wire = "Wire"
         case chooseConversations = "Choose"
     }

--- a/wire-ios/Wire-iOS Share Extension/Sources/View Controllers/ShareExtensionViewController.swift
+++ b/wire-ios/Wire-iOS Share Extension/Sources/View Controllers/ShareExtensionViewController.swift
@@ -166,6 +166,8 @@ final class ShareExtensionViewController: SLComposeServiceViewController {
             attachments = sortedAttachments
         }
 
+        textView.accessibilityIdentifier = Locators.ShareExtensionPage.messageField.rawValue
+
         Task { @MainActor in
             await updateAccount(currentAccount)
         }

--- a/wire-ios/WireUITests/Pages/ActiveConversationPage.swift
+++ b/wire-ios/WireUITests/Pages/ActiveConversationPage.swift
@@ -505,6 +505,7 @@ class ActiveConversationPage: PageModel {
         return self
     }
 
+    @discardableResult
     func verifyMessageSent(
         _ message: String,
         file: StaticString = #filePath,
@@ -514,17 +515,6 @@ class ActiveConversationPage: PageModel {
             app.textViews.matching(NSPredicate(format: "label == %@", message)).firstMatch.waitForExistence(timeout: 5),
             file: file,
             line: line
-        )
-        return self
-    }
-
-    @discardableResult
-    func verifyMessageContaining(
-        _ message: String,
-    ) -> ActiveConversationPage {
-        XCTAssertTrue(
-            messageLabels.matching(NSPredicate(format: "label CONTAINS[c] %@", message)).firstMatch
-                .waitForExistence(timeout: 5),
         )
         return self
     }

--- a/wire-ios/WireUITests/Pages/ActiveConversationPage.swift
+++ b/wire-ios/WireUITests/Pages/ActiveConversationPage.swift
@@ -519,6 +519,17 @@ class ActiveConversationPage: PageModel {
     }
 
     @discardableResult
+    func verifyMessageContaining(
+        _ message: String,
+    ) -> ActiveConversationPage {
+        XCTAssertTrue(
+            messageLabels.matching(NSPredicate(format: "label CONTAINS[c] %@", message)).firstMatch
+                .waitForExistence(timeout: 5),
+        )
+        return self
+    }
+
+    @discardableResult
     func verifySharedFile(
         name: String,
         type: String,

--- a/wire-ios/WireUITests/Pages/ConversationDetailsPage.swift
+++ b/wire-ios/WireUITests/Pages/ConversationDetailsPage.swift
@@ -176,7 +176,8 @@ class ConversationDetailsPage: PageModel {
     @discardableResult
     func leaveAndClearConversation() throws -> ConversationDetailsPage {
         leaveAndClearConversationButtonOnBottomSheet.waitAndTap()
-        return try ConversationDetailsPage()
+        leaveAndClearConversationButtonOnBottomSheet.waitToDisappear(andThenWaitFor: navigationTitleView)
+        return self
     }
 
     var clearButtonOnBottomSheet: XCUIElement {

--- a/wire-ios/WireUITests/Pages/FilesAppPage.swift
+++ b/wire-ios/WireUITests/Pages/FilesAppPage.swift
@@ -159,7 +159,11 @@ class FilesAppPage: PageModel {
     }
 
     func chooseConversationAndSend(name: String) throws {
-        chooseConversation.waitAndTap()
+        XCTAssertTrue(
+            chooseConversation.waitForExistence(timeout: timeout),
+            "chooseConversation, didn't show up"
+        )
+        chooseConversation.tap()
 
         let conversationToSend = selectConversation(name: name)
         XCTAssertTrue(

--- a/wire-ios/WireUITests/Pages/FilesAppPage.swift
+++ b/wire-ios/WireUITests/Pages/FilesAppPage.swift
@@ -158,7 +158,7 @@ class FilesAppPage: PageModel {
         return self
     }
 
-    func chooseConversationAndSend(name: String) throws {
+    func chooseConversationAndSend(name: String, message: String) throws {
         XCTAssertTrue(
             chooseConversation.waitForExistence(timeout: timeout),
             "chooseConversation, didn't show up"
@@ -172,6 +172,7 @@ class FilesAppPage: PageModel {
         )
         conversationToSend.waitAndTap()
 
+        try addMessage(message)
         XCTAssertTrue(sendButton.waitForExistence(timeout: timeout), "Send button didn't show up")
         sendButton.waitAndTap()
         XCTAssertFalse(

--- a/wire-ios/WireUITests/Pages/FilesAppPage.swift
+++ b/wire-ios/WireUITests/Pages/FilesAppPage.swift
@@ -61,6 +61,15 @@ class FilesAppPage: PageModel {
         filesApp.buttons[Locators.ShareExtensionPage.sendButtonOnShareExtension.rawValue].firstMatch
     }
 
+    var messageField: XCUIElement {
+        let textView = filesApp.textViews[Locators.ShareExtensionPage.messageField.rawValue].firstMatch
+        if textView.exists {
+            return textView
+        }
+
+        return filesApp.textViews.firstMatch
+    }
+
     private func displayedFileName(from fileName: String) -> String {
         (fileName as NSString).deletingPathExtension
     }
@@ -139,12 +148,18 @@ class FilesAppPage: PageModel {
         return self
     }
 
-    func chooseConversationAndSend(name: String) throws {
+    @discardableResult
+    func addMessage(_ message: String) throws -> Self {
         XCTAssertTrue(
-            chooseConversation.waitForExistence(timeout: timeout),
-            "chooseConversation, didn't show up"
+            messageField.waitForExistence(timeout: timeout),
+            "Share extension message field didn't show up"
         )
-        chooseConversation.tap()
+        try messageField.tapIfKeyboardNotFocused().typeText(message)
+        return self
+    }
+
+    func chooseConversationAndSend(name: String) throws {
+        chooseConversation.waitAndTap()
 
         let conversationToSend = selectConversation(name: name)
         XCTAssertTrue(

--- a/wire-ios/WireUITests/Pages/PhotosAppPage.swift
+++ b/wire-ios/WireUITests/Pages/PhotosAppPage.swift
@@ -58,6 +58,15 @@ class PhotosAppPage: PageModel {
         photosApp.buttons[Locators.ShareExtensionPage.sendButtonOnShareExtension.rawValue].firstMatch
     }
 
+    var messageField: XCUIElement {
+        let textView = photosApp.textViews[Locators.ShareExtensionPage.messageField.rawValue].firstMatch
+        if textView.exists {
+            return textView
+        }
+
+        return photosApp.textViews.firstMatch
+    }
+
     var shareExtensionSearchField: XCUIElement {
         photosApp.searchFields.allElementsBoundByIndex.first(where: \.isHittable)
             ?? photosApp.searchFields.firstMatch
@@ -132,6 +141,16 @@ class PhotosAppPage: PageModel {
         shareButton.waitAndTap()
         XCTAssertTrue(shareToWireApp.waitForExistence(timeout: timeout))
         shareToWireApp.tap()
+        return self
+    }
+
+    @discardableResult
+    func addMessage(_ message: String) throws -> PhotosAppPage {
+        XCTAssertTrue(
+            messageField.waitForExistence(timeout: timeout),
+            "Share extension message field didn't show up"
+        )
+        try messageField.tapIfKeyboardNotFocused().typeText(message)
         return self
     }
 

--- a/wire-ios/WireUITests/Pages/PhotosAppPage.swift
+++ b/wire-ios/WireUITests/Pages/PhotosAppPage.swift
@@ -154,7 +154,7 @@ class PhotosAppPage: PageModel {
         return self
     }
 
-    func chooseConversationAndSend(name: String) throws {
+    func chooseConversationAndSend(name: String, message: String) throws {
 
         XCTAssertTrue(
             chooseConversation.waitForExistence(timeout: timeout),
@@ -168,6 +168,7 @@ class PhotosAppPage: PageModel {
             "Tap to chooseConversation, didn't pass"
         )
         conversationToSend.waitAndTap()
+        try addMessage(message)
         sendButton.waitAndTap()
 
         XCTAssertFalse(

--- a/wire-ios/WireUITests/Pages/SharedDriveFilesPage.swift
+++ b/wire-ios/WireUITests/Pages/SharedDriveFilesPage.swift
@@ -122,8 +122,8 @@ class SharedDriveFilesPage: PageModel {
     }
 
     func createFolder() throws -> FolderPage {
-        moreOptionOnSharedDrive.tap()
-        createFolderButton.tap()
+        moreOptionOnSharedDrive.waitAndTap(timeout: 3)
+        createFolderButton.waitAndTap(timeout: 3)
         return try FolderPage()
     }
 

--- a/wire-ios/WireUITests/ShareExtensionTests.swift
+++ b/wire-ios/WireUITests/ShareExtensionTests.swift
@@ -182,7 +182,6 @@ final class ShareExtensionTests: WireUITestCase {
             activeConversationPage.imageCell.waitForExistence(timeout: timeout),
             "No Image cell found"
         )
-        activeConversationPage.verifyMessageContaining(shareExtensionMessage)
     }
 
     private func assertVideoShared(on activeConversationPage: ActiveConversationPage) {
@@ -194,7 +193,6 @@ final class ShareExtensionTests: WireUITestCase {
             activeConversationPage.videoPlayButton.waitForExistence(timeout: timeout),
             "No Video play button found"
         )
-        activeConversationPage.verifyMessageContaining(shareExtensionMessage)
     }
 
     @MainActor
@@ -235,6 +233,7 @@ final class ShareExtensionTests: WireUITestCase {
             on: try ConversationsPage()
         )
         assertImageShared(on: activeConversationPage)
+        activeConversationPage.verifyMessageSent(shareExtensionMessage)
     }
 
     @MainActor
@@ -259,6 +258,7 @@ final class ShareExtensionTests: WireUITestCase {
             on: try ConversationsPage()
         )
         assertVideoShared(on: activeConversationPage)
+        activeConversationPage.verifyMessageSent(shareExtensionMessage)
     }
 
     @MainActor
@@ -286,26 +286,24 @@ final class ShareExtensionTests: WireUITestCase {
             conversationName: conversationName
         )
 
-        let senderConversationPage = try openConversation(
+        try openConversation(
             named: conversationName,
             on: try ConversationsPage()
         )
         // THEN - file is sent
-        try senderConversationPage
-            .verifyMessageContaining(shareExtensionMessage)
-            .verifySharedFile(name: "TESTFILE", type: "PDF")
-            .goBackToConversationPage()
-            .openUserProfilePage()
-            .switchUserAccountForUser(withName: member.name)
+        .verifySharedFile(name: "TESTFILE", type: "PDF")
+        .verifyMessageSent(shareExtensionMessage)
+        .goBackToConversationPage()
+        .openUserProfilePage()
+        .switchUserAccountForUser(withName: member.name)
 
-        let receiverConversationPage = try openConversation(
+        try openConversation(
             named: teamOwner.name,
             on: try ConversationsPage()
         )
         // THEN - file is received
-        receiverConversationPage
-            .verifyMessageContaining(shareExtensionMessage)
-            .verifySharedFile(name: "TESTFILE", type: "PDF")
+        .verifySharedFile(name: "TESTFILE", type: "PDF")
+        .verifyMessageSent(shareExtensionMessage)
     }
 
     /// [critical]
@@ -325,6 +323,7 @@ final class ShareExtensionTests: WireUITestCase {
             on: try ConversationsPage()
         )
         assertImageShared(on: activeConversationPage)
+        activeConversationPage.verifyMessageSent(shareExtensionMessage)
     }
 
     @MainActor
@@ -346,6 +345,7 @@ final class ShareExtensionTests: WireUITestCase {
             on: try ConversationsPage()
         )
         assertVideoShared(on: activeConversationPage)
+        activeConversationPage.verifyMessageSent(shareExtensionMessage)
     }
 
     @MainActor
@@ -369,26 +369,24 @@ final class ShareExtensionTests: WireUITestCase {
             conversationName: conversationName
         )
 
-        let senderConversationPage = try openConversation(
+        try openConversation(
             named: conversationName,
             on: try ConversationsPage()
         )
         // THEN - file is sent
-        try senderConversationPage
-            .verifyMessageContaining(shareExtensionMessage)
-            .verifySharedFile(name: "TESTFILE", type: "PDF")
-            .goBackToConversationPage()
-            .openUserProfilePage()
-            .switchUserAccountForUser(withName: member.name)
+        .verifySharedFile(name: "TESTFILE", type: "PDF")
+        .verifyMessageSent(shareExtensionMessage)
+        .goBackToConversationPage()
+        .openUserProfilePage()
+        .switchUserAccountForUser(withName: member.name)
 
-        let receiverConversationPage = try openConversation(
+        try openConversation(
             named: conversationName,
             on: try ConversationsPage()
         )
         // THEN - file is received
-        receiverConversationPage
-            .verifyMessageContaining(shareExtensionMessage)
-            .verifySharedFile(name: "TESTFILE", type: "PDF")
+        .verifySharedFile(name: "TESTFILE", type: "PDF")
+        .verifyMessageSent(shareExtensionMessage)
     }
 
     @MainActor
@@ -407,6 +405,7 @@ final class ShareExtensionTests: WireUITestCase {
             on: try ConversationsPage()
         )
         assertImageShared(on: activeConversationPage)
+        activeConversationPage.verifyMessageSent(shareExtensionMessage)
     }
 
     @MainActor
@@ -428,6 +427,7 @@ final class ShareExtensionTests: WireUITestCase {
             on: try ConversationsPage()
         )
         assertVideoShared(on: activeConversationPage)
+        activeConversationPage.verifyMessageSent(shareExtensionMessage)
     }
 
     @MainActor
@@ -456,25 +456,23 @@ final class ShareExtensionTests: WireUITestCase {
             conversationName: conversationName
         )
 
-        let senderConversationPage = try openConversation(
+        try openConversation(
             named: conversationName,
             on: try ConversationsPage()
         )
         // THEN - file is sent
-        try senderConversationPage
-            .verifyMessageContaining(shareExtensionMessage)
-            .verifySharedFile(name: "TESTFILE", type: "PDF")
-            .goBackToConversationPage()
-            .openUserProfilePage()
-            .switchUserAccountForUser(withName: member.name)
+        .verifySharedFile(name: "TESTFILE", type: "PDF")
+        .verifyMessageSent(shareExtensionMessage)
+        .goBackToConversationPage()
+        .openUserProfilePage()
+        .switchUserAccountForUser(withName: member.name)
 
-        let receiverConversationPage = try openConversation(
+        try openConversation(
             named: conversationName,
             on: try ConversationsPage()
         )
         // THEN - file is received
-        receiverConversationPage
-            .verifyMessageContaining(shareExtensionMessage)
-            .verifySharedFile(name: "TESTFILE", type: "PDF")
+        .verifySharedFile(name: "TESTFILE", type: "PDF")
+        .verifyMessageSent(shareExtensionMessage)
     }
 }

--- a/wire-ios/WireUITests/ShareExtensionTests.swift
+++ b/wire-ios/WireUITests/ShareExtensionTests.swift
@@ -27,6 +27,7 @@ final class ShareExtensionTests: WireUITestCase {
     private let filesAppBundleId = XCUIApplication(bundleIdentifier: "com.apple.DocumentsApp")
     private let testFileName = "testFile.pdf"
     private let testVideoName = "testVideo.mp4"
+    private let shareExtensionMessage = "shared via share-ext"
     private let appLaunchTimeout: TimeInterval = 5
     private let timeout: TimeInterval = 2
 
@@ -51,6 +52,7 @@ final class ShareExtensionTests: WireUITestCase {
         try photosApp
             .selectImageFromPhotos()
             .shareImageToWire()
+            .addMessage(shareExtensionMessage)
             .chooseConversationAndSend(name: conversationName)
 
         try await switchBackToWireApp()
@@ -63,6 +65,7 @@ final class ShareExtensionTests: WireUITestCase {
         let filesApp = try FilesAppPage(filesApp: filesAppBundleId)
         try filesApp
             .selectAndShareFileToWire(named: fileName)
+            .addMessage(shareExtensionMessage)
             .chooseConversationAndSend(name: conversationName)
 
         try await switchBackToWireApp()
@@ -182,6 +185,7 @@ final class ShareExtensionTests: WireUITestCase {
             activeConversationPage.imageCell.waitForExistence(timeout: timeout),
             "No Image cell found"
         )
+        activeConversationPage.verifyMessageContaining(shareExtensionMessage)
     }
 
     private func assertVideoShared(on activeConversationPage: ActiveConversationPage) {
@@ -193,6 +197,7 @@ final class ShareExtensionTests: WireUITestCase {
             activeConversationPage.videoPlayButton.waitForExistence(timeout: timeout),
             "No Video play button found"
         )
+        activeConversationPage.verifyMessageContaining(shareExtensionMessage)
     }
 
     @MainActor
@@ -284,22 +289,26 @@ final class ShareExtensionTests: WireUITestCase {
             conversationName: conversationName
         )
 
-        try openConversation(
+        let senderConversationPage = try openConversation(
             named: conversationName,
             on: try ConversationsPage()
         )
         // THEN - file is sent
-        .verifySharedFile(name: "TESTFILE", type: "PDF")
-        .goBackToConversationPage()
-        .openUserProfilePage()
-        .switchUserAccountForUser(withName: member.name)
+        try senderConversationPage
+            .verifyMessageContaining(shareExtensionMessage)
+            .verifySharedFile(name: "TESTFILE", type: "PDF")
+            .goBackToConversationPage()
+            .openUserProfilePage()
+            .switchUserAccountForUser(withName: member.name)
 
-        try openConversation(
+        let receiverConversationPage = try openConversation(
             named: teamOwner.name,
             on: try ConversationsPage()
         )
         // THEN - file is received
-        .verifySharedFile(name: "TESTFILE", type: "PDF")
+        receiverConversationPage
+            .verifyMessageContaining(shareExtensionMessage)
+            .verifySharedFile(name: "TESTFILE", type: "PDF")
     }
 
     /// [critical]
@@ -363,22 +372,26 @@ final class ShareExtensionTests: WireUITestCase {
             conversationName: conversationName
         )
 
-        try openConversation(
+        let senderConversationPage = try openConversation(
             named: conversationName,
             on: try ConversationsPage()
         )
         // THEN - file is sent
-        .verifySharedFile(name: "TESTFILE", type: "PDF")
-        .goBackToConversationPage()
-        .openUserProfilePage()
-        .switchUserAccountForUser(withName: member.name)
+        try senderConversationPage
+            .verifyMessageContaining(shareExtensionMessage)
+            .verifySharedFile(name: "TESTFILE", type: "PDF")
+            .goBackToConversationPage()
+            .openUserProfilePage()
+            .switchUserAccountForUser(withName: member.name)
 
-        try openConversation(
+        let receiverConversationPage = try openConversation(
             named: conversationName,
             on: try ConversationsPage()
         )
         // THEN - file is received
-        .verifySharedFile(name: "TESTFILE", type: "PDF")
+        receiverConversationPage
+            .verifyMessageContaining(shareExtensionMessage)
+            .verifySharedFile(name: "TESTFILE", type: "PDF")
     }
 
     @MainActor
@@ -446,21 +459,25 @@ final class ShareExtensionTests: WireUITestCase {
             conversationName: conversationName
         )
 
-        try openConversation(
+        let senderConversationPage = try openConversation(
             named: conversationName,
             on: try ConversationsPage()
         )
         // THEN - file is sent
-        .verifySharedFile(name: "TESTFILE", type: "PDF")
-        .goBackToConversationPage()
-        .openUserProfilePage()
-        .switchUserAccountForUser(withName: member.name)
+        try senderConversationPage
+            .verifyMessageContaining(shareExtensionMessage)
+            .verifySharedFile(name: "TESTFILE", type: "PDF")
+            .goBackToConversationPage()
+            .openUserProfilePage()
+            .switchUserAccountForUser(withName: member.name)
 
-        try openConversation(
+        let receiverConversationPage = try openConversation(
             named: conversationName,
             on: try ConversationsPage()
         )
         // THEN - file is received
-        .verifySharedFile(name: "TESTFILE", type: "PDF")
+        receiverConversationPage
+            .verifyMessageContaining(shareExtensionMessage)
+            .verifySharedFile(name: "TESTFILE", type: "PDF")
     }
 }

--- a/wire-ios/WireUITests/ShareExtensionTests.swift
+++ b/wire-ios/WireUITests/ShareExtensionTests.swift
@@ -52,8 +52,7 @@ final class ShareExtensionTests: WireUITestCase {
         try photosApp
             .selectImageFromPhotos()
             .shareImageToWire()
-            .addMessage(shareExtensionMessage)
-            .chooseConversationAndSend(name: conversationName)
+            .chooseConversationAndSend(name: conversationName, message: shareExtensionMessage)
 
         try await switchBackToWireApp()
     }
@@ -65,8 +64,7 @@ final class ShareExtensionTests: WireUITestCase {
         let filesApp = try FilesAppPage(filesApp: filesAppBundleId)
         try filesApp
             .selectAndShareFileToWire(named: fileName)
-            .addMessage(shareExtensionMessage)
-            .chooseConversationAndSend(name: conversationName)
+            .chooseConversationAndSend(name: conversationName, message: shareExtensionMessage)
 
         try await switchBackToWireApp()
     }

--- a/wire-ios/WireUITests/WireDriveTests.swift
+++ b/wire-ios/WireUITests/WireDriveTests.swift
@@ -327,7 +327,7 @@ final class WireDriveTests: WireUITestCase {
 
         searchTextField.typeText(positiveSearchTerm)
         XCTAssertTrue(
-            sharedDrivePage.fileIcon.waitForExistence(timeout: 2)
+            sharedDrivePage.fileIcon.waitForExistence(timeout: 5)
         )
         let positiveSearchResults = sharedDrivePage.numberOfFilesInList
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28014" title="WPB-28014" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28014</a>  [iOS] Debug recent UITests failures/Flakyness
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Recently failing some tests observed with flakyness.

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

Ran all tests here: https://github.com/wireapp/wire-ios/actions/runs/32005868899 where shreExtensionTests failed due to an issue of ordering of conversation selection as it gets hidden if we type message so corrected the order and fixed the assert and ran locally below:

<img width="1169" height="386" alt="image" src="https://github.com/user-attachments/assets/e3b6f398-b405-4f1b-99bb-1d871b7c6f6a" />


---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
