### PR TITLE
revert: "fix: clear retained account data after SSO identity change - WPB-27416 (#5086)" - WPB-27416

### DIFF
--- a/WireAuthentication/Sources/WireAuthentication/Components/DetermineAuthMethodComponent.swift
+++ b/WireAuthentication/Sources/WireAuthentication/Components/DetermineAuthMethodComponent.swift
@@ -41,7 +41,7 @@ final class DetermineAuthMethodComponent: Component<DetermineAuthMethodComponent
     private let existsAnotherAccount: Bool
     private let allowsMultipleBackends: Bool
     private let existingBackendHosts: Set<String>
-    private let isAccountAlreadyLoggedIn: (AuthenticationResult) -> Bool
+    private let isAccountAlreadyLoggedIn: (UUID) -> Bool
 
     init(
         parent: any Scope,
@@ -49,7 +49,7 @@ final class DetermineAuthMethodComponent: Component<DetermineAuthMethodComponent
         existsAnotherAccount: Bool,
         allowsMultipleBackends: Bool,
         existingBackendHosts: Set<String>,
-        isAccountAlreadyLoggedIn: @escaping (AuthenticationResult) -> Bool
+        isAccountAlreadyLoggedIn: @escaping (UUID) -> Bool
     ) {
         self.networkStack = networkStack
         self.existsAnotherAccount = existsAnotherAccount

--- a/WireAuthentication/Sources/WireAuthentication/Components/RootComponent.swift
+++ b/WireAuthentication/Sources/WireAuthentication/Components/RootComponent.swift
@@ -44,7 +44,7 @@ final class RootComponent: BootstrapComponent {
     public let appStoreURL: URL
     public let accountsPublisher: CurrentValuePublisher<[AccountUIModel]>
     public let registrationAnalyticsTracker: (any RegistrationAnalyticsTrackerProtocol)?
-    public let isAccountAlreadyLoggedIn: (AuthenticationResult) -> Bool
+    public let isAccountAlreadyLoggedIn: (UUID) -> Bool
     public let overrideAllowEmailLoginOnly: Bool
 
     @MainActor public var bridge: WireAuthenticationBridge {
@@ -75,7 +75,7 @@ final class RootComponent: BootstrapComponent {
         appStoreURL: URL,
         accountsPublisher: CurrentValuePublisher<[AccountUIModel]>,
         registrationAnalyticsTracker: (any RegistrationAnalyticsTrackerProtocol)?,
-        isAccountAlreadyLoggedIn: @escaping (AuthenticationResult) -> Bool,
+        isAccountAlreadyLoggedIn: @escaping (UUID) -> Bool,
         overrideAllowEmailLoginOnly: Bool
     ) {
         self.authenticationType = authenticationType

--- a/WireAuthentication/Sources/WireAuthentication/WireAuthenticationAssembly.swift
+++ b/WireAuthentication/Sources/WireAuthentication/WireAuthenticationAssembly.swift
@@ -53,7 +53,7 @@ public struct WireAuthenticationAssembly {
         appStoreURL: URL,
         accountsPublisher: CurrentValuePublisher<[AccountUIModel]>,
         registrationAnalyticsTracker: (any RegistrationAnalyticsTrackerProtocol)?,
-        isAccountAlreadyLoggedIn: @escaping (AuthenticationResult) -> Bool = { _ in false },
+        isAccountAlreadyLoggedIn: @escaping (UUID) -> Bool = { _ in false },
         overrideAllowEmailLoginOnly: Bool
     ) -> (view: some View, bridge: WireAuthenticationBridge) {
         let rootComponent = RootComponent(

--- a/WireAuthentication/Sources/WireAuthenticationAPI/Models/AuthenticationResult.swift
+++ b/WireAuthentication/Sources/WireAuthenticationAPI/Models/AuthenticationResult.swift
@@ -51,10 +51,6 @@ public struct AuthenticationResult: Equatable, Hashable, Sendable {
 
     public let proxyCredentials: ProxyCredentials?
 
-    /// The identity provider selected by multi-ingress email discovery, if applicable.
-
-    public package(set) var multiIngressIdentityProviderID: UUID?
-
     public init(
         userID: UUID,
         cookies: [HTTPCookie],

--- a/WireAuthentication/Sources/WireAuthenticationAPI/Use cases/DetermineAuthMethodUseCaseProtocol.swift
+++ b/WireAuthentication/Sources/WireAuthenticationAPI/Use cases/DetermineAuthMethodUseCaseProtocol.swift
@@ -37,7 +37,7 @@ public enum AuthenticationMethod: Sendable, Hashable {
 
     /// Cloud SSO login
 
-    case loginViaSSO(code: UUID, multiIngressIdentityProviderID: UUID? = nil)
+    case loginViaSSO(code: UUID)
 
     /// On-prem login, either via email or SSO
 

--- a/WireAuthentication/Sources/WireAuthenticationLogic/DetermineAuthMethodUseCase.swift
+++ b/WireAuthentication/Sources/WireAuthenticationLogic/DetermineAuthMethodUseCase.swift
@@ -46,7 +46,7 @@ package struct DetermineAuthMethodUseCase: DetermineAuthMethodUseCaseProtocol {
 
             do {
                 let ssoCode = try await authenticationAPI.getSSOCode(forEmail: email)
-                return .loginViaSSO(code: ssoCode, multiIngressIdentityProviderID: ssoCode)
+                return .loginViaSSO(code: ssoCode)
             } catch AuthenticationAPIError.unsupportedEndpointForAPIVersion, AuthenticationAPIError.ssoCodeNotFound {
                 // back to default behaviour - no default sso code
                 return try await determineAuthMethod(email: email, domain: domain)

--- a/WireAuthentication/Sources/WireAuthenticationUI/Views/DetermineAuthMethod/DetermineAuthMethodViewModel.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Views/DetermineAuthMethod/DetermineAuthMethodViewModel.swift
@@ -67,7 +67,7 @@ package final class DetermineAuthMethodViewModel: ObservableObject {
 
     /// The `restAPIURL` hosts of the accounts already logged in on this device.
     private let existingBackendHosts: Set<String>
-    private let isAccountAlreadyLoggedIn: (AuthenticationResult) -> Bool
+    private let isAccountAlreadyLoggedIn: (UUID) -> Bool
 
     private var cancellable: AnyCancellable?
 
@@ -83,7 +83,7 @@ package final class DetermineAuthMethodViewModel: ObservableObject {
         allowsMultipleBackends: Bool,
         existingBackendHosts: Set<String>,
         isLoading: Bool = false,
-        isAccountAlreadyLoggedIn: @escaping (AuthenticationResult) -> Bool = { _ in false },
+        isAccountAlreadyLoggedIn: @escaping (UUID) -> Bool = { _ in false },
         overrideAllowEmailLoginOnly: Bool
     ) {
         self.factory = factory
@@ -205,11 +205,10 @@ package final class DetermineAuthMethodViewModel: ObservableObject {
                 environment: environment
             ))
 
-        case let .loginViaSSO(code, multiIngressIdentityProviderID):
+        case let .loginViaSSO(code):
             do {
-                var authResult = try await loginViaSSO(code: code, environment: nil)
-                authResult.multiIngressIdentityProviderID = multiIngressIdentityProviderID
-                if isAccountAlreadyLoggedIn(authResult) {
+                let authResult = try await loginViaSSO(code: code, environment: nil)
+                if isAccountAlreadyLoggedIn(authResult.userID) {
                     alert = .alreadyLoggedIn
                 } else {
                     router.navigate(to: DetermineAuthMethodDestination.noHistory(authResult))
@@ -306,7 +305,7 @@ package final class DetermineAuthMethodViewModel: ObservableObject {
                 code: nil,
                 environment: environment
             )
-            if isAccountAlreadyLoggedIn(authResult) {
+            if isAccountAlreadyLoggedIn(authResult.userID) {
                 alert = .alreadyLoggedIn
             } else {
                 router.navigate(to: DetermineAuthMethodDestination.noHistory(authResult))

--- a/WireAuthentication/Tests/WireAuthenticationLogicTests/DetermineAuthMethodUseCaseTests.swift
+++ b/WireAuthentication/Tests/WireAuthenticationLogicTests/DetermineAuthMethodUseCaseTests.swift
@@ -80,7 +80,7 @@ final class DetermineAuthMethodUseCaseTests: XCTestCase {
         let authMethod = try await sut.invoke(emailOrSSOCode: email)
 
         // then
-        XCTAssertEqual(authMethod, .loginViaSSO(code: ssoCode, multiIngressIdentityProviderID: ssoCode))
+        XCTAssertEqual(authMethod, .loginViaSSO(code: ssoCode))
         XCTAssertEqual(mockAuthenticationAPI.getSSOCodeForEmail_Invocations, [email])
         XCTAssertEqual(mockAuthenticationAPI.getDomainRegistrationForEmail_Invocations.count, 0)
     }

--- a/WireAuthentication/Tests/WireAuthenticationUITests/Views/DetermineAuthMethod/DetermineAuthMethodViewModelTests.swift
+++ b/WireAuthentication/Tests/WireAuthenticationUITests/Views/DetermineAuthMethod/DetermineAuthMethodViewModelTests.swift
@@ -160,15 +160,12 @@ final class DetermineAuthMethodViewModelTests: XCTestCase, DetermineAuthMethodVi
     @MainActor
     func test_ssoLogin_whenAlreadyLoggedIn_showsAlreadyLoggedInAlert() async {
         // given the SSO flow returns a user ID that is already logged in
-        let identityProviderID = UUID()
-        stubbedAuthMethod = .loginViaSSO(code: identityProviderID, multiIngressIdentityProviderID: identityProviderID)
+        stubbedAuthMethod = .loginViaSSO(code: UUID())
         let userID = stubbedSSOUserID
         makeSUT(
             allowsMultipleBackends: true,
             existingBackendHosts: [],
-            isAccountAlreadyLoggedIn: { result in
-                result.userID == userID && result.multiIngressIdentityProviderID == identityProviderID
-            }
+            isAccountAlreadyLoggedIn: { id in id == userID }
         )
 
         // when
@@ -180,10 +177,9 @@ final class DetermineAuthMethodViewModelTests: XCTestCase, DetermineAuthMethodVi
     }
 
     @MainActor
-    func test_ssoLogin_whenNotAlreadyLoggedIn_propagatesIdentityProviderIDAndNavigates() async {
+    func test_ssoLogin_whenNotAlreadyLoggedIn_navigates() async {
         // given the SSO flow returns a user ID that is not yet logged in
-        let identityProviderID = UUID()
-        stubbedAuthMethod = .loginViaSSO(code: UUID(), multiIngressIdentityProviderID: identityProviderID)
+        stubbedAuthMethod = .loginViaSSO(code: UUID())
         makeSUT(
             allowsMultipleBackends: true,
             existingBackendHosts: [],
@@ -195,13 +191,7 @@ final class DetermineAuthMethodViewModelTests: XCTestCase, DetermineAuthMethodVi
 
         // then navigation proceeds normally
         XCTAssertNil(sut.alert)
-        guard
-            let destination = router.navigate_Invocations.first as? DetermineAuthMethodDestination,
-            case let .noHistory(authenticationResult) = destination
-        else {
-            return XCTFail("Expected navigation to no-history")
-        }
-        XCTAssertEqual(authenticationResult.multiIngressIdentityProviderID, identityProviderID)
+        XCTAssertFalse(router.navigate_Invocations.isEmpty)
     }
 
     @MainActor
@@ -211,7 +201,7 @@ final class DetermineAuthMethodViewModelTests: XCTestCase, DetermineAuthMethodVi
         makeSUT(
             allowsMultipleBackends: true,
             existingBackendHosts: [],
-            isAccountAlreadyLoggedIn: { result in result.userID == userID }
+            isAccountAlreadyLoggedIn: { id in id == userID }
         )
 
         // when
@@ -247,7 +237,7 @@ final class DetermineAuthMethodViewModelTests: XCTestCase, DetermineAuthMethodVi
         existingBackendHosts: Set<String>,
         emailOrSSOCode: String = "",
         overrideAllowEmailLoginOnly: Bool = false,
-        isAccountAlreadyLoggedIn: @escaping (AuthenticationResult) -> Bool = { _ in false }
+        isAccountAlreadyLoggedIn: @escaping (UUID) -> Bool = { _ in false }
     ) {
         sut = DetermineAuthMethodViewModel(
             factory: self,

--- a/WireDomain/Sources/WireDomain/Account/StoredAccount.swift
+++ b/WireDomain/Sources/WireDomain/Account/StoredAccount.swift
@@ -29,7 +29,6 @@ struct StoredAccount: Codable {
     var teamImage: Data?
     var backendName: String?
     var loginCredentials: StoredLoginCredentials?
-    var lastSSOIdentityProviderID: UUID?
     var unreadConversationCount: Int
 
     init(_ account: Account) {
@@ -43,7 +42,6 @@ struct StoredAccount: Codable {
         self.loginCredentials = account.loginCredentials.map {
             StoredLoginCredentials($0)
         }
-        self.lastSSOIdentityProviderID = account.lastSSOIdentityProviderID
         self.unreadConversationCount = account.unreadConversationCount
     }
 
@@ -77,7 +75,6 @@ extension Account {
                 LoginCredentials($0)
             }
         )
-        lastSSOIdentityProviderID = storedAccount.lastSSOIdentityProviderID
     }
 
 }

--- a/WireDomain/Tests/WireDomainTests/Account/AccountManagerTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Account/AccountManagerTests.swift
@@ -176,13 +176,11 @@ final class AccountManagerTests {
         // Given
         let sut = try makeSUT()
         let accountID = UUID()
-        let updatedIdentityProviderID = UUID()
         sut.addAndSelect(Account(userName: "Alice", userIdentifier: accountID))
         let account = try #require(sut.selectedAccount)
 
         // When
         let updatedAccount = Account(userName: "Bob", userIdentifier: accountID, teamName: "Wire")
-        updatedAccount.lastSSOIdentityProviderID = updatedIdentityProviderID
         sut.addAndSelect(updatedAccount)
 
         // Then
@@ -190,7 +188,6 @@ final class AccountManagerTests {
         #expect(account.userIdentifier == accountID)
         #expect(account.userName == "Bob")
         #expect(account.teamName == "Wire")
-        #expect(account.lastSSOIdentityProviderID == updatedIdentityProviderID)
     }
 
     @Test("It sorts accounts without team before accounts with team")

--- a/WireDomain/Tests/WireDomainTests/Account/AccountStoreTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Account/AccountStoreTests.swift
@@ -56,17 +56,13 @@ final class AccountStoreTests {
     func itCanStoreAndRetrieveAnAccount() throws {
         // Given
         let sut = try AccountStore(directory: url)
-        let identityProviderID = UUID()
         let account = Account(userName: "Alice", userIdentifier: UUID())
-        account.lastSSOIdentityProviderID = identityProviderID
 
         // When
         #expect(sut.storeAccount(account) == true)
 
         // Then
         #expect(sut.fetchAllAccounts() == [account])
-        let storedAccount = try #require(sut.fetchAccount(with: account.userIdentifier))
-        #expect(storedAccount.lastSSOIdentityProviderID == identityProviderID)
     }
 
     @Test("It can remove an account")
@@ -336,7 +332,6 @@ final class AccountStoreTests {
             loginCredentials: nil
         )
         #expect(account == expectedAccount)
-        #expect(account?.lastSSOIdentityProviderID == nil)
     }
 
     @Test("It decodes account on disk with login credentials")

--- a/wire-ios-data-model/Source/Model/Account/Account.swift
+++ b/wire-ios-data-model/Source/Model/Account/Account.swift
@@ -46,7 +46,6 @@ public final class Account: NSObject, Codable, @unchecked Sendable {
         case _teamImageData = "teamImage"
         case _unreadConversationCount = "unreadConversationCount"
         case _loginCredentials = "loginCredentials"
-        case _lastSSOIdentityProviderID = "lastSSOIdentityProviderID"
     }
 
     // MARK: - Private mutable properties with locked access
@@ -58,7 +57,6 @@ public final class Account: NSObject, Codable, @unchecked Sendable {
     private var _imageData: Data?
     private var _teamImageData: Data?
     private var _loginCredentials: LoginCredentials?
-    private var _lastSSOIdentityProviderID: UUID?
     private var _unreadConversationCount: Int = 0
 
     // MARK: - Public
@@ -98,11 +96,6 @@ public final class Account: NSObject, Codable, @unchecked Sendable {
     public var loginCredentials: LoginCredentials? {
         get { lock.withLock { _loginCredentials } }
         set { lock.withLock { _loginCredentials = newValue } }
-    }
-
-    public var lastSSOIdentityProviderID: UUID? {
-        get { lock.withLock { _lastSSOIdentityProviderID } }
-        set { lock.withLock { _lastSSOIdentityProviderID = newValue } }
     }
 
     public var unreadConversationCount: Int {
@@ -154,7 +147,6 @@ public final class Account: NSObject, Codable, @unchecked Sendable {
             _imageData = account._imageData
             _teamImageData = account._teamImageData
             _loginCredentials = account._loginCredentials
-            _lastSSOIdentityProviderID = account._lastSSOIdentityProviderID
             _handle = account._handle
             _backendName = account._backendName
         }

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -261,11 +261,6 @@ public final class SessionManager: NSObject, SessionManagerType {
         case accountLimitReached
     }
 
-    enum RetainedAccountDataError: Error {
-        case accountIsActive
-        case failedToDeleteAccountData
-    }
-
     /// Maximum number of accounts which can be logged in simultanously
     public let maxNumberAccounts: Int
 
@@ -381,10 +376,6 @@ public final class SessionManager: NSObject, SessionManagerType {
         }
 
         return environment.isAuthenticated(selectedAccount)
-    }
-
-    public func isAccountActive(_ account: Account) -> Bool {
-        backgroundUserSessions[account.userIdentifier] != nil || environment.isAuthenticated(account)
     }
 
     public var activeUnauthenticatedSession: UnauthenticatedSession {
@@ -1174,48 +1165,11 @@ public final class SessionManager: NSObject, SessionManagerType {
     fileprivate func deleteAccountData(for account: Account) {
         WireLogger.sessionManager.debug("Deleting the data for \(account.userName) -- \(account.userIdentifier)")
         WireLogger.session.debug("Deleting the data for account \(account)")
-
-        do {
-            try deleteAccountData(for: account, keepAccountOnFailure: false)
-        } catch {
-            WireLogger.sessionManager.critical("Failed to delete account data for \(account): \(error)")
-        }
-    }
-
-    public func purgeRetainedAccountData(for userID: UUID) throws {
-        guard let account = accountManager.account(with: userID) else { return }
-        guard !isAccountActive(account) else { throw RetainedAccountDataError.accountIsActive }
-
-        try deleteAccountData(for: account, keepAccountOnFailure: true)
-    }
-
-    private func deleteAccountData(
-        for account: Account,
-        keepAccountOnFailure: Bool
-    ) throws {
-        let accountID = account.userIdentifier
-        let accountDataFolder = CoreDataStack.accountDataFolder(
-            accountIdentifier: accountID,
-            applicationContainer: sharedContainerURL
-        )
-
-        do {
-            try FileManager.default.removeItem(at: accountDataFolder)
-        } catch let error as NSError where error.domain == NSCocoaErrorDomain && error.code == NSFileNoSuchFileError {
-            // The desired state has already been reached.
-        } catch {
-            if keepAccountOnFailure {
-                throw error
-            }
-            WireLogger.sessionManager.critical("Impossible to delete the account \(account): \(error)")
-        }
-
         do {
             try environment.cookieStorage(for: account).removeCookies()
         } catch {
             WireLogger.sessionManager.error("Failed to remove cookies: \(error)")
         }
-
         account.deleteKeychainItems()
 
         clearCRLExpirationDates(for: account)
@@ -1232,9 +1186,16 @@ public final class SessionManager: NSObject, SessionManagerType {
         PrivateUserDefaults.removeAll(forUserID: account.userIdentifier, in: sharedUserDefaults)
         PrivateUserDefaults.removeAll(forUserID: account.userIdentifier, in: .standard)
 
+        let accountID = account.userIdentifier
         accountManager.remove(account)
-        guard accountManager.account(with: accountID) == nil else {
-            throw RetainedAccountDataError.failedToDeleteAccountData
+
+        do {
+            try FileManager.default.removeItem(at: CoreDataStack.accountDataFolder(
+                accountIdentifier: accountID,
+                applicationContainer: sharedContainerURL
+            ))
+        } catch {
+            WireLogger.sessionManager.critical("Impossible to delete the account \(account): \(error)")
         }
     }
 
@@ -1625,9 +1586,6 @@ extension SessionManager: UnauthenticatedSessionDelegate {
             storage: sharedUserDefaults
         )
         journal[.isInitialSyncRequired] = true
-
-        account.lastSSOIdentityProviderID = account.lastSSOIdentityProviderID ??
-            accountManager.account(with: account.userIdentifier)?.lastSSOIdentityProviderID
 
         accountManager.addAndSelect(account)
 

--- a/wire-ios-sync-engine/Source/UnauthenticatedSession/UnauthenticatedSession.swift
+++ b/wire-ios-sync-engine/Source/UnauthenticatedSession/UnauthenticatedSession.swift
@@ -179,11 +179,9 @@ extension UnauthenticatedSession: UserInfoParser {
 
     public func upgradeToAuthenticatedSession(
         with userInfo: UserInfo,
-        newEnvironment: NewEnvironment,
-        multiIngressIdentityProviderID: UUID? = nil
+        newEnvironment: NewEnvironment
     ) {
         let account = Account(userName: "", userIdentifier: userInfo.identifier)
-        account.lastSSOIdentityProviderID = multiIngressIdentityProviderID
         let cookieStorage = transportSession.environment.cookieStorage(for: account)
         do {
             try cookieStorage.storeCookies(userInfo.cookies)

--- a/wire-ios-sync-engine/Tests/Source/UserSession/UnauthenticatedSessionTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/UnauthenticatedSessionTests.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import WireNetwork
 import WireTesting
 import WireTransportSupport
 import XCTest
@@ -229,33 +228,6 @@ public final class UnauthenticatedSessionTests: ZMTBaseTest {
         XCTAssertTrue(transportSession.environment.cookieStorage(for: account).hasAuthenticationCookie)
     }
 
-    func testThatUpgradingStoresTheSSOIdentityProviderIDOnTheAccount() throws {
-        // given
-        let userID = UUID.create()
-        let identityProviderID = UUID.create()
-        let newEnvironment = NewEnvironment(
-            backendEnvironment: backendEnvironment(),
-            metadata: ResolvedBackendMetadata(
-                apiVersion: .v8,
-                domain: "example.com",
-                isFederationEnabled: false
-            ),
-            cookies: [],
-            proxyCredentials: nil
-        )
-
-        // when
-        sut.upgradeToAuthenticatedSession(
-            with: UserInfo(identifier: userID, cookies: []),
-            newEnvironment: newEnvironment,
-            multiIngressIdentityProviderID: identityProviderID
-        )
-
-        // then
-        let account = try XCTUnwrap(mockDelegate.createdAccounts.first)
-        XCTAssertEqual(account.lastSSOIdentityProviderID, identityProviderID)
-    }
-
     func testThatItDoesNotParseAnAccountWithWrongUserIdKey() {
         // given
         let cookie =
@@ -314,27 +286,6 @@ public final class UnauthenticatedSessionTests: ZMTBaseTest {
         XCTAssertLessThanOrEqual(mockDelegate.createdAccounts.count, 1, line: line)
         if mockDelegate.createdAccounts.isEmpty { throw NSError(domain: "No account", code: 1) }
         return mockDelegate.createdAccounts.first!
-    }
-
-    private func backendEnvironment() -> BackendEnvironment2 {
-        let url = URL(string: "https://example.com")!
-        return BackendEnvironment2(
-            title: "Example",
-            environmentType: .default,
-            config: .init(
-                endpoints: .init(
-                    restAPIURL: url,
-                    websocketURL: url,
-                    blacklistURL: url,
-                    teamsURL: url,
-                    accountsURL: url,
-                    websiteURL: url,
-                    countlyURL: nil
-                ),
-                pinnedKeys: [],
-                proxyConfig: nil
-            )
-        )
     }
 }
 

--- a/wire-ios/Wire-iOS/Sources/Authentication/AuthenticationInterfaceBuilder.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/AuthenticationInterfaceBuilder.swift
@@ -348,10 +348,8 @@ final class AuthenticationInterfaceBuilder {
             appStoreURL: WireURLs.shared.appOnItunes,
             accountsPublisher: CurrentValuePublisher(subject: CurrentValueSubject(accounts)),
             registrationAnalyticsTracker: registrationAnalyticsTracker,
-            isAccountAlreadyLoggedIn: { result in
-                guard let sessionManager = SessionManager.shared,
-                      let account = sessionManager.accountManager.account(with: result.userID) else { return false }
-                return result.multiIngressIdentityProviderID == nil || sessionManager.isAccountActive(account)
+            isAccountAlreadyLoggedIn: { userID in
+                SessionManager.shared?.accountManager.accounts.contains { $0.userIdentifier == userID } ?? false
             },
             overrideAllowEmailLoginOnly: featureProvider.allowOnlyEmailLogin
         )

--- a/wire-ios/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
@@ -17,7 +17,6 @@
 //
 
 import UIKit
-import WireAuthenticationAPI
 import WireDomain
 import WireFoundation
 import WireLogging
@@ -316,13 +315,6 @@ extension AuthenticationCoordinator: AuthenticationActioner, SessionManagerCreat
                 unauthenticatedSession.continueAfterBackupImportStep()
 
             case let .completeWireAuthenticationLogin((result, trackingConsent)):
-                if let account = sessionManager.accountManager.account(with: result.userID),
-                   let identityProviderID = result.multiIngressIdentityProviderID,
-                   account.lastSSOIdentityProviderID != identityProviderID {
-                    presentSSOIdentityChangeAlert(for: (result, trackingConsent))
-                    return
-                }
-
                 // Don't store the env here... pass it along when upgrading
                 // to an authenticated session.
 
@@ -367,15 +359,8 @@ extension AuthenticationCoordinator: AuthenticationActioner, SessionManagerCreat
                 )
                 unauthenticatedSession.upgradeToAuthenticatedSession(
                     with: userInfo,
-                    newEnvironment: newEnvironment,
-                    multiIngressIdentityProviderID: result.multiIngressIdentityProviderID
+                    newEnvironment: newEnvironment
                 )
-
-            case let .purgeRetainedAccountAndContinue(context):
-                purgeRetainedAccountAndContinue(context)
-
-            case .restartWireAuthentication:
-                restartWireAuthentication()
 
             case let .executeFeedbackAction(action):
                 currentViewController?.executeErrorFeedbackAction(action)
@@ -577,54 +562,6 @@ extension AuthenticationCoordinator {
             presentAlert(for: alertModel)
         } else {
             deleteSession(eraseData: true)
-        }
-    }
-
-    private func presentSSOIdentityChangeAlert(
-        for context: (AuthenticationResult, RegistrationAnalyticsTrackingConsent)
-    ) {
-        typealias Strings = L10n.Localizable.SsoIdentityChanged
-
-        let deleteAction = AuthenticationCoordinatorAlertAction(
-            title: Strings.deleteDataAndContinue,
-            coordinatorActions: [.showLoadingView, .purgeRetainedAccountAndContinue(context)],
-            style: .destructive
-        )
-        let cancelAction = AuthenticationCoordinatorAlertAction(
-            title: L10n.Localizable.General.cancel,
-            coordinatorActions: [.restartWireAuthentication],
-            style: .cancel
-        )
-
-        stopActivityIndicator()
-        presentAlert(for: AuthenticationCoordinatorAlert(
-            title: Strings.title,
-            message: Strings.message,
-            actions: [cancelAction, deleteAction]
-        ))
-    }
-
-    private func purgeRetainedAccountAndContinue(
-        _ context: (AuthenticationResult, RegistrationAnalyticsTrackingConsent)
-    ) {
-        do {
-            try sessionManager.purgeRetainedAccountData(for: context.0.userID)
-            executeActions([.completeWireAuthenticationLogin(context)])
-        } catch {
-            logger.error("Failed to purge retained account data: \(error)")
-            restartWireAuthentication(error: NSError(userSessionErrorCode: .unknownError, userInfo: nil))
-        }
-    }
-
-    private func restartWireAuthentication(error: Error? = nil) {
-        let error = error as NSError?
-        stopActivityIndicator()
-        Task { @MainActor [weak self] in
-            guard let self else { return }
-            stateDidChange(stateController.currentStep, mode: .reset)
-            if let error {
-                presenter?.showAlert(for: error)
-            }
         }
     }
 

--- a/wire-ios/Wire-iOS/Sources/Authentication/Event Handlers/AuthenticationCoordinatorAction.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Event Handlers/AuthenticationCoordinatorAction.swift
@@ -30,8 +30,6 @@ enum AuthenticationCoordinatorAction {
     case presentErrorAlert(AuthenticationCoordinatorErrorAlert)
     case completeBackupStep(didSucceed: Bool?)
     case completeWireAuthenticationLogin((AuthenticationResult, RegistrationAnalyticsTrackingConsent))
-    case purgeRetainedAccountAndContinue((AuthenticationResult, RegistrationAnalyticsTrackingConsent))
-    case restartWireAuthentication
     case completeLoginFlow
     case startPostLoginFlow
     case transition(AuthenticationFlowStep, mode: AuthenticationStateController.StateChangeMode)

--- a/wire-ios/Wire-iOS/Sources/Authentication/Helpers/ObservableSessionManager.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Helpers/ObservableSessionManager.swift
@@ -53,8 +53,6 @@ protocol ObservableSessionManager: SessionManagerType {
     /// Deletes the selected account.
     func delete(account: Account, eraseData: Bool)
 
-    func purgeRetainedAccountData(for userID: UUID) throws
-
     /// Add a new account.
     func addAccount(userInfo: [String: Any]?, completion: (() -> Void)?)
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27416" title="WPB-27416" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-27416</a>  [iOS] Clear retained account data when logging in with a different SSO identity
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

### Issue

This PR reverts https://github.com/wireapp/wire-ios/pull/5086 as it failed review. 

For simplicity It **does not** revert the strings that were added to the PR as these have been localized and changed in follow up PRs. This strings remain in the codebase but are unused.

There were NO conflicts outside of the string changes

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
