### PR TITLE
fix: default file size to 0 when nil (occurs for empty folders) - WPB-27777

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Item/FilesItemViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Item/FilesItemViewModel.swift
@@ -400,8 +400,8 @@ private extension FilesItemViewModel {
                     primary = Strings.AllFiles.Item.subtitle(ownedBy, conversationName)
                 }
             case .size:
-                if let conversationName,
-                   let size = formattedFileSize(size: size) {
+                if let conversationName {
+                    let size = formattedFileSize(size: size)
                     primary = Strings.AllFiles.Item.subtitle(size, conversationName)
                 }
             default:
@@ -424,7 +424,8 @@ private extension FilesItemViewModel {
                     primary = Strings.Files.Item.subtitle(Strings.Sorting.Key.date, ownedBy)
                 }
             case .size:
-                if let size = formattedFileSize(size: size), let ownedBy {
+                if let ownedBy {
+                    let size = formattedFileSize(size: size)
                     primary = Strings.Files.Item.subtitle(size, ownedBy)
                 }
             default:
@@ -441,12 +442,12 @@ private extension FilesItemViewModel {
         }
     }
 
-    private static func formattedFileSize(size: UInt64?) -> String? {
-        guard let size else { return nil }
+    private static func formattedFileSize(size: UInt64?) -> String {
         let formatter = ByteCountFormatter()
         formatter.allowedUnits = [.useBytes, .useKB, .useMB, .useGB]
         formatter.countStyle = .file
-        return formatter.string(fromByteCount: Int64(size))
+        formatter.allowsNonnumericFormatting = false
+        return formatter.string(fromByteCount: Int64(size ?? 0))
     }
 
     private static func formattedDate(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27777" title="WPB-27777" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-27777</a>  [iOS] Add "0 bytes" to the size attribute when folder is empty
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR sets a default size to 0 when nil value is returned which occurs specifically when folders are empty.

### Testing

- open Shared Drive
- create a new folder
- sort by size
- observe the caption "0 bytes" is correctly displayed

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
