### PR TITLE
fix: failing UI test - WPB-28461

### DIFF
--- a/WireNetwork/Sources/WireNetwork/APIs/Rest/AuthenticationAPI/AuthenticationAPIV0.swift
+++ b/WireNetwork/Sources/WireNetwork/APIs/Rest/AuthenticationAPI/AuthenticationAPIV0.swift
@@ -289,12 +289,15 @@ class AuthenticationAPIV0: AuthenticationAPI, VersionedAPI {
             .withBody(body, contentType: .json)
             .build()
 
-        let (_, response) = try await networkService.executeRequest(request)
+        let (data, response) = try await networkService.executeRequest(request)
 
         try ResponseParser()
             .success(code: .ok)
             .failure(code: .badRequest, label: "bad-request", error: AuthenticationAPIError.invalidEmail)
-            .parse(code: response.statusCode, data: nil)
+            .parse(
+                code: response.statusCode,
+                data: response.statusCode == HTTPStatusCode.ok.rawValue ? nil : data
+            )
     }
 
     func requestEmailVerificationCode(for email: String) async throws {

--- a/wire-ios/WireUITests/AccountManagementTests.swift
+++ b/wire-ios/WireUITests/AccountManagementTests.swift
@@ -39,6 +39,11 @@ final class AccountManagementTests: WireUITestCase {
             .updateUsernameAndSave()
 
         XCTAssertTrue(
+            accountSettingPage.nameField.waitForExistence(timeout: 3),
+            "Name field was not visible"
+        )
+
+        XCTAssertTrue(
             (accountSettingPage.nameField.value as? String)?.contains("-updated") == true,
             "Updated name was not visible"
         )

--- a/wire-ios/WireUITests/AdminPromotionTests.swift
+++ b/wire-ios/WireUITests/AdminPromotionTests.swift
@@ -200,7 +200,7 @@ class AdminPromotionTests: WireUITestCase {
         participantDescription: String
     ) throws {
         XCTAssertTrue(
-            conversationDetailsPage.userCell(named: leavingUserName).waitForNonExistence(timeout: 0.5),
+            conversationDetailsPage.userCell(named: leavingUserName).waitForNonExistence(timeout: 5),
             "\(participantDescription) should not appear in participant list after leaving"
         )
 

--- a/wire-ios/WireUITests/Pages/ActiveConversationPage.swift
+++ b/wire-ios/WireUITests/Pages/ActiveConversationPage.swift
@@ -319,7 +319,7 @@ class ActiveConversationPage: PageModel {
     func mentionUserAndSendMessage(nameOfUser: String) throws -> ActiveConversationPage {
         mentionButton.tap()
         chooseUser(nameOfUser: nameOfUser)
-        sendButton.tap()
+        sendButton.tapAndWait()
         return self
     }
 

--- a/wire-ios/WireUITests/Pages/ActiveConversationPage.swift
+++ b/wire-ios/WireUITests/Pages/ActiveConversationPage.swift
@@ -662,15 +662,25 @@ class ActiveConversationPage: PageModel {
     }
 
     func verifyLinkPreviewCell(
+        shouldExist: Bool = true,
         file: StaticString = #filePath,
         line: UInt = #line
     ) -> ActiveConversationPage {
-        XCTAssertTrue(
-            linkPreviewCell.waitForExistence(timeout: 10),
-            "Link preview cell did not appear",
-            file: file,
-            line: line
-        )
+        if shouldExist {
+            XCTAssertTrue(
+                linkPreviewCell.waitForExistence(timeout: 10),
+                "Link preview cell did not appear",
+                file: file,
+                line: line
+            )
+        } else {
+            XCTAssertFalse(
+                linkPreviewCell.waitForExistence(timeout: 3),
+                "Link preview cell should not appear",
+                file: file,
+                line: line
+            )
+        }
         return self
     }
 

--- a/wire-ios/WireUITests/SettingsTests.swift
+++ b/wire-ios/WireUITests/SettingsTests.swift
@@ -105,7 +105,6 @@ final class SettingsTests: WireUITestCase {
             conversation: .group("Test")
         )
 
-        // Login & Disable link previews
         let conversationPage = try app.loginUser(email: stagingTeam.email, password: stagingTeam.password)
             .acceptPopup()
             .openSettings()
@@ -113,26 +112,26 @@ final class SettingsTests: WireUITestCase {
             .disableCreateLinkPreviews()
             .backToSettings()
             .switchToConversationsTab()
-            // Open conversation and send first link
             .openConversation()
             .sendMessage("First link: https://github.com/wireapp/wire-ios")
+
+        // Verify first message is sent without link preview
+        let conversationsPage = try conversationPage
+            .verifyMessageSent("First link: https://github.com/wireapp/wire-ios")
+            .verifyLinkPreviewCell(shouldExist: false)
             .goBackToConversationPage()
-            // Enable link previews
+
+        let conversationPageWithPreview = try conversationsPage
             .openSettings()
             .openOptionsMenu()
             .enableCreateLinkPreviews()
             .backToSettings()
             .switchToConversationsTab()
-            // Open conversation and send first link
             .openConversation()
             .sendMessage("Second link: https://github.com/wireapp/wire-android")
 
-        // Verify first message is the original message without preview
-        _ = conversationPage
-            .verifyMessageSent("First link: https://github.com/wireapp/wire-ios")
-
         // Verify second message has link preview
-        _ = conversationPage
+        _ = conversationPageWithPreview
             .verifyMessageSent("Second link:")
             .verifyLinkPreviewCell()
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28461" title="WPB-28461" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28461</a>  [iOS] Fix recently UITest failures
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

_Please describe the issue._

_Optional: add details about technical approach, solutions etc._

_Optional: reference dependencies to other pull requests etc._
### Some failing test in nightly and critical flow

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._
Ran locally - worked now.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
