### PR TITLE
fix: align meeting time range formatting - WPB-28053

### DIFF
--- a/WireCalling/Sources/WireCallingUI/Views/WireMeetings/MeetingsView/Meeting/MeetingRow.swift
+++ b/WireCalling/Sources/WireCallingUI/Views/WireMeetings/MeetingsView/Meeting/MeetingRow.swift
@@ -241,7 +241,7 @@ private extension MeetingRecurrence {
     VStack(alignment: .leading, spacing: 24) {
         MeetingRow(
             occurrence: MeetingOccurrence(meeting: meeting),
-            formatTime: { formatter.startedAt($0.start) },
+            formatTime: { formatter.timeRange(from: $0.start, to: $0.end) },
             isOrganizer: true,
             isLive: true,
             onEdit: {},
@@ -251,7 +251,7 @@ private extension MeetingRecurrence {
 
         MeetingRow(
             occurrence: MeetingOccurrence(meeting: meeting),
-            formatTime: { formatter.startedAt($0.start) },
+            formatTime: { formatter.timeRange(from: $0.start, to: $0.end) },
             isOrganizer: true,
             isAttending: true,
             isLive: true,

--- a/WireCalling/Sources/WireCallingUI/Views/WireMeetings/MeetingsView/MeetingsFormatter.swift
+++ b/WireCalling/Sources/WireCallingUI/Views/WireMeetings/MeetingsView/MeetingsFormatter.swift
@@ -21,7 +21,6 @@ package import Foundation
 package protocol MeetingsFormatterProtocol {
     func dayHeader(for date: Date, now: Date) -> String
     func timeRange(from start: Date, to end: Date) -> String
-    func startedAt(_ start: Date) -> String
 }
 
 package struct MeetingsFormatter: MeetingsFormatterProtocol {
@@ -41,13 +40,14 @@ package struct MeetingsFormatter: MeetingsFormatterProtocol {
     }
 
     package func timeRange(from start: Date, to end: Date) -> String {
-        let startString = DateFormatter.meetingTimeWithoutPeriod.string(from: start)
+        let calendar = Calendar.current
+        let startPeriod = calendar.component(.hour, from: start) / 12
+        let endPeriod = calendar.component(.hour, from: end) / 12
+        let isSamePeriod = startPeriod == endPeriod
+        let startFormatter = isSamePeriod ? DateFormatter.meetingTimeWithoutPeriod : DateFormatter.meetingTime
+        let startString = startFormatter.string(from: start)
         let endString = DateFormatter.meetingTime.string(from: end)
         return "\(startString) - \(endString)"
-    }
-
-    package func startedAt(_ start: Date) -> String {
-        Strings.startedAt(DateFormatter.meetingTime.string(from: start))
     }
 
 }
@@ -70,14 +70,14 @@ private extension DateFormatter {
     static let meetingTimeWithoutPeriod: DateFormatter = {
         let formatter = DateFormatter()
         formatter.locale = .current
-        formatter.dateFormat = "h:mm"
+        formatter.dateFormat = "hh:mm"
         return formatter
     }()
 
     static let meetingTime: DateFormatter = {
         let formatter = DateFormatter()
         formatter.locale = .current
-        formatter.dateFormat = "h:mm a"
+        formatter.dateFormat = "hh:mm a"
         return formatter
     }()
 

--- a/WireCalling/Sources/WireCallingUI/Views/WireMeetings/MeetingsView/MeetingsViewModel.swift
+++ b/WireCalling/Sources/WireCallingUI/Views/WireMeetings/MeetingsView/MeetingsViewModel.swift
@@ -186,11 +186,7 @@ package final class MeetingsViewModel {
     }
 
     func formatTime(for occurrence: MeetingOccurrence) -> String {
-        if isHappeningNow(occurrence) {
-            formatter.startedAt(occurrence.start)
-        } else {
-            formatter.timeRange(from: occurrence.start, to: occurrence.end)
-        }
+        formatter.timeRange(from: occurrence.start, to: occurrence.end)
     }
 
     /// Deletes the meeting awaiting confirmation. Synchronous on purpose: it must capture

--- a/WireCalling/Tests/WireCallingTests/WireMeetings/PresentationTests/MeetingsFormatterTests.swift
+++ b/WireCalling/Tests/WireCallingTests/WireMeetings/PresentationTests/MeetingsFormatterTests.swift
@@ -50,4 +50,34 @@ struct MeetingsFormatterTests {
         #expect(!result.isEmpty)
     }
 
+    // MARK: - Time Range Tests
+
+    @Test("timeRange places the period once for a morning range")
+    func timeRange_sameMorningPeriod() throws {
+        let start = try makeDate(hour: 7, minute: 30)
+        let end = try makeDate(hour: 7, minute: 40)
+
+        #expect(formatter.timeRange(from: start, to: end) == "07:30 - 07:40 AM")
+    }
+
+    @Test("timeRange places the period once for an afternoon range")
+    func timeRange_sameAfternoonPeriod() throws {
+        let start = try makeDate(hour: 14, minute: 0)
+        let end = try makeDate(hour: 15, minute: 15)
+
+        #expect(formatter.timeRange(from: start, to: end) == "02:00 - 03:15 PM")
+    }
+
+    @Test("timeRange places the period on both times when crossing from morning to afternoon")
+    func timeRange_crossesPeriod() throws {
+        let start = try makeDate(hour: 11, minute: 30)
+        let end = try makeDate(hour: 13, minute: 15)
+
+        #expect(formatter.timeRange(from: start, to: end) == "11:30 AM - 01:15 PM")
+    }
+
+    private func makeDate(hour: Int, minute: Int) throws -> Date {
+        try #require(calendar.date(from: DateComponents(year: 2026, month: 6, day: 15, hour: hour, minute: minute)))
+    }
+
 }

--- a/WireCalling/Tests/WireCallingTests/WireMeetings/PresentationTests/MeetingsViewModelTests.swift
+++ b/WireCalling/Tests/WireCallingTests/WireMeetings/PresentationTests/MeetingsViewModelTests.swift
@@ -553,6 +553,21 @@ struct MeetingsViewModelTests {
         #expect(viewModel.formatTimeRange(for: meeting) == formatter.timeRange(from: meeting.start, to: meeting.end))
     }
 
+    @Test("formatTime returns the full range for an ongoing occurrence")
+    func formatTime_ongoingOccurrence() {
+        let meeting = Meeting.fixture(
+            title: "Ongoing",
+            start: mockDateProvider.now.addingTimeInterval(-60),
+            duration: 3600
+        )
+        let occurrence = MeetingOccurrence(meeting: meeting)
+
+        #expect(viewModel.isHappeningNow(occurrence))
+        #expect(
+            viewModel.formatTime(for: occurrence) == formatter.timeRange(from: occurrence.start, to: occurrence.end)
+        )
+    }
+
     @Test("formatDay delegates to the formatter")
     func formatDay() {
         let day = mockDateProvider.now


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28053" title="WPB-28053" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28053</a>  [iOS] Changing time format for consistency
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Align meeting-list time formatting with the other clients:

- Zero-pad 12-hour values.
- Show the day period once when both times are AM or both are PM.
- Show it for both times when crossing from AM to PM.

---

### Checklist

- [X] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [X] Description is filled and free of optional paragraphs.
- [X] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
