### PR TITLE
feat: Hide/show the meetings UI depends on the feature flag - WPB-25683

### DIFF
--- a/WireUI/Sources/WireMainNavigationUI/Containers/MainTabBarController.swift
+++ b/WireUI/Sources/WireMainNavigationUI/Containers/MainTabBarController.swift
@@ -196,23 +196,7 @@ public final class MainTabBarController<
                 archiveNavigationController.tabBarItem = tabBarItem
 
             case .meetings:
-                let tabBarItem = UITabBarItem(
-                    title: String(localized: "tabBar.meetings.title", bundle: .module),
-                    image: .init(resource: .videoCall),
-                    selectedImage: .init(resource: .videoCallFilled)
-                )
-                tabBarItem.accessibilityIdentifier = "bottomBarMeetingsButton"
-                tabBarItem.accessibilityLabel = String(
-                    localized: "tabBar.meetings.description",
-                    table: "Accessibility",
-                    bundle: .module
-                )
-                tabBarItem.accessibilityHint = String(
-                    localized: "tabBar.meetings.hint",
-                    table: "Accessibility",
-                    bundle: .module
-                )
-                meetingsNavigationController?.tabBarItem = tabBarItem
+                setupMeetingsTabBarItem()
 
             case .settings:
                 let tabBarItem = UITabBarItem(
@@ -280,17 +264,39 @@ public final class MainTabBarController<
     }
 
     private func setMeetingsUI(_ meetingsUI: MeetingsUI?, animated: Bool) {
-        guard
-            showMeetings,
-            let meetingsNavigationController
-        else {
-            return
+        if meetingsNavigationController == nil, meetingsUI != nil {
+            let meetingsNavigationController = UINavigationController()
+            meetingsNavigationController.navigationBar.isTranslucent = false
+            self.meetingsNavigationController = meetingsNavigationController
+            viewControllers?.insert(meetingsNavigationController, at: 2)
+            setupMeetingsTabBarItem()
         }
+
         _meetingsUI = meetingsUI
 
         let viewControllers = [meetingsUI].compactMap(\.self)
-        meetingsNavigationController.setViewControllers(viewControllers, animated: animated)
-        meetingsNavigationController.view.layoutIfNeeded()
+        meetingsNavigationController?.setViewControllers(viewControllers, animated: animated)
+        meetingsNavigationController?.view.layoutIfNeeded()
+    }
+
+    private func setupMeetingsTabBarItem() {
+        let tabBarItem = UITabBarItem(
+            title: String(localized: "tabBar.meetings.title", bundle: .module),
+            image: .init(resource: .videoCall),
+            selectedImage: .init(resource: .videoCallFilled)
+        )
+        tabBarItem.accessibilityIdentifier = "bottomBarMeetingsButton"
+        tabBarItem.accessibilityLabel = String(
+            localized: "tabBar.meetings.description",
+            table: "Accessibility",
+            bundle: .module
+        )
+        tabBarItem.accessibilityHint = String(
+            localized: "tabBar.meetings.hint",
+            table: "Accessibility",
+            bundle: .module
+        )
+        meetingsNavigationController?.tabBarItem = tabBarItem
     }
 
     private func setSettingsUI(_ settingsUI: SettingsUI?, animated: Bool) {

--- a/wire-ios-sync-engine/Source/UserSession/UserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/UserSession.swift
@@ -226,6 +226,8 @@ public protocol UserSession: AnyObject {
 
     var isWireDriveEnabled: Bool { get }
 
+    var isMeetingsEnabled: Bool { get }
+
     var wireDriveBackendURL: URL? { get }
 
     var isEnterpriseUser: Bool { get }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -173,6 +173,14 @@ public final class ZMUserSession: NSObject {
         return isFeatureEnabled && hasBackendURL
     }
 
+    public var isMeetingsEnabled: Bool {
+        // TODO: [WPB-28001] Remove developer flag before release
+        guard DeveloperFlag.wireMeetings.isOn else { return false }
+
+        let feature = Feature.fetch(name: .meetings, context: coreDataStack.viewContext)
+        return feature?.status == .enabled
+    }
+
     public var conferenceCallingFeature: Feature.ConferenceCalling {
         let featureRepository = LegacyFeatureRepository(context: coreDataStack.viewContext)
         return featureRepository.fetchConferenceCalling()

--- a/wire-ios-sync-engine/Support/Sourcery/generated/AutoMockable.manual.swift
+++ b/wire-ios-sync-engine/Support/Sourcery/generated/AutoMockable.manual.swift
@@ -511,7 +511,9 @@ public class MockUserSession: UserSession {
     public var underlyingMlsFeature: Feature.MLS!
 
     public var isWireDriveEnabled: Bool = false
-    
+
+    public var isMeetingsEnabled: Bool = false
+
     public var wireDriveBackendURL: URL? = nil
 
     public var isEnterpriseUser: Bool = false

--- a/wire-ios/Tests/Mocks/UserSessionMock.swift
+++ b/wire-ios/Tests/Mocks/UserSessionMock.swift
@@ -418,6 +418,8 @@ final class UserSessionMock: UserSession {
 
     var isWireDriveEnabled: Bool = false
 
+    var isMeetingsEnabled: Bool = false
+
     var wireDriveBackendURL: URL?
 
     var isEnterpriseUser: Bool = false

--- a/wire-ios/Wire-iOS/Sources/UserInterface/MainController/SidebarViewControllerBuilder.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/MainController/SidebarViewControllerBuilder.swift
@@ -29,7 +29,8 @@ struct SidebarViewControllerBuilder {
     @MainActor
     func build(
         isWireDriveEnabled: Bool = false,
-        isChannelsEnabled: Bool = false
+        isChannelsEnabled: Bool = false,
+        isMeetingsEnabled: Bool = false
     ) -> SidebarViewController {
 
         let accountImageViewDesign = AccountImageViewDesign()
@@ -69,7 +70,7 @@ struct SidebarViewControllerBuilder {
         // Configure unread filters visibility based on feature flag
         sidebarViewController.showUnreadFilters = DeveloperFlag.showUnreadConversationsFilter.isOn
         sidebarViewController.showChannels = isChannelsEnabled
-        sidebarViewController.showMeetings = DeveloperFlag.wireMeetings.isOn
+        sidebarViewController.showMeetings = isMeetingsEnabled
         sidebarViewController.showFiles = isWireDriveEnabled
 
         return sidebarViewController

--- a/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -365,15 +365,18 @@ final class ZClientViewController: UIViewController {
     }
 
     private func setupMeetingsTab() {
-        guard userSession.isMeetingsEnabled else { return }
+        let isEnabled = userSession.isMeetingsEnabled
 
         if UIDevice.current.userInterfaceIdiom == .pad {
-            guard !sidebarViewController.showMeetings else { return }
-            sidebarViewController.showMeetings = true
-            mainTabBarController.meetingsUI = makeMeetingsUI()
-        } else {
+            sidebarViewController.showMeetings = isEnabled
+        }
+
+        if isEnabled {
             guard mainTabBarController.meetingsUI == nil else { return }
             mainTabBarController.meetingsUI = makeMeetingsUI()
+        } else {
+            guard mainTabBarController.meetingsUI != nil else { return }
+            mainTabBarController.meetingsUI = nil
         }
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -86,7 +86,8 @@ final class ZClientViewController: UIViewController {
 
     private lazy var sidebarViewController = SidebarViewControllerBuilder().build(
         isWireDriveEnabled: userSession.isWireDriveEnabled,
-        isChannelsEnabled: userSession.channelsFeature.isEnabled
+        isChannelsEnabled: userSession.channelsFeature.isEnabled,
+        isMeetingsEnabled: userSession.isMeetingsEnabled
     )
 
     private lazy var sidebarViewControllerDelegate = SidebarViewControllerDelegate(
@@ -108,7 +109,7 @@ final class ZClientViewController: UIViewController {
 
     lazy var mainTabBarController = {
         let tabBarController = MainCoordinator.TabBarController(
-            showMeetings: DeveloperFlag.wireMeetings.isOn,
+            showMeetings: userSession.isMeetingsEnabled,
             showFiles: userSession.isWireDriveEnabled
         )
         tabBarController.applyMainTabBarControllerAppearance()
@@ -284,10 +285,10 @@ final class ZClientViewController: UIViewController {
             .observe(\.showUnreadConversationsFilter, options: [.new]) { [weak self] _, _ in
                 // Update sidebar's showUnreadFilters when developer flag changes
                 self?.sidebarViewController.showUnreadFilters = DeveloperFlag.showUnreadConversationsFilter.isOn
-                self?.sidebarViewController.showMeetings = DeveloperFlag.wireMeetings.isOn
+                self?.sidebarViewController.showMeetings = self?.userSession.isMeetingsEnabled ?? false
             }
 
-        observeCellsFeatureChange()
+        observeFeatureConfigChanges()
         createLegalHoldDisclosureController()
     }
 
@@ -300,9 +301,11 @@ final class ZClientViewController: UIViewController {
         AVSMediaManager.sharedInstance().unregisterMedia(mediaPlaybackManager)
     }
 
-    /// Allows to be notified when the cells feature config is updated locally so we can setup the Files tab.
-    /// On login, tab will show up with a slight delay, after resources have been pulled from the server (initial sync).
-    private func observeCellsFeatureChange() {
+    /// Allows to be notified when the cells or meetings feature configs are updated locally so we can setup the
+    /// Files and Meetings tabs.
+    /// On login, tabs will show up with a slight delay, after resources have been pulled from the server (initial
+    /// sync).
+    private func observeFeatureConfigChanges() {
         subscription = clientSessionComponent?.featureConfigRepository
             .observeFeatureStates()
             .receive(on: DispatchQueue.main)
@@ -311,6 +314,8 @@ final class ZClientViewController: UIViewController {
                 switch featureState.name {
                 case .cells, .cellsInternal:
                     setupWireDriveFilesTab()
+                case .meetings:
+                    setupMeetingsTab()
                 default:
                     break
                 }
@@ -333,6 +338,42 @@ final class ZClientViewController: UIViewController {
         } else {
             guard mainTabBarController.filesUI == nil else { return }
             mainTabBarController.filesUI = filesBrowserView
+        }
+    }
+
+    private func makeMeetingsUI() -> UIViewController {
+        let memberRepository = WireMeetingsMemberRepository(userSession: userSession)
+        let conversationRepository = clientSessionComponent.conversationRepository
+
+        return wireMeetingsFactory.makeMeetingsView(
+            meetingRepository: clientSessionComponent.meetingRepository,
+            memberRepository: memberRepository,
+            conversationRepository: MeetingConversationRepositoryBridge(
+                conversationRepository: conversationRepository,
+                contextProvider: userSession.contextProvider,
+                participantsService: ConversationParticipantsService(
+                    context: userSession.contextProvider.syncContext,
+                    localDomain: userSession.selfUser.domain
+                )
+            ),
+            callRepository: MeetingCallRepositoryBridge(
+                userSession: userSession,
+                alertPresenter: self
+            ),
+            accentColorState: meetingsAccentColorState
+        )
+    }
+
+    private func setupMeetingsTab() {
+        guard userSession.isMeetingsEnabled else { return }
+
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            guard !sidebarViewController.showMeetings else { return }
+            sidebarViewController.showMeetings = true
+            mainTabBarController.meetingsUI = makeMeetingsUI()
+        } else {
+            guard mainTabBarController.meetingsUI == nil else { return }
+            mainTabBarController.meetingsUI = makeMeetingsUI()
         }
     }
 
@@ -426,26 +467,9 @@ final class ZClientViewController: UIViewController {
         settingsViewControllerBuilder.settingsPropertyFactoryDelegate = defaultSettingsPropertyFactoryDelegate
         mainTabBarController.archiveUI = archiveUI
 
-        let memberRepository = WireMeetingsMemberRepository(userSession: userSession)
-        let conversationRepository = clientSessionComponent.conversationRepository
-        let meetingsUI = wireMeetingsFactory.makeMeetingsView(
-            meetingRepository: clientSessionComponent.meetingRepository,
-            memberRepository: memberRepository,
-            conversationRepository: MeetingConversationRepositoryBridge(
-                conversationRepository: conversationRepository,
-                contextProvider: userSession.contextProvider,
-                participantsService: ConversationParticipantsService(
-                    context: userSession.contextProvider.syncContext,
-                    localDomain: userSession.selfUser.domain
-                )
-            ),
-            callRepository: MeetingCallRepositoryBridge(
-                userSession: userSession,
-                alertPresenter: self
-            ),
-            accentColorState: meetingsAccentColorState
-        )
-        mainTabBarController.meetingsUI = meetingsUI
+        if userSession.isMeetingsEnabled {
+            mainTabBarController.meetingsUI = makeMeetingsUI()
+        }
         mainTabBarController.settingsUI = settingsViewControllerBuilder
             .build(mainCoordinator: mainCoordinator)
         if userSession.isWireDriveEnabled {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25683" title="WPB-25683" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-25683</a>  [iOS] Hide/show the UI depends on the feature flag
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

We should show/hide the Meeting tab depends on the “meetings“ feature flag.

### Testing



### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
