### PR TITLE
fix: retry-uitest-when-failing-in-first-attempt - WPB-28592

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -635,6 +635,11 @@ platform :ios do
 
         ENV['TEST_RUNNER_CI'] = ENV['CI']
 
+        xcargs = ["-collect-test-diagnostics never"]
+        xcargs << "-test-repetition-relaunch-enabled YES" if scheme == "WireUITests" && build.number_of_retries > 0
+
+        output_directory = "#{build.artifact_path(with_filename: false)}/tests/#{scheme}"
+
         run_tests_options = {
             step_name: "🧪 Running tests for scheme: #{scheme}",
             testplan: testplan,
@@ -648,14 +653,14 @@ platform :ios do
             buildlog_path: build.build_path,
             result_bundle: true,
             # suppress_xcode_output: true,
-            output_directory: "#{build.artifact_path(with_filename: false)}/tests/#{scheme}",
+            output_directory: output_directory,
             output_types: "junit",
             cloned_source_packages_path: ENV['PACKAGES_DIR'],
             disable_package_automatic_updates: true,
             skip_package_dependencies_resolution: true,
             number_of_retries: build.number_of_retries,
             output_remove_retry_attempts: options[:output_remove_retry_attempts].to_s == "true",
-            xcargs: "-collect-test-diagnostics never" # Disable verbose diagnostics as these are generally not useful and collecting them can cause 600 second delays per test scheme.
+            xcargs: xcargs.join(" ") # Disable verbose diagnostics as these are generally not useful and collecting them can cause 600 second delays per test scheme.
         }
         only_testing = normalize_test_identifiers(options[:only_testing])
         skip_testing = normalize_test_identifiers(options[:skip_testing])


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28592" title="WPB-28592" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28592</a>  [iOS] Fix-retry-mechanism for UITests
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

_Please describe the issue._

_Optional: add details about technical approach, solutions etc._

_Optional: reference dependencies to other pull requests etc._

**Currently UITests doesn't not attempt retry if it fails in 1st attempt, with this change if failure reported it will retry and if passed test will be passed but on html report it can be seen as passed on retry.**

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
