### PR TITLE
fix: refresh meeting participants after member-add - WPB-27623

### DIFF
--- a/WireDomain/Sources/WireDomain/Event Processing/MeetingEventProcessor/MeetingUpdateEventProcessor.swift
+++ b/WireDomain/Sources/WireDomain/Event Processing/MeetingEventProcessor/MeetingUpdateEventProcessor.swift
@@ -29,17 +29,7 @@ struct MeetingUpdateEventProcessor: MeetingUpdateEventProcessorProtocol {
         // was already deleted, so there is nothing left to link.
         guard let meeting = try await repository.pullMeeting(id: event.meetingID) else { return }
 
-        // The meeting's conversation arrives via its own conversation.create-meeting
-        // event, but that event isn't guaranteed to have been processed before this
-        // one. If the conversation isn't stored locally yet, pull it and store the
-        // meeting again so the two are linked; meetings without a locally stored
-        // conversation are not listed.
         let conversationID = meeting.conversationID
-        guard await conversationRepository.fetchConversation(
-            id: conversationID.id,
-            domain: conversationID.domain
-        ) == nil else { return }
-
         try await conversationRepository.pullConversation(
             id: conversationID.id,
             domain: conversationID.domain

--- a/WireDomain/Tests/WireDomainTests/Event Processing/MeetingEventProcessor/MeetingUpdateEventProcessorTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Event Processing/MeetingEventProcessor/MeetingUpdateEventProcessorTests.swift
@@ -100,7 +100,7 @@ final class MeetingUpdateEventProcessorTests: XCTestCase {
         XCTAssertEqual(repository.storeMeetingMeetingMeetingVoidReceivedInvocations.map(\.id), [Scaffolding.meetingID])
     }
 
-    func testProcessEvent_It_Does_Not_Pull_Conversation_When_It_Is_Already_Known() async throws {
+    func testProcessEvent_It_Pulls_Conversation_When_It_Is_Already_Known() async throws {
         // Mock
 
         let coreDataStackHelper = CoreDataStackHelper()
@@ -116,6 +116,7 @@ final class MeetingUpdateEventProcessorTests: XCTestCase {
 
         repository.pullMeetingIdQualifiedIDMeetingReturnValue = Scaffolding.meeting
         conversationRepository.fetchConversationIdDomain_MockValue = conversation
+        conversationRepository.pullConversationIdDomain_MockMethod = { _, _ in }
 
         // When
 
@@ -123,8 +124,8 @@ final class MeetingUpdateEventProcessorTests: XCTestCase {
 
         // Then
 
-        XCTAssertTrue(conversationRepository.pullConversationIdDomain_Invocations.isEmpty)
-        XCTAssertTrue(repository.storeMeetingMeetingMeetingVoidReceivedInvocations.isEmpty)
+        XCTAssertEqual(conversationRepository.pullConversationIdDomain_Invocations.count, 1)
+        XCTAssertEqual(repository.storeMeetingMeetingMeetingVoidReceivedInvocations.map(\.id), [Scaffolding.meetingID])
 
         try coreDataStackHelper.cleanupDirectory()
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27623" title="WPB-27623" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-27623</a>  Support meeting.member-add events on iOS
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Fixes the reopened QA issue where a newly added user can see a meeting, but its participant list is empty.

The related `meeting.member-add`, `conversation.member-join`, and `conversation.mls-welcome` events can arrive in any order. The meeting processor previously skipped fetching the authoritative conversation whenever a local conversation already existed, including an empty placeholder created by another event.

Always pull the meeting conversation after refreshing the meeting, then store the meeting again so the refreshed participants are linked and the existing meeting-change broadcaster refreshes the UI.

---

### Checklist

- [X] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [X] Description is filled and free of optional paragraphs.
- [X] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
