### PR TITLE
fix: German localization - WPB-27847

### DIFF
--- a/WireAuthentication/Sources/WireAuthenticationUI/Resources/Localization/de.lproj/Localizable.strings
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Resources/Localization/de.lproj/Localizable.strings
@@ -96,6 +96,7 @@
 "verification_code.message" = "Geben Sie den Code ein, den wir an %@ gesendet haben.";
 "verification_code.confirm" = "Bestätigen";
 "verification_code.resend_code" = "Code erneut senden";
+"verification_code.resend_code_after_seconds" = "Code erneut senden (warten: %@)";
 
 "authentication.no_history.title" = "Sie nutzen Wire zum ersten Mal auf diesem Gerät.";
 "authentication.no_history.message" = "Aus Datenschutzgründen wird der bisherige Gesprächsverlauf nicht angezeigt.";

--- a/wire-ios/Wire-iOS/Resources/Localization/de.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/de.lproj/Localizable.strings
@@ -1344,7 +1344,7 @@
 
 // By popular demand
 "self.settings.popular_demand.title" = "Auf allgemeinen Wunsch";
-"self.settings.popular_demand.send_button.title" = "Senden Taste";
+"self.settings.popular_demand.send_button.title" = "Senden-Taste";
 "self.settings.popular_demand.send_button.footer" = "Deaktivieren, um Nachrichten mit der Enter-Taste zu senden.";
 "self.settings.popular_demand.dark_mode.footer" = "Zwischen dunklem und hellem Hintergrund wechseln.";
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
@@ -417,7 +417,7 @@ final class AddParticipantsViewController: UIViewController {
 
         guard let title else { return }
 
-        setupNavigationBarTitle(title.capitalized)
+        setupNavigationBarTitle(title)
     }
 
     private func rightNavigationItemTapped() -> UIAction {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewModel.swift
@@ -66,7 +66,7 @@ struct AddParticipantsViewModel {
     func title(with users: UserSet) -> String {
         users.isEmpty
             ? L10n.Localizable.Peoplepicker.Group.Title.singular
-        : L10n.Localizable.Peoplepicker.Group.Title.plural(users.count)
+            : L10n.Localizable.Peoplepicker.Group.Title.plural(users.count)
     }
 
     var filterConversation: ZMConversation? {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewModel.swift
@@ -65,8 +65,8 @@ struct AddParticipantsViewModel {
 
     func title(with users: UserSet) -> String {
         users.isEmpty
-            ? L10n.Localizable.Peoplepicker.Group.Title.singular.capitalized
-            : L10n.Localizable.Peoplepicker.Group.Title.plural(users.count).capitalized
+            ? L10n.Localizable.Peoplepicker.Group.Title.singular
+        : L10n.Localizable.Peoplepicker.Group.Title.plural(users.count)
     }
 
     var filterConversation: ZMConversation? {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27847" title="WPB-27847" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-27847</a>  [iOS] [Localization] German labels contain spelling errors or remain untranslated when navigating settings, group creation, and 2FA by users
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Fix couple of german localization, see ticket:

* Add hyphen: “Senden Taste” change to “Senden-Taste”
* Removed forced capitalization: “Teilnehmer Auswählen” change to “Teilnehmer auswählen”
* Ported missing translation to release branch: “Resend Code”use “Code erneut senden” (exists in crowdin)

Crowdin was already updated by Astrid

### Testing

<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 14 - 18 5 - 2026-09-07 at 17 15 10" src="https://github.com/user-attachments/assets/2d25f946-07b6-4b11-b142-0da01a1b9a8c" />
<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 14 - 18 5 - 2026-09-07 at 17 14 57" src="https://github.com/user-attachments/assets/02036011-4460-41a5-a225-a8cd357e6b7b" />


---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
