### PR TITLE
chore: adding testcase-id-to-existing test, increased timeouts - WPB-28506

### DIFF
--- a/wire-ios/WireUITests/BackupRestoreConversationListTests.swift
+++ b/wire-ios/WireUITests/BackupRestoreConversationListTests.swift
@@ -36,7 +36,7 @@ final class BackupRestoreConversationListTests: WireUITestCase {
     /// 5. Owner receives a message in A.
     ///    -> A shows exactly 1 unread message.
     @MainActor
-    func testConversationListOrderAndUnreadAfterBackupRestore_TC_11583() async throws {
+    func testConversationListOrderAndUnreadAfterBackupRestore_TC_11583_11756() async throws {
 
         // GIVEN a team with one owner and one member who shares three conversations.
         let nameA = "Conversation A"

--- a/wire-ios/WireUITests/Pages/ActiveConversationPage.swift
+++ b/wire-ios/WireUITests/Pages/ActiveConversationPage.swift
@@ -688,7 +688,7 @@ class ActiveConversationPage: PageModel {
     func verifyImagePreviewIsVisible(
     ) -> ActiveConversationPage {
         XCTAssertTrue(
-            imagePreview.waitForExistence(timeout: 7),
+            imagePreview.waitForExistence(timeout: 10),
             "Image preview did not appear"
         )
         return self
@@ -698,7 +698,7 @@ class ActiveConversationPage: PageModel {
     func verifyVideoPreviewIsVisible(
     ) -> ActiveConversationPage {
         XCTAssertTrue(
-            videoPreview.waitForExistence(timeout: 7),
+            videoPreview.waitForExistence(timeout: 10),
             "Video preview did not appear"
         )
         return self

--- a/wire-ios/WireUITests/Pages/ActiveConversationPage.swift
+++ b/wire-ios/WireUITests/Pages/ActiveConversationPage.swift
@@ -364,7 +364,12 @@ class ActiveConversationPage: PageModel {
 
     func waitToUploadToFinishAndSend() {
         XCTAssertTrue(attachmentImagePreview.waitForExistence(timeout: 3))
-        sendButton.waitAndTap()
+
+        XCTAssertTrue(
+            sendButton.waitAndTap(timeout: 10),
+            "Send button did not become hittable for attachment"
+        )
+
         XCTAssertTrue(attachmentImagePreview.waitForNonExistence(timeout: 10))
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28506" title="WPB-28506" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28506</a>  [iOS] Automate - 11756 As a user Conversation shows read when messages were read before backup and restore on new message
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

_Please describe the issue._

_Optional: add details about technical approach, solutions etc._

_Optional: reference dependencies to other pull requests etc._

### UITest is already there, just need to add the testcase ID

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

No need to test this.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
