### PR TITLE
chore: bump AVS to 10.5.10 - WPB-28110

### DIFF
--- a/WireAVS/Package.swift
+++ b/WireAVS/Package.swift
@@ -17,8 +17,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "WireAVS",
-            url: "https://github.com/wireapp/wire-avs/releases/download/10.5.8/avs.xcframework.zip",
-            checksum: "0d58623fdf25570477ca0bc9018d7cf2767c10804be6740b2e6c78fa11ab675b"
+            url: "https://github.com/wireapp/wire-avs/releases/download/10.5.10/avs.xcframework.zip",
+            checksum: "67ebe389b81a66aaf95fa3cb151c2863728ec4c08b0c6879822ef21aa7fcd1fb"
         )
     ]
 )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28110" title="WPB-28110" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28110</a>  [Calling][iOS] Bump AVS to 10.5.10
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

To facilitate the full rollout of the fix linked to WPB-28110, AVS needs to be updated to 10.5.10.
---

### Checklist

- [X] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [X] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
