### PR TITLE
fix: Fix landscape rotation bubble margins - WPB-21023

### DIFF
--- a/WireUI/Sources/WireMainNavigationUI/Containers/MainSplitViewController.swift
+++ b/WireUI/Sources/WireMainNavigationUI/Containers/MainSplitViewController.swift
@@ -143,6 +143,11 @@ public final class MainSplitViewController<Sidebar, TabController>: UISplitViewC
         with coordinator: any UIViewControllerTransitionCoordinator
     ) {
         super.viewWillTransition(to: size, with: coordinator)
+
+        // On iPhone the split view must never tile into two columns, even during a
+        // transient size change from a rotation attempt that gets reverted (the phone
+        // is locked to portrait elsewhere). Skip the width-based recalculation there.
+        guard traitCollection.userInterfaceIdiom == .pad else { return }
         setPreferredSplitBehaviorAndDisplayMode(basedOn: size.width)
     }
 

--- a/wire-ios/Wire-iOS/Sources/Helpers/UITraitEnvironment+LayoutMargins.swift
+++ b/wire-ios/Wire-iOS/Sources/Helpers/UITraitEnvironment+LayoutMargins.swift
@@ -50,6 +50,13 @@ struct HorizontalMargins {
     static func conversationHorizontalMargins(
         windowWidth: CGFloat? = UIApplication.shared.delegate?.window??.frame.width ?? UIScreen.main.bounds.width
     ) -> HorizontalMargins {
+        // The regular/compact split below is only meaningful for iPad split view widths.
+        // On iPhone, a transient window width (e.g. from a rotation attempt) must never
+        // select the wider iPad margins.
+        guard UIDevice.current.userInterfaceIdiom == .pad else {
+            return HorizontalMargins(userInterfaceSizeClass: .compact)
+        }
+
         let userInterfaceSizeClass: UIUserInterfaceSizeClass
 
             // On iPad 9.7 inch 2/3 mode, right view's width is 396pt, use the compact mode's narrower margin

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
@@ -85,7 +85,7 @@ final class ConversationTableViewDataSource: NSObject {
 
     var contentWidth: CGFloat = UIScreen.main.bounds.width {
         didSet {
-            guard UIDevice.current.userInterfaceIdiom == .pad else { return }
+            guard contentWidth != oldValue else { return }
             resetSectionControllers()
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21023" title="WPB-21023" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21023</a>  [iOS] Chat view renders incorrectly when device is rotated to landscape mode
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
### Description 
Fixes incorrect bubble margins after rotation by changing when the conversation resets its section controllers: instead of only resetting on iPad, we now reset only when the contentWidth actually changes. This is a single-line change in ConversationTableViewDataSource.swift.

### What changed

`ConversationTableViewDataSource.swift`: replace
`guard UIDevice.current.userInterfaceIdiom == .pad else { return }` with
`guard contentWidth != oldValue else { return }`

### Result: 
`resetSectionControllers()` is triggered when the measured content width changes (any device).

### How to test
Open a conversation with short/long messages and attachments.
Rotate on iPhone and iPad (portrait ⇄ landscape): verify bubbles don’t clip and margins/alignment are correct.
Confirm scroll position and composer/keyboard state are preserved.
Run UI/snapshot tests if available.

### Risk 
Low — change is localized to the conversation data source; main risk is reload-related side effects (scroll/keyboard). Run the checks above before merging.