### PR TITLE
fix: handle meeting participant errors - WPB-28579

### DIFF
--- a/WireCalling/Sources/WireCallingDomain/WireMeetings/Protocols/MeetingConversationRepositoryProtocol.swift
+++ b/WireCalling/Sources/WireCallingDomain/WireMeetings/Protocols/MeetingConversationRepositoryProtocol.swift
@@ -41,3 +41,10 @@ public protocol MeetingConversationRepositoryProtocol: Sendable {
     func updateConversationName(_ name: String, for conversationID: QualifiedID) async throws
 
 }
+
+public enum MeetingParticipantsError: Error, Equatable {
+
+    /// The group is ready, but these participants could not be added.
+    case failedToAddParticipants([MeetingMember])
+
+}

--- a/WireCalling/Sources/WireCallingDomain/WireMeetings/UseCases/CreateMeetingUseCase.swift
+++ b/WireCalling/Sources/WireCallingDomain/WireMeetings/UseCases/CreateMeetingUseCase.swift
@@ -55,12 +55,23 @@ package struct CreateMeetingUseCase: CreateMeetingUseCaseProtocol {
         // The backend doesn't name the conversation it creates for the
         // meeting, so mirror the meeting title onto it.
         try await conversationRepository.setConversationName(title, for: meeting.conversationID)
-        try await conversationRepository.addParticipants(participants, to: meeting.conversationID)
+        do {
+            try await conversationRepository.addParticipants(participants, to: meeting.conversationID)
+        } catch let MeetingParticipantsError.failedToAddParticipants(participants) {
+            await meetingRepository.storeMeeting(meeting)
+            throw CreateMeetingUseCaseError.participantsNotAdded(meeting: meeting, participants: participants)
+        }
         // Store the meeting again now that its conversation exists locally,
         // so the two are linked; meetings without a local conversation are
         // not listed.
         await meetingRepository.storeMeeting(meeting)
         return meeting
     }
+
+}
+
+package enum CreateMeetingUseCaseError: Error, Equatable {
+
+    case participantsNotAdded(meeting: Meeting, participants: [MeetingMember])
 
 }

--- a/WireCalling/Sources/WireCallingDomain/WireMeetings/UseCases/UpdateMeetingUseCase.swift
+++ b/WireCalling/Sources/WireCallingDomain/WireMeetings/UseCases/UpdateMeetingUseCase.swift
@@ -67,11 +67,17 @@ package struct UpdateMeetingUseCase: UpdateMeetingUseCaseProtocol {
             .sorted { $0.name < $1.name }
         let previousIDs = Set(previousMembers.map(\.qualifiedID))
         let selectedIDs = Set(participants.map(\.qualifiedID))
-        let membersToAdd = participants.filter { !previousIDs.contains($0.qualifiedID) }
-        let membersToRemove = previousMembers.filter { !selectedIDs.contains($0.qualifiedID) }
+        let currentIDs = Set((updatedMeeting.conversation ?? conversation).participants.map(\.qualifiedID))
+        let membersToAdd = participants.filter {
+            !previousIDs.contains($0.qualifiedID) && !currentIDs.contains($0.qualifiedID)
+        }
+        let membersToRemove = previousMembers.filter {
+            !selectedIDs.contains($0.qualifiedID) && currentIDs.contains($0.qualifiedID)
+        }
 
         try await conversationRepository.addParticipants(membersToAdd, to: meeting.conversationID)
         try await conversationRepository.removeParticipants(membersToRemove, from: meeting.conversationID)
+        await meetingRepository.storeMeeting(updatedMeeting)
 
         if title != meeting.title {
             do {

--- a/WireCalling/Sources/WireCallingUI/Resources/Localization/en.lproj/Localizable.strings
+++ b/WireCalling/Sources/WireCallingUI/Resources/Localization/en.lproj/Localizable.strings
@@ -67,6 +67,8 @@
 "wireMeetings.schedule.setupParticipants.placeholder" = "Add participants";
 "wireMeetings.schedule.error.alert.title" = "Something went wrong";
 "wireMeetings.schedule.error.alert.ok" = "OK";
+"wireMeetings.schedule.participantsNotAdded.title" = "Meeting created";
+"wireMeetings.schedule.participantsNotAdded.message" = "The meeting was created, but these users could not be added:\n\n%@";
 "wireMeetings.schedule.error.conversationName.title" = "Could not update call name";
 "wireMeetings.schedule.error.conversationName.message" = "The meeting title was updated, but the name shown in the call could not be updated. Please try again.";
 "wireMeetings.schedule.error.conversationName.retry" = "Try again";

--- a/WireCalling/Sources/WireCallingUI/Views/WireMeetings/MeetingForm/MeetingFormView.swift
+++ b/WireCalling/Sources/WireCallingUI/Views/WireMeetings/MeetingForm/MeetingFormView.swift
@@ -78,6 +78,15 @@ struct MeetingFormView: View {
                 )
             }
             .alert(
+                Strings.ParticipantsNotAdded.title,
+                isPresented: $viewModel.hasParticipantsNotAddedAlert
+            ) {
+                Button(Strings.Error.Alert.ok, action: viewModel.acknowledgeParticipantsNotAdded)
+            } message: {
+                Text(Strings.ParticipantsNotAdded
+                    .message(viewModel.participantsNotAdded.map(\.name).joined(separator: ", ")))
+            }
+            .alert(
                 Strings.Error.ExpiredStartDate.title,
                 isPresented: $viewModel.hasExpiredStartDateError
             ) {

--- a/WireCalling/Sources/WireCallingUI/Views/WireMeetings/MeetingForm/MeetingFormViewModel.swift
+++ b/WireCalling/Sources/WireCallingUI/Views/WireMeetings/MeetingForm/MeetingFormViewModel.swift
@@ -142,6 +142,11 @@ package final class MeetingFormViewModel {
     var hasConversationNameUpdateError = false
     private var meetingPendingConversationNameUpdate: Meeting?
 
+    var hasParticipantsNotAddedAlert = false
+    private(set) var participantsNotAdded: [MeetingMember] = []
+    private var meetingWithParticipantsNotAdded: Meeting?
+    private var didAcknowledgeParticipantsNotAdded = false
+
     var selectedMembersSummary: String {
         selectedMembers
             .map(\.name)
@@ -215,7 +220,7 @@ package final class MeetingFormViewModel {
         // corrupt subsequent pagination (e.g. the next “load more” would re-fetch from offset 0 and replace data
         // unexpectedly). Consider making load(pageSize:) return/throw on failure so reloadLoadedMeetings() can restore
         // futureOffset (and possibly coalesce missed reloads while isLoading is true).
-        guard !isLoading else { return }
+        guard !isLoading, meetingWithParticipantsNotAdded == nil else { return }
         hasError = false
         hasConversationNameUpdateError = false
         meetingPendingConversationNameUpdate = nil
@@ -229,6 +234,10 @@ package final class MeetingFormViewModel {
         do {
             let meeting = try await saveMeeting()
             onSuccess(meeting)
+        } catch let CreateMeetingUseCaseError.participantsNotAdded(meeting, participants) {
+            meetingWithParticipantsNotAdded = meeting
+            participantsNotAdded = participants
+            hasParticipantsNotAddedAlert = true
         } catch let UpdateMeetingUseCaseError.conversationNameUpdateFailed(updatedMeeting) {
             meetingPendingConversationNameUpdate = updatedMeeting
             hasConversationNameUpdateError = true
@@ -237,6 +246,13 @@ package final class MeetingFormViewModel {
             WireLogger.search.error("failed to save meeting: \(String(describing: errorType))")
             hasError = true
         }
+    }
+
+    func acknowledgeParticipantsNotAdded() {
+        guard !didAcknowledgeParticipantsNotAdded, let meeting = meetingWithParticipantsNotAdded else { return }
+        didAcknowledgeParticipantsNotAdded = true
+        hasParticipantsNotAddedAlert = false
+        onSuccess(meeting)
     }
 
     func retryConversationNameUpdate() async {

--- a/WireCalling/Tests/WireCallingTests/WireMeetings/DomainTests/CreateMeetingUseCaseTests.swift
+++ b/WireCalling/Tests/WireCallingTests/WireMeetings/DomainTests/CreateMeetingUseCaseTests.swift
@@ -150,6 +150,30 @@ struct CreateMeetingUseCaseTests {
         #expect(conversationRepository.pullConversationIdUUIDDomainStringVoidCallsCount == 1)
     }
 
+    @Test("invoke stores the created meeting before reporting participants who could not be added")
+    func invokeStoresMeetingWhenParticipantsCouldNotBeAdded() async {
+        meetingRepository
+            .createMeetingTitleStringStartTimeDateEndTimeDateRecurrenceMeetingRecurrenceMeetingReturnValue = meeting
+        conversationRepository
+            .addParticipantsParticipantsMeetingMemberToConversationIDQualifiedIDVoidThrowableError =
+            MeetingParticipantsError.failedToAddParticipants([participant])
+
+        await #expect(throws: CreateMeetingUseCaseError.participantsNotAdded(
+            meeting: meeting,
+            participants: [participant]
+        )) {
+            _ = try await useCase.invoke(
+                title: meeting.title,
+                startTime: meeting.start,
+                endTime: meeting.end,
+                recurrence: nil,
+                participants: [participant]
+            )
+        }
+
+        #expect(meetingRepository.storeMeetingMeetingMeetingVoidReceivedInvocations == [meeting])
+    }
+
     @Test("invoke does not touch the conversation when creating the meeting fails")
     func invokeFailsWhenCreatingMeetingFails() async {
         // Given

--- a/WireCalling/Tests/WireCallingTests/WireMeetings/DomainTests/UpdateMeetingUseCaseTests.swift
+++ b/WireCalling/Tests/WireCallingTests/WireMeetings/DomainTests/UpdateMeetingUseCaseTests.swift
@@ -80,14 +80,14 @@ struct UpdateMeetingUseCaseTests {
         )
     }
 
-    private func makeMeeting(title: String) -> Meeting {
+    private func makeMeeting(title: String, participants: Set<MeetingMember>? = nil) -> Meeting {
         Meeting(
             id: meeting.id,
             title: title,
             start: meeting.start,
             end: meeting.end,
             recurrence: meeting.recurrence,
-            conversation: meeting.conversation,
+            conversation: participants.map { MeetingConversation(participants: $0) } ?? meeting.conversation,
             conversationID: meeting.conversationID,
             creatorID: meeting.creatorID
         )
@@ -175,6 +175,12 @@ struct UpdateMeetingUseCaseTests {
         meetingRepository
             .updateMeetingIdQualifiedIDTitleStringStartTimeDateEndTimeDateRecurrenceMeetingRecurrenceMeetingReturnValue =
             meeting
+        meetingRepository.storeMeetingMeetingMeetingVoidClosure = { _ in
+            #expect(conversationRepository
+                .addParticipantsParticipantsMeetingMemberToConversationIDQualifiedIDVoidCallsCount == 1)
+            #expect(conversationRepository
+                .removeParticipantsParticipantsMeetingMemberFromConversationIDQualifiedIDVoidCallsCount == 1)
+        }
 
         // When
         _ = try await useCase.invoke(
@@ -195,6 +201,36 @@ struct UpdateMeetingUseCaseTests {
             .removeParticipantsParticipantsMeetingMemberFromConversationIDQualifiedIDVoidReceivedArguments
         #expect(removeArguments?.participants == [Self.removedMember])
         #expect(removeArguments?.conversationID == meeting.conversationID)
+        #expect(meetingRepository.storeMeetingMeetingMeetingVoidReceivedInvocations == [meeting])
+    }
+
+    @Test("invoke skips completed participant changes without undoing changes from another device", arguments: [
+        [keptMember, addedMember],
+        [keptMember, removedMember]
+    ])
+    func invokePreservesParticipantChanges(selectedMembers: [MeetingMember]) async throws {
+        // Given a newer membership snapshot than the one the form was opened with.
+        meetingRepository
+            .updateMeetingIdQualifiedIDTitleStringStartTimeDateEndTimeDateRecurrenceMeetingRecurrenceMeetingReturnValue =
+            makeMeeting(title: meeting.title, participants: [Self.keptMember, Self.addedMember])
+
+        // When
+        _ = try await useCase.invoke(
+            meeting: meeting,
+            title: meeting.title,
+            startTime: meeting.start,
+            endTime: meeting.end,
+            recurrence: nil,
+            participants: selectedMembers
+        )
+
+        // Then
+        #expect(conversationRepository
+            .addParticipantsParticipantsMeetingMemberToConversationIDQualifiedIDVoidReceivedArguments?.participants
+            .isEmpty == true)
+        #expect(conversationRepository
+            .removeParticipantsParticipantsMeetingMemberFromConversationIDQualifiedIDVoidReceivedArguments?.participants
+            .isEmpty == true)
     }
 
     @Test("invoke leaves the participants unchanged when the selection matches the members")

--- a/WireCalling/Tests/WireCallingTests/WireMeetings/PresentationTests/MeetingFormViewModelTests.swift
+++ b/WireCalling/Tests/WireCallingTests/WireMeetings/PresentationTests/MeetingFormViewModelTests.swift
@@ -356,6 +356,36 @@ struct MeetingFormViewModelTests {
         #expect(viewModel.isLoading == false)
     }
 
+    @Test("missing participants are acknowledged without creating another meeting", arguments: [
+        MeetingFormViewModel.Mode.instant, .scheduled
+    ])
+    func submit_ParticipantsNotAdded_ContinuesWithCreatedMeeting(mode: MeetingFormViewModel.Mode) async {
+        var completedMeetings: [Meeting] = []
+        let viewModel = makeViewModel(mode: mode) { completedMeetings.append($0) }
+        createMeetingUseCaseMock
+            .invokeTitleStringStartTimeDateEndTimeDateRecurrenceMeetingRecurrenceParticipantsMeetingMemberMeetingThrowableError =
+            CreateMeetingUseCaseError.participantsNotAdded(meeting: meeting, participants: [member])
+
+        await viewModel.submit()
+
+        #expect(viewModel.hasParticipantsNotAddedAlert)
+        #expect(viewModel.participantsNotAdded == [member])
+        #expect(!viewModel.hasError)
+        #expect(!viewModel.isLoading)
+        #expect(completedMeetings.isEmpty)
+
+        await viewModel.submit()
+        viewModel.acknowledgeParticipantsNotAdded()
+        await viewModel.submit()
+        viewModel.acknowledgeParticipantsNotAdded()
+
+        #expect(!viewModel.hasParticipantsNotAddedAlert)
+        #expect(completedMeetings == [meeting])
+        #expect(createMeetingUseCaseMock
+            .invokeTitleStringStartTimeDateEndTimeDateRecurrenceMeetingRecurrenceParticipantsMeetingMemberMeetingCallsCount ==
+            1)
+    }
+
     @Test("submit sets the error flag and does not call onSuccess when the use case fails")
     func submit_Failure_SetsError() async {
         // Given

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/Meetings/MeetingConversationRepositoryBridge.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/Meetings/MeetingConversationRepositoryBridge.swift
@@ -233,17 +233,40 @@ struct MeetingConversationRepositoryBridge: MeetingConversationRepositoryProtoco
             MLSUser(id: member.qualifiedID.id, domain: member.qualifiedID.domain)
         }
 
-        let ciphersuite = try await mlsService.establishGroup(
-            for: mlsGroupID,
-            with: mlsUsers,
-            removalKeys: nil
-        )
+        let ciphersuite: MLSCipherSuite
+        var failedParticipants: [MeetingMember] = []
+        do {
+            ciphersuite = try await mlsService.establishGroup(
+                for: mlsGroupID,
+                with: mlsUsers,
+                removalKeys: nil
+            )
+        } catch let MLSService.MLSAddMembersError.failedToClaimKeyPackages(failedUsers) {
+            guard !failedUsers.isEmpty, failedUsers.allSatisfy({ mlsUsers.contains($0) }) else {
+                throw MLSService.MLSAddMembersError.failedToClaimKeyPackages(users: failedUsers)
+            }
 
-        await syncContext.perform {
-            guard let conv = ZMConversation.existingObject(for: objectID, in: syncContext) else { return }
+            // Failed establishment wipes the group, so recreate it with the eligible invitees and host devices.
+            ciphersuite = try await mlsService.establishGroup(
+                for: mlsGroupID,
+                with: mlsUsers.filter { !failedUsers.contains($0) },
+                removalKeys: nil
+            )
+            failedParticipants = zip(participants, mlsUsers).compactMap { participant, user in
+                failedUsers.contains(user) ? participant : nil
+            }
+        }
+
+        let isGroupReady = await syncContext.perform {
+            guard let conv = ZMConversation.existingObject(for: objectID, in: syncContext) else { return false }
             conv.mlsStatus = .ready
             conv.ciphersuite = ciphersuite
-            _ = syncContext.saveOrRollback()
+            return syncContext.saveOrRollback()
+        }
+
+        if !failedParticipants.isEmpty {
+            guard isGroupReady else { throw MLSService.MLSGroupCreationError.failedToCreateGroup }
+            throw MeetingParticipantsError.failedToAddParticipants(failedParticipants)
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28579" title="WPB-28579" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-28579</a>  [iOS] “Something went wrong” error is shown after adding participants who have not logged into any device are selected
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Fixes two causes of “Something went wrong” after saving a meeting:

- Meet Now and scheduled meetings recover when invitees cannot provide encryption keys. The host sees who could not be added and continues with the same meeting.
- Editing skips participant changes that already succeeded and refreshes membership, preventing repeated additions or removals.

---

### Checklist

- [X] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [X] Description is filled and free of optional paragraphs.
- [X] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
