### PR TITLE
fix: suppress meeting conversation notifications - WPB-28540

### DIFF
--- a/WireDomain/Sources/WireDomain/Notifications/Builders/Conversation/ConversationCreateEventNotificationBuilder.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Builders/Conversation/ConversationCreateEventNotificationBuilder.swift
@@ -27,6 +27,7 @@ struct ConversationCreateEventNotificationBuilder: ConversationCreateEventNotifi
     func buildContent(
         event: ConversationCreateEvent
     ) async -> UserNotification? {
+        guard event.conversation.groupType != .meeting else { return nil }
         let canBuildNotification = await validator.validate()
 
         guard canBuildNotification else {

--- a/WireDomain/Sources/WireDomain/Notifications/Builders/Conversation/ConversationEventNotificationBuilder.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Builders/Conversation/ConversationEventNotificationBuilder.swift
@@ -120,6 +120,9 @@ extension ConversationEventNotificationBuilder {
                 domain: conversationID.domain
             )
 
+            let isMeetingConversation = await conversationLocalStore.isMeetingConversation(conversation)
+            guard !isMeetingConversation else { return false }
+
             let conversationMutedMessages = await conversationLocalStore
                 .conversationMutedMessageTypesIncludingAvailability(
                     conversation

--- a/WireDomain/Tests/WireDomainTests/Notifications/Conversations/ConversationCreateEventNotificationBuilderTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Notifications/Conversations/ConversationCreateEventNotificationBuilderTests.swift
@@ -82,6 +82,15 @@ final class ConversationCreateEventNotificationBuilderTests: XCTestCase {
             isGroup: isGroup,
             isTeam: isTeam
         )
+
+        let meetingEvent = ConversationCreateEvent(
+            conversationID: Scaffolding.conversationID,
+            senderID: Scaffolding.userID,
+            timestamp: .now,
+            conversation: .init(groupType: .meeting)
+        )
+        let meetingNotification = await sut.buildContent(event: meetingEvent)
+        XCTAssertNil(meetingNotification)
     }
 
     func testGenerateConversationCreateEventNotification_Is_Group_Conversation_And_Is_Personal_User() async throws {

--- a/WireDomain/Tests/WireDomainTests/Notifications/Conversations/ConversationCreateEventNotificationBuilderTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Notifications/Conversations/ConversationCreateEventNotificationBuilderTests.swift
@@ -82,6 +82,18 @@ final class ConversationCreateEventNotificationBuilderTests: XCTestCase {
             isGroup: isGroup,
             isTeam: isTeam
         )
+    }
+
+    func testGenerateConversationCreateEventNotification_Is_Meeting_Conversation() async {
+        await setupMock(isGroup: true, isTeam: true)
+
+        sut = ConversationCreateEventNotificationBuilder(
+            context: .init(
+                conversationLocalStore: conversationLocalStore,
+                userLocalStore: userLocalStore
+            ),
+            validator: .init(userLocalStore: userLocalStore)
+        )
 
         let meetingEvent = ConversationCreateEvent(
             conversationID: Scaffolding.conversationID,

--- a/WireDomain/Tests/WireDomainTests/Notifications/Conversations/ConversationEventNotificationBuilderValidatorTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Notifications/Conversations/ConversationEventNotificationBuilderValidatorTests.swift
@@ -119,8 +119,12 @@ final class ConversationEventNotificationBuilderValidatorTests: XCTestCase {
 
         // Then
         XCTAssertTrue(result)
+    }
 
+    func test_validate_RejectsMeetingConversation() async {
+        await setupMocks(lastReadTimestamp: nil)
         conversationLocalStore.isMeetingConversation_MockValue = true
+
         let meetingResult = await sut.validate(
             conversationID: Scaffolding.qualifiedID,
             senderID: Scaffolding.qualifiedID,

--- a/WireDomain/Tests/WireDomainTests/Notifications/Conversations/ConversationEventNotificationBuilderValidatorTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Notifications/Conversations/ConversationEventNotificationBuilderValidatorTests.swift
@@ -119,6 +119,14 @@ final class ConversationEventNotificationBuilderValidatorTests: XCTestCase {
 
         // Then
         XCTAssertTrue(result)
+
+        conversationLocalStore.isMeetingConversation_MockValue = true
+        let meetingResult = await sut.validate(
+            conversationID: Scaffolding.qualifiedID,
+            senderID: Scaffolding.qualifiedID,
+            time: Date()
+        )
+        XCTAssertFalse(meetingResult)
     }
 
     func test_validate_AcceptsOtherUserEventsInSelfConversation() async {
@@ -269,6 +277,7 @@ final class ConversationEventNotificationBuilderValidatorTests: XCTestCase {
             modelHelper.createSelfUser(in: context)
         }
         conversationLocalStore.fetchOrCreateConversationIdDomain_MockValue = conversation
+        conversationLocalStore.isMeetingConversation_MockValue = false
         conversationLocalStore.conversationMutedMessageTypesIncludingAvailability_MockMethod = { _ in
             isConversationMuted ? .all : .none
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28540" title="WPB-28540" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-28540</a>  [iOS] Opening Wire Meetings notifications navigates participants to the underlying conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Generic meeting notifications can open the underlying meeting conversation. Suppress notifications for meeting creation events and conversations identified as meetings.

---

### Checklist

- [X] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [X] Description is filled and free of optional paragraphs.
- [X] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
