### PR TITLE
chore: call attendees tile in shown alphabetical order - WPB-27829

### DIFF
--- a/wire-ios/WireUITests/Helper/UserGenerator.swift
+++ b/wire-ios/WireUITests/Helper/UserGenerator.swift
@@ -20,7 +20,7 @@ import XCTest
 
 enum UserGenerator {
 
-    static func generateUniqueUserInfo() -> UserInfo {
+    static func generateUniqueUserInfo(preferredName: String? = nil) -> UserInfo {
         let password = generateRandomPassword()
 
         let time = Int(Date().timeIntervalSince1970 * 1000)
@@ -28,7 +28,7 @@ enum UserGenerator {
 
         let username = "smoketester\(time)\(random)"
         let domain = "wire.engineering"
-        let name = "Smoke Tester \(time)\(random)"
+        let name = "\(preferredName ?? "Smoke Tester") \(time)\(random)"
         let teamName = "Team-Smoke \(time)\(random)"
         return UserInfo(
             name: name,

--- a/wire-ios/WireUITests/Helper/UserHelper.swift
+++ b/wire-ios/WireUITests/Helper/UserHelper.swift
@@ -274,9 +274,12 @@ final class UserHelper {
     /// Register a team owner with a provided team name.
     /// - Parameter teamName: team name to create.
     /// - Returns: qualifiedId of the owner and ownerInfo
-    func registerUserAsTeamOwner(teamName: String) async throws -> (qualifiedID: QualifiedID, owner: UserInfo) {
+    func registerUserAsTeamOwner(
+        teamName: String,
+        preferredName: String? = nil
+    ) async throws -> (qualifiedID: QualifiedID, owner: UserInfo) {
 
-        let teamOwner = UserGenerator.generateUniqueUserInfo()
+        let teamOwner = UserGenerator.generateUniqueUserInfo(preferredName: preferredName)
         teamOwner.teamName = teamName
 
         let (teamID, qualifiedId) = try await authenticationAPI.registerTeamOwner(
@@ -399,10 +402,11 @@ final class UserHelper {
 
     func registerUsersAsTeamMemberWithUserHandleSet(
         ownerAccessToken: String,
-        teamID: UUID
+        teamID: UUID,
+        preferredName: String? = nil
     ) async throws -> (qualifiedID: QualifiedID, member: UserInfo) {
 
-        let teamMember = UserGenerator.generateUniqueUserInfo()
+        let teamMember = UserGenerator.generateUniqueUserInfo(preferredName: preferredName)
 
         let invitationID = try await teamsAPI.inviteMemberToTeam(
             access_token: ownerAccessToken,
@@ -584,11 +588,16 @@ final class UserHelper {
     func registerTeam(
         withMemberCount memberCount: Int,
         conversation: CreateConversationOption? = nil,
-        driveEnabled: Bool = false
+        driveEnabled: Bool = false,
+        names: [String] = []
     ) async throws
         -> (teamOwner: UserInfo, teamMembers: [UserInfo], qualifiedIDs: [QualifiedID], conversationId: UUID?) {
 
-        let (_, teamOwner) = try await registerUserAsTeamOwner()
+        let generated = UserGenerator.generateUniqueUserInfo()
+        let (_, teamOwner) = try await registerUserAsTeamOwner(
+            teamName: generated.teamName,
+            preferredName: names.first
+        )
         guard let teamID = teamOwner.teamID else {
             throw RuntimeError("registerTeam: teamOwner.teamID is nil")
         }
@@ -608,10 +617,11 @@ final class UserHelper {
         var teamMembers: [UserInfo] = []
         teamMembers.reserveCapacity(memberCount)
 
-        for _ in 0 ..< memberCount {
+        for index in 0 ..< memberCount {
             let (qualifiedId, teamMember) = try await registerUsersAsTeamMemberWithUserHandleSet(
                 ownerAccessToken: ownerAccessToken.token,
-                teamID: teamID
+                teamID: teamID,
+                preferredName: names.indices.contains(index + 1) ? names[index + 1] : nil
             )
             qualifiedIDs.append(qualifiedId)
             teamMembers.append(teamMember)

--- a/wire-ios/WireUITests/Pages/OngoingCallPage.swift
+++ b/wire-ios/WireUITests/Pages/OngoingCallPage.swift
@@ -68,6 +68,55 @@ class OngoingCallPage: PageModel {
         app.buttons[Locators.OngoingCallPage.participantIdentifier(name)]
     }
 
+    func callTile(named name: String) -> XCUIElement {
+        app.buttons.matching(
+            NSPredicate(
+                format: """
+                (identifier BEGINSWITH %@ OR identifier BEGINSWITH %@) AND
+                identifier CONTAINS %@
+                """,
+                "audioView.",
+                "videoView.",
+                ".\(name)."
+            )
+        ).firstMatch
+    }
+
+    @discardableResult
+    func verifyParticipantsShownInOrder(
+        _ expectedNames: [String]
+    ) -> OngoingCallPage {
+        for name in expectedNames {
+            _ = callTile(named: name).waitForExistence(timeout: 15)
+        }
+
+        XCTAssertEqual(
+            visibleParticipantNames(from: expectedNames),
+            expectedNames,
+            "Call participant tiles are not shown in expected order"
+        )
+        return self
+    }
+
+    private func visibleParticipantNames(from expectedNames: [String]) -> [String] {
+        let tiles = app.buttons.matching(
+            NSPredicate(
+                format: "identifier BEGINSWITH %@ OR identifier BEGINSWITH %@",
+                "audioView.",
+                "videoView."
+            )
+        ).allElementsBoundByIndex
+
+        var seenNames = Set<String>()
+        return tiles.compactMap { tile in
+            guard let name = expectedNames.first(where: { tile.identifier.contains(".\($0).") }),
+                  seenNames.insert(name).inserted else {
+                return nil
+            }
+            return name
+        }
+    }
+
     func verifyGroupNameAndTimerShowingOnceCallJoined(groupName: String) {
         XCTAssertTrue(
             timeLabel.waitForExistence(timeout: 10),

--- a/wire-ios/WireUITests/ZCallingTests.swift
+++ b/wire-ios/WireUITests/ZCallingTests.swift
@@ -77,6 +77,12 @@ final class ZCallingTests: WireUITestCase {
         return ownerId
     }
 
+    private func sortedByName(_ users: [UserInfo]) -> [UserInfo] {
+        users.sorted { firstUser, secondUser in
+            firstUser.name.localizedCaseInsensitiveCompare(secondUser.name) == .orderedAscending
+        }
+    }
+
     private func acceptIncomingCall(groupName: String) throws -> OngoingCallPage {
         let incomingCallPage = try IncomingCallPage()
         XCTAssertTrue(incomingCallPage.acceptButton.exists, "Expected call not received")
@@ -509,5 +515,63 @@ final class ZCallingTests: WireUITestCase {
         rejoinedCallPage.verifyGroupNameAndTimerShowingOnceCallJoined(
             groupName: teamAndGroupCallSetup.groupName
         )
+    }
+
+    @MainActor
+    func testCallParticipantTilesShownInOrder_TC_9462() async throws {
+        // GIVEN
+        let teamAndGroupCallSetup = try await makeTeamAndGroupCallSetup(memberCount: 3)
+
+        let firstTimePage = try app.loginUser(
+            email: teamAndGroupCallSetup.appUserReceivingCall.email,
+            password: teamAndGroupCallSetup.appUserReceivingCall.password
+        )
+        _ = try firstTimePage.acceptPopup()
+
+        let instances = try await createCallingServiceInstances(users: teamAndGroupCallSetup.callingServiceUsers)
+        let ownerInstanceId = try requireOwnerInstanceId(from: instances)
+
+        // WHEN
+        _ = try await callingServiceClient.startCall(
+            instanceId: ownerInstanceId,
+            conversationId: teamAndGroupCallSetup.conversationId
+        )
+
+        let acceptingIds = instances.dropFirst().compactMap(\.id).filter { !$0.isEmpty }
+        let responses = try await callingManager.acceptNextCalls(
+            instanceIds: acceptingIds,
+            conversationId: teamAndGroupCallSetup.conversationId
+        )
+        XCTAssertEqual(responses.count, acceptingIds.count)
+
+        let ongoingCallPage = try acceptIncomingCall(groupName: teamAndGroupCallSetup.groupName)
+
+        // THEN
+        let expectedAudioOrder = [teamAndGroupCallSetup.appUserReceivingCall.name] +
+            sortedByName(teamAndGroupCallSetup.callingServiceUsers).map(\.name)
+        ongoingCallPage.verifyParticipantsShownInOrder(expectedAudioOrder)
+
+        let videoFirstUser = try XCTUnwrap(sortedByName(teamAndGroupCallSetup.callingServiceUsers).last)
+        let videoFirstUserIndex = try XCTUnwrap(
+            teamAndGroupCallSetup.callingServiceUsers.firstIndex { $0 === videoFirstUser }
+        )
+        let videoFirstInstanceId = instances[videoFirstUserIndex].id
+        try await callingManager.waitForCurrentCallStatus(
+            instanceId: videoFirstInstanceId,
+            expectedStatuses: ["ACTIVE"],
+            timeout: 30
+        )
+        try await callingManager.switchVideoOn(instanceId: videoFirstInstanceId)
+        XCTAssertTrue(
+            ongoingCallPage.videoView(for: videoFirstUser.name).waitForExistence(timeout: 20),
+            "Video tile did not appear for \(videoFirstUser.name)"
+        )
+
+        let expectedVideoOrder = [
+            teamAndGroupCallSetup.appUserReceivingCall.name,
+            videoFirstUser.name
+        ] + sortedByName(teamAndGroupCallSetup.callingServiceUsers.filter { $0.email != videoFirstUser.email })
+            .map(\.name)
+        ongoingCallPage.verifyParticipantsShownInOrder(expectedVideoOrder)
     }
 }

--- a/wire-ios/WireUITests/ZCallingTests.swift
+++ b/wire-ios/WireUITests/ZCallingTests.swift
@@ -35,14 +35,16 @@ final class ZCallingTests: WireUITestCase {
 
     private func makeTeamAndGroupCallSetup(
         memberCount: Int,
-        groupName: String? = nil
+        groupName: String? = nil,
+        preferredNames: [String] = []
     ) async throws -> GroupCallScenario {
         let groupName = groupName ?? UserGenerator.generateRandomConversationName()
 
         let (teamOwner, teamMembers, _, conversationId) = try await UserHelper.default
             .registerTeam(
                 withMemberCount: memberCount,
-                conversation: .group(groupName)
+                conversation: .group(groupName),
+                names: preferredNames
             )
 
         let convId = try XCTUnwrap(conversationId, "conversationId is nil").uuidString.lowercased()
@@ -518,9 +520,12 @@ final class ZCallingTests: WireUITestCase {
     }
 
     @MainActor
-    func testCallParticipantTilesShownInOrder_TC_9462() async throws {
+    func testCallParticipantTilesShownInAlphabeticalOrder_TC_9462() async throws {
         // GIVEN
-        let teamAndGroupCallSetup = try await makeTeamAndGroupCallSetup(memberCount: 3)
+        let teamAndGroupCallSetup = try await makeTeamAndGroupCallSetup(
+            memberCount: 3,
+            preferredNames: ["A", "B", "C", "D"]
+        )
 
         let firstTimePage = try app.loginUser(
             email: teamAndGroupCallSetup.appUserReceivingCall.email,
@@ -547,6 +552,7 @@ final class ZCallingTests: WireUITestCase {
         let ongoingCallPage = try acceptIncomingCall(groupName: teamAndGroupCallSetup.groupName)
 
         // THEN
+        // Self user should be shown first, then other participants should be shown in alphabetical order.
         let expectedAudioOrder = [teamAndGroupCallSetup.appUserReceivingCall.name] +
             sortedByName(teamAndGroupCallSetup.callingServiceUsers).map(\.name)
         ongoingCallPage.verifyParticipantsShownInOrder(expectedAudioOrder)
@@ -561,17 +567,22 @@ final class ZCallingTests: WireUITestCase {
             expectedStatuses: ["ACTIVE"],
             timeout: 30
         )
+        // WHEN - switched video on
         try await callingManager.switchVideoOn(instanceId: videoFirstInstanceId)
         XCTAssertTrue(
             ongoingCallPage.videoView(for: videoFirstUser.name).waitForExistence(timeout: 20),
             "Video tile did not appear for \(videoFirstUser.name)"
         )
 
+        // When a participant enables video, self user stays first, video participant shows next,
+        // and remaining participants stay in alphabetical order.
         let expectedVideoOrder = [
             teamAndGroupCallSetup.appUserReceivingCall.name,
             videoFirstUser.name
         ] + sortedByName(teamAndGroupCallSetup.callingServiceUsers.filter { $0.email != videoFirstUser.email })
             .map(\.name)
+
+        // THEN
         ongoingCallPage.verifyParticipantsShownInOrder(expectedVideoOrder)
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27829" title="WPB-27829" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-27829</a>  [iOS] Automate - TC-9462 Verify that the tiles appearing on the call should be in alphabetical order.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

**UITest - participants shows in alphabetical order**


### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

Ran locally

https://github.com/user-attachments/assets/01db59eb-9b8e-4db7-b698-97e0d46614bb



---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
