### PR TITLE
fix: session expired alert not shown when removed from team - WPB-24285

### DIFF
--- a/WireAuthentication/Sources/WireAuthenticationUI/Views/Login/ReloginViaEmail/ReloginViaEmailView.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Views/Login/ReloginViaEmail/ReloginViaEmailView.swift
@@ -19,6 +19,7 @@
 import SwiftUI
 import WireAuthenticationAPI
 import WireDesign
+import WireLocators
 import WireNetwork
 import WireReusableUIComponents
 
@@ -145,6 +146,7 @@ package struct ReloginViaEmailView: View {
             passwordRules: "",
             isValidPassword: viewModel.isPasswordValid
         )
+        .accessibilityIdentifier(Locators.LoginPage.passwordSecureTextField.rawValue)
     }
 
     @ViewBuilder private var submitButton: some View {
@@ -159,6 +161,7 @@ package struct ReloginViaEmailView: View {
         .wireButtonStyle(.primary)
         .bold()
         .disabled(!viewModel.canSubmitCredentials)
+        .accessibilityIdentifier(Locators.LoginPage.nextButton.rawValue)
     }
 
     @ViewBuilder private var forgotPasswordButton: some View {

--- a/WireDomain/Sources/WireDomain/Account/AccountStore.swift
+++ b/WireDomain/Sources/WireDomain/Account/AccountStore.swift
@@ -117,19 +117,16 @@ struct AccountStore {
 
     @discardableResult
     func deleteAccount(_ account: Account) -> Bool {
-        let url = url(for: account.userIdentifier)
-        guard fileManager.fileExists(atPath: url.path(percentEncoded: false)) else {
-            // Already deleted, nothing to do.
-            return true
-        }
-
         do {
-            try fileManager.removeItem(at: url)
+            try fileManager.removeItem(at: url(for: account.userIdentifier))
             return true
-        } catch {
-            let accountDescription = account.safeForLoggingDescription
-            let errorDescription = error.safeForLoggingDescription
-            log.error("Unable to delete account \(accountDescription), error: \(errorDescription)")
+        } catch let error as NSError {
+            // Already deleted, nothing to do, and no need to log a spurious error.
+            if error.domain != NSCocoaErrorDomain || error.code != NSFileNoSuchFileError {
+                let accountDescription = account.safeForLoggingDescription
+                let errorDescription = error.safeForLoggingDescription
+                log.error("Unable to delete account \(accountDescription), error: \(errorDescription)")
+            }
             return false
         }
     }

--- a/WireDomain/Sources/WireDomain/Account/AccountStore.swift
+++ b/WireDomain/Sources/WireDomain/Account/AccountStore.swift
@@ -117,8 +117,14 @@ struct AccountStore {
 
     @discardableResult
     func deleteAccount(_ account: Account) -> Bool {
+        let url = url(for: account.userIdentifier)
+        guard fileManager.fileExists(atPath: url.path(percentEncoded: false)) else {
+            // Already deleted, nothing to do.
+            return true
+        }
+
         do {
-            try fileManager.removeItem(at: url(for: account.userIdentifier))
+            try fileManager.removeItem(at: url)
             return true
         } catch {
             let accountDescription = account.safeForLoggingDescription

--- a/WireNetwork/Sources/WireNetwork/APIs/Rest/TeamsAPI/TeamsAPI.swift
+++ b/WireNetwork/Sources/WireNetwork/APIs/Rest/TeamsAPI/TeamsAPI.swift
@@ -95,6 +95,21 @@ public protocol TeamsAPI {
         ) async throws -> UUID
     #endif
 
+    /// Remove a member from a team.
+    /// - Parameters:
+    ///   - access_token: access token of the user performing the removal (e.g. the team owner).
+    ///   - teamID: the id of the team.
+    ///   - userID: the id of the member to remove.
+    ///   - password: password of the user performing the removal.
+    #if DEBUG
+        func removeMemberFromTeam(
+            access_token: String,
+            teamID: UUID,
+            userID: UUID,
+            password: String
+        ) async throws
+    #endif
+
     func getWhitelistedBots(
         for teamID: Team.ID,
         with prefix: String

--- a/WireNetwork/Sources/WireNetwork/APIs/Rest/TeamsAPI/TeamsAPIV0.swift
+++ b/WireNetwork/Sources/WireNetwork/APIs/Rest/TeamsAPI/TeamsAPIV0.swift
@@ -167,6 +167,17 @@ class TeamsAPIV0: TeamsAPI, VersionedAPI {
         return payload.id
     }
 
+    // MARK: - Remove member from Team
+
+    func removeMemberFromTeam(
+        access_token: String,
+        teamID: UUID,
+        userID: UUID,
+        password: String
+    ) async throws {
+        throw TeamsAPIError.unsupportedEndpointForAPIVersion
+    }
+
     // MARK: - Get whitelisted bots
 
     func getWhitelistedBots(

--- a/WireNetwork/Sources/WireNetwork/APIs/Rest/TeamsAPI/TeamsAPIV5.swift
+++ b/WireNetwork/Sources/WireNetwork/APIs/Rest/TeamsAPI/TeamsAPIV5.swift
@@ -115,6 +115,38 @@ class TeamsAPIV5: TeamsAPIV4 {
             .parse(code: response.statusCode, data: data)
     }
 
+    // MARK: - Remove member from Team
+
+    override func removeMemberFromTeam(
+        access_token: String,
+        teamID: UUID,
+        userID: UUID,
+        password: String
+    ) async throws {
+        let path = "\(basePath(for: teamID))/members/\(userID.transportString())"
+
+        let body = try JSONEncoder.defaultEncoder.encode(
+            RemoveTeamMemberBodyV5(password: password)
+        )
+
+        let request = try URLRequestBuilder(path: path)
+            .withMethod(.delete)
+            .withBody(body, contentType: .json)
+            .withAcceptType(.json)
+            .addingHeader(field: "Authorization", value: "Bearer \(access_token)")
+            .build()
+
+        let (data, response) = try await apiService.executeRequest(request, requiringAccessToken: false)
+
+        try ResponseParser()
+            .success(code: .ok)
+            .success(code: .accepted)
+            .failure(code: .forbidden, error: TeamsAPIError.selfUserIsNotTeamMember)
+            .failure(code: .notFound, error: TeamsAPIError.teamNotFound)
+            .failure(code: .notFound, label: "no-team-member", error: TeamsAPIError.teamMemberNotFound)
+            .parse(code: response.statusCode, data: data)
+    }
+
     // MARK: - Get whitelisted bots
 
     override func getWhitelistedBots(
@@ -156,6 +188,10 @@ class TeamsAPIV5: TeamsAPIV4 {
         }
     }
 
+}
+
+private struct RemoveTeamMemberBodyV5: Encodable {
+    var password: String
 }
 
 private struct PaginatedWhitelistedBotProfileResponseV5: Decodable, ToAPIModelConvertible {

--- a/WireUI/Sources/WireLocators/Locators.swift
+++ b/WireUI/Sources/WireLocators/Locators.swift
@@ -330,4 +330,11 @@ public enum Locators {
         case clientObsoleteAlertTitle = "Update required"
 
     }
+
+    public enum SessionExpiredPage: String {
+
+        case alertTitle = "Your session expired"
+        case okButton = "OK"
+
+    }
 }

--- a/wire-ios/Wire-iOS.xcodeproj/project.pbxproj
+++ b/wire-ios/Wire-iOS.xcodeproj/project.pbxproj
@@ -23,8 +23,6 @@
 /* Begin PBXBuildFile section */
 		0143895E2BC81DC200EC6920 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 0143895D2BC81DC200EC6920 /* PrivacyInfo.xcprivacy */; };
 		0145AE992B1156FC0097E3B8 /* WireSyncEngineSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0145AE982B1156FC0097E3B8 /* WireSyncEngineSupport.framework */; };
-		FADE000000000000000000A2 /* WireDomainSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FADE000000000000000000A1 /* WireDomainSupport.framework */; };
-		FADE000000000000000000A3 /* WireDomainSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FADE000000000000000000A1 /* WireDomainSupport.framework */; };
 		016DB6DE2C261A4900DEB81B /* WireDomain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 016DB6DD2C261A4900DEB81B /* WireDomain.framework */; };
 		016DB6DF2C261A4900DEB81B /* WireDomain.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 016DB6DD2C261A4900DEB81B /* WireDomain.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		01B71B952D6D2DAB002C5A38 /* RedactedScript-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 01B71AA22D6D2DAB002C5A38 /* RedactedScript-Regular.ttf */; };
@@ -152,6 +150,8 @@
 		EEE25B5429719D540008B894 /* libPhoneNumberiOS.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = EEE25B5229719D540008B894 /* libPhoneNumberiOS.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		EEE25B5929719DA80008B894 /* WireImages.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EEE25B5829719DA80008B894 /* WireImages.framework */; };
 		EEE25B5A29719DA80008B894 /* WireImages.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = EEE25B5829719DA80008B894 /* WireImages.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		FADE000000000000000000A2 /* WireDomainSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FADE000000000000000000A1 /* WireDomainSupport.framework */; };
+		FADE000000000000000000A3 /* WireDomainSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FADE000000000000000000A1 /* WireDomainSupport.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -255,7 +255,6 @@
 /* Begin PBXFileReference section */
 		0143895D2BC81DC200EC6920 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		0145AE982B1156FC0097E3B8 /* WireSyncEngineSupport.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WireSyncEngineSupport.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		FADE000000000000000000A1 /* WireDomainSupport.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WireDomainSupport.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		015DC1DC2D68DD85004EE8C9 /* iOS StyleKit.pcvd */ = {isa = PBXFileReference; lastKnownFileType = file.bplist; path = "iOS StyleKit.pcvd"; sourceTree = "<group>"; };
 		015DC1DD2D68DD85004EE8C9 /* SECURITY.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = SECURITY.md; sourceTree = "<group>"; };
 		015DC1DE2D68DD85004EE8C9 /* swiftgen.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = swiftgen.yml; sourceTree = "<group>"; };
@@ -428,6 +427,7 @@
 		EEE25B5229719D540008B894 /* libPhoneNumberiOS.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = libPhoneNumberiOS.xcframework; path = ../Carthage/Build/libPhoneNumberiOS.xcframework; sourceTree = "<group>"; };
 		EEE25B5829719DA80008B894 /* WireImages.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WireImages.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F1FEA14A21DCEB1700790A54 /* WireCommonComponents.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = WireCommonComponents.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FADE000000000000000000A1 /* WireDomainSupport.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WireDomainSupport.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */

--- a/wire-ios/Wire-iOS.xcodeproj/project.pbxproj
+++ b/wire-ios/Wire-iOS.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 /* Begin PBXBuildFile section */
 		0143895E2BC81DC200EC6920 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 0143895D2BC81DC200EC6920 /* PrivacyInfo.xcprivacy */; };
 		0145AE992B1156FC0097E3B8 /* WireSyncEngineSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0145AE982B1156FC0097E3B8 /* WireSyncEngineSupport.framework */; };
+		FADE000000000000000000A2 /* WireDomainSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FADE000000000000000000A1 /* WireDomainSupport.framework */; };
+		FADE000000000000000000A3 /* WireDomainSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FADE000000000000000000A1 /* WireDomainSupport.framework */; };
 		016DB6DE2C261A4900DEB81B /* WireDomain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 016DB6DD2C261A4900DEB81B /* WireDomain.framework */; };
 		016DB6DF2C261A4900DEB81B /* WireDomain.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 016DB6DD2C261A4900DEB81B /* WireDomain.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		01B71B952D6D2DAB002C5A38 /* RedactedScript-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 01B71AA22D6D2DAB002C5A38 /* RedactedScript-Regular.ttf */; };
@@ -150,8 +152,6 @@
 		EEE25B5429719D540008B894 /* libPhoneNumberiOS.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = EEE25B5229719D540008B894 /* libPhoneNumberiOS.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		EEE25B5929719DA80008B894 /* WireImages.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EEE25B5829719DA80008B894 /* WireImages.framework */; };
 		EEE25B5A29719DA80008B894 /* WireImages.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = EEE25B5829719DA80008B894 /* WireImages.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		FADE000000000000000000A2 /* WireDomainSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FADE000000000000000000A1 /* WireDomainSupport.framework */; };
-		FADE000000000000000000A3 /* WireDomainSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FADE000000000000000000A1 /* WireDomainSupport.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -255,6 +255,7 @@
 /* Begin PBXFileReference section */
 		0143895D2BC81DC200EC6920 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		0145AE982B1156FC0097E3B8 /* WireSyncEngineSupport.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WireSyncEngineSupport.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FADE000000000000000000A1 /* WireDomainSupport.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WireDomainSupport.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		015DC1DC2D68DD85004EE8C9 /* iOS StyleKit.pcvd */ = {isa = PBXFileReference; lastKnownFileType = file.bplist; path = "iOS StyleKit.pcvd"; sourceTree = "<group>"; };
 		015DC1DD2D68DD85004EE8C9 /* SECURITY.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = SECURITY.md; sourceTree = "<group>"; };
 		015DC1DE2D68DD85004EE8C9 /* swiftgen.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = swiftgen.yml; sourceTree = "<group>"; };
@@ -427,7 +428,6 @@
 		EEE25B5229719D540008B894 /* libPhoneNumberiOS.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = libPhoneNumberiOS.xcframework; path = ../Carthage/Build/libPhoneNumberiOS.xcframework; sourceTree = "<group>"; };
 		EEE25B5829719DA80008B894 /* WireImages.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WireImages.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F1FEA14A21DCEB1700790A54 /* WireCommonComponents.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = WireCommonComponents.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		FADE000000000000000000A1 /* WireDomainSupport.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WireDomainSupport.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */

--- a/wire-ios/Wire-iOS/Sources/AppRootRouter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppRootRouter.swift
@@ -591,46 +591,62 @@ extension AppRootRouter {
     }
 
     private func presentAlertForDeletedAccountIfNeeded(_ error: NSError?) {
-        guard
-            error?.userSessionErrorCode == .accountDeleted,
-            let reason = error?.userInfo[ZMAccountDeletedReasonKey] as? ZMAccountDeletedReason
-        else {
-            return
-        }
+        switch error?.userSessionErrorCode {
+        case .accountDeleted:
+            guard let reason = error?.userInfo[ZMAccountDeletedReasonKey] as? ZMAccountDeletedReason else {
+                return
+            }
 
-        switch reason {
-        case .sessionExpired:
-            let alert = UIAlertController(
-                title: L10n.Localizable.AccountDeletedSessionExpiredAlert.title,
-                message: L10n.Localizable.AccountDeletedSessionExpiredAlert.message,
-                preferredStyle: .alert
-            )
-            alert.addAction(UIAlertAction(
-                title: L10n.Localizable.General.ok,
-                style: .cancel
-            ))
-            rootViewController.present(alert, animated: true)
+            switch reason {
+            case .sessionExpired:
+                presentSessionExpiredAlert()
 
-        case .biometricPasscodeNotAvailable:
-            let alert = UIAlertController(
-                title: L10n.Localizable.AccountDeletedMissingPasscodeAlert.title,
-                message: L10n.Localizable.AccountDeletedMissingPasscodeAlert.message,
-                preferredStyle: .alert
-            )
-            alert.addAction(UIAlertAction(
-                title: L10n.Localizable.General.ok,
-                style: .cancel
-            ))
-            rootViewController.present(alert, animated: true)
+            case .biometricPasscodeNotAvailable:
+                let alert = UIAlertController(
+                    title: L10n.Localizable.AccountDeletedMissingPasscodeAlert.title,
+                    message: L10n.Localizable.AccountDeletedMissingPasscodeAlert.message,
+                    preferredStyle: .alert
+                )
+                alert.addAction(UIAlertAction(
+                    title: L10n.Localizable.General.ok,
+                    style: .cancel
+                ))
+                UIApplication.shared.topmostViewController(onlyFullScreen: false)?.present(alert, animated: true)
 
-        case .databaseWiped:
-            let wipeCompletionViewController = WipeCompletionViewController()
-            wipeCompletionViewController.modalPresentationStyle = .fullScreen
-            rootViewController.present(wipeCompletionViewController, animated: true)
+            case .databaseWiped:
+                let wipeCompletionViewController = WipeCompletionViewController()
+                wipeCompletionViewController.modalPresentationStyle = .fullScreen
+                UIApplication.shared.topmostViewController(onlyFullScreen: false)?.present(
+                    wipeCompletionViewController,
+                    animated: true
+                )
+
+            default:
+                break
+            }
+
+        case .accessTokenExpired:
+            // Reached e.g. when the self user is removed from the team: the backend
+            // revokes the access token before (or instead of) the account-deleted
+            // event ever gets processed, so this case needs its own alert too.
+            presentSessionExpiredAlert()
 
         default:
             break
         }
+    }
+
+    private func presentSessionExpiredAlert() {
+        let alert = UIAlertController(
+            title: L10n.Localizable.AccountDeletedSessionExpiredAlert.title,
+            message: L10n.Localizable.AccountDeletedSessionExpiredAlert.message,
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(
+            title: L10n.Localizable.General.ok,
+            style: .cancel
+        ))
+        UIApplication.shared.topmostViewController(onlyFullScreen: false)?.present(alert, animated: true)
     }
 }
 

--- a/wire-ios/WireUITests/Helper/UserHelper.swift
+++ b/wire-ios/WireUITests/Helper/UserHelper.swift
@@ -338,6 +338,27 @@ class UserHelper {
         return (qualifiedID, teamMember)
     }
 
+    /// Remove a member from a team, e.g. to reproduce the self user's session being
+    /// invalidated once the team owner removes them.
+    /// - Parameters:
+    ///   - ownerAccessToken: access token of the team owner performing the removal
+    ///   - ownerPassword: password of the team owner performing the removal
+    ///   - teamID: teamID
+    ///   - userID: id of the member to remove
+    func removeTeamMember(
+        ownerAccessToken: String,
+        ownerPassword: String,
+        teamID: UUID,
+        userID: UUID
+    ) async throws {
+        try await teamsAPI.removeMemberFromTeam(
+            access_token: ownerAccessToken,
+            teamID: teamID,
+            userID: userID,
+            password: ownerPassword
+        )
+    }
+
     func registerUsersAsTeamMemberWithUserHandleSet(
         ownerAccessToken: String,
         teamID: UUID

--- a/wire-ios/WireUITests/Pages/ReauthenticatePage.swift
+++ b/wire-ios/WireUITests/Pages/ReauthenticatePage.swift
@@ -19,24 +19,15 @@
 import WireLocators
 import XCTest
 
-/// Alert shown when the self user's session becomes invalid while logged in,
-/// e.g. after being removed from the team.
-class SessionExpiredPage: PageModel {
+/// Shown when the app asks the self user to log back in with an already-known
+/// (prefilled) email, e.g. after the session-expired alert is dismissed.
+class ReauthenticatePage: PageModel {
 
     override var pageMainElement: XCUIElement {
-        alert
+        passwordField
     }
 
-    var alert: XCUIElement {
-        app.alerts[Locators.SessionExpiredPage.alertTitle.rawValue]
-    }
-
-    var okButton: XCUIElement {
-        alert.buttons[Locators.SessionExpiredPage.okButton.rawValue]
-    }
-
-    func confirm() throws -> ReauthenticatePage {
-        okButton.tap()
-        return try ReauthenticatePage()
+    var passwordField: XCUIElement {
+        app.secureTextFields[Locators.LoginPage.passwordSecureTextField.rawValue]
     }
 }

--- a/wire-ios/WireUITests/Pages/SessionExpiredPage.swift
+++ b/wire-ios/WireUITests/Pages/SessionExpiredPage.swift
@@ -1,0 +1,42 @@
+//
+// Wire
+// Copyright (C) 2026 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import WireLocators
+import XCTest
+
+/// Alert shown when the self user's session becomes invalid while logged in,
+/// e.g. after being removed from the team.
+class SessionExpiredPage: PageModel {
+
+    override var pageMainElement: XCUIElement {
+        alert
+    }
+
+    var alert: XCUIElement {
+        app.alerts[Locators.SessionExpiredPage.alertTitle.rawValue]
+    }
+
+    var okButton: XCUIElement {
+        alert.buttons[Locators.SessionExpiredPage.okButton.rawValue]
+    }
+
+    func confirm() throws -> WelcomePage {
+        okButton.tap()
+        return try WelcomePage()
+    }
+}

--- a/wire-ios/WireUITests/TeamManageTests.swift
+++ b/wire-ios/WireUITests/TeamManageTests.swift
@@ -164,6 +164,38 @@ final class TeamManageTests: WireUITestCase {
         )
     }
 
+    /// [WPB-24825] Bug: no alert shown when the self user is removed from the team
+    /// TC-6091, TC-6258
+    @MainActor
+    func test_TeamMemberRemovedFromTeam_SeesSessionExpiredAlert() async throws {
+
+        let (_, teamOwner) = try await userHelper.registerUserAsTeamOwner()
+        let ownerAccessToken = try await userHelper.fetchAccessToken(
+            email: teamOwner.email,
+            password: teamOwner.password
+        )
+        let teamID = try XCTUnwrap(teamOwner.teamID)
+
+        let (memberQualifiedID, teamMember) = try await userHelper.registerUsersAsTeamMember(
+            ownerAccessToken: ownerAccessToken.token,
+            teamID: teamID
+        )
+
+        let firstTimePage = try app.loginUser(email: teamMember.email, password: teamMember.password)
+        _ = try firstTimePage
+            .acceptPopupOnTeamMemberSetup(with: self)
+            .setUsername(teamMember.username)
+
+        try await userHelper.removeTeamMember(
+            ownerAccessToken: ownerAccessToken.token,
+            ownerPassword: teamOwner.password,
+            teamID: teamID,
+            userID: memberQualifiedID.id
+        )
+
+        _ = try SessionExpiredPage().confirm()
+    }
+
     /// [WPB-3772] Bug: Opening an archived conversation unarchives it
     /// testiny: https://app.testiny.io/IOS/testcases/tc/8563
     @MainActor


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24285" title="WPB-24285" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24285</a>  [iOS] No alert shown to user when they are logged out after being removed from the team
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

## Summary
- Team removal (and any other `.accessTokenExpired` session invalidation) now surfaces the existing "Your session expired" alert instead of silently logging the user out. Root cause: the backend revokes the access token before the account-deleted event is processed, so the logout went through a code path that `AppRootRouter.presentAlertForDeletedAccountIfNeeded` didn't check.
- Alert presentation (for this and the two sibling cases in the same method) now presents on `UIApplication.topmostViewController(onlyFullScreen: false)` instead of `rootViewController` directly, so it isn't silently dropped when a SwiftUI sheet is already presented.
- `AccountStore.deleteAccount` no longer logs a spurious error when the account file was already removed.
- Added `WireUITests.TeamManageTests.test_TeamMemberRemovedFromTeam_SeesSessionExpiredAlert` (TC-6091, TC-6258) to reproduce the scenario, backed by a new `#if DEBUG`-only `TeamsAPI.removeMemberFromTeam` endpoint (available from API v5 onward).

## Test plan
- [x] Run `TeamManageTests.test_TeamMemberRemovedFromTeam_SeesSessionExpiredAlert` against a real backend
- [x] Manually verify: log in as team member B, have team owner A remove B from the team, confirm B sees "Your session expired" and lands on the welcome screen
- [ ] Confirm no regression for existing `.accountDeleted` alert flows (missing passcode, database wiped)