### PR TITLE
chore: bump Edge version - WPB-28103

### DIFF
--- a/wire-ios/Wire-iOS/Resources/Configuration/Version.xcconfig
+++ b/wire-ios/Wire-iOS/Resources/Configuration/Version.xcconfig
@@ -16,5 +16,5 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-WIRE_SHORT_VERSION = 4.26.0
+WIRE_SHORT_VERSION = 4.27.0
 MAJOR_VERSION = 4


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28103" title="WPB-28103" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28103</a>  [iOS] Release 4.27.0 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Cutting the `release/cycle-4.26` release cycle. This PR bumps the Edge
(develop) version from `4.26.0` to `4.27.0` so develop
keeps building the next cycle.

### Testing

Version bump only — no functional changes. Verify the Edge build reports
version `4.27.0`.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.