### PR TITLE
fix: recover MLS conversations after key-package exhaustion - WPB-27395

### DIFF
--- a/wire-ios-data-model/Source/MLS/MLSClientManager.swift
+++ b/wire-ios-data-model/Source/MLS/MLSClientManager.swift
@@ -86,11 +86,6 @@ public final class MLSClientManager: MLSClientManagerProtocol {
             return
         }
 
-        do {
-            try await mlsService.performPendingJoins()
-        } catch {
-            WireLogger.mls.error("Failed to performPendingJoins: \(String(reflecting: error))")
-        }
         await mlsService.updateKeyMaterialForAllStaleGroupsIfNeeded()
         didPerformMLSClientUpdate = true
     }

--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -63,6 +63,8 @@ public final class MLSService: MLSServiceInterface {
     private let userDefaults: PrivateUserDefaults<Keys>
     private let logger = WireLogger.mls
     private let groupsBeingRepaired = GroupsBeingRepaired()
+    private let pendingConversationRecoveryLock = NSLock()
+    private var isRecoveringPendingConversations = false
     private let featureRepository: LegacyFeatureRepositoryInterface
     private weak var resetBrokenMLSConversationDelegate: (any ResetBrokenMLSConversationDelegate)?
     private let onEpochChangedSubject = PassthroughSubject<MLSGroupID, Never>()
@@ -93,6 +95,13 @@ public final class MLSService: MLSServiceInterface {
     // The number of days to wait until refreshing the key material for a group.
 
     private static let epochChangeBufferSize: Int = 1000
+    private static let pendingConversationRecoveryBatchSize = 10
+
+    private typealias PendingConversationRecovery = (
+        groupID: MLSGroupID,
+        qualifiedID: QualifiedID,
+        shouldResync: Bool
+    )
 
     private let maxRetryAttempts = 3
 
@@ -782,6 +791,7 @@ public final class MLSService: MLSServiceInterface {
 
             userDefaults.set(.now, forKey: .keyPackageQueriedTime)
         } catch {
+            userDefaults.removeObject(forKey: .keyPackageQueriedTime)
             logger.warn("failed to upload key packages for client \(clientID). \(String(describing: error))")
         }
     }
@@ -791,6 +801,11 @@ public final class MLSService: MLSServiceInterface {
             guard await featureRepository.fetchMLS().isEnabled else {
                 logger.info("shouldn't query unclaimed key packages count: MLS is not enabled")
                 return false
+            }
+
+            if let context, try await !pendingConversationsToRecover(in: context).isEmpty {
+                logger.info("pending conversations require checking the backend key-package count")
+                return true
             }
 
             let ciphersuite = await featureRepository.fetchMLS().config.defaultCipherSuite.coreCryptoCipherSuite
@@ -1076,6 +1091,94 @@ public final class MLSService: MLSServiceInterface {
         }
         if needToSave {
             await save(context)
+        }
+    }
+
+    public func recoverPendingConversationBatchIfNeeded() async -> Bool {
+        guard pendingConversationRecoveryLock.withLock({
+            guard !isRecoveringPendingConversations else { return false }
+            isRecoveringPendingConversations = true
+            return true
+        }) else {
+            return false
+        }
+        defer {
+            pendingConversationRecoveryLock.withLock {
+                isRecoveringPendingConversations = false
+            }
+        }
+
+        guard let context else { return false }
+
+        do {
+            let pendingConversations = try await pendingConversationsToRecover(in: context)
+            let batch = pendingConversations.prefix(Self.pendingConversationRecoveryBatchSize)
+
+            var recovered = 0
+            for conversation in batch {
+                do {
+                    if conversation.shouldResync {
+                        try await reEstablishPendingGroup(groupID: conversation.groupID)
+                    } else {
+                        try await joinGroup(with: conversation.groupID)
+                    }
+                    recovered += 1
+                } catch {
+                    logger.error(
+                        "failed to recover pending conversation: \(error)",
+                        attributes: [
+                            .mlsGroupID: conversation.groupID.safeForLoggingDescription,
+                            .conversationId: conversation.qualifiedID.safeForLoggingDescription
+                        ]
+                    )
+                }
+            }
+
+            if recovered > 0 {
+                await save(context)
+            }
+
+            if !batch.isEmpty {
+                logger.info("pending conversation recovery batch: recovered \(recovered) of \(batch.count)")
+            }
+
+            // Return whether another batch should be processed immediately.
+            return recovered == batch.count && pendingConversations.count > batch.count
+        } catch {
+            logger.error("failed pending conversation recovery batch: \(String(reflecting: error))")
+            return false
+        }
+    }
+
+    private func pendingConversationsToRecover(in context: NSManagedObjectContext) async throws
+        -> [PendingConversationRecovery] {
+        try await context.perform {
+            let pendingConversations = try ZMConversation.fetchConversationsWithMLSGroupStatus(
+                mlsGroupStatus: .pendingJoin,
+                messageProtocols: [.mls, .mixed],
+                in: context
+            ) + ZMConversation.fetchConversationsWithMLSGroupStatus(
+                mlsGroupStatus: .pendingJoinAfterReset,
+                domain: self.localDomain,
+                messageProtocols: [.mls, .mixed],
+                in: context
+            )
+
+            return pendingConversations.compactMap { conversation in
+                guard conversation.conversationType != .group || conversation.isSelfAnActiveMember,
+                      let groupID = conversation.mlsGroupID,
+                      let qualifiedID = conversation.qualifiedID else {
+                    return nil
+                }
+
+                return (
+                    groupID,
+                    qualifiedID,
+                    conversation.mlsStatus == .pendingJoinAfterReset ||
+                        conversation.conversationType == .oneOnOne ||
+                        qualifiedID.domain == self.localDomain
+                )
+            }
         }
     }
 

--- a/wire-ios-data-model/Source/MLS/MLSServiceInterface.swift
+++ b/wire-ios-data-model/Source/MLS/MLSServiceInterface.swift
@@ -153,6 +153,11 @@ public protocol MLSServiceInterface: MLSEncryptionServiceInterface, MLSDecryptio
 
     func performPendingJoins() async throws
 
+    /// Recovers one bounded batch of pending conversations.
+    ///
+    /// - Returns: `true` when another pending batch remains after this batch completed successfully.
+    func recoverPendingConversationBatchIfNeeded() async -> Bool
+
     /// Wipes the group from core crypto's storage
     ///
     /// - Parameter groupID: The ID of the group to wipe

--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+Messaging.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+Messaging.swift
@@ -211,6 +211,7 @@ public extension ZMConversation {
     static func fetchConversationsWithMLSGroupStatus(
         mlsGroupStatus: MLSGroupStatus,
         domain: String? = nil,
+        messageProtocols: [MessageProtocol] = [.mls],
         in context: NSManagedObjectContext
     ) throws -> [ZMConversation] {
 
@@ -229,9 +230,25 @@ public extension ZMConversation {
             )
         }
 
+        let matchingMessageProtocol = NSPredicate(
+            format: "%K IN %@",
+            argumentArray: [Self.messageProtocolKey, messageProtocols.map(\.int16Value)]
+        )
+
+        let hasMLSGroupID = NSPredicate(
+            format: "%K != nil",
+            argumentArray: [Self.mlsGroupIdKey]
+        )
+
+        let notDeleted = NSPredicate(format: "%K == NO", #keyPath(ZMConversation.isDeletedRemotely))
+
         request.predicate = NSCompoundPredicate(
             andPredicateWithSubpredicates: [
-                matchingGroupStatus, .isMLSConversation, matchingDomain
+                matchingGroupStatus,
+                matchingMessageProtocol,
+                hasMLSGroupID,
+                matchingDomain,
+                notDeleted
             ].compactMap(\.self)
         )
 

--- a/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
@@ -4581,6 +4581,24 @@ public class MockMLSServiceInterface: MLSServiceInterface {
         try await mock()
     }
 
+    // MARK: - recoverPendingConversationBatchIfNeeded
+
+    public var recoverPendingConversationBatchIfNeeded_Invocations: [Void] = []
+    public var recoverPendingConversationBatchIfNeeded_MockMethod: (() async -> Bool)?
+    public var recoverPendingConversationBatchIfNeeded_MockValue: Bool?
+
+    public func recoverPendingConversationBatchIfNeeded() async -> Bool {
+        recoverPendingConversationBatchIfNeeded_Invocations.append(())
+
+        if let mock = recoverPendingConversationBatchIfNeeded_MockMethod {
+            return await mock()
+        } else if let mock = recoverPendingConversationBatchIfNeeded_MockValue {
+            return mock
+        } else {
+            fatalError("no mock for `recoverPendingConversationBatchIfNeeded`")
+        }
+    }
+
     // MARK: - wipeGroup
 
     public var wipeGroup_Invocations: [MLSGroupID] = []

--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -1402,11 +1402,10 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         XCTAssertEqual(conversationMLSStatus, .ready)
     }
 
-    func test_PerformPendingJoins_It_JoinsViaExternalCommit_FederationGroup() async throws {
+    func test_RecoverPendingConversationBatchIfNeeded_JoinsPendingConversationOnlyOnce() async {
         // Given
         let groupID = MLSGroupID.random()
         let conversationID = UUID.create()
-        let domain = localDomain
         let conversation = await uiMOC.perform { [uiMOC] in
             let conversation = ZMConversation.insertNewObject(in: uiMOC)
             conversation.remoteIdentifier = conversationID
@@ -1418,22 +1417,41 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
             conversation.epoch = 0
             conversation.domain = "foreign.domain"
+            conversation.addParticipantAndUpdateConversationState(
+                user: ZMUser.selfUser(in: uiMOC),
+                role: nil
+            )
             XCTAssertNotEqual(conversation.domain, self.localDomain)
             return conversation
         }
+        await uiMOC.perform {
+            XCTAssertTrue(self.uiMOC.saveOrRollback())
+        }
+
         // mock
-        mockCoreCryptoContext.conversationExistsConversationId_MockValue = false
         mockActionsProvider.fetchConversationGroupInfoConversationIdDomainSubgroupTypeContext_MockValue = Data()
         mockMLSActionExecutor.mockJoinGroup = { _, _ in }
 
         // When
-        try await sut.performPendingJoins()
+        _ = await sut.recoverPendingConversationBatchIfNeeded()
 
         // Then
         XCTAssertEqual(
             mockActionsProvider.fetchConversationGroupInfoConversationIdDomainSubgroupTypeContext_Invocations.count,
             1
         )
+        XCTAssertEqual(mockMLSActionExecutor.mockJoinGroupCount, 1)
+
+        let persistedStatus = await uiMOC.perform {
+            self.uiMOC.refresh(conversation, mergeChanges: false)
+            return conversation.mlsStatus
+        }
+        XCTAssertEqual(persistedStatus, .ready)
+
+        // When
+        _ = await sut.recoverPendingConversationBatchIfNeeded()
+
+        // Then
         XCTAssertEqual(mockMLSActionExecutor.mockJoinGroupCount, 1)
     }
 
@@ -2000,36 +2018,46 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         )
     }
 
-    func test_UploadKeyPackages_DoesntCountUnclaimedKeyPackages_WhenNotNeeded() async {
+    func test_UploadKeyPackages_CountsBackendPackagesOnlyWhenAConversationIsPending() async {
         // Given
         await uiMOC.perform { _ = self.createSelfClient(onMOC: self.uiMOC) }
-
-        // expectation
-        let countUnclaimedKeyPackages = XCTestExpectation(description: "Count unclaimed key packages")
-        countUnclaimedKeyPackages.isInverted = true
-
-        // mock that we queried kp count recently
         privateUserDefaults.set(Date(), forKey: .keyPackageQueriedTime)
-
-        // mock that there are enough kp locally
         mockCoreCryptoContext.clientValidKeypackagesCountCiphersuiteCredentialType_MockMethod = { _, _ in
             UInt64(self.sut.targetUnclaimedKeyPackageCount)
         }
-
-        mockActionsProvider.countUnclaimedKeyPackagesClientIDCiphersuiteContext_MockMethod = { _, _, _ in
-            countUnclaimedKeyPackages.fulfill()
-            return 0
-        }
+        mockActionsProvider.countUnclaimedKeyPackagesClientIDCiphersuiteContext_MockValue =
+            sut.targetUnclaimedKeyPackageCount
 
         // When
         await sut.uploadKeyPackagesIfNeeded()
 
         // Then
-        await fulfillment(of: [countUnclaimedKeyPackages], timeout: 1)
+        XCTAssertTrue(mockActionsProvider.countUnclaimedKeyPackagesClientIDCiphersuiteContext_Invocations.isEmpty)
+
+        // When
+        _ = await uiMOC.perform { [uiMOC] in
+            let conversation = ZMConversation.insertNewObject(in: uiMOC)
+            conversation.remoteIdentifier = UUID()
+            conversation.domain = self.localDomain
+            conversation.mlsGroupID = .random()
+            conversation.mlsStatus = .pendingJoin
+            conversation.messageProtocol = .mls
+            conversation.conversationType = .oneOnOne
+            conversation.epoch = 1
+            return conversation
+        }
+        await sut.uploadKeyPackagesIfNeeded()
+
+        // Then
+        XCTAssertEqual(
+            mockActionsProvider.countUnclaimedKeyPackagesClientIDCiphersuiteContext_Invocations.count,
+            1
+        )
     }
 
     enum TestError: Error {
         case failedToCountUnclaimedKeyPackages
+        case pendingJoinFailed
     }
 
     func test_CountUnclaimedKeyPackages_DoesNotSetKeyPackageQueriedTime_IfItFails() async {
@@ -2080,9 +2108,10 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         XCTAssertNotNil(privateUserDefaults.date(forKey: .keyPackageQueriedTime))
     }
 
-    func test_UploadKeyPackages_DoesNotSetKeyPackageQueriedTime_WhenGenerationFails() async {
+    func test_UploadKeyPackages_ClearsKeyPackageQueriedTime_WhenGenerationFails() async {
         // Given
         await uiMOC.perform { _ = self.createSelfClient(onMOC: self.uiMOC) }
+        privateUserDefaults.set(Date(), forKey: .keyPackageQueriedTime)
 
         // mock that we don't have enough unclaimed kp locally
         mockCoreCryptoContext.clientValidKeypackagesCountCiphersuiteCredentialType_MockMethod = { _, _ in

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -1324,6 +1324,13 @@ extension ZMUserSession: SyncAgentDelegate {
 
             // always check if need to upload key packages if needed
             await mlsService.uploadKeyPackagesIfNeeded()
+            while mlsFeature.isEnabled,
+                  isBackendMLSEnabled,
+                  application.applicationState == .active {
+                guard await mlsService.recoverPendingConversationBatchIfNeeded() else {
+                    break
+                }
+            }
             await resolveOneOnOneConversationsIfNeeded()
             await recurringActionService.performActionsIfNeeded()
         }

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests.swift
@@ -405,10 +405,16 @@ final class ZMUserSessionTests: ZMUserSessionTestsBase {
         XCTAssertEqual(conversations.filter { $0.firstUnreadMessage != nil }.count, 0)
     }
 
-    func test_itUploadKeyPackagesIfNeeded_AfterQuickSync() async throws {
+    func test_itRecoversPendingConversationsAfterQuickSyncWhileActive() async throws {
         // GIVEN
+        sut.journal[.isBackendMLSEnabled] = true
+        mockMLSService.updateKeyMaterialForAllStaleGroupsIfNeeded_MockMethod = {}
+        mockMLSService.recoverPendingConversationBatchIfNeeded_MockMethod = {
+            self.mockMLSService.recoverPendingConversationBatchIfNeeded_Invocations.count == 1
+        }
         mockCoreCryptoProvider.registerMlsTransport_MockMethod = { _ in }
         await syncMOC.perform { [self, syncMOC] in
+            LegacyFeatureRepository(context: syncMOC).storeMLS(.init(status: .enabled))
             let domain = "anta.com"
             ZMUser.selfUser(in: syncMOC).domain = domain
             let selfUserClient = createSelfClient()
@@ -428,6 +434,17 @@ final class ZMUserSessionTests: ZMUserSessionTestsBase {
         // THEN
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         XCTAssertEqual(mockMLSService.uploadKeyPackagesIfNeeded_Invocations.count, 1)
+        XCTAssertEqual(mockMLSService.recoverPendingConversationBatchIfNeeded_Invocations.count, 2)
+
+        // When
+        application.applicationState = .background
+        await syncMOC.perform {
+            self.sut.didFinishIncrementalSync(isRecovering: false)
+        }
+
+        // Then
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        XCTAssertEqual(mockMLSService.recoverPendingConversationBatchIfNeeded_Invocations.count, 2)
     }
 
     func test_OnSelfClientInvalidated() async throws {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27395" title="WPB-27395" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-27395</a>  [iOS] Recover MLS conversations after key-package exhaustion
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

Manual cherry-pick from #5074

### Testing

N/A
---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
