### PR TITLE
chore: fix build issue and UTs - WPB-28558

### DIFF
--- a/wire-ios/WireUITests/AdminPromotionTests.swift
+++ b/wire-ios/WireUITests/AdminPromotionTests.swift
@@ -22,10 +22,6 @@ import XCTest
 
 class AdminPromotionTests: WireUITestCase {
 
-    override func additionalDeveloperFlags() -> [DeveloperFlag: Bool] {
-        [.preventAdminlessGroups: true]
-    }
-
     @MainActor
     func testLastAdmin_promotesNewAdmin_andLeavesGroup_TC_11032() async throws {
         let groupName = UserGenerator.generateRandomConversationName()
@@ -35,6 +31,8 @@ class AdminPromotionTests: WireUITestCase {
             conversation: .group(groupName)
         )
         let member = try XCTUnwrap(teamMembers.first)
+        let teamID = try XCTUnwrap(owner.teamID)
+        try await UserHelper.default.unlockAndEnablePreventAdminlessGroupsFeature(teamID: teamID)
 
         let conversationDetailsPage = try app.loginUser(email: owner.email, password: owner.password)
             .acceptPopup()
@@ -68,6 +66,9 @@ class AdminPromotionTests: WireUITestCase {
             conversation: .group(groupName)
         )
 
+        let teamID = try XCTUnwrap(owner.teamID)
+        try await UserHelper.default.unlockAndEnablePreventAdminlessGroupsFeature(teamID: teamID)
+
         let conversationsPage = try app.loginUser(email: owner.email, password: owner.password)
             .acceptPopup()
             .openConversation()
@@ -98,6 +99,9 @@ class AdminPromotionTests: WireUITestCase {
             conversation: .group(groupName)
         )
 
+        let teamID = try XCTUnwrap(owner.teamID)
+        try await UserHelper.default.unlockAndEnablePreventAdminlessGroupsFeature(teamID: teamID)
+
         let conversationDetailsPage = try app.loginUser(email: owner.email, password: owner.password)
             .acceptPopup()
             .openConversation()
@@ -117,13 +121,13 @@ class AdminPromotionTests: WireUITestCase {
     }
 
     @MainActor
-    func testLastPersonalUserAdmin_CannotLeaveGroup_PromotesNewAdmin_ThenLeaveGroupSuccessfully_TC_11577() async throws {
-        let groupName = "Personal User Leave Group Test"
+    func testLastGuestUserAdmin_CannotLeaveGroup_PromotesNewAdmin_ThenLeaveGroupSuccessfully_TC_11577() async throws {
+        let groupName = "Guest User Leave Group Test"
         let (
             owner,
             personalUser
         ) =
-            try await createGroupConversationWithTeamMemberAndLastPersonalUserAdmin(groupName: groupName)
+            try await createGroupConversationWithTeamMemberAndLastGuestUserAdmin(groupName: groupName)
 
         let conversationsPage = try app
             .loginUser(email: personalUser.email, password: personalUser.password)
@@ -156,22 +160,27 @@ class AdminPromotionTests: WireUITestCase {
         )
     }
 
-    private func createGroupConversationWithTeamMemberAndLastPersonalUserAdmin(groupName: String) async throws
+    private func createGroupConversationWithTeamMemberAndLastGuestUserAdmin(groupName: String) async throws
         -> (teamMember: UserInfo, personalUser: UserInfo) {
-        let (teamMember, personalUser) = try await UserHelper.default.connectTeamUserWithPersonalUser()
+        let (teamMember, guestUser) = try await UserHelper.default.connectDriveEnabledTeamUserWithGuestUser()
 
         let domain = BackendTarget.staging.domainInfo
         let teamMemberQualifiedID = WireFoundation.QualifiedID(
             id: try XCTUnwrap(UUID(uuidString: teamMember.id)),
             domain: domain
         )
-        let personalUserQualifiedID = WireFoundation.QualifiedID(
-            id: try XCTUnwrap(UUID(uuidString: personalUser.id)),
+        let guestUserQualifiedID = WireFoundation.QualifiedID(
+            id: try XCTUnwrap(UUID(uuidString: guestUser.id)),
             domain: domain
         )
 
+        try await UserHelper.default
+            .unlockAndEnablePreventAdminlessGroupsFeature(teamID: try XCTUnwrap(teamMember.teamID))
+        try await UserHelper.default
+            .unlockAndEnablePreventAdminlessGroupsFeature(teamID: try XCTUnwrap(guestUser.teamID))
+
         let conversation = try await UserHelper.default.createGroupConversations(
-            qualifiedIds: [personalUserQualifiedID],
+            qualifiedIds: [guestUserQualifiedID],
             owner: teamMember,
             groupName: groupName,
             driveEnabled: true
@@ -181,7 +190,7 @@ class AdminPromotionTests: WireUITestCase {
 
         try await UserHelper.default.updateRole(
             "wire_admin",
-            userID: personalUserQualifiedID,
+            userID: guestUserQualifiedID,
             conversationID: conversationQualifiedID
         )
 
@@ -190,7 +199,7 @@ class AdminPromotionTests: WireUITestCase {
             conversationID: conversationQualifiedID
         )
 
-        return (teamMember, personalUser)
+        return (teamMember, guestUser)
     }
 
     @MainActor
@@ -226,6 +235,9 @@ class AdminPromotionTests: WireUITestCase {
             groupAdminCount: 2,
             preventAdminlessGroupsEnabled: true
         )
+
+        let teamID = try XCTUnwrap(owner.teamID)
+        try await UserHelper.default.unlockAndEnablePreventAdminlessGroupsFeature(teamID: teamID)
 
         let conversationDetailsPage = try app.loginUser(email: owner.email, password: owner.password)
             .acceptPopup()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28558" title="WPB-28558" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28558</a>  [iOS] Remove `preventAdminlessGroups` developer flag
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

`AdminPromotionTests` were still relying on the DeveloperFlag which was removed in https://github.com/wireapp/wire-ios/pull/5196.
This PR fixes the build issue by now relying on the team feature flag. UTs were updated accordingly.

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
