### PR TITLE
fix: prevent MLS group read receipts - WPB-27764

### DIFF
--- a/wire-ios-data-model/Source/Model/Message/ZMOTRMessage+Confirmations.swift
+++ b/wire-ios-data-model/Source/Model/Message/ZMOTRMessage+Confirmations.swift
@@ -68,7 +68,7 @@ extension ZMOTRMessage {
             return expectsReadConfirmation && readReceiptsEnabled
 
         } else if conversation.conversationType == .group {
-            return expectsReadConfirmation
+            return conversation.messageProtocol != .mls && expectsReadConfirmation
         }
 
         return false

--- a/wire-ios-data-model/Tests/Source/Model/Messages/ZMMessageTests+Confirmation.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Messages/ZMMessageTests+Confirmation.swift
@@ -57,6 +57,32 @@ extension ZMMessageTests_Confirmation {
         XCTAssertFalse(message.needsReadConfirmation)
     }
 
+    func testThatMessageDoesntNeedReadConfirmation_InAnMLSGroup_WhenItExpectsReadConfirmation() {
+        // given
+        let user = createUser(in: uiMOC)
+        let conversation = createConversation(in: uiMOC)
+        conversation.messageProtocol = .mls
+
+        let message = insertMessage(conversation, fromSender: user, timestamp: Date()) as! ZMClientMessage
+        message.expectsReadConfirmation = true
+
+        // then
+        XCTAssertFalse(message.needsReadConfirmation)
+    }
+
+    func testThatMessageNeedsReadConfirmation_InAMixedGroup_WhenItExpectsReadConfirmation() {
+        // given
+        let user = createUser(in: uiMOC)
+        let conversation = createConversation(in: uiMOC)
+        conversation.messageProtocol = .mixed
+
+        let message = insertMessage(conversation, fromSender: user, timestamp: Date()) as! ZMClientMessage
+        message.expectsReadConfirmation = true
+
+        // then
+        XCTAssertTrue(message.needsReadConfirmation)
+    }
+
     func testThatMessageDoesntExpectReadConfirmation_InAGroup_ForMessagesSentBySelfUser() {
         // given
         let conversation = createConversation(in: uiMOC)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-27764" title="WPB-27764" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-27764</a>  [iOS] Read receipts are still enable after migration to mls
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Cherry-pick of #5124.

### Testing

N/A
---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
