### PR TITLE
fix: update conversation title when meeting title changes - WPB-27618

### DIFF
--- a/WireCalling/Sources/WireCallingDomain/WireMeetings/Protocols/MeetingConversationRepositoryProtocol.swift
+++ b/WireCalling/Sources/WireCallingDomain/WireMeetings/Protocols/MeetingConversationRepositoryProtocol.swift
@@ -37,4 +37,7 @@ public protocol MeetingConversationRepositoryProtocol: Sendable {
     /// Set the name of the underlying conversation.
     func setConversationName(_ name: String, for conversationID: QualifiedID) async throws
 
+    /// Update the name of the underlying conversation and await the backend response.
+    func updateConversationName(_ name: String, for conversationID: QualifiedID) async throws
+
 }

--- a/WireCalling/Sources/WireCallingDomain/WireMeetings/Protocols/UpdateMeetingUseCaseProtocol.swift
+++ b/WireCalling/Sources/WireCallingDomain/WireMeetings/Protocols/UpdateMeetingUseCaseProtocol.swift
@@ -41,4 +41,7 @@ package protocol UpdateMeetingUseCaseProtocol: Sendable {
         participants: [MeetingMember]
     ) async throws -> Meeting
 
+    /// Updates the meeting's dedicated conversation name without updating the meeting itself.
+    func updateConversationName(for meeting: Meeting) async throws
+
 }

--- a/WireCalling/Sources/WireCallingDomain/WireMeetings/UseCases/UpdateMeetingUseCase.swift
+++ b/WireCalling/Sources/WireCallingDomain/WireMeetings/UseCases/UpdateMeetingUseCase.swift
@@ -59,12 +59,6 @@ package struct UpdateMeetingUseCase: UpdateMeetingUseCaseProtocol {
             recurrence: recurrence
         )
 
-        // Mirror the new title onto the underlying conversation, which the
-        // backend doesn't rename on a meeting update.
-        if title != meeting.title {
-            try await conversationRepository.setConversationName(title, for: meeting.conversationID)
-        }
-
         // The creator is implicit in the form's participant selection, so it
         // is excluded from the baseline too — otherwise every update would
         // try to remove the creator from the conversation.
@@ -79,15 +73,33 @@ package struct UpdateMeetingUseCase: UpdateMeetingUseCaseProtocol {
         try await conversationRepository.addParticipants(membersToAdd, to: meeting.conversationID)
         try await conversationRepository.removeParticipants(membersToRemove, from: meeting.conversationID)
 
+        if title != meeting.title {
+            do {
+                try await updateConversationName(for: updatedMeeting)
+            } catch {
+                throw UpdateMeetingUseCaseError.conversationNameUpdateFailed(updatedMeeting: updatedMeeting)
+            }
+        }
+
         return updatedMeeting
+    }
+
+    package func updateConversationName(for meeting: Meeting) async throws {
+        try await conversationRepository.updateConversationName(
+            meeting.title,
+            for: meeting.conversationID
+        )
     }
 
 }
 
-package enum UpdateMeetingUseCaseError: Error {
+package enum UpdateMeetingUseCaseError: Error, Equatable {
 
     /// The meeting's conversation has not been resolved from the local store,
     /// so there is no baseline to diff the selected participants against.
     case conversationNotResolved
+
+    /// The meeting update succeeded, but its dedicated conversation could not be renamed.
+    case conversationNameUpdateFailed(updatedMeeting: Meeting)
 
 }

--- a/WireCalling/Sources/WireCallingUI/Resources/Localization/en.lproj/Localizable.strings
+++ b/WireCalling/Sources/WireCallingUI/Resources/Localization/en.lproj/Localizable.strings
@@ -62,10 +62,14 @@
 "wireMeetings.schedule.start.button" = "Start";
 "wireMeetings.schedule.setupTitle.header" = "Title";
 "wireMeetings.schedule.setupTitle.placeholder" = "Enter meeting title";
+"wireMeetings.schedule.setupTitle.error.tooLong" = "Too many characters";
 "wireMeetings.schedule.setupParticipants.header" = "Participants";
 "wireMeetings.schedule.setupParticipants.placeholder" = "Add participants";
 "wireMeetings.schedule.error.alert.title" = "Something went wrong";
 "wireMeetings.schedule.error.alert.ok" = "OK";
+"wireMeetings.schedule.error.conversationName.title" = "Could not update call name";
+"wireMeetings.schedule.error.conversationName.message" = "The meeting title was updated, but the name shown in the call could not be updated. Please try again.";
+"wireMeetings.schedule.error.conversationName.retry" = "Try again";
 "wireMeetings.schedule.disableGuestAccess.alert.title" = "Disable guest access?";
 "wireMeetings.schedule.disableGuestAccess.alert.disable" = "Disable";
 "wireMeetings.schedule.disableGuestAccess.alert.cancel" = "Cancel";

--- a/WireCalling/Sources/WireCallingUI/Views/WireMeetings/MeetingForm/MeetingFormView.swift
+++ b/WireCalling/Sources/WireCallingUI/Views/WireMeetings/MeetingForm/MeetingFormView.swift
@@ -77,6 +77,16 @@ struct MeetingFormView: View {
                     dismissButton: .default(Text(Strings.Error.Alert.ok))
                 )
             }
+            .alert(
+                Strings.Error.ConversationName.title,
+                isPresented: $viewModel.hasConversationNameUpdateError
+            ) {
+                Button(Strings.Error.ConversationName.retry) {
+                    Task { await viewModel.retryConversationNameUpdate() }
+                }
+            } message: {
+                Text(Strings.Error.ConversationName.message)
+            }
         }
     }
 
@@ -103,7 +113,7 @@ struct MeetingFormView: View {
     }
 
     private var titleSection: some View {
-        Section(Strings.SetupTitle.header) {
+        Section {
             HStack {
                 TextField(Strings.SetupTitle.placeholder, text: $viewModel.meetingTitle)
                     .focused($isTitleFieldFocused)
@@ -114,6 +124,13 @@ struct MeetingFormView: View {
                             viewModel.clearTitle()
                         }
                 }
+            }
+        } header: {
+            Text(Strings.SetupTitle.header)
+        } footer: {
+            if viewModel.isMeetingTitleTooLong {
+                Text(Strings.SetupTitle.Error.tooLong)
+                    .foregroundStyle(ColorTheme.Base.error.color)
             }
         }
         .textCase(nil)

--- a/WireCalling/Sources/WireCallingUI/Views/WireMeetings/MeetingForm/MeetingFormViewModel.swift
+++ b/WireCalling/Sources/WireCallingUI/Views/WireMeetings/MeetingForm/MeetingFormViewModel.swift
@@ -63,6 +63,9 @@ package final class MeetingFormViewModel {
     private let onSuccess: (Meeting) -> Void
 
     private static let timePickerMinuteInterval = 15
+    // Match the limits enforced by SimpleTextFieldValidator for conversation names.
+    private static let maximumConversationNameLength = 64
+    private static let maximumConversationNameByteLength = 256
 
     /// The smallest selectable interval between start and end time.
     private static let minimumDuration = TimeInterval(timePickerMinuteInterval) * TimeInterval.oneMinute
@@ -125,6 +128,10 @@ package final class MeetingFormViewModel {
     /// logged; the view shows a generic alert.
     var hasError = false
 
+    /// Set when the meeting was saved but its dedicated conversation could not be renamed.
+    var hasConversationNameUpdateError = false
+    private var meetingPendingConversationNameUpdate: Meeting?
+
     var selectedMembersSummary: String {
         selectedMembers
             .map(\.name)
@@ -132,7 +139,12 @@ package final class MeetingFormViewModel {
     }
 
     var isNextButtonEnabled: Bool {
-        !meetingTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        !meetingTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isMeetingTitleTooLong
+    }
+
+    var isMeetingTitleTooLong: Bool {
+        meetingTitle.count > Self.maximumConversationNameLength ||
+            meetingTitle.utf8.count > Self.maximumConversationNameByteLength
     }
 
     // MARK: - Public Interface
@@ -196,14 +208,36 @@ package final class MeetingFormViewModel {
         guard !isLoading else { return }
         isLoading = true
         hasError = false
+        hasConversationNameUpdateError = false
+        meetingPendingConversationNameUpdate = nil
         defer { isLoading = false }
         do {
             let meeting = try await saveMeeting()
             onSuccess(meeting)
+        } catch let UpdateMeetingUseCaseError.conversationNameUpdateFailed(updatedMeeting) {
+            meetingPendingConversationNameUpdate = updatedMeeting
+            hasConversationNameUpdateError = true
         } catch {
             let errorType = Swift.type(of: error)
             WireLogger.search.error("failed to save meeting: \(String(describing: errorType))")
             hasError = true
+        }
+    }
+
+    func retryConversationNameUpdate() async {
+        guard !isLoading, let meeting = meetingPendingConversationNameUpdate else { return }
+        isLoading = true
+        hasConversationNameUpdateError = false
+        defer { isLoading = false }
+
+        do {
+            try await updateMeetingUseCase.updateConversationName(for: meeting)
+            meetingPendingConversationNameUpdate = nil
+            onSuccess(meeting)
+        } catch {
+            let errorType = Swift.type(of: error)
+            WireLogger.search.error("failed to update conversation name: \(String(describing: errorType))")
+            hasConversationNameUpdateError = true
         }
     }
 

--- a/WireCalling/Tests/WireCallingTests/WireMeetings/DomainTests/UpdateMeetingUseCaseTests.swift
+++ b/WireCalling/Tests/WireCallingTests/WireMeetings/DomainTests/UpdateMeetingUseCaseTests.swift
@@ -80,6 +80,19 @@ struct UpdateMeetingUseCaseTests {
         )
     }
 
+    private func makeMeeting(title: String) -> Meeting {
+        Meeting(
+            id: meeting.id,
+            title: title,
+            start: meeting.start,
+            end: meeting.end,
+            recurrence: meeting.recurrence,
+            conversation: meeting.conversation,
+            conversationID: meeting.conversationID,
+            creatorID: meeting.creatorID
+        )
+    }
+
     @Test("invoke updates the meeting via the repository and returns it")
     func invokeUpdatesMeeting() async throws {
         // Given
@@ -112,9 +125,10 @@ struct UpdateMeetingUseCaseTests {
     @Test("invoke renames the underlying conversation when the title changed")
     func invokeRenamesConversation() async throws {
         // Given
+        let updatedMeeting = makeMeeting(title: "Saved Standup")
         meetingRepository
             .updateMeetingIdQualifiedIDTitleStringStartTimeDateEndTimeDateRecurrenceMeetingRecurrenceMeetingReturnValue =
-            meeting
+            updatedMeeting
 
         // When
         _ = try await useCase.invoke(
@@ -128,8 +142,8 @@ struct UpdateMeetingUseCaseTests {
 
         // Then
         let nameArguments = conversationRepository
-            .setConversationNameNameStringForConversationIDQualifiedIDVoidReceivedArguments
-        #expect(nameArguments?.name == "Renamed Standup")
+            .updateConversationNameNameStringForConversationIDQualifiedIDVoidReceivedArguments
+        #expect(nameArguments?.name == updatedMeeting.title)
         #expect(nameArguments?.conversationID == meeting.conversationID)
     }
 
@@ -152,7 +166,7 @@ struct UpdateMeetingUseCaseTests {
 
         // Then
         #expect(conversationRepository
-            .setConversationNameNameStringForConversationIDQualifiedIDVoidCallsCount == 0)
+            .updateConversationNameNameStringForConversationIDQualifiedIDVoidCallsCount == 0)
     }
 
     @Test("invoke adds newly selected members and removes deselected ones")
@@ -228,7 +242,7 @@ struct UpdateMeetingUseCaseTests {
             )
         }
         #expect(conversationRepository
-            .setConversationNameNameStringForConversationIDQualifiedIDVoidCallsCount == 0)
+            .updateConversationNameNameStringForConversationIDQualifiedIDVoidCallsCount == 0)
         #expect(conversationRepository
             .addParticipantsParticipantsMeetingMemberToConversationIDQualifiedIDVoidCallsCount == 0)
         #expect(conversationRepository
@@ -309,6 +323,45 @@ struct UpdateMeetingUseCaseTests {
         let removeArguments = conversationRepository
             .removeParticipantsParticipantsMeetingMemberFromConversationIDQualifiedIDVoidReceivedArguments
         #expect(removeArguments?.participants.isEmpty == true)
+    }
+
+    @Test("a failed conversation rename can be retried without updating the meeting again")
+    func invokeWithFailedConversationRenameRetriesOnlyRename() async throws {
+        // Given
+        let updatedMeeting = makeMeeting(title: "Saved Standup")
+        meetingRepository
+            .updateMeetingIdQualifiedIDTitleStringStartTimeDateEndTimeDateRecurrenceMeetingRecurrenceMeetingReturnValue =
+            updatedMeeting
+        conversationRepository
+            .updateConversationNameNameStringForConversationIDQualifiedIDVoidThrowableError =
+            URLError(.badServerResponse)
+
+        // When
+        await #expect(throws: UpdateMeetingUseCaseError.conversationNameUpdateFailed(updatedMeeting: updatedMeeting)) {
+            _ = try await useCase.invoke(
+                meeting: meeting,
+                title: "Submitted Standup",
+                startTime: meeting.start,
+                endTime: meeting.end,
+                recurrence: nil,
+                participants: [Self.keptMember, Self.addedMember]
+            )
+        }
+        conversationRepository.updateConversationNameNameStringForConversationIDQualifiedIDVoidThrowableError = nil
+        try await useCase.updateConversationName(for: updatedMeeting)
+
+        // Then
+        #expect(meetingRepository
+            .updateMeetingIdQualifiedIDTitleStringStartTimeDateEndTimeDateRecurrenceMeetingRecurrenceMeetingCallsCount ==
+            1)
+        let renameInvocations = conversationRepository
+            .updateConversationNameNameStringForConversationIDQualifiedIDVoidReceivedInvocations
+        #expect(renameInvocations.map(\.name) == [updatedMeeting.title, updatedMeeting.title])
+        #expect(renameInvocations.map(\.conversationID) == [meeting.conversationID, meeting.conversationID])
+        #expect(conversationRepository
+            .addParticipantsParticipantsMeetingMemberToConversationIDQualifiedIDVoidCallsCount == 1)
+        #expect(conversationRepository
+            .removeParticipantsParticipantsMeetingMemberFromConversationIDQualifiedIDVoidCallsCount == 1)
     }
 
 }

--- a/WireDomain/Sources/WireDomain/Repositories/Conversations/Repository/ConversationRepository.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Conversations/Repository/ConversationRepository.swift
@@ -181,6 +181,34 @@ public final class ConversationRepository: ConversationRepositoryProtocol {
         )
     }
 
+    public func renameConversation(
+        _ conversationID: WireDataModel.QualifiedID,
+        to newName: String
+    ) async throws {
+        let event = try await conversationsAPI.updateConversationName(
+            newName,
+            for: WireNetwork.QualifiedID(conversationID)
+        )
+
+        if let event {
+            await updateConversationName(
+                newName: event.newName,
+                conversationID: event.conversationID.id,
+                conversationDomain: event.conversationID.domain,
+                senderID: event.senderID.id,
+                senderDomain: event.senderID.domain,
+                date: event.timestamp
+            )
+        }
+
+        await conversationsLocalStore.execute(conversationID: conversationID) { conversation, context in
+            if event == nil {
+                conversation?.userDefinedName = newName
+            }
+            context.saveOrRollback()
+        }
+    }
+
     public func updateConversationName(
         newName: String,
         conversationID: UUID,

--- a/WireDomain/Tests/WireDomainTests/UseCases/RepairRemovalKeysUseCaseTests.swift
+++ b/WireDomain/Tests/WireDomainTests/UseCases/RepairRemovalKeysUseCaseTests.swift
@@ -248,6 +248,13 @@ final class MockConversationsAPIProtocol: ConversationsAPI {
         fatalError("not implemented")
     }
 
+    func updateConversationName(
+        _ name: String,
+        for conversationID: WireNetwork.QualifiedID
+    ) async throws -> WireNetwork.ConversationRenameEvent? {
+        fatalError("not implemented")
+    }
+
     func createGroupConversation(
         parameters: WireNetwork.CreateGroupConversationParameters
     ) async throws -> WireNetwork.Conversation {

--- a/WireNetwork/Sources/WireNetwork/APIs/Rest/ConversationsAPI/ConversationsAPI.swift
+++ b/WireNetwork/Sources/WireNetwork/APIs/Rest/ConversationsAPI/ConversationsAPI.swift
@@ -50,6 +50,16 @@ public protocol ConversationsAPI {
         conversationID: String
     ) async throws -> String?
 
+    /// Updates the name of a qualified conversation.
+    /// - Parameters:
+    ///   - name: The new conversation name.
+    ///   - conversationID: The conversation identifier.
+    /// - Returns: The conversation rename event, when supplied by the backend.
+    func updateConversationName(
+        _ name: String,
+        for conversationID: QualifiedID
+    ) async throws -> ConversationRenameEvent?
+
     /// Creates a group conversation given provided parameters.
     /// - parameter parameters: API body parameters required to create the group.
     /// - returns: The created group conversation.

--- a/WireNetwork/Sources/WireNetwork/APIs/Rest/ConversationsAPI/ConversationsAPIV0.swift
+++ b/WireNetwork/Sources/WireNetwork/APIs/Rest/ConversationsAPI/ConversationsAPIV0.swift
@@ -142,6 +142,13 @@ class ConversationsAPIV0: ConversationsAPI, VersionedAPI {
             .parse(code: response.statusCode, data: data)
     }
 
+    func updateConversationName(
+        _ name: String,
+        for conversationID: QualifiedID
+    ) async throws -> ConversationRenameEvent? {
+        throw ConversationsAPIError.unsupportedEndpointForAPIVersion
+    }
+
     func createGroupConversation(
         parameters: CreateGroupConversationParameters
     ) async throws -> Conversation {

--- a/WireNetwork/Sources/WireNetwork/APIs/Rest/ConversationsAPI/ConversationsAPIV1.swift
+++ b/WireNetwork/Sources/WireNetwork/APIs/Rest/ConversationsAPI/ConversationsAPIV1.swift
@@ -51,6 +51,42 @@ class ConversationsAPIV1: ConversationsAPIV0 {
         }
     }
 
+    override func updateConversationName(
+        _ name: String,
+        for conversationID: QualifiedID
+    ) async throws -> ConversationRenameEvent? {
+        let parameters = UpdateConversationNameParametersV1(name: name)
+        let body = try JSONEncoder.defaultEncoder.encode(parameters)
+        let path = "\(pathPrefix)\(basePath)/\(conversationID.domain)/\(conversationID.id)/name"
+
+        let request = try URLRequestBuilder(path: path)
+            .withMethod(.put)
+            .withBody(body, contentType: .json)
+            .build()
+
+        let (data, response) = try await apiService.executeRequest(
+            request,
+            requiringAccessToken: true
+        )
+
+        guard response.statusCode != HTTPStatusCode.noContent.rawValue else {
+            return nil
+        }
+
+        return try ResponseParser()
+            .success(code: .ok, type: ConversationRenameResponseV1.self)
+            .failure(code: .badRequest, error: ConversationsAPIError.invalidBody)
+            .failure(code: .forbidden, label: "access-denied", error: ConversationsAPIError.accessDenied)
+            .failure(
+                code: .forbidden,
+                label: "action-denied",
+                error: ConversationsAPIError.insufficientAuthorization
+            )
+            .failure(code: .forbidden, label: "operation-denied", error: ConversationsAPIError.operationDenied)
+            .failure(code: .notFound, label: "no-conversation", error: ConversationsAPIError.conversationNotFound)
+            .parse(code: response.statusCode, data: data)
+    }
+
     override func removeParticipant(
         userID: UserID,
         conversationID: ConversationID
@@ -92,5 +128,30 @@ private struct PaginatedConversationIDsV1: Decodable, ToAPIModelConvertible {
             hasMore: hasMore,
             nextStart: pagingState
         )
+    }
+}
+
+private struct UpdateConversationNameParametersV1: Encodable {
+    let name: String
+}
+
+private struct ConversationRenameResponseV1: Decodable, ToAPIModelConvertible {
+
+    let event: ConversationRenameEvent
+
+    init(from decoder: any Decoder) throws {
+        let updateEvent = try UpdateEventDecodingProxy(from: decoder).updateEvent
+
+        guard case let .conversation(.rename(event)) = updateEvent else {
+            throw DecodingError.dataCorrupted(
+                .init(codingPath: decoder.codingPath, debugDescription: "Expected a conversation rename event")
+            )
+        }
+
+        self.event = event
+    }
+
+    func toAPIModel() -> ConversationRenameEvent {
+        event
     }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/Meetings/MeetingConversationRepositoryBridge.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/Meetings/MeetingConversationRepositoryBridge.swift
@@ -23,13 +23,13 @@ import WireDomain
 import WireFoundation
 import WireSyncEngine
 
-/// Bridges `WireDomain`'s `ConversationRepositoryProtocol` into `WireCallingDomain`'s
+/// Bridges `WireDomain`'s `ConversationRepository` into `WireCallingDomain`'s
 /// `MeetingConversationRepositoryProtocol`, so the meetings feature can pull meeting
 /// conversations and add or remove participants (including MLS group establishment)
 /// without depending on `WireDomain` directly.
 struct MeetingConversationRepositoryBridge: MeetingConversationRepositoryProtocol, @unchecked Sendable {
 
-    let conversationRepository: any ConversationRepositoryProtocol
+    let conversationRepository: ConversationRepository
     let contextProvider: any ContextProvider
     let participantsService: any ConversationParticipantsServiceInterface
 
@@ -161,6 +161,30 @@ struct MeetingConversationRepositoryBridge: MeetingConversationRepositoryProtoco
             conv.userDefinedName = name
             _ = viewContext.saveOrRollback()
         }
+    }
+
+    func updateConversationName(
+        _ name: String,
+        for conversationID: WireCallingDomain.QualifiedID
+    ) async throws {
+        let syncContext = contextProvider.syncContext
+        let isMeeting = try await syncContext.perform {
+            guard let conversation = ZMConversation.fetch(
+                with: conversationID.id,
+                domain: conversationID.domain,
+                in: syncContext
+            ) else {
+                throw ConversationRemoveParticipantError.conversationNotFound
+            }
+            return conversation.isMeeting
+        }
+
+        guard isMeeting else { return }
+
+        try await conversationRepository.renameConversation(
+            WireDataModel.QualifiedID(uuid: conversationID.id, domain: conversationID.domain),
+            to: name
+        )
     }
 
     /// Resolves the meeting members and the conversation into their managed


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27618" title="WPB-27618" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-27618</a>  [iOS] Update the conversation title when the meeting title is edited
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

- Rename a meeting’s dedicated conversation after its title is updated.
- Skip the rename when the title is unchanged or the meeting uses an existing conversation.
- If renaming fails, show an explicit error and retry only the conversation rename.
- Enforce conversation-name limits on the meeting title field.

---

### Checklist

- [X] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [X] Description is filled and free of optional paragraphs.
- [X] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
