### PR TITLE
fix: restrict meeting participant search to organization members - WPB-28507

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/Meetings/WireMeetingsMemberRepository.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/Meetings/WireMeetingsMemberRepository.swift
@@ -36,10 +36,10 @@ struct WireMeetingsMemberRepository: MeetingMemberRepositoryProtocol, @unchecked
 
         let result = await searchUsersUseCase.invoke(
             query: query,
-            options: [.contacts, .teamMembers], // in large teams find team members which are not yet known to us
+            options: [.teamMembers], // in large teams find team members which are not yet known to us
             messageProtocol: .mls // meetings are always mls
         )
-        return (result.contacts + result.teamMembers).compactMap { result in
+        return result.teamMembers.compactMap { result in
             guard let qualifiedID = result.qualifiedID(localDomain: nil) else { return MeetingMember?.none }
             return MeetingMember(
                 qualifiedID: .init(qualifiedID),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28507" title="WPB-28507" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-28507</a>  [iOS] Host can add external users to a Wire Meeting
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Meeting participant search included external contacts. Restrict it to organization members.

---

### Checklist

- [X] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [X] Description is filled and free of optional paragraphs.
- [X] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
