### PR TITLE
fix: cherry-pick #5023 show MLS-specific learn more link for empty key packages - WPB-28103

### DIFF
--- a/WireDomain/Sources/WireDomain/UseCases/CreateChannelUseCase.swift
+++ b/WireDomain/Sources/WireDomain/UseCases/CreateChannelUseCase.swift
@@ -448,7 +448,8 @@ public struct CreateChannelUseCase: CreateChannelUseCaseProtocol {
 
         await appendFailedToAddUsersMessage(
             in: conversation,
-            users: failedUsers
+            users: failedUsers,
+            type: .failedToAddParticipantsMLS
         )
     }
 
@@ -514,13 +515,15 @@ public struct CreateChannelUseCase: CreateChannelUseCaseProtocol {
 
     private func appendFailedToAddUsersMessage(
         in conversation: ZMConversation,
-        users: Set<ZMUser>
+        users: Set<ZMUser>,
+        type: ZMSystemMessageType = .failedToAddParticipants
     ) async {
         await context.perform {
             conversation.appendFailedToAddUsersSystemMessage(
                 users: users,
                 sender: conversation.creator,
-                at: conversation.lastServerTimeStamp ?? Date()
+                at: conversation.lastServerTimeStamp ?? Date(),
+                type: type
             )
             context.enqueueDelayedSave()
         }

--- a/WireDomain/Sources/WireDomain/UseCases/CreateGroupConversationUseCase.swift
+++ b/WireDomain/Sources/WireDomain/UseCases/CreateGroupConversationUseCase.swift
@@ -460,7 +460,8 @@ public struct CreateGroupConversationUseCase: CreateGroupConversationUseCaseProt
 
         await appendFailedToAddUsersMessage(
             in: conversation,
-            users: failedUsers
+            users: failedUsers,
+            type: .failedToAddParticipantsMLS
         )
     }
 
@@ -526,13 +527,15 @@ public struct CreateGroupConversationUseCase: CreateGroupConversationUseCaseProt
 
     private func appendFailedToAddUsersMessage(
         in conversation: ZMConversation,
-        users: Set<ZMUser>
+        users: Set<ZMUser>,
+        type: ZMSystemMessageType = .failedToAddParticipants
     ) async {
         await context.perform {
             conversation.appendFailedToAddUsersSystemMessage(
                 users: users,
                 sender: conversation.creator,
-                at: conversation.lastServerTimeStamp ?? Date()
+                at: conversation.lastServerTimeStamp ?? Date(),
+                type: type
             )
             context.enqueueDelayedSave()
         }

--- a/WireDomain/Tests/WireDomainTests/UseCases/CreateChannelUseCaseTests.swift
+++ b/WireDomain/Tests/WireDomainTests/UseCases/CreateChannelUseCaseTests.swift
@@ -303,7 +303,7 @@ final class CreateChannelUseCaseTests: XCTestCase {
                 conversation.allMessages.compactMap { $0 as? ZMSystemMessage }.first
             )
 
-            XCTAssertEqual(systemMessage.systemMessageType, .failedToAddParticipants)
+            XCTAssertEqual(systemMessage.systemMessageType, .failedToAddParticipantsMLS)
             XCTAssertEqual(systemMessage.users, [participant1])
         }
     }

--- a/WireDomain/Tests/WireDomainTests/UseCases/CreateGroupConversationUseCaseTests.swift
+++ b/WireDomain/Tests/WireDomainTests/UseCases/CreateGroupConversationUseCaseTests.swift
@@ -454,7 +454,7 @@ final class CreateGroupConversationUseCaseTests: XCTestCase {
                 conversation.allMessages.compactMap { $0 as? ZMSystemMessage }.first
             )
 
-            XCTAssertEqual(systemMessage.systemMessageType, .failedToAddParticipants)
+            XCTAssertEqual(systemMessage.systemMessageType, .failedToAddParticipantsMLS)
             XCTAssertEqual(systemMessage.users, [participant1])
         }
     }

--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+SystemMessages.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+SystemMessages.swift
@@ -70,9 +70,14 @@ public extension ZMConversation {
         )
     }
 
-    func appendFailedToAddUsersSystemMessage(users: Set<ZMUser>, sender: ZMUser?, at timestamp: Date) {
+    func appendFailedToAddUsersSystemMessage(
+        users: Set<ZMUser>,
+        sender: ZMUser?,
+        at timestamp: Date,
+        type: ZMSystemMessageType = .failedToAddParticipants
+    ) {
         appendSystemMessage(
-            type: .failedToAddParticipants,
+            type: type,
             sender: sender,
             users: users,
             clients: nil,

--- a/wire-ios-data-model/Source/Public/ZMMessage.h
+++ b/wire-ios-data-model/Source/Public/ZMMessage.h
@@ -115,6 +115,8 @@ typedef NS_CLOSED_ENUM(int16_t, ZMSystemMessageType) {
     ZMSystemMessageTypeUserRemovedFromTeam,
     ZMSystemMessageTypeUnknownMessageContentTypeReceived,
     ZMSystemMessageTypePromotedToGroupAdmin,
+    /// Failed to add participants because their MLS key packages could not be claimed (e.g. no MLS client).
+    ZMSystemMessageTypeFailedToAddParticipantsMLS,
     ZMSystemMessageTypeConversationScheduledForDeletion
 };
 

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationParticipantsService.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationParticipantsService.swift
@@ -43,12 +43,12 @@ enum FederationError: Error, Equatable {
 enum ConversationParticipantsError: Error, Equatable {
     case invalidOperation
     case missingMLSParticipantsService
-    case failedToAddSomeUsers(users: Set<ZMUser>)
+    case failedToAddSomeUsers(users: Set<ZMUser>, type: ZMSystemMessageType = .failedToAddParticipants)
 }
 
 extension Error {
     var isFailedToAddSomeUsersError: Bool {
-        if case ConversationParticipantsError.failedToAddSomeUsers(_)? = (self as? ConversationParticipantsError) {
+        if case ConversationParticipantsError.failedToAddSomeUsers(_, _)? = (self as? ConversationParticipantsError) {
             return true
         }
         if case ConversationAddParticipantsError.failedToAddMLSMembers? = (self as? ConversationAddParticipantsError) {
@@ -107,7 +107,7 @@ public class ConversationParticipantsService: ConversationParticipantsServiceInt
                 users: users,
                 conversation: conversation
             )
-        } catch let ConversationParticipantsError.failedToAddSomeUsers(users: failedUsers) {
+        } catch let ConversationParticipantsError.failedToAddSomeUsers(users: failedUsers, type: type) {
             let failedUserIds = await context.perform { failedUsers.map { $0.remoteIdentifier.transportString() } }
             Flow.addParticipants
                 .checkpoint(
@@ -116,7 +116,8 @@ public class ConversationParticipantsService: ConversationParticipantsServiceInt
 
             await appendFailedToAddUsersMessage(
                 in: conversation,
-                users: failedUsers
+                users: failedUsers,
+                type: type
             )
         }
     }
@@ -181,7 +182,10 @@ public class ConversationParticipantsService: ConversationParticipantsServiceInt
                 Flow.addParticipants.checkpoint(description: "retrying failedUsers end")
             }
 
-            throw ConversationParticipantsError.failedToAddSomeUsers(users: failedUsers)
+            throw ConversationParticipantsError.failedToAddSomeUsers(
+                users: failedUsers,
+                type: .failedToAddParticipantsMLS
+            )
         }
     }
 
@@ -256,13 +260,15 @@ public class ConversationParticipantsService: ConversationParticipantsServiceInt
 
     private func appendFailedToAddUsersMessage(
         in conversation: ZMConversation,
-        users: Set<ZMUser>
+        users: Set<ZMUser>,
+        type: ZMSystemMessageType = .failedToAddParticipants
     ) async {
         await context.perform {
             conversation.appendFailedToAddUsersSystemMessage(
                 users: users,
                 sender: conversation.creator,
-                at: conversation.lastServerTimeStamp ?? Date()
+                at: conversation.lastServerTimeStamp ?? Date(),
+                type: type
             )
             self.context.enqueueDelayedSave()
         }

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationParticipantsServiceTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationParticipantsServiceTests.swift
@@ -220,7 +220,8 @@ class ConversationParticipantsServiceTests: MessagingTestBase {
         // It inserts a system message for the users that failed key package claim
         await assertSystemMessageWasInserted(
             forUsers: Set([failedUser1, failedUser2]),
-            in: conversation
+            in: conversation,
+            type: .failedToAddParticipantsMLS
         )
     }
 
@@ -396,6 +397,7 @@ private extension ConversationParticipantsServiceTests {
     func assertSystemMessageWasInserted(
         forUsers users: Set<ZMUser>,
         in conversation: ZMConversation,
+        type: ZMSystemMessageType = .failedToAddParticipants,
         file: StaticString = #filePath,
         line: UInt = #line
     ) async {
@@ -404,7 +406,7 @@ private extension ConversationParticipantsServiceTests {
                 return XCTFail("expected system message", file: file, line: line)
             }
 
-            XCTAssertEqual(systemMessage.systemMessageType, .failedToAddParticipants, file: file, line: line)
+            XCTAssertEqual(systemMessage.systemMessageType, type, file: file, line: line)
             XCTAssertEqual(systemMessage.userTypes, users, file: file, line: line)
         }
     }

--- a/wire-ios/Wire-iOS Tests/ConversationMessageCell/ConversationFailedToAddParticipantsSystemMessageCellDescriptionTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationMessageCell/ConversationFailedToAddParticipantsSystemMessageCellDescriptionTests.swift
@@ -1,0 +1,62 @@
+//
+// Wire
+// Copyright (C) 2026 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import WireDataModel
+import XCTest
+
+@testable import Wire
+
+final class ConversationFailedToAddParticipantsSystemMessageCellDescriptionTests: XCTestCase {
+
+    private func learnMoreLink(for content: NSAttributedString) -> URL? {
+        var foundLink: URL?
+        content.enumerateAttribute(.link, in: NSRange(location: 0, length: content.length)) { value, _, _ in
+            if let url = value as? URL {
+                foundLink = url
+            }
+        }
+        return foundLink
+    }
+
+    func testLearnMoreLink_PointsToUnreachableBackendInfo_ForDefaultReason() {
+        // GIVEN, WHEN
+        let sut = ConversationFailedToAddParticipantsSystemMessageCellDescription(
+            failedUsers: [MockUserType.createUser(name: "Bruno")],
+            isCollapsed: false,
+            reason: .failedToAddParticipants,
+            buttonAction: {}
+        )
+
+        // THEN
+        XCTAssertEqual(learnMoreLink(for: sut.configuration.content), WireURLs.shared.unreachableBackendInfo)
+    }
+
+    func testLearnMoreLink_PointsToMLSInfo_ForMissingKeyPackagesReason() {
+        // GIVEN, WHEN
+        let sut = ConversationFailedToAddParticipantsSystemMessageCellDescription(
+            failedUsers: [MockUserType.createUser(name: "Bruno")],
+            isCollapsed: false,
+            reason: .failedToAddParticipantsMLS,
+            buttonAction: {}
+        )
+
+        // THEN
+        XCTAssertEqual(learnMoreLink(for: sut.configuration.content), WireURLs.shared.mlsInfo)
+    }
+
+}

--- a/wire-ios/Wire-iOS Tests/ConversationMessageCell/ConversationSystemMessageTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationMessageCell/ConversationSystemMessageTests.swift
@@ -43,6 +43,12 @@ final class ConversationSystemMessageTests: ConversationMessageSnapshotTestCase 
         verify(message: message)
     }
 
+    func testFailedToAddParticipantsMLS() throws {
+        let message = try XCTUnwrap(MockMessageFactory.systemMessage(with: .failedToAddParticipantsMLS, users: 1))
+
+        verify(message: message)
+    }
+
     func testRenameConversation() {
         let message = MockMessageFactory.systemMessage(with: .conversationNameChanged, users: 0, clients: 0)!
         message.backingSystemMessageData.text = "Blue room"

--- a/wire-ios/Wire-iOS Tests/ReferenceImages/ConversationSystemMessageTests/testFailedToAddParticipantsMLS.320-0.png
+++ b/wire-ios/Wire-iOS Tests/ReferenceImages/ConversationSystemMessageTests/testFailedToAddParticipantsMLS.320-0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9530d402851dead0a85650b25ec51a78b88a69e37becdeb030d86a8112486b14
+size 25012

--- a/wire-ios/Wire-iOS Tests/ReferenceImages/ConversationSystemMessageTests/testFailedToAddParticipantsMLS.375-0.png
+++ b/wire-ios/Wire-iOS Tests/ReferenceImages/ConversationSystemMessageTests/testFailedToAddParticipantsMLS.375-0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e94187613aa9163d4e24b26fde3013bc352b4d55dda1fe22168eca5f0b63e855
+size 24458

--- a/wire-ios/Wire-iOS Tests/ReferenceImages/ConversationSystemMessageTests/testFailedToAddParticipantsMLS.414-0.png
+++ b/wire-ios/Wire-iOS Tests/ReferenceImages/ConversationSystemMessageTests/testFailedToAddParticipantsMLS.414-0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29520e44c785cd4e9dfbd76e62ae63b9919f8467236385663b0577dddb8216dd
+size 26047

--- a/wire-ios/Wire-iOS.xcodeproj/project.pbxproj
+++ b/wire-ios/Wire-iOS.xcodeproj/project.pbxproj
@@ -634,6 +634,7 @@
 				ConversationMessageCell/CompleteReactionPickerViewControllerTests.swift,
 				ConversationMessageCell/ConversationAudioMessageCellTests.swift,
 				ConversationMessageCell/ConversationCollapsedMessageCellSnapshotTests.swift,
+				ConversationMessageCell/ConversationFailedToAddParticipantsSystemMessageCellDescriptionTests.swift,
 				ConversationMessageCell/ConversationFileMessageCellTests.swift,
 				ConversationMessageCell/ConversationImageMessageTests.swift,
 				ConversationMessageCell/ConversationLinkAttachmentMessageCellTests.swift,

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationFailedToAddParticipantsSystemMessageCellDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationFailedToAddParticipantsSystemMessageCellDescription.swift
@@ -38,10 +38,18 @@ final class ConversationFailedToAddParticipantsSystemMessageCellDescription: Con
     let accessibilityIdentifier: String? = nil
     let accessibilityLabel: String? = nil
 
-    init(failedUsers: [UserType], isCollapsed: Bool, buttonAction: @escaping Completion) {
+    init(
+        failedUsers: [UserType],
+        isCollapsed: Bool,
+        reason: ZMSystemMessageType = .failedToAddParticipants,
+        buttonAction: @escaping Completion
+    ) {
         self.configuration = View.Configuration(
             title: ConversationFailedToAddParticipantsSystemMessageCellDescription.configureTitle(for: failedUsers),
-            content: ConversationFailedToAddParticipantsSystemMessageCellDescription.configureContent(for: failedUsers),
+            content: ConversationFailedToAddParticipantsSystemMessageCellDescription.configureContent(
+                for: failedUsers,
+                reason: reason
+            ),
             isCollapsed: isCollapsed,
             icon: .init(resource: .attention).withRenderingMode(.alwaysOriginal),
             buttonAction: buttonAction
@@ -57,7 +65,10 @@ final class ConversationFailedToAddParticipantsSystemMessageCellDescription: Con
         return .markdown(from: title, style: .errorLabelStyle)
     }
 
-    private static func configureContent(for failedUsers: [UserType]) -> NSAttributedString {
+    private static func configureContent(
+        for failedUsers: [UserType],
+        reason: ZMSystemMessageType
+    ) -> NSAttributedString {
         let keyString = "content.system.failedtoadd_participants.could_not_be_added"
 
         let userNames = failedUsers.compactMap(\.name)
@@ -65,7 +76,12 @@ final class ConversationFailedToAddParticipantsSystemMessageCellDescription: Con
         let text = keyString.localized(args: userNames.count, userNamesJoined)
 
         let attributedText = NSAttributedString.errorSystemMessage(withText: text, andHighlighted: userNamesJoined)
-        let learnMore = NSAttributedString.unreachableBackendLearnMoreLink
+        let learnMore: NSAttributedString = switch reason {
+        case .failedToAddParticipantsMLS:
+            .mlsMissingKeyPackageLearnMoreLink
+        default:
+            .unreachableBackendLearnMoreLink
+        }
 
         return [attributedText, learnMore].joined(separator: " ".attributedString)
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationMessageFailedRecipientsCellDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationMessageFailedRecipientsCellDescription.swift
@@ -116,6 +116,18 @@ extension NSAttributedString {
         )
     }
 
+    static var mlsMissingKeyPackageLearnMoreLink: NSAttributedString {
+        typealias SystemContent = L10n.Localizable.Content.System
+
+        return NSAttributedString(
+            string: SystemContent.FailedParticipants.learnMore,
+            attributes: [
+                .font: UIFont.mediumSemiboldFont,
+                .link: WireURLs.shared.mlsInfo
+            ]
+        )
+    }
+
     static func errorSystemMessage(withText text: String, andHighlighted highlighted: String) -> NSAttributedString {
         .markdown(from: text, style: .errorLabelStyle)
             .adding(font: .mediumSemiboldFont, to: highlighted)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCellDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCellDescription.swift
@@ -179,12 +179,13 @@ enum ConversationSystemMessageCellDescription {
             // Displayed in the table header via GroupConversationHeaderView.
             return []
 
-        case .failedToAddParticipants:
+        case .failedToAddParticipants, .failedToAddParticipantsMLS:
             if let users = Array(systemMessageData.userTypes) as? [UserType], let buttonAction {
 
                 let cellDescription = ConversationFailedToAddParticipantsSystemMessageCellDescription(
                     failedUsers: users,
                     isCollapsed: isCollapsed,
+                    reason: systemMessageData.systemMessageType,
                     buttonAction: buttonAction
                 )
                 return [AnyConversationMessageCellDescription(cellDescription)]


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28103" title="WPB-28103" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28103</a>  [iOS] Release 4.27.0 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR cherry-picks https://github.com/wireapp/wire-ios/pull/5023 for the 4.27 release.

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
