### PR TITLE
fix: backup/restore in multi-ingress setups - WPB-28070

### DIFF
--- a/WireDomain/Tests/WireDomainTests/Synchronization/IncrementalSyncTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/IncrementalSyncTests.swift
@@ -87,13 +87,13 @@ final class IncrementalSyncTests: XCTestCase {
             mlsGroupRepairAgent: mlsGroupRepairAgent,
             earService: earService,
             backgroundTaskExecuter: PassthroughTaskExecuter(),
-            beforeProcessingLiveEvent: { event in
-                self.liveEventsObservedBeforeProcessing.append(event)
+            beforeProcessingLiveEvent: { [weak self] event in
+                self?.liveEventsObservedBeforeProcessing.append(event)
             }
         )
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         sut = nil
         journal = nil
         pushChannelAPI = nil
@@ -402,10 +402,12 @@ final class IncrementalSyncTests: XCTestCase {
         let task = Task {
             try await sut.perform()
         }
+        task.cancel()
 
         // Then
         do {
             _ = try await task.value
+            XCTFail("Expected CancellationError to be thrown")
         } catch {
             XCTAssertEqual(pushChannel.close_Invocations.count, 1)
             XCTAssertTrue(error is CancellationError)

--- a/wire-ios-data-model/Source/ManagedObjectContext/CoreDataStack.swift
+++ b/wire-ios-data-model/Source/ManagedObjectContext/CoreDataStack.swift
@@ -137,6 +137,8 @@ public final class CoreDataStack: NSObject, CoreDataStackProtocol, ContextProvid
         // Set the EARMessageEncryptionService on the new background context
         context.performAndWait {
             context.earMessageEncryptionService = earMessageEncryptionService
+            context.localDomain = localDomain
+            context.isFederationEnabled = isFederationEnabled
         }
 
         return context

--- a/wire-ios-data-model/Tests/ManagedObjectContext/CoreDataStackTests+BackgroundContext.swift
+++ b/wire-ios-data-model/Tests/ManagedObjectContext/CoreDataStackTests+BackgroundContext.swift
@@ -1,0 +1,55 @@
+//
+// Wire
+// Copyright (C) 2026 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import Testing
+
+@testable import WireDataModel
+
+@Suite
+struct CoreDataStackTests_BackgroundContext {
+
+    @Test(arguments: [
+        (localDomain: "example.com", isFederationEnabled: true),
+        (localDomain: "example.com", isFederationEnabled: false),
+        (localDomain: String?.none, isFederationEnabled: false)
+    ])
+    func `newBackgroundContext propagates localDomain and isFederationEnabled`(
+        localDomain: String?,
+        isFederationEnabled: Bool
+    ) async throws {
+        // GIVEN
+        let stack = CoreDataStack(
+            account: Account(userName: "", userIdentifier: UUID()),
+            applicationContainer: URL.documentsDirectory,
+            inMemoryStore: true,
+            localDomain: localDomain,
+            isFederationEnabled: isFederationEnabled
+        )
+        try await stack.load()
+
+        // WHEN
+        let context = stack.newBackgroundContext()
+
+        // THEN
+        await context.perform {
+            #expect(context.localDomain == localDomain)
+            #expect(context.isFederationEnabled == isFederationEnabled)
+        }
+    }
+}

--- a/wire-ios/Wire-iOS Tests/Backup/BackupLocalStoreMessagesTests.swift
+++ b/wire-ios/Wire-iOS Tests/Backup/BackupLocalStoreMessagesTests.swift
@@ -39,7 +39,10 @@ final class BackupLocalStoreMessagesTests: XCTestCase {
 
     override func setUp() async throws {
         try await super.setUp()
+        try await setUpSUT(isFederationEnabled: true)
+    }
 
+    private func setUpSUT(isFederationEnabled: Bool) async throws {
         // Create Core Data stack with temporary SQLite store
         let account = Account(userName: "", userIdentifier: UUID())
         let tempDirectory = FileManager.default.temporaryDirectory
@@ -52,26 +55,33 @@ final class BackupLocalStoreMessagesTests: XCTestCase {
             applicationContainer: tempDirectory,
             inMemoryStore: false,
             localDomain: "wire.com",
-            isFederationEnabled: true
+            isFederationEnabled: isFederationEnabled
         )
         try await coreDataStack.load()
 
         sut = BackupLocalStore(contextProvider: coreDataStack)
-        context = sut.backupContext
+        context = coreDataStack.syncContext
 
         // Create test fixtures
         conversationID = QualifiedID(id: UUID(), domain: "wire.com")
         senderID = QualifiedID(id: UUID(), domain: "wire.com")
 
         try await context.perform { [context, senderID, conversationID] in
-            let sender = ZMUser.insertNewObject(in: context!)
-            sender.remoteIdentifier = senderID?.id
-            sender.domain = senderID?.domain
+            let selfUser = ZMUser.selfUser(in: context!)
+            selfUser.domain = "wire.com"
+
+            let sender = ZMUser.fetchOrCreate(
+                with: senderID!.id,
+                domain: senderID!.domain,
+                in: context!
+            )
             sender.name = "Bob"
 
-            let conversation = ZMConversation.insertNewObject(in: context!)
-            conversation.remoteIdentifier = conversationID?.id
-            conversation.domain = conversationID?.domain
+            let conversation = ZMConversation.fetchOrCreate(
+                with: conversationID!.id,
+                domain: conversationID!.domain,
+                in: context!
+            )
             conversation.conversationType = .group
 
             try context!.save()
@@ -223,6 +233,34 @@ final class BackupLocalStoreMessagesTests: XCTestCase {
         try await context.perform { [fetchMessages] in
             let fetchedMessages = try fetchMessages()
             XCTAssertEqual(fetchedMessages.count, 3)
+        }
+    }
+
+    // MARK: - Federation disabled
+
+    func test_AddMessages_ImportsMessages_WhenFederationDisabled() async throws {
+        // GIVEN
+        try await setUpSUT(isFederationEnabled: false)
+
+        let messages = [
+            makeValidTextMessage(
+                conversationID: conversationID,
+                senderID: senderID
+            )
+        ]
+
+        // WHEN
+        let result = try await sut.addMessages(messages)
+
+        // THEN
+        XCTAssertEqual(result.validationCount.successCount, 1)
+        XCTAssertEqual(result.insertionCount.successCount, 1)
+        XCTAssertEqual(result.rehydrationCount.successCount, 1)
+
+        // Verify that all messages are in database
+        try await context.perform { [fetchMessages] in
+            let fetchedMessages = try fetchMessages()
+            XCTAssertEqual(fetchedMessages.count, 1)
         }
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Backup/BackupLocalStore/BackupLocalStore+Messages.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Backup/BackupLocalStore/BackupLocalStore+Messages.swift
@@ -282,12 +282,12 @@ extension BackupLocalStore {
             return try await context.perform {
                 let fetchRequest = T.fetchRequest()
 
-                let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
-                    NSPredicate(format: "%K IN %@", T.remoteIdentifierDataKey(), uuidsData),
-                    NSPredicate(format: "%K IN %@", T.domainKey(), domains)
-                ])
-
-                fetchRequest.predicate = predicate
+                var subpredicates = [NSPredicate(format: "%K IN %@", T.remoteIdentifierDataKey(), uuidsData)]
+                // If federation is not enabled, Users & Conversations may not have domains set.
+                if context.isFederationEnabled {
+                    subpredicates.append(NSPredicate(format: "%K IN %@", T.domainKey(), domains))
+                }
+                fetchRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: subpredicates)
 
                 let fetchResult = try context.fetch(fetchRequest) as! [T]
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28070" title="WPB-28070" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-28070</a>  [iOS]Backup creation is failing on iOS devices against on Prem backend
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Backup and restore is currently broken in environments where federation is disabled such as multi ingress environments. When federation is disabled the domain is not stored on User & Conversation objects. Backup files require a full qualified ID. User & Conversation will return a qualified ID by falling back to the domain of the context. In backup / restore we use a context provided by `newBackgroundContext()`. This currently doesn't have a domain and federation value set (vs sync and view contexts). Furthermore some of the restore code requires currently requires the domain set when doing a predicate search.

This PR:

- Ensures we set local domain and federation enabled properties when calling `CoreDataStack.newBackgroundContext()`
- When fetching stored items don't require a domain if federation is disabled. 

This fixes both creating and restoring from backup when federation is disabled.

### Testing

For both cloud and multi-ingress environments (see ticket) do the following.

1. Login in a new account
2. Create a multiple conversations with multiple users
3. Create a number of messages of each type
4. Go to Settings > Account > Back up or Restore > Back Up Now
5. Save the backup file somewhere
6. Log out
7. Re-login
8. Send a few more messages in some conversations
9. Go to Settings > Account > Back up or Restore > Restore from Backup
10. Ensure that old conversation / message data is restored and new messages are still there.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.