### PR TITLE
fix: use SSO URL as cookie parsing context - WPB-28508

### DIFF
--- a/WireAuthentication/Sources/WireAuthenticationLogic/LoginViaSSOUseCase.swift
+++ b/WireAuthentication/Sources/WireAuthenticationLogic/LoginViaSSOUseCase.swift
@@ -237,7 +237,8 @@ package struct LoginViaSSOUseCase: LoginViaSSOUseCaseProtocol {
                 throw LoginViaSSOUseCaseError.invalidCallbackURL
             }
 
-            // Use the SSO URL as the cookie context. iOS 27 rejects Secure cookies when parsed against the custom callback URL.
+            // Use the SSO URL as the cookie context. iOS 27 rejects Secure cookies when parsed against the custom
+            // callback URL.
             let cookies = HTTPCookie.cookies(
                 withResponseHeaderFields: ["Set-Cookie": cookieString],
                 for: ssoURL

--- a/WireAuthentication/Sources/WireAuthenticationLogic/LoginViaSSOUseCase.swift
+++ b/WireAuthentication/Sources/WireAuthenticationLogic/LoginViaSSOUseCase.swift
@@ -193,12 +193,14 @@ package struct LoginViaSSOUseCase: LoginViaSSOUseCaseProtocol {
 
         return try parseCallbackURL(
             callbackURL,
+            ssoURL: url,
             verificationToken: verificationToken
         )
     }
 
     private func parseCallbackURL(
         _ url: URL,
+        ssoURL: URL,
         verificationToken: SSOLoginVerificationToken
     ) throws -> (UUID, [HTTPCookie]) {
         guard
@@ -235,9 +237,10 @@ package struct LoginViaSSOUseCase: LoginViaSSOUseCaseProtocol {
                 throw LoginViaSSOUseCaseError.invalidCallbackURL
             }
 
+            // Use the SSO URL as the cookie context. iOS 27 rejects Secure cookies when parsed against the custom callback URL.
             let cookies = HTTPCookie.cookies(
                 withResponseHeaderFields: ["Set-Cookie": cookieString],
-                for: url
+                for: ssoURL
             )
 
             guard !cookies.isEmpty else {

--- a/wire-ios/Wire-iOS/Resources/Configuration/Version.xcconfig
+++ b/wire-ios/Wire-iOS/Resources/Configuration/Version.xcconfig
@@ -16,5 +16,5 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-WIRE_SHORT_VERSION = 4.26.0
+WIRE_SHORT_VERSION = 4.26.1
 MAJOR_VERSION = 4


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28508" title="WPB-28508" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-28508</a>  [iOS] cannot log on to Wire app on iOS 27 Beta
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

SSO login was getting stuck on iOS 27 Beta because HTTPCookie.cookies(withResponseHeaderFields:for:) returned no cookies when parsing a Secure cookie against the custom callback URL.

Fix is to use the SSO URL as the cookie parsing context instead of the custom callback URL.
Also, bumped the app version to 4.26.1 to prepare for the release.

### Testing

- Have iOS 27 Beta installed on a device
- Login using SSO
- Before fix: login fails, alert pop up shows up
- After fix: Login successfully

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
