### PR TITLE
chore: add missing generated strings - WPB-27416

### DIFF
--- a/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
+++ b/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
@@ -6408,10 +6408,11 @@ internal enum L10n {
     internal enum SsoIdentityChanged {
       /// Delete data and continue
       internal static let deleteDataAndContinue = L10n.tr("Localizable", "sso_identity_changed.delete_data_and_continue", fallback: "Delete data and continue")
-      /// This account was previously used with a different identity provider. Continuing will delete all locally stored conversations and account data on this device. To keep or back up your data, cancel and sign in with the previous identity provider.
-      internal static let message = L10n.tr("Localizable", "sso_identity_changed.message", fallback: "This account was previously used with a different identity provider. Continuing will delete all locally stored conversations and account data on this device. To keep or back up your data, cancel and sign in with the previous identity provider.")
-      /// Different identity provider detected
-      internal static let title = L10n.tr("Localizable", "sso_identity_changed.title", fallback: "Different identity provider detected")
+      /// This account was used with a different identity provider. Continuing will delete all conversations from this device.
+      /// To keep your data, select Cancel, then log in with your previous identity provider.
+      internal static let message = L10n.tr("Localizable", "sso_identity_changed.message", fallback: "This account was used with a different identity provider. Continuing will delete all conversations from this device.\nTo keep your data, select Cancel, then log in with your previous identity provider.")
+      /// Identity provider changed
+      internal static let title = L10n.tr("Localizable", "sso_identity_changed.title", fallback: "Identity provider changed")
     }
     internal enum SystemStatusBar {
       internal enum NoInternet {


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27416" title="WPB-27416" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-27416</a>  [iOS] Clear retained account data when logging in with a different SSO identity
  </td></table>
  <br />

<!--jira-description-action-hidden-marker-end-->

### Issue

This PR adds some missing generated strings related to the different SSO identity alert.

### Testing

See tests steps in WPB-27416

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.
