### PR TITLE
chore: remove meetings developer toggle - WPB-28001

### DIFF
--- a/WireDomain/Sources/WireDomain/Components/ClientSessionComponent.swift
+++ b/WireDomain/Sources/WireDomain/Components/ClientSessionComponent.swift
@@ -729,7 +729,6 @@ public final class ClientSessionComponent {
     private lazy var meetingDeleteEventNotificationBuilder = MeetingDeleteEventNotificationBuilder(
         meetingLocalStore: MeetingLocalStore(context: syncContext),
         userLocalStore: userLocalStore,
-        developerFlagStorage: sharedUserDefaults,
         featureConfigLocalStore: featureConfigsLocalStore,
         accountID: selfUserID
     )

--- a/WireDomain/Sources/WireDomain/Notifications/Builders/Meeting/MeetingDeleteEventNotificationBuilder.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Builders/Meeting/MeetingDeleteEventNotificationBuilder.swift
@@ -31,13 +31,10 @@ struct MeetingDeleteEventNotificationBuilder: MeetingDeleteEventNotificationBuil
 
     let meetingLocalStore: any MeetingLocalStoreProtocol
     let userLocalStore: any UserLocalStoreProtocol
-    // TODO: [WPB-25517] Remove developer flag before release
-    let developerFlagStorage: UserDefaults
     let featureConfigLocalStore: any FeatureConfigLocalStoreProtocol
     let accountID: UUID
 
     func buildContent(event: MeetingDeleteEvent) async -> UserNotification? {
-        guard developerFlagStorage.bool(forKey: DeveloperFlag.wireMeetings.rawValue) else { return nil }
         guard let feature = try? await featureConfigLocalStore.fetchFeature(name: .meetings) else { return nil }
         guard await featureConfigLocalStore.isFeatureEnabled(feature: feature) else { return nil }
         guard let meeting = await meetingLocalStore.storedMeeting(id: event.meetingID) else { return nil }

--- a/WireDomain/Sources/WireDomain/Notifications/Components/NSEClientScope.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Components/NSEClientScope.swift
@@ -400,7 +400,6 @@ final class NSEClientScope: Component<NSEClientScopeDependency> {
             MeetingDeleteEventNotificationBuilder(
                 meetingLocalStore: MeetingLocalStore(context: coreDataStack.syncContext),
                 userLocalStore: userLocalStore,
-                developerFlagStorage: dependency.sharedUserDefaults,
                 featureConfigLocalStore: FeatureConfigLocalStore(context: coreDataStack.syncContext),
                 accountID: dependency.accountID
             )

--- a/WireUI/Sources/WireMainNavigationUI/Containers/MainTabBarController.swift
+++ b/WireUI/Sources/WireMainNavigationUI/Containers/MainTabBarController.swift
@@ -94,8 +94,6 @@ public final class MainTabBarController<
     private weak var _settingsUI: SettingsUI?
     private weak var _conversationUI: ConversationUI?
     private weak var _settingsContentUI: UIViewController?
-    /// We should use DeveloperFlag 'wireMeetings' after moving it to WireFoundation:
-    /// https://wearezeta.atlassian.net/browse/WPB-19065
     private var showMeetings: Bool
     private var showFiles: Bool
 

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -174,9 +174,6 @@ public final class ZMUserSession: NSObject {
     }
 
     public var isMeetingsEnabled: Bool {
-        // TODO: [WPB-28001] Remove developer flag before release
-        guard DeveloperFlag.wireMeetings.isOn else { return false }
-
         let feature = Feature.fetch(name: .meetings, context: coreDataStack.viewContext)
         return feature?.status == .enabled
     }

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests.swift
@@ -39,6 +39,24 @@ final class ZMUserSessionTests: ZMUserSessionTestsBase {
         cancellables = nil
     }
 
+    func testThatMeetingsAvailabilityFollowsBackendFeatureStatus() {
+        let testCases: [(status: Feature.Status, isEnabled: Bool)] = [
+            (.enabled, true),
+            (.disabled, false)
+        ]
+
+        for testCase in testCases {
+            syncMOC.performAndWait {
+                Feature.updateOrCreate(havingName: .meetings, in: syncMOC) {
+                    $0.status = testCase.status
+                }
+            }
+            uiMOC.refreshAllObjects()
+
+            XCTAssertEqual(sut.isMeetingsEnabled, testCase.isEnabled)
+        }
+    }
+
     func testThatSyncContextReturnsSelfForLinkedSyncContext() {
         // GIVEN
         XCTAssertNotNil(sut.syncManagedObjectContext)

--- a/wire-ios-utilities/Source/DeveloperFlag.swift
+++ b/wire-ios-utilities/Source/DeveloperFlag.swift
@@ -39,7 +39,6 @@ public enum DeveloperFlag: String, CaseIterable {
     case showUnreadConversationsFilter
     case skipMLSMessagesDecryption
     case useWireAuthentication
-    case wireMeetings
     case lowKeyPackageCount
     case enabledCCDebugLogs
     case shakeToReport
@@ -103,9 +102,6 @@ public enum DeveloperFlag: String, CaseIterable {
 
         case .consumableNotifications:
             "Turn on to enable consumable notifications"
-
-        case .wireMeetings:
-            "Turn on to enable Wire meetings"
 
         case .lowKeyPackageCount:
             "Turn on to set the minimum number of packages to 1"

--- a/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -285,7 +285,6 @@ final class ZClientViewController: UIViewController {
             .observe(\.showUnreadConversationsFilter, options: [.new]) { [weak self] _, _ in
                 // Update sidebar's showUnreadFilters when developer flag changes
                 self?.sidebarViewController.showUnreadFilters = DeveloperFlag.showUnreadConversationsFilter.isOn
-                self?.sidebarViewController.showMeetings = self?.userSession.isMeetingsEnabled ?? false
             }
 
         observeFeatureConfigChanges()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28001" title="WPB-28001" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28001</a>  [iOS] Remove local Meetings feature toggle for M1 rollout
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Meetings availability was gated by both the backend `meetings` team feature flag and the local `wireMeetings` developer toggle. This meant backend enablement alone was insufficient.

This change:

- Removes `wireMeetings` from developer settings.
- Makes Meetings UI availability depend only on the backend team feature flag.
- Removes obsolete developer-flag plumbing and references.

---

### Checklist

- [X] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [X] Description is filled and free of optional paragraphs.
- [X] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
