### PR TITLE
fix: restoring backup shows unread conversations - WPB-23380

### DIFF
--- a/wire-ios/Wire-iOS Tests/Backup/BackupLocalStoreMessagesTests.swift
+++ b/wire-ios/Wire-iOS Tests/Backup/BackupLocalStoreMessagesTests.swift
@@ -411,19 +411,147 @@ final class BackupLocalStoreMessagesTests: XCTestCase {
         }
     }
 
+    // MARK: - lastReadServerTimeStamp
+
+    func test_AddMessages_AdvancesLastReadServerTimeStampToLatestRestoredMessage() async throws {
+        // GIVEN: a freshly-synced conversation whose lastReadServerTimeStamp
+        // was seeded from an old conversation.lastEventTime (or .distantPast)
+        let oldLastRead = Date(timeIntervalSince1970: 1000)
+        try await context.perform { [context, conversationID] in
+            let conversation = try XCTUnwrap(ZMConversation.fetch(
+                with: conversationID!.id,
+                domain: conversationID!.domain,
+                in: context!
+            ))
+            conversation.lastReadServerTimeStamp = oldLastRead
+            try context!.save()
+        }
+
+        let latestMessageDate = Date(timeIntervalSince1970: 2_000_000)
+        let messages = [
+            makeValidTextMessage(
+                conversationID: conversationID,
+                senderID: senderID,
+                creationDate: Date(timeIntervalSince1970: 1_000_000)
+            ),
+            makeValidTextMessage(
+                conversationID: conversationID,
+                senderID: senderID,
+                creationDate: latestMessageDate
+            )
+        ]
+
+        // WHEN
+        _ = try await sut.addMessages(messages)
+
+        // THEN
+        try await context.perform { [context, conversationID] in
+            let conversation = try XCTUnwrap(ZMConversation.fetch(
+                with: conversationID!.id,
+                domain: conversationID!.domain,
+                in: context!
+            ))
+            XCTAssertEqual(conversation.lastReadServerTimeStamp, latestMessageDate)
+            // The advance must not mark the key as locally modified,
+            // otherwise ConversationStatusStrategy would broadcast it via
+            // the self-conversation sync.
+            XCTAssertFalse(conversation.hasLocalModifications(forKey: ZMConversationLastReadServerTimeStampKey))
+        }
+    }
+
+    func test_AddMessages_AdvancesLastReadServerTimeStampToLatestEvenWithIntermediateLastRead() async throws {
+        // GIVEN: lastReadServerTimeStamp sits between two imported timestamps.
+        let middleLastRead = Date(timeIntervalSince1970: 1_500_000)
+        try await context.perform { [context, conversationID] in
+            let conversation = try XCTUnwrap(ZMConversation.fetch(
+                with: conversationID!.id,
+                domain: conversationID!.domain,
+                in: context!
+            ))
+            conversation.lastReadServerTimeStamp = middleLastRead
+            try context!.save()
+        }
+
+        let latestMessageDate = Date(timeIntervalSince1970: 2_000_000)
+        let messages = [
+            makeValidTextMessage(
+                conversationID: conversationID,
+                senderID: senderID,
+                creationDate: Date(timeIntervalSince1970: 1_000_000)
+            ),
+            makeValidTextMessage(
+                conversationID: conversationID,
+                senderID: senderID,
+                creationDate: latestMessageDate
+            )
+        ]
+
+        // WHEN
+        _ = try await sut.addMessages(messages)
+
+        // THEN: advances to the newest imported, not the middle marker.
+        try await context.perform { [context, conversationID] in
+            let conversation = try XCTUnwrap(ZMConversation.fetch(
+                with: conversationID!.id,
+                domain: conversationID!.domain,
+                in: context!
+            ))
+            XCTAssertEqual(conversation.lastReadServerTimeStamp, latestMessageDate)
+            XCTAssertFalse(conversation.hasLocalModifications(forKey: ZMConversationLastReadServerTimeStampKey))
+        }
+    }
+
+    func test_AddMessages_DoesNotMoveLastReadServerTimeStampBackward() async throws {
+        // GIVEN: lastReadServerTimeStamp already ahead of restored history
+        // (e.g. self-conversation sync brought a fresher value from another device).
+        let futureLastRead = Date(timeIntervalSince1970: 5_000_000)
+        try await context.perform { [context, conversationID] in
+            let conversation = try XCTUnwrap(ZMConversation.fetch(
+                with: conversationID!.id,
+                domain: conversationID!.domain,
+                in: context!
+            ))
+            conversation.lastReadServerTimeStamp = futureLastRead
+            try context!.save()
+        }
+
+        let messages = [
+            makeValidTextMessage(
+                conversationID: conversationID,
+                senderID: senderID,
+                creationDate: Date(timeIntervalSince1970: 1_000_000)
+            )
+        ]
+
+        // WHEN
+        _ = try await sut.addMessages(messages)
+
+        // THEN
+        try await context.perform { [context, conversationID] in
+            let conversation = try XCTUnwrap(ZMConversation.fetch(
+                with: conversationID!.id,
+                domain: conversationID!.domain,
+                in: context!
+            ))
+            XCTAssertEqual(conversation.lastReadServerTimeStamp, futureLastRead)
+            XCTAssertFalse(conversation.hasLocalModifications(forKey: ZMConversationLastReadServerTimeStampKey))
+        }
+    }
+
     // MARK: - Helper Methods
 
     private func makeValidTextMessage(
         conversationID: QualifiedID,
         senderID: QualifiedID,
-        senderClientID: String? = "client-id"
+        senderClientID: String? = "client-id",
+        creationDate: Date = Date()
     ) -> MessageBackupModel {
         MessageBackupModel(
             id: UUID().uuidString.lowercased(),
             conversationID: conversationID,
             senderUserID: senderID,
             senderClientID: senderClientID,
-            creationDate: Date(),
+            creationDate: creationDate,
             content: .text("Test message \(UUID().uuidString)")
         )
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Backup/BackupLocalStore/BackupLocalStore+Messages.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Backup/BackupLocalStore/BackupLocalStore+Messages.swift
@@ -447,12 +447,28 @@ extension BackupLocalStore {
                     WireLogger.backupImport.warn("Failed to delete invalid messages \(String(describing: error))")
                 }
             }
+
+            // Imported history was already read on other devices: advance
+            // lastReadServerTimeStamp so scrolling restored history doesn't
+            // broadcast an older lastRead via the self-conversation sync.
+            advanceLastReadAfterImport(conversationsByID: conversationsByID)
         }
 
         return .init(
             successCount: restoredCount,
             failureCount: failedCount
         )
+    }
+
+    private func advanceLastReadAfterImport(
+        conversationsByID: [QualifiedID: ZMConversation]
+    ) {
+        for conversation in conversationsByID.values {
+            guard let lastModified = conversation.lastModifiedDate else { continue }
+            let currentLastRead = conversation.lastReadServerTimeStamp ?? .distantPast
+            guard currentLastRead < lastModified else { continue }
+            conversation.lastReadServerTimeStamp = lastModified
+        }
     }
 
     private enum RehydrationFailure: Error {

--- a/wire-ios/WireUITests/BackupRestoreConversationListTests.swift
+++ b/wire-ios/WireUITests/BackupRestoreConversationListTests.swift
@@ -1,0 +1,207 @@
+//
+// Wire
+// Copyright (C) 2026 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import WireFoundation
+import XCTest
+
+final class BackupRestoreConversationListTests: WireUITestCase {
+
+    /// Verifies that backing up, logging out, logging back in and restoring keeps the
+    /// conversation list in the same order, and that the restored conversations are read
+    /// (no stale unread badges broadcast by the import) so that a freshly received message
+    /// shows exactly one unread message.
+    ///
+    /// Scenario (team owner is the user under test, `member` drives received messages):
+    /// 1. Create conversations A, B, C in this order.
+    /// 2. Owner sends a message in A, then in B.
+    /// 3. Owner receives a message in A.
+    ///    -> list order becomes A, B, C and A has 1 unread message.
+    /// 4. Backup, logout, login, restore.
+    ///    -> list order is still A, B, C and no conversation is unread.
+    /// 5. Owner receives a message in A.
+    ///    -> A shows exactly 1 unread message.
+    @MainActor
+    func testConversationListOrderAndUnreadAfterBackupRestore_TC_11583() async throws {
+
+        // GIVEN a team with one owner and one member who shares three conversations.
+        let nameA = "Conversation A"
+        let nameB = "Conversation B"
+        let nameC = "Conversation C"
+
+        let messageInA = UserGenerator.generateRandomMessage()
+        let messageInB = UserGenerator.generateRandomMessage()
+        let receivedInABeforeBackup = UserGenerator.generateRandomMessage()
+        let receivedInAAfterRestore = UserGenerator.generateRandomMessage()
+
+        let (_, teamOwner) = try await UserHelper.default.registerUserAsTeamOwner()
+        let ownerAccessToken = try await UserHelper.default.fetchAccessToken(
+            email: teamOwner.email,
+            password: teamOwner.password
+        )
+        let teamID = try XCTUnwrap(teamOwner.teamID)
+
+        let (memberQualifiedID, member) = try await UserHelper.default.registerUsersAsTeamMemberWithUserHandleSet(
+            ownerAccessToken: ownerAccessToken.token,
+            teamID: teamID
+        )
+
+        // Create A, B, C in this order so the initial list order is C, B, A (newest first).
+        for name in [nameA, nameB, nameC] {
+            try await UserHelper.default.createGroupConversations(
+                qualifiedIds: [memberQualifiedID],
+                owner: teamOwner,
+                groupName: name
+            )
+        }
+
+        let (conversationIdA, _) = try await UserHelper.default.getConversationId(
+            matching: .conversationName(nameA)
+        )
+        let conversationDomain = UserHelper.default.backend.domainInfo
+
+        // WHEN the owner logs in and sends a message in A, then in B.
+        var conversationsPage = try app.loginUser(email: teamOwner.email, password: teamOwner.password)
+            .acceptPopup()
+
+        conversationsPage = try conversationsPage
+            .openConversation(named: nameA)
+            .sendMessage(messageInA)
+            .goBackToConversationPage()
+
+        conversationsPage = try conversationsPage
+            .openConversation(named: nameB)
+            .sendMessage(messageInB)
+            .goBackToConversationPage()
+
+        // AND the member sends a message in A, which the owner receives.
+        try await testServicesClient.sendText(
+            user: member,
+            text: receivedInABeforeBackup,
+            conversationId: conversationIdA,
+            domain: conversationDomain
+        )
+
+        XCTAssertTrue(
+            conversationsPage.unreadMessagesCount.waitForExistence(timeout: 5),
+            "Unread badge did not appear after receiving a message in A"
+        )
+
+        // THEN the list shows A, B, C and A has one unread message.
+        XCTAssertEqual(
+            try conversationsPage.conversationNamesInOrder(),
+            [nameA, nameB, nameC],
+            "Unexpected conversation order before backup"
+        )
+        XCTAssertEqual(
+            try conversationsPage.getUnreadMessageCountValue(),
+            "1",
+            "Expected exactly one unread message in A before backup"
+        )
+
+        // WHEN backing up, logging out, logging back in and restoring.
+        let backupFileName = try createBackupAndLogout(user: teamOwner)
+
+        conversationsPage = try restoreBackup(fileName: backupFileName, user: teamOwner)
+
+        // THEN the list order is preserved as A, B, C ...
+        XCTAssertEqual(
+            try conversationsPage.conversationNamesInOrder(),
+            [nameA, nameB, nameC],
+            "Unexpected conversation order after restore"
+        )
+
+        // ... and no conversation is unread (the import advanced lastRead).
+        XCTAssertFalse(
+            conversationsPage.unreadMessagesCount.waitForExistence(timeout: 3),
+            "No conversation should be unread right after restoring the backup"
+        )
+
+        // WHEN the member sends another message in A.
+        try await testServicesClient.sendText(
+            user: member,
+            text: receivedInAAfterRestore,
+            conversationId: conversationIdA,
+            domain: conversationDomain
+        )
+
+        // THEN A shows exactly one unread message.
+        XCTAssertTrue(
+            conversationsPage.unreadMessagesCount.waitForExistence(timeout: 5),
+            "Unread badge did not appear after receiving a message in A post-restore"
+        )
+        XCTAssertEqual(
+            try conversationsPage.getUnreadMessageCountValue(),
+            "1",
+            "Expected exactly one unread message in A after restore"
+        )
+        XCTAssertEqual(
+            try conversationsPage.conversationNamesInOrder(),
+            [nameA, nameB, nameC],
+            "Unexpected conversation order after receiving a message post-restore"
+        )
+    }
+
+    /// Creates a password-protected backup, saves it to Files, then logs out.
+    /// - Returns: the name of the saved backup file.
+    @MainActor
+    private func createBackupAndLogout(user: UserInfo) throws -> String {
+        let creatingBackupPage = try ConversationsPage()
+            .openSettings()
+            .openAccountSettings()
+            .tapBackupOrRestore()
+            .tapBackupNow()
+            .enterBackupPasswordAndBackup(user.password)
+
+        XCTAssertTrue(creatingBackupPage.backupSuccessfullyCreatedLabel.exists, "Backup was not created")
+
+        let saveBackupFileBottomSheetPage = try creatingBackupPage.tapSaveFile()
+        let backupFileName = try XCTUnwrap(saveBackupFileBottomSheetPage.getBackupFileName())
+
+        _ = try saveBackupFileBottomSheetPage.tapSaveToFilesOnBottomSheet()
+            .tapSaveButtonOnMyiPhonePage()
+            .goBackToAccountPage()
+            .logout()
+            .enterPassword(user.password)
+
+        return backupFileName
+    }
+
+    /// Logs the user back in and restores history from the given backup file.
+    /// - Returns: the conversation list shown after the restore completes.
+    @MainActor
+    private func restoreBackup(fileName: String, user: UserInfo) throws -> ConversationsPage {
+        let setPasswordPage = try app.loginUser(email: user.email, password: user.password)
+            .acceptPopup()
+            .openSettings()
+            .openAccountSettings()
+            .tapBackupOrRestore()
+            .tapRestoreFromBackupButton()
+            .selectBackupFileWithPassword(withName: fileName)
+            .enterBackupPasswordAndRestore(user.password)
+
+        XCTAssertTrue(
+            setPasswordPage.historyRestoredAlert.waitForExistence(timeout: 5),
+            "History restored alert did not appear"
+        )
+
+        return try setPasswordPage.acceptHistoryrestoredAlert()
+            .goBackToAccountPage()
+            .goBackToSettingsPage()
+            .switchToConversationsTab()
+    }
+}

--- a/wire-ios/WireUITests/BackupRestoreConversationListTests.swift
+++ b/wire-ios/WireUITests/BackupRestoreConversationListTests.swift
@@ -165,10 +165,10 @@ final class BackupRestoreConversationListTests: WireUITestCase {
             .openAccountSettings()
             .tapBackupOrRestore()
             .tapBackupNow()
-            .enterBackupPasswordAndBackup(user.password)
-
-        XCTAssertTrue(creatingBackupPage.backupSuccessfullyCreatedLabel.exists, "Backup was not created")
-
+        XCTAssertTrue(
+            creatingBackupPage.backupSuccessfullyCreatedLabel.waitForExistence(timeout: 30),
+            "Backup was not created"
+        )
         let saveBackupFileBottomSheetPage = try creatingBackupPage.tapSaveFile()
         let backupFileName = try XCTUnwrap(saveBackupFileBottomSheetPage.getBackupFileName())
 

--- a/wire-ios/WireUITests/Pages/ConversationsPage.swift
+++ b/wire-ios/WireUITests/Pages/ConversationsPage.swift
@@ -247,6 +247,30 @@ class ConversationsPage: PageModel {
         return try ActiveConversationPage()
     }
 
+    /// Opens the conversation whose name matches `name`.
+    @discardableResult
+    func openConversation(named name: String) throws -> ActiveConversationPage {
+        try letTheSyncFinish()
+        let cell = conversationCell(named: name)
+        XCTAssertTrue(
+            cell.waitForExistence(timeout: 10),
+            "Conversation '\(name)' did not appear in the list"
+        )
+        cell.waitAndTap()
+        return try ActiveConversationPage()
+    }
+
+    /// Names of the conversation cells, ordered top-to-bottom as displayed in the list.
+    func conversationNamesInOrder() throws -> [String] {
+        try letTheSyncFinish()
+        XCTAssertTrue(conversationCell.waitForExistence(timeout: 10), "No conversation cells appeared in the list")
+        return app.buttons
+            .matching(identifier: Locators.ConversationsPage.conversationCell.rawValue)
+            .allElementsBoundByIndex
+            .sorted { $0.frame.minY < $1.frame.minY }
+            .map(\.label)
+    }
+
     @discardableResult
     func openConversationWithGuest(groupName: String) throws -> ActiveConversationPage {
         try letTheSyncFinish()

--- a/wire-ios/WireUITests/Pages/ConversationsPage.swift
+++ b/wire-ios/WireUITests/Pages/ConversationsPage.swift
@@ -264,8 +264,7 @@ class ConversationsPage: PageModel {
     func conversationNamesInOrder() throws -> [String] {
         try letTheSyncFinish()
         XCTAssertTrue(conversationCell.waitForExistence(timeout: 10), "No conversation cells appeared in the list")
-        return app.buttons
-            .matching(identifier: Locators.ConversationsPage.conversationCell.rawValue)
+        return conversationCells
             .allElementsBoundByIndex
             .sorted { $0.frame.minY < $1.frame.minY }
             .map(\.label)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23380" title="WPB-23380" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23380</a>  [iOS] Conversation shows unread when messages were read
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Cherry-pick from  (#5005)

### Testing

N/A
---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
