### PR TITLE
chore: UITest - open conversation and correct conversation opens - WPB-28224

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/Conversation/ConversationTitleView/ConversationTitleView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/Conversation/ConversationTitleView/ConversationTitleView.swift
@@ -61,6 +61,7 @@ public class ConversationTitleView: UIView {
     private func configureViews() {
         nameLabel.font = .preferredFont(forTextStyle: .headline)
         nameLabel.textColor = SemanticColors.Label.textDefault
+        nameLabel.accessibilityIdentifier = Locators.ActiveConversationPage.conversationTitleLabel.rawValue
 
         subtitleLabel.font = .boldSystemFont(ofSize: 9)
         subtitleLabel.textColor = .white

--- a/WireUI/Sources/WireLocators/Locators.swift
+++ b/WireUI/Sources/WireLocators/Locators.swift
@@ -175,6 +175,7 @@ public enum Locators {
         case inputField
         case sendButton
         case authorName
+        case conversationTitleLabel
         case conversationTitleButton
         case conversationDetailsButton
         case sharedDriveButton

--- a/wire-ios/WireUITests/ConversationTests.swift
+++ b/wire-ios/WireUITests/ConversationTests.swift
@@ -205,4 +205,50 @@ final class ConversationTests: WireUITestCase {
         XCTAssertFalse(activeConversationPage.userLeftSystemMessage.exists, "the system message has not been removed")
     }
 
+    @MainActor
+    func testOpenConversationOpensCorrectOne_TC_8818() async throws {
+        // GIVEN a team with several group and channel conversations
+        let (owner, _, qualifiedIDs, _) = try await UserHelper.default.registerTeam(withMemberCount: 1)
+        let member = try XCTUnwrap(qualifiedIDs.first)
+
+        var conversationNames: [String] = []
+
+        for _ in 0 ..< 3 {
+            let groupName = UserGenerator.generateRandomConversationName()
+            try await UserHelper.default.createGroupConversations(
+                qualifiedIds: [member],
+                owner: owner,
+                groupName: groupName
+            )
+            conversationNames.append(groupName)
+        }
+
+        guard let teamID = owner.teamID else {
+            throw XCTSkip("owner.teamID is nil")
+        }
+        try await UserHelper.default.unlockAndEnableChannelFeature(teamID: teamID)
+
+        for _ in 0 ..< 3 {
+            let channelName = UserGenerator.generateRandomConversationName()
+            try await UserHelper.default.createChannelConversations(
+                qualifiedIds: [member],
+                owner: owner,
+                channelName: channelName
+            )
+            conversationNames.append(channelName)
+        }
+
+        let targetName = try XCTUnwrap(conversationNames.last)
+
+        // WHEN opening one of the created conversations from the list
+        let conversationsPage = try await loginToBackend(user: owner)
+        let activeConversationPage = try conversationsPage.openConversation(named: targetName)
+
+        // THEN the header shows the conversation that was actually opened.
+        let conversationNameLabel = activeConversationPage.conversationTitle(named: targetName)
+        XCTAssertTrue(
+            conversationNameLabel.waitForExistence(timeout: 5),
+            "wrong conversation opened, expected header '\(targetName)' not found"
+        )
+    }
 }

--- a/wire-ios/WireUITests/ConversationTests.swift
+++ b/wire-ios/WireUITests/ConversationTests.swift
@@ -206,7 +206,7 @@ final class ConversationTests: WireUITestCase {
     }
 
     @MainActor
-    func testOpenConversationOpensCorrectOne_TC_8818() async throws {
+    func testOpeningConversationOpensCorrectOne_TC_8818() async throws {
         // GIVEN a team with several group and channel conversations
         let (owner, _, qualifiedIDs, _) = try await UserHelper.default.registerTeam(withMemberCount: 1)
         let member = try XCTUnwrap(qualifiedIDs.first)

--- a/wire-ios/WireUITests/Pages/ActiveConversationPage.swift
+++ b/wire-ios/WireUITests/Pages/ActiveConversationPage.swift
@@ -64,6 +64,16 @@ class ActiveConversationPage: PageModel {
         app.buttons[Locators.ActiveConversationPage.conversationTitleButton.rawValue].firstMatch
     }
 
+    func conversationTitle(named name: String) -> XCUIElement {
+        app.staticTexts.matching(
+            NSPredicate(
+                format: "identifier == %@ AND label == %@",
+                Locators.ActiveConversationPage.conversationTitleLabel.rawValue,
+                name
+            )
+        ).firstMatch
+    }
+
     var conversationDetailsButton: XCUIElement {
         app.buttons[Locators.ActiveConversationPage.conversationDetailsButton.rawValue]
     }

--- a/wire-ios/WireUITests/Pages/ConversationsPage.swift
+++ b/wire-ios/WireUITests/Pages/ConversationsPage.swift
@@ -248,6 +248,21 @@ class ConversationsPage: PageModel {
     }
 
     @discardableResult
+    func openConversation(named name: String) throws -> ActiveConversationPage {
+        try letTheSyncFinish()
+        let targetConversation = conversationCell(named: name)
+        XCTAssertTrue(
+            targetConversation.waitForExistence(timeout: 10),
+            "Conversation cell '\(name)' did not appear"
+        )
+        XCTAssertTrue(
+            targetConversation.waitAndTap(timeout: 5),
+            "Conversation cell '\(name)' was not tappable"
+        )
+        return try ActiveConversationPage()
+    }
+
+    @discardableResult
     func openConversationWithGuest(groupName: String) throws -> ActiveConversationPage {
         try letTheSyncFinish()
         let groupConversationWithGuestCell = app.buttons


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28224" title="WPB-28224" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28224</a>  [iOS] Automate - TC-8818 As a user, I can open conversation and correct conversation gets opened
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

_Please describe the issue._

_Optional: add details about technical approach, solutions etc._

_Optional: reference dependencies to other pull requests etc._

### UITest - open conversation and correct conversation opens

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._
Local run

https://github.com/user-attachments/assets/f1b20b10-efb1-45df-bfd2-30a9f698b3eb



---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
