### PR TITLE
chore: remove `preventAdminlessGroups` developer flag - WPB-28558

### DIFF
--- a/wire-ios-utilities/Source/DeveloperFlag.swift
+++ b/wire-ios-utilities/Source/DeveloperFlag.swift
@@ -34,7 +34,6 @@ public enum DeveloperFlag: String, CaseIterable {
     case ignoreIncomingEvents
     case newRegistration
     case noAPNSTokenCache
-    case preventAdminlessGroups
     case showCreateMLSGroupToggle
     case showUnreadConversationsFilter
     case skipMLSMessagesDecryption
@@ -87,9 +86,6 @@ public enum DeveloperFlag: String, CaseIterable {
 
         case .noAPNSTokenCache:
             "Turn on to always request the APNS token from the system instead of reading a cached one"
-
-        case .preventAdminlessGroups:
-            "Turn on to prevent last admins from leaving groups without promoting someone else"
 
         case .showUnreadConversationsFilter:
             "Turn on to show the new conversation filter options"

--- a/wire-ios/Wire-iOS Tests/ConversationCell/ConversationSystemMessageCellSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationCell/ConversationSystemMessageCellSnapshotTests.swift
@@ -79,8 +79,6 @@ final class ConversationSystemMessageCellSnapshotTests: ConversationMessageSnaps
     }
 
     func test_conversationScheduledForDeletion() {
-        DeveloperFlag.preventAdminlessGroups.enable(true)
-        defer { DeveloperFlag.preventAdminlessGroups.enable(false) }
         let message = makeMessage(messageType: .conversationScheduledForDeletion)
         message.systemMessageData?.conversationScheduledDeletionDate = .distantFuture
         verify(message: message)

--- a/wire-ios/Wire-iOS Tests/ConversationList/ConversationListCell/ConversationListCellTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationList/ConversationListCell/ConversationListCellTests.swift
@@ -209,9 +209,6 @@ final class ConversationListCellTests: XCTestCase {
     }
 
     func testThatItRendersScheduledForDeletionConversation() {
-        // GIVEN
-        DeveloperFlag.preventAdminlessGroups.enable(true)
-        defer { DeveloperFlag.preventAdminlessGroups.enable(false) }
 
         // WHEN
         let status = ConversationStatus(

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCellDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCellDescription.swift
@@ -233,8 +233,7 @@ enum ConversationSystemMessageCellDescription {
             return [AnyConversationMessageCellDescription(cell)]
 
         case .conversationScheduledForDeletion:
-            guard let deletionDate = systemMessageData.conversationScheduledDeletionDate,
-                  DeveloperFlag.preventAdminlessGroups.isOn else {
+            guard let deletionDate = systemMessageData.conversationScheduledDeletionDate else {
                 break
             }
             let cell = ConversationScheduledForDeletionCellDescription(deletionDate: deletionDate)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ZMConversation+Status.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ZMConversation+Status.swift
@@ -277,7 +277,7 @@ extension ZMConversation {
 // "Will be deleted soon"
 final class ScheduledForDeletionMatcher: ConversationStatusMatcher {
     func isMatching(with status: ConversationStatus) -> Bool {
-        status.isScheduledForDeletion && DeveloperFlag.preventAdminlessGroups.isOn
+        status.isScheduledForDeletion
     }
 
     func description(with status: ConversationStatus, conversation: MatcherConversation) -> NSAttributedString? {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+Leave.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+Leave.swift
@@ -79,12 +79,8 @@ extension ConversationActionController {
     func requestLeave(for conversation: ZMConversation) {
         let session = userSession
         Task { @MainActor in
-            let isPreventAdminlessGroupsEnabled: Bool = if DeveloperFlag.preventAdminlessGroups.isOn {
-                true
-            } else {
-                await session.clientSessionComponent?
-                    .featureConfigRepository.isFeatureEnabled(.preventAdminlessGroups) ?? false
-            }
+            let isPreventAdminlessGroupsEnabled: Bool = await session.clientSessionComponent?
+                .featureConfigRepository.isFeatureEnabled(.preventAdminlessGroups) ?? false
 
             guard isPreventAdminlessGroupsEnabled, self.isLastAdmin(in: conversation) else {
                 self.request(LeaveResult.self) { result in


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28558" title="WPB-28558" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28558</a>  [iOS] Remove `preventAdminlessGroups` developer flag
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR removes `preventAdminlessGroups` developer flag in preparation for the 4.28 PROD release (EOM).

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
