### PR TITLE
fix: refresh confirm button color on accent color change - WPB-22033

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Components/Controllers/ConfirmAssetViewController/ConfirmAssetViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Components/Controllers/ConfirmAssetViewController/ConfirmAssetViewController.swift
@@ -83,6 +83,7 @@ final class ConfirmAssetViewController: UIViewController {
     )
     private let contentLayoutGuide: UILayoutGuide = .init()
     private let imageToolbarSeparatorView: UIView = .init()
+    private var accentColorChangeHandler: AccentColorChangeHandler?
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         wr_supportedInterfaceOrientations
@@ -116,6 +117,7 @@ final class ConfirmAssetViewController: UIViewController {
         createConstraints()
 
         setupStyle()
+        setupAccentColorChangeHandler()
 
         presentationController?.delegate = self
     }
@@ -146,6 +148,13 @@ final class ConfirmAssetViewController: UIViewController {
         topPanel.backgroundColor = SemanticColors.View.backgroundDefault
 
         titleLabel.textColor = SemanticColors.Label.textDefault
+    }
+
+    private func setupAccentColorChangeHandler() {
+        accentColorChangeHandler = AccentColorChangeHandler
+            .addObserver(userSession: userSession) { [weak self] _ in
+                self?.acceptImageButton.applyStyle(.accentColorTextButtonStyle)
+            }
     }
 
     /// Show editing options only if the image is not animated


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22033" title="WPB-22033" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-22033</a>  [iOS] UI button showing wrong colour instead of chosen one after navigating colour change
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Fix: UI button showing wrong colour instead of chosen one after navigating colour change

## Problem
**Tackling this as reported breaching SLA**

When a user changes their profile color in Settings → Account → Profile Color and then changes their profile picture, the OK/Send button (arrow) in the image confirmation screen displays the **previous color** instead of the newly selected profile color.

### Steps to Reproduce
1. Open the Wire app
2. Navigate to Settings → Account → Profile Color
3. Set profile color to Turquoise (or any other available color)
4. Change profile picture (choose from album)
5. Observe the color of the OK button

### Expected Behavior
The OK button/arrow should reflect the user's selected profile color (Turquoise).

### Actual Behavior
The OK button/arrow appears in the previous color choice (e.g., Red), ignoring the newly selected profile color.

### Workaround
Closing and reopening the app correctly reflects the chosen color.

---

## Root Cause

The `ConfirmAssetViewController`, which displays the image confirmation screen with the accept button, was not observing changes to the accent color (user's selected profile color). When the user navigated to this view after changing their profile color, the button's styling was initialized from the cached accent color value rather than the current one.

---

## Solution

Implemented an **accent color change observer** in `ConfirmAssetViewController` that listens for color changes and immediately updates the accept button's styling:

Testing Recommendations
 Change profile color to a new value
 Navigate to change profile picture
 Verify the OK button displays the new profile color immediately
 Test with multiple color transitions
 Verify button styling persists during screen rotation
 Verify no memory leaks (weak self in closure)