### PR TITLE
chore: UITest preview Image and video in drive enabled conversations - WPB-28108

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/AttachmentsPreviewView/WireDriveLargeVideoPreviewView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/AttachmentsPreviewView/WireDriveLargeVideoPreviewView.swift
@@ -19,6 +19,7 @@
 import SwiftUI
 import WireDesign
 import WireFoundation
+import WireLocators
 import WireMessagingDomain
 
 private typealias Strings = L10n.Localizable.Conversation.WireCells
@@ -77,6 +78,7 @@ struct WireDriveLargeVideoPreviewView: View {
                 image
                     .resizable()
                     .aspectRatio(imageAspectRatio, contentMode: .fit)
+                    .accessibilityIdentifier(Locators.ActiveConversationPage.videoPreview.rawValue)
                     .overlay {
                         switch state {
                         case .notLoaded, .loaded:

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/ConversationPreviews/WireDriveImageConversationAttachmentPreview.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/ConversationPreviews/WireDriveImageConversationAttachmentPreview.swift
@@ -19,6 +19,7 @@
 import SwiftUI
 import WireDesign
 import WireFoundation
+import WireLocators
 
 private typealias Strings = L10n.Localizable.Conversation.WireCells
 private typealias Accessibility = L10n.Accessibility.Conversation.WireCells
@@ -61,6 +62,7 @@ struct WireDriveImageConversationAttachmentPreview: View {
                                     .resizable()
                                     .scaledToFill()
                                     .frame(width: geometry.size.width, height: geometry.size.height)
+                                    .accessibilityIdentifier(Locators.ActiveConversationPage.imagePreview.rawValue)
                             }
                         case let .failure(error) where !error.isURLErrorCancelled && !isAssetDownloadError:
                             noPreviewMessageView

--- a/WireUI/Sources/WireLocators/Locators.swift
+++ b/WireUI/Sources/WireLocators/Locators.swift
@@ -184,6 +184,8 @@ public enum Locators {
         case imageCell
         case videoCell
         case videoPlayButton
+        case imagePreview
+        case videoPreview
         case mentionButton
         case userCellName
         case labelSharedDriveON = "Shared Drive is on"

--- a/WireUI/Sources/WireLocators/Locators.swift
+++ b/WireUI/Sources/WireLocators/Locators.swift
@@ -201,8 +201,10 @@ public enum Locators {
         case attachmentVideoPreview
         case classifiedBanner = "ClassificationBannerClassified"
         case photoButton
+        case cameraRollButton
         case uploadFileButton
         case locationButton
+        case add = "Add"
         case browse = "Browse"
         case open = "Open"
         case allowFullAccess = "Allow Full Access"

--- a/wire-ios/WireUITests/Pages/ActiveConversationPage.swift
+++ b/wire-ios/WireUITests/Pages/ActiveConversationPage.swift
@@ -84,6 +84,14 @@ class ActiveConversationPage: PageModel {
         app.descendants(matching: .any)[Locators.ActiveConversationPage.videoPlayButton.rawValue].firstMatch
     }
 
+    var imagePreview: XCUIElement {
+        app.descendants(matching: .any)[Locators.ActiveConversationPage.imagePreview.rawValue].firstMatch
+    }
+
+    var videoPreview: XCUIElement {
+        app.descendants(matching: .any)[Locators.ActiveConversationPage.videoPreview.rawValue].firstMatch
+    }
+
     var userRemovedSystemMessage: XCUIElement {
         app.descendants(matching: .any)[Locators.ConversationsPage.userRemovedSystemMessage.rawValue]
     }
@@ -338,6 +346,34 @@ class ActiveConversationPage: PageModel {
         XCTAssertTrue(attachmentImagePreview.waitForNonExistence(timeout: 10))
     }
 
+    @discardableResult
+    func sendDriveImageAttachment(
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> ActiveConversationPage {
+        XCTAssertTrue(
+            sendButton.waitAndTap(timeout: 10),
+            "Send button did not become available for image attachment",
+            file: file,
+            line: line
+        )
+        return self
+    }
+
+    @discardableResult
+    func sendDriveVideoAttachment(
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> ActiveConversationPage {
+        XCTAssertTrue(
+            sendButton.waitAndTap(timeout: 10),
+            "Send button did not become available for video attachment",
+            file: file,
+            line: line
+        )
+        return self
+    }
+
     func openSharedDrive() throws -> SharedDriveFilesPage {
         conversationTitleButton.waitAndTap()
         sharedDriveButton.tap()
@@ -589,6 +625,46 @@ class ActiveConversationPage: PageModel {
         XCTAssertTrue(
             attachment.waitForExistence(timeout: 5),
             "Expected \(type) attachment '\(name)' not found",
+            file: file,
+            line: line
+        )
+        return self
+    }
+
+    @discardableResult
+    func verifyImagePreviewIsVisible(
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> ActiveConversationPage {
+        XCTAssertTrue(
+            imageCell.waitForExistence(timeout: 5),
+            "No Image cell found",
+            file: file,
+            line: line
+        )
+        XCTAssertTrue(
+            imagePreview.waitForExistence(timeout: 5),
+            "Image preview did not appear",
+            file: file,
+            line: line
+        )
+        return self
+    }
+
+    @discardableResult
+    func verifyVideoPreviewIsVisible(
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> ActiveConversationPage {
+        XCTAssertTrue(
+            videoCell.waitForExistence(timeout: 10),
+            "No Video cell found",
+            file: file,
+            line: line
+        )
+        XCTAssertTrue(
+            videoPreview.waitForExistence(timeout: 10),
+            "Video preview did not appear",
             file: file,
             line: line
         )

--- a/wire-ios/WireUITests/Pages/ActiveConversationPage.swift
+++ b/wire-ios/WireUITests/Pages/ActiveConversationPage.swift
@@ -153,6 +153,10 @@ class ActiveConversationPage: PageModel {
         app.images[Locators.ActiveConversationPage.attachmentImagePreview.rawValue]
     }
 
+    var attachmentVideoPreview: XCUIElement {
+        app.images[Locators.ActiveConversationPage.attachmentVideoPreview.rawValue]
+    }
+
     var classifiedBanner: XCUIElement {
         app.otherElements[Locators.ActiveConversationPage.classifiedBanner.rawValue]
     }
@@ -173,8 +177,16 @@ class ActiveConversationPage: PageModel {
         app.buttons[Locators.ActiveConversationPage.photoButton.rawValue]
     }
 
+    var cameraRollButton: XCUIElement {
+        app.buttons[Locators.ActiveConversationPage.cameraRollButton.rawValue]
+    }
+
     var uploadFileButton: XCUIElement {
         app.buttons[Locators.ActiveConversationPage.uploadFileButton.rawValue].firstMatch
+    }
+
+    var addButton: XCUIElement {
+        app.buttons[Locators.ActiveConversationPage.add.rawValue].firstMatch
     }
 
     var locationButton: XCUIElement {
@@ -347,29 +359,10 @@ class ActiveConversationPage: PageModel {
     }
 
     @discardableResult
-    func sendDriveImageAttachment(
-        file: StaticString = #filePath,
-        line: UInt = #line
-    ) -> ActiveConversationPage {
+    func sendAttachments() -> ActiveConversationPage {
         XCTAssertTrue(
             sendButton.waitAndTap(timeout: 10),
-            "Send button did not become available for image attachment",
-            file: file,
-            line: line
-        )
-        return self
-    }
-
-    @discardableResult
-    func sendDriveVideoAttachment(
-        file: StaticString = #filePath,
-        line: UInt = #line
-    ) -> ActiveConversationPage {
-        XCTAssertTrue(
-            sendButton.waitAndTap(timeout: 10),
-            "Send button did not become available for video attachment",
-            file: file,
-            line: line
+            "Send button did not become hittable for attachment"
         )
         return self
     }
@@ -460,6 +453,56 @@ class ActiveConversationPage: PageModel {
             "OK button did not appear after selecting media"
         )
         okToSend.waitAndTap()
+        return self
+    }
+    
+    func selectImageAndSendInDriveEnabledConversation(at index: Int = 3) throws -> ActiveConversationPage {
+        if !imageToChoose(at: index).waitForExistence(timeout: 2) {
+            photoButton.waitAndTap()
+        }
+        imageToChoose(at: index).waitAndTap()
+
+        XCTAssertTrue(
+            attachmentImagePreview.waitForExistence(timeout: 5),
+            "Image attachment preview did not appear"
+        )
+
+        XCTAssertTrue(
+            sendButton.waitAndTap(timeout: 10),
+            "Send button did not become hittable for attachment"
+        )
+        return self
+    }
+
+    func selectVideoFromCameraRoll() throws -> ActiveConversationPage {
+        if !cameraRollButton.waitForExistence(timeout: 2) {
+            photoButton.waitAndTap()
+        }
+
+        XCTAssertTrue(
+            cameraRollButton.waitAndTap(),
+            "cameraRollButton did not show up"
+        )
+
+        // NOTE: Tap the center via coordinates because Photos grid cells are often not directly hittable in UITests
+
+        let video = app.images.matching(NSPredicate(
+            format: "identifier == %@ AND label BEGINSWITH %@",
+            Locators.PhotosAppPage.imageTile.rawValue,
+            "Video"
+        )).firstMatch
+        XCTAssertTrue(video.waitForExistence(timeout: 8), "No video found in camera roll")
+        video.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+
+        XCTAssertTrue(
+            addButton.waitAndTap(),
+            "Not able to add media after selecting"
+        )
+
+        XCTAssertTrue(
+            attachmentVideoPreview.waitForExistence(timeout: 5),
+            "Video attachment preview did not appear"
+        )
         return self
     }
 
@@ -633,40 +676,20 @@ class ActiveConversationPage: PageModel {
 
     @discardableResult
     func verifyImagePreviewIsVisible(
-        file: StaticString = #filePath,
-        line: UInt = #line
     ) -> ActiveConversationPage {
         XCTAssertTrue(
-            imageCell.waitForExistence(timeout: 5),
-            "No Image cell found",
-            file: file,
-            line: line
-        )
-        XCTAssertTrue(
             imagePreview.waitForExistence(timeout: 5),
-            "Image preview did not appear",
-            file: file,
-            line: line
+            "Image preview did not appear"
         )
         return self
     }
 
     @discardableResult
     func verifyVideoPreviewIsVisible(
-        file: StaticString = #filePath,
-        line: UInt = #line
     ) -> ActiveConversationPage {
         XCTAssertTrue(
-            videoCell.waitForExistence(timeout: 10),
-            "No Video cell found",
-            file: file,
-            line: line
-        )
-        XCTAssertTrue(
-            videoPreview.waitForExistence(timeout: 10),
-            "Video preview did not appear",
-            file: file,
-            line: line
+            videoPreview.waitForExistence(timeout: 5),
+            "Video preview did not appear"
         )
         return self
     }

--- a/wire-ios/WireUITests/Pages/ActiveConversationPage.swift
+++ b/wire-ios/WireUITests/Pages/ActiveConversationPage.swift
@@ -455,7 +455,7 @@ class ActiveConversationPage: PageModel {
         okToSend.waitAndTap()
         return self
     }
-    
+
     func selectImageAndSendInDriveEnabledConversation(at index: Int = 3) throws -> ActiveConversationPage {
         if !imageToChoose(at: index).waitForExistence(timeout: 2) {
             photoButton.waitAndTap()

--- a/wire-ios/WireUITests/WireDriveTests.swift
+++ b/wire-ios/WireUITests/WireDriveTests.swift
@@ -353,18 +353,17 @@ final class WireDriveTests: WireUITestCase {
         // WHEN
         let activeConversationPage = try loginAndOpenConversation(for: teamOwner)
             .openPhotosAndGrantPermission()
-            .selectImageAndSend()
-            .sendDriveImageAttachment()
+            .selectImageAndSendInDriveEnabledConversation()
 
         // THEN - image preview is shown after sending
         activeConversationPage.verifyImagePreviewIsVisible()
 
         // WHEN
-        activeConversationPage
-            .uploadFile(named: "testVideo.mp4")
-            .sendDriveVideoAttachment()
+        try activeConversationPage
+            .selectVideoFromCameraRoll()
+            .sendAttachments()
 
-        // THEN - video preview is shown after sending
+        // THEN - image and video preview shown together
         activeConversationPage.verifyVideoPreviewIsVisible()
     }
 }

--- a/wire-ios/WireUITests/WireDriveTests.swift
+++ b/wire-ios/WireUITests/WireDriveTests.swift
@@ -341,4 +341,30 @@ final class WireDriveTests: WireUITestCase {
         XCTAssertEqual(positiveSearchResults, 1)
         XCTAssertEqual(negativeSearchResults, 0)
     }
+
+    @MainActor
+    func testVideoAndImagePreviewShown_TC_11684_11685() async throws {
+
+        // GIVEN
+        let teamOwner = try await createDriveEnabledConversation(
+            .group(UserGenerator.generateRandomConversationName())
+        )
+
+        // WHEN
+        let activeConversationPage = try loginAndOpenConversation(for: teamOwner)
+            .openPhotosAndGrantPermission()
+            .selectImageAndSend()
+            .sendDriveImageAttachment()
+
+        // THEN - image preview is shown after sending
+        activeConversationPage.verifyImagePreviewIsVisible()
+
+        // WHEN
+        activeConversationPage
+            .uploadFile(named: "testVideo.mp4")
+            .sendDriveVideoAttachment()
+
+        // THEN - video preview is shown after sending
+        activeConversationPage.verifyVideoPreviewIsVisible()
+    }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28108" title="WPB-28108" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28108</a>  [iOS] Automate - video/Image preview  in drive conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

_Please describe the issue._

_Optional: add details about technical approach, solutions etc._

_Optional: reference dependencies to other pull requests etc._

### UITest - for image and video preview for drive enabled conversation

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._
Ran locally - worked now.


https://github.com/user-attachments/assets/53d2ab50-a29c-4932-8288-830f5ff8e70a


---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
