### PR TITLE
feat: fetch team apps and collaborators - WPB-28430

### DIFF
--- a/wire-ios-sync-engine/Source/UserSession/Search/SearchResult.swift
+++ b/wire-ios-sync-engine/Source/UserSession/Search/SearchResult.swift
@@ -42,6 +42,12 @@ public struct SearchResult {
 
     public var apps: [any UserType]
 
+    /// Team collaborators (resolved from `/teams/:tid/collaborators`) whose profile is not app-typed,
+    /// i.e. human users with team permissions who aren't full team members. These should be surfaced
+    /// like regular contacts, never through the apps-specific UI.
+
+    public var collaborators: [ZMSearchUser] = []
+
     public var bots: [any UserType]
 
     /// Cache for search users.
@@ -59,6 +65,7 @@ extension SearchResult {
         self.directory = []
         self.conversations = []
         self.apps = []
+        self.collaborators = []
         self.bots = []
         self.searchUsersCache = nil
     }
@@ -92,6 +99,7 @@ extension SearchResult {
         self.directory = searchUsers.filter { !$0.isConnected && !$0.isTeamMember }
         self.conversations = []
         self.apps = []
+        self.collaborators = []
         self.bots = []
         self.searchUsersCache = searchUsersCache
 
@@ -143,6 +151,7 @@ extension SearchResult {
             directory: directory,
             conversations: copiedConversations,
             apps: apps,
+            collaborators: collaborators,
             bots: bots,
             searchUsersCache: searchUsersCache
         )
@@ -156,6 +165,7 @@ extension SearchResult {
             directory: directory,
             conversations: result.conversations,
             apps: result.apps,
+            collaborators: collaborators,
             bots: bots,
             searchUsersCache: searchUsersCache
         )
@@ -173,6 +183,28 @@ extension SearchResult {
                     newApp.remoteIdentifier == existingApp.remoteIdentifier
                 }
             },
+            collaborators: collaborators,
+            bots: bots,
+            searchUsersCache: searchUsersCache
+        )
+    }
+
+    /// Merges in newly resolved human collaborators (non-app team collaborators), deduplicating by
+    /// `remoteIdentifier` against collaborators, contacts and team members already present in `self`.
+    func union(withCollaboratorsResult result: SearchResult) -> SearchResult {
+        let existingUsers = contacts + teamMembers + collaborators
+        return SearchResult(
+            context: context,
+            contacts: contacts,
+            teamMembers: teamMembers,
+            directory: directory,
+            conversations: conversations,
+            apps: apps,
+            collaborators: collaborators + result.collaborators.filter { newCollaborator in
+                !existingUsers.contains { existingUser in
+                    newCollaborator.remoteIdentifier == existingUser.remoteIdentifier
+                }
+            },
             bots: bots,
             searchUsersCache: searchUsersCache
         )
@@ -186,6 +218,7 @@ extension SearchResult {
             directory: directory,
             conversations: conversations,
             apps: apps,
+            collaborators: collaborators,
             bots: bots + result.bots,
             searchUsersCache: searchUsersCache
         )
@@ -199,6 +232,7 @@ extension SearchResult {
             directory: result.directory,
             conversations: conversations,
             apps: apps,
+            collaborators: collaborators,
             bots: bots,
             searchUsersCache: searchUsersCache
         )
@@ -212,6 +246,7 @@ extension SearchResult {
             directory: result.directory + directory,
             conversations: conversations,
             apps: apps,
+            collaborators: collaborators,
             bots: bots,
             searchUsersCache: searchUsersCache
         )

--- a/wire-ios-sync-engine/Source/UserSession/Search/SearchTask.swift
+++ b/wire-ios-sync-engine/Source/UserSession/Search/SearchTask.swift
@@ -140,7 +140,7 @@ public final class SearchTask {
             }
             taskGroup.addTask {
                 do {
-                    return try await self.listAllAppsAndCollaboratorApps()
+                    return try await self.listAppsAndCollaborators()
                 } catch {
                     let errorType = Swift.type(of: error)
                     WireLogger.search
@@ -495,18 +495,28 @@ public final class SearchTask {
 
     /// If no search query is provided we cannot use the search API.
     /// This func basically serves two purposes:
-    /// - Apps added to the team don't trigger events, so this allows apps being added right now (while the iOS client
-    /// is running) to be displayed in the search results.
-    /// - In large teams apps might not be discovered without this code (2000 members cap).
-    private func listAllAppsAndCollaboratorApps() async throws -> SearchResultAggregator {
+    /// - Apps/collaborators added to the team don't trigger events, so this allows apps/collaborators being added
+    /// right now (while the iOS client is running) to be displayed in the search results.
+    /// - In large teams apps/collaborators might not be discovered without this code (2000 members cap).
+    ///
+    /// Team-owned apps come from `GET /teams/:tid/apps`. Team collaborators come from
+    /// `GET /teams/:tid/collaborators`, which only returns a bare `{user, team, permissions}` shape with no
+    /// human/app discriminator, so each collaborator's user ID is resolved into a full profile via
+    /// `usersAPI.getUsers` to determine whether it's an app or a human. App-typed collaborator profiles are folded
+    /// into the same apps bucket as the team-owned apps (deduplicated). Non-app-typed (human) collaborator profiles
+    /// are surfaced separately so they can be displayed like regular contacts, never through the apps-specific UI.
+    func listAppsAndCollaborators() async throws -> SearchResultAggregator {
         guard
             let apiVersion,
             apiVersion >= .v10, // collaborators: v10, apps: v15
             case let .search(searchRequest) = type,
             searchRequest.query.string.isEmpty,
             !searchRequest.searchOptions.contains(.localResultsOnly),
-            searchRequest.searchOptions.contains(.apps)
+            !searchRequest.searchOptions.isDisjoint(with: [.apps, .contacts, .teamMembers])
         else { return { _ in } }
+
+        let includeApps = searchRequest.searchOptions.contains(.apps)
+        let includeCollaborators = !searchRequest.searchOptions.isDisjoint(with: [.contacts, .teamMembers])
 
         let searchContext = contextProvider.newBackgroundContext()
         let (teamID, selfUserDomain) = await searchContext.perform {
@@ -551,18 +561,18 @@ public final class SearchTask {
 
         try Task.checkCancellation()
 
-        let collaborators = try await usersAPI.getUsers(userIDs: collaboratorIDs)
-        if !collaborators.failed.isEmpty {
+        let collaboratorProfiles = try await usersAPI.getUsers(userIDs: collaboratorIDs)
+        if !collaboratorProfiles.failed.isEmpty {
             WireLogger.network.warn("at least one collaborator's info couldn't be fetched", attributes: .safePublic)
         }
 
         try Task.checkCancellation()
 
         let viewContext = contextProvider.viewContext
-        let searchUsers = await viewContext.perform { [searchUsersCache] in
-            var searchUsers = [ZMSearchUser]()
-            for app in apps + collaborators.found {
-                guard app.type == .app else { continue }
+        let (appSearchUsers, collaboratorSearchUsers) = await viewContext.perform { [searchUsersCache] in
+            var appSearchUsers = [ZMSearchUser]()
+            var collaboratorSearchUsers = [ZMSearchUser]()
+            for app in apps + collaboratorProfiles.found {
                 let localUser = ZMUser.fetch(with: app.id.id, domain: app.id.domain, in: viewContext)
                 let searchUser: ZMSearchUser
                 if let cachedSearchUser = searchUsersCache?.object(forKey: app.id.id as NSUUID) {
@@ -576,9 +586,13 @@ public final class SearchTask {
                         searchUsersCache: searchUsersCache
                     )
                 }
-                searchUsers += [searchUser]
+                if app.type == .app {
+                    appSearchUsers += [searchUser]
+                } else {
+                    collaboratorSearchUsers += [searchUser]
+                }
             }
-            return searchUsers
+            return (appSearchUsers, collaboratorSearchUsers)
         }
         let partialResult = SearchResult(
             context: viewContext,
@@ -586,12 +600,16 @@ public final class SearchTask {
             teamMembers: [],
             directory: [],
             conversations: [],
-            apps: searchUsers,
+            apps: includeApps ? appSearchUsers : [],
+            collaborators: includeCollaborators ? collaboratorSearchUsers : [],
             bots: [],
             searchUsersCache: searchUsersCache
         )
 
-        return { $0 = $0.union(withAppsResult: partialResult) }
+        return { result in
+            result = result.union(withAppsResult: partialResult)
+            result = result.union(withCollaboratorsResult: partialResult)
+        }
     }
 
     // MARK: -

--- a/wire-ios-sync-engine/Source/UserSession/Search/SearchTask.swift
+++ b/wire-ios-sync-engine/Source/UserSession/Search/SearchTask.swift
@@ -239,7 +239,7 @@ public final class SearchTask {
         }
 
         let searchContext = contextProvider.newBackgroundContext()
-        let (connectedUserIDs, teamMemberIDs, appIDs, conversationIDs) = await searchContext.perform { [self] in
+        let (connectedUserIDs, teamMemberIDs, conversationIDs) = await searchContext.perform { [self] in
 
             var team: WireDataModel.Team?
             if let teamObjectID = request.team?.objectID {
@@ -259,10 +259,6 @@ public final class SearchTask {
                 searchOptions: request.searchOptions,
                 in: searchContext
             ) : []
-            let apps = request.searchOptions.contains(.apps) ? apps(
-                in: team,
-                matching: request.normalizedQuery
-            ) : []
 
             let conversations = request.searchOptions.contains(.conversations) ? conversations(
                 matchingQuery: request.query,
@@ -273,7 +269,6 @@ public final class SearchTask {
             return (
                 connectedUsers.map(\.objectID),
                 teamMembers.map(\.objectID),
-                apps.map(\.objectID),
                 conversations.map(\.objectID)
             )
 
@@ -285,8 +280,6 @@ public final class SearchTask {
             let copiedConversations = conversationIDs
                 .compactMap { viewContext.object(with: $0) as? ZMConversation }
             let copiedConnectedUsers = connectedUserIDs
-                .compactMap { viewContext.object(with: $0) as? ZMUser }
-            let copiedApps = appIDs
                 .compactMap { viewContext.object(with: $0) as? ZMUser }
             let searchConnectedUsers = copiedConnectedUsers
                 .map {
@@ -317,7 +310,7 @@ public final class SearchTask {
                 teamMembers: searchTeamMembers,
                 directory: [],
                 conversations: copiedConversations,
-                apps: copiedApps,
+                apps: [],
                 bots: [],
                 searchUsersCache: searchUsersCache
             )
@@ -376,16 +369,6 @@ public final class SearchTask {
         }
 
         return partialResult
-    }
-
-    private func apps(
-        in team: WireDataModel.Team?,
-        matching query: String
-    ) -> [ZMUser] {
-        team?.members(
-            matchingQuery: query,
-            filteredBy: .app
-        ).compactMap(\.user) ?? []
     }
 
     private func connectedUsers(
@@ -501,10 +484,11 @@ public final class SearchTask {
     ///
     /// Team-owned apps come from `GET /teams/:tid/apps`. Team collaborators come from
     /// `GET /teams/:tid/collaborators`, which only returns a bare `{user, team, permissions}` shape with no
-    /// human/app discriminator, so each collaborator's user ID is resolved into a full profile via
-    /// `usersAPI.getUsers` to determine whether it's an app or a human. App-typed collaborator profiles are folded
-    /// into the same apps bucket as the team-owned apps (deduplicated). Non-app-typed (human) collaborator profiles
-    /// are surfaced separately so they can be displayed like regular contacts, never through the apps-specific UI.
+    /// type discriminator, so each collaborator's user ID is resolved into a full profile via
+    /// `usersAPI.getUsers` to determine whether it's an app, a (legacy) bot, or a human. App- and bot-typed
+    /// collaborator profiles are folded into the same apps bucket as the team-owned apps (deduplicated).
+    /// Regular (human) collaborator profiles are surfaced separately so they can be displayed like regular
+    /// contacts, never through the apps-specific UI.
     func listAppsAndCollaborators() async throws -> SearchResultAggregator {
         guard
             let apiVersion,
@@ -586,9 +570,13 @@ public final class SearchTask {
                         searchUsersCache: searchUsersCache
                     )
                 }
-                if app.type == .app {
+                if searchUser.assetKeys == nil, let assetKeys = SearchUserAssetKeys(app.assets) {
+                    searchUser.assetKeys = assetKeys
+                }
+                switch app.type {
+                case .app, .bot:
                     appSearchUsers += [searchUser]
-                } else {
+                case .regular, nil:
                     collaboratorSearchUsers += [searchUser]
                 }
             }

--- a/wire-ios-sync-engine/Tests/Source/UserSession/Search/SearchTaskTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/Search/SearchTaskTests.swift
@@ -425,6 +425,36 @@ final class SearchTaskTests: DatabaseTest {
         XCTAssertEqual(result.teamMembers.compactMap(\.user), [user])
     }
 
+    func testThatItDoesNotListAppsFromLocalTeamMembers() async throws {
+        let task = await uiMOC.perform { [self] in
+            // given
+            let team = Team.insertNewObject(in: uiMOC)
+            let appUser = ZMUser.insertNewObject(in: uiMOC)
+            let member = Member.insertNewObject(in: uiMOC)
+
+            appUser.name = "Some App"
+            appUser.type = .app
+
+            member.team = team
+            member.user = appUser
+
+            uiMOC.saveOrRollback()
+
+            let request = SearchRequest(query: "", searchOptions: [.apps], team: team)
+            return makeSearchTask(request: request)
+        }
+
+        // when
+        var result = SearchResult()
+        let resultAggregator = await task.performLocalSearch()
+        await uiMOC.perform {
+            resultAggregator(&result)
+        }
+
+        // then
+        XCTAssertTrue(result.apps.isEmpty)
+    }
+
     func testThatItCanExcludeNonActiveTeamMembersLocally() async throws {
         let (userA, task) = await uiMOC.perform { [self] in
             // given
@@ -1094,7 +1124,10 @@ final class SearchTaskTests: DatabaseTest {
             teamID: teamIdentifier,
             type: .app,
             accentID: 2,
-            assets: [],
+            assets: [
+                UserAsset(key: "app-preview-key", size: .preview, type: .image),
+                UserAsset(key: "app-complete-key", size: .complete, type: .image)
+            ],
             deleted: nil,
             email: nil,
             expiresAt: nil,
@@ -1112,7 +1145,9 @@ final class SearchTaskTests: DatabaseTest {
             teamID: otherTeamID,
             type: .app,
             accentID: 1,
-            assets: [],
+            assets: [
+                UserAsset(key: "collaborator-app-complete-key", size: .complete, type: .image)
+            ],
             deleted: nil,
             email: nil,
             expiresAt: nil,
@@ -1186,13 +1221,81 @@ final class SearchTaskTests: DatabaseTest {
         XCTAssertEqual(result.apps.first?.handle, "a")
         XCTAssertEqual(result.apps.first?.teamIdentifier, teamIdentifier)
         XCTAssertEqual(result.apps.first?.zmAccentColor?.rawValue, 2)
+        // Profile picture asset keys must be populated straight away from the `/teams/:tid/apps` /
+        // `/teams/:tid/collaborators` response, not left empty until some later detail-screen visit or
+        // remote search happens to enrich the same cached ZMSearchUser.
+        let firstApp = try XCTUnwrap(result.apps.first as? ZMSearchUser)
+        XCTAssertEqual(firstApp.assetKeys?.preview, "app-preview-key")
+        XCTAssertEqual(firstApp.assetKeys?.complete, "app-complete-key")
         XCTAssertEqual(result.apps.last?.qualifiedID(localDomain: "-"), qualifiedID1)
         XCTAssertEqual(result.apps.last?.name, "collaborator app")
         XCTAssertEqual(result.apps.last?.handle, "ca")
         XCTAssertEqual(result.apps.last?.teamIdentifier, otherTeamID)
         XCTAssertEqual(result.apps.last?.zmAccentColor?.rawValue, 1)
+        let lastApp = try XCTUnwrap(result.apps.last as? ZMSearchUser)
+        XCTAssertNil(lastApp.assetKeys?.preview)
+        XCTAssertEqual(lastApp.assetKeys?.complete, "collaborator-app-complete-key")
         // The human collaborator isn't surfaced anywhere for an `.apps`-only request either, since it doesn't
         // request `.contacts`/`.teamMembers`.
+        XCTAssertTrue(result.collaborators.isEmpty)
+    }
+
+    func testThatItListsBotTypedCollaboratorsAsApps() async throws {
+        // given
+        let request = SearchRequest(
+            query: "",
+            searchDomain: "wire.com",
+            searchOptions: [.apps]
+        )
+        let task = makeSearchTask(request: request, apiVersion: .v15)
+
+        let qualifiedID = QualifiedID(uuid: UUID(), domain: "")
+        let otherTeamID = UUID()
+        // A legacy (Proteus) bot shared in as a collaborator. It must surface via the apps result, alongside
+        // real apps, never via the human collaborators result.
+        let collaboratorBotResult = User(
+            id: UserID(qualifiedID),
+            name: "collaborator bot",
+            handle: "cb",
+            teamID: otherTeamID,
+            type: .bot,
+            accentID: 4,
+            assets: [],
+            deleted: nil,
+            email: nil,
+            expiresAt: nil,
+            app: nil,
+            service: nil,
+            supportedProtocols: [.proteus],
+            legalholdStatus: .noConsent
+        )
+
+        teamsAPIMock.getAppsFor_MockMethod = { _ in [] }
+        teamsAPIMock.getCollaboratorsFor_MockMethod = { [teamIdentifier] teamID in
+            XCTAssertEqual(teamID, teamIdentifier)
+            return [
+                CollaboratorInfo(
+                    userID: qualifiedID.uuid,
+                    teamID: otherTeamID,
+                    permissions: [.createTeamConversation]
+                )
+            ]
+        }
+        usersAPIMock.getUsersUserIDs_MockMethod = { userIDs in
+            XCTAssertEqual(userIDs, [UserID(qualifiedID)])
+            return UserList(found: [collaboratorBotResult], failed: [])
+        }
+
+        // when
+        var result = SearchResult()
+        let resultAggregator = try await task.listAppsAndCollaborators()
+        resultAggregator(&result)
+
+        // then
+        XCTAssertEqual(result.apps.count, 1)
+        let app = try XCTUnwrap(result.apps.first)
+        XCTAssertEqual(app.name, "collaborator bot")
+        XCTAssertEqual(app.remoteIdentifier, qualifiedID.uuid)
         XCTAssertTrue(result.collaborators.isEmpty)
     }
 
@@ -1205,7 +1308,9 @@ final class SearchTaskTests: DatabaseTest {
         )
         let task = makeSearchTask(request: request, apiVersion: .v15)
 
-        let qualifiedID = QualifiedID(uuid: UUID(), domain: "wire.com")
+        // The resolved collaborator's QualifiedID sent to `usersAPI.getUsers` is built from the self user's
+        // domain (not the collaborator's own), and the self user has no domain set in this fixture, hence "".
+        let qualifiedID = QualifiedID(uuid: UUID(), domain: "")
         let humanCollaboratorResult = User(
             id: UserID(qualifiedID),
             name: "human collaborator",
@@ -1229,7 +1334,7 @@ final class SearchTaskTests: DatabaseTest {
             return [
                 CollaboratorInfo(
                     userID: qualifiedID.uuid,
-                    teamID: teamIdentifier,
+                    teamID: teamIdentifier!,
                     permissions: [.createTeamConversation]
                 )
             ]
@@ -1284,7 +1389,7 @@ final class SearchTaskTests: DatabaseTest {
             [
                 CollaboratorInfo(
                     userID: qualifiedID.uuid,
-                    teamID: teamIdentifier,
+                    teamID: teamIdentifier!,
                     permissions: [.createTeamConversation]
                 )
             ]

--- a/wire-ios-sync-engine/Tests/Source/UserSession/Search/SearchTaskTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/Search/SearchTaskTests.swift
@@ -1121,6 +1121,26 @@ final class SearchTaskTests: DatabaseTest {
             supportedProtocols: [.mls],
             legalholdStatus: .noConsent
         )
+        // A collaborator whose resolved profile is NOT app-typed (a human with team permissions). It must never
+        // surface via the apps result - only via the (separate) collaborators result, see
+        // testThatItListsCollaboratorsForContactsAndTeamMembersSearch below.
+        let qualifiedID2 = QualifiedID(uuid: UUID(), domain: "")
+        let humanCollaboratorResult = User(
+            id: UserID(qualifiedID2),
+            name: "human collaborator",
+            handle: "hc",
+            teamID: otherTeamID,
+            type: .regular,
+            accentID: 3,
+            assets: [],
+            deleted: nil,
+            email: nil,
+            expiresAt: nil,
+            app: nil,
+            service: nil,
+            supportedProtocols: [.mls],
+            legalholdStatus: .noConsent
+        )
 
         let expectation = XCTestExpectation()
         expectation.expectedFulfillmentCount = 3
@@ -1139,13 +1159,18 @@ final class SearchTaskTests: DatabaseTest {
                     userID: qualifiedID1.uuid,
                     teamID: otherTeamID,
                     permissions: [.createTeamConversation]
+                ),
+                CollaboratorInfo(
+                    userID: qualifiedID2.uuid,
+                    teamID: otherTeamID,
+                    permissions: [.createTeamConversation]
                 )
             ]
         }
         usersAPIMock.getUsersUserIDs_MockMethod = { userIDs in
-            XCTAssertEqual(userIDs, [UserID(qualifiedID1)])
+            XCTAssertEqual(userIDs, [UserID(qualifiedID1), UserID(qualifiedID2)])
             expectation.fulfill()
-            return UserList(found: [collaboratorAppResult], failed: [])
+            return UserList(found: [collaboratorAppResult, humanCollaboratorResult], failed: [])
         }
 
         // when
@@ -1153,6 +1178,8 @@ final class SearchTaskTests: DatabaseTest {
 
         // then
         await fulfillment(of: [expectation], timeout: 1)
+        // Only the two app-typed profiles (team-owned app + collaborator app) surface as apps; the human
+        // collaborator is dropped from this bucket entirely, since this request only asked for `.apps`.
         XCTAssertEqual(result.apps.count, 2)
         XCTAssertEqual(result.apps.first?.qualifiedID(localDomain: "-"), qualifiedID0)
         XCTAssertEqual(result.apps.first?.name, "app")
@@ -1164,6 +1191,135 @@ final class SearchTaskTests: DatabaseTest {
         XCTAssertEqual(result.apps.last?.handle, "ca")
         XCTAssertEqual(result.apps.last?.teamIdentifier, otherTeamID)
         XCTAssertEqual(result.apps.last?.zmAccentColor?.rawValue, 1)
+        // The human collaborator isn't surfaced anywhere for an `.apps`-only request either, since it doesn't
+        // request `.contacts`/`.teamMembers`.
+        XCTAssertTrue(result.collaborators.isEmpty)
+    }
+
+    func testThatItListsCollaboratorsForContactsAndTeamMembersSearch() async throws {
+        // given
+        let request = SearchRequest(
+            query: "",
+            searchDomain: "wire.com",
+            searchOptions: [.contacts, .teamMembers]
+        )
+        let task = makeSearchTask(request: request, apiVersion: .v15)
+
+        let qualifiedID = QualifiedID(uuid: UUID(), domain: "wire.com")
+        let humanCollaboratorResult = User(
+            id: UserID(qualifiedID),
+            name: "human collaborator",
+            handle: "hc",
+            teamID: teamIdentifier,
+            type: .regular,
+            accentID: 3,
+            assets: [],
+            deleted: nil,
+            email: nil,
+            expiresAt: nil,
+            app: nil,
+            service: nil,
+            supportedProtocols: [.mls],
+            legalholdStatus: .noConsent
+        )
+
+        teamsAPIMock.getAppsFor_MockMethod = { _ in [] }
+        teamsAPIMock.getCollaboratorsFor_MockMethod = { [teamIdentifier] teamID in
+            XCTAssertEqual(teamID, teamIdentifier)
+            return [
+                CollaboratorInfo(
+                    userID: qualifiedID.uuid,
+                    teamID: teamIdentifier,
+                    permissions: [.createTeamConversation]
+                )
+            ]
+        }
+        usersAPIMock.getUsersUserIDs_MockMethod = { userIDs in
+            XCTAssertEqual(userIDs, [UserID(qualifiedID)])
+            return UserList(found: [humanCollaboratorResult], failed: [])
+        }
+
+        // when
+        var result = SearchResult()
+        let resultAggregator = try await task.listAppsAndCollaborators()
+        resultAggregator(&result)
+
+        // then
+        XCTAssertTrue(result.apps.isEmpty)
+        XCTAssertEqual(result.collaborators.count, 1)
+        XCTAssertEqual(result.collaborators.first?.name, "human collaborator")
+        XCTAssertEqual(result.collaborators.first?.handle, "hc")
+        XCTAssertEqual(result.collaborators.first?.remoteIdentifier, qualifiedID.uuid)
+    }
+
+    func testThatItDeduplicatesCollaboratorsAgainstExistingTeamMembers() async throws {
+        // given
+        let request = SearchRequest(
+            query: "",
+            searchDomain: "wire.com",
+            searchOptions: [.contacts, .teamMembers]
+        )
+        let task = makeSearchTask(request: request, apiVersion: .v15)
+
+        let qualifiedID = QualifiedID(uuid: UUID(), domain: "wire.com")
+        let humanCollaboratorResult = User(
+            id: UserID(qualifiedID),
+            name: "human collaborator",
+            handle: "hc",
+            teamID: teamIdentifier,
+            type: .regular,
+            accentID: 3,
+            assets: [],
+            deleted: nil,
+            email: nil,
+            expiresAt: nil,
+            app: nil,
+            service: nil,
+            supportedProtocols: [.mls],
+            legalholdStatus: .noConsent
+        )
+
+        teamsAPIMock.getAppsFor_MockMethod = { _ in [] }
+        teamsAPIMock.getCollaboratorsFor_MockMethod = { [teamIdentifier] _ in
+            [
+                CollaboratorInfo(
+                    userID: qualifiedID.uuid,
+                    teamID: teamIdentifier,
+                    permissions: [.createTeamConversation]
+                )
+            ]
+        }
+        usersAPIMock.getUsersUserIDs_MockMethod = { _ in
+            UserList(found: [humanCollaboratorResult], failed: [])
+        }
+
+        // A team member already present in the accumulated result under the same remote identifier - e.g. because
+        // the local team-members search resolved first. The collaborator must not be added a second time.
+        let existingTeamMember = await uiMOC.perform { [uiMOC] in
+            ZMSearchUser(
+                viewContext: uiMOC,
+                name: "human collaborator",
+                handle: "hc",
+                accentColor: nil,
+                remoteIdentifier: qualifiedID.uuid,
+                domain: qualifiedID.domain,
+                teamIdentifier: self.teamIdentifier,
+                providerIdentifier: nil,
+                user: nil,
+                searchUsersCache: nil,
+                type: .regular
+            )
+        }
+        var result = SearchResult()
+        result.teamMembers = [existingTeamMember]
+
+        // when
+        let resultAggregator = try await task.listAppsAndCollaborators()
+        resultAggregator(&result)
+
+        // then
+        XCTAssertEqual(result.teamMembers.count, 1)
+        XCTAssertTrue(result.collaborators.isEmpty)
     }
 
     func testThatItSendsASearchAppsRequest() async throws {

--- a/wire-ios/Wire-iOS Tests/AddParticipantsViewModelTests.swift
+++ b/wire-ios/Wire-iOS Tests/AddParticipantsViewModelTests.swift
@@ -1,0 +1,87 @@
+//
+// Wire
+// Copyright (C) 2026 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+
+@testable import Wire
+
+final class AddParticipantsViewModelTests: XCTestCase {
+
+    var mockSelfUser: MockUserType!
+
+    override func setUp() {
+        super.setUp()
+        SelfUser.setupMockSelfUser(inTeam: UUID())
+        mockSelfUser = SelfUser.provider?.providedSelfUser as? MockUserType
+        mockSelfUser.canCreateService = true
+    }
+
+    override func tearDown() {
+        mockSelfUser = nil
+        super.tearDown()
+    }
+
+    /// Apps must never be offered when creating a brand new conversation, regardless of whether apps/bots are
+    /// otherwise enabled for the team - the apps group selector should simply never show up in `.create` context.
+    func testThatBotCanBeAdded_IsAlwaysFalse_ForCreateContext() {
+        let values = ConversationCreationValues(
+            isChannel: false,
+            isAppsFeatureEnabled: true,
+            areLegacyBotsAvailable: true,
+            name: "",
+            participants: [],
+            allowGuests: true,
+            encryptionProtocol: .proteus,
+            selfUser: mockSelfUser
+        )
+
+        let sut = AddParticipantsViewModel(
+            context: .create(values),
+            isAppsFeatureEnabled: true,
+            areLegacyBotsAvailable: true
+        )
+
+        XCTAssertFalse(sut.botCanBeAdded)
+    }
+
+    /// Regression guard: the `.create` (new-conversation) flow must never add the apps group selector to its
+    /// view hierarchy, even though the same search path now also surfaces human team collaborators.
+    func testThatCreateContext_NeverAddsSearchGroupSelector() throws {
+        let values = ConversationCreationValues(
+            isChannel: false,
+            isAppsFeatureEnabled: true,
+            areLegacyBotsAvailable: true,
+            name: "",
+            participants: [],
+            allowGuests: true,
+            encryptionProtocol: .proteus,
+            selfUser: mockSelfUser
+        )
+        let userSession = UserSessionMock(mockUser: mockSelfUser)
+
+        let sut = try XCTUnwrap(AddParticipantsViewController(
+            context: .create(values),
+            userSession: userSession,
+            isAppsFeatureEnabled: true,
+            areLegacyBotsAvailable: true
+        ))
+
+        XCTAssertFalse(sut.view.subviews.contains { $0 is SearchGroupSelector })
+    }
+
+}

--- a/wire-ios/Wire-iOS Tests/Search/SearchResultsViewControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/Search/SearchResultsViewControllerTests.swift
@@ -19,9 +19,94 @@
 import UIKit
 import XCTest
 @testable import Wire
+@testable import WireSyncEngine
 
 final class SearchResultsViewControllerTests: XCTestCase {
     weak var sut: SearchResultsViewController!
+    private var coreDataFixture: CoreDataFixture!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        coreDataFixture = try await CoreDataFixture()
+    }
+
+    override func tearDown() {
+        coreDataFixture = nil
+        super.tearDown()
+    }
+
+    @MainActor
+    func testThatUpdateSectionsKeepsSearchUserBackedApps_ButExcludesExistingParticipants() throws {
+        let uiMOC = coreDataFixture.uiMOC!
+        let selfUser = coreDataFixture.selfUser!
+        let existingParticipantApp = coreDataFixture.otherUser!
+        existingParticipantApp.type = .app
+
+        let conversation = ZMConversation.createGroupConversation(
+            moc: uiMOC,
+            otherUser: existingParticipantApp,
+            selfUser: selfUser
+        )
+
+        // A collaborator app already known locally as a `ZMUser`, but NOT a participant of this conversation -
+        // wrapped in `ZMSearchUser`, as every apps search result is.
+        let knownCollaboratorAppUser = coreDataFixture.createUser(name: "Collaborator App")
+        knownCollaboratorAppUser.type = .app
+        let knownCollaboratorAppSearchResult = ZMSearchUser(
+            viewContext: uiMOC,
+            name: "Collaborator App",
+            handle: "collaborator-app",
+            accentColor: nil,
+            remoteIdentifier: knownCollaboratorAppUser.remoteIdentifier,
+            domain: knownCollaboratorAppUser.domain,
+            teamIdentifier: knownCollaboratorAppUser.teamIdentifier,
+            providerIdentifier: nil,
+            user: knownCollaboratorAppUser,
+            searchUsersCache: nil,
+            type: .app,
+            summary: nil,
+            isDeleted: false
+        )
+
+        // A collaborator app not known locally at all (no backing `ZMUser`) - the common case for apps
+        // resolved purely from `/teams/:tid/collaborators` + `/users`.
+        let remoteOnlyAppSearchResult = ZMSearchUser(
+            viewContext: uiMOC,
+            name: "Remote-Only App",
+            handle: "remote-only-app",
+            accentColor: nil,
+            remoteIdentifier: UUID(),
+            domain: nil,
+            teamIdentifier: UUID(),
+            providerIdentifier: nil,
+            user: nil,
+            searchUsersCache: nil,
+            type: .app,
+            summary: nil,
+            isDeleted: false
+        )
+
+        var searchResult = SearchResult()
+        searchResult.apps = [existingParticipantApp, knownCollaboratorAppSearchResult, remoteOnlyAppSearchResult]
+
+        let mockUserSession = UserSessionMock(mockUser: MockUserType.createSelfUser(name: selfUser.name ?? ""))
+        let sut = try XCTUnwrap(SearchResultsViewController(
+            userSelection: UserSelection(),
+            userSession: mockUserSession,
+            isAddingParticipants: true,
+            shouldIncludeGuests: true,
+            isFederationEnabled: false
+        ))
+        sut.filterConversation = conversation
+
+        sut.updateSections(withSearchResult: searchResult)
+
+        let remainingRemoteIdentifiers = Set(sut.appsSection.apps.map(\.remoteIdentifier))
+        XCTAssertEqual(remainingRemoteIdentifiers.count, 2)
+        XCTAssertFalse(remainingRemoteIdentifiers.contains(existingParticipantApp.remoteIdentifier))
+        XCTAssertTrue(remainingRemoteIdentifiers.contains(knownCollaboratorAppUser.remoteIdentifier))
+        XCTAssertTrue(remainingRemoteIdentifiers.contains(remoteOnlyAppSearchResult.remoteIdentifier))
+    }
 
     func testThatSearchResultsViewControllerIsNotRetained() {
         autoreleasepool {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Services/ServiceDetailViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Services/ServiceDetailViewController.swift
@@ -275,7 +275,7 @@ final class ServiceDetailViewController: UIViewController {
         contextProvider: some ContextProvider,
         completion: @escaping (AddBotResult) -> Void
     ) {
-        guard let user = service.user as? ZMUser else {
+        guard let user = service.user.materialize(in: contextProvider.viewContext) else {
             return completion(.failure(error: .general))
         }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
@@ -376,9 +376,12 @@ final class SearchResultsViewController: UIViewController {
                 }
                 return !filteredParticipants.contains(user)
             }
-            filteredApps = filteredApps
-                .compactMap { $0 as? ZMUser }
-                .filter { !filteredParticipants.contains($0) }
+            filteredApps = filteredApps.filter { app in
+                guard let user = (app as? ZMUser) ?? (app as? ZMSearchUser)?.user else {
+                    return true
+                }
+                return !filteredParticipants.contains(user)
+            }
             filteredCollaborators = filteredCollaborators.filter {
                 guard let user = $0.user else {
                     return true
@@ -454,17 +457,17 @@ extension SearchResultsViewController: SearchSectionControllerDelegate {
         didSelectUser user: UserType,
         at indexPath: IndexPath
     ) {
-        if let user = user as? ZMUser, user.type == .regular {
+        if user.isApp {
+            delegate?.searchResultsViewController(self, didTapOnApp: user)
+        } else if user.isBot {
+            delegate?.searchResultsViewController(self, didTapOnBot: user)
+        } else if let user = user as? ZMUser {
             delegate?.searchResultsViewController(
                 self,
                 didTapOnUser: user,
                 indexPath: indexPath,
                 section: sectionFor(controller: searchSectionController)
             )
-        } else if let user = user as? ZMUser, user.type == .app {
-            delegate?.searchResultsViewController(self, didTapOnApp: user)
-        } else if user.isAppOrBot {
-            delegate?.searchResultsViewController(self, didTapOnBot: user)
         } else if let searchUser = user as? ZMSearchUser {
             delegate?.searchResultsViewController(
                 self,

--- a/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
@@ -359,6 +359,9 @@ final class SearchResultsViewController: UIViewController {
         var filteredContacts = searchResult.contacts
         var filteredTeamContacts = searchResult.teamMembers
         var filteredApps = searchResult.apps
+        // Human team collaborators (resolved from `/teams/:tid/collaborators`) are rendered like regular
+        // contacts/team members, never through the apps-specific section controller.
+        var filteredCollaborators = searchResult.collaborators
 
         if let filteredParticipants = filterConversation?.localParticipants {
             filteredContacts = filteredContacts.filter {
@@ -376,26 +379,25 @@ final class SearchResultsViewController: UIViewController {
             filteredApps = filteredApps
                 .compactMap { $0 as? ZMUser }
                 .filter { !filteredParticipants.contains($0) }
+            filteredCollaborators = filteredCollaborators.filter {
+                guard let user = $0.user else {
+                    return true
+                }
+                return !filteredParticipants.contains(user)
+            }
         }
 
         contactsSection.contacts = filteredContacts
 
-        // Access mode is not set, or the guests are allowed.
-        if shouldIncludeGuests {
-            teamMemberAndContactsSection.contacts = Set(filteredTeamContacts + filteredContacts).sorted {
-                let name0 = $0.name ?? ""
-                let name1 = $1.name ?? ""
+        // Collaborators are team-scoped (fetched per-team, like team members), so they're always included
+        // alongside team members regardless of whether personal (non-team) contacts are shown.
+        let teamMembersAndCollaborators = filteredTeamContacts + filteredCollaborators
 
-                if name0 == name1 {
-                    let pseudo0 = $0.handle ?? ""
-                    let pseudo1 = $1.handle ?? ""
-                    return pseudo0.compare(pseudo1) == .orderedAscending
-                }
-                return name0.compare(name1) == .orderedAscending
-            }
-        } else {
-            teamMemberAndContactsSection.contacts = filteredTeamContacts
-        }
+        // Access mode is not set, or the guests are allowed.
+        let combinedContacts = shouldIncludeGuests ?
+            teamMembersAndCollaborators + filteredContacts :
+            teamMembersAndCollaborators
+        teamMemberAndContactsSection.contacts = sorted(byNameThenHandle: Set(combinedContacts))
 
         directorySection.suggestions = searchResult.directory.filter { !$0.isFederated }
         conversationsSection.groupConversations = searchResult.conversations
@@ -404,6 +406,21 @@ final class SearchResultsViewController: UIViewController {
         federationSection.users = searchResult.directory.filter(\.isFederated)
 
         sectionController.collectionView?.reloadData()
+    }
+
+    /// Sorts search users by name, falling back to handle for users sharing the same name.
+    private func sorted(byNameThenHandle users: some Sequence<ZMSearchUser>) -> [ZMSearchUser] {
+        users.sorted {
+            let name0 = $0.name ?? ""
+            let name1 = $1.name ?? ""
+
+            if name0 == name1 {
+                let pseudo0 = $0.handle ?? ""
+                let pseudo1 = $1.handle ?? ""
+                return pseudo0.compare(pseudo1) == .orderedAscending
+            }
+            return name0.compare(name1) == .orderedAscending
+        }
     }
 
     func sectionFor(controller: CollectionViewSectionController) -> SearchResultsViewControllerSection {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-28430" title="WPB-28430" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-28430</a>  Add apps and collaborators to iOS app
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

- clients are not able to show external apps to add them to conversations. External apps are returned by backend call /teams/:tid/collaborators
- collaborators can potentially also contain regular users in the future, not only apps
- internal apps are currently returned by /teams/:tid/members which will change because treating apps as team members incorrectly contributes to used seat count, that's why we need to add call to /teams/:tid/apps to fetch internal apps as well

This is a diagram of how different endpoints return different schemas, and how they all map to apps and people (regular users) in the end.

<img width="918" height="273" alt="Screenshot 2026-09-14 at 15 08 18" src="https://github.com/user-attachments/assets/3e52f7bf-5939-45cf-89a8-9852ff6e76ae" />

### Testing

I have tested it on staging backend using a testing teams with both own apps and external apps added.

External apps flow is unlocked on dev environment of teams: [wire-teams-dev.zinfra.io](https://wire-teams-dev.zinfra.io/) (uses staging version of backend and dev version of wire teams).


https://github.com/user-attachments/assets/cd47aca3-e626-4ce5-9c2a-33198a9e5ecb



---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
