### PR TITLE
fix: increased timeout for Image/Video preview assert - WPB-28108

### DIFF
--- a/wire-ios/WireUITests/Pages/ActiveConversationPage.swift
+++ b/wire-ios/WireUITests/Pages/ActiveConversationPage.swift
@@ -678,7 +678,7 @@ class ActiveConversationPage: PageModel {
     func verifyImagePreviewIsVisible(
     ) -> ActiveConversationPage {
         XCTAssertTrue(
-            imagePreview.waitForExistence(timeout: 5),
+            imagePreview.waitForExistence(timeout: 7),
             "Image preview did not appear"
         )
         return self
@@ -688,7 +688,7 @@ class ActiveConversationPage: PageModel {
     func verifyVideoPreviewIsVisible(
     ) -> ActiveConversationPage {
         XCTAssertTrue(
-            videoPreview.waitForExistence(timeout: 5),
+            videoPreview.waitForExistence(timeout: 7),
             "Video preview did not appear"
         )
         return self

--- a/wire-ios/WireUITests/Pages/ConversationsPage.swift
+++ b/wire-ios/WireUITests/Pages/ConversationsPage.swift
@@ -272,21 +272,6 @@ class ConversationsPage: PageModel {
     }
 
     @discardableResult
-    func openConversation(named name: String) throws -> ActiveConversationPage {
-        try letTheSyncFinish()
-        let targetConversation = conversationCell(named: name)
-        XCTAssertTrue(
-            targetConversation.waitForExistence(timeout: 10),
-            "Conversation cell '\(name)' did not appear"
-        )
-        XCTAssertTrue(
-            targetConversation.waitAndTap(timeout: 5),
-            "Conversation cell '\(name)' was not tappable"
-        )
-        return try ActiveConversationPage()
-    }
-
-    @discardableResult
     func openConversationWithGuest(groupName: String) throws -> ActiveConversationPage {
         try letTheSyncFinish()
         let groupConversationWithGuestCell = app.buttons


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

_Please describe the issue._

_Optional: add details about technical approach, solutions etc._

_Optional: reference dependencies to other pull requests etc._

Fix: Increased image/video timeouts as sometimes it fails to show preview in 5 seconds so increased.
Duplicate function removed.

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

Ran on Ci - worked https://github.com/wireapp/wire-ios/actions/runs/34197057945
---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
