### PR TITLE
fix: apply possible fix for no audio during calls - WPB-28228

### DIFF
--- a/wire-ios-sync-engine/Source/Calling/CallKitManager.swift
+++ b/wire-ios-sync-engine/Source/Calling/CallKitManager.swift
@@ -390,6 +390,8 @@ public class CallKitManager: NSObject, CallKitManagerInterface {
         update.supportsGrouping = false
         update.supportsUngrouping = false
 
+        // Re-set configuration as potential iOS bug fix. See [WPB-28164]
+        provider.configuration = CallKitManager.providerConfiguration
         // Don't use the async version, it's broken
         // It doesn't get executed when waking up the app from the background and ends up crashing
         // See latest comments https://stackoverflow.com/questions/56788314/ios-13-killing-app-because-it-never-posted-an-incoming-call-to-the-system-after
@@ -474,6 +476,8 @@ public class CallKitManager: NSObject, CallKitManagerInterface {
 
         logger.info("provider.reportNewIncomingCall", attributes: .safePublic)
 
+        // Re-set configuration as potential iOS bug fix. See [WPB-28164]
+        provider.configuration = CallKitManager.providerConfiguration
         provider.reportNewIncomingCall(
             with: call.id,
             update: update


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28228" title="WPB-28228" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28228</a>  [iOS] Always set configuration before reporting call
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

We have had a couple of instances where there is no audio when joining a call (only video) and the user is kicked out the call after a few seconds. Based on logs It appears in those cases that `provider(_:didActivate:)` was never called by CallKit which I've confirmed results in the above behaviour. 

I have been unable to reproduce the issue. It maybe a race condition related to activating the audio session (AVS doing it instead of CallKit) but an Apple engineer also recommended the change in this PR as a workaround in case it relates to an iOS bug. See https://developer.apple.com/forums/thread/835520?answerId=895166022#895166022. 

This PR just re-sets the `configuration` on a the `CXProvider` before reporting a new call.

### Testing

Test that calls are working normally including answering via call kit and via the `join` button in app. Playground build here: https://github.com/wireapp/wire-ios/actions/runs/32717389363

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.